### PR TITLE
feat(sources/community/workos): add WorkOS source

### DIFF
--- a/sources/community/workos/README.md
+++ b/sources/community/workos/README.md
@@ -34,7 +34,7 @@ Official docs:
 | --- | --- |
 | `workos.organizations` | WorkOS organizations. |
 | `workos.users` | User Management users. Supports `organization_id` and `email`. |
-| `workos.organization_memberships` | User-to-organization memberships. Requires `organization_id`; optionally supports `user_id`. |
+| `workos.organization_memberships` | User-to-organization memberships. WorkOS requires either `organization_id` or `user_id`. |
 | `workos.directories` | Directory Sync directories. |
 | `workos.events` | WorkOS environment events. Supports organization, event, time range, and order filters. |
 
@@ -67,6 +67,15 @@ WHERE organization_id = 'org_...'
 LIMIT 25;
 ```
 
+Review memberships for one user:
+
+```sql
+SELECT id, user_id, organization_id, status, role_slug
+FROM workos.organization_memberships
+WHERE user_id = 'user_...'
+LIMIT 25;
+```
+
 Review recent events:
 
 ```sql
@@ -80,6 +89,9 @@ LIMIT 25;
 ## Notes
 
 - WorkOS list endpoints are cursor paginated with `after` and `limit`.
+- WorkOS requires `organization_id` or `user_id` for membership queries; an
+  unscoped `workos.organization_memberships` query is expected to fail at the
+  provider API.
 - The source is read-only and does not create, update, or delete WorkOS
   resources.
 - Event `data` and `context` are JSON metadata columns; avoid selecting them in

--- a/sources/community/workos/README.md
+++ b/sources/community/workos/README.md
@@ -34,7 +34,8 @@ Official docs:
 | --- | --- |
 | `workos.organizations` | WorkOS organizations. |
 | `workos.users` | User Management users. Supports `organization_id` and `email`. |
-| `workos.organization_memberships` | User-to-organization memberships. WorkOS requires either `organization_id` or `user_id`. |
+| `workos.organization_memberships_by_organization` | User-to-organization memberships. Requires `organization_id`. |
+| `workos.organization_memberships_by_user` | User-to-organization memberships. Requires `user_id`. |
 | `workos.directories` | Directory Sync directories. |
 | `workos.events` | WorkOS environment events. Supports organization, event, time range, and order filters. |
 
@@ -62,7 +63,7 @@ Review memberships for one organization:
 
 ```sql
 SELECT id, user_id, organization_id, status, role_slug
-FROM workos.organization_memberships
+FROM workos.organization_memberships_by_organization
 WHERE organization_id = 'org_...'
 LIMIT 25;
 ```
@@ -71,7 +72,7 @@ Review memberships for one user:
 
 ```sql
 SELECT id, user_id, organization_id, status, role_slug
-FROM workos.organization_memberships
+FROM workos.organization_memberships_by_user
 WHERE user_id = 'user_...'
 LIMIT 25;
 ```
@@ -89,9 +90,9 @@ LIMIT 25;
 ## Notes
 
 - WorkOS list endpoints are cursor paginated with `after` and `limit`.
-- WorkOS requires `organization_id` or `user_id` for membership queries; an
-  unscoped `workos.organization_memberships` query is expected to fail at the
-  provider API.
+- WorkOS requires `organization_id` or `user_id` for membership queries, so the
+  source exposes separate membership tables with required scope filters instead
+  of an unscoped membership table.
 - The source is read-only and does not create, update, or delete WorkOS
   resources.
 - Event `data` and `context` are JSON metadata columns; avoid selecting them in
@@ -111,10 +112,11 @@ Live Coral evidence:
 ```text
 ✓ workos connected successfully
 
-workos (5 tables)
+workos (6 tables)
 ├─ directories
 ├─ events
-├─ organization_memberships
+├─ organization_memberships_by_organization
+├─ organization_memberships_by_user
 ├─ organizations
 └─ users
 Query tests

--- a/sources/community/workos/README.md
+++ b/sources/community/workos/README.md
@@ -1,0 +1,101 @@
+# WorkOS
+
+Query WorkOS identity and organization metadata from Coral. The source covers
+organizations, User Management users, organization memberships, Directory Sync
+directories, and WorkOS Events.
+
+## Authentication
+
+Create a WorkOS secret API key in the WorkOS dashboard and provide:
+
+| Input | Description |
+| --- | --- |
+| `WORKOS_API_KEY` | WorkOS secret API key sent as a bearer token. |
+
+The key is modeled as a secret. Use the narrowest dashboard role and
+environment access that can read the metadata Coral agents need.
+
+Official docs:
+
+- <https://workos.com/docs/reference>
+- <https://workos.com/docs/reference/organization/list>
+- <https://workos.com/docs/reference/user-management/user/list>
+- <https://workos.com/docs/reference/events/list-events>
+
+## Tables
+
+| Table | Description |
+| --- | --- |
+| `workos.organizations` | WorkOS organizations. |
+| `workos.users` | User Management users. Supports `organization_id` and `email`. |
+| `workos.organization_memberships` | User-to-organization memberships. Supports `organization_id` and `user_id`. |
+| `workos.directories` | Directory Sync directories. |
+| `workos.events` | WorkOS environment events. Supports organization, event, time range, and order filters. |
+
+## Examples
+
+List organizations:
+
+```sql
+SELECT id, name, created_at
+FROM workos.organizations
+ORDER BY created_at DESC
+LIMIT 25;
+```
+
+Find users in one organization:
+
+```sql
+SELECT id, email, first_name, last_name, email_verified
+FROM workos.users
+WHERE organization_id = 'org_...'
+LIMIT 25;
+```
+
+Review recent events:
+
+```sql
+SELECT id, event, created_at
+FROM workos.events
+WHERE range_start = '2026-05-01T00:00:00Z'
+ORDER BY created_at DESC
+LIMIT 25;
+```
+
+## Notes
+
+- WorkOS list endpoints are cursor paginated with `after` and `limit`.
+- The source is read-only and does not create, update, or delete WorkOS
+  resources.
+- Event `data` and `context` are JSON metadata columns; avoid selecting them in
+  broad queries unless you need the raw event payload.
+- Results depend on the API key's environment and permissions.
+
+## Validation
+
+- YAML parsing: passed
+- Coral manifest schema validation: passed
+- `git diff --check`: passed
+- `make lint-sources`: passed
+- Live API tests: passed against a WorkOS staging environment
+
+Live Coral evidence:
+
+```text
+✓ workos connected successfully
+
+workos (5 tables)
+├─ directories
+├─ events
+├─ organization_memberships
+├─ organizations
+└─ users
+Query tests
+2 declared · 2 passed · 0 failed
+
+✓ SELECT id, name FROM workos.organizations LIMIT 1
+  1 row
+
+✓ SELECT id, email FROM workos.users LIMIT 1
+  0 rows
+```

--- a/sources/community/workos/README.md
+++ b/sources/community/workos/README.md
@@ -34,8 +34,8 @@ Official docs:
 | --- | --- |
 | `workos.organizations` | WorkOS organizations. |
 | `workos.users` | User Management users. Supports `organization_id` and `email`. |
-| `workos.organization_memberships_by_organization` | User-to-organization memberships. Requires `organization_id`. |
-| `workos.organization_memberships_by_user` | User-to-organization memberships. Requires `user_id`. |
+| `workos.organization_memberships_by_organization` | User-to-organization memberships. Requires `organization_id`; supports `statuses`. |
+| `workos.organization_memberships_by_user` | User-to-organization memberships. Requires `user_id`; supports `statuses`. |
 | `workos.directories` | Directory Sync directories. |
 | `workos.events` | WorkOS environment events. Supports organization, event, time range, and order filters. |
 
@@ -68,6 +68,16 @@ WHERE organization_id = 'org_...'
 LIMIT 25;
 ```
 
+Review pending or inactive memberships:
+
+```sql
+SELECT id, user_id, organization_id, status, role_slug
+FROM workos.organization_memberships_by_organization
+WHERE organization_id = 'org_...'
+  AND statuses = 'pending,inactive'
+LIMIT 25;
+```
+
 Review memberships for one user:
 
 ```sql
@@ -93,6 +103,9 @@ LIMIT 25;
 - WorkOS requires `organization_id` or `user_id` for membership queries, so the
   source exposes separate membership tables with required scope filters instead
   of an unscoped membership table.
+- WorkOS membership lists return active memberships by default. Use the
+  `statuses` filter, such as `pending,inactive`, when auditing invitations or
+  inactive memberships.
 - The source is read-only and does not create, update, or delete WorkOS
   resources.
 - Event `data` and `context` are JSON metadata columns; avoid selecting them in

--- a/sources/community/workos/README.md
+++ b/sources/community/workos/README.md
@@ -12,14 +12,20 @@ Create a WorkOS secret API key in the WorkOS dashboard and provide:
 | --- | --- |
 | `WORKOS_API_KEY` | WorkOS secret API key sent as a bearer token. |
 
-The key is modeled as a secret. Use the narrowest dashboard role and
-environment access that can read the metadata Coral agents need.
+The key is modeled as a secret. WorkOS secret keys are environment-scoped
+credentials that can perform API requests for that environment; this source is
+read-only, but the key itself is not inherently read-only. Use a non-production
+or least-privileged environment key whenever possible, rotate it if exposed, and
+only share it with Coral agents that need identity and audit metadata access.
 
 Official docs:
 
 - <https://workos.com/docs/reference>
+- <https://workos.com/docs/reference/api-authentication>
 - <https://workos.com/docs/reference/organization/list>
 - <https://workos.com/docs/reference/user-management/user/list>
+- <https://workos.com/docs/reference/authkit/organization-membership>
+- <https://workos.com/docs/reference/directory-sync/directory>
 - <https://workos.com/docs/reference/events/list-events>
 
 ## Tables
@@ -28,7 +34,7 @@ Official docs:
 | --- | --- |
 | `workos.organizations` | WorkOS organizations. |
 | `workos.users` | User Management users. Supports `organization_id` and `email`. |
-| `workos.organization_memberships` | User-to-organization memberships. Supports `organization_id` and `user_id`. |
+| `workos.organization_memberships` | User-to-organization memberships. Requires `organization_id`; optionally supports `user_id`. |
 | `workos.directories` | Directory Sync directories. |
 | `workos.events` | WorkOS environment events. Supports organization, event, time range, and order filters. |
 
@@ -48,6 +54,15 @@ Find users in one organization:
 ```sql
 SELECT id, email, first_name, last_name, email_verified
 FROM workos.users
+WHERE organization_id = 'org_...'
+LIMIT 25;
+```
+
+Review memberships for one organization:
+
+```sql
+SELECT id, user_id, organization_id, status, role_slug
+FROM workos.organization_memberships
 WHERE organization_id = 'org_...'
 LIMIT 25;
 ```
@@ -91,11 +106,14 @@ workos (5 tables)
 ├─ organizations
 └─ users
 Query tests
-2 declared · 2 passed · 0 failed
+3 declared · 3 passed · 0 failed
 
 ✓ SELECT id, name FROM workos.organizations LIMIT 1
   1 row
 
 ✓ SELECT id, email FROM workos.users LIMIT 1
+  0 rows
+
+✓ SELECT id, name FROM workos.directories LIMIT 1
   0 rows
 ```

--- a/sources/community/workos/manifest.yaml
+++ b/sources/community/workos/manifest.yaml
@@ -173,10 +173,13 @@ tables:
     description: WorkOS User Management organization memberships scoped by organization.
     guide: |
       Requires `organization_id` from `workos.organizations`. Use this table
-      to inspect all user memberships for one organization.
+      to inspect all user memberships for one organization. WorkOS returns
+      active memberships by default; pass `statuses` to include states such as
+      pending or inactive.
     filters:
       - name: organization_id
         required: true
+      - name: statuses
     fetch_limit_default: 100
     request:
       method: GET
@@ -185,6 +188,9 @@ tables:
         - name: organization_id
           from: filter
           key: organization_id
+        - name: statuses
+          from: filter
+          key: statuses
     response:
       rows_path: [data]
       row_strategy: direct
@@ -239,10 +245,12 @@ tables:
     description: WorkOS User Management organization memberships scoped by user.
     guide: |
       Requires `user_id` from `workos.users`. Use this table to inspect all
-      organization memberships for one user.
+      organization memberships for one user. WorkOS returns active memberships
+      by default; pass `statuses` to include states such as pending or inactive.
     filters:
       - name: user_id
         required: true
+      - name: statuses
     fetch_limit_default: 100
     request:
       method: GET
@@ -251,6 +259,9 @@ tables:
         - name: user_id
           from: filter
           key: user_id
+        - name: statuses
+          from: filter
+          key: statuses
     response:
       rows_path: [data]
       row_strategy: direct

--- a/sources/community/workos/manifest.yaml
+++ b/sources/community/workos/manifest.yaml
@@ -11,8 +11,9 @@ inputs:
   WORKOS_API_KEY:
     kind: secret
     hint: |
-      WorkOS secret API key. Create it in the WorkOS dashboard and grant only
-      the read access needed for the tables you want Coral agents to inspect.
+      WorkOS secret API key. Create it in the WorkOS dashboard for the intended
+      environment and treat it as privileged because WorkOS secret keys are not
+      inherently read-only.
 
 auth:
   type: HeaderAuth
@@ -29,6 +30,7 @@ request_headers:
 test_queries:
   - SELECT id, name FROM workos.organizations LIMIT 1
   - SELECT id, email FROM workos.users LIMIT 1
+  - SELECT id, name FROM workos.directories LIMIT 1
 
 tables:
   - name: organizations
@@ -170,10 +172,11 @@ tables:
   - name: organization_memberships
     description: WorkOS User Management organization memberships.
     guide: |
-      Use `organization_id` or `user_id` to scope membership inventory and
-      avoid scanning every membership in large environments.
+      Requires `organization_id` from `workos.organizations`. Add `user_id`
+      when you want to narrow membership inventory to one user.
     filters:
       - name: organization_id
+        required: true
       - name: user_id
     fetch_limit_default: 100
     request:
@@ -217,7 +220,8 @@ tables:
       - name: role_slug
         type: Utf8
         nullable: true
-        description: Role slug when returned by WorkOS.
+        description: Role slug from the nested membership role object.
+        expr: {kind: path, path: [role, slug]}
       - name: created_at
         type: Timestamp
         nullable: true
@@ -244,7 +248,7 @@ tables:
     fetch_limit_default: 100
     request:
       method: GET
-      path: /directory_sync/directories
+      path: /directories
     response:
       rows_path: [data]
       row_strategy: direct

--- a/sources/community/workos/manifest.yaml
+++ b/sources/community/workos/manifest.yaml
@@ -1,0 +1,367 @@
+name: workos
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query WorkOS organizations, user-management users, organization memberships,
+  directory sync directories, and environment events.
+base_url: https://api.workos.com
+
+inputs:
+  WORKOS_API_KEY:
+    kind: secret
+    hint: |
+      WorkOS secret API key. Create it in the WorkOS dashboard and grant only
+      the read access needed for the tables you want Coral agents to inspect.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.WORKOS_API_KEY}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT id, name FROM workos.organizations LIMIT 1
+  - SELECT id, email FROM workos.users LIMIT 1
+
+tables:
+  - name: organizations
+    description: WorkOS organizations in the current environment.
+    guide: |
+      Uses WorkOS list pagination with `limit` and `after`. Filter locally in
+      SQL for organization inventory and ownership workflows.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /organizations
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [list_metadata, after]
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: WorkOS organization ID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Organization display name.
+      - name: domains
+        type: Json
+        nullable: true
+        description: Organization domains.
+      - name: metadata
+        type: Json
+        nullable: true
+        description: Organization metadata.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Organization creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Organization update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+
+  - name: users
+    description: WorkOS User Management users.
+    guide: |
+      Lists AuthKit/User Management users visible to the API key. Use
+      `organization_id` when you want membership-scoped user inventory.
+    filters:
+      - name: organization_id
+      - name: email
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /user_management/users
+      query:
+        - name: organization_id
+          from: filter
+          key: organization_id
+        - name: email
+          from: filter
+          key: email
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [list_metadata, after]
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: WorkOS user ID.
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address.
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: User first name.
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: User last name.
+      - name: email_verified
+        type: Boolean
+        nullable: true
+        description: Whether the user email is verified.
+      - name: profile_picture_url
+        type: Utf8
+        nullable: true
+        description: User profile picture URL when returned.
+      - name: metadata
+        type: Json
+        nullable: true
+        description: User metadata.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: User creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: User update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+      - name: organization_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional organization filter.
+        expr: {kind: from_filter, key: organization_id}
+
+  - name: organization_memberships
+    description: WorkOS User Management organization memberships.
+    guide: |
+      Use `organization_id` or `user_id` to scope membership inventory and
+      avoid scanning every membership in large environments.
+    filters:
+      - name: organization_id
+      - name: user_id
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /user_management/organization_memberships
+      query:
+        - name: organization_id
+          from: filter
+          key: organization_id
+        - name: user_id
+          from: filter
+          key: user_id
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [list_metadata, after]
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Organization membership ID.
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: WorkOS user ID.
+      - name: organization_id
+        type: Utf8
+        nullable: true
+        description: WorkOS organization ID.
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Membership status.
+      - name: role_slug
+        type: Utf8
+        nullable: true
+        description: Role slug when returned by WorkOS.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Membership creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Membership update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+
+  - name: directories
+    description: WorkOS Directory Sync directories.
+    guide: |
+      Lists Directory Sync directories and their provider/status metadata.
+      Directory users and groups are intentionally not included in v1 to keep
+      the source surface small and predictable.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /directory_sync/directories
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [list_metadata, after]
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Directory ID.
+      - name: organization_id
+        type: Utf8
+        nullable: true
+        description: Associated organization ID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Directory name.
+      - name: domain
+        type: Utf8
+        nullable: true
+        description: Directory domain when returned.
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Directory provider type.
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Directory state.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Directory creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Directory update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+
+  - name: events
+    description: WorkOS environment events.
+    guide: |
+      Lists WorkOS Events for the current environment. Use event type and
+      organization filters to keep event queries bounded and relevant.
+    filters:
+      - name: organization_id
+      - name: event
+      - name: range_start
+      - name: range_end
+      - name: order
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /events
+      query:
+        - name: organization_id
+          from: filter
+          key: organization_id
+        - name: events
+          from: filter
+          key: event
+        - name: range_start
+          from: filter
+          key: range_start
+        - name: range_end
+          from: filter
+          key: range_end
+        - name: order
+          from: filter
+          key: order
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [list_metadata, after]
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Event ID.
+      - name: event
+        type: Utf8
+        nullable: true
+        description: WorkOS event type.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Event creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: data
+        type: Json
+        nullable: true
+        description: Event payload.
+      - name: context
+        type: Json
+        nullable: true
+        description: Event context.

--- a/sources/community/workos/manifest.yaml
+++ b/sources/community/workos/manifest.yaml
@@ -169,15 +169,14 @@ tables:
         description: Optional organization filter.
         expr: {kind: from_filter, key: organization_id}
 
-  - name: organization_memberships
-    description: WorkOS User Management organization memberships.
+  - name: organization_memberships_by_organization
+    description: WorkOS User Management organization memberships scoped by organization.
     guide: |
-      WorkOS requires at least one scoping filter: `organization_id` from
-      `workos.organizations` or `user_id` from `workos.users`. Unscoped
-      membership queries are rejected by the provider.
+      Requires `organization_id` from `workos.organizations`. Use this table
+      to inspect all user memberships for one organization.
     filters:
       - name: organization_id
-      - name: user_id
+        required: true
     fetch_limit_default: 100
     request:
       method: GET
@@ -186,6 +185,69 @@ tables:
         - name: organization_id
           from: filter
           key: organization_id
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [list_metadata, after]
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Organization membership ID.
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: WorkOS user ID.
+      - name: organization_id
+        type: Utf8
+        nullable: true
+        description: WorkOS organization ID.
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Membership status.
+      - name: role_slug
+        type: Utf8
+        nullable: true
+        description: Role slug from the nested membership role object.
+        expr: {kind: path, path: [role, slug]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Membership creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Membership update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+
+  - name: organization_memberships_by_user
+    description: WorkOS User Management organization memberships scoped by user.
+    guide: |
+      Requires `user_id` from `workos.users`. Use this table to inspect all
+      organization memberships for one user.
+    filters:
+      - name: user_id
+        required: true
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /user_management/organization_memberships
+      query:
         - name: user_id
           from: filter
           key: user_id

--- a/sources/community/workos/manifest.yaml
+++ b/sources/community/workos/manifest.yaml
@@ -172,11 +172,11 @@ tables:
   - name: organization_memberships
     description: WorkOS User Management organization memberships.
     guide: |
-      Requires `organization_id` from `workos.organizations`. Add `user_id`
-      when you want to narrow membership inventory to one user.
+      WorkOS requires at least one scoping filter: `organization_id` from
+      `workos.organizations` or `user_id` from `workos.users`. Unscoped
+      membership queries are rejected by the provider.
     filters:
       - name: organization_id
-        required: true
       - name: user_id
     fetch_limit_default: 100
     request:


### PR DESCRIPTION
Summary:
- Adds a community Coral source for WorkOS organizations, users, organization memberships, directories, and events.
- Keeps API credentials as secret input and uses bounded cursor pagination.
- Includes README setup, examples, limitations, and validation notes.

Validation:
- YAML parsing: passed
- Coral manifest schema validation: passed
- git diff --check: passed
- make lint-sources: passed
- Live API tests: passed against a WorkOS staging environment