### PR TITLE
perf(catalog): reduce startup catalog/runtime work

### DIFF
--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -138,6 +138,15 @@ message CatalogItem {
   }
 }
 
+// Per-kind catalog counts after workspace/schema filtering and before item-kind
+// filtering or pagination.
+message CatalogCounts {
+  // Query-visible table count.
+  uint32 table_count = 1;
+  // Query-visible table function count.
+  uint32 table_function_count = 2;
+}
+
 // Lists queryable catalog items in one workspace.
 message ListCatalogRequest {
   // Workspace whose current queryable catalog should be listed.
@@ -156,6 +165,8 @@ message ListCatalogResponse {
   repeated CatalogItem items = 1;
   // Page metadata for the catalog list.
   PaginationResponse pagination = 2;
+  // Per-kind counts for the current workspace/schema catalog snapshot.
+  CatalogCounts counts = 3;
 }
 
 // Searches queryable catalog metadata.

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 
-use coral_engine::{ColumnInfo, TableFunctionInfo, TableInfo};
+use coral_engine::{CatalogInfo, ColumnInfo, TableFunctionInfo, TableInfo};
 use regex::{Regex, RegexBuilder};
 
 use crate::bootstrap::AppError;
@@ -31,6 +31,18 @@ pub(crate) struct Page<T> {
     pub(crate) offset: u32,
     pub(crate) has_more: bool,
     pub(crate) next_offset: Option<u32>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CatalogCounts {
+    pub(crate) table_count: u32,
+    pub(crate) table_function_count: u32,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CatalogPage {
+    pub(crate) items: Page<CatalogItem>,
+    pub(crate) counts: CatalogCounts,
 }
 
 #[derive(Clone, Debug)]
@@ -157,11 +169,17 @@ impl CatalogDiscovery {
         schema_name: Option<&str>,
         kind: Option<CatalogItemKind>,
         pagination: Pagination,
-    ) -> Result<Page<CatalogItem>, QueryManagerError> {
-        let items = self
-            .catalog_items(workspace_name, schema_name, kind)
+    ) -> Result<CatalogPage, QueryManagerError> {
+        let catalog = self
+            .queries
+            .list_catalog(workspace_name, schema_name)
             .await?;
-        Ok(page_items(items, pagination))
+        let counts = catalog_counts(&catalog);
+        let items = catalog_items(catalog, kind);
+        Ok(CatalogPage {
+            items: page_items(items, pagination),
+            counts,
+        })
     }
 
     async fn catalog_items(
@@ -174,25 +192,72 @@ impl CatalogDiscovery {
             .queries
             .list_catalog(workspace_name, schema_name)
             .await?;
-        let mut items = Vec::with_capacity(catalog.tables.len() + catalog.table_functions.len());
-        if kind.is_none_or(|kind| kind == CatalogItemKind::Table) {
-            items.extend(catalog.tables.into_iter().map(|mut table| {
-                table.columns.clear();
-                CatalogItem::Table(table)
-            }));
-        }
-        if kind.is_none_or(|kind| kind == CatalogItemKind::TableFunction) {
-            items.extend(
-                catalog
-                    .table_functions
-                    .into_iter()
-                    .map(CatalogItem::TableFunction),
-            );
-        }
-        items.sort_by(|left, right| catalog_item_sort_key(left).cmp(&catalog_item_sort_key(right)));
-        Ok(items)
+        Ok(catalog_items(catalog, kind))
     }
 
+    pub(crate) async fn describe_table(
+        &self,
+        workspace_name: &WorkspaceName,
+        table_ref: CatalogTableRef<'_>,
+    ) -> Result<DescribeTableResult, QueryManagerError> {
+        let table_lookup = self
+            .queries
+            .describe_table(workspace_name, table_ref.schema_name, table_ref.table_name)
+            .await?;
+        if let Some(table) = table_lookup.table {
+            return Ok(DescribeTableResult::Found(table));
+        }
+
+        let tables = table_lookup.missing_context_tables;
+        let available_schemas = tables
+            .iter()
+            .map(|table| table.schema_name.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let same_schema_tables = tables
+            .iter()
+            .filter(|table| table.schema_name == table_ref.schema_name)
+            .take(MISSING_TABLE_SUGGESTION_LIMIT)
+            .cloned()
+            .collect::<Vec<_>>();
+        let suggestions = missing_table_suggestions(&tables, table_ref, &same_schema_tables);
+        Ok(DescribeTableResult::Missing(MissingTableContext {
+            suggestions,
+            available_schemas,
+            same_schema_tables,
+        }))
+    }
+}
+
+fn catalog_items(catalog: CatalogInfo, kind: Option<CatalogItemKind>) -> Vec<CatalogItem> {
+    let mut items = Vec::with_capacity(catalog.tables.len() + catalog.table_functions.len());
+    if kind.is_none_or(|kind| kind == CatalogItemKind::Table) {
+        items.extend(catalog.tables.into_iter().map(|mut table| {
+            table.columns.clear();
+            CatalogItem::Table(table)
+        }));
+    }
+    if kind.is_none_or(|kind| kind == CatalogItemKind::TableFunction) {
+        items.extend(
+            catalog
+                .table_functions
+                .into_iter()
+                .map(CatalogItem::TableFunction),
+        );
+    }
+    items.sort_by(|left, right| catalog_item_sort_key(left).cmp(&catalog_item_sort_key(right)));
+    items
+}
+
+fn catalog_counts(catalog: &CatalogInfo) -> CatalogCounts {
+    CatalogCounts {
+        table_count: u32::try_from(catalog.tables.len()).unwrap_or(u32::MAX),
+        table_function_count: u32::try_from(catalog.table_functions.len()).unwrap_or(u32::MAX),
+    }
+}
+
+impl CatalogDiscovery {
     pub(crate) async fn search_catalog(
         &self,
         workspace_name: &WorkspaceName,
@@ -216,52 +281,6 @@ impl CatalogDiscovery {
             })
             .collect();
         Ok(page_items(matches, pagination))
-    }
-
-    pub(crate) async fn describe_table(
-        &self,
-        workspace_name: &WorkspaceName,
-        table_ref: CatalogTableRef<'_>,
-    ) -> Result<DescribeTableResult, QueryManagerError> {
-        let exact = self
-            .queries
-            .list_tables(
-                workspace_name,
-                Some(table_ref.schema_name),
-                Some(table_ref.table_name),
-            )
-            .await?
-            .into_iter()
-            .find(|table| {
-                table.schema_name == table_ref.schema_name
-                    && table.table_name == table_ref.table_name
-            });
-        if let Some(table) = exact {
-            return Ok(DescribeTableResult::Found(table));
-        }
-
-        let mut all_tables = self.queries.list_tables(workspace_name, None, None).await?;
-        for table in &mut all_tables {
-            table.columns.clear();
-        }
-        let available_schemas = all_tables
-            .iter()
-            .map(|table| table.schema_name.clone())
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect();
-        let same_schema_tables = all_tables
-            .iter()
-            .filter(|table| table.schema_name == table_ref.schema_name)
-            .take(MISSING_TABLE_SUGGESTION_LIMIT)
-            .cloned()
-            .collect::<Vec<_>>();
-        let suggestions = missing_table_suggestions(&all_tables, table_ref, &same_schema_tables);
-        Ok(DescribeTableResult::Missing(MissingTableContext {
-            suggestions,
-            available_schemas,
-            same_schema_tables,
-        }))
     }
 
     pub(crate) async fn list_columns(

--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -2,9 +2,10 @@
 
 use coral_api::v1::catalog_service_server::CatalogService as CatalogServiceApi;
 use coral_api::v1::{
-    CatalogItemKind as ProtoCatalogItemKind, DescribeTableRequest, DescribeTableResponse,
-    ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListColumnsResponse,
-    PaginationRequest, SearchCatalogRequest, SearchCatalogResponse,
+    CatalogCounts as ProtoCatalogCounts, CatalogItemKind as ProtoCatalogItemKind,
+    DescribeTableRequest, DescribeTableResponse, ListCatalogRequest, ListCatalogResponse,
+    ListColumnsRequest, ListColumnsResponse, PaginationRequest, SearchCatalogRequest,
+    SearchCatalogResponse,
 };
 use tonic::{Request, Response, Status};
 
@@ -47,10 +48,11 @@ impl CatalogServiceApi for CatalogService {
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let schema_name = optional_trimmed(&request.schema_name);
             let kind = catalog_item_kind_from_proto(request.kind)?;
-            let page = catalog
+            let catalog_page = catalog
                 .list_catalog(&workspace_name, schema_name, kind, pagination)
                 .await
                 .map_err(query_status)?;
+            let page = catalog_page.items;
             let pagination = pagination_to_proto(
                 page.total,
                 page.limit,
@@ -65,6 +67,10 @@ impl CatalogServiceApi for CatalogService {
                     .map(|item| catalog_item_to_proto(&workspace_name, item))
                     .collect(),
                 pagination: Some(pagination),
+                counts: Some(ProtoCatalogCounts {
+                    table_count: catalog_page.counts.table_count,
+                    table_function_count: catalog_page.counts.table_function_count,
+                }),
             }))
         })
         .await

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -101,7 +101,7 @@ impl QueryManager {
         let sources = self
             .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
-        let runtime = self.runtime_config(&sources);
+        let runtime = self.runtime_config(workspace_name, &sources);
         CoralQuery::describe_table(&sources, runtime, schema_name, table_name)
             .await
             .map_err(QueryManagerError::Core)

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -6,8 +6,9 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use coral_engine::{
-    CatalogInfo, CoralQuery, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig,
-    QueryRuntimeContext, QuerySource, SourceValidationReport, StatusCode, TableInfo,
+    CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, QueryExecution, QueryPlan,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, SourceValidationReport, StatusCode,
+    TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::{KeyValue, trace::Status as OtelStatus};
@@ -91,6 +92,21 @@ impl QueryManager {
             .map_err(QueryManagerError::Core)
     }
 
+    pub(crate) async fn describe_table(
+        &self,
+        workspace_name: &WorkspaceName,
+        schema_name: &str,
+        table_name: &str,
+    ) -> Result<DescribeTableInfo, QueryManagerError> {
+        let sources = self
+            .load_query_sources(workspace_name)
+            .map_err(QueryManagerError::App)?;
+        let runtime = self.runtime_config(&sources);
+        CoralQuery::describe_table(&sources, runtime, schema_name, table_name)
+            .await
+            .map_err(QueryManagerError::Core)
+    }
+
     pub(crate) async fn execute_sql(
         &self,
         workspace_name: &WorkspaceName,
@@ -167,6 +183,12 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<QuerySource>, AppError> {
+        let span = tracing::info_span!(
+            "coral.app.query_sources.load",
+            workspace = %workspace_name,
+            source.count = tracing::field::Empty,
+        );
+        let _guard = span.enter();
         let catalog = self.config_store.load_catalog()?;
         let mut query_sources = Vec::new();
         for source in catalog.workspace_sources(workspace_name) {
@@ -184,6 +206,7 @@ impl QueryManager {
                 }
             }
         }
+        span.record("source.count", query_sources.len());
         Ok(query_sources)
     }
 

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, InlineTable, Item, Value, value};
-use tracing::warn;
+use tracing::{info_span, warn};
 
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialStorageKind;
@@ -324,6 +324,8 @@ impl ConfigStore {
     }
 
     pub(crate) fn load_catalog(&self) -> Result<SourceCatalog, AppError> {
+        let span = info_span!("coral.app.config.load_catalog");
+        let _guard = span.enter();
         let _lock = self.lock_shared()?;
         self.load_unlocked().map(|config| config.catalog)
     }

--- a/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
+++ b/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
@@ -107,6 +107,9 @@ async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagina
     assert_eq!(pagination.offset, 0);
     assert!(pagination.has_more);
     assert_eq!(pagination.next_offset, 2);
+    let counts = response.counts.as_ref().expect("catalog counts");
+    assert_eq!(counts.table_count, 1);
+    assert_eq!(counts.table_function_count, 2);
     assert_eq!(response.items.len(), 2);
     let function = match response.items[0].item.as_ref().expect("catalog item") {
         catalog_item::Item::TableFunction(function) => function,
@@ -144,6 +147,9 @@ async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagina
             .total_count,
         2
     );
+    let counts = function_only.counts.as_ref().expect("catalog counts");
+    assert_eq!(counts.table_count, 1);
+    assert_eq!(counts.table_function_count, 2);
     assert!(function_only.items.iter().all(|item| {
         matches!(
             item.item.as_ref().expect("catalog item"),

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -304,6 +304,9 @@ async fn list_catalog_supports_table_kind_and_pagination() {
     assert_eq!(page_pagination.offset, 0);
     assert!(page_pagination.has_more);
     assert_eq!(page_pagination.next_offset, 2);
+    let counts = page.counts.as_ref().expect("catalog counts");
+    assert_eq!(counts.table_count, 3);
+    assert_eq!(counts.table_function_count, 0);
     assert_eq!(
         page.items
             .iter()
@@ -334,6 +337,9 @@ async fn list_catalog_supports_table_kind_and_pagination() {
         .as_ref()
         .expect("unknown schema pagination");
     assert_eq!(unknown_schema_pagination.total_count, 0);
+    let unknown_counts = unknown_schema.counts.as_ref().expect("catalog counts");
+    assert_eq!(unknown_counts.table_count, 0);
+    assert_eq!(unknown_counts.table_function_count, 0);
     assert!(unknown_schema.items.is_empty());
     assert!(!unknown_schema_pagination.has_more);
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -17,8 +17,8 @@ use coral_api::v1::catalog_service_server::{CatalogService, CatalogServiceServer
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::{
-    CatalogItem, CatalogSearchResult, Column, ColumnSearchResult, CreateBundledSourceRequest,
-    CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
+    CatalogCounts, CatalogItem, CatalogSearchResult, Column, ColumnSearchResult,
+    CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
     CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DeleteSourceResponse,
     DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
     ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
@@ -534,9 +534,13 @@ impl MockServerConfig {
 }
 
 fn list_catalog_response(request: &ListCatalogRequest) -> ListCatalogResponse {
-    let items = mock_visible_tables()
+    let tables = mock_visible_tables()
         .into_iter()
         .filter(|table| request.schema_name.is_empty() || table.schema_name == request.schema_name)
+        .collect::<Vec<_>>();
+    let table_count = u32::try_from(tables.len()).unwrap_or(u32::MAX);
+    let items = tables
+        .into_iter()
         .filter(|_| request.kind == 0 || request.kind == 1)
         .map(|table| CatalogItem {
             item: Some(catalog_item::Item::Table(table_summary(&table))),
@@ -552,6 +556,10 @@ fn list_catalog_response(request: &ListCatalogRequest) -> ListCatalogResponse {
     ListCatalogResponse {
         items,
         pagination: Some(pagination),
+        counts: Some(CatalogCounts {
+            table_count,
+            table_function_count: 0,
+        }),
     }
 }
 

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -289,6 +289,17 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .expect("search_catalog description")
             .contains("3 table(s) and 0 table function(s) are currently visible")
     );
+    let catalog_requests = server.list_catalog_requests();
+    let count_request = catalog_requests
+        .last()
+        .expect("tools/list should request catalog counts");
+    assert_eq!(count_request.kind, 0);
+    let count_pagination = count_request
+        .pagination
+        .as_ref()
+        .expect("count request pagination");
+    assert_eq!(count_pagination.limit, 1);
+    assert_eq!(count_pagination.offset, 0);
 
     let resources = client.list_all_resources().await?;
     assert_eq!(

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -45,6 +45,15 @@ pub struct CatalogInfo {
     pub table_functions: Vec<TableFunctionInfo>,
 }
 
+/// Result of a table lookup from one runtime snapshot.
+#[derive(Debug, Clone)]
+pub struct DescribeTableInfo {
+    /// Exact table match, when present.
+    pub table: Option<TableInfo>,
+    /// Lightweight table metadata for missing-table context.
+    pub missing_context_tables: Vec<TableInfo>,
+}
+
 /// Describes one argument accepted by a source-scoped table function.
 #[derive(Debug, Clone)]
 pub struct TableFunctionArgumentInfo {

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -6,7 +6,7 @@ mod query;
 mod query_error;
 
 pub use catalog::{
-    CatalogInfo, ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo,
+    CatalogInfo, ColumnInfo, DescribeTableInfo, TableFunctionArgumentInfo, TableFunctionInfo,
     TableFunctionResultColumnInfo, TableInfo,
 };
 pub use error::{CoreError, StatusCode, StructuredQueryError};

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -66,10 +66,10 @@ pub use composition::{
     SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError, SourceTables,
 };
 pub use contracts::{
-    CatalogInfo, ColumnInfo, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig,
-    QueryRuntimeContext, QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess,
-    SourceValidationReport, StatusCode, StructuredQueryError, TableFunctionArgumentInfo,
-    TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
+    CatalogInfo, ColumnInfo, CoreError, DescribeTableInfo, QueryExecution, QueryPlan,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTestFailure, QueryTestResult,
+    QueryTestSuccess, SourceValidationReport, StatusCode, StructuredQueryError,
+    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// High-level query operations for the local query engine.
@@ -117,6 +117,27 @@ impl CoralQuery {
         Ok(runtime::query::build_runtime(sources, runtime)
             .await?
             .catalog_info(schema_filter))
+    }
+
+    /// Describes one table or returns lightweight table metadata for missing-table help.
+    ///
+    /// This builds the runtime once, clones only the matched table on exact
+    /// hits, and clones lightweight table metadata when the table is missing.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if credential resolution fails, if any validated
+    /// source spec cannot be compiled, or if the underlying query runtime
+    /// cannot be built.
+    pub async fn describe_table(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        schema_name: &str,
+        table_name: &str,
+    ) -> Result<DescribeTableInfo, CoreError> {
+        Ok(runtime::query::build_runtime(sources, runtime)
+            .await?
+            .describe_table(schema_name, table_name))
     }
 
     /// Executes one `SQL` statement over the provided source set.

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -192,11 +192,7 @@ impl QueryRuntimeAdapter {
         let missing_context_tables = self
             .tables
             .iter()
-            .cloned()
-            .map(|mut table| {
-                table.columns.clear();
-                table
-            })
+            .map(table_metadata_without_columns)
             .collect();
         DescribeTableInfo {
             table: None,
@@ -279,6 +275,17 @@ fn read_only_sql_options() -> SQLOptions {
         .with_allow_statements(false)
 }
 
+fn table_metadata_without_columns(table: &TableInfo) -> TableInfo {
+    TableInfo {
+        schema_name: table.schema_name.clone(),
+        table_name: table.table_name.clone(),
+        description: table.description.clone(),
+        guide: table.guide.clone(),
+        columns: Vec::new(),
+        required_filters: table.required_filters.clone(),
+    }
+}
+
 fn query_result_observer_error(name: &str, error: &QueryResultObserverError) -> CoreError {
     let core = query_result_observer_error_to_core(error);
     match core {
@@ -289,5 +296,59 @@ fn query_result_observer_error(name: &str, error: &QueryResultObserverError) -> 
             CoreError::FailedPrecondition(format!("query result observer '{name}': {detail}"))
         }
         other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ColumnInfo;
+
+    fn adapter_with_table() -> QueryRuntimeAdapter {
+        QueryRuntimeAdapter {
+            ctx: Arc::new(SessionContext::new()),
+            tables: vec![TableInfo {
+                schema_name: "demo".to_string(),
+                table_name: "events".to_string(),
+                description: "Event rows".to_string(),
+                guide: "Query event rows.".to_string(),
+                columns: vec![ColumnInfo {
+                    name: "event_id".to_string(),
+                    data_type: "Utf8".to_string(),
+                    nullable: false,
+                    is_virtual: false,
+                    is_required_filter: false,
+                    description: "Event ID".to_string(),
+                    ordinal_position: 0,
+                }],
+                required_filters: vec!["owner".to_string()],
+            }],
+            table_functions: Vec::new(),
+            failures: Vec::new(),
+            query_result_observers: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn describe_table_hit_returns_full_table_without_missing_context() {
+        let result = adapter_with_table().describe_table("demo", "events");
+
+        let table = result.table.expect("exact table");
+        assert_eq!(table.columns.len(), 1);
+        assert!(result.missing_context_tables.is_empty());
+    }
+
+    #[test]
+    fn describe_table_miss_returns_columnless_context_tables() {
+        let result = adapter_with_table().describe_table("demo", "missing");
+
+        assert!(result.table.is_none());
+        assert_eq!(result.missing_context_tables.len(), 1);
+        let context_table = result
+            .missing_context_tables
+            .first()
+            .expect("missing context table");
+        assert!(context_table.columns.is_empty());
+        assert_eq!(context_table.required_filters, ["owner".to_string()]);
     }
 }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -8,6 +8,7 @@ use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::physical_plan::displayable;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
 use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
+use tracing::{Instrument as _, info_span};
 
 use crate::backends::compile_query_source;
 use crate::runtime::catalog;
@@ -21,7 +22,7 @@ use crate::runtime::registry::{
 };
 use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
-    CatalogInfo, CoreError, QueryExecution, QueryPlan, QueryResultObserver,
+    CatalogInfo, CoreError, DescribeTableInfo, QueryExecution, QueryPlan, QueryResultObserver,
     QueryResultObserverError, QueryRuntimeConfig, QuerySource, TableFunctionInfo, TableInfo,
 };
 
@@ -34,6 +35,14 @@ pub(crate) struct QueryRuntimeAdapter {
 }
 
 pub(crate) async fn build_runtime(
+    sources: &[QuerySource],
+    runtime: QueryRuntimeConfig,
+) -> Result<QueryRuntimeAdapter, CoreError> {
+    let span = info_span!("coral.engine.runtime.build", source.count = sources.len());
+    build_runtime_inner(sources, runtime).instrument(span).await
+}
+
+async fn build_runtime_inner(
     sources: &[QuerySource],
     runtime: QueryRuntimeConfig,
 ) -> Result<QueryRuntimeAdapter, CoreError> {
@@ -164,6 +173,34 @@ impl QueryRuntimeAdapter {
         CatalogInfo {
             tables: self.list_tables(source_filter, None),
             table_functions: self.list_table_functions(source_filter, None),
+        }
+    }
+
+    pub(crate) fn describe_table(&self, schema_name: &str, table_name: &str) -> DescribeTableInfo {
+        if let Some(table) = self
+            .tables
+            .iter()
+            .find(|table| table.schema_name == schema_name && table.table_name == table_name)
+            .cloned()
+        {
+            return DescribeTableInfo {
+                table: Some(table),
+                missing_context_tables: Vec::new(),
+            };
+        }
+
+        let missing_context_tables = self
+            .tables
+            .iter()
+            .cloned()
+            .map(|mut table| {
+                table.columns.clear();
+                table
+            })
+            .collect();
+        DescribeTableInfo {
+            table: None,
+            missing_context_tables,
         }
     }
 

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::prelude::SessionContext;
+use tracing::{Instrument as _, info_span};
 
 use crate::backends::{
     BackendRegistration, BackendRegistrationContext, CompiledBackendSource, RegisteredSource,
@@ -75,6 +76,20 @@ fn check_reserved_schema(schema: &str) -> DataFusionResult<()> {
 /// itself cannot be processed. Individual source registration failures are
 /// logged and skipped so the remaining sources can still be registered.
 pub(crate) async fn register_sources(
+    ctx: &SessionContext,
+    sources: Vec<SourceRegistrationCandidate>,
+    source_decorators: &mut [Box<dyn SourceDecorator>],
+) -> std::result::Result<SourceRegistrationResult, CoreError> {
+    let span = info_span!(
+        "coral.engine.sources.register",
+        source.count = sources.len(),
+    );
+    register_sources_inner(ctx, sources, source_decorators)
+        .instrument(span)
+        .await
+}
+
+async fn register_sources_inner(
     ctx: &SessionContext,
     sources: Vec<SourceRegistrationCandidate>,
     source_decorators: &mut [Box<dyn SourceDecorator>],

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -37,9 +37,8 @@ use crate::{
     telemetry,
 };
 
-const LIST_TABLES_COUNT_LIMIT: u32 = 1;
-const LIST_TABLE_FUNCTIONS_COUNT_LIMIT: u32 = 1;
 const LIST_CATALOG_UNBOUNDED_LIMIT: u32 = 0;
+const LIST_CATALOG_COUNT_LIMIT: u32 = 1;
 const CATALOG_KIND_ALL: ProtoCatalogItemKind = ProtoCatalogItemKind::Unspecified;
 const CATALOG_KIND_TABLE: ProtoCatalogItemKind = ProtoCatalogItemKind::Table;
 const CATALOG_KIND_TABLE_FUNCTION: ProtoCatalogItemKind = ProtoCatalogItemKind::TableFunction;
@@ -179,48 +178,33 @@ impl CoralMcpServer {
             .into_inner())
     }
 
-    async fn load_table_count(&self) -> Result<usize, tonic::Status> {
-        self.load_catalog(
-            None,
-            CATALOG_KIND_TABLE,
-            PaginationRequest {
-                limit: LIST_TABLES_COUNT_LIMIT,
-                offset: 0,
-            },
-        )
-        .await
-        .map(|response| {
-            response
-                .pagination
-                .map_or(0, |pagination| pagination.total_count as usize)
-        })
-    }
-
-    async fn load_table_function_count(&self) -> Result<usize, tonic::Status> {
-        self.load_catalog(
-            None,
-            CATALOG_KIND_TABLE_FUNCTION,
-            PaginationRequest {
-                limit: LIST_TABLE_FUNCTIONS_COUNT_LIMIT,
-                offset: 0,
-            },
-        )
-        .await
-        .map(|response| {
-            response
-                .pagination
-                .map_or(0, |pagination| pagination.total_count as usize)
-        })
+    async fn load_catalog_counts(&self) -> Result<(usize, usize), tonic::Status> {
+        // One item is enough: the app returns per-kind counts before pagination.
+        let response = self
+            .load_catalog(
+                None,
+                CATALOG_KIND_ALL,
+                PaginationRequest {
+                    limit: LIST_CATALOG_COUNT_LIMIT,
+                    offset: 0,
+                },
+            )
+            .await?;
+        let counts = response
+            .counts
+            .ok_or_else(|| tonic::Status::internal("catalog response missing counts"))?;
+        Ok((
+            usize::try_from(counts.table_count).unwrap_or(usize::MAX),
+            usize::try_from(counts.table_function_count).unwrap_or(usize::MAX),
+        ))
     }
 
     async fn load_sources_and_catalog_counts(
         &self,
     ) -> Result<(Vec<Source>, usize, usize), tonic::Status> {
-        tokio::try_join!(
-            self.load_sources(),
-            self.load_table_count(),
-            self.load_table_function_count()
-        )
+        let (sources, (table_count, table_function_count)) =
+            tokio::try_join!(self.load_sources(), self.load_catalog_counts())?;
+        Ok((sources, table_count, table_function_count))
     }
 
     async fn load_sources_and_guide_catalog(

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -457,9 +457,10 @@ impl ServerHandler for CoralMcpServer {
     ) -> Result<ListToolsResult, ErrorData> {
         let span = telemetry::list_tools_span(self.options.trace_parent.as_deref());
         telemetry::instrument_protocol(span, async {
-            let (visible_table_count, visible_function_count) =
-                tokio::try_join!(self.load_table_count(), self.load_table_function_count())
-                    .map_err(|status| status_to_error_data(&status))?;
+            let (visible_table_count, visible_function_count) = self
+                .load_catalog_counts()
+                .await
+                .map_err(|status| status_to_error_data(&status))?;
             let mut tools = vec![
                 sql_tool(visible_table_count),
                 list_catalog_tool(visible_table_count, visible_function_count),


### PR DESCRIPTION
## Summary

Reduce startup catalog/runtime work on the short-lived MCP path while keeping catalog aggregation and runtime lookup owned by the app/engine layers.

This removes avoidable repeated work by:

- adding app-computed per-kind `CatalogCounts` to `ListCatalogResponse`, letting callers request one bounded catalog item (`limit=1`) when they only need counts
- using that count contract in MCP `tools/list` instead of transferring/counting broader catalog pages
- moving exact `describe_table` lookup into the engine runtime snapshot, so hits clone only the matched table while misses still use one runtime build for suggestions
- adding startup tracing spans around catalog config loading, query-source loading, runtime builds, and source registration

## Validation

- `cargo test -p coral-cli --features cli-test-server mcp_stdio_lists_tools_and_resources`
- `cargo test -p coral-app --test grpc list_catalog`
- `make rust-checks` - 889 tests passed after merging current `origin/main`

## Benchmark

Measured process spawn through MCP `initialize` and `tools/list` response using debug binaries, 10 runs after 1 warmup:

- `origin/main` (`16087f2`): 4.176 s +/- 0.228 s
- this branch: 3.769 s +/- 0.078 s
- result: branch ran 1.11x +/- 0.06x faster

