### PR TITLE
refactor(spec): drop unused known_filters binding in validate_mcp_table

### DIFF
--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -546,13 +546,12 @@ fn validate_mcp_table(source_name: &str, table: &RawMcpTableSpec) -> Result<()> 
         source_name,
         &format!("table '{}'", table.name),
     )?;
-    let known_filters = validate_filters_and_column_exprs(
+    validate_filters_and_column_exprs(
         &table.filter_specs(),
         &table.columns,
         source_name,
         &format!("table '{}'", table.name),
     )?;
-    let _ = known_filters;
 
     let mut bound_tool_args: HashSet<&str> = HashSet::new();
     for (name, source) in &table.tool_args {


### PR DESCRIPTION
validate_filters_and_column_exprs is called only for its validation side effect (MCP tables bind filters via filters[].tool_arg, validated separately below). Its returned HashSet was bound to known_filters and then immediately discarded with `let _ = known_filters;`. Keep the call and its `?` propagation; remove the dead binding and discard. No behavior change.

