### PR TITLE
refactor(spec): dedupe validate_unique_values/validate_identifier into validate.rs

### DIFF
--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -18,7 +18,8 @@ use crate::{
     inputs::{
         collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
     },
-    validate_columns, validate_filters_and_column_exprs, validate_test_queries,
+    validate_columns, validate_filters_and_column_exprs, validate_identifier,
+    validate_test_queries, validate_unique_values,
 };
 
 /// Validated top-level manifest for a Model Context Protocol-backed source.
@@ -812,43 +813,6 @@ fn validate_function_binding<'a>(
         return Err(ManifestError::validation(format!(
             "source '{source_name}' function '{function_name}' has multiple bindings for tool arg '{}'",
             binding.arg
-        )));
-    }
-    Ok(())
-}
-
-fn validate_unique_values(values: &[String], context: &str) -> Result<()> {
-    let mut seen = HashSet::new();
-    for value in values {
-        if value.trim().is_empty() {
-            return Err(ManifestError::validation(format!(
-                "{context} values must not contain empty strings"
-            )));
-        }
-        if !seen.insert(value.as_str()) {
-            return Err(ManifestError::validation(format!(
-                "{context} value '{value}' is declared more than once"
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn validate_identifier(value: &str, context: &str) -> Result<()> {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
-        return Err(ManifestError::validation(format!(
-            "{context} must not be empty"
-        )));
-    };
-    if !(first == '_' || first.is_ascii_alphabetic()) {
-        return Err(ManifestError::validation(format!(
-            "{context} '{value}' must start with a letter or underscore"
-        )));
-    }
-    if chars.any(|ch| !(ch == '_' || ch.is_ascii_alphanumeric())) {
-        return Err(ManifestError::validation(format!(
-            "{context} '{value}' may only contain letters, numbers, and underscores"
         )));
     }
     Ok(())

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -117,5 +117,6 @@ pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToke
 pub(crate) use validate::{
     DetailHintDeclaringSurface, DetailHintTargetTable, validate_columns,
     validate_detail_hint_references, validate_filters_and_column_exprs, validate_http_function,
-    validate_http_function_names, validate_http_table, validate_table_names,
+    validate_http_function_names, validate_http_table, validate_identifier, validate_table_names,
+    validate_unique_values,
 };

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -734,7 +734,7 @@ fn validate_arg_template(
     Ok(())
 }
 
-fn validate_identifier(value: &str, context: &str) -> Result<()> {
+pub(crate) fn validate_identifier(value: &str, context: &str) -> Result<()> {
     let mut chars = value.chars();
     let Some(first) = chars.next() else {
         return Err(ManifestError::validation(format!(


### PR DESCRIPTION
backends/mcp.rs carried byte-for-byte copies of validate_unique_values and validate_identifier (identical bodies and error strings) that already exist in validate.rs. Make validate_identifier pub(crate) (validate_unique_values already was), re-export both at the crate root next to the other shared validators, and import them in mcp.rs instead of redefining them. All error messages and behavior are unchanged. validate_function_binding is intentionally left alone since its error text differs ('request arg' vs 'tool arg').

