### PR TITLE
refactor(engine): bind extract_table_not_found once in table_not_found_ref

### DIFF
--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -164,16 +164,13 @@ fn table_not_found_ref(
         return Some(table_ref);
     }
 
-    if !is_legacy_table_not_found_plan(detail) {
-        return None;
-    }
+    let raw = extract_table_not_found(detail)?;
 
-    extract_table_not_found(detail)
-        .and_then(table_ref_parts_from_sql_object)
-        .or_else(|| {
-            extract_table_not_found(detail)
-                .map(|raw| TableRefParts::new(raw.split('.').map(ToString::to_string).collect()))
-        })
+    table_ref_parts_from_sql_object(raw).or_else(|| {
+        Some(TableRefParts::new(
+            raw.split('.').map(ToString::to_string).collect(),
+        ))
+    })
 }
 
 fn looks_like_table_not_found(detail: &str) -> bool {
@@ -181,10 +178,6 @@ fn looks_like_table_not_found(detail: &str) -> bool {
     lowered.contains("table")
         && lowered.contains("not found")
         && !lowered.contains("table function")
-}
-
-fn is_legacy_table_not_found_plan(detail: &str) -> bool {
-    extract_table_not_found(detail).is_some()
 }
 
 fn extract_table_not_found(detail: &str) -> Option<&str> {


### PR DESCRIPTION
table_not_found_ref guarded with is_legacy_table_not_found_plan (whose body is just extract_table_not_found(detail).is_some()) and then called extract_table_not_found twice more, re-parsing the same detail string up to three times per error. Bind the single result with the ? operator and reuse it for both the sql-object attempt and the dotted-split fallback; delete the single-use alias. extract_table_not_found is pure and deterministic, so the resulting Option<TableRefParts> is identical on both the None and Some paths. No behavior change.

