### PR TITLE
refactor(engine): hoist filter-pushdown classification into shared/filter_expr

### DIFF
--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown, TableType};
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 use serde_json::Value;
 
@@ -16,10 +16,9 @@ use crate::backends::http::HttpSourceClient;
 use crate::backends::http::ProviderQueryError;
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::schema_from_columns;
-use crate::backends::shared::filter_expr::{extract_filter_values, literal_to_string};
+use crate::backends::shared::filter_expr::{classify_filter_pushdown, extract_filter_values};
 use crate::backends::shared::json_exec::{JsonExec, RowFetcher};
 use crate::backends::shared::mapping::convert_items;
-use coral_spec::FilterMode;
 use coral_spec::backends::http::HttpTableSpec;
 
 /// Table provider that exposes one manifest-defined HTTP table to `DataFusion`.
@@ -166,23 +165,7 @@ impl TableProvider for HttpSourceTableProvider {
         &self,
         filters: &[&Expr],
     ) -> Result<Vec<TableProviderFilterPushDown>> {
-        let allowed: HashSet<&str> = self
-            .table
-            .filters()
-            .iter()
-            .map(|f| f.name.as_str())
-            .collect();
-        let filter_modes: HashMap<&str, FilterMode> = self
-            .table
-            .filters()
-            .iter()
-            .map(|f| (f.name.as_str(), f.mode))
-            .collect();
-
-        Ok(filters
-            .iter()
-            .map(|expr| classify_filter(expr, &allowed, &filter_modes))
-            .collect())
+        Ok(classify_filter_pushdown(filters, self.table.filters()))
     }
 
     async fn scan(
@@ -220,174 +203,5 @@ impl TableProvider for HttpSourceTableProvider {
             projection,
             limit,
         })
-    }
-}
-
-fn classify_filter(
-    expr: &Expr,
-    allowed: &HashSet<&str>,
-    filter_modes: &HashMap<&str, FilterMode>,
-) -> TableProviderFilterPushDown {
-    if let Expr::Column(col) = expr
-        && allowed.contains(col.name())
-    {
-        return TableProviderFilterPushDown::Exact;
-    }
-    if let Expr::Not(inner) = expr
-        && let Expr::Column(col) = inner.as_ref()
-        && allowed.contains(col.name())
-    {
-        return TableProviderFilterPushDown::Exact;
-    }
-    if let Expr::IsTrue(inner) | Expr::IsFalse(inner) = expr
-        && let Expr::Column(col) = inner.as_ref()
-        && allowed.contains(col.name())
-    {
-        return TableProviderFilterPushDown::Exact;
-    }
-    if let Expr::BinaryExpr(binary) = expr
-        && binary.op == Operator::Eq
-        && let Expr::Column(col) = binary.left.as_ref()
-        && allowed.contains(col.name())
-        && literal_to_string(binary.right.as_ref()).is_some()
-    {
-        return TableProviderFilterPushDown::Exact;
-    }
-    if let Expr::Like(like) = expr
-        && !like.negated
-        && let Expr::Column(col) = like.expr.as_ref()
-        && allowed.contains(col.name())
-        && literal_to_string(like.pattern.as_ref()).is_some()
-    {
-        let mode = filter_modes.get(col.name()).copied().unwrap_or_default();
-        if matches!(mode, FilterMode::Search | FilterMode::Contains) {
-            // Inexact: the API receives the stripped search/contains term (performance
-            // win) but DataFusion keeps a residual filter to enforce exact
-            // LIKE/ILIKE semantics client-side (correctness win).
-            return TableProviderFilterPushDown::Inexact;
-        }
-    }
-    TableProviderFilterPushDown::Unsupported
-}
-
-#[cfg(test)]
-mod tests {
-    use super::classify_filter;
-    use coral_spec::FilterMode;
-    use datafusion::common::Column;
-    use datafusion::logical_expr::{
-        Expr, Operator, TableProviderFilterPushDown, binary_expr, expr::Like, lit,
-    };
-    use std::collections::{HashMap, HashSet};
-    use std::ops::Not;
-
-    fn allowed<'a>(names: &'a [&'a str]) -> HashSet<&'a str> {
-        names.iter().copied().collect()
-    }
-
-    fn modes<'a>(entries: &'a [(&'a str, FilterMode)]) -> HashMap<&'a str, FilterMode> {
-        entries.iter().copied().collect()
-    }
-
-    fn like_expr(col_name: &str, pattern: &str) -> Expr {
-        Expr::Like(Like::new(
-            false,
-            Box::new(col(col_name)),
-            Box::new(lit(pattern)),
-            None,
-            false,
-        ))
-    }
-
-    fn col(name: &str) -> Expr {
-        Expr::Column(Column::from_name(name))
-    }
-
-    #[test]
-    fn like_ignored_for_equality_mode_filter() {
-        let pushdown = classify_filter(
-            &like_expr("status", "%open%"),
-            &allowed(&["status"]),
-            &modes(&[("status", FilterMode::Equality)]),
-        );
-        assert_eq!(pushdown, TableProviderFilterPushDown::Unsupported);
-    }
-
-    #[test]
-    fn strips_wildcards_from_like_pattern() {
-        let pushdown = classify_filter(
-            &like_expr("q", "%deploy runbook%"),
-            &allowed(&["q"]),
-            &modes(&[("q", FilterMode::Contains)]),
-        );
-        assert_eq!(pushdown, TableProviderFilterPushDown::Inexact);
-    }
-
-    #[test]
-    fn contains_filter_also_accepts_equality() {
-        let pushdown = classify_filter(
-            &binary_expr(col("query"), Operator::Eq, lit("deploy")),
-            &allowed(&["query"]),
-            &modes(&[("query", FilterMode::Contains)]),
-        );
-        assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
-    }
-
-    #[test]
-    fn extracts_like_value_for_contains_mode_filter() {
-        let pushdown = classify_filter(
-            &like_expr("query", "%deploy%"),
-            &allowed(&["query"]),
-            &modes(&[("query", FilterMode::Contains)]),
-        );
-        assert_eq!(pushdown, TableProviderFilterPushDown::Inexact);
-    }
-
-    #[test]
-    fn extracts_like_value_for_legacy_search_mode_filter() {
-        let pushdown = classify_filter(
-            &like_expr("query", "%deploy%"),
-            &allowed(&["query"]),
-            &modes(&[("query", FilterMode::Search)]),
-        );
-        assert_eq!(pushdown, TableProviderFilterPushDown::Inexact);
-    }
-
-    #[test]
-    fn boolean_column_filter_pushes_down_exactly() {
-        let pushdown = classify_filter(&col("descending"), &allowed(&["descending"]), &modes(&[]));
-        assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
-    }
-
-    #[test]
-    fn negated_boolean_column_filter_pushes_down_exactly() {
-        let pushdown = classify_filter(
-            &col("descending").not(),
-            &allowed(&["descending"]),
-            &modes(&[]),
-        );
-        assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
-    }
-
-    #[test]
-    fn boolean_is_true_and_is_false_push_down_exactly() {
-        for expr in [
-            Expr::IsTrue(Box::new(col("descending"))),
-            Expr::IsFalse(Box::new(col("descending"))),
-        ] {
-            let pushdown = classify_filter(&expr, &allowed(&["descending"]), &modes(&[]));
-            assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
-        }
-    }
-
-    #[test]
-    fn null_inclusive_boolean_is_predicates_are_not_pushed_down() {
-        for expr in [
-            Expr::IsNotTrue(Box::new(col("descending"))),
-            Expr::IsNotFalse(Box::new(col("descending"))),
-        ] {
-            let pushdown = classify_filter(&expr, &allowed(&["descending"]), &modes(&[]));
-            assert_eq!(pushdown, TableProviderFilterPushDown::Unsupported);
-        }
     }
 }

--- a/crates/coral-engine/src/backends/mcp/provider.rs
+++ b/crates/coral-engine/src/backends/mcp/provider.rs
@@ -3,12 +3,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use coral_spec::ManifestDataType;
 use coral_spec::backends::mcp::McpTableSpec;
-use coral_spec::{FilterMode, ManifestDataType};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown, TableType};
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 use rmcp::model::JsonObject;
 use serde_json::Value;
@@ -18,7 +18,7 @@ use super::client::McpSourceClient;
 use super::error::McpProviderQueryError;
 use super::fetch::McpFetchPlan;
 use crate::backends::schema_from_columns;
-use crate::backends::shared::filter_expr::{extract_filter_values, literal_to_string};
+use crate::backends::shared::filter_expr::{classify_filter_pushdown, extract_filter_values};
 use crate::backends::shared::json_exec::JsonExec;
 use crate::backends::shared::mapping::convert_items;
 
@@ -76,23 +76,7 @@ impl TableProvider for McpTableProvider {
         &self,
         filters: &[&Expr],
     ) -> Result<Vec<TableProviderFilterPushDown>> {
-        let allowed: std::collections::HashSet<&str> = self
-            .table
-            .filters()
-            .iter()
-            .map(|f| f.name.as_str())
-            .collect();
-        let filter_modes: HashMap<&str, FilterMode> = self
-            .table
-            .filters()
-            .iter()
-            .map(|f| (f.name.as_str(), f.mode))
-            .collect();
-
-        Ok(filters
-            .iter()
-            .map(|expr| classify_filter(expr, &allowed, &filter_modes))
-            .collect())
+        Ok(classify_filter_pushdown(filters, self.table.filters()))
     }
 
     async fn scan(
@@ -281,48 +265,4 @@ fn invalid_filter_value_plan_error(
         "{source_schema}.{table_name} filter '{filter_name}' is declared as {declared} but value \
          '{value}' could not be parsed as {declared}"
     ))
-}
-
-fn classify_filter(
-    expr: &Expr,
-    allowed: &std::collections::HashSet<&str>,
-    filter_modes: &HashMap<&str, FilterMode>,
-) -> TableProviderFilterPushDown {
-    if let Expr::Column(col) = expr
-        && allowed.contains(col.name())
-    {
-        return TableProviderFilterPushDown::Exact;
-    }
-    if let Expr::Not(inner) = expr
-        && let Expr::Column(col) = inner.as_ref()
-        && allowed.contains(col.name())
-    {
-        return TableProviderFilterPushDown::Exact;
-    }
-    if let Expr::IsTrue(inner) | Expr::IsFalse(inner) = expr
-        && let Expr::Column(col) = inner.as_ref()
-        && allowed.contains(col.name())
-    {
-        return TableProviderFilterPushDown::Exact;
-    }
-    if let Expr::BinaryExpr(binary) = expr
-        && binary.op == Operator::Eq
-        && let Expr::Column(col) = binary.left.as_ref()
-        && allowed.contains(col.name())
-        && literal_to_string(binary.right.as_ref()).is_some()
-    {
-        return TableProviderFilterPushDown::Exact;
-    }
-    if let Expr::Like(like) = expr
-        && !like.negated
-        && let Expr::Column(col) = like.expr.as_ref()
-        && allowed.contains(col.name())
-        && literal_to_string(like.pattern.as_ref()).is_some()
-    {
-        let mode = filter_modes.get(col.name()).copied().unwrap_or_default();
-        if matches!(mode, FilterMode::Search | FilterMode::Contains) {
-            return TableProviderFilterPushDown::Inexact;
-        }
-    }
-    TableProviderFilterPushDown::Unsupported
 }

--- a/crates/coral-engine/src/backends/shared/filter_expr.rs
+++ b/crates/coral-engine/src/backends/shared/filter_expr.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use datafusion::logical_expr::{Expr, Operator};
+use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown};
 use datafusion::scalar::ScalarValue;
 
 use coral_spec::{FilterMode, FilterSpec};
@@ -24,6 +24,104 @@ pub(crate) fn extract_filter_values(
     }
 
     filters
+}
+
+/// Classifies pushed-down logical expressions for `supports_filters_pushdown`,
+/// mirroring [`extract_filter_values`] arm-for-arm so the pushdown decision and
+/// the value extraction stay in lockstep.
+pub(crate) fn classify_filter_pushdown(
+    filters: &[&Expr],
+    defined_filters: &[FilterSpec],
+) -> Vec<TableProviderFilterPushDown> {
+    let allowed: HashSet<&str> = defined_filters.iter().map(|f| f.name.as_str()).collect();
+    let filter_modes: HashMap<&str, FilterMode> = defined_filters
+        .iter()
+        .map(|f| (f.name.as_str(), f.mode))
+        .collect();
+
+    filters
+        .iter()
+        .map(|expr| classify_filter(expr, &allowed, &filter_modes))
+        .collect()
+}
+
+fn classify_filter(
+    expr: &Expr,
+    allowed: &HashSet<&str>,
+    filter_modes: &HashMap<&str, FilterMode>,
+) -> TableProviderFilterPushDown {
+    if let Expr::BinaryExpr(binary) = expr
+        && binary.op == Operator::And
+    {
+        return classify_filter_conjunction(
+            classify_filter(binary.left.as_ref(), allowed, filter_modes),
+            classify_filter(binary.right.as_ref(), allowed, filter_modes),
+        );
+    }
+    if let Expr::Column(col) = expr
+        && allowed.contains(col.name())
+    {
+        return TableProviderFilterPushDown::Exact;
+    }
+    if let Expr::Not(inner) = expr
+        && let Expr::Column(col) = inner.as_ref()
+        && allowed.contains(col.name())
+    {
+        return TableProviderFilterPushDown::Exact;
+    }
+    if let Expr::IsTrue(inner) | Expr::IsFalse(inner) = expr
+        && let Expr::Column(col) = inner.as_ref()
+        && allowed.contains(col.name())
+    {
+        return TableProviderFilterPushDown::Exact;
+    }
+    if let Expr::BinaryExpr(binary) = expr
+        && binary.op == Operator::Eq
+        && (extract_column_equality(binary.left.as_ref(), binary.right.as_ref(), allowed).is_some()
+            || extract_column_equality(binary.right.as_ref(), binary.left.as_ref(), allowed)
+                .is_some())
+    {
+        return TableProviderFilterPushDown::Exact;
+    }
+    if let Expr::Like(like) = expr
+        && !like.negated
+        && extract_column_like(
+            like.expr.as_ref(),
+            like.pattern.as_ref(),
+            allowed,
+            filter_modes,
+        )
+        .is_some()
+    {
+        // Inexact: the API receives the stripped search/contains term (performance
+        // win) but DataFusion keeps a residual filter to enforce exact
+        // LIKE/ILIKE semantics client-side (correctness win).
+        return TableProviderFilterPushDown::Inexact;
+    }
+    if let Expr::InList(in_list) = expr
+        && !in_list.negated
+        && in_list.list.len() == 1
+        && let Expr::Column(col) = in_list.expr.as_ref()
+        && allowed.contains(col.name())
+        && let Some(literal) = in_list.list.first()
+        && literal_to_string(literal).is_some()
+    {
+        return TableProviderFilterPushDown::Exact;
+    }
+    TableProviderFilterPushDown::Unsupported
+}
+
+fn classify_filter_conjunction(
+    left: TableProviderFilterPushDown,
+    right: TableProviderFilterPushDown,
+) -> TableProviderFilterPushDown {
+    use TableProviderFilterPushDown::{Exact, Inexact, Unsupported};
+
+    match (left, right) {
+        (Unsupported, Unsupported) => Unsupported,
+        (Exact, Exact) => Exact,
+        _ => Inexact,
+    }
 }
 
 fn collect_filter_values(
@@ -315,6 +413,176 @@ mod tests {
         ] {
             let values = extract_filter_values(&[expr], &filters);
             assert!(values.is_empty());
+        }
+    }
+}
+
+#[cfg(test)]
+mod pushdown_classification_tests {
+    use super::classify_filter;
+    use coral_spec::FilterMode;
+    use datafusion::common::Column;
+    use datafusion::logical_expr::{
+        Expr, Operator, TableProviderFilterPushDown, binary_expr, expr::Like, lit,
+    };
+    use std::collections::{HashMap, HashSet};
+    use std::ops::Not;
+
+    fn allowed<'a>(names: &'a [&'a str]) -> HashSet<&'a str> {
+        names.iter().copied().collect()
+    }
+
+    fn modes<'a>(entries: &'a [(&'a str, FilterMode)]) -> HashMap<&'a str, FilterMode> {
+        entries.iter().copied().collect()
+    }
+
+    fn like_expr(col_name: &str, pattern: &str) -> Expr {
+        Expr::Like(Like::new(
+            false,
+            Box::new(col(col_name)),
+            Box::new(lit(pattern)),
+            None,
+            false,
+        ))
+    }
+
+    fn col(name: &str) -> Expr {
+        Expr::Column(Column::from_name(name))
+    }
+
+    #[test]
+    fn like_ignored_for_equality_mode_filter() {
+        let pushdown = classify_filter(
+            &like_expr("status", "%open%"),
+            &allowed(&["status"]),
+            &modes(&[("status", FilterMode::Equality)]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Unsupported);
+    }
+
+    #[test]
+    fn strips_wildcards_from_like_pattern() {
+        let pushdown = classify_filter(
+            &like_expr("q", "%deploy runbook%"),
+            &allowed(&["q"]),
+            &modes(&[("q", FilterMode::Contains)]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Inexact);
+    }
+
+    #[test]
+    fn contains_filter_also_accepts_equality() {
+        let pushdown = classify_filter(
+            &binary_expr(col("query"), Operator::Eq, lit("deploy")),
+            &allowed(&["query"]),
+            &modes(&[("query", FilterMode::Contains)]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+    }
+
+    #[test]
+    fn reversed_equality_filter_pushes_down_exactly() {
+        let pushdown = classify_filter(
+            &binary_expr(lit("deploy"), Operator::Eq, col("query")),
+            &allowed(&["query"]),
+            &modes(&[]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+    }
+
+    #[test]
+    fn single_value_in_list_filter_pushes_down_exactly() {
+        let pushdown = classify_filter(
+            &col("repo").in_list(vec![lit("coral")], false),
+            &allowed(&["repo"]),
+            &modes(&[]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+    }
+
+    #[test]
+    fn conjunction_of_extractable_filters_pushes_down_exactly() {
+        let pushdown = classify_filter(
+            &binary_expr(col("owner"), Operator::Eq, lit("alice")).and(binary_expr(
+                lit("open"),
+                Operator::Eq,
+                col("status"),
+            )),
+            &allowed(&["owner", "status"]),
+            &modes(&[]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+    }
+
+    #[test]
+    fn partial_conjunction_pushdown_remains_inexact() {
+        let pushdown = classify_filter(
+            &binary_expr(col("owner"), Operator::Eq, lit("alice")).and(binary_expr(
+                col("unmanaged"),
+                Operator::Eq,
+                lit("open"),
+            )),
+            &allowed(&["owner"]),
+            &modes(&[]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Inexact);
+    }
+
+    #[test]
+    fn extracts_like_value_for_contains_mode_filter() {
+        let pushdown = classify_filter(
+            &like_expr("query", "%deploy%"),
+            &allowed(&["query"]),
+            &modes(&[("query", FilterMode::Contains)]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Inexact);
+    }
+
+    #[test]
+    fn extracts_like_value_for_legacy_search_mode_filter() {
+        let pushdown = classify_filter(
+            &like_expr("query", "%deploy%"),
+            &allowed(&["query"]),
+            &modes(&[("query", FilterMode::Search)]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Inexact);
+    }
+
+    #[test]
+    fn boolean_column_filter_pushes_down_exactly() {
+        let pushdown = classify_filter(&col("descending"), &allowed(&["descending"]), &modes(&[]));
+        assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+    }
+
+    #[test]
+    fn negated_boolean_column_filter_pushes_down_exactly() {
+        let pushdown = classify_filter(
+            &col("descending").not(),
+            &allowed(&["descending"]),
+            &modes(&[]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+    }
+
+    #[test]
+    fn boolean_is_true_and_is_false_push_down_exactly() {
+        for expr in [
+            Expr::IsTrue(Box::new(col("descending"))),
+            Expr::IsFalse(Box::new(col("descending"))),
+        ] {
+            let pushdown = classify_filter(&expr, &allowed(&["descending"]), &modes(&[]));
+            assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+        }
+    }
+
+    #[test]
+    fn null_inclusive_boolean_is_predicates_are_not_pushed_down() {
+        for expr in [
+            Expr::IsNotTrue(Box::new(col("descending"))),
+            Expr::IsNotFalse(Box::new(col("descending"))),
+        ] {
+            let pushdown = classify_filter(&expr, &allowed(&["descending"]), &modes(&[]));
+            assert_eq!(pushdown, TableProviderFilterPushDown::Unsupported);
         }
     }
 }


### PR DESCRIPTION
The HTTP and MCP table providers carried byte-identical classify_filter functions (differing only in a HashSet path) and near-identical supports_filters_pushdown bodies. Hoist the per-expr classifier plus a new classify_filter_pushdown(filters, defined_filters) wrapper into backends/shared/filter_expr.rs, next to its lockstep sibling extract_filter_values (which already builds the same allowed/filter_modes maps). Both providers now delegate via Ok(classify_filter_pushdown(filters, self.table.filters())). The classify_filter unit tests move to filter_expr.rs unchanged. Classification results - and therefore pushdown decisions, query planning, and over-the-wire filter behavior - are identical. Aligns with the backends module guidance to prefer extending the shared module over duplicating.

