### PR TITLE
refactor(cli): remove the dead run(app, ctx) entrypoint

### DIFF
--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -510,41 +510,6 @@ async fn run_ui(args: UiArgs) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// Parses CLI arguments and runs the shared Coral CLI.
-///
-/// # Errors
-///
-/// Returns an error if argument parsing, command execution, or output
-/// formatting fails.
-pub async fn run(app: AppClient, ctx: coral_app::RunContext) -> Result<(), CliError> {
-    let Cli {
-        feature_overrides,
-        command,
-    } = Cli::parse();
-    let feature_overrides = feature_overrides.into_overrides();
-    let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
-
-    match command.required_runtime() {
-        RequiredRuntime::AppClient if is_mcp_stdio => {
-            run_app_command(app, command, Some(&ctx), &feature_overrides).await
-        }
-        RequiredRuntime::AppClient => {
-            coral_app::run_with_context(
-                &ctx,
-                Box::pin(run_app_command(app, command, None, &feature_overrides)),
-            )
-            .await
-        }
-        RequiredRuntime::None => {
-            coral_app::run_with_context(
-                &ctx,
-                Box::pin(run_no_runtime_command(command, &feature_overrides)),
-            )
-            .await
-        }
-    }
-}
-
 async fn run_no_runtime_command(
     command: Command,
     feature_overrides: &coral_app::features::FeatureOverrides,


### PR DESCRIPTION
pub async fn run(app, ctx) had no callers: main.rs calls run_from_env, no crate depends on the coral-cli library, and integration tests drive the compiled binary via assert_cmd. Its body re-implemented the RequiredRuntime dispatch that run_from_env already performs. Remove it; run_from_env remains the sole entrypoint and every referenced symbol (AppClient, RunContext, run_app_command, run_no_runtime_command) stays live elsewhere. Library symbol only - no command/flag/exit-code/JSON/config change.

