### PR TITLE
refactor(cli): drop dead pub enables_stderr_logs() argv re-parse

### DIFF
--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -398,16 +398,12 @@ impl coral_app::RunErrorTelemetry for CliError {
     }
 }
 
-/// Returns whether this CLI invocation should render telemetry logs to stderr.
-///
-/// `MCP` stdio reserves stdout for protocol messages, so stderr is the only
-/// local diagnostics stream that can be safely exposed while the server is
-/// running.
-#[must_use]
-pub fn enables_stderr_logs() -> bool {
-    command_enables_stderr_logs(std::env::args_os())
-}
-
+/// Classifies whether a parsed CLI invocation should render telemetry logs to
+/// stderr. `MCP` stdio reserves stdout for protocol messages, so stderr is the
+/// only local diagnostics stream that can be safely exposed while the server is
+/// running. Exercised only in tests; the live decision uses
+/// `command.enables_stderr_logs()` directly in `run_from_env`.
+#[cfg(test)]
 fn command_enables_stderr_logs<I, T>(args: I) -> bool
 where
     I: IntoIterator<Item = T>,


### PR DESCRIPTION
The public enables_stderr_logs() free fn re-parsed std::env::args_os() only to ask whether the command is mcp-stdio. It had no callers: run_from_env computes command.enables_stderr_logs() on the already-parsed command, and no crate/test/doc references the free fn. Remove it. Its private helper command_enables_stderr_logs - now exercised only by the three argv-classification unit tests - is #[cfg(test)]-gated so the non-test build stays dead-code-clean while preserving the tests. The live stderr-log decision is unchanged.

