### PR TITLE
refactor(cli): drop always-WarnOnly severity_mode param from validate_and_print

### DIFF
--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -659,11 +659,10 @@ pub(crate) async fn validate_and_print(
     app: &AppClient,
     source_name: &str,
     limit: TableDisplayLimit,
-    severity_mode: ValidationSeverityMode,
 ) -> Result<(), anyhow::Error> {
     let response = validate_source(app, source_name).await?;
     print_validation_pretty(&response, limit)?;
-    match validation_follow_up(&response, severity_mode) {
+    match validation_follow_up(&response, ValidationSeverityMode::WarnOnly) {
         ValidationFollowUp::None => Ok(()),
         ValidationFollowUp::Warn(message) => {
             eprintln!("Warning: {message}");
@@ -678,9 +677,7 @@ pub(crate) async fn validate_and_warn(
     source_name: &str,
     limit: TableDisplayLimit,
 ) -> Result<(), anyhow::Error> {
-    if let Err(err) =
-        validate_and_print(app, source_name, limit, ValidationSeverityMode::WarnOnly).await
-    {
+    if let Err(err) = validate_and_print(app, source_name, limit).await {
         eprintln!("Warning: validation failed: {err}");
     }
     Ok(())


### PR DESCRIPTION
validate_and_print's only caller, validate_and_warn, always passed ValidationSeverityMode::WarnOnly, making the parameter dead generality and the ValidationFollowUp::Fail arm unreachable. Hardcode WarnOnly and drop the parameter. The genuine Strict consumer (test_and_print, called from lib.rs) does not route through validate_and_print, so ValidationSeverityMode, validation_follow_up, and the Strict path stay intact. Behavior is identical: query-test failures still print a Warning and return Ok, while RPC/decode errors still surface via ?.

