### PR TITLE
refactor(mcp): inline load_table_summaries, drop dead schema_name filter

### DIFF
--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -127,15 +127,8 @@ impl CoralMcpServer {
     }
 
     async fn load_all_table_summaries(&self) -> Result<Vec<ProtoTableSummary>, tonic::Status> {
-        self.load_table_summaries(None).await
-    }
-
-    async fn load_table_summaries(
-        &self,
-        schema_name: Option<&str>,
-    ) -> Result<Vec<ProtoTableSummary>, tonic::Status> {
         self.load_catalog(
-            schema_name,
+            None,
             CATALOG_KIND_TABLE,
             PaginationRequest {
                 limit: LIST_CATALOG_UNBOUNDED_LIMIT,


### PR DESCRIPTION
load_table_summaries(schema_name) had a single caller, load_all_table_summaries, which always passed None; load_all_table_summaries is itself used only by the coral://tables read path. Inline the body into load_all_table_summaries and drop the unused schema_name parameter and the forwarding wrapper. The surviving code path is exactly the schema_name = None case that was the only one ever executed, so the coral://tables payload is byte-identical.

