### PR TITLE
refactor(mcp): map JSON resource error directly to ErrorData

### DIFF
--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -28,11 +28,11 @@ use crate::{
     surface::{
         CatalogToolKind, build_tool_result, describe_table_arguments, describe_table_tool,
         describe_table_value, feedback_tool, guide_resource, guide_resource_content,
-        initial_instructions, internal_status, list_catalog_arguments, list_catalog_tool,
-        list_catalog_value, list_columns_arguments, list_columns_tool, list_columns_value,
-        required_string_argument, search_catalog_arguments, search_catalog_tool,
-        search_catalog_value, sql_tool, status_to_error_data, tables_resource,
-        tables_resource_content, tool_error_from_status, tool_error_result,
+        initial_instructions, list_catalog_arguments, list_catalog_tool, list_catalog_value,
+        list_columns_arguments, list_columns_tool, list_columns_value, required_string_argument,
+        search_catalog_arguments, search_catalog_tool, search_catalog_value, sql_tool,
+        status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
+        tool_error_result,
     },
     telemetry,
 };
@@ -552,8 +552,7 @@ impl ServerHandler for CoralMcpServer {
                         .await
                         .map_err(|status| status_to_error_data(&status))?;
                     let text = tables_resource_content(&tables)
-                        .map_err(|error| internal_status(&error))
-                        .map_err(|status| status_to_error_data(&status))?;
+                        .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
                     Ok(ReadResourceResult::new(vec![
                         ResourceContents::text(text, request.uri)
                             .with_mime_type("application/json"),

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -141,10 +141,6 @@ pub(crate) fn status_to_error_data(status: &tonic::Status) -> ErrorData {
     }
 }
 
-pub(crate) fn internal_status(error: &serde_json::Error) -> tonic::Status {
-    tonic::Status::internal(error.to_string())
-}
-
 #[derive(Serialize)]
 struct StructuredToolErrorValue<'a> {
     error: ToolErrorValue<'a>,

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -11,9 +11,7 @@ pub(crate) use catalog::{
     describe_table_value, list_catalog_value, list_columns_value, search_catalog_value,
 };
 pub(crate) use discovery::{Pagination, parse_pagination, parse_pagination_with_limits};
-pub(crate) use errors::{
-    internal_status, status_to_error_data, tool_error_from_status, tool_error_result,
-};
+pub(crate) use errors::{status_to_error_data, tool_error_from_status, tool_error_result};
 pub(crate) use resources::{
     guide_resource, guide_resource_content, initial_instructions, tables_resource,
     tables_resource_content,


### PR DESCRIPTION
In the coral://tables read path, a serde_json::Error was mapped via internal_status into a detail-less tonic::Status::internal and then immediately decoded by status_to_error_data, which yields exactly ErrorData::internal_error(message, None) for a plain Internal status. Map the error straight to ErrorData::internal_error(error.to_string(), None) and delete the single-use internal_status helper plus its surface re-export and server import. The produced ErrorData is identical; no tonic Status is involved in JSON serialization.

