### PR TITLE
refactor(mcp): stop fetching unused sources on the tools/list path

### DIFF
--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -473,12 +473,11 @@ impl ServerHandler for CoralMcpServer {
     ) -> Result<ListToolsResult, ErrorData> {
         let span = telemetry::list_tools_span(self.options.trace_parent.as_deref());
         telemetry::instrument_protocol(span, async {
-            let (sources, visible_table_count, visible_function_count) = self
-                .load_sources_and_catalog_counts()
-                .await
-                .map_err(|status| status_to_error_data(&status))?;
+            let (visible_table_count, visible_function_count) =
+                tokio::try_join!(self.load_table_count(), self.load_table_function_count())
+                    .map_err(|status| status_to_error_data(&status))?;
             let mut tools = vec![
-                sql_tool(&sources, visible_table_count),
+                sql_tool(visible_table_count),
                 list_catalog_tool(visible_table_count, visible_function_count),
                 search_catalog_tool(visible_table_count, visible_function_count),
                 describe_table_tool(),

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use coral_api::v1::Source;
 use rmcp::{
     ErrorData,
     model::{CallToolResult, Content, Tool, ToolAnnotations},
@@ -43,10 +42,10 @@ pub(crate) struct ListColumnsArguments {
     pub(crate) pagination: Pagination,
 }
 
-pub(crate) fn sql_tool(sources: &[Source], visible_table_count: usize) -> Tool {
+pub(crate) fn sql_tool(visible_table_count: usize) -> Tool {
     Tool::new(
         "sql",
-        sql_tool_description(sources, visible_table_count),
+        sql_tool_description(visible_table_count),
         json_object_schema(&json!({
             "type": "object",
             "required": ["sql"],
@@ -379,7 +378,7 @@ pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorDat
     Ok(result)
 }
 
-fn sql_tool_description(_sources: &[Source], visible_table_count: usize) -> String {
+fn sql_tool_description(visible_table_count: usize) -> String {
     if visible_table_count == 0 {
         "Execute read-only SQL against the Coral database. No user tables are currently visible."
             .to_string()


### PR DESCRIPTION
list_tools called load_sources_and_catalog_counts (a try_join of three gRPC RPCs including list_sources) and passed sources to sql_tool, but sql_tool forwards them to sql_tool_description where the parameter was already ignored (_sources) - the description branches only on visible_table_count. Drop the sources parameter from sql_tool/sql_tool_description and the now-unused Source import, and replace the loader in list_tools with a counts-only tokio::try_join!(load_table_count, load_table_function_count). load_sources_and_catalog_counts stays for list_resources, which genuinely uses sources. tools/list output is byte-identical; as a side effect, a ListSources failure no longer fails tools/list.

