### PR TITLE
refactor(app): remove dead no-override FeatureStore::load/statuses

### DIFF
--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -210,16 +210,6 @@ impl FeatureStore {
         })
     }
 
-    /// Loads the effective runtime feature state.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AppError`] if `config.toml` exists but cannot be read or parsed.
-    pub fn load(&self) -> Result<Features, AppError> {
-        let raw = crate::state::load_raw_feature_overrides(&self.layout)?;
-        Ok(Features::from_raw_overrides(&raw))
-    }
-
     /// Loads effective runtime feature state, applying process-local overrides.
     ///
     /// # Errors
@@ -230,17 +220,6 @@ impl FeatureStore {
         let mut features = Features::from_raw_overrides(&raw);
         features.apply_overrides(overrides);
         Ok(features)
-    }
-
-    /// Lists every known feature with configured and effective status.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AppError`] if `config.toml` exists but cannot be read or parsed.
-    pub fn statuses(&self) -> Result<Vec<FeatureStatus>, AppError> {
-        let raw = crate::state::load_raw_feature_overrides(&self.layout)?;
-        let features = Features::from_raw_overrides(&raw);
-        Ok(statuses_from_raw(&raw, &features))
     }
 
     /// Lists every known feature, applying process-local overrides to effective state.


### PR DESCRIPTION
FeatureStore::load and FeatureStore::statuses have no callers in the workspace; coral-cli uses load_with_overrides and statuses_with_overrides exclusively. Passing an empty FeatureOverrides yields identical results since apply_overrides over an empty map is a no-op, so the no-override variants are pure dead code. Remove both; the _with_overrides variants remain the sole entry points. coral features list and MCP feature gating are unchanged.

