### PR TITLE
refactor(app): drop redundant ensure_feature_table guard

### DIFF
--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -223,7 +223,6 @@ pub(crate) fn set_raw_feature_override(
 ) -> Result<(), AppError> {
     let _lock = FileLock::exclusive(layout.state_lock())?;
     let mut doc = read_config_document(layout)?;
-    ensure_feature_table(&doc)?;
     if doc.get("features").is_none() {
         doc.insert("features", toml_edit::table());
     }
@@ -281,19 +280,6 @@ fn write_config_document(layout: &AppStateLayout, doc: &DocumentMut) -> Result<(
     }
     storage_fs::write_atomic(layout.config_file(), doc.to_string().as_bytes())?;
     Ok(())
-}
-
-fn ensure_feature_table(doc: &DocumentMut) -> Result<(), AppError> {
-    let Some(features) = doc.get("features") else {
-        return Ok(());
-    };
-    if features.is_table() {
-        Ok(())
-    } else {
-        Err(AppError::InvalidInput(
-            "unsupported [features] config; expected a table".to_string(),
-        ))
-    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
set_raw_feature_override called ensure_feature_table(&doc)? and then, four lines later, re-checked the same invariant inline via doc.get_mut("features").and_then(Item::as_table_mut), returning the identical InvalidInput error. After the absent case inserts a real table, the inline as_table_mut guard is the only branch that can reject a bad-shape features entry, and both checks run before any write. Remove the ensure_feature_table call and the function; the inline guard preserves identical behavior and error text. Covered by feature_mutations_reject_inline_feature_container_without_rewriting_file and raw_feature_overrides_ignore_inline_feature_table.

