### PR TITLE
refactor(app): inline send_import_event one-hop wrapper

### DIFF
--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -790,9 +790,8 @@ impl SourceManager {
                     move |authorization| {
                         let events = authorization_events;
                         async move {
-                            send_import_event(
-                                &events,
-                                ImportSourceWithCredentialsEvent::OAuthAuthorization {
+                            events
+                                .send(ImportSourceWithCredentialsEvent::OAuthAuthorization {
                                     input_key: authorization_input_key,
                                     authorization_url: authorization.authorization_url,
                                     expires_in_seconds: authorization.expires_in_seconds,
@@ -800,21 +799,18 @@ impl SourceManager {
                                     verification_uri: authorization.verification_uri,
                                     verification_uri_complete: authorization
                                         .verification_uri_complete,
-                                },
-                            )
-                            .await
+                                })
+                                .await
                         }
                     },
                 )
                 .await?;
-            send_import_event(
-                &events,
-                ImportSourceWithCredentialsEvent::OAuthCompleted {
+            events
+                .send(ImportSourceWithCredentialsEvent::OAuthCompleted {
                     input_key: material.input_key.clone(),
                     metadata: material.safe_metadata.clone(),
-                },
-            )
-            .await?;
+                })
+                .await?;
             materials.push(material);
         }
         Ok(materials)
@@ -1160,13 +1156,6 @@ fn merge_oauth_material_into_bindings(
         bindings.secrets.extend(internal_metadata);
     }
     Ok(())
-}
-
-async fn send_import_event(
-    events: &ImportSourceEventSender,
-    event: ImportSourceWithCredentialsEvent,
-) -> Result<(), AppError> {
-    events.send(event).await
 }
 
 fn import_stream_closed_message() -> String {


### PR DESCRIPTION
send_import_event(events, event) was a free async fn whose entire body was events.send(event).await - no transformation, logging, or error mapping. Both call sites already held an ImportSourceEventSender by reference. Inline events.send(...).await at the two sites (OAuth authorization and completion) and delete the wrapper. The ? propagation and AppError::FailedPrecondition mapping live inside ImportSourceEventSender::send and are unchanged; no control-flow or backpressure change.

