### PR TITLE
refactor(ui): compute navigableSpanIds once in TimelineWaterfall

### DIFF
--- a/ui/src/views/traces/trace-detail.tsx
+++ b/ui/src/views/traces/trace-detail.tsx
@@ -502,17 +502,15 @@ function TimelineWaterfall({
     // Drag resizing updates both detailPanelRatio and animatedDetailPanelRatio directly.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedHttpSpanId])
-  useEffect(() => {
-    onNavigableSpanIdsChange(
-      rows.filter((row) => isHttpSpan(row.span)).map((row) => row.span.spanId),
-    )
-  }, [onNavigableSpanIdsChange, rows])
-  const traceStart = BigInt(summary?.startTimeUnixNanos || rows[0]?.span.startTimeUnixNanos || 0)
-  const durationMs = Math.max(nanosToMs(summary?.durationNanos || '0'), 1)
   const navigableSpanIds = useMemo(
     () => rows.filter((row) => isHttpSpan(row.span)).map((row) => row.span.spanId),
     [rows],
   )
+  useEffect(() => {
+    onNavigableSpanIdsChange(navigableSpanIds)
+  }, [onNavigableSpanIdsChange, navigableSpanIds])
+  const traceStart = BigInt(summary?.startTimeUnixNanos || rows[0]?.span.startTimeUnixNanos || 0)
+  const durationMs = Math.max(nanosToMs(summary?.durationNanos || '0'), 1)
   const renderedHttpSpanIndex = renderedHttpSpanId
     ? navigableSpanIds.indexOf(renderedHttpSpanId)
     : -1


### PR DESCRIPTION
The effect that lifts navigable span IDs to the parent and the useMemo that derives them for local Prev/Next navigation computed the byte-identical rows.filter(isHttpSpan).map(spanId) expression twice. Move the memo above the effect and feed onNavigableSpanIdsChange(navigableSpanIds), depending on [onNavigableSpanIdsChange, navigableSpanIds]. The emitted array and the effect firing cadence are unchanged (navigableSpanIds is memoized on [rows], so it changes exactly when rows changes), removing a latent drift hazard between the in-panel Prev/Next buttons and the parent's keyboard navigation.

