### PR TITLE
refactor(scripts): dedupe release-fetch curl in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,22 +33,15 @@ detect_target() {
 
 fetch_latest_version() {
     token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
-    if [ -n "$token" ]; then
-        curl -fsSL \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "User-Agent: withcoral-install" \
-            -H "Authorization: Bearer ${token}" \
-            "https://api.github.com/repos/${REPO}/releases/latest" |
-            sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' |
-            head -n 1
-        return
-    fi
-
-    curl -fsSL \
+    set -- \
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
-        -H "User-Agent: withcoral-install" \
+        -H "User-Agent: withcoral-install"
+    if [ -n "$token" ]; then
+        set -- "$@" -H "Authorization: Bearer ${token}"
+    fi
+
+    curl -fsSL "$@" \
         "https://api.github.com/repos/${REPO}/releases/latest" |
         sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' |
         head -n 1


### PR DESCRIPTION
fetch_latest_version had two near-identical curl invocations differing only by the optional Authorization header. Build the shared header arguments once with set -- and conditionally append the Bearer header when GITHUB_TOKEN/GH_TOKEN is present, then issue a single curl. Request headers, URL, and tag_name parsing are unchanged for both the authenticated and anonymous paths (verified with a stubbed-curl behavioral test; sh -n clean). No change to supported OS/arch targets, so the Validate workflow's install-script matrix stays in sync.

