### PR TITLE
ci: add coral.tables performance regression check

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -489,7 +489,7 @@ jobs:
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: coral-performance-${{ runner.os }}
+          shared-key: coral-validate-${{ runner.os }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -504,7 +504,7 @@ jobs:
 
       - name: Benchmark coral.tables query
         run: |
-          cargo run --locked -p xtask -- perf-check \
+          cargo run --locked -p xtask --release -- perf-check \
             --coral-bin target/release/coral \
             --max-mean-seconds 0.75
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,6 +33,7 @@ jobs:
       source-lint: ${{ steps.filter.outputs.source-lint }}
       docs-freshness: ${{ steps.filter.outputs.docs-freshness }}
       license-check: ${{ steps.filter.outputs.license-check }}
+      performance-regression: ${{ steps.filter.outputs.performance-regression }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -96,6 +97,16 @@ jobs:
               - 'Cargo.lock'
               - 'crates/**/Cargo.toml'
               - 'deny.toml'
+            performance-regression:
+              - '.github/workflows/validate.yml'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'Makefile'
+              - 'rust-toolchain.toml'
+              - 'rust-toolchain'
+              - 'crates/**'
+              - 'xtask/**'
+              - 'sources/core/github/**'
 
   rust-checks:
     name: Rust checks
@@ -439,6 +450,41 @@ jobs:
       - name: Run make license-check
         run: make license-check
 
+  performance-regression:
+    name: Performance regression
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.performance-regression == 'true' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: coral-performance-${{ runner.os }}
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install hyperfine
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+        with:
+          tool: hyperfine@1.20.0
+          fallback: cargo-install
+
+      - name: Build CLI
+        run: cargo build --locked -p coral-cli --release
+
+      - name: Benchmark coral.tables query
+        run: |
+          cargo run --locked -p xtask -- perf-check \
+            --coral-bin target/release/coral \
+            --max-mean-seconds 0.75
+
   validate:
     runs-on: ubuntu-latest
     needs:
@@ -455,6 +501,7 @@ jobs:
         source-lint,
         docs-freshness,
         license-check,
+        performance-regression,
       ]
     # Run even when upstream jobs fail or are conditionally skipped so this
     # job can act as the single required status check for the workflow.
@@ -474,6 +521,7 @@ jobs:
           SOURCE_LINT_RESULT: ${{ needs.source-lint.result }}
           DOCS_FRESHNESS_RESULT: ${{ needs.docs-freshness.result }}
           LICENSE_CHECK_RESULT: ${{ needs.license-check.result }}
+          PERFORMANCE_REGRESSION_RESULT: ${{ needs.performance-regression.result }}
         run: |
           jobs=(
             "changes:$CHANGES_RESULT"
@@ -488,6 +536,7 @@ jobs:
             "source-lint:$SOURCE_LINT_RESULT"
             "docs-freshness:$DOCS_FRESHNESS_RESULT"
             "license-check:$LICENSE_CHECK_RESULT"
+            "performance-regression:$PERFORMANCE_REGRESSION_RESULT"
           )
 
           failed=0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -209,13 +209,36 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve latest Coral release
+        id: coral-release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          version="$(
+            curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -H "User-Agent: withcoral-install-ci" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/latest" |
+              sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' |
+              head -n 1
+          )"
+
+          if [ -z "$version" ]; then
+            echo "Could not determine latest Coral release version" >&2
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Run install script
         env:
-          # Note: the install script generally runs fine without a GITHUB_TOKEN set, and we don't advise users to set
-          # one during installation, but in CI it often fails. See https://github.com/orgs/community/discussions/42748
-          # for the discussion.
-          # Do not expose even a read-scoped token to PR-controlled install script changes.
-          GITHUB_TOKEN: ${{ github.event_name != 'pull_request' && github.token || '' }}
+          # Keep tokens out of PR-controlled installer code; pass only the resolved release version.
+          CORAL_VERSION: ${{ steps.coral-release.outputs.version }}
+          GITHUB_TOKEN: ""
         run: |
           install_dir="$RUNNER_TEMP/coral-bin"
           CORAL_INSTALL_DIR="$install_dir" sh < scripts/install.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@
 
 - Run `make rust-checks` before submitting PRs that include changes to Rust code.
 - UI changes must pass `npm run check --prefix ui` (oxfmt + oxlint) before submitting.
+- Run `make perf-check` before submitting PRs that could affect CLI startup,
+  local server bootstrap, source registration, or `coral.tables` catalog query
+  latency. CI installs the bundled `github` source with fake credentials and
+  fails when release `coral sql "select * from coral.tables"` has a hyperfine
+  mean above 750 ms.
 - `make rust-checks` is the Rust-only local gate and should keep using
   `--all-features`; the embedded UI feature is a normal CLI build surface.
 - The built UI artifact is produced by repo/CI orchestration (`make ui-build`
@@ -44,6 +49,8 @@
 - Changes to `scripts/install.sh` must keep the `Validate` workflow's
   install-script matrix in sync with every OS/architecture target that the
   installer supports.
+- Keep general repository automation in `xtask`; reserve `scripts/` for the
+  bash Coral installer and installer-specific support.
 - `make docs-check` intentionally skips the aggregate community source catalog.
   Any PR may leave that generated page stale so unrelated changes do not fail
   on aggregate community catalog drift; keep docs freshness strict for bundled

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install ui-build rust-checks license-check lint-proto lint-sources fix-sources docs-generate docs-check
+.PHONY: install ui-build rust-checks perf-check license-check lint-proto lint-sources fix-sources docs-generate docs-check
 
 install: ui-build
 	cargo install --path crates/coral-cli --locked
@@ -13,6 +13,10 @@ rust-checks:
 	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 	cargo nextest run --workspace --all-targets --all-features --locked --no-fail-fast
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
+
+perf-check:
+	cargo build --locked -p coral-cli --release
+	cargo run --locked -p xtask -- perf-check --coral-bin target/release/coral
 
 # ----------------------------------------------------------------------------
 # Dependency license scan

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ rust-checks:
 
 perf-check:
 	cargo build --locked -p coral-cli --release
-	cargo run --locked -p xtask -- perf-check --coral-bin target/release/coral
+	cargo run --locked -p xtask --release -- perf-check --coral-bin target/release/coral
 
 # ----------------------------------------------------------------------------
 # Dependency license scan

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,7 @@
 //!     (the regression gate for the SOURCE-465 manifest cleanup).
 //!   - `export-skills` exports installable agent skills from the canonical
 //!     plugin tree into a distribution checkout.
+//!   - `perf-check` runs command-level performance regression checks.
 
 #![allow(
     clippy::print_stderr,
@@ -25,6 +26,7 @@ use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 
 mod detect;
 mod nav;
+mod perf;
 mod render;
 mod skills;
 
@@ -43,6 +45,8 @@ enum Command {
     DetectTruncations(DetectArgs),
     /// Export installable skills from plugins/coral/skills.
     ExportSkills(ExportSkillsArgs),
+    /// Run command-level performance regression checks.
+    PerfCheck(perf::Args),
 }
 
 #[derive(Debug, clap::Args)]
@@ -139,6 +143,7 @@ fn run(command: &Command) -> Result<bool> {
             detect::run(&paths, args.verbose)
         }
         Command::ExportSkills(args) => skills::export(&args.dest),
+        Command::PerfCheck(args) => perf::run(args),
     }
 }
 

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -1,0 +1,292 @@
+//! Performance regression checks for user-visible Coral commands.
+
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+
+const DEFAULT_SQL: &str = "select * from coral.tables";
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct Args {
+    /// Path to the release Coral binary to benchmark.
+    #[arg(long, default_value = "target/release/coral")]
+    coral_bin: PathBuf,
+
+    /// Fail when hyperfine reports a mean above this many seconds.
+    #[arg(long, default_value_t = 0.75)]
+    max_mean_seconds: f64,
+
+    /// Number of measured hyperfine runs.
+    #[arg(long, default_value_t = 5)]
+    runs: u32,
+
+    /// Number of hyperfine warmup runs.
+    #[arg(long, default_value_t = 1)]
+    warmup: u32,
+
+    /// Fake token used to install the GitHub source without real credentials.
+    #[arg(long, default_value = "coral-ci-fake-token")]
+    github_token: String,
+}
+
+pub(crate) fn run(args: &Args) -> Result<bool> {
+    validate_args(args)?;
+    require_command("hyperfine")?;
+
+    let coral_bin = absolute_path(&args.coral_bin)?;
+    ensure_executable(&coral_bin)?;
+
+    let temp_dir = TempDir::create("coral-tables-perf")?;
+    let config_dir = temp_dir.path().join("coral-config");
+    fs::create_dir_all(&config_dir)
+        .with_context(|| format!("creating {}", config_dir.display()))?;
+    fs::write(
+        config_dir.join("config.toml"),
+        "[credentials]\nstorage = \"file\"\n",
+    )
+    .with_context(|| format!("writing {}", config_dir.join("config.toml").display()))?;
+
+    install_github_source(&coral_bin, &config_dir, &args.github_token)?;
+    run_coral_sql(&coral_bin, &config_dir)?;
+
+    let result_json = temp_dir.path().join("hyperfine.json");
+    run_hyperfine(args, &coral_bin, &config_dir, &result_json)?;
+
+    let result = load_hyperfine_result(&result_json)?;
+    println!(
+        "coral.tables mean: {:.3}s (stddev {:.3}s, threshold {:.3}s)",
+        result.mean, result.stddev, args.max_mean_seconds
+    );
+    if result.mean > args.max_mean_seconds {
+        eprintln!(
+            "Performance regression: mean {:.3}s exceeds {:.3}s",
+            result.mean, args.max_mean_seconds
+        );
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+fn validate_args(args: &Args) -> Result<()> {
+    if args.max_mean_seconds <= 0.0 {
+        bail!("--max-mean-seconds must be positive");
+    }
+    if args.runs == 0 {
+        bail!("--runs must be positive");
+    }
+    Ok(())
+}
+
+fn require_command(command: &str) -> Result<()> {
+    let status = Command::new(command)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .with_context(|| format!("{command} is required for the coral.tables performance check"))?;
+    if !status.success() {
+        bail!("{command} is required for the coral.tables performance check");
+    }
+    Ok(())
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    Ok(std::env::current_dir()
+        .context("resolving current directory")?
+        .join(path))
+}
+
+fn ensure_executable(path: &Path) -> Result<()> {
+    let metadata = fs::metadata(path).with_context(|| format!("reading {}", path.display()))?;
+    if !metadata.is_file() {
+        bail!("Coral binary is not a file: {}", path.display());
+    }
+    Ok(())
+}
+
+fn install_github_source(coral_bin: &Path, config_dir: &Path, github_token: &str) -> Result<()> {
+    let output = Command::new(coral_bin)
+        .args(["source", "add", "github"])
+        .env("CORAL_CONFIG_DIR", config_dir)
+        .env("GITHUB_TOKEN", github_token)
+        .output()
+        .with_context(|| format!("running {} source add github", coral_bin.display()))?;
+
+    let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
+    log.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    if !output.status.success() {
+        print!("{log}");
+        bail!("failed to install github source with fake credentials");
+    }
+
+    println!("Installed github source with fake credentials.");
+    print_tail(&log, 20);
+    Ok(())
+}
+
+fn run_coral_sql(coral_bin: &Path, config_dir: &Path) -> Result<()> {
+    let status = Command::new(coral_bin)
+        .args(["sql", DEFAULT_SQL])
+        .env("CORAL_CONFIG_DIR", config_dir)
+        .stdout(Stdio::null())
+        .status()
+        .with_context(|| format!("running {} sql", coral_bin.display()))?;
+    if !status.success() {
+        bail!("coral.tables warmup query failed");
+    }
+    Ok(())
+}
+
+fn run_hyperfine(
+    args: &Args,
+    coral_bin: &Path,
+    config_dir: &Path,
+    result_json: &Path,
+) -> Result<()> {
+    let coral_bin = path_to_str(coral_bin)?;
+    let warmup = args.warmup.to_string();
+    let runs = args.runs.to_string();
+    let result_json = path_to_str(result_json)?;
+    let command = format!(
+        "{} sql '{}' > /dev/null",
+        shell_quote(coral_bin),
+        DEFAULT_SQL
+    );
+    let status = Command::new("hyperfine")
+        .args([
+            "--warmup",
+            &warmup,
+            "--runs",
+            &runs,
+            "--export-json",
+            result_json,
+            "--command-name",
+            "coral tables",
+            &command,
+        ])
+        .env("CORAL_CONFIG_DIR", config_dir)
+        .status()
+        .context("running hyperfine")?;
+    if !status.success() {
+        bail!("hyperfine failed");
+    }
+    Ok(())
+}
+
+fn load_hyperfine_result(path: &Path) -> Result<HyperfineResult> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let json: Value = serde_json::from_str(&raw).context("parsing hyperfine JSON")?;
+    let first = json
+        .get("results")
+        .and_then(Value::as_array)
+        .and_then(|results| results.first())
+        .context("hyperfine JSON did not contain results[0]")?;
+    let mean = first
+        .get("mean")
+        .and_then(Value::as_f64)
+        .context("hyperfine JSON did not contain results[0].mean")?;
+    let stddev = first
+        .get("stddev")
+        .and_then(Value::as_f64)
+        .context("hyperfine JSON did not contain results[0].stddev")?;
+    Ok(HyperfineResult { mean, stddev })
+}
+
+fn print_tail(log: &str, max_lines: usize) {
+    let lines: Vec<&str> = log.lines().collect();
+    let start = lines.len().saturating_sub(max_lines);
+    for line in lines.iter().skip(start) {
+        println!("{line}");
+    }
+}
+
+fn path_to_str(path: &Path) -> Result<&str> {
+    path.to_str()
+        .with_context(|| format!("path is not valid UTF-8: {}", path.display()))
+}
+
+fn shell_quote(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    if value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-'))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[derive(Debug)]
+struct HyperfineResult {
+    mean: f64,
+    stddev: f64,
+}
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn create(prefix: &str) -> Result<Self> {
+        let base = std::env::temp_dir();
+        let pid = std::process::id();
+        for attempt in 0..100 {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .context("system clock is before unix epoch")?
+                .as_nanos();
+            let path = base.join(format!("{prefix}-{pid}-{nonce}-{attempt}"));
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+                Err(error) => {
+                    return Err(error).with_context(|| format!("creating {}", path.display()));
+                }
+            }
+        }
+        bail!(
+            "failed to allocate temporary directory under {}",
+            base.display()
+        )
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        if let Err(_error) = fs::remove_dir_all(&self.path) {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shell_quote;
+
+    #[test]
+    fn shell_quote_leaves_safe_paths_unquoted() {
+        assert_eq!(shell_quote("/tmp/coral-bin/coral"), "/tmp/coral-bin/coral");
+    }
+
+    #[test]
+    fn shell_quote_wraps_spaces_and_single_quotes() {
+        assert_eq!(
+            shell_quote("/tmp/coral bin/it'works"),
+            "'/tmp/coral bin/it'\\''works'"
+        );
+    }
+}


### PR DESCRIPTION
## Intent

Catch regressions in the user-visible latency of catalog discovery through the actual CLI path. The check intentionally benchmarks `coral sql "select * from coral.tables"` against a release binary after installing the bundled GitHub source with fake credentials, so it covers process startup, local server bootstrap, source registration, credential lookup, catalog materialization, and result rendering.

## Changes

- Add `xtask perf-check` as the benchmark harness instead of adding another script under `scripts/`.
- Add `make perf-check` as the local entrypoint.
- Add a Validate workflow job that installs hyperfine, builds release `coral`, runs the xtask benchmark, and fails when the mean exceeds 750 ms.
- Run `xtask perf-check` in release mode so the perf job reuses the release profile built for `coral-cli` instead of compiling a separate dev profile.
- Reuse the existing Ubuntu Validate Rust cache namespace for the perf job instead of introducing a cold `coral-performance-*` cache key.
- Keep `scripts/` reserved for the Coral installer in agent guidance.

## Validation

- `cargo check --locked -p xtask`
- `cargo clippy --locked -p xtask --all-targets --all-features -- -D warnings`
- `cargo test --locked -p xtask`
- `make perf-check` mean: 0.236s against a 0.750s threshold
- `sh -n scripts/install.sh`
- Parsed `.github/workflows/validate.yml` with PyYAML
