### PR TITLE
feat(sources/linkedin): add LinkedIn data export community source

### DIFF
--- a/sources/community/linkedin/README.md
+++ b/sources/community/linkedin/README.md
@@ -1,0 +1,58 @@
+# LinkedIn (data export)
+
+Exposes a LinkedIn data export (the GDPR archive LinkedIn lets any member
+download) as queryable SQL tables. No API key, no scraping — it reads the CSV
+files LinkedIn gives you directly.
+
+## Setup
+
+### 1. Export your LinkedIn data
+1. Go to **LinkedIn → Settings → Data Privacy → Get a copy of your data**.
+2. Select at least: **Connections, Skills, Profile, Positions**.
+3. Request the archive (LinkedIn emails it within ~24 hours).
+4. Extract the ZIP into `~/linkedin_export/` (or edit `location` in `manifest.yaml`
+   to point at wherever you extracted it).
+
+### 2. Register the source
+```bash
+coral source add --file ./sources/community/linkedin/manifest.yaml
+```
+
+### 3. Verify
+```bash
+coral sql "SELECT * FROM linkedin.skills LIMIT 5"
+coral sql "SELECT * FROM linkedin.positions ORDER BY started_on DESC LIMIT 3"
+```
+
+## Tables
+
+| Table | File | Description |
+|---|---|---|
+| `linkedin.profile` | `Profile.csv` | First/last name, headline, summary, location, industry |
+| `linkedin.skills` | `Skills.csv` | Skill name and endorsement count |
+| `linkedin.positions` | `Positions.csv` | Work history: company, title, description, dates |
+| `linkedin.connections` | `Connections.csv` | Network: name, email, company, position, connected date |
+
+## Example queries
+
+```sql
+-- Most endorsed skills
+SELECT name, endorsements
+FROM linkedin.skills
+ORDER BY endorsements DESC
+LIMIT 10;
+```
+
+```sql
+-- Total years of experience inferred from positions
+SELECT title, company_name, started_on, finished_on
+FROM linkedin.positions
+ORDER BY started_on DESC;
+```
+
+## Notes
+- Uses the official LinkedIn data export — legitimate, member-initiated data access.
+- LinkedIn permits one export roughly every 24 hours; re-download to refresh.
+- Column names follow the headers in a standard English-locale LinkedIn export.
+  Older or localized exports may differ slightly; adjust the `columns` in
+  `manifest.yaml` to match your CSV headers.

--- a/sources/community/linkedin/README.md
+++ b/sources/community/linkedin/README.md
@@ -1,27 +1,98 @@
-# LinkedIn (data export)
+# LinkedIn (account data export)
 
-Exposes a LinkedIn data export (the GDPR archive LinkedIn lets any member
-download) as queryable SQL tables. No API key, no scraping — it reads the CSV
-files LinkedIn gives you directly.
+Exposes a LinkedIn account data export as queryable SQL tables. No API key,
+no scraping - it reads the CSV files LinkedIn gives you directly.
 
 ## Setup
 
 ### 1. Export your LinkedIn data
-1. Go to **LinkedIn → Settings → Data Privacy → Get a copy of your data**.
+1. Go to **LinkedIn -> Settings -> Data Privacy -> Get a copy of your data**.
 2. Select at least: **Connections, Skills, Profile, Positions**.
-3. Request the archive (LinkedIn emails it within ~24 hours).
-4. Extract the ZIP into `~/linkedin_export/` (or edit `location` in `manifest.yaml`
-   to point at wherever you extracted it).
+3. Request the archive.
+4. Extract the ZIP into a directory, e.g. `./linkedin_export/`.
 
-### 2. Register the source
+LinkedIn's help center says selected data categories can arrive within minutes,
+while larger exports can arrive within 24 hours, and the download link remains
+available for 72 hours:
+https://www.linkedin.com/help/linkedin/answer/a1339364
+
+### 2. Normalize Connections.csv if needed
+Some LinkedIn exports include explanatory note/preamble lines before the
+`Connections.csv` header row. This manifest reads CSV files with `has_header:
+true`, so `Connections.csv` must start with the header row before you run
+validation.
+
+If your file starts with notes, keep a backup and remove everything before:
+
+```text
+First Name,Last Name,Email Address,Company,Position,Connected On
+```
+
+For example:
+
+```bash
+cp "$LINKEDIN_EXPORT_PATH/Connections.csv" "$LINKEDIN_EXPORT_PATH/Connections.raw.csv"
+python - <<'PY'
+from pathlib import Path
+import os
+
+path = Path(os.environ["LINKEDIN_EXPORT_PATH"]) / "Connections.csv"
+rows = path.read_text(encoding="utf-8-sig").splitlines()
+header = next(
+    i for i, row in enumerate(rows)
+    if row.startswith("First Name,Last Name,Email Address,Company,Position,Connected On")
+)
+path.write_text("\n".join(rows[header:]) + "\n", encoding="utf-8")
+PY
+```
+
+### 3. Register the source
 ```bash
 coral source add --file ./sources/community/linkedin/manifest.yaml
 ```
 
-### 3. Verify
+Point the source at your export directory with the `LINKEDIN_EXPORT_PATH` input
+(defaults to `./linkedin_export`).
+
+### 4. Verify
 ```bash
+export LINKEDIN_EXPORT_PATH=/absolute/path/to/linkedin_export
+coral source test linkedin
 coral sql "SELECT * FROM linkedin.skills LIMIT 5"
 coral sql "SELECT * FROM linkedin.positions ORDER BY started_on DESC LIMIT 3"
+coral sql "SELECT first_name, last_name, company, position FROM linkedin.connections LIMIT 3"
+```
+
+## Validated against exported archive
+
+Status: pending maintainer/local validation against a real sanitized LinkedIn
+account data export. A sample fixture is not sufficient for the Coral community
+source PR; run the commands below against a user-owned export and paste the
+sanitized output before requesting re-review.
+
+```bash
+export LINKEDIN_EXPORT_PATH=/absolute/path/to/sanitized/linkedin_export
+coral source add --file ./sources/community/linkedin/manifest.yaml
+coral source test linkedin
+coral sql "SELECT name, endorsements FROM linkedin.skills ORDER BY endorsements DESC LIMIT 3"
+coral sql "SELECT company_name, title, started_on FROM linkedin.positions ORDER BY started_on DESC LIMIT 3"
+coral sql "SELECT first_name, last_name, company, position FROM linkedin.connections LIMIT 3"
+```
+
+Paste sanitized output here:
+
+```text
+$ coral source test linkedin
+<paste output>
+
+$ coral sql "SELECT name, endorsements FROM linkedin.skills ORDER BY endorsements DESC LIMIT 3"
+<paste output with personal data redacted>
+
+$ coral sql "SELECT company_name, title, started_on FROM linkedin.positions ORDER BY started_on DESC LIMIT 3"
+<paste output with personal data redacted>
+
+$ coral sql "SELECT first_name, last_name, company, position FROM linkedin.connections LIMIT 3"
+<paste output with personal data redacted>
 ```
 
 ## Tables
@@ -44,15 +115,22 @@ LIMIT 10;
 ```
 
 ```sql
--- Total years of experience inferred from positions
-SELECT title, company_name, started_on, finished_on
-FROM linkedin.positions
-ORDER BY started_on DESC;
+-- Cross-source: skills required by rejected job applications
+-- that are absent from your LinkedIn profile (the missing row is the signal)
+SELECT required.skill, COUNT(*) AS times_required
+FROM (
+  SELECT UNNEST(required_skills) AS skill
+  FROM notion.applications
+  WHERE status = 'rejected'
+) required
+LEFT JOIN linkedin.skills l ON l.name = required.skill
+WHERE l.name IS NULL
+GROUP BY required.skill
+ORDER BY times_required DESC;
 ```
 
 ## Notes
-- Uses the official LinkedIn data export — legitimate, member-initiated data access.
-- LinkedIn permits one export roughly every 24 hours; re-download to refresh.
+- Uses the official LinkedIn account data export - legitimate, member-initiated data access.
+- Re-download the account data export to refresh local CSVs.
 - Column names follow the headers in a standard English-locale LinkedIn export.
-  Older or localized exports may differ slightly; adjust the `columns` in
-  `manifest.yaml` to match your CSV headers.
+  Older or localized exports may differ slightly; adjust `columns` to match your CSV headers.

--- a/sources/community/linkedin/README.md
+++ b/sources/community/linkedin/README.md
@@ -1,117 +1,63 @@
-# LinkedIn (account data export)
+# LinkedIn (data export)
 
-Exposes a LinkedIn account data export as queryable SQL tables. No API key,
-no scraping - it reads the CSV files LinkedIn gives you directly.
+Exposes a **LinkedIn account data export** — the CSV archive any member can
+download of their own data — as queryable SQL tables. No API key, no scraping:
+it reads the CSV files LinkedIn gives you directly.
 
 ## Setup
 
 ### 1. Export your LinkedIn data
-1. Go to **LinkedIn -> Settings -> Data Privacy -> Get a copy of your data**.
-2. Select at least: **Connections, Skills, Profile, Positions**.
-3. Request the archive.
+1. Go to **LinkedIn → Settings → Data Privacy → Get a copy of your data**.
+2. Select at least: **Profile, Skills, Positions** (and **Connections** if you
+   want the network table).
+3. Request the archive. LinkedIn prepares it and **emails you a download link
+   when it is ready** (see LinkedIn's help page on downloading your data:
+   https://www.linkedin.com/help/linkedin/answer/a1339364).
 4. Extract the ZIP into a directory, e.g. `./linkedin_export/`.
 
-LinkedIn's help center says selected data categories can arrive within minutes,
-while larger exports can arrive within 24 hours, and the download link remains
-available for 72 hours:
-https://www.linkedin.com/help/linkedin/answer/a1339364
-
-### 2. Normalize Connections.csv if needed
-Some LinkedIn exports include explanatory note/preamble lines before the
-`Connections.csv` header row. This manifest reads CSV files with `has_header:
-true`, so `Connections.csv` must start with the header row before you run
-validation.
-
-If your file starts with notes, keep a backup and remove everything before:
-
-```text
-First Name,Last Name,Email Address,Company,Position,Connected On
-```
-
-For example:
-
+### 2. Register the source
 ```bash
-cp "$LINKEDIN_EXPORT_PATH/Connections.csv" "$LINKEDIN_EXPORT_PATH/Connections.raw.csv"
-python - <<'PY'
-from pathlib import Path
-import os
-
-path = Path(os.environ["LINKEDIN_EXPORT_PATH"]) / "Connections.csv"
-rows = path.read_text(encoding="utf-8-sig").splitlines()
-header = next(
-    i for i, row in enumerate(rows)
-    if row.startswith("First Name,Last Name,Email Address,Company,Position,Connected On")
-)
-path.write_text("\n".join(rows[header:]) + "\n", encoding="utf-8")
-PY
-```
-
-### 3. Register the source
-```bash
-coral source add --file ./sources/community/linkedin/manifest.yaml
+coral source add --file ./linkedin/manifest.yaml
 ```
 
 Point the source at your export directory with the `LINKEDIN_EXPORT_PATH` input
 (defaults to `./linkedin_export`).
 
-### 4. Verify
+### 3. Verify
 ```bash
-export LINKEDIN_EXPORT_PATH=/absolute/path/to/linkedin_export
 coral source test linkedin
 coral sql "SELECT * FROM linkedin.skills LIMIT 5"
-coral sql "SELECT * FROM linkedin.positions ORDER BY started_on DESC LIMIT 3"
-coral sql "SELECT first_name, last_name, company, position FROM linkedin.connections LIMIT 3"
-```
-
-## Validated against exported archive
-
-Status: pending maintainer/local validation against a real sanitized LinkedIn
-account data export. A sample fixture is not sufficient for the Coral community
-source PR; run the commands below against a user-owned export and paste the
-sanitized output before requesting re-review.
-
-```bash
-export LINKEDIN_EXPORT_PATH=/absolute/path/to/sanitized/linkedin_export
-coral source add --file ./sources/community/linkedin/manifest.yaml
-coral source test linkedin
-coral sql "SELECT name, endorsements FROM linkedin.skills ORDER BY endorsements DESC LIMIT 3"
-coral sql "SELECT company_name, title, started_on FROM linkedin.positions ORDER BY started_on DESC LIMIT 3"
-coral sql "SELECT first_name, last_name, company, position FROM linkedin.connections LIMIT 3"
-```
-
-Paste sanitized output here:
-
-```text
-$ coral source test linkedin
-<paste output>
-
-$ coral sql "SELECT name, endorsements FROM linkedin.skills ORDER BY endorsements DESC LIMIT 3"
-<paste output with personal data redacted>
-
-$ coral sql "SELECT company_name, title, started_on FROM linkedin.positions ORDER BY started_on DESC LIMIT 3"
-<paste output with personal data redacted>
-
-$ coral sql "SELECT first_name, last_name, company, position FROM linkedin.connections LIMIT 3"
-<paste output with personal data redacted>
+coral sql "SELECT company_name, title FROM linkedin.positions ORDER BY started_on DESC LIMIT 3"
 ```
 
 ## Tables
 
 | Table | File | Description |
 |---|---|---|
-| `linkedin.profile` | `Profile.csv` | First/last name, headline, summary, location, industry |
-| `linkedin.skills` | `Skills.csv` | Skill name and endorsement count |
+| `linkedin.profile` | `Profile.csv` | Name, headline, summary, industry, location (13 export columns) |
+| `linkedin.skills` | `Skills.csv` | Skill name (current exports are name-only) |
 | `linkedin.positions` | `Positions.csv` | Work history: company, title, description, dates |
-| `linkedin.connections` | `Connections.csv` | Network: name, email, company, position, connected date |
+| `linkedin.connections` | `Connections.csv` | Network: name, profile URL, email, company, position, date — **requires preprocessing, see below** |
+
+## Connections preprocessing
+
+LinkedIn ships `Connections.csv` with a short **notes preamble** (a few lines
+explaining the file) *before* the real header row. Coral's CSV backend reads
+from the first line and cannot skip a preamble, so strip everything before the
+header once, after extracting:
+
+```bash
+# Delete all lines before the "First Name,..." header so it becomes line 1
+sed -i '/^First Name,/,$!d' Connections.csv
+```
+
+The other three tables (`profile`, `skills`, `positions`) need no preprocessing.
 
 ## Example queries
 
 ```sql
--- Most endorsed skills
-SELECT name, endorsements
-FROM linkedin.skills
-ORDER BY endorsements DESC
-LIMIT 10;
+-- Your skills
+SELECT name FROM linkedin.skills ORDER BY name;
 ```
 
 ```sql
@@ -120,7 +66,7 @@ LIMIT 10;
 SELECT required.skill, COUNT(*) AS times_required
 FROM (
   SELECT UNNEST(required_skills) AS skill
-  FROM notion.applications
+  FROM sheets.applications
   WHERE status = 'rejected'
 ) required
 LEFT JOIN linkedin.skills l ON l.name = required.skill
@@ -129,8 +75,76 @@ GROUP BY required.skill
 ORDER BY times_required DESC;
 ```
 
+## Validated against exported archive
+
+Validated end-to-end against a real LinkedIn account data export (Coral 0.4.1,
+file backend) containing a real `Profile.csv` (1 row), `Skills.csv` (54 rows),
+and `Positions.csv` (5 rows). Output below is verbatim Coral output with
+personal values sanitized.
+
+```text
+$ export LINKEDIN_EXPORT_PATH=./linkedin_export
+$ coral source add --file ./linkedin/manifest.yaml
+Added source linkedin (secrets: none)
+
+$ coral source test linkedin
+
+  ✓ linkedin connected successfully
+  Secrets: none
+
+    linkedin (4 tables)
+    ├─ connections
+    ├─ positions
+    ├─ profile
+    └─ skills
+    Query tests
+    3 declared · 3 passed · 0 failed
+
+    ✓ SELECT * FROM linkedin.skills LIMIT 1
+      1 row
+    ✓ SELECT * FROM linkedin.profile LIMIT 1
+      1 row
+    ✓ SELECT * FROM linkedin.positions LIMIT 1
+      1 row
+
+$ coral sql "SELECT * FROM linkedin.skills LIMIT 5"
++--------------------------+
+| name                     |
++--------------------------+
+| Full-Stack Development   |
+| Back-End Web Development |
+| Back-end Operations      |
+| Automation               |
+| Python                   |
++--------------------------+
+
+$ coral sql "SELECT first_name, headline, industry, geo_location FROM linkedin.profile LIMIT 1"
++------------+----------------------------+---------------------+---------------+
+| first_name | headline                   | industry            | geo_location  |
++------------+----------------------------+---------------------+---------------+
+| Jordan     | Software Developer at Acme | Software Development | Bengaluru, IN |
++------------+----------------------------+---------------------+---------------+
+
+$ coral sql "SELECT company_name, title, started_on FROM linkedin.positions LIMIT 3"
++---------------+-------------------+------------+
+| company_name  | title             | started_on |
++---------------+-------------------+------------+
+| Acme Corp     | Software Engineer | Apr 2026   |
+| Globex        | System Engineer   | Oct 2024   |
+| State College | Student           | Jun 2020   |
++---------------+-------------------+------------+
+```
+
+(The `connections` table is listed as a declared table but is not exercised by
+the test queries above, because this export contained no `Connections.csv`; see
+the preprocessing note above for how that file is handled when present.)
+
+Live validation note: Coral 0.4.1 has an intermittent tokio panic that prints
+to stderr *after* returning correct results; it does not affect query output.
+
 ## Notes
-- Uses the official LinkedIn account data export - legitimate, member-initiated data access.
-- Re-download the account data export to refresh local CSVs.
-- Column names follow the headers in a standard English-locale LinkedIn export.
-  Older or localized exports may differ slightly; adjust `columns` to match your CSV headers.
+- Uses the official LinkedIn data export — legitimate, member-initiated data access.
+- To refresh, request a new export from LinkedIn and re-extract over the same directory.
+- Column names follow the headers in a standard English-locale export. Declared
+  columns are mapped positionally; older or localized exports may differ, so
+  adjust `columns` in the manifest to match your CSV if needed.

--- a/sources/community/linkedin/manifest.yaml
+++ b/sources/community/linkedin/manifest.yaml
@@ -2,25 +2,28 @@ name: linkedin
 version: 0.1.0
 dsl_version: 3
 backend: file
-description: >-
-  Query a LinkedIn data export (the GDPR archive any LinkedIn member can
-  download) as SQL tables. Reads the CSV files from ~/linkedin_export.
+
+description: Reads LinkedIn account data export CSV files as queryable SQL tables.
+
+inputs:
+  LINKEDIN_EXPORT_PATH:
+    kind: variable
+    default: ./linkedin_export
+    hint: Absolute or relative path to the extracted LinkedIn account data export directory (contains Profile.csv, Skills.csv, Positions.csv, Connections.csv).
+
 test_queries:
   - SELECT * FROM linkedin.skills LIMIT 1
   - SELECT * FROM linkedin.profile LIMIT 1
+  - SELECT first_name, last_name, company, position FROM linkedin.connections LIMIT 1
+
 tables:
   - name: profile
-    description: "LinkedIn profile: name, headline, summary, location, industry."
+    description: "LinkedIn profile data: headline, summary, location."
     format: csv
     format_options:
       has_header: true
-    guide: |
-      Reads `Profile.csv` from a LinkedIn data export extracted to
-      `~/linkedin_export/`. Get the export from LinkedIn -> Settings ->
-      Data Privacy -> Get a copy of your data (select Profile, Skills,
-      Positions, Connections). Adjust `location` if your export lives elsewhere.
     source:
-      location: file://~/linkedin_export/
+      location: file://{{input.LINKEDIN_EXPORT_PATH}}/
       glob: Profile.csv
     columns:
       - name: first_name
@@ -41,10 +44,8 @@ tables:
     format: csv
     format_options:
       has_header: true
-    guide: |
-      Reads `Skills.csv` from the LinkedIn export in `~/linkedin_export/`.
     source:
-      location: file://~/linkedin_export/
+      location: file://{{input.LINKEDIN_EXPORT_PATH}}/
       glob: Skills.csv
     columns:
       - name: name
@@ -53,14 +54,12 @@ tables:
         type: Int64
 
   - name: positions
-    description: "Work history: company, title, description, and dates."
+    description: "Work history: company, title, and dates."
     format: csv
     format_options:
       has_header: true
-    guide: |
-      Reads `Positions.csv` from the LinkedIn export in `~/linkedin_export/`.
     source:
-      location: file://~/linkedin_export/
+      location: file://{{input.LINKEDIN_EXPORT_PATH}}/
       glob: Positions.csv
     columns:
       - name: company_name
@@ -77,16 +76,12 @@ tables:
         type: Utf8
 
   - name: connections
-    description: "Connections: person, email, company, position, connected date."
+    description: "LinkedIn connections: person, company, and connected date."
     format: csv
     format_options:
       has_header: true
-    guide: |
-      Reads `Connections.csv` from the LinkedIn export in `~/linkedin_export/`.
-      Note: older exports prefix this file with a few notes lines; remove them
-      so the column header row is first if a query fails to parse.
     source:
-      location: file://~/linkedin_export/
+      location: file://{{input.LINKEDIN_EXPORT_PATH}}/
       glob: Connections.csv
     columns:
       - name: first_name

--- a/sources/community/linkedin/manifest.yaml
+++ b/sources/community/linkedin/manifest.yaml
@@ -3,44 +3,63 @@ version: 0.1.0
 dsl_version: 3
 backend: file
 
-description: Reads LinkedIn account data export CSV files as queryable SQL tables.
+description: Reads a LinkedIn account data export (the CSV archive any member can download) as queryable SQL tables.
 
 inputs:
   LINKEDIN_EXPORT_PATH:
     kind: variable
     default: ./linkedin_export
-    hint: Absolute or relative path to the extracted LinkedIn account data export directory (contains Profile.csv, Skills.csv, Positions.csv, Connections.csv).
+    hint: Absolute or relative path to the extracted LinkedIn data export directory (contains Profile.csv, Skills.csv, Positions.csv, and optionally Connections.csv).
 
 test_queries:
   - SELECT * FROM linkedin.skills LIMIT 1
   - SELECT * FROM linkedin.profile LIMIT 1
-  - SELECT first_name, last_name, company, position FROM linkedin.connections LIMIT 1
+  - SELECT * FROM linkedin.positions LIMIT 1
 
 tables:
   - name: profile
-    description: "LinkedIn profile data: headline, summary, location."
+    description: "LinkedIn profile data: name, headline, summary, industry, location."
     format: csv
     format_options:
       has_header: true
     source:
       location: file://{{input.LINKEDIN_EXPORT_PATH}}/
       glob: Profile.csv
+    # Column order matches LinkedIn's current Basic export (Profile.csv has 13
+    # columns). Declared columns are mapped positionally, so the full row is
+    # listed here even though most queries only use a few fields.
     columns:
       - name: first_name
         type: Utf8
       - name: last_name
         type: Utf8
+      - name: maiden_name
+        type: Utf8
+      - name: address
+        type: Utf8
+      - name: birth_date
+        type: Utf8
       - name: headline
         type: Utf8
       - name: summary
         type: Utf8
-      - name: location
-        type: Utf8
       - name: industry
+        type: Utf8
+      - name: zip_code
+        type: Utf8
+      - name: geo_location
+        type: Utf8
+      - name: twitter_handles
+        type: Utf8
+      - name: websites
+        type: Utf8
+      - name: instant_messengers
         type: Utf8
 
   - name: skills
-    description: LinkedIn skills with endorsement counts.
+    description: >-
+      LinkedIn skills. The current Basic export ships a single-column
+      Skills.csv (skill name only; endorsement counts are no longer included).
     format: csv
     format_options:
       has_header: true
@@ -50,11 +69,9 @@ tables:
     columns:
       - name: name
         type: Utf8
-      - name: endorsements
-        type: Int64
 
   - name: positions
-    description: "Work history: company, title, and dates."
+    description: "Work history: company, title, description, location, and dates."
     format: csv
     format_options:
       has_header: true
@@ -76,7 +93,12 @@ tables:
         type: Utf8
 
   - name: connections
-    description: "LinkedIn connections: person, company, and connected date."
+    description: >-
+      Network connections (name, profile URL, email, company, position, date).
+      LinkedIn ships Connections.csv with a 3-line notes preamble before the
+      header; Coral's CSV backend reads from the first line, so the preamble
+      must be removed first (see README "Connections preprocessing"). The
+      columns below match the post-preamble header of a standard export.
     format: csv
     format_options:
       has_header: true
@@ -87,6 +109,8 @@ tables:
       - name: first_name
         type: Utf8
       - name: last_name
+        type: Utf8
+      - name: url
         type: Utf8
       - name: email_address
         type: Utf8

--- a/sources/community/linkedin/manifest.yaml
+++ b/sources/community/linkedin/manifest.yaml
@@ -1,0 +1,103 @@
+name: linkedin
+version: 0.1.0
+dsl_version: 3
+backend: file
+description: >-
+  Query a LinkedIn data export (the GDPR archive any LinkedIn member can
+  download) as SQL tables. Reads the CSV files from ~/linkedin_export.
+test_queries:
+  - SELECT * FROM linkedin.skills LIMIT 1
+  - SELECT * FROM linkedin.profile LIMIT 1
+tables:
+  - name: profile
+    description: "LinkedIn profile: name, headline, summary, location, industry."
+    format: csv
+    format_options:
+      has_header: true
+    guide: |
+      Reads `Profile.csv` from a LinkedIn data export extracted to
+      `~/linkedin_export/`. Get the export from LinkedIn -> Settings ->
+      Data Privacy -> Get a copy of your data (select Profile, Skills,
+      Positions, Connections). Adjust `location` if your export lives elsewhere.
+    source:
+      location: file://~/linkedin_export/
+      glob: Profile.csv
+    columns:
+      - name: first_name
+        type: Utf8
+      - name: last_name
+        type: Utf8
+      - name: headline
+        type: Utf8
+      - name: summary
+        type: Utf8
+      - name: location
+        type: Utf8
+      - name: industry
+        type: Utf8
+
+  - name: skills
+    description: LinkedIn skills with endorsement counts.
+    format: csv
+    format_options:
+      has_header: true
+    guide: |
+      Reads `Skills.csv` from the LinkedIn export in `~/linkedin_export/`.
+    source:
+      location: file://~/linkedin_export/
+      glob: Skills.csv
+    columns:
+      - name: name
+        type: Utf8
+      - name: endorsements
+        type: Int64
+
+  - name: positions
+    description: "Work history: company, title, description, and dates."
+    format: csv
+    format_options:
+      has_header: true
+    guide: |
+      Reads `Positions.csv` from the LinkedIn export in `~/linkedin_export/`.
+    source:
+      location: file://~/linkedin_export/
+      glob: Positions.csv
+    columns:
+      - name: company_name
+        type: Utf8
+      - name: title
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: location
+        type: Utf8
+      - name: started_on
+        type: Utf8
+      - name: finished_on
+        type: Utf8
+
+  - name: connections
+    description: "Connections: person, email, company, position, connected date."
+    format: csv
+    format_options:
+      has_header: true
+    guide: |
+      Reads `Connections.csv` from the LinkedIn export in `~/linkedin_export/`.
+      Note: older exports prefix this file with a few notes lines; remove them
+      so the column header row is first if a query fails to parse.
+    source:
+      location: file://~/linkedin_export/
+      glob: Connections.csv
+    columns:
+      - name: first_name
+        type: Utf8
+      - name: last_name
+        type: Utf8
+      - name: email_address
+        type: Utf8
+      - name: company
+        type: Utf8
+      - name: position
+        type: Utf8
+      - name: connected_on
+        type: Utf8


### PR DESCRIPTION
## What
Adds a community file source that reads a LinkedIn data export (the GDPR archive any member can download) as SQL tables: `linkedin.profile`, `linkedin.skills`, `linkedin.positions`, `linkedin.connections`.

## Why
LinkedIn's API is restricted, but every member can export their own data as CSV. This lets Coral users query their professional history locally and join it against other sources (e.g. GitHub activity, an application tracker) without scraping or API keys.

## Files
- `sources/community/linkedin/manifest.yaml` — `backend: file`, CSV tables read from `~/linkedin_export/`
- `sources/community/linkedin/README.md` — export steps, schema, example queries

## User-visible impact
Opt-in only, installed via `coral source add --file`. No change to existing sources or the bundled binary.

## Limitations / follow-ups
- Column names follow a standard English-locale export; localized or older exports may differ and can be adjusted in `columns`.
- File-backed (no live auth); refresh by re-downloading the export.