### PR TITLE
feat(search): add universal search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +795,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +876,31 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -955,6 +998,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
 name = "cfg-if"
@@ -1197,6 +1246,8 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "sqlparser",
+ "tantivy",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1401,6 +1452,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2230,6 +2309,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "datasketches"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,6 +2350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -2329,6 +2415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2389,6 +2481,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2542,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastrand"
@@ -2524,6 +2633,16 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2797,6 +2916,12 @@ checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
@@ -3136,6 +3261,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,7 +3287,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -3256,6 +3390,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "lexical-core"
@@ -3386,6 +3526,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3426,10 +3575,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "measure_time"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -3455,6 +3622,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3484,6 +3657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,6 +3672,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3669,6 +3858,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3770,6 +3965,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3784,6 +3988,15 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "ownedbytes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "parking"
@@ -4406,6 +4619,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "recursive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4612,6 +4845,16 @@ dependencies = [
  "mime_guess",
  "sha2 0.10.9",
  "walkdir",
+]
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4983,6 +5226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5116,6 +5368,154 @@ dependencies = [
 ]
 
 [[package]]
+name = "tantivy"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64",
+ "bitpacking",
+ "bon",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "datasketches",
+ "downcast-rs",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "itertools",
+ "levenshtein_automata",
+ "log",
+ "lru",
+ "lz4_flex",
+ "measure_time",
+ "memmap2",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror",
+ "time",
+ "typetag",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fed3d674429bcd2de5d0a6d1aa5495fed8afd9c5ecce993019caf7615f53fa4"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57166f5bcfd478f370ab8445afb4678dce44801fa5ce5c451aaf8595583c5dc"
+dependencies = [
+ "downcast-rs",
+ "fastdivide",
+ "itertools",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf10915aa75da3c3b0d58b58853d2e889efbaf32d4982a4c3715dde6bba23e5"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfadb8526b6da90704feb293b0701a6aae62ea14983143344be2dc5ce30f1d82"
+dependencies = [
+ "fnv",
+ "nom 7.1.3",
+ "ordered-float 5.3.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2cfc3ac5164cbadc28965ffb145a8f47582a60ae5897859ad8d4316596c606"
+dependencies = [
+ "futures-util",
+ "itertools",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbb051742da9d53ca9e8fff43a9b10e319338b24e2c0e15d0372df19ffeb951"
+dependencies = [
+ "murmurhash32",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac258c2c6390673f2685813afeeafcb8c4e0ee7de8dd3fc46838dcc37263f98"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5183,7 +5583,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]
@@ -5193,6 +5593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5623,10 +6024,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typetag"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "uds_windows"
@@ -5698,6 +6129,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8_iter"
@@ -6075,6 +6512,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,14 +81,14 @@ prost = "0.14.1"
 reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "json", "rustls-tls-native-roots", "system-proxy"] }
 regex = "1"
 rmcp = { version = "1.6.0", features = ["client", "transport-child-process"] }
-rusqlite = { version = "0.37", features = ["bundled"] }
 rust-embed = { version = "8", features = ["mime-guess"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.9"
 sha2 = "0.10"
-sqlparser = "0.59.0"
+sqlparser = "0.61.0"
 strsim = "0.11"
+tantivy = "0.26.1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ npx skills add withcoral/skills
 ```
 
 Once connected, ask your agent to "list the tables available in Coral" or to
-run a small query. It should use `list_catalog`, `search_catalog`, or the
+run a small query. It should use `search`, `list_catalog`, or the
 `coral.tables` / `coral.table_functions` metadata tables as database catalog
 discovery, then answer with SQL over your visible schemas, tables, and table
 functions.

--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -19,6 +19,7 @@ fn main() {
                 "proto/coral/v1/feedback.proto",
                 "proto/coral/v1/sources.proto",
                 "proto/coral/v1/query.proto",
+                "proto/coral/v1/search.proto",
                 "proto/coral/v1/traces.proto",
             ],
             &["proto"],

--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -115,6 +115,10 @@ message TableFunction {
   repeated TableFunctionArgument arguments = 5;
   // Columns returned by the function.
   repeated TableFunctionResultColumn result_columns = 6;
+  // Function role. "search" marks provider-native retrieval.
+  string kind = 7;
+  // JSON-encoded provider search limit metadata, when declared by the source.
+  string search_limits_json = 8;
 }
 
 // Catalog item kind filter for unified discovery.
@@ -155,38 +159,6 @@ message ListCatalogResponse {
   // Queryable catalog items for the requested page.
   repeated CatalogItem items = 1;
   // Page metadata for the catalog list.
-  PaginationResponse pagination = 2;
-}
-
-// Searches queryable catalog metadata.
-message SearchCatalogRequest {
-  // Workspace whose current queryable catalog should be searched.
-  Workspace workspace = 1;
-  // Rust regex pattern matched over catalog metadata.
-  string pattern = 2;
-  // Whether regex matching should ignore case.
-  bool ignore_case = 3;
-  // Optional exact schema/source name.
-  string schema_name = 4;
-  // Optional item kind. Unspecified searches every currently supported kind.
-  CatalogItemKind kind = 5;
-  // Optional page request. Missing or zero limit applies the search default.
-  PaginationRequest pagination = 6;
-}
-
-// One catalog search match.
-message CatalogSearchResult {
-  // Matched catalog item metadata.
-  CatalogItem item = 1;
-  // Metadata fields matched by the pattern.
-  repeated string matched_fields = 2;
-}
-
-// Returns catalog metadata matches.
-message SearchCatalogResponse {
-  // Matching catalog items for the requested page.
-  repeated CatalogSearchResult items = 1;
-  // Page metadata for the catalog search.
   PaginationResponse pagination = 2;
 }
 
@@ -250,8 +222,6 @@ message ListColumnsResponse {
 service CatalogService {
   // Lists queryable catalog items for one workspace.
   rpc ListCatalog(ListCatalogRequest) returns (ListCatalogResponse);
-  // Searches queryable catalog metadata.
-  rpc SearchCatalog(SearchCatalogRequest) returns (SearchCatalogResponse);
   // Fetches one query-visible table.
   rpc DescribeTable(DescribeTableRequest) returns (DescribeTableResponse);
   // Lists and filters columns for one query-visible table.

--- a/crates/coral-api/proto/coral/v1/search.proto
+++ b/crates/coral-api/proto/coral/v1/search.proto
@@ -1,0 +1,167 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/catalog.proto";
+import "coral/v1/resources.proto";
+
+// Universal Search request for clue routing over Coral metadata and local search indexes.
+message SearchRequest {
+  // Workspace whose current search context should be inspected.
+  Workspace workspace = 1;
+  // User or agent clue to route to likely Coral surfaces.
+  string query = 2;
+  // Optional maximum results. Zero applies the API default.
+  uint32 limit = 3;
+}
+
+// Universal Search response with typed, bounded routing hints.
+message SearchResponse {
+  // Ordered search hints.
+  repeated SearchResult results = 1;
+  // Provider coverage and error disclosure.
+  repeated SearchProviderStatus provider_statuses = 2;
+  // Result truncation metadata.
+  SearchResultTruncation truncation = 3;
+}
+
+// Result truncation metadata.
+message SearchResultTruncation {
+  // Whether more results were available than returned.
+  bool truncated = 1;
+  // Number of results returned in this response.
+  uint32 returned_count = 2;
+  // Applied maximum result count.
+  uint32 max_results = 3;
+  // Human-readable truncation note.
+  string note = 4;
+}
+
+// Backing provider status for a search response.
+message SearchProviderStatus {
+  // Provider name.
+  SearchProvider provider = 1;
+  // Provider state for this request.
+  SearchProviderState state = 2;
+  // Short coverage or error note.
+  string note = 3;
+}
+
+// Universal Search backing providers.
+enum SearchProvider {
+  // Unknown provider.
+  SEARCH_PROVIDER_UNSPECIFIED = 0;
+  // Catalog metadata provider.
+  SEARCH_PROVIDER_CATALOG_METADATA = 1;
+  // Local observed-value provider.
+  SEARCH_PROVIDER_OBSERVED_VALUES = 2;
+}
+
+// Provider state for one request.
+enum SearchProviderState {
+  // Unknown provider state.
+  SEARCH_PROVIDER_STATE_UNSPECIFIED = 0;
+  // Provider returned one or more results.
+  SEARCH_PROVIDER_STATE_RESULTS_FOUND = 1;
+  // Provider ran and returned no results.
+  SEARCH_PROVIDER_STATE_EMPTY = 2;
+  // Provider is not enabled.
+  SEARCH_PROVIDER_STATE_NOT_ENABLED = 3;
+  // Provider was skipped for this request.
+  SEARCH_PROVIDER_STATE_SKIPPED = 4;
+  // Provider returned partial results.
+  SEARCH_PROVIDER_STATE_PARTIAL = 5;
+  // Provider failed for this request.
+  SEARCH_PROVIDER_STATE_ERROR = 6;
+}
+
+// One typed Universal Search result.
+message SearchResult {
+  // Result type, duplicated outside the payload for compact consumers.
+  SearchResultType type = 1;
+  // Typed result payload.
+  oneof payload {
+    // Source, table, or table-function metadata hit.
+    CatalogItem catalog_item = 10;
+    // Column, filter, argument, or result-column hint.
+    ColumnHint column_hint = 11;
+    // Local observed-value hit. Reserved for the observed-value provider.
+    ObservedValue observed_value = 12;
+    // Registered provider-native search function the agent can call explicitly.
+    NativeSearchPath native_search_path = 13;
+  }
+}
+
+// Universal Search result types.
+enum SearchResultType {
+  // Unknown result type.
+  SEARCH_RESULT_TYPE_UNSPECIFIED = 0;
+  // Catalog item result.
+  SEARCH_RESULT_TYPE_CATALOG_ITEM = 1;
+  // Column/filter/argument hint result.
+  SEARCH_RESULT_TYPE_COLUMN_HINT = 2;
+  // Local observed-value result.
+  SEARCH_RESULT_TYPE_OBSERVED_VALUE = 3;
+  // Provider-native search path result.
+  SEARCH_RESULT_TYPE_NATIVE_SEARCH_PATH = 4;
+}
+
+// Surface kind for a column-style hint.
+enum SearchSurfaceKind {
+  // Unknown surface kind.
+  SEARCH_SURFACE_KIND_UNSPECIFIED = 0;
+  // Table surface.
+  SEARCH_SURFACE_KIND_TABLE = 1;
+  // Table-function surface.
+  SEARCH_SURFACE_KIND_TABLE_FUNCTION = 2;
+}
+
+// A field-level hint that may hold or accept the query clue.
+message ColumnHint {
+  // Workspace that scopes this hint.
+  Workspace workspace = 1;
+  // Source schema that owns the surface.
+  string schema_name = 2;
+  // Table or table-function name.
+  string surface_name = 3;
+  // Whether the owning surface is a table or table function.
+  SearchSurfaceKind surface_kind = 4;
+  // Column, required filter, argument, or result-column name.
+  string name = 5;
+  // Data type when known.
+  string data_type = 6;
+  // Whether this field must be supplied or constrained.
+  bool required = 7;
+  // Human-readable field description.
+  string description = 8;
+  // Metadata fields that matched the query.
+  repeated string matched_fields = 9;
+}
+
+// Placeholder shape for local observed-value results.
+message ObservedValue {
+  // Matched value or redacted display value.
+  string value = 1;
+  // Source schema where the value was observed.
+  string schema_name = 2;
+  // Table or function where the value was observed.
+  string surface_name = 3;
+  // Column that produced the value.
+  string column_name = 4;
+}
+
+// A registered provider-native search path that can search upstream data explicitly.
+message NativeSearchPath {
+  // Source-scoped table function that performs provider-native retrieval.
+  TableFunction table_function = 1;
+  // Example SQL call using the provider-native search function.
+  string sql_call_example = 2;
+  // Metadata fields that matched the query.
+  repeated string matched_fields = 3;
+}
+
+// Universal Search APIs.
+service SearchService {
+  // Routes a clue to typed Coral search hints.
+  rpc Search(SearchRequest) returns (SearchResponse);
+}

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -55,6 +55,12 @@ pub const QUERY_RESPONSE_MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
 /// responses larger than tonic's 4 MB default.
 pub const CATALOG_RESPONSE_MAX_MESSAGE_SIZE: usize = QUERY_RESPONSE_MAX_MESSAGE_SIZE;
 
+/// Maximum gRPC message size for `SearchService` *responses*, in bytes.
+///
+/// Universal Search returns bounded metadata hints, but it may include source,
+/// table-function, and column descriptions for many installed sources.
+pub const SEARCH_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
+
 /// Maximum gRPC message size for `TraceService` *responses*, in bytes.
 ///
 /// Trace details can include large span attributes, which may exceed tonic's

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -27,6 +27,8 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
+sqlparser.workspace = true
+tantivy.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { workspace = true, features = ["net"] }

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -17,11 +17,12 @@ use axum::response::Response as AxumResponse;
 use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
+use coral_api::v1::search_service_server::SearchServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
 use coral_api::v1::trace_service_server::TraceServiceServer;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
-    TRACE_RESPONSE_MAX_MESSAGE_SIZE,
+    SEARCH_RESPONSE_MAX_MESSAGE_SIZE, TRACE_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -47,9 +48,10 @@ use crate::feedback::publisher::{
 use crate::feedback::service::FeedbackService;
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
+use crate::search::service::{SearchIndexRefresher, SearchService};
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
-use crate::state::ConfigStore;
+use crate::state::{AppStateLayout, ConfigStore};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
@@ -280,7 +282,7 @@ impl ServerBuilder {
             config_store,
             credential_manager,
             query_runtime_context,
-            layout,
+            layout.clone(),
             self.config.engine_extensions_providers,
         );
         let trace_service = if telemetry_config.trace_history.enabled {
@@ -293,6 +295,7 @@ impl ServerBuilder {
             query_manager,
             feedback_manager,
             trace_service,
+            layout,
             self.config.mode,
         )
         .await
@@ -374,10 +377,17 @@ async fn start_server(
     query_manager: QueryManager,
     feedback_manager: FeedbackManager,
     trace_service: Option<TraceService>,
+    layout: AppStateLayout,
     mode: ServerMode,
 ) -> Result<RunningServer, AppError> {
-    let source_service = SourceService::new(source_manager, query_manager.clone());
+    let search_index_refresher = SearchIndexRefresher::new(layout);
+    let source_service = SourceService::new(
+        source_manager,
+        query_manager.clone(),
+        search_index_refresher.clone(),
+    );
     let catalog_service = CatalogService::new(query_manager.clone());
+    let search_service = SearchService::new(query_manager.clone(), search_index_refresher);
     let query_service = QueryService::new(query_manager);
     let feedback_service = FeedbackService::new(feedback_manager);
     let mut routes = Routes::default()
@@ -387,6 +397,10 @@ async fn start_server(
         .add_service(GrpcMethodAnnotatedService::new(
             CatalogServiceServer::new(catalog_service)
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
+        ))
+        .add_service(GrpcMethodAnnotatedService::new(
+            SearchServiceServer::new(search_service)
+                .max_encoding_message_size(SEARCH_RESPONSE_MAX_MESSAGE_SIZE),
         ))
         .add_service(GrpcMethodAnnotatedService::new(FeedbackServiceServer::new(
             feedback_service,
@@ -712,7 +726,7 @@ enabled = false
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let trace_service =
@@ -722,6 +736,7 @@ enabled = false
             query_manager,
             feedback_manager,
             Some(trace_service),
+            layout,
             ServerMode::NativeGrpc,
         )
         .await
@@ -1093,7 +1108,7 @@ tables:
                 home_dir: Some(fake_home.clone()),
                 ..QueryRuntimeContext::default()
             },
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let running = start_server(
@@ -1101,6 +1116,7 @@ tables:
             query_manager,
             feedback_manager,
             None,
+            layout,
             ServerMode::NativeGrpc,
         )
         .await
@@ -1192,7 +1208,7 @@ tables:
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let running = start_server(
@@ -1200,6 +1216,7 @@ tables:
             query_manager,
             feedback_manager,
             None,
+            layout,
             ServerMode::NativeGrpc,
         )
         .await
@@ -1291,7 +1308,7 @@ tables:
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let running = start_server(
@@ -1299,6 +1316,7 @@ tables:
             query_manager,
             feedback_manager,
             None,
+            layout,
             ServerMode::NativeGrpc,
         )
         .await

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -9,8 +9,6 @@ use crate::bootstrap::AppError;
 use crate::query::manager::{QueryManager, QueryManagerError};
 use crate::workspaces::WorkspaceName;
 
-const DEFAULT_SEARCH_LIMIT: u32 = 20;
-const MAX_SEARCH_LIMIT: u32 = 100;
 const DEFAULT_COLUMN_LIMIT: u32 = 50;
 const MAX_COLUMN_LIMIT: u32 = 200;
 const MAX_METADATA_PATTERN_BYTES: usize = 256;
@@ -43,41 +41,6 @@ pub(crate) enum CatalogItem {
 pub(crate) enum CatalogItemKind {
     Table,
     TableFunction,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct CatalogSearchResult {
-    pub(crate) item: CatalogItem,
-    pub(crate) matched_fields: Vec<CatalogMetadataField>,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum CatalogMetadataField {
-    SchemaName,
-    TableName,
-    FunctionName,
-    Name,
-    Description,
-    Guide,
-    RequiredFilters,
-    Arguments,
-    ResultColumns,
-}
-
-impl CatalogMetadataField {
-    pub(crate) fn as_proto_name(self) -> &'static str {
-        match self {
-            Self::SchemaName => "schema_name",
-            Self::TableName => "table_name",
-            Self::FunctionName => "function_name",
-            Self::Name => "name",
-            Self::Description => "description",
-            Self::Guide => "guide",
-            Self::RequiredFilters => "required_filters",
-            Self::Arguments => "arguments",
-            Self::ResultColumns => "result_columns",
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -193,31 +156,6 @@ impl CatalogDiscovery {
         Ok(items)
     }
 
-    pub(crate) async fn search_catalog(
-        &self,
-        workspace_name: &WorkspaceName,
-        pattern: &str,
-        schema_name: Option<&str>,
-        kind: Option<CatalogItemKind>,
-        ignore_case: bool,
-        pagination: Pagination,
-    ) -> Result<Page<CatalogSearchResult>, QueryManagerError> {
-        let regex = compile_metadata_regex(pattern, ignore_case).map_err(QueryManagerError::App)?;
-        let matches = self
-            .catalog_items(workspace_name, schema_name, kind)
-            .await?
-            .into_iter()
-            .filter_map(|item| {
-                let matched_fields = catalog_item_matched_fields(&item, &regex);
-                (!matched_fields.is_empty()).then_some(CatalogSearchResult {
-                    item,
-                    matched_fields,
-                })
-            })
-            .collect();
-        Ok(page_items(matches, pagination))
-    }
-
     pub(crate) async fn describe_table(
         &self,
         workspace_name: &WorkspaceName,
@@ -324,10 +262,6 @@ fn catalog_item_sort_key(item: &CatalogItem) -> (&str, &str, &'static str) {
     }
 }
 
-pub(crate) fn search_pagination(pagination: Option<Pagination>) -> Result<Pagination, AppError> {
-    pagination_with_limits(pagination, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT)
-}
-
 pub(crate) fn column_pagination(pagination: Option<Pagination>) -> Result<Pagination, AppError> {
     pagination_with_limits(pagination, DEFAULT_COLUMN_LIMIT, MAX_COLUMN_LIMIT)
 }
@@ -373,78 +307,6 @@ pub(crate) fn compile_metadata_regex(pattern: &str, ignore_case: bool) -> Result
         .size_limit(REGEX_SIZE_LIMIT_BYTES)
         .build()
         .map_err(|error| AppError::InvalidInput(format!("invalid regex pattern: {error}")))
-}
-
-fn catalog_item_matched_fields(item: &CatalogItem, regex: &Regex) -> Vec<CatalogMetadataField> {
-    match item {
-        CatalogItem::Table(table) => table_matched_fields(table, regex),
-        CatalogItem::TableFunction(function) => table_function_matched_fields(function, regex),
-    }
-}
-
-fn table_matched_fields(table: &TableInfo, regex: &Regex) -> Vec<CatalogMetadataField> {
-    let name = format!("{}.{}", table.schema_name, table.table_name);
-    let candidates = [
-        (CatalogMetadataField::SchemaName, table.schema_name.as_str()),
-        (CatalogMetadataField::TableName, table.table_name.as_str()),
-        (CatalogMetadataField::Name, name.as_str()),
-        (
-            CatalogMetadataField::Description,
-            table.description.as_str(),
-        ),
-        (CatalogMetadataField::Guide, table.guide.as_str()),
-    ];
-    let mut matches = candidates
-        .into_iter()
-        .filter_map(|(field, value)| regex.is_match(value).then_some(field))
-        .collect::<Vec<_>>();
-    if table
-        .required_filters
-        .iter()
-        .any(|filter| regex.is_match(filter))
-    {
-        matches.push(CatalogMetadataField::RequiredFilters);
-    }
-    matches
-}
-
-fn table_function_matched_fields(
-    function: &TableFunctionInfo,
-    regex: &Regex,
-) -> Vec<CatalogMetadataField> {
-    let name = format!("{}.{}", function.schema_name, function.function_name);
-    let candidates = [
-        (
-            CatalogMetadataField::SchemaName,
-            function.schema_name.as_str(),
-        ),
-        (
-            CatalogMetadataField::FunctionName,
-            function.function_name.as_str(),
-        ),
-        (CatalogMetadataField::Name, name.as_str()),
-        (
-            CatalogMetadataField::Description,
-            function.description.as_str(),
-        ),
-    ];
-    let mut matches = candidates
-        .into_iter()
-        .filter_map(|(field, value)| regex.is_match(value).then_some(field))
-        .collect::<Vec<_>>();
-    if function.arguments.iter().any(|argument| {
-        regex.is_match(&argument.name) || argument.values.iter().any(|value| regex.is_match(value))
-    }) {
-        matches.push(CatalogMetadataField::Arguments);
-    }
-    if function.result_columns.iter().any(|column| {
-        regex.is_match(&column.name)
-            || regex.is_match(&column.data_type)
-            || regex.is_match(&column.description)
-    }) {
-        matches.push(CatalogMetadataField::ResultColumns);
-    }
-    matches
 }
 
 fn column_matched_fields(column: &ColumnInfo, regex: &Regex) -> Vec<ColumnMetadataField> {
@@ -532,32 +394,7 @@ pub(crate) fn page_items<T>(items: Vec<T>, pagination: Pagination) -> Page<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CatalogMetadataField, compile_metadata_regex, table_matched_fields};
-    use coral_engine::TableInfo;
-
-    fn table(required_filters: Vec<String>) -> TableInfo {
-        TableInfo {
-            schema_name: "github".to_string(),
-            table_name: "Pull.Requests".to_string(),
-            description: "Pull request table".to_string(),
-            guide: "Query pull requests.".to_string(),
-            columns: Vec::new(),
-            required_filters,
-        }
-    }
-
-    #[test]
-    fn required_filters_match_each_filter_independently() {
-        let summary = table(vec!["owner".to_string(), "repo".to_string()]);
-
-        assert_eq!(
-            table_matched_fields(&summary, &regex::Regex::new("^repo$").expect("regex")),
-            vec![CatalogMetadataField::RequiredFilters]
-        );
-        assert!(
-            table_matched_fields(&summary, &regex::Regex::new("r.r").expect("regex")).is_empty()
-        );
-    }
+    use super::compile_metadata_regex;
 
     #[test]
     fn empty_metadata_pattern_is_invalid() {

--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -4,20 +4,19 @@ use coral_api::v1::catalog_service_server::CatalogService as CatalogServiceApi;
 use coral_api::v1::{
     CatalogItemKind as ProtoCatalogItemKind, DescribeTableRequest, DescribeTableResponse,
     ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListColumnsResponse,
-    PaginationRequest, SearchCatalogRequest, SearchCatalogResponse,
+    PaginationRequest,
 };
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::catalog::discovery::{
     CatalogDiscovery, CatalogItemKind, CatalogTableRef, ListColumnsQuery, Pagination,
-    column_pagination, search_pagination,
+    column_pagination,
 };
 use crate::query::manager::QueryManager;
 use crate::transport::{
-    catalog_item_to_proto, catalog_search_result_to_proto, column_search_result_to_proto,
-    describe_table_response_to_proto, grpc_span, instrument_grpc, pagination_to_proto,
-    query_status, workspace_name_from_proto,
+    catalog_item_to_proto, column_search_result_to_proto, describe_table_response_to_proto,
+    grpc_span, instrument_grpc, pagination_to_proto, query_status, workspace_name_from_proto,
 };
 
 #[derive(Clone)]
@@ -63,49 +62,6 @@ impl CatalogServiceApi for CatalogService {
                     .items
                     .into_iter()
                     .map(|item| catalog_item_to_proto(&workspace_name, item))
-                    .collect(),
-                pagination: Some(pagination),
-            }))
-        })
-        .await
-    }
-
-    async fn search_catalog(
-        &self,
-        request: Request<SearchCatalogRequest>,
-    ) -> Result<Response<SearchCatalogResponse>, Status> {
-        let span = grpc_span(&request);
-        let catalog = self.catalog.clone();
-        instrument_grpc(span, async move {
-            let request = request.into_inner();
-            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let schema_name = optional_trimmed(&request.schema_name);
-            let kind = catalog_item_kind_from_proto(request.kind)?;
-            let pagination = search_pagination(request.pagination.map(pagination_from_proto))
-                .map_err(app_status)?;
-            let page = catalog
-                .search_catalog(
-                    &workspace_name,
-                    &request.pattern,
-                    schema_name,
-                    kind,
-                    request.ignore_case,
-                    pagination,
-                )
-                .await
-                .map_err(query_status)?;
-            let pagination = pagination_to_proto(
-                page.total,
-                page.limit,
-                page.offset,
-                page.has_more,
-                page.next_offset,
-            );
-            Ok(Response::new(SearchCatalogResponse {
-                items: page
-                    .items
-                    .into_iter()
-                    .map(|result| catalog_search_result_to_proto(&workspace_name, result))
                     .collect(),
                 pagination: Some(pagination),
             }))

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -41,6 +41,7 @@ pub mod features;
 mod feedback;
 mod identity;
 mod query;
+mod search;
 mod sources;
 mod state;
 mod storage;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -19,6 +19,7 @@ use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::query::extensions::{
     CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
 };
+use crate::search::observed::ObservedValueIndexer;
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::model::InstalledSource;
@@ -104,7 +105,7 @@ impl QueryManager {
                 let sources = self
                     .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
-                let runtime = self.runtime_config(workspace_name, &sources);
+                let runtime = self.runtime_config_for_execute(workspace_name, &sources);
                 CoralQuery::execute_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -249,6 +250,23 @@ impl QueryManager {
             provider_input_resolver,
         )));
         QueryRuntimeConfig::new(self.runtime_context.clone(), extensions)
+    }
+
+    fn runtime_config_for_execute(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[QuerySource],
+    ) -> QueryRuntimeConfig {
+        let mut runtime = self.runtime_config(workspace_name, selected_sources);
+        runtime
+            .extensions
+            .query_result_observers
+            .push(Arc::new(ObservedValueIndexer::new(
+                self.layout.clone(),
+                workspace_name.clone(),
+                selected_sources,
+            )));
+        runtime
     }
 }
 

--- a/crates/coral-app/src/search/index.rs
+++ b/crates/coral-app/src/search/index.rs
@@ -1,0 +1,1519 @@
+//! Workspace-scoped Tantivy storage for Universal Search retrieval.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{SecondsFormat, Utc};
+use coral_engine::{
+    CatalogInfo, ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo,
+    TableFunctionResultColumnInfo, TableInfo,
+};
+use serde::{Deserialize, Serialize};
+use tantivy::collector::TopDocs;
+use tantivy::query::{BooleanQuery, Occur, Query, QueryParser, TermQuery};
+use tantivy::schema::{
+    Field, IndexRecordOption, STORED, STRING, Schema, TextFieldIndexing, TextOptions, Value as _,
+};
+use tantivy::tokenizer::{LowerCaser, NgramTokenizer, TextAnalyzer};
+use tantivy::{Index, IndexWriter, ReloadPolicy, TantivyDocument, Term};
+use uuid::Uuid;
+
+use crate::sources::SourceName;
+use crate::state::AppStateLayout;
+use crate::storage::fs::ensure_dir;
+use crate::workspaces::WorkspaceName;
+
+pub(crate) const SEARCH_INDEX_SCHEMA_VERSION: u32 = 2;
+
+const OBSERVED_STATE_FILE_NAME: &str = "observed_values.json";
+const TRIGRAM_TOKENIZER: &str = "coral_trigram";
+const TANTIVY_VERSION: &str = "0.26.1";
+const WRITER_MEMORY_BUDGET_BYTES: usize = 50_000_000;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SearchIndexStore {
+    path: PathBuf,
+    index: Index,
+    fields: SearchIndexFields,
+    capabilities: TantivySearchCapabilities,
+}
+
+impl SearchIndexStore {
+    pub(crate) fn replace_workspace_catalog(
+        layout: &AppStateLayout,
+        workspace_name: &WorkspaceName,
+        catalog: &CatalogInfo,
+    ) -> Result<Self, SearchIndexError> {
+        Self::replace_catalog_index(layout.search_index_dir(workspace_name), catalog)
+    }
+
+    pub(crate) fn replace_catalog_index(
+        path: impl Into<PathBuf>,
+        catalog: &CatalogInfo,
+    ) -> Result<Self, SearchIndexError> {
+        let path = path.into();
+        replace_catalog_index_at(&path, catalog)?;
+        Self::open(path)
+    }
+
+    pub(crate) fn open_workspace(
+        layout: &AppStateLayout,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Self, SearchIndexError> {
+        Self::open(layout.search_index_dir(workspace_name))
+    }
+
+    pub(crate) fn open_existing_workspace(
+        layout: &AppStateLayout,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<Self>, SearchIndexError> {
+        let path = layout.search_index_dir(workspace_name);
+        if !path.exists() {
+            return Ok(None);
+        }
+        Self::open(path).map(Some)
+    }
+
+    pub(crate) fn open(path: impl Into<PathBuf>) -> Result<Self, SearchIndexError> {
+        let path = path.into();
+        ensure_dir(&path)?;
+
+        let index = open_or_create_index(&path)?;
+        Self::from_index(path, index)
+    }
+
+    fn from_index(path: PathBuf, index: Index) -> Result<Self, SearchIndexError> {
+        register_tokenizers(&index)?;
+        let fields = SearchIndexFields::from_schema(&index.schema())?;
+        Ok(Self {
+            path,
+            index,
+            fields,
+            capabilities: TantivySearchCapabilities {
+                tantivy_version: TANTIVY_VERSION.to_string(),
+                tokenizer: TRIGRAM_TOKENIZER.to_string(),
+            },
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn capabilities(&self) -> &TantivySearchCapabilities {
+        &self.capabilities
+    }
+
+    pub(crate) fn search_catalog(
+        &self,
+        _workspace_name: &WorkspaceName,
+        terms: &[String],
+        limit: usize,
+    ) -> Result<Vec<CatalogSearchHit>, SearchIndexError> {
+        let Some(query) = self.scoped_query("catalog", terms) else {
+            return Ok(Vec::new());
+        };
+        let docs = self.search_documents(&query, limit)?;
+        let mut hits = docs
+            .into_iter()
+            .filter(|doc| doc_text(doc, self.fields.entity_kind) == "catalog")
+            .map(|doc| CatalogSearchHit {
+                entity_key: doc_text(&doc, self.fields.doc_key),
+                result_type: CatalogSearchResultType::from_str(&doc_text(
+                    &doc,
+                    self.fields.result_type,
+                )),
+                surface_kind: CatalogSearchSurfaceKind::from_str(&doc_text(
+                    &doc,
+                    self.fields.surface_kind,
+                )),
+                schema_name: doc_text(&doc, self.fields.schema_name),
+                surface_name: doc_text(&doc, self.fields.surface_name),
+                name: doc_text(&doc, self.fields.name),
+                data_type: doc_text(&doc, self.fields.data_type),
+                required: doc_text(&doc, self.fields.required) == "true",
+                description: doc_text(&doc, self.fields.description),
+                matched_fields: matched_fields(
+                    terms,
+                    [
+                        ("name", doc_text(&doc, self.fields.name).as_str()),
+                        (
+                            "qualified_name",
+                            doc_text(&doc, self.fields.qualified_name).as_str(),
+                        ),
+                        (
+                            "description",
+                            doc_text(&doc, self.fields.description).as_str(),
+                        ),
+                        (
+                            "searchable_text",
+                            doc_text(&doc, self.fields.searchable_text).as_str(),
+                        ),
+                    ],
+                ),
+                score: 0,
+            })
+            .collect::<Vec<_>>();
+        assign_rank_scores(&mut hits, |hit, score| hit.score = score);
+        Ok(hits)
+    }
+
+    pub(crate) fn upsert_observed_values(
+        &self,
+        _workspace_name: &WorkspaceName,
+        records: Vec<ObservedValueRecord>,
+    ) -> Result<(), SearchIndexError> {
+        if records.is_empty() {
+            return Ok(());
+        }
+
+        let mut state = self.load_observed_state()?;
+        let mut stored = state
+            .records
+            .into_iter()
+            .map(|record| (record.doc_key(), record))
+            .collect::<BTreeMap<_, _>>();
+        let now = now_timestamp();
+        let mut affected_keys = BTreeSet::new();
+
+        for record in records {
+            let key = observed_doc_key(
+                &record.source_name,
+                record.surface_kind,
+                &record.surface_name,
+                &record.column_name,
+                &record.normalized_value_key,
+            );
+            affected_keys.insert(key.clone());
+            stored
+                .entry(key)
+                .and_modify(|existing| {
+                    existing.display_value.clone_from(&record.display_value);
+                    existing.searchable_text.clone_from(&record.searchable_text);
+                    existing.sensitivity_tier = record.sensitivity_tier.as_str().to_string();
+                    existing.suggested_operator = record.suggested_operator.as_str().to_string();
+                    existing.last_observed_at.clone_from(&now);
+                    existing.observed_count = existing
+                        .observed_count
+                        .saturating_add(record.observed_count);
+                })
+                .or_insert_with(|| ObservedValueStoredRecord {
+                    source_name: record.source_name,
+                    surface_kind: record.surface_kind.as_str().to_string(),
+                    surface_name: record.surface_name,
+                    column_name: record.column_name,
+                    normalized_value_key: record.normalized_value_key,
+                    display_value: record.display_value,
+                    searchable_text: record.searchable_text,
+                    sensitivity_tier: record.sensitivity_tier.as_str().to_string(),
+                    suggested_operator: record.suggested_operator.as_str().to_string(),
+                    first_observed_at: now.clone(),
+                    last_observed_at: now.clone(),
+                    observed_count: record.observed_count,
+                });
+        }
+
+        let mut writer = self.writer()?;
+        for key in &affected_keys {
+            let _opstamp = writer.delete_term(Term::from_field_text(self.fields.doc_key, key));
+            if let Some(record) = stored.get(key) {
+                writer.add_document(self.observed_document(record))?;
+            }
+        }
+        writer.commit()?;
+
+        state = ObservedValueState {
+            schema_version: SEARCH_INDEX_SCHEMA_VERSION,
+            records: stored.into_values().collect(),
+        };
+        self.write_observed_state(&state)?;
+        Ok(())
+    }
+
+    pub(crate) fn search_observed_values(
+        &self,
+        _workspace_name: &WorkspaceName,
+        terms: &[String],
+        limit: usize,
+    ) -> Result<Vec<ObservedValueSearchHit>, SearchIndexError> {
+        let Some(query) = self.scoped_query("observed_value", terms) else {
+            return Ok(Vec::new());
+        };
+        let docs = self.search_documents(&query, limit)?;
+        let mut hits = docs
+            .into_iter()
+            .filter(|doc| doc_text(doc, self.fields.entity_kind) == "observed_value")
+            .map(|doc| ObservedValueSearchHit {
+                source_name: doc_text(&doc, self.fields.source_name),
+                surface_name: doc_text(&doc, self.fields.surface_name),
+                column_name: doc_text(&doc, self.fields.column_name),
+                normalized_value_key: doc_text(&doc, self.fields.normalized_value_key),
+                display_value: doc_text(&doc, self.fields.display_value),
+                last_observed_at: doc_text(&doc, self.fields.last_observed_at),
+                score: 0,
+            })
+            .collect::<Vec<_>>();
+        assign_rank_scores(&mut hits, |hit, score| hit.score = score);
+        Ok(hits)
+    }
+
+    pub(crate) fn delete_observed_values_for_source(
+        &self,
+        _workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), SearchIndexError> {
+        let mut state = self.load_observed_state()?;
+        let (removed, retained): (Vec<_>, Vec<_>) = state
+            .records
+            .into_iter()
+            .partition(|record| record.source_name == source_name.as_str());
+        if removed.is_empty() {
+            return Ok(());
+        }
+
+        let mut writer = self.writer()?;
+        for record in &removed {
+            let _opstamp = writer.delete_term(Term::from_field_text(
+                self.fields.doc_key,
+                &record.doc_key(),
+            ));
+        }
+        writer.commit()?;
+
+        state.records = retained;
+        self.write_observed_state(&state)?;
+        Ok(())
+    }
+
+    pub(crate) fn purge_observed_values_before(
+        &self,
+        _workspace_name: &WorkspaceName,
+        cutoff: &str,
+    ) -> Result<(), SearchIndexError> {
+        let mut state = self.load_observed_state()?;
+        let (removed, retained): (Vec<_>, Vec<_>) = state
+            .records
+            .into_iter()
+            .partition(|record| record.last_observed_at.as_str() < cutoff);
+        if removed.is_empty() {
+            return Ok(());
+        }
+
+        let mut writer = self.writer()?;
+        for record in &removed {
+            let _opstamp = writer.delete_term(Term::from_field_text(
+                self.fields.doc_key,
+                &record.doc_key(),
+            ));
+        }
+        writer.commit()?;
+
+        state.records = retained;
+        self.write_observed_state(&state)?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn observed_count_for_test(
+        &self,
+        display_value: &str,
+    ) -> Result<Option<u64>, SearchIndexError> {
+        Ok(self
+            .load_observed_state()?
+            .records
+            .into_iter()
+            .find(|record| record.display_value == display_value)
+            .map(|record| record.observed_count))
+    }
+
+    fn writer(&self) -> Result<IndexWriter, SearchIndexError> {
+        Ok(self.index.writer(WRITER_MEMORY_BUDGET_BYTES)?)
+    }
+
+    fn scoped_query(&self, entity_kind: &'static str, terms: &[String]) -> Option<Box<dyn Query>> {
+        let query_text = tantivy_query_text(terms)?;
+        let mut parser = QueryParser::for_index(
+            &self.index,
+            vec![
+                self.fields.name_text,
+                self.fields.qualified_name_text,
+                self.fields.description_text,
+                self.fields.searchable_text_text,
+                self.fields.value_text,
+            ],
+        );
+        parser.set_field_boost(self.fields.name_text, 4.0);
+        parser.set_field_boost(self.fields.qualified_name_text, 5.0);
+        parser.set_field_boost(self.fields.description_text, 2.0);
+        parser.set_field_boost(self.fields.value_text, 4.0);
+        let (parsed_query, errors) = parser.parse_query_lenient(&query_text);
+        if !errors.is_empty() {
+            tracing::debug!(
+                entity_kind,
+                query = query_text,
+                errors = ?errors,
+                "Tantivy query parser ignored invalid search clauses"
+            );
+        }
+        let kind_query = Box::new(TermQuery::new(
+            Term::from_field_text(self.fields.entity_kind, entity_kind),
+            IndexRecordOption::Basic,
+        ));
+        Some(Box::new(BooleanQuery::new(vec![
+            (Occur::Must, kind_query),
+            (Occur::Must, parsed_query),
+        ])))
+    }
+
+    fn search_documents(
+        &self,
+        query: &dyn Query,
+        limit: usize,
+    ) -> Result<Vec<TantivyDocument>, SearchIndexError> {
+        let reader = self
+            .index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()?;
+        reader.reload()?;
+        let searcher = reader.searcher();
+        let top_docs = searcher.search(query, &TopDocs::with_limit(limit).order_by_score())?;
+        let mut documents = Vec::with_capacity(top_docs.len());
+        for (_score, address) in top_docs {
+            documents.push(searcher.doc(address)?);
+        }
+        Ok(documents)
+    }
+
+    fn catalog_document(&self, record: &CatalogEntityRecord) -> TantivyDocument {
+        let mut doc = TantivyDocument::default();
+        doc.add_text(self.fields.doc_key, &record.entity_key);
+        doc.add_text(self.fields.entity_kind, "catalog");
+        doc.add_text(self.fields.result_type, record.result_type.as_str());
+        doc.add_text(self.fields.surface_kind, record.surface_kind.as_str());
+        doc.add_text(self.fields.schema_name, &record.schema_name);
+        doc.add_text(self.fields.source_name, &record.schema_name);
+        doc.add_text(self.fields.surface_name, &record.surface_name);
+        doc.add_text(self.fields.name, &record.name);
+        doc.add_text(self.fields.qualified_name, &record.qualified_name);
+        doc.add_text(self.fields.data_type, &record.data_type);
+        doc.add_text(
+            self.fields.required,
+            if record.required { "true" } else { "false" },
+        );
+        doc.add_text(self.fields.description, &record.description);
+        doc.add_text(self.fields.searchable_text, &record.searchable_text);
+        doc.add_text(self.fields.name_text, &record.name);
+        doc.add_text(self.fields.qualified_name_text, &record.qualified_name);
+        doc.add_text(self.fields.description_text, &record.description);
+        doc.add_text(self.fields.searchable_text_text, &record.searchable_text);
+        doc
+    }
+
+    fn observed_document(&self, record: &ObservedValueStoredRecord) -> TantivyDocument {
+        let mut doc = TantivyDocument::default();
+        doc.add_text(self.fields.doc_key, record.doc_key());
+        doc.add_text(self.fields.entity_kind, "observed_value");
+        doc.add_text(self.fields.source_name, &record.source_name);
+        doc.add_text(self.fields.schema_name, &record.source_name);
+        doc.add_text(self.fields.surface_kind, &record.surface_kind);
+        doc.add_text(self.fields.surface_name, &record.surface_name);
+        doc.add_text(self.fields.column_name, &record.column_name);
+        doc.add_text(self.fields.name, &record.column_name);
+        doc.add_text(
+            self.fields.qualified_name,
+            format!(
+                "{}.{}.{}",
+                record.source_name, record.surface_name, record.column_name
+            ),
+        );
+        doc.add_text(
+            self.fields.normalized_value_key,
+            &record.normalized_value_key,
+        );
+        doc.add_text(self.fields.display_value, &record.display_value);
+        doc.add_text(self.fields.searchable_text, &record.searchable_text);
+        doc.add_text(self.fields.last_observed_at, &record.last_observed_at);
+        doc.add_text(
+            self.fields.observed_count,
+            record.observed_count.to_string(),
+        );
+        doc.add_text(self.fields.name_text, &record.column_name);
+        doc.add_text(
+            self.fields.qualified_name_text,
+            format!(
+                "{}.{}.{}",
+                record.source_name, record.surface_name, record.column_name
+            ),
+        );
+        doc.add_text(self.fields.searchable_text_text, &record.searchable_text);
+        doc.add_text(self.fields.value_text, &record.display_value);
+        doc
+    }
+
+    fn observed_state_file(&self) -> PathBuf {
+        observed_state_file_for_index(&self.path)
+    }
+
+    fn load_observed_state(&self) -> Result<ObservedValueState, SearchIndexError> {
+        load_observed_state_for_index(&self.path)
+    }
+
+    fn write_observed_state(&self, state: &ObservedValueState) -> Result<(), SearchIndexError> {
+        let path = self.observed_state_file();
+        let temp_path = path.with_extension("json.tmp");
+        fs::write(&temp_path, serde_json::to_vec_pretty(state)?)?;
+        fs::rename(temp_path, path)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TantivySearchCapabilities {
+    pub(crate) tantivy_version: String,
+    pub(crate) tokenizer: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SearchIndexError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Tantivy(#[from] tantivy::TantivyError),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error("Tantivy search index schema is missing required field '{field}'")]
+    MissingField { field: &'static str },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogSearchHit {
+    pub(crate) entity_key: String,
+    pub(crate) result_type: Option<CatalogSearchResultType>,
+    pub(crate) surface_kind: Option<CatalogSearchSurfaceKind>,
+    pub(crate) schema_name: String,
+    pub(crate) surface_name: String,
+    pub(crate) name: String,
+    pub(crate) data_type: String,
+    pub(crate) required: bool,
+    pub(crate) description: String,
+    pub(crate) matched_fields: Vec<String>,
+    pub(crate) score: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatalogSearchResultType {
+    CatalogTable,
+    CatalogTableFunction,
+    ColumnHint,
+    NativeSearchPath,
+}
+
+impl CatalogSearchResultType {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::CatalogTable => "catalog_table",
+            Self::CatalogTableFunction => "catalog_table_function",
+            Self::ColumnHint => "column_hint",
+            Self::NativeSearchPath => "native_search_path",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "catalog_table" => Some(Self::CatalogTable),
+            "catalog_table_function" => Some(Self::CatalogTableFunction),
+            "column_hint" => Some(Self::ColumnHint),
+            "native_search_path" => Some(Self::NativeSearchPath),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum CatalogSearchSurfaceKind {
+    Table,
+    TableFunction,
+}
+
+impl CatalogSearchSurfaceKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Table => "table",
+            Self::TableFunction => "table_function",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "table" => Some(Self::Table),
+            "table_function" => Some(Self::TableFunction),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ObservedValueRecord {
+    pub(crate) source_name: String,
+    pub(crate) surface_kind: ObservedValueSurfaceKind,
+    pub(crate) surface_name: String,
+    pub(crate) column_name: String,
+    pub(crate) normalized_value_key: String,
+    pub(crate) display_value: String,
+    pub(crate) searchable_text: String,
+    pub(crate) sensitivity_tier: ObservedValueSensitivityTier,
+    pub(crate) suggested_operator: ObservedValueSuggestedOperator,
+    pub(crate) observed_count: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ObservedValueSearchHit {
+    pub(crate) source_name: String,
+    pub(crate) surface_name: String,
+    pub(crate) column_name: String,
+    pub(crate) normalized_value_key: String,
+    pub(crate) display_value: String,
+    pub(crate) last_observed_at: String,
+    pub(crate) score: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum ObservedValueSurfaceKind {
+    Table,
+    TableFunction,
+}
+
+impl ObservedValueSurfaceKind {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Table => "table",
+            Self::TableFunction => "table_function",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ObservedValueSensitivityTier {
+    LowRisk,
+}
+
+impl ObservedValueSensitivityTier {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::LowRisk => "low_risk",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ObservedValueSuggestedOperator {
+    Exact,
+}
+
+impl ObservedValueSuggestedOperator {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ObservedValueState {
+    schema_version: u32,
+    records: Vec<ObservedValueStoredRecord>,
+}
+
+impl Default for ObservedValueState {
+    fn default() -> Self {
+        Self {
+            schema_version: SEARCH_INDEX_SCHEMA_VERSION,
+            records: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ObservedValueStoredRecord {
+    source_name: String,
+    surface_kind: String,
+    surface_name: String,
+    column_name: String,
+    normalized_value_key: String,
+    display_value: String,
+    searchable_text: String,
+    sensitivity_tier: String,
+    suggested_operator: String,
+    first_observed_at: String,
+    last_observed_at: String,
+    observed_count: u64,
+}
+
+impl ObservedValueStoredRecord {
+    fn doc_key(&self) -> String {
+        observed_doc_key(
+            &self.source_name,
+            match self.surface_kind.as_str() {
+                "table_function" => ObservedValueSurfaceKind::TableFunction,
+                _ => ObservedValueSurfaceKind::Table,
+            },
+            &self.surface_name,
+            &self.column_name,
+            &self.normalized_value_key,
+        )
+    }
+}
+
+#[derive(Debug)]
+struct CatalogEntityRecord {
+    entity_key: String,
+    result_type: CatalogSearchResultType,
+    surface_kind: CatalogSearchSurfaceKind,
+    schema_name: String,
+    surface_name: String,
+    name: String,
+    qualified_name: String,
+    data_type: String,
+    required: bool,
+    description: String,
+    searchable_text: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SearchIndexFields {
+    doc_key: Field,
+    entity_kind: Field,
+    result_type: Field,
+    surface_kind: Field,
+    source_name: Field,
+    schema_name: Field,
+    surface_name: Field,
+    column_name: Field,
+    name: Field,
+    qualified_name: Field,
+    data_type: Field,
+    required: Field,
+    description: Field,
+    normalized_value_key: Field,
+    display_value: Field,
+    searchable_text: Field,
+    last_observed_at: Field,
+    observed_count: Field,
+    name_text: Field,
+    qualified_name_text: Field,
+    description_text: Field,
+    searchable_text_text: Field,
+    value_text: Field,
+}
+
+impl SearchIndexFields {
+    fn from_schema(schema: &Schema) -> Result<Self, SearchIndexError> {
+        Ok(Self {
+            doc_key: required_field(schema, "doc_key")?,
+            entity_kind: required_field(schema, "entity_kind")?,
+            result_type: required_field(schema, "result_type")?,
+            surface_kind: required_field(schema, "surface_kind")?,
+            source_name: required_field(schema, "source_name")?,
+            schema_name: required_field(schema, "schema_name")?,
+            surface_name: required_field(schema, "surface_name")?,
+            column_name: required_field(schema, "column_name")?,
+            name: required_field(schema, "name")?,
+            qualified_name: required_field(schema, "qualified_name")?,
+            data_type: required_field(schema, "data_type")?,
+            required: required_field(schema, "required")?,
+            description: required_field(schema, "description")?,
+            normalized_value_key: required_field(schema, "normalized_value_key")?,
+            display_value: required_field(schema, "display_value")?,
+            searchable_text: required_field(schema, "searchable_text")?,
+            last_observed_at: required_field(schema, "last_observed_at")?,
+            observed_count: required_field(schema, "observed_count")?,
+            name_text: required_field(schema, "name_text")?,
+            qualified_name_text: required_field(schema, "qualified_name_text")?,
+            description_text: required_field(schema, "description_text")?,
+            searchable_text_text: required_field(schema, "searchable_text_text")?,
+            value_text: required_field(schema, "value_text")?,
+        })
+    }
+}
+
+fn replace_catalog_index_at(path: &Path, catalog: &CatalogInfo) -> Result<(), SearchIndexError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    ensure_dir(parent)?;
+
+    let replacement_path = sibling_index_path(path, "rebuild");
+    if replacement_path.exists() {
+        fs::remove_dir_all(&replacement_path)?;
+    }
+
+    let observed_state = load_observed_state_for_index(path)?;
+    if let Err(error) = build_replacement_index(&replacement_path, catalog, &observed_state) {
+        if let Err(cleanup_error) = fs::remove_dir_all(&replacement_path) {
+            tracing::warn!(
+                path = %replacement_path.display(),
+                error = %cleanup_error,
+                "failed to remove incomplete Tantivy replacement index"
+            );
+        }
+        return Err(error);
+    }
+
+    swap_index_directory(path, &replacement_path)
+}
+
+fn build_replacement_index(
+    path: &Path,
+    catalog: &CatalogInfo,
+    observed_state: &ObservedValueState,
+) -> Result<(), SearchIndexError> {
+    ensure_dir(path)?;
+    let index = Index::create_in_dir(path, search_schema())?;
+    let store = SearchIndexStore::from_index(path.to_path_buf(), index)?;
+    let mut writer = store.writer()?;
+
+    for record in catalog_entity_records(catalog) {
+        writer.add_document(store.catalog_document(&record))?;
+    }
+    for record in &observed_state.records {
+        writer.add_document(store.observed_document(record))?;
+    }
+    writer.commit()?;
+    Ok(())
+}
+
+fn swap_index_directory(path: &Path, replacement_path: &Path) -> Result<(), SearchIndexError> {
+    let old_path = if path.exists() {
+        let old_path = sibling_index_path(path, "old");
+        if old_path.exists() {
+            fs::remove_dir_all(&old_path)?;
+        }
+        fs::rename(path, &old_path)?;
+        Some(old_path)
+    } else {
+        None
+    };
+
+    if let Err(error) = fs::rename(replacement_path, path) {
+        if let Some(old_path) = &old_path
+            && let Err(restore_error) = fs::rename(old_path, path)
+        {
+            tracing::warn!(
+                old_path = %old_path.display(),
+                path = %path.display(),
+                error = %restore_error,
+                "failed to restore previous Tantivy search index after replacement failure"
+            );
+        }
+        return Err(error.into());
+    }
+
+    if let Some(old_path) = old_path
+        && let Err(error) = fs::remove_dir_all(&old_path)
+    {
+        tracing::warn!(
+            path = %old_path.display(),
+            error = %error,
+            "failed to remove replaced Tantivy search index"
+        );
+    }
+    Ok(())
+}
+
+fn sibling_index_path(path: &Path, label: &str) -> PathBuf {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("tantivy");
+    parent.join(format!(".{name}-{label}-{}", Uuid::new_v4()))
+}
+
+fn observed_state_file_for_index(path: &Path) -> PathBuf {
+    path.parent().unwrap_or(path).join(OBSERVED_STATE_FILE_NAME)
+}
+
+fn load_observed_state_for_index(path: &Path) -> Result<ObservedValueState, SearchIndexError> {
+    let path = observed_state_file_for_index(path);
+    if !path.exists() {
+        return Ok(ObservedValueState::default());
+    }
+    let contents = fs::read_to_string(path)?;
+    let mut state: ObservedValueState = serde_json::from_str(&contents)?;
+    if state.schema_version != SEARCH_INDEX_SCHEMA_VERSION {
+        state = ObservedValueState::default();
+    }
+    Ok(state)
+}
+
+fn open_or_create_index(path: &Path) -> Result<Index, SearchIndexError> {
+    let meta_file = path.join("meta.json");
+    if meta_file.exists() {
+        let index = Index::open_in_dir(path)?;
+        if schema_has_required_fields(&index.schema()) {
+            return Ok(index);
+        }
+        fs::remove_dir_all(path)?;
+        ensure_dir(path)?;
+    }
+    Ok(Index::create_in_dir(path, search_schema())?)
+}
+
+fn search_schema() -> Schema {
+    let mut builder = Schema::builder();
+    builder.add_text_field("doc_key", STRING | STORED);
+    builder.add_text_field("entity_kind", STRING | STORED);
+    builder.add_text_field("result_type", STRING | STORED);
+    builder.add_text_field("surface_kind", STRING | STORED);
+    builder.add_text_field("source_name", STRING | STORED);
+    builder.add_text_field("schema_name", STRING | STORED);
+    builder.add_text_field("surface_name", STRING | STORED);
+    builder.add_text_field("column_name", STRING | STORED);
+    builder.add_text_field("name", STRING | STORED);
+    builder.add_text_field("qualified_name", STRING | STORED);
+    builder.add_text_field("data_type", STRING | STORED);
+    builder.add_text_field("required", STRING | STORED);
+    builder.add_text_field("description", stored_text_options());
+    builder.add_text_field("normalized_value_key", STRING | STORED);
+    builder.add_text_field("display_value", stored_text_options());
+    builder.add_text_field("searchable_text", stored_text_options());
+    builder.add_text_field("last_observed_at", STRING | STORED);
+    builder.add_text_field("observed_count", STRING | STORED);
+    builder.add_text_field("name_text", trigram_text_options());
+    builder.add_text_field("qualified_name_text", trigram_text_options());
+    builder.add_text_field("description_text", trigram_text_options());
+    builder.add_text_field("searchable_text_text", trigram_text_options());
+    builder.add_text_field("value_text", trigram_text_options());
+    builder.build()
+}
+
+fn stored_text_options() -> TextOptions {
+    TextOptions::default().set_stored()
+}
+
+fn trigram_text_options() -> TextOptions {
+    TextOptions::default().set_indexing_options(
+        TextFieldIndexing::default()
+            .set_tokenizer(TRIGRAM_TOKENIZER)
+            .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+    )
+}
+
+fn register_tokenizers(index: &Index) -> Result<(), SearchIndexError> {
+    let tokenizer = TextAnalyzer::builder(NgramTokenizer::all_ngrams(3, 3)?)
+        .filter(LowerCaser)
+        .build();
+    index.tokenizers().register(TRIGRAM_TOKENIZER, tokenizer);
+    Ok(())
+}
+
+fn schema_has_required_fields(schema: &Schema) -> bool {
+    [
+        "doc_key",
+        "entity_kind",
+        "result_type",
+        "surface_kind",
+        "source_name",
+        "schema_name",
+        "surface_name",
+        "column_name",
+        "name",
+        "qualified_name",
+        "data_type",
+        "required",
+        "description",
+        "normalized_value_key",
+        "display_value",
+        "searchable_text",
+        "last_observed_at",
+        "observed_count",
+        "name_text",
+        "qualified_name_text",
+        "description_text",
+        "searchable_text_text",
+        "value_text",
+    ]
+    .into_iter()
+    .all(|field| schema.get_field(field).is_ok())
+}
+
+fn required_field(schema: &Schema, field: &'static str) -> Result<Field, SearchIndexError> {
+    schema
+        .get_field(field)
+        .map_err(|_error| SearchIndexError::MissingField { field })
+}
+
+fn catalog_entity_records(catalog: &CatalogInfo) -> Vec<CatalogEntityRecord> {
+    let mut records = Vec::new();
+    for table in &catalog.tables {
+        table_entity_records(table, &mut records);
+    }
+    for function in &catalog.table_functions {
+        table_function_entity_records(function, &mut records);
+    }
+    records
+}
+
+fn table_entity_records(table: &TableInfo, records: &mut Vec<CatalogEntityRecord>) {
+    let qualified_name = qualified_name(&table.schema_name, &table.table_name);
+    records.push(CatalogEntityRecord {
+        entity_key: format!("catalog:table:{qualified_name}"),
+        result_type: CatalogSearchResultType::CatalogTable,
+        surface_kind: CatalogSearchSurfaceKind::Table,
+        schema_name: table.schema_name.clone(),
+        surface_name: table.table_name.clone(),
+        name: table.table_name.clone(),
+        qualified_name: qualified_name.clone(),
+        data_type: String::new(),
+        required: false,
+        description: table.description.clone(),
+        searchable_text: join_search_text([
+            table.schema_name.as_str(),
+            table.table_name.as_str(),
+            qualified_name.as_str(),
+            table.description.as_str(),
+            table.guide.as_str(),
+            table.required_filters.join(" ").as_str(),
+        ]),
+    });
+
+    for column in &table.columns {
+        table_column_record(table, column, records);
+    }
+    for filter in &table.required_filters {
+        table_required_filter_record(table, filter, records);
+    }
+}
+
+fn table_column_record(
+    table: &TableInfo,
+    column: &ColumnInfo,
+    records: &mut Vec<CatalogEntityRecord>,
+) {
+    let surface_name = qualified_name(&table.schema_name, &table.table_name);
+    records.push(CatalogEntityRecord {
+        entity_key: format!("column:table:{surface_name}:{}", column.name),
+        result_type: CatalogSearchResultType::ColumnHint,
+        surface_kind: CatalogSearchSurfaceKind::Table,
+        schema_name: table.schema_name.clone(),
+        surface_name: table.table_name.clone(),
+        name: column.name.clone(),
+        qualified_name: format!("{surface_name}.{}", column.name),
+        data_type: column.data_type.clone(),
+        required: column.is_required_filter,
+        description: column.description.clone(),
+        searchable_text: join_search_text([
+            table.schema_name.as_str(),
+            table.table_name.as_str(),
+            column.name.as_str(),
+            column.data_type.as_str(),
+            column.description.as_str(),
+        ]),
+    });
+}
+
+fn table_required_filter_record(
+    table: &TableInfo,
+    filter: &str,
+    records: &mut Vec<CatalogEntityRecord>,
+) {
+    let surface_name = qualified_name(&table.schema_name, &table.table_name);
+    records.push(CatalogEntityRecord {
+        entity_key: format!("filter:table:{surface_name}:{filter}"),
+        result_type: CatalogSearchResultType::ColumnHint,
+        surface_kind: CatalogSearchSurfaceKind::Table,
+        schema_name: table.schema_name.clone(),
+        surface_name: table.table_name.clone(),
+        name: filter.to_string(),
+        qualified_name: format!("{surface_name}.{filter}"),
+        data_type: String::new(),
+        required: true,
+        description: "Required table filter".to_string(),
+        searchable_text: join_search_text([
+            table.schema_name.as_str(),
+            table.table_name.as_str(),
+            filter,
+            "required table filter",
+        ]),
+    });
+}
+
+fn table_function_entity_records(
+    function: &TableFunctionInfo,
+    records: &mut Vec<CatalogEntityRecord>,
+) {
+    let qualified_name = qualified_name(&function.schema_name, &function.function_name);
+    let arguments = function
+        .arguments
+        .iter()
+        .map(|argument| argument.name.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let result_columns = function
+        .result_columns
+        .iter()
+        .map(|column| column.name.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    records.push(CatalogEntityRecord {
+        entity_key: format!("catalog:function:{qualified_name}"),
+        result_type: CatalogSearchResultType::CatalogTableFunction,
+        surface_kind: CatalogSearchSurfaceKind::TableFunction,
+        schema_name: function.schema_name.clone(),
+        surface_name: function.function_name.clone(),
+        name: function.function_name.clone(),
+        qualified_name: qualified_name.clone(),
+        data_type: String::new(),
+        required: false,
+        description: function.description.clone(),
+        searchable_text: join_search_text([
+            function.schema_name.as_str(),
+            function.function_name.as_str(),
+            qualified_name.as_str(),
+            function.description.as_str(),
+            function.kind.as_str(),
+            arguments.as_str(),
+            result_columns.as_str(),
+        ]),
+    });
+
+    if function.kind == "search" {
+        records.push(CatalogEntityRecord {
+            entity_key: format!("native_search:{qualified_name}"),
+            result_type: CatalogSearchResultType::NativeSearchPath,
+            surface_kind: CatalogSearchSurfaceKind::TableFunction,
+            schema_name: function.schema_name.clone(),
+            surface_name: function.function_name.clone(),
+            name: function.function_name.clone(),
+            qualified_name: qualified_name.clone(),
+            data_type: String::new(),
+            required: false,
+            description: function.description.clone(),
+            searchable_text: join_search_text([
+                function.schema_name.as_str(),
+                function.function_name.as_str(),
+                qualified_name.as_str(),
+                function.description.as_str(),
+                "native search path source scoped table function",
+                arguments.as_str(),
+                result_columns.as_str(),
+            ]),
+        });
+    }
+
+    for argument in &function.arguments {
+        table_function_argument_record(function, argument, records);
+    }
+    for column in &function.result_columns {
+        table_function_result_column_record(function, column, records);
+    }
+}
+
+fn table_function_argument_record(
+    function: &TableFunctionInfo,
+    argument: &TableFunctionArgumentInfo,
+    records: &mut Vec<CatalogEntityRecord>,
+) {
+    let surface_name = qualified_name(&function.schema_name, &function.function_name);
+    let values = argument.values.join(" ");
+    records.push(CatalogEntityRecord {
+        entity_key: format!("argument:function:{surface_name}:{}", argument.name),
+        result_type: CatalogSearchResultType::ColumnHint,
+        surface_kind: CatalogSearchSurfaceKind::TableFunction,
+        schema_name: function.schema_name.clone(),
+        surface_name: function.function_name.clone(),
+        name: argument.name.clone(),
+        qualified_name: format!("{surface_name}.{}", argument.name),
+        data_type: String::new(),
+        required: argument.required,
+        description: "Table function argument".to_string(),
+        searchable_text: join_search_text([
+            function.schema_name.as_str(),
+            function.function_name.as_str(),
+            argument.name.as_str(),
+            values.as_str(),
+            "table function argument",
+        ]),
+    });
+}
+
+fn table_function_result_column_record(
+    function: &TableFunctionInfo,
+    column: &TableFunctionResultColumnInfo,
+    records: &mut Vec<CatalogEntityRecord>,
+) {
+    let surface_name = qualified_name(&function.schema_name, &function.function_name);
+    records.push(CatalogEntityRecord {
+        entity_key: format!("result_column:function:{surface_name}:{}", column.name),
+        result_type: CatalogSearchResultType::ColumnHint,
+        surface_kind: CatalogSearchSurfaceKind::TableFunction,
+        schema_name: function.schema_name.clone(),
+        surface_name: function.function_name.clone(),
+        name: column.name.clone(),
+        qualified_name: format!("{surface_name}.{}", column.name),
+        data_type: column.data_type.clone(),
+        required: false,
+        description: column.description.clone(),
+        searchable_text: join_search_text([
+            function.schema_name.as_str(),
+            function.function_name.as_str(),
+            column.name.as_str(),
+            column.data_type.as_str(),
+            column.description.as_str(),
+            "table function result column",
+        ]),
+    });
+}
+
+fn observed_doc_key(
+    source_name: &str,
+    surface_kind: ObservedValueSurfaceKind,
+    surface_name: &str,
+    column_name: &str,
+    normalized_value_key: &str,
+) -> String {
+    format!(
+        "observed:{}:{}:{}:{}:{}",
+        source_name,
+        surface_kind.as_str(),
+        surface_name,
+        column_name,
+        normalized_value_key
+    )
+}
+
+fn qualified_name(schema_name: &str, surface_name: &str) -> String {
+    format!("{schema_name}.{surface_name}")
+}
+
+fn join_search_text<const N: usize>(parts: [&str; N]) -> String {
+    parts
+        .into_iter()
+        .filter(|part| !part.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn tantivy_query_text(terms: &[String]) -> Option<String> {
+    let phrases = terms
+        .iter()
+        .filter(|term| term.chars().count() >= 3)
+        .map(|term| format!("\"{}\"", escape_tantivy_phrase(term)))
+        .collect::<Vec<_>>();
+    if phrases.is_empty() {
+        None
+    } else {
+        Some(phrases.join(" OR "))
+    }
+}
+
+fn escape_tantivy_phrase(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn matched_fields<const N: usize>(
+    terms: &[String],
+    fields: [(&'static str, &str); N],
+) -> Vec<String> {
+    let mut matched = fields
+        .into_iter()
+        .filter_map(|(field, value)| {
+            let normalized = value.to_ascii_lowercase();
+            terms
+                .iter()
+                .any(|term| normalized.contains(term.as_str()))
+                .then_some(field.to_string())
+        })
+        .collect::<Vec<_>>();
+    matched.sort();
+    matched.dedup();
+    matched
+}
+
+fn doc_text(doc: &TantivyDocument, field: Field) -> String {
+    doc.get_first(field)
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn now_timestamp() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn assign_rank_scores<T>(hits: &mut [T], mut set_score: impl FnMut(&mut T, u32)) {
+    let hit_count = u32::try_from(hits.len()).unwrap_or(u32::MAX);
+    for (position, hit) in hits.iter_mut().enumerate() {
+        let position = u32::try_from(position).unwrap_or(u32::MAX);
+        set_score(hit, hit_count.saturating_sub(position));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use coral_engine::{
+        CatalogInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
+    };
+    use tempfile::tempdir;
+
+    use super::{
+        CatalogSearchResultType, ObservedValueRecord, ObservedValueSensitivityTier,
+        ObservedValueState, ObservedValueSuggestedOperator, ObservedValueSurfaceKind,
+        SEARCH_INDEX_SCHEMA_VERSION, SearchIndexStore, tantivy_query_text,
+    };
+    use crate::state::AppStateLayout;
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn open_workspace_creates_search_index_schema() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let store = SearchIndexStore::open_workspace(&layout, &workspace).expect("store");
+
+        assert_eq!(store.path(), layout.search_index_dir(&workspace));
+        assert_eq!(store.capabilities().tantivy_version, "0.26.1");
+        assert_eq!(store.capabilities().tokenizer, "coral_trigram");
+        assert!(store.path().join("meta.json").exists());
+    }
+
+    #[test]
+    fn catalog_tantivy_supports_bm25_trigram_matches() {
+        let temp = tempdir().expect("tempdir");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let store = SearchIndexStore::replace_catalog_index(
+            temp.path().join("tantivy"),
+            &catalog_with_search_function(),
+        )
+        .expect("replace catalog");
+
+        let hits = store
+            .search_catalog(&workspace, &["commit".to_string()], 10)
+            .expect("search catalog");
+        assert!(
+            hits.iter()
+                .any(|hit| hit.surface_name == "search_deployments")
+        );
+    }
+
+    #[test]
+    fn replace_catalog_indexes_function_metadata() {
+        let temp = tempdir().expect("tempdir");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let path = temp.path().join("tantivy");
+        let store = SearchIndexStore::replace_catalog_index(&path, &catalog_with_search_function())
+            .expect("replace catalog");
+
+        let hits = store
+            .search_catalog(
+                &workspace,
+                &[
+                    "github".to_string(),
+                    "deployments".to_string(),
+                    "sha".to_string(),
+                ],
+                10,
+            )
+            .expect("search catalog");
+
+        assert!(hits.iter().any(|hit| hit.result_type
+            == Some(CatalogSearchResultType::NativeSearchPath)
+            && hit.surface_name == "search_deployments"));
+        assert!(hits.iter().any(|hit| hit.result_type
+            == Some(CatalogSearchResultType::ColumnHint)
+            && hit.name == "sha"));
+
+        let store = SearchIndexStore::replace_catalog_index(
+            &path,
+            &CatalogInfo {
+                tables: Vec::new(),
+                table_functions: Vec::new(),
+            },
+        )
+        .expect("replace empty catalog");
+        let hits = store
+            .search_catalog(&workspace, &["github".to_string()], 10)
+            .expect("search empty catalog");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn replace_catalog_rebuild_preserves_observed_values() {
+        let temp = tempdir().expect("tempdir");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let path = temp.path().join("tantivy");
+        {
+            let store = SearchIndexStore::open(&path).expect("store");
+            store
+                .upsert_observed_values(&workspace, vec![observed_record("payments-api", 1)])
+                .expect("upsert observed");
+        }
+
+        let store = SearchIndexStore::replace_catalog_index(&path, &catalog_with_search_function())
+            .expect("replace catalog");
+
+        assert!(
+            !store
+                .search_catalog(&workspace, &["deployments".to_string()], 10)
+                .expect("search catalog")
+                .is_empty()
+        );
+        let observed_hits = store
+            .search_observed_values(&workspace, &["payments-api".to_string()], 10)
+            .expect("search observed");
+        assert_eq!(observed_hits.len(), 1);
+        assert_eq!(
+            observed_hits.first().expect("observed hit").display_value,
+            "payments-api"
+        );
+    }
+
+    #[test]
+    fn tantivy_query_text_quotes_technical_terms() {
+        assert_eq!(
+            tantivy_query_text(&["github.search_commits".to_string(), "id".to_string()])
+                .expect("query"),
+            "\"github.search_commits\""
+        );
+    }
+
+    #[test]
+    fn observed_values_upsert_count_and_search() {
+        let temp = tempdir().expect("tempdir");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let store = SearchIndexStore::open(temp.path().join("tantivy")).expect("store");
+
+        store
+            .upsert_observed_values(
+                &workspace,
+                vec![
+                    observed_record("payments-api", 2),
+                    observed_record("payments-api", 1),
+                ],
+            )
+            .expect("upsert observed");
+
+        let hits = store
+            .search_observed_values(&workspace, &["payments-api".to_string()], 10)
+            .expect("search observed");
+        assert_eq!(hits.len(), 1);
+        let hit = hits.first().expect("observed hit");
+        assert_eq!(hit.column_name, "service");
+
+        assert_eq!(
+            store
+                .observed_count_for_test("payments-api")
+                .expect("observed state")
+                .expect("stored observed value"),
+            3
+        );
+    }
+
+    #[test]
+    fn observed_values_purge_by_source_and_last_observed_at() {
+        let temp = tempdir().expect("tempdir");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = crate::sources::SourceName::parse("notion").expect("source");
+        let store = SearchIndexStore::open(temp.path().join("tantivy")).expect("store");
+
+        store
+            .upsert_observed_values(
+                &workspace,
+                vec![
+                    observed_record("stale-value", 1),
+                    ObservedValueRecord {
+                        source_name: "notion".to_string(),
+                        display_value: "notion-value".to_string(),
+                        searchable_text: "notion page notion-value".to_string(),
+                        ..observed_record("notion-value", 1)
+                    },
+                ],
+            )
+            .expect("upsert observed");
+
+        let mut state = store.load_observed_state().expect("observed state");
+        for record in &mut state.records {
+            if record.source_name == "github" {
+                record.last_observed_at = "2000-01-01T00:00:00.000Z".to_string();
+            }
+        }
+        store
+            .write_observed_state(&state)
+            .expect("write aged observed state");
+
+        store
+            .purge_observed_values_before(&workspace, "2001-01-01T00:00:00.000Z")
+            .expect("purge stale");
+        assert!(
+            store
+                .search_observed_values(&workspace, &["stale-value".to_string()], 10)
+                .expect("search stale")
+                .is_empty()
+        );
+        assert!(
+            !store
+                .search_observed_values(&workspace, &["notion-value".to_string()], 10)
+                .expect("search fresh")
+                .is_empty()
+        );
+
+        store
+            .delete_observed_values_for_source(&workspace, &source)
+            .expect("delete source values");
+        assert!(
+            store
+                .search_observed_values(&workspace, &["notion-value".to_string()], 10)
+                .expect("search deleted")
+                .is_empty()
+        );
+    }
+
+    fn catalog_with_search_function() -> CatalogInfo {
+        CatalogInfo {
+            tables: Vec::new(),
+            table_functions: vec![TableFunctionInfo {
+                schema_name: "github".to_string(),
+                function_name: "search_deployments".to_string(),
+                description: "Search GitHub deployments".to_string(),
+                arguments: vec![TableFunctionArgumentInfo {
+                    name: "q".to_string(),
+                    required: true,
+                    values: Vec::new(),
+                }],
+                result_columns: vec![TableFunctionResultColumnInfo {
+                    name: "sha".to_string(),
+                    data_type: "Utf8".to_string(),
+                    nullable: false,
+                    description: "Deployment commit SHA".to_string(),
+                }],
+                kind: "search".to_string(),
+                search_limits_json: None,
+            }],
+        }
+    }
+
+    fn observed_record(value: &str, observed_count: u64) -> ObservedValueRecord {
+        ObservedValueRecord {
+            source_name: "github".to_string(),
+            surface_kind: ObservedValueSurfaceKind::Table,
+            surface_name: "deployments".to_string(),
+            column_name: "service".to_string(),
+            normalized_value_key: format!("key:{value}"),
+            display_value: value.to_string(),
+            searchable_text: format!("github deployments service {value}"),
+            sensitivity_tier: ObservedValueSensitivityTier::LowRisk,
+            suggested_operator: ObservedValueSuggestedOperator::Exact,
+            observed_count,
+        }
+    }
+
+    #[test]
+    fn observed_state_version_matches_index_schema_version() {
+        assert_eq!(
+            ObservedValueState::default().schema_version,
+            SEARCH_INDEX_SCHEMA_VERSION
+        );
+    }
+}

--- a/crates/coral-app/src/search/mod.rs
+++ b/crates/coral-app/src/search/mod.rs
@@ -1,0 +1,5 @@
+//! App-owned Universal Search behavior.
+
+pub(crate) mod index;
+pub(crate) mod observed;
+pub(crate) mod service;

--- a/crates/coral-app/src/search/observed.rs
+++ b/crates/coral-app/src/search/observed.rs
@@ -1,0 +1,705 @@
+//! Passive observed-value indexing for successful SQL results.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
+use coral_engine::{QueryResultObserver, QueryResultObserverError, QuerySource};
+use coral_spec::ColumnSpec;
+use serde_json::{Map, Value};
+use sha2::{Digest as _, Sha256};
+use sqlparser::ast::{
+    Expr, Ident, ObjectName, Select, SelectItem, Statement, TableFactor, TableWithJoins,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+use crate::search::index::{
+    ObservedValueRecord, ObservedValueSensitivityTier, ObservedValueSuggestedOperator,
+    ObservedValueSurfaceKind, SearchIndexError, SearchIndexStore,
+};
+use crate::state::AppStateLayout;
+use crate::workspaces::WorkspaceName;
+
+/// Query-result observer that writes direct-provenance cell values into search index storage.
+pub(crate) struct ObservedValueIndexer {
+    layout: AppStateLayout,
+    workspace_name: WorkspaceName,
+    surfaces: Vec<ObservedSurface>,
+}
+
+impl ObservedValueIndexer {
+    pub(crate) fn new(
+        layout: AppStateLayout,
+        workspace_name: WorkspaceName,
+        selected_sources: &[QuerySource],
+    ) -> Self {
+        Self {
+            layout,
+            workspace_name,
+            surfaces: observed_surfaces(selected_sources),
+        }
+    }
+
+    fn observe_result_inner(
+        &self,
+        sql: &str,
+        schema: &Schema,
+        batches: &[RecordBatch],
+    ) -> Result<(), ObservedValueIndexError> {
+        let provenance = resolve_projection_provenance(sql, schema, &self.surfaces);
+        if provenance.iter().all(Option::is_none) {
+            tracing::debug!(
+                "skipping observed-value indexing because result provenance is unknown"
+            );
+            return Ok(());
+        }
+
+        let records = observed_records_from_batches(schema, batches, &provenance)?;
+        if records.is_empty() {
+            return Ok(());
+        }
+
+        let store = SearchIndexStore::open_workspace(&self.layout, &self.workspace_name)?;
+        store.upsert_observed_values(&self.workspace_name, records)?;
+        Ok(())
+    }
+}
+
+impl QueryResultObserver for ObservedValueIndexer {
+    fn name(&self) -> &'static str {
+        "observed_value_indexer"
+    }
+
+    fn observe_result(
+        &self,
+        sql: &str,
+        schema: &Schema,
+        batches: &[RecordBatch],
+    ) -> Result<(), QueryResultObserverError> {
+        if let Err(error) = self.observe_result_inner(sql, schema, batches) {
+            tracing::warn!(
+                error = %error,
+                "observed-value indexing failed; returning SQL result without indexed values"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ObservedValueIndexError {
+    #[error(transparent)]
+    SearchIndex(#[from] SearchIndexError),
+    #[error(transparent)]
+    Arrow(#[from] arrow::error::ArrowError),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone)]
+struct ObservedSurface {
+    source_name: String,
+    surface_kind: ObservedValueSurfaceKind,
+    surface_name: String,
+    column_names: BTreeSet<String>,
+}
+
+impl ObservedSurface {
+    fn allows_column(&self, column_name: &str) -> bool {
+        self.column_names.is_empty()
+            || self
+                .column_names
+                .contains(&normalize_identifier(column_name))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct FieldProvenance {
+    source_name: String,
+    surface_kind: ObservedValueSurfaceKind,
+    surface_name: String,
+    column_name: String,
+}
+
+fn observed_surfaces(selected_sources: &[QuerySource]) -> Vec<ObservedSurface> {
+    let mut surfaces = Vec::new();
+    for source in selected_sources {
+        let source_name = source.source_name().to_string();
+        let spec = source.source_spec();
+        if let Some(http) = spec.as_http() {
+            for table in &http.tables {
+                surfaces.push(observed_surface(
+                    &source_name,
+                    ObservedValueSurfaceKind::Table,
+                    table.name(),
+                    table.columns(),
+                ));
+            }
+            for function in &http.functions {
+                surfaces.push(observed_surface(
+                    &source_name,
+                    ObservedValueSurfaceKind::TableFunction,
+                    &function.name,
+                    &function.columns,
+                ));
+            }
+        }
+        if let Some(file) = spec.as_file() {
+            for table in &file.tables {
+                surfaces.push(observed_surface(
+                    &source_name,
+                    ObservedValueSurfaceKind::Table,
+                    table.name(),
+                    table.columns(),
+                ));
+            }
+        }
+        if let Some(mcp) = spec.as_mcp() {
+            for table in &mcp.tables {
+                surfaces.push(observed_surface(
+                    &source_name,
+                    ObservedValueSurfaceKind::Table,
+                    table.name(),
+                    table.columns(),
+                ));
+            }
+            for function in &mcp.functions {
+                surfaces.push(observed_surface(
+                    &source_name,
+                    ObservedValueSurfaceKind::TableFunction,
+                    function.name(),
+                    function.columns(),
+                ));
+            }
+        }
+    }
+    surfaces
+}
+
+fn observed_surface(
+    source_name: &str,
+    surface_kind: ObservedValueSurfaceKind,
+    surface_name: &str,
+    columns: &[ColumnSpec],
+) -> ObservedSurface {
+    ObservedSurface {
+        source_name: source_name.to_string(),
+        surface_kind,
+        surface_name: surface_name.to_string(),
+        column_names: columns
+            .iter()
+            .map(|column| normalize_identifier(&column.name))
+            .collect(),
+    }
+}
+
+fn resolve_projection_provenance(
+    sql: &str,
+    schema: &Schema,
+    surfaces: &[ObservedSurface],
+) -> Vec<Option<FieldProvenance>> {
+    let empty = vec![None; schema.fields().len()];
+    let Ok(statements) = Parser::parse_sql(&GenericDialect {}, sql) else {
+        return empty;
+    };
+    let [Statement::Query(query)] = statements.as_slice() else {
+        return empty;
+    };
+    let Some(select) = query.body.as_select() else {
+        return empty;
+    };
+    let Some(surface) = select_from_surface(select, surfaces) else {
+        return empty;
+    };
+
+    if let [item] = select.projection.as_slice()
+        && projection_is_wildcard(item)
+    {
+        return schema
+            .fields()
+            .iter()
+            .map(|field| {
+                direct_field_provenance(
+                    surface,
+                    field.name(),
+                    field.name(),
+                    std::slice::from_ref(&surface.surface_name),
+                )
+            })
+            .collect();
+    }
+
+    if select.projection.len() != schema.fields().len() {
+        return empty;
+    }
+
+    let qualifiers = surface_qualifiers(surface);
+    select
+        .projection
+        .iter()
+        .zip(schema.fields().iter())
+        .map(|(item, field)| {
+            projection_column_name(item, &qualifiers).and_then(|column_name| {
+                direct_field_provenance(surface, &column_name, field.name(), &qualifiers)
+            })
+        })
+        .collect()
+}
+
+fn select_from_surface<'a>(
+    select: &Select,
+    surfaces: &'a [ObservedSurface],
+) -> Option<&'a ObservedSurface> {
+    let [from] = select.from.as_slice() else {
+        return None;
+    };
+    if !from.joins.is_empty() {
+        return None;
+    }
+    table_with_joins_surface(from, surfaces)
+}
+
+fn table_with_joins_surface<'a>(
+    from: &TableWithJoins,
+    surfaces: &'a [ObservedSurface],
+) -> Option<&'a ObservedSurface> {
+    match &from.relation {
+        TableFactor::Table { name, args, .. } => {
+            let expected_kind = if args.is_some() {
+                Some(ObservedValueSurfaceKind::TableFunction)
+            } else {
+                Some(ObservedValueSurfaceKind::Table)
+            };
+            resolve_surface_name(name, expected_kind, surfaces)
+        }
+        TableFactor::Function { name, .. } => resolve_surface_name(
+            name,
+            Some(ObservedValueSurfaceKind::TableFunction),
+            surfaces,
+        ),
+        _ => None,
+    }
+}
+
+fn resolve_surface_name<'a>(
+    name: &ObjectName,
+    expected_kind: Option<ObservedValueSurfaceKind>,
+    surfaces: &'a [ObservedSurface],
+) -> Option<&'a ObservedSurface> {
+    let parts = object_name_parts(name)?;
+    let matches = surfaces
+        .iter()
+        .filter(|surface| expected_kind.is_none_or(|kind| surface.surface_kind == kind))
+        .filter(|surface| surface_matches_parts(surface, &parts))
+        .collect::<Vec<_>>();
+    let [surface] = matches.as_slice() else {
+        return None;
+    };
+    Some(*surface)
+}
+
+fn surface_matches_parts(surface: &ObservedSurface, parts: &[String]) -> bool {
+    if let [surface_name] = parts {
+        return same_identifier(surface_name, &surface.surface_name);
+    }
+    if parts.len() < 2 {
+        return false;
+    }
+    for split in 1..parts.len() {
+        let Some(source_parts) = parts.get(..split) else {
+            continue;
+        };
+        let Some(surface_parts) = parts.get(split..) else {
+            continue;
+        };
+        let source = source_parts.join(".");
+        let surface_name = surface_parts.join(".");
+        if same_identifier(&source, &surface.source_name)
+            && same_identifier(&surface_name, &surface.surface_name)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn projection_is_wildcard(item: &SelectItem) -> bool {
+    matches!(
+        item,
+        SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(_, _)
+    )
+}
+
+fn projection_column_name(item: &SelectItem, qualifiers: &[String]) -> Option<String> {
+    match item {
+        SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => {
+            expr_column_name(expr, qualifiers)
+        }
+        SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(_, _) => None,
+    }
+}
+
+fn expr_column_name(expr: &Expr, qualifiers: &[String]) -> Option<String> {
+    match expr {
+        Expr::Identifier(ident) => Some(ident.value.clone()),
+        Expr::CompoundIdentifier(idents) => {
+            let (column, qualifier_parts) = idents.split_last()?;
+            qualifier_matches(qualifier_parts, qualifiers).then(|| column.value.clone())
+        }
+        _ => None,
+    }
+}
+
+fn direct_field_provenance(
+    surface: &ObservedSurface,
+    column_name: &str,
+    output_field_name: &str,
+    _qualifiers: &[String],
+) -> Option<FieldProvenance> {
+    if !surface.allows_column(column_name) || is_sensitive_column(column_name) {
+        return None;
+    }
+    if output_field_name.trim().is_empty() {
+        return None;
+    }
+    Some(FieldProvenance {
+        source_name: surface.source_name.clone(),
+        surface_kind: surface.surface_kind,
+        surface_name: surface.surface_name.clone(),
+        column_name: column_name.to_string(),
+    })
+}
+
+fn surface_qualifiers(surface: &ObservedSurface) -> Vec<String> {
+    let qualified = format!("{}.{}", surface.source_name, surface.surface_name);
+    vec![
+        normalize_identifier(&surface.source_name),
+        normalize_identifier(&surface.surface_name),
+        normalize_identifier(&qualified),
+    ]
+}
+
+fn qualifier_matches(idents: &[Ident], qualifiers: &[String]) -> bool {
+    let parts = idents
+        .iter()
+        .map(|ident| ident.value.clone())
+        .collect::<Vec<_>>();
+    qualifier_matches_parts(&parts, qualifiers)
+}
+
+fn qualifier_matches_parts(parts: &[String], qualifiers: &[String]) -> bool {
+    let qualifier = normalize_identifier(&parts.join("."));
+    qualifiers.iter().any(|known| known == &qualifier)
+}
+
+fn object_name_parts(name: &ObjectName) -> Option<Vec<String>> {
+    name.0
+        .iter()
+        .map(|part| part.as_ident().map(|ident| ident.value.clone()))
+        .collect()
+}
+
+fn observed_records_from_batches(
+    schema: &Schema,
+    batches: &[RecordBatch],
+    provenance: &[Option<FieldProvenance>],
+) -> Result<Vec<ObservedValueRecord>, ObservedValueIndexError> {
+    let mut records = BTreeMap::<ObservedValueRecordKey, ObservedValueRecord>::new();
+    for batch in batches {
+        for row in record_batch_rows(batch)? {
+            for (field_index, field_provenance) in provenance.iter().enumerate() {
+                let Some(field_provenance) = field_provenance else {
+                    continue;
+                };
+                let Some(field) = schema.fields().get(field_index) else {
+                    continue;
+                };
+                let Some(value) = row.get(field.name()) else {
+                    continue;
+                };
+                let Some(display_value) = observed_display_value(value) else {
+                    continue;
+                };
+                let normalized_value_key = normalized_value_key(&display_value);
+                let key = ObservedValueRecordKey {
+                    source_name: field_provenance.source_name.clone(),
+                    surface_kind: field_provenance.surface_kind,
+                    surface_name: field_provenance.surface_name.clone(),
+                    column_name: field_provenance.column_name.clone(),
+                    normalized_value_key: normalized_value_key.clone(),
+                };
+                records
+                    .entry(key)
+                    .and_modify(|record| {
+                        record.observed_count = record.observed_count.saturating_add(1);
+                    })
+                    .or_insert_with(|| ObservedValueRecord {
+                        source_name: field_provenance.source_name.clone(),
+                        surface_kind: field_provenance.surface_kind,
+                        surface_name: field_provenance.surface_name.clone(),
+                        column_name: field_provenance.column_name.clone(),
+                        normalized_value_key,
+                        display_value: display_value.clone(),
+                        searchable_text: observed_searchable_text(field_provenance, &display_value),
+                        sensitivity_tier: ObservedValueSensitivityTier::LowRisk,
+                        suggested_operator: ObservedValueSuggestedOperator::Exact,
+                        observed_count: 1,
+                    });
+            }
+        }
+    }
+    Ok(records.into_values().collect())
+}
+
+fn record_batch_rows(
+    batch: &RecordBatch,
+) -> Result<Vec<Map<String, Value>>, ObservedValueIndexError> {
+    let mut bytes = Vec::new();
+    {
+        let mut writer = arrow::json::ArrayWriter::new(&mut bytes);
+        writer.write(batch)?;
+        writer.finish()?;
+    }
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+fn observed_display_value(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(value) => {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        Value::Bool(value) => Some(value.to_string()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Array(_) | Value::Object(_) => serde_json::to_string(value).ok(),
+    }
+}
+
+fn observed_searchable_text(provenance: &FieldProvenance, display_value: &str) -> String {
+    [
+        provenance.source_name.as_str(),
+        provenance.surface_name.as_str(),
+        provenance.column_name.as_str(),
+        display_value,
+    ]
+    .into_iter()
+    .filter(|part| !part.trim().is_empty())
+    .collect::<Vec<_>>()
+    .join(" ")
+}
+
+fn normalized_value_key(display_value: &str) -> String {
+    let normalized = display_value.trim().to_ascii_lowercase();
+    let digest = Sha256::digest(normalized.as_bytes());
+    format!("{digest:x}")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ObservedValueRecordKey {
+    source_name: String,
+    surface_kind: ObservedValueSurfaceKind,
+    surface_name: String,
+    column_name: String,
+    normalized_value_key: String,
+}
+
+fn is_sensitive_column(column_name: &str) -> bool {
+    let normalized = normalize_identifier(column_name);
+    [
+        "api_key",
+        "apikey",
+        "auth",
+        "authorization",
+        "cookie",
+        "password",
+        "private_key",
+        "refresh_token",
+        "secret",
+        "session",
+        "token",
+    ]
+    .into_iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn same_identifier(left: &str, right: &str) -> bool {
+    normalize_identifier(left) == normalize_identifier(right)
+}
+
+fn normalize_identifier(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use arrow::array::StringArray;
+    use arrow::datatypes::{DataType, Field};
+    use coral_engine::QuerySource;
+    use coral_spec::parse_source_manifest_value;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn indexes_direct_table_values_including_long_text_and_json_strings() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = query_source("fixture");
+        let indexer = ObservedValueIndexer::new(layout.clone(), workspace.clone(), &[source]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("service", DataType::Utf8, true),
+            Field::new("body", DataType::Utf8, true),
+            Field::new("payload", DataType::Utf8, true),
+            Field::new("api_token", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["payments-api", "billing-worker"])),
+                Arc::new(StringArray::from(vec![
+                    "short incident note",
+                    "very long incident body with retry budget exhausted and deploy rollback context",
+                ])),
+                Arc::new(StringArray::from(vec![
+                    r#"{"error":"timeout","region":"us-east-1"}"#,
+                    r#"{"error":"deploy_failed","sha":"abc123"}"#,
+                ])),
+                Arc::new(StringArray::from(vec!["secret-token", "another-secret"])),
+            ],
+        )
+        .expect("batch");
+
+        indexer
+            .observe_result(
+                "SELECT service, body, payload, api_token FROM fixture.messages",
+                &schema,
+                &[batch],
+            )
+            .expect("observer does not fail SQL");
+
+        let store = SearchIndexStore::open_workspace(&layout, &workspace).expect("store");
+        let hits = store
+            .search_observed_values(&workspace, &["deploy_failed".to_string()], 10)
+            .expect("search observed");
+        assert!(hits.iter().any(|hit| hit.column_name == "payload"));
+
+        let hits = store
+            .search_observed_values(&workspace, &["rollback".to_string()], 10)
+            .expect("search observed");
+        assert!(hits.iter().any(|hit| hit.column_name == "body"));
+
+        let hits = store
+            .search_observed_values(&workspace, &["secret-token".to_string()], 10)
+            .expect("search sensitive");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn skips_queries_without_direct_single_surface_provenance() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = query_source("fixture");
+        let indexer = ObservedValueIndexer::new(layout.clone(), workspace.clone(), &[source]);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "service",
+            DataType::Utf8,
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["payments-api"]))],
+        )
+        .expect("batch");
+
+        indexer
+            .observe_result(
+                "SELECT upper(service) AS service FROM fixture.messages",
+                &schema,
+                &[batch],
+            )
+            .expect("observer does not fail SQL");
+
+        let store = SearchIndexStore::open_workspace(&layout, &workspace).expect("store");
+        let hits = store
+            .search_observed_values(&workspace, &["payments-api".to_string()], 10)
+            .expect("search observed");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn duplicate_values_are_aggregated_before_storage() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = query_source("fixture");
+        let indexer = ObservedValueIndexer::new(layout.clone(), workspace.clone(), &[source]);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "service",
+            DataType::Utf8,
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![
+                "payments-api",
+                "payments-api",
+                "payments-api",
+            ]))],
+        )
+        .expect("batch");
+
+        indexer
+            .observe_result("SELECT service FROM fixture.messages", &schema, &[batch])
+            .expect("observer does not fail SQL");
+
+        let store = SearchIndexStore::open_workspace(&layout, &workspace).expect("store");
+        let hits = store
+            .search_observed_values(&workspace, &["payments-api".to_string()], 10)
+            .expect("search observed");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(
+            store
+                .observed_count_for_test("payments-api")
+                .expect("observed state")
+                .expect("observed count"),
+            3
+        );
+    }
+
+    fn query_source(name: &str) -> QuerySource {
+        let manifest = parse_source_manifest_value(json!({
+            "name": name,
+            "version": "0.1.0",
+            "dsl_version": 3,
+            "backend": "file",
+            "tables": [{
+                "name": "messages",
+                "description": "Messages fixture",
+                "format": "jsonl",
+                "source": {
+                    "location": "file:///tmp",
+                    "glob": "**/*.jsonl"
+                },
+                "columns": [
+                    {"name": "service", "type": "Utf8"},
+                    {"name": "body", "type": "Utf8"},
+                    {"name": "payload", "type": "Utf8"},
+                    {"name": "api_token", "type": "Utf8"}
+                ]
+            }]
+        }))
+        .expect("manifest");
+        QuerySource::new(manifest, BTreeMap::new(), BTreeMap::new())
+    }
+}

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -1,0 +1,794 @@
+//! Implements the gRPC `SearchService`.
+
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use chrono::{Duration, SecondsFormat, Utc};
+use coral_api::v1::search_result::Payload;
+use coral_api::v1::search_service_server::SearchService as SearchServiceApi;
+use coral_api::v1::{
+    ColumnHint, NativeSearchPath, ObservedValue, SearchProvider, SearchProviderState,
+    SearchProviderStatus, SearchRequest, SearchResponse, SearchResult, SearchResultTruncation,
+    SearchResultType, SearchSurfaceKind,
+};
+use coral_engine::{CatalogInfo, TableFunctionInfo, TableInfo};
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::{AppError, app_status};
+use crate::query::manager::{QueryManager, QueryManagerError};
+use crate::search::index::{
+    CatalogSearchHit, CatalogSearchResultType, CatalogSearchSurfaceKind, ObservedValueSearchHit,
+    SearchIndexError, SearchIndexStore,
+};
+use crate::sources::SourceName;
+use crate::state::AppStateLayout;
+use crate::transport::{
+    catalog_item_to_proto, grpc_span, instrument_grpc, query_status, table_function_to_proto,
+    workspace_name_from_proto, workspace_to_proto,
+};
+use crate::workspaces::WorkspaceName;
+use tokio::sync::Mutex;
+
+const DEFAULT_SEARCH_LIMIT: u32 = 10;
+const MAX_SEARCH_LIMIT: u32 = 50;
+const MAX_QUERY_BYTES: usize = 512;
+const MAX_COLUMN_HINTS_PER_SURFACE: usize = 2;
+const OBSERVED_VALUE_RETENTION_DAYS: i64 = 90;
+
+#[derive(Clone)]
+pub(crate) struct SearchService {
+    search: UniversalSearch,
+}
+
+impl SearchService {
+    pub(crate) fn new(query_manager: QueryManager, indexes: SearchIndexRefresher) -> Self {
+        Self {
+            search: UniversalSearch::new(query_manager, indexes),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SearchIndexRefresher {
+    layout: AppStateLayout,
+    refreshed_workspaces: Arc<Mutex<BTreeSet<WorkspaceName>>>,
+}
+
+impl SearchIndexRefresher {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self {
+            layout,
+            refreshed_workspaces: Arc::new(Mutex::new(BTreeSet::new())),
+        }
+    }
+
+    async fn refresh_catalog_if_needed(
+        &self,
+        workspace_name: &WorkspaceName,
+        catalog: &CatalogInfo,
+    ) -> Result<SearchIndexStore, SearchIndexError> {
+        let mut refreshed_workspaces = self.refreshed_workspaces.lock().await;
+        let index = if refreshed_workspaces.contains(workspace_name) {
+            SearchIndexStore::open_workspace(&self.layout, workspace_name)?
+        } else {
+            let index =
+                SearchIndexStore::replace_workspace_catalog(&self.layout, workspace_name, catalog)?;
+            refreshed_workspaces.insert(workspace_name.clone());
+            index
+        };
+        Ok(index)
+    }
+
+    pub(crate) async fn mark_catalog_dirty(&self, workspace_name: &WorkspaceName) {
+        self.refreshed_workspaces
+            .lock()
+            .await
+            .remove(workspace_name);
+    }
+
+    pub(crate) fn discard_source_observed_values(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        match SearchIndexStore::open_existing_workspace(&self.layout, workspace_name) {
+            Ok(Some(index)) => {
+                if let Err(error) =
+                    index.delete_observed_values_for_source(workspace_name, source_name)
+                {
+                    tracing::warn!(
+                        workspace = %workspace_name,
+                        source = %source_name,
+                        error = %error,
+                        "failed to discard observed values for mutated source"
+                    );
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(
+                    workspace = %workspace_name,
+                    source = %source_name,
+                    error = %error,
+                    "failed to open search index while discarding observed values"
+                );
+            }
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl SearchServiceApi for SearchService {
+    async fn search(
+        &self,
+        request: Request<SearchRequest>,
+    ) -> Result<Response<SearchResponse>, Status> {
+        let span = grpc_span(&request);
+        let search = self.search.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let limit = search_limit(request.limit).map_err(app_status)?;
+            let response = search
+                .search(&workspace_name, &request.query, limit)
+                .await
+                .map_err(query_status)?;
+            Ok(Response::new(response))
+        })
+        .await
+    }
+}
+
+#[derive(Clone)]
+struct UniversalSearch {
+    queries: QueryManager,
+    indexes: SearchIndexRefresher,
+}
+
+impl UniversalSearch {
+    fn new(query_manager: QueryManager, indexes: SearchIndexRefresher) -> Self {
+        Self {
+            queries: query_manager,
+            indexes,
+        }
+    }
+
+    async fn search(
+        &self,
+        workspace_name: &WorkspaceName,
+        query: &str,
+        limit: u32,
+    ) -> Result<SearchResponse, QueryManagerError> {
+        let terms = query_terms(query).map_err(QueryManagerError::App)?;
+        let catalog = self.queries.list_catalog(workspace_name, None).await?;
+        let (mut candidates, catalog_status) = self
+            .catalog_metadata_candidates(workspace_name, &catalog, &terms, limit)
+            .await;
+        let (observed_candidates, observed_status) =
+            self.observed_value_candidates(workspace_name, &catalog, &terms, limit);
+        candidates.extend(observed_candidates);
+        candidates.sort();
+
+        let total_count = candidates.len();
+        let max_results = usize::try_from(limit).unwrap_or(usize::MAX);
+        let truncated = total_count > max_results;
+        let results = candidates
+            .into_iter()
+            .take(max_results)
+            .map(|candidate| candidate.result)
+            .collect::<Vec<_>>();
+        let returned_count = u32::try_from(results.len()).unwrap_or(u32::MAX);
+        Ok(SearchResponse {
+            results,
+            provider_statuses: vec![
+                SearchProviderStatus {
+                    provider: SearchProvider::CatalogMetadata as i32,
+                    state: catalog_status.state as i32,
+                    note: catalog_status.note,
+                },
+                SearchProviderStatus {
+                    provider: SearchProvider::ObservedValues as i32,
+                    state: observed_status.state as i32,
+                    note: observed_status.note,
+                },
+            ],
+            truncation: Some(SearchResultTruncation {
+                truncated,
+                returned_count,
+                max_results: limit,
+                note: truncation_note(truncated, total_count, max_results),
+            }),
+        })
+    }
+
+    async fn catalog_metadata_candidates(
+        &self,
+        workspace_name: &WorkspaceName,
+        catalog: &CatalogInfo,
+        terms: &QueryTerms,
+        limit: u32,
+    ) -> (Vec<Candidate>, CatalogProviderStatus) {
+        let index = match self
+            .indexes
+            .refresh_catalog_if_needed(workspace_name, catalog)
+            .await
+        {
+            Ok(index) => index,
+            Err(error) => return (Vec::new(), catalog_index_error_status(&error)),
+        };
+        let capabilities = index.capabilities();
+        tracing::debug!(
+            workspace = %workspace_name,
+            tantivy_version = %capabilities.tantivy_version,
+            tokenizer = %capabilities.tokenizer,
+            "using Tantivy catalog search index"
+        );
+        let search_limit = usize::try_from(limit)
+            .unwrap_or(usize::MAX)
+            .saturating_mul(5)
+            .max(25);
+        let hits = match index.search_catalog(workspace_name, &terms.terms, search_limit) {
+            Ok(hits) => hits,
+            Err(error) => return (Vec::new(), catalog_index_error_status(&error)),
+        };
+        let candidates =
+            dedupe_candidates(catalog_candidates_from_hits(workspace_name, catalog, hits));
+        let state = if candidates.is_empty() {
+            SearchProviderState::Empty
+        } else {
+            SearchProviderState::ResultsFound
+        };
+        let note = catalog_provider_note(state, candidates.len());
+        (candidates, CatalogProviderStatus { state, note })
+    }
+
+    fn observed_value_candidates(
+        &self,
+        workspace_name: &WorkspaceName,
+        catalog: &CatalogInfo,
+        terms: &QueryTerms,
+        limit: u32,
+    ) -> (Vec<Candidate>, ObservedProviderStatus) {
+        let index = match SearchIndexStore::open_workspace(&self.indexes.layout, workspace_name) {
+            Ok(index) => index,
+            Err(error) => return (Vec::new(), observed_index_error_status(&error)),
+        };
+        let retention_cutoff = observed_value_retention_cutoff();
+        if let Err(error) = index.purge_observed_values_before(workspace_name, &retention_cutoff) {
+            tracing::warn!(
+                workspace = %workspace_name,
+                error = %error,
+                "failed to purge stale observed values before search"
+            );
+        }
+        let search_limit = usize::try_from(limit)
+            .unwrap_or(usize::MAX)
+            .saturating_mul(3)
+            .max(25);
+        let hits = match index.search_observed_values(workspace_name, &terms.terms, search_limit) {
+            Ok(hits) => hits,
+            Err(error) => return (Vec::new(), observed_index_error_status(&error)),
+        };
+        let live_sources = catalog_source_names(catalog);
+        let candidates = hits
+            .into_iter()
+            .filter(|hit| live_sources.contains(&hit.source_name))
+            .map(|hit| observed_value_candidate(workspace_name, hit))
+            .collect::<Vec<_>>();
+        let state = if candidates.is_empty() {
+            SearchProviderState::Empty
+        } else {
+            SearchProviderState::ResultsFound
+        };
+        let note = observed_provider_note(state, candidates.len());
+        (candidates, ObservedProviderStatus { state, note })
+    }
+}
+
+struct CatalogProviderStatus {
+    state: SearchProviderState,
+    note: String,
+}
+
+struct ObservedProviderStatus {
+    state: SearchProviderState,
+    note: String,
+}
+
+#[derive(Clone)]
+struct Candidate {
+    key: String,
+    score: u32,
+    type_order: u8,
+    result: SearchResult,
+}
+
+impl Eq for Candidate {}
+
+impl PartialEq for Candidate {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+
+impl Ord for Candidate {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (Reverse(self.score), self.type_order, self.key.as_str()).cmp(&(
+            Reverse(other.score),
+            other.type_order,
+            other.key.as_str(),
+        ))
+    }
+}
+
+impl PartialOrd for Candidate {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn dedupe_candidates(candidates: Vec<Candidate>) -> Vec<Candidate> {
+    let mut deduped = BTreeMap::<String, Candidate>::new();
+    for candidate in candidates {
+        deduped
+            .entry(candidate.key.clone())
+            .and_modify(|existing| {
+                if candidate.score > existing.score {
+                    *existing = candidate.clone();
+                }
+            })
+            .or_insert(candidate);
+    }
+    deduped.into_values().collect()
+}
+
+#[derive(Clone, Debug)]
+struct QueryTerms {
+    terms: Vec<String>,
+}
+
+fn search_limit(limit: u32) -> Result<u32, AppError> {
+    if limit == 0 {
+        return Ok(DEFAULT_SEARCH_LIMIT);
+    }
+    if limit > MAX_SEARCH_LIMIT {
+        return Err(AppError::InvalidInput(format!(
+            "search limit must be between 1 and {MAX_SEARCH_LIMIT}"
+        )));
+    }
+    Ok(limit)
+}
+
+fn query_terms(query: &str) -> Result<QueryTerms, AppError> {
+    let query = query.trim();
+    if query.is_empty() {
+        return Err(AppError::InvalidInput(
+            "argument 'query' must not be empty".to_string(),
+        ));
+    }
+    if query.len() > MAX_QUERY_BYTES {
+        return Err(AppError::InvalidInput(format!(
+            "argument 'query' must be at most {MAX_QUERY_BYTES} bytes"
+        )));
+    }
+
+    let normalized_query = normalize(query);
+    let mut terms = query
+        .split(|ch: char| !is_query_token_char(ch))
+        .filter_map(|part| {
+            let part = normalize(part);
+            (part.len() > 1).then_some(part)
+        })
+        .collect::<Vec<_>>();
+    if !terms.iter().any(|term| term == &normalized_query) {
+        terms.push(normalized_query.clone());
+    }
+    terms.sort();
+    terms.dedup();
+
+    Ok(QueryTerms { terms })
+}
+
+fn is_query_token_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '#' | '/' | '@')
+}
+
+fn normalize(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn catalog_candidates_from_hits(
+    workspace_name: &WorkspaceName,
+    catalog: &CatalogInfo,
+    hits: Vec<CatalogSearchHit>,
+) -> Vec<Candidate> {
+    let mut candidates = Vec::new();
+    let mut column_hints_by_surface =
+        BTreeMap::<(CatalogSearchSurfaceKind, String, String), usize>::new();
+    for hit in hits {
+        match hit.result_type {
+            Some(CatalogSearchResultType::CatalogTable) => {
+                if let Some(table) = find_table(catalog, &hit.schema_name, &hit.surface_name) {
+                    candidates.push(Candidate {
+                        key: hit.entity_key,
+                        score: hit.score,
+                        type_order: 1,
+                        result: SearchResult {
+                            r#type: SearchResultType::CatalogItem as i32,
+                            payload: Some(Payload::CatalogItem(catalog_item_to_proto(
+                                workspace_name,
+                                crate::catalog::discovery::CatalogItem::Table(table_summary(table)),
+                            ))),
+                        },
+                    });
+                }
+            }
+            Some(CatalogSearchResultType::CatalogTableFunction) => {
+                if let Some(function) = find_function(catalog, &hit.schema_name, &hit.surface_name)
+                {
+                    candidates.push(Candidate {
+                        key: hit.entity_key,
+                        score: hit.score,
+                        type_order: 1,
+                        result: SearchResult {
+                            r#type: SearchResultType::CatalogItem as i32,
+                            payload: Some(Payload::CatalogItem(catalog_item_to_proto(
+                                workspace_name,
+                                crate::catalog::discovery::CatalogItem::TableFunction(
+                                    function.clone(),
+                                ),
+                            ))),
+                        },
+                    });
+                }
+            }
+            Some(CatalogSearchResultType::ColumnHint) => {
+                let Some(surface_kind) = hit.surface_kind else {
+                    continue;
+                };
+                let count_key = (
+                    surface_kind,
+                    hit.schema_name.clone(),
+                    hit.surface_name.clone(),
+                );
+                let count = column_hints_by_surface.entry(count_key).or_default();
+                if *count >= MAX_COLUMN_HINTS_PER_SURFACE {
+                    continue;
+                }
+                candidates.push(column_hint_candidate(
+                    ColumnHintCandidate {
+                        workspace_name,
+                        schema_name: &hit.schema_name,
+                        surface_name: &hit.surface_name,
+                        surface_kind: surface_kind.to_proto(),
+                        name: &hit.name,
+                        data_type: &hit.data_type,
+                        required: hit.required,
+                        description: &hit.description,
+                        matched_fields: hit.matched_fields,
+                    },
+                    hit.score,
+                ));
+                *count += 1;
+            }
+            Some(CatalogSearchResultType::NativeSearchPath) => {
+                if let Some(function) = find_function(catalog, &hit.schema_name, &hit.surface_name)
+                    && function.kind == "search"
+                {
+                    candidates.push(native_search_path_candidate(
+                        workspace_name,
+                        function,
+                        hit.matched_fields,
+                        hit.score,
+                    ));
+                }
+            }
+            None => {}
+        }
+    }
+
+    candidates
+}
+
+struct ColumnHintCandidate<'a> {
+    workspace_name: &'a WorkspaceName,
+    schema_name: &'a str,
+    surface_name: &'a str,
+    surface_kind: SearchSurfaceKind,
+    name: &'a str,
+    data_type: &'a str,
+    required: bool,
+    description: &'a str,
+    matched_fields: Vec<String>,
+}
+
+impl CatalogSearchSurfaceKind {
+    fn to_proto(self) -> SearchSurfaceKind {
+        match self {
+            Self::Table => SearchSurfaceKind::Table,
+            Self::TableFunction => SearchSurfaceKind::TableFunction,
+        }
+    }
+}
+
+fn column_hint_candidate(input: ColumnHintCandidate<'_>, score: u32) -> Candidate {
+    Candidate {
+        key: format!(
+            "column:{}:{}.{}:{}",
+            input.surface_kind.as_str_name(),
+            input.schema_name,
+            input.surface_name,
+            input.name
+        ),
+        score,
+        type_order: 2,
+        result: SearchResult {
+            r#type: SearchResultType::ColumnHint as i32,
+            payload: Some(Payload::ColumnHint(ColumnHint {
+                workspace: Some(workspace_to_proto(input.workspace_name)),
+                schema_name: input.schema_name.to_string(),
+                surface_name: input.surface_name.to_string(),
+                surface_kind: input.surface_kind as i32,
+                name: input.name.to_string(),
+                data_type: input.data_type.to_string(),
+                required: input.required,
+                description: input.description.to_string(),
+                matched_fields: input.matched_fields,
+            })),
+        },
+    }
+}
+
+fn native_search_path_candidate(
+    workspace_name: &WorkspaceName,
+    function: &TableFunctionInfo,
+    matched_fields: Vec<String>,
+    score: u32,
+) -> Candidate {
+    Candidate {
+        key: format!(
+            "native_search:{}.{}",
+            function.schema_name, function.function_name
+        ),
+        score,
+        type_order: 0,
+        result: SearchResult {
+            r#type: SearchResultType::NativeSearchPath as i32,
+            payload: Some(Payload::NativeSearchPath(NativeSearchPath {
+                table_function: Some(table_function_to_proto(workspace_name, function.clone())),
+                sql_call_example: sql_call_example(function),
+                matched_fields,
+            })),
+        },
+    }
+}
+
+fn observed_value_candidate(
+    _workspace_name: &WorkspaceName,
+    hit: ObservedValueSearchHit,
+) -> Candidate {
+    let value = observed_value_display(&hit.display_value);
+    Candidate {
+        key: format!(
+            "observed:{}:{}:{}:{}:{}",
+            hit.source_name,
+            hit.surface_name,
+            hit.column_name,
+            hit.normalized_value_key,
+            hit.last_observed_at
+        ),
+        score: hit.score,
+        type_order: 0,
+        result: SearchResult {
+            r#type: SearchResultType::ObservedValue as i32,
+            payload: Some(Payload::ObservedValue(ObservedValue {
+                value,
+                schema_name: hit.source_name,
+                surface_name: hit.surface_name,
+                column_name: hit.column_name,
+            })),
+        },
+    }
+}
+
+fn observed_value_display(value: &str) -> String {
+    const MAX_DISPLAY_CHARS: usize = 240;
+    let mut chars = value.chars();
+    let display = chars.by_ref().take(MAX_DISPLAY_CHARS).collect::<String>();
+    if chars.next().is_some() {
+        format!("{display}...")
+    } else {
+        display
+    }
+}
+
+fn table_summary(table: &TableInfo) -> TableInfo {
+    let mut table = table.clone();
+    table.columns.clear();
+    table
+}
+
+fn sql_call_example(function: &TableFunctionInfo) -> String {
+    let args = function
+        .arguments
+        .iter()
+        .filter(|argument| argument.required)
+        .map(|argument| format!("{} => '<{}>'", argument.name, argument.name))
+        .collect::<Vec<_>>();
+    format!(
+        "SELECT * FROM {}.{}({}) LIMIT 10",
+        function.schema_name,
+        function.function_name,
+        args.join(", ")
+    )
+}
+
+fn find_table<'a>(
+    catalog: &'a CatalogInfo,
+    schema_name: &str,
+    table_name: &str,
+) -> Option<&'a TableInfo> {
+    catalog
+        .tables
+        .iter()
+        .find(|table| table.schema_name == schema_name && table.table_name == table_name)
+}
+
+fn find_function<'a>(
+    catalog: &'a CatalogInfo,
+    schema_name: &str,
+    function_name: &str,
+) -> Option<&'a TableFunctionInfo> {
+    catalog.table_functions.iter().find(|function| {
+        function.schema_name == schema_name && function.function_name == function_name
+    })
+}
+
+fn catalog_provider_note(state: SearchProviderState, total_count: usize) -> String {
+    match state {
+        SearchProviderState::ResultsFound => {
+            format!("Catalog metadata returned {total_count} candidate search hints")
+        }
+        SearchProviderState::Empty => "Catalog metadata returned no search hints".to_string(),
+        _ => String::new(),
+    }
+}
+
+fn observed_provider_note(state: SearchProviderState, total_count: usize) -> String {
+    match state {
+        SearchProviderState::ResultsFound => {
+            format!("Observed values returned {total_count} candidate search hints")
+        }
+        SearchProviderState::Empty => "Observed values returned no search hints".to_string(),
+        _ => String::new(),
+    }
+}
+
+fn catalog_index_error_status(error: &SearchIndexError) -> CatalogProviderStatus {
+    CatalogProviderStatus {
+        state: SearchProviderState::Error,
+        note: format!("Catalog metadata search index is unavailable: {error}"),
+    }
+}
+
+fn observed_index_error_status(error: &SearchIndexError) -> ObservedProviderStatus {
+    ObservedProviderStatus {
+        state: SearchProviderState::Error,
+        note: format!("Observed-value search index is unavailable: {error}"),
+    }
+}
+
+fn catalog_source_names(catalog: &CatalogInfo) -> BTreeSet<String> {
+    catalog
+        .tables
+        .iter()
+        .map(|table| table.schema_name.clone())
+        .chain(
+            catalog
+                .table_functions
+                .iter()
+                .map(|function| function.schema_name.clone()),
+        )
+        .collect()
+}
+
+fn observed_value_retention_cutoff() -> String {
+    (Utc::now() - Duration::days(OBSERVED_VALUE_RETENTION_DAYS))
+        .to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn truncation_note(truncated: bool, total_count: usize, max_results: usize) -> String {
+    if truncated {
+        format!("Returned {max_results} of {total_count} search hints")
+    } else {
+        String::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use coral_api::v1::SearchSurfaceKind;
+    use coral_engine::{CatalogInfo, TableInfo};
+    use tempfile::tempdir;
+
+    use super::{SearchIndexRefresher, query_terms};
+    use crate::state::AppStateLayout;
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn query_terms_preserve_identifier_punctuation() {
+        let terms = query_terms("payments-api #eng acme/repo").expect("terms");
+
+        assert!(terms.terms.iter().any(|term| term == "payments-api"));
+        assert!(terms.terms.iter().any(|term| term == "#eng"));
+        assert!(terms.terms.iter().any(|term| term == "acme/repo"));
+    }
+
+    #[test]
+    fn surface_kind_has_stable_proto_names() {
+        assert_eq!(
+            SearchSurfaceKind::Table.as_str_name(),
+            "SEARCH_SURFACE_KIND_TABLE"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_index_refresher_only_refreshes_once_until_forced() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let refresher = SearchIndexRefresher::new(layout);
+
+        let first_catalog = catalog_with_table("messages", "Fixture messages");
+        let second_catalog = catalog_with_table("tasks", "Fixture tasks");
+
+        let index = refresher
+            .refresh_catalog_if_needed(&workspace, &first_catalog)
+            .await
+            .expect("initial refresh");
+        assert!(catalog_has_surface(&index, &workspace, "messages"));
+
+        let index = refresher
+            .refresh_catalog_if_needed(&workspace, &second_catalog)
+            .await
+            .expect("skipped refresh");
+        assert!(catalog_has_surface(&index, &workspace, "messages"));
+        assert!(!catalog_has_surface(&index, &workspace, "tasks"));
+
+        refresher.mark_catalog_dirty(&workspace).await;
+        let index = refresher
+            .refresh_catalog_if_needed(&workspace, &second_catalog)
+            .await
+            .expect("dirty refresh");
+        assert!(!catalog_has_surface(&index, &workspace, "messages"));
+        assert!(catalog_has_surface(&index, &workspace, "tasks"));
+    }
+
+    fn catalog_with_table(table_name: &str, description: &str) -> CatalogInfo {
+        CatalogInfo {
+            tables: vec![TableInfo {
+                schema_name: "fixture".to_string(),
+                table_name: table_name.to_string(),
+                description: description.to_string(),
+                guide: String::new(),
+                columns: Vec::new(),
+                required_filters: Vec::new(),
+            }],
+            table_functions: Vec::new(),
+        }
+    }
+
+    fn catalog_has_surface(
+        index: &crate::search::index::SearchIndexStore,
+        workspace: &WorkspaceName,
+        surface_name: &str,
+    ) -> bool {
+        index
+            .search_catalog(workspace, &[surface_name.to_string()], 10)
+            .expect("search catalog")
+            .iter()
+            .any(|hit| hit.surface_name == surface_name)
+    }
+}

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -34,6 +34,7 @@ use tonic::{Request, Response, Status};
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
 use crate::query::manager::QueryManager;
+use crate::search::service::SearchIndexRefresher;
 use crate::sources::SourceName;
 use crate::sources::manager::{
     CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
@@ -55,13 +56,19 @@ use tokio_stream::StreamExt as _;
 pub(crate) struct SourceService {
     sources: SourceManager,
     queries: QueryManager,
+    search_indexes: SearchIndexRefresher,
 }
 
 impl SourceService {
-    pub(crate) fn new(source_manager: SourceManager, query_manager: QueryManager) -> Self {
+    pub(crate) fn new(
+        source_manager: SourceManager,
+        query_manager: QueryManager,
+        search_indexes: SearchIndexRefresher,
+    ) -> Self {
         Self {
             sources: source_manager,
             queries: query_manager,
+            search_indexes,
         }
     }
 }
@@ -157,6 +164,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<CreateBundledSourceResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let search_indexes = self.search_indexes.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -168,6 +176,9 @@ impl SourceServiceApi for SourceService {
             let installed = sources
                 .create_bundled_source(&workspace_name, &command)
                 .map_err(app_status)?;
+            let source_name = installed.name.clone();
+            search_indexes.mark_catalog_dirty(&workspace_name).await;
+            search_indexes.discard_source_observed_values(&workspace_name, &source_name);
             Ok(Response::new(CreateBundledSourceResponse {
                 source: Some(installed_source_to_proto(&workspace_name, installed)),
             }))
@@ -181,6 +192,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let search_indexes = self.search_indexes.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -198,14 +210,19 @@ impl SourceServiceApi for SourceService {
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        sources
+                        let installed = sources
                             .create_bundled_source_with_oauth(
                                 &workspace_name,
                                 command,
                                 event_sender,
                             )
                             .await
-                            .map_err(app_status)
+                            .map_err(app_status)?;
+                        let source_name = installed.name.clone();
+                        search_indexes.mark_catalog_dirty(&workspace_name).await;
+                        search_indexes
+                            .discard_source_observed_values(&workspace_name, &source_name);
+                        Ok(installed)
                     })
                 });
             Ok(Response::new(Box::pin(stream.map(|response| {
@@ -222,6 +239,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Self::ImportSourceStream>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let search_indexes = self.search_indexes.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -234,6 +252,9 @@ impl SourceServiceApi for SourceService {
                 let installed = sources
                     .import_source(&workspace_name, &command)
                     .map_err(app_status)?;
+                let source_name = installed.name.clone();
+                search_indexes.mark_catalog_dirty(&workspace_name).await;
+                search_indexes.discard_source_observed_values(&workspace_name, &source_name);
                 let response = ImportSourceResponse {
                     event: Some(import_source_response::Event::Source(
                         installed_source_to_proto(&response_workspace_name, installed),
@@ -256,10 +277,15 @@ impl SourceServiceApi for SourceService {
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        sources
+                        let installed = sources
                             .import_source_with_credentials(&workspace_name, command, event_sender)
                             .await
-                            .map_err(app_status)
+                            .map_err(app_status)?;
+                        let source_name = installed.name.clone();
+                        search_indexes.mark_catalog_dirty(&workspace_name).await;
+                        search_indexes
+                            .discard_source_observed_values(&workspace_name, &source_name);
+                        Ok(installed)
                     })
                 });
             Ok(Response::new(stream))
@@ -273,6 +299,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<DeleteSourceResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let search_indexes = self.search_indexes.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -280,6 +307,8 @@ impl SourceServiceApi for SourceService {
             sources
                 .delete_source(&workspace_name, &source_name)
                 .map_err(app_status)?;
+            search_indexes.mark_catalog_dirty(&workspace_name).await;
+            search_indexes.discard_source_observed_values(&workspace_name, &source_name);
             Ok(Response::new(DeleteSourceResponse {}))
         })
         .await

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -86,6 +86,14 @@ impl AppStateLayout {
         self.feedback_dir(workspace_name).join("reports.jsonl")
     }
 
+    pub(crate) fn search_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.workspace_dir(workspace_name).join("search")
+    }
+
+    pub(crate) fn search_index_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.search_dir(workspace_name).join("tantivy")
+    }
+
     pub(crate) fn source_dir(
         &self,
         workspace_name: &WorkspaceName,
@@ -166,6 +174,14 @@ mod tests {
                 .join("default")
                 .join("feedback")
                 .join("reports.jsonl")
+        );
+        assert_eq!(
+            layout.search_index_dir(&workspace_name),
+            config_dir
+                .join("workspaces")
+                .join("default")
+                .join("search")
+                .join("tantivy")
         );
         assert_eq!(
             layout.local_trace_store_dir(),

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -5,8 +5,7 @@ use std::future::Future;
 use coral_api::{
     CORAL_ERROR_DOMAIN, grpc_response_status_code,
     v1::{
-        CatalogItem as ProtoCatalogItem, CatalogSearchResult as ProtoCatalogSearchResult, Column,
-        ColumnSearchResult as ProtoColumnSearchResult,
+        CatalogItem as ProtoCatalogItem, Column, ColumnSearchResult as ProtoColumnSearchResult,
         DescribeTableResponse as ProtoDescribeTableResponse, PaginationResponse, QueryTestFailure,
         QueryTestResult, QueryTestSuccess, Source, Table, TableFunction, TableFunctionArgument,
         TableFunctionResultColumn, TableSummary, ValidateSourceResponse, Workspace, catalog_item,
@@ -23,8 +22,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::{AppError, app_status, core_status};
 use crate::catalog::discovery::{
-    CatalogItem, CatalogMetadataField, CatalogSearchResult, ColumnMetadataField,
-    ColumnSearchResult, DescribeTableResult,
+    CatalogItem, ColumnMetadataField, ColumnSearchResult, DescribeTableResult,
 };
 use crate::query::manager::QueryManagerError;
 use crate::workspaces::WorkspaceName;
@@ -292,21 +290,6 @@ pub(crate) fn catalog_item_to_proto(
     }
 }
 
-pub(crate) fn catalog_search_result_to_proto(
-    workspace_name: &WorkspaceName,
-    result: CatalogSearchResult,
-) -> ProtoCatalogSearchResult {
-    ProtoCatalogSearchResult {
-        item: Some(catalog_item_to_proto(workspace_name, result.item)),
-        matched_fields: result
-            .matched_fields
-            .into_iter()
-            .map(CatalogMetadataField::as_proto_name)
-            .map(str::to_string)
-            .collect(),
-    }
-}
-
 pub(crate) fn table_function_to_proto(
     workspace_name: &WorkspaceName,
     function: coral_engine::TableFunctionInfo,
@@ -335,6 +318,8 @@ pub(crate) fn table_function_to_proto(
                 description: column.description,
             })
             .collect(),
+        kind: function.kind,
+        search_limits_json: function.search_limits_json.unwrap_or_default(),
     }
 }
 

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -13,6 +13,8 @@ mod harness;
 mod oauth_refresh_tests;
 #[path = "grpc/resilience_tests.rs"]
 mod resilience_tests;
+#[path = "grpc/search_tests.rs"]
+mod search_tests;
 #[path = "grpc/server_lifecycle_tests.rs"]
 mod server_lifecycle_tests;
 #[path = "grpc/source_lifecycle_tests.rs"]

--- a/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
+++ b/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
@@ -4,8 +4,7 @@
 )]
 
 use coral_api::v1::{
-    DescribeTableRequest, ListCatalogRequest, ListColumnsRequest, PaginationRequest,
-    SearchCatalogRequest, catalog_item,
+    DescribeTableRequest, ListCatalogRequest, ListColumnsRequest, PaginationRequest, catalog_item,
 };
 use coral_client::default_workspace;
 use tonic::Request;
@@ -14,66 +13,6 @@ use super::harness::{
     GrpcHarness, fixture_manifest_with_functions_yaml, fixture_manifest_with_multiple_tables_yaml,
     fixture_manifest_with_required_filter_yaml,
 };
-
-#[tokio::test]
-async fn search_catalog_matches_metadata_and_paginates_after_filtering() {
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(
-            fixture_manifest_with_functions_yaml(),
-            Vec::new(),
-            Vec::new(),
-        )
-        .await;
-
-    let response = harness
-        .catalog_client()
-        .search_catalog(Request::new(SearchCatalogRequest {
-            workspace: Some(default_workspace()),
-            pattern: "Issue".to_string(),
-            ignore_case: true,
-            schema_name: "searchy".to_string(),
-            kind: 0,
-            pagination: Some(PaginationRequest {
-                limit: 2,
-                offset: 0,
-            }),
-        }))
-        .await
-        .expect("search catalog")
-        .into_inner();
-
-    let pagination = response.pagination.expect("pagination");
-    assert_eq!(pagination.total_count, 2);
-    assert_eq!(pagination.limit, 2);
-    assert_eq!(pagination.offset, 0);
-    assert!(!pagination.has_more);
-    assert_eq!(response.items.len(), 2);
-    let function = match response.items[0]
-        .item
-        .as_ref()
-        .expect("search result")
-        .item
-        .as_ref()
-        .expect("catalog item")
-    {
-        catalog_item::Item::TableFunction(function) => function,
-        catalog_item::Item::Table(_) => panic!("expected table function"),
-    };
-    assert_eq!(function.name, "lookup_issue");
-    assert!(
-        response.items[0]
-            .matched_fields
-            .iter()
-            .any(|field| field == "description")
-    );
-    assert!(
-        response.items[0]
-            .matched_fields
-            .iter()
-            .any(|field| field == "result_columns")
-    );
-}
 
 #[tokio::test]
 async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagination() {
@@ -307,21 +246,6 @@ async fn list_columns_missing_table_takes_precedence_over_invalid_pattern() {
 #[tokio::test]
 async fn invalid_regex_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
-
-    let error = harness
-        .catalog_client()
-        .search_catalog(Request::new(SearchCatalogRequest {
-            workspace: Some(default_workspace()),
-            pattern: "[".to_string(),
-            ignore_case: true,
-            schema_name: String::new(),
-            kind: 0,
-            pagination: None,
-        }))
-        .await
-        .expect_err("invalid catalog regex should fail");
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(error.message().contains("invalid regex pattern"));
 
     harness
         .import_source(

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -7,7 +7,7 @@ use coral_api::v1::{
     ValidateSourceResponse, catalog_item, import_source_response,
 };
 use coral_client::{
-    AppClient, CatalogClient, QueryClient, SourceClient, batches_to_json_rows,
+    AppClient, CatalogClient, QueryClient, SearchClient, SourceClient, batches_to_json_rows,
     decode_execute_sql_response, default_workspace,
     local::{RunningServer, ServerBuilder},
 };
@@ -75,6 +75,10 @@ impl GrpcHarness {
 
     pub(crate) fn query_client(&self) -> QueryClient {
         self.app.query_client()
+    }
+
+    pub(crate) fn search_client(&self) -> SearchClient {
+        self.app.search_client()
     }
 
     pub(crate) async fn import_source(
@@ -362,6 +366,12 @@ pub(crate) fn fixture_manifest_with_functions_yaml() -> String {
             },
             {
                 "name": "search_issues",
+                "kind": "search",
+                "search_limits": {
+                    "default_top_k": 10,
+                    "max_top_k": 100,
+                    "max_calls_per_query": 1,
+                },
                 "description": "Search issues",
                 "args": [
                     {

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -1,0 +1,306 @@
+#![allow(
+    clippy::indexing_slicing,
+    reason = "Proto regression assertions intentionally fail loudly in tests."
+)]
+
+use coral_api::v1::search_result::Payload;
+use coral_api::v1::{
+    DeleteSourceRequest, SearchProvider, SearchProviderState, SearchRequest, SearchResultType,
+    SearchSurfaceKind,
+};
+use coral_client::default_workspace;
+use tantivy::collector::Count;
+use tantivy::query::{BooleanQuery, Occur, TermQuery};
+use tantivy::schema::IndexRecordOption;
+use tantivy::{Index, Term};
+use tonic::Request;
+
+use super::harness::{
+    GrpcHarness, fixture_manifest_with_functions_yaml, fixture_manifest_with_test_queries_yaml,
+};
+
+#[tokio::test]
+async fn search_returns_typed_metadata_and_native_search_results() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            fixture_manifest_with_functions_yaml(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let response = harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: "issue search title".to_string(),
+            limit: 10,
+        }))
+        .await
+        .expect("search")
+        .into_inner();
+
+    assert_provider_state(
+        &response,
+        SearchProvider::CatalogMetadata,
+        SearchProviderState::ResultsFound,
+    );
+    assert_provider_state(
+        &response,
+        SearchProvider::ObservedValues,
+        SearchProviderState::Empty,
+    );
+    assert!(!response.truncation.expect("truncation").truncated);
+    assert!(
+        harness
+            .config_dir()
+            .join("workspaces")
+            .join("default")
+            .join("search")
+            .join("tantivy")
+            .exists(),
+        "search should create the workspace Tantivy search index"
+    );
+    assert!(response.results.iter().any(|result| result.r#type
+        == SearchResultType::NativeSearchPath as i32
+        && matches!(
+            result.payload.as_ref(),
+            Some(Payload::NativeSearchPath(path))
+                if path
+                    .table_function
+                    .as_ref()
+                    .is_some_and(|function| function.name == "search_issues")
+                    && path.sql_call_example.contains("searchy.search_issues")
+                    && path.sql_call_example.contains("q => '<q>'")
+        )));
+    assert!(response.results.iter().any(|result| result.r#type
+        == SearchResultType::CatalogItem as i32
+        && matches!(
+            result.payload.as_ref(),
+            Some(Payload::CatalogItem(item))
+                if item.item.as_ref().is_some_and(|item| match item {
+                    coral_api::v1::catalog_item::Item::TableFunction(function) =>
+                        function.name == "search_issues" && function.kind == "search",
+                    coral_api::v1::catalog_item::Item::Table(_) => false,
+                })
+        )));
+    assert!(response.results.iter().any(|result| result.r#type
+        == SearchResultType::ColumnHint as i32
+        && matches!(
+            result.payload.as_ref(),
+            Some(Payload::ColumnHint(hint))
+                if hint.surface_name == "search_issues"
+                    && hint.surface_kind == SearchSurfaceKind::TableFunction as i32
+                    && hint.name == "title"
+        )));
+}
+
+#[tokio::test]
+async fn search_rejects_empty_and_too_large_queries() {
+    let harness = GrpcHarness::new().await;
+
+    let empty = harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: "   ".to_string(),
+            limit: 10,
+        }))
+        .await
+        .expect_err("empty query should fail");
+    assert_eq!(empty.code(), tonic::Code::InvalidArgument);
+    assert!(empty.message().contains("query"));
+
+    let too_long = harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: "a".repeat(513),
+            limit: 10,
+        }))
+        .await
+        .expect_err("long query should fail");
+    assert_eq!(too_long.code(), tonic::Code::InvalidArgument);
+    assert!(too_long.message().contains("at most 512 bytes"));
+}
+
+#[tokio::test]
+async fn search_returns_observed_values_after_successful_sql() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            fixture_manifest_with_test_queries_yaml(harness.temp_path(), &[]),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let rows = harness
+        .execute_sql_rows("SELECT text FROM local_messages.messages WHERE text = 'hello'")
+        .await;
+    assert_eq!(rows.len(), 1);
+
+    let response = harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: "hello".to_string(),
+            limit: 10,
+        }))
+        .await
+        .expect("search")
+        .into_inner();
+
+    assert_provider_state(
+        &response,
+        SearchProvider::ObservedValues,
+        SearchProviderState::ResultsFound,
+    );
+    assert!(response.results.iter().any(|result| result.r#type
+        == SearchResultType::ObservedValue as i32
+        && matches!(
+            result.payload.as_ref(),
+            Some(Payload::ObservedValue(value))
+                if value.schema_name == "local_messages"
+                    && value.surface_name == "messages"
+                    && value.column_name == "text"
+                    && value.value == "hello"
+        )));
+}
+
+#[tokio::test]
+async fn search_applies_limit_and_reports_truncation() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            fixture_manifest_with_functions_yaml(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let response = harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: "issue".to_string(),
+            limit: 1,
+        }))
+        .await
+        .expect("search")
+        .into_inner();
+    let truncation = response.truncation.expect("truncation");
+
+    assert_eq!(response.results.len(), 1);
+    assert!(truncation.truncated);
+    assert_eq!(truncation.returned_count, 1);
+    assert_eq!(truncation.max_results, 1);
+}
+
+#[tokio::test]
+async fn source_mutations_mark_catalog_search_index_dirty() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_with_functions_yaml();
+    harness
+        .import_source(manifest_yaml.clone(), Vec::new(), Vec::new())
+        .await;
+
+    assert!(!search_index_path(&harness).exists());
+    search(&harness, "issue search title").await;
+    assert!(catalog_entity_count(&harness, "search_issues") > 0);
+
+    let updated_manifest_yaml = manifest_yaml.replace("search_issues", "search_tasks");
+    harness
+        .import_source(updated_manifest_yaml, Vec::new(), Vec::new())
+        .await;
+    assert!(catalog_entity_count(&harness, "search_issues") > 0);
+    assert_eq!(catalog_entity_count(&harness, "search_tasks"), 0);
+
+    search(&harness, "task search title").await;
+    assert_eq!(catalog_entity_count(&harness, "search_issues"), 0);
+    assert!(catalog_entity_count(&harness, "search_tasks") > 0);
+
+    harness
+        .source_client()
+        .delete_source(Request::new(DeleteSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "searchy".to_string(),
+        }))
+        .await
+        .expect("delete source");
+    assert!(total_catalog_entity_count(&harness) > 0);
+
+    search(&harness, "task search title").await;
+    assert_eq!(total_catalog_entity_count(&harness), 0);
+}
+
+async fn search(harness: &GrpcHarness, query: &str) {
+    harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: query.to_string(),
+            limit: 10,
+        }))
+        .await
+        .expect("search");
+}
+
+fn assert_provider_state(
+    response: &coral_api::v1::SearchResponse,
+    provider: SearchProvider,
+    state: SearchProviderState,
+) {
+    let status = response
+        .provider_statuses
+        .iter()
+        .find(|status| status.provider == provider as i32)
+        .expect("provider status");
+    assert_eq!(status.state, state as i32);
+}
+
+fn catalog_entity_count(harness: &GrpcHarness, surface_name: &str) -> u32 {
+    catalog_count_for_terms(harness, vec![("surface_name", surface_name)])
+}
+
+fn total_catalog_entity_count(harness: &GrpcHarness) -> u32 {
+    catalog_count_for_terms(harness, Vec::new())
+}
+
+fn catalog_count_for_terms(harness: &GrpcHarness, terms: Vec<(&str, &str)>) -> u32 {
+    let index = Index::open_in_dir(search_index_path(harness)).expect("open search index");
+    let schema = index.schema();
+    let entity_kind = schema.get_field("entity_kind").expect("entity_kind field");
+    let mut clauses = vec![(
+        Occur::Must,
+        Box::new(TermQuery::new(
+            Term::from_field_text(entity_kind, "catalog"),
+            IndexRecordOption::Basic,
+        )) as Box<dyn tantivy::query::Query>,
+    )];
+    for (field_name, value) in terms {
+        let field = schema.get_field(field_name).expect("field");
+        clauses.push((
+            Occur::Must,
+            Box::new(TermQuery::new(
+                Term::from_field_text(field, value),
+                IndexRecordOption::Basic,
+            )),
+        ));
+    }
+    let query = BooleanQuery::new(clauses);
+    let reader = index.reader().expect("reader");
+    let searcher = reader.searcher();
+    let count = searcher.search(&query, &Count).expect("catalog count");
+    u32::try_from(count).expect("count fits u32")
+}
+
+fn search_index_path(harness: &GrpcHarness) -> std::path::PathBuf {
+    harness
+        .config_dir()
+        .join("workspaces")
+        .join("default")
+        .join("search")
+        .join("tantivy")
+}

--- a/crates/coral-cli/Cargo.toml
+++ b/crates/coral-cli/Cargo.toml
@@ -24,6 +24,7 @@ clap.workspace = true
 clap_complete.workspace = true
 dialoguer.workspace = true
 rust-embed = { workspace = true, optional = true }
+serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tonic.workspace = true
@@ -39,7 +40,6 @@ assert_cmd.workspace = true
 jsonschema.workspace = true
 regex.workspace = true
 rmcp = { workspace = true, features = ["transport-child-process"] }
-serde_json.workspace = true
 tempfile.workspace = true
 tokio-stream.workspace = true
 tonic-types.workspace = true

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -15,6 +15,7 @@ mod embedded_ui;
 pub mod env;
 mod onboard;
 mod query_error;
+mod search_output;
 mod source_ops;
 
 use std::borrow::Cow;
@@ -27,7 +28,7 @@ use clap::{
     Parser, Subcommand, ValueEnum,
 };
 use clap_complete::{Shell, generate};
-use coral_api::v1::ExecuteSqlRequest;
+use coral_api::v1::{ExecuteSqlRequest, SearchRequest};
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
 use coral_client::{
@@ -63,6 +64,8 @@ struct Cli {
 enum Command {
     /// Execute a SQL query
     Sql(SqlArgs),
+    /// Route a clue to likely catalog items, columns, filters, and native search paths
+    Search(SearchArgs),
     /// Manage data sources
     Source(SourceArgs),
     /// Interactive wizard to set up Coral and explore use cases
@@ -204,6 +207,16 @@ fn add_feature_override_args(mut cmd: clap::Command) -> clap::Command {
             );
     }
     cmd
+}
+
+#[derive(Debug, Args)]
+/// Route a clue to likely catalog items, columns, filters, and native search paths
+struct SearchArgs {
+    /// Emit JSON instead of compact text output
+    #[arg(long)]
+    json: bool,
+    /// Clue, identifier, phrase, or partial intent to route
+    query: String,
 }
 
 #[derive(Debug, Args)]
@@ -358,9 +371,11 @@ impl CliError {
 impl Command {
     fn required_runtime(&self) -> RequiredRuntime {
         match self {
-            Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
-                RequiredRuntime::AppClient
-            }
+            Command::Sql(_)
+            | Command::Search(_)
+            | Command::Source(_)
+            | Command::Onboard
+            | Command::McpStdio(_) => RequiredRuntime::AppClient,
             Command::Features(_) | Command::Completion(_) => RequiredRuntime::None,
             #[cfg(feature = "embedded-ui")]
             Command::Ui(_) => RequiredRuntime::None,
@@ -559,7 +574,11 @@ async fn run_no_runtime_command(
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args).await.map_err(Into::into),
-        Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
+        Command::Sql(_)
+        | Command::Search(_)
+        | Command::Source(_)
+        | Command::Onboard
+        | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
         }
     }
@@ -592,6 +611,19 @@ async fn run_app_command(
             };
             let result = decode_execute_sql_response(&response).map_err(anyhow::Error::from)?;
             print_batches(result.batches(), args.format)?;
+        }
+        Command::Search(args) => {
+            let response = app
+                .search_client()
+                .search(Request::new(SearchRequest {
+                    workspace: Some(default_workspace()),
+                    query: args.query,
+                    limit: 0,
+                }))
+                .await
+                .map_err(anyhow::Error::from)?
+                .into_inner();
+            print_search_response(&response, args.json)?;
         }
         Command::Source(args) => run_source(&app, args).await?,
         Command::Onboard => {
@@ -654,6 +686,24 @@ fn run_features(
             store.disable(&feature)?;
             println!("Disabled feature `{feature}` in config.toml.");
         }
+    }
+    Ok(())
+}
+
+fn print_search_response(
+    response: &coral_api::v1::SearchResponse,
+    json: bool,
+) -> Result<(), anyhow::Error> {
+    if json {
+        println!("{}", search_output::search_json(response)?);
+        return Ok(());
+    }
+
+    let rows = search_output::search_rows(response);
+    if rows.is_empty() {
+        println!("No search results.");
+    } else {
+        print_text_table(["Type", "Name", "Details"], rows);
     }
     Ok(())
 }

--- a/crates/coral-cli/src/search_output.rs
+++ b/crates/coral-cli/src/search_output.rs
@@ -1,0 +1,376 @@
+//! Rendering helpers for `coral search`.
+
+use coral_api::v1::catalog_item;
+use coral_api::v1::search_result::Payload;
+use coral_api::v1::{
+    CatalogItem, ColumnHint, NativeSearchPath, ObservedValue, SearchProvider, SearchProviderState,
+    SearchProviderStatus, SearchResponse, SearchResult, SearchResultTruncation, SearchResultType,
+    SearchSurfaceKind, TableFunction, TableFunctionArgument, TableFunctionResultColumn,
+    TableSummary,
+};
+use serde_json::{Value, json};
+
+pub(crate) fn search_rows(response: &SearchResponse) -> Vec<[String; 3]> {
+    response
+        .results
+        .iter()
+        .filter_map(search_result_row)
+        .collect()
+}
+
+pub(crate) fn search_json(response: &SearchResponse) -> Result<String, serde_json::Error> {
+    serde_json::to_string(&search_value(response))
+}
+
+fn search_value(response: &SearchResponse) -> Value {
+    json!({
+        "provider_statuses": response
+            .provider_statuses
+            .iter()
+            .map(provider_status_value)
+            .collect::<Vec<_>>(),
+        "truncation": response
+            .truncation
+            .as_ref()
+            .map_or(Value::Null, truncation_value),
+        "results": response
+            .results
+            .iter()
+            .filter_map(search_result_value)
+            .collect::<Vec<_>>()
+    })
+}
+
+fn search_result_row(result: &SearchResult) -> Option<[String; 3]> {
+    match result.payload.as_ref()? {
+        Payload::CatalogItem(item) => catalog_item_row(item),
+        Payload::ColumnHint(hint) => Some([
+            search_result_type_name(SearchResultType::ColumnHint).to_string(),
+            qualified_field_name(&hint.schema_name, &hint.surface_name, &hint.name),
+            field_details(&hint.data_type, hint.required, &hint.description),
+        ]),
+        Payload::ObservedValue(value) => Some([
+            search_result_type_name(SearchResultType::ObservedValue).to_string(),
+            qualified_field_name(&value.schema_name, &value.surface_name, &value.column_name),
+            value.value.clone(),
+        ]),
+        Payload::NativeSearchPath(path) => native_search_path_row(path),
+    }
+}
+
+fn catalog_item_row(item: &CatalogItem) -> Option<[String; 3]> {
+    match item.item.as_ref()? {
+        catalog_item::Item::Table(table) => Some([
+            search_result_type_name(SearchResultType::CatalogItem).to_string(),
+            qualified_name(&table.schema_name, &table.name),
+            compact_details("table", &table.description),
+        ]),
+        catalog_item::Item::TableFunction(function) => Some([
+            search_result_type_name(SearchResultType::CatalogItem).to_string(),
+            qualified_name(&function.schema_name, &function.name),
+            compact_details("table_function", &function.description),
+        ]),
+    }
+}
+
+fn native_search_path_row(path: &NativeSearchPath) -> Option<[String; 3]> {
+    let function = path.table_function.as_ref()?;
+    Some([
+        search_result_type_name(SearchResultType::NativeSearchPath).to_string(),
+        qualified_name(&function.schema_name, &function.name),
+        if path.sql_call_example.is_empty() {
+            function.description.clone()
+        } else {
+            path.sql_call_example.clone()
+        },
+    ])
+}
+
+fn field_details(data_type: &str, required: bool, description: &str) -> String {
+    let mut parts = Vec::new();
+    if !data_type.is_empty() {
+        parts.push(data_type.to_string());
+    }
+    if required {
+        parts.push("required".to_string());
+    }
+    if !description.is_empty() {
+        parts.push(description.to_string());
+    }
+    parts.join("; ")
+}
+
+fn compact_details(kind: &str, description: &str) -> String {
+    if description.is_empty() {
+        kind.to_string()
+    } else {
+        format!("{kind}; {description}")
+    }
+}
+
+fn provider_status_value(status: &SearchProviderStatus) -> Value {
+    json!({
+        "provider": provider_name(SearchProvider::try_from(status.provider).ok()),
+        "state": provider_state(SearchProviderState::try_from(status.state).ok()),
+        "note": status.note
+    })
+}
+
+fn truncation_value(truncation: &SearchResultTruncation) -> Value {
+    json!({
+        "truncated": truncation.truncated,
+        "returned_count": truncation.returned_count,
+        "max_results": truncation.max_results,
+        "note": truncation.note
+    })
+}
+
+fn search_result_value(result: &SearchResult) -> Option<Value> {
+    match result.payload.as_ref()? {
+        Payload::CatalogItem(item) => catalog_item_value(item),
+        Payload::ColumnHint(hint) => Some(column_hint_value(hint)),
+        Payload::ObservedValue(value) => Some(observed_value(value)),
+        Payload::NativeSearchPath(path) => native_search_path_value(path),
+    }
+}
+
+fn catalog_item_value(item: &CatalogItem) -> Option<Value> {
+    match item.item.as_ref()? {
+        catalog_item::Item::Table(table) => Some(table_summary_value(table)),
+        catalog_item::Item::TableFunction(function) => Some(table_function_value(function)),
+    }
+}
+
+fn table_summary_value(table: &TableSummary) -> Value {
+    json!({
+        "type": search_result_type_name(SearchResultType::CatalogItem),
+        "kind": "table",
+        "schema_name": table.schema_name,
+        "name": qualified_name(&table.schema_name, &table.name),
+        "sql_reference": format_sql_reference(&table.schema_name, &table.name),
+        "description": table.description,
+        "table": {
+            "table_name": table.name,
+            "guide": table.guide,
+            "required_filters": table.required_filters
+        }
+    })
+}
+
+fn table_function_value(function: &TableFunction) -> Value {
+    json!({
+        "type": search_result_type_name(SearchResultType::CatalogItem),
+        "kind": "table_function",
+        "schema_name": function.schema_name,
+        "name": qualified_name(&function.schema_name, &function.name),
+        "sql_reference": format_sql_reference(&function.schema_name, &function.name),
+        "description": function.description,
+        "table_function": {
+            "function_name": function.name,
+            "kind": function.kind,
+            "arguments": function.arguments.iter().map(argument_value).collect::<Vec<_>>(),
+            "result_columns": function
+                .result_columns
+                .iter()
+                .map(result_column_value)
+                .collect::<Vec<_>>()
+        }
+    })
+}
+
+fn column_hint_value(hint: &ColumnHint) -> Value {
+    json!({
+        "type": search_result_type_name(SearchResultType::ColumnHint),
+        "schema_name": hint.schema_name,
+        "surface_name": hint.surface_name,
+        "surface_kind": surface_kind(SearchSurfaceKind::try_from(hint.surface_kind).ok()),
+        "name": hint.name,
+        "data_type": hint.data_type,
+        "required": hint.required,
+        "description": hint.description,
+        "matched_fields": hint.matched_fields
+    })
+}
+
+fn observed_value(value: &ObservedValue) -> Value {
+    json!({
+        "type": search_result_type_name(SearchResultType::ObservedValue),
+        "value": value.value,
+        "schema_name": value.schema_name,
+        "surface_name": value.surface_name,
+        "column_name": value.column_name
+    })
+}
+
+fn native_search_path_value(path: &NativeSearchPath) -> Option<Value> {
+    let function = path.table_function.as_ref()?;
+    Some(json!({
+        "type": search_result_type_name(SearchResultType::NativeSearchPath),
+        "schema_name": function.schema_name,
+        "name": qualified_name(&function.schema_name, &function.name),
+        "sql_reference": format_sql_reference(&function.schema_name, &function.name),
+        "sql_call_example": path.sql_call_example,
+        "description": function.description,
+        "arguments": function.arguments.iter().map(argument_value).collect::<Vec<_>>(),
+        "result_columns": function
+            .result_columns
+            .iter()
+            .map(result_column_value)
+            .collect::<Vec<_>>(),
+        "matched_fields": path.matched_fields
+    }))
+}
+
+fn argument_value(argument: &TableFunctionArgument) -> Value {
+    json!({
+        "name": argument.name,
+        "required": argument.required,
+        "values": argument.values
+    })
+}
+
+fn result_column_value(column: &TableFunctionResultColumn) -> Value {
+    json!({
+        "column_name": column.name,
+        "data_type": column.data_type,
+        "is_nullable": column.nullable,
+        "description": column.description
+    })
+}
+
+fn search_result_type_name(result_type: SearchResultType) -> &'static str {
+    match result_type {
+        SearchResultType::CatalogItem => "catalog_item",
+        SearchResultType::ColumnHint => "column_hint",
+        SearchResultType::ObservedValue => "observed_value",
+        SearchResultType::NativeSearchPath => "native_search_path",
+        SearchResultType::Unspecified => "unknown",
+    }
+}
+
+fn provider_name(provider: Option<SearchProvider>) -> &'static str {
+    match provider {
+        Some(SearchProvider::CatalogMetadata) => "catalog_metadata",
+        Some(SearchProvider::ObservedValues) => "observed_values",
+        Some(SearchProvider::Unspecified) | None => "unknown",
+    }
+}
+
+fn provider_state(state: Option<SearchProviderState>) -> &'static str {
+    match state {
+        Some(SearchProviderState::ResultsFound) => "results_found",
+        Some(SearchProviderState::Empty) => "empty",
+        Some(SearchProviderState::NotEnabled) => "not_enabled",
+        Some(SearchProviderState::Skipped) => "skipped",
+        Some(SearchProviderState::Partial) => "partial",
+        Some(SearchProviderState::Error) => "error",
+        Some(SearchProviderState::Unspecified) | None => "unknown",
+    }
+}
+
+fn surface_kind(kind: Option<SearchSurfaceKind>) -> &'static str {
+    match kind {
+        Some(SearchSurfaceKind::Table) => "table",
+        Some(SearchSurfaceKind::TableFunction) => "table_function",
+        Some(SearchSurfaceKind::Unspecified) | None => "unknown",
+    }
+}
+
+fn qualified_name(schema_name: &str, name: &str) -> String {
+    format!("{schema_name}.{name}")
+}
+
+fn qualified_field_name(schema_name: &str, surface_name: &str, field_name: &str) -> String {
+    format!("{schema_name}.{surface_name}.{field_name}")
+}
+
+fn format_sql_reference(schema_name: &str, name: &str) -> String {
+    format!(
+        "{}.{}",
+        format_sql_identifier(schema_name),
+        format_sql_identifier(name)
+    )
+}
+
+fn format_sql_identifier(identifier: &str) -> String {
+    if identifier_needs_quotes(identifier) {
+        format!("\"{}\"", identifier.replace('"', "\"\""))
+    } else {
+        identifier.to_string()
+    }
+}
+
+fn identifier_needs_quotes(identifier: &str) -> bool {
+    let mut chars = identifier.chars();
+    let Some(first) = chars.next() else {
+        return true;
+    };
+    if !(first.is_ascii_lowercase() || first == '_') {
+        return true;
+    }
+    !chars.all(|char| char.is_ascii_lowercase() || char.is_ascii_digit() || char == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use coral_api::v1::search_result::Payload;
+    use coral_api::v1::{
+        ColumnHint, SearchProvider, SearchProviderState, SearchProviderStatus, SearchResponse,
+        SearchResult, SearchResultTruncation, SearchResultType, SearchSurfaceKind,
+    };
+    use serde_json::Value;
+
+    use super::{search_json, search_rows};
+
+    #[test]
+    fn search_output_renders_rows_and_named_json() {
+        let response = SearchResponse {
+            results: vec![SearchResult {
+                r#type: SearchResultType::ColumnHint as i32,
+                payload: Some(Payload::ColumnHint(ColumnHint {
+                    workspace: None,
+                    schema_name: "github".to_string(),
+                    surface_name: "issues".to_string(),
+                    surface_kind: SearchSurfaceKind::Table as i32,
+                    name: "title".to_string(),
+                    data_type: "Utf8".to_string(),
+                    required: false,
+                    description: "Issue title".to_string(),
+                    matched_fields: vec!["description".to_string()],
+                })),
+            }],
+            provider_statuses: vec![SearchProviderStatus {
+                provider: SearchProvider::CatalogMetadata as i32,
+                state: SearchProviderState::ResultsFound as i32,
+                note: "1 result".to_string(),
+            }],
+            truncation: Some(SearchResultTruncation {
+                truncated: false,
+                returned_count: 1,
+                max_results: 10,
+                note: String::new(),
+            }),
+        };
+
+        assert_eq!(
+            search_rows(&response),
+            vec![[
+                "column_hint".to_string(),
+                "github.issues.title".to_string(),
+                "Utf8; Issue title".to_string()
+            ]]
+        );
+
+        let json: Value =
+            serde_json::from_str(&search_json(&response).expect("json")).expect("parse json");
+        assert_eq!(
+            json.pointer("/provider_statuses/0/provider")
+                .and_then(Value::as_str),
+            Some("catalog_metadata")
+        );
+        assert_eq!(
+            json.pointer("/results/0/type").and_then(Value::as_str),
+            Some("column_hint")
+        );
+    }
+}

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -133,6 +133,99 @@ async fn sql_command_renders_json_output() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn search_command_renders_text_output() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["search", "github issue title"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(stdout.contains("Type"), "expected type header: {stdout}");
+    assert!(
+        stdout.contains("native_search_path"),
+        "expected native search path row: {stdout}"
+    );
+    assert!(
+        stdout.contains("github.search_issues"),
+        "expected qualified search function: {stdout}"
+    );
+    assert!(
+        stdout.contains("github.search_issues(q => '<q>')"),
+        "expected SQL call example: {stdout}"
+    );
+    assert!(
+        stdout.contains("column_hint"),
+        "expected column hint row: {stdout}"
+    );
+    assert!(
+        stdout.contains("github.issues.title"),
+        "expected qualified column hint: {stdout}"
+    );
+
+    let requests = server.search_requests();
+    assert_eq!(requests.len(), 1, "expected one search call");
+    assert_eq!(requests[0].query, "github issue title");
+    assert_eq!(requests[0].limit, 0);
+    assert_default_workspace(requests[0].workspace.as_ref());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_command_renders_json_output() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["search", "--json", "github issue title"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let value: serde_json::Value = serde_json::from_str(stdout.trim()).expect("search JSON output");
+    assert_eq!(
+        value
+            .pointer("/provider_statuses/0/provider")
+            .and_then(serde_json::Value::as_str),
+        Some("catalog_metadata")
+    );
+    assert_eq!(
+        value
+            .pointer("/truncation/returned_count")
+            .and_then(serde_json::Value::as_u64),
+        Some(2)
+    );
+    assert_eq!(
+        value
+            .pointer("/results/0/type")
+            .and_then(serde_json::Value::as_str),
+        Some("native_search_path")
+    );
+    assert_eq!(
+        value
+            .pointer("/results/0/sql_call_example")
+            .and_then(serde_json::Value::as_str),
+        Some("github.search_issues(q => '<q>')")
+    );
+    assert_eq!(
+        value
+            .pointer("/results/1/type")
+            .and_then(serde_json::Value::as_str),
+        Some("column_hint")
+    );
+
+    let requests = server.search_requests();
+    assert_eq!(requests.len(), 1, "expected one search call");
+    assert_eq!(requests[0].query, "github issue title");
+    assert_default_workspace(requests[0].workspace.as_ref());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn source_discover_renders_available_sources() {
     let server = MockServer::start().await;
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -15,9 +15,10 @@ use arrow::record_batch::RecordBatch;
 use assert_cmd::Command;
 use coral_api::v1::catalog_service_server::{CatalogService, CatalogServiceServer};
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
+use coral_api::v1::search_service_server::{SearchService, SearchServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::{
-    CatalogItem, CatalogSearchResult, Column, ColumnSearchResult, CreateBundledSourceRequest,
+    CatalogItem, Column, ColumnHint, ColumnSearchResult, CreateBundledSourceRequest,
     CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
     CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DeleteSourceResponse,
     DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
@@ -25,11 +26,13 @@ use coral_api::v1::{
     GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest, GetSourceResponse,
     ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
     ListColumnsRequest, ListColumnsResponse, ListSourcesRequest, ListSourcesResponse,
-    PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse,
-    Source, SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput,
-    Table, TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
-    create_bundled_source_with_o_auth_response, import_source_response,
-    source_input_spec::Input as ProtoSourceInput,
+    NativeSearchPath, PaginationRequest, PaginationResponse, QueryPlan, SearchProvider,
+    SearchProviderState, SearchProviderStatus, SearchRequest, SearchResponse, SearchResult,
+    SearchResultTruncation, SearchResultType, SearchSurfaceKind, Source, SourceCredentialStorage,
+    SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableFunction,
+    TableFunctionArgument, TableFunctionResultColumn, TableSummary, ValidateSourceRequest,
+    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
+    import_source_response, search_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
 use tempfile::TempDir;
@@ -125,6 +128,29 @@ fn mock_visible_tables() -> Vec<Table> {
     vec![events, messages, sessions]
 }
 
+fn mock_search_function() -> TableFunction {
+    TableFunction {
+        workspace: Some(workspace()),
+        schema_name: "github".to_string(),
+        name: "search_issues".to_string(),
+        description: "Provider-native issue search".to_string(),
+        arguments: vec![TableFunctionArgument {
+            name: "q".to_string(),
+            required: true,
+            values: Vec::new(),
+        }],
+        result_columns: vec![TableFunctionResultColumn {
+            name: "title".to_string(),
+            data_type: "Utf8".to_string(),
+            nullable: false,
+            description: "Issue title".to_string(),
+        }],
+        kind: "search".to_string(),
+        search_limits_json: r#"{"default_top_k":10,"max_top_k":100,"max_calls_per_query":1}"#
+            .to_string(),
+    }
+}
+
 fn table_summary(table: &Table) -> TableSummary {
     TableSummary {
         workspace: table.workspace.clone(),
@@ -167,29 +193,6 @@ fn paginate<T>(items: Vec<T>, pagination: PaginationRequest) -> (Vec<T>, Paginat
             next_offset,
         },
     )
-}
-
-fn table_matched_fields(table: &Table, regex: &regex::Regex) -> Vec<String> {
-    let name = format!("{}.{}", table.schema_name, table.name);
-    let candidates = [
-        ("schema_name", table.schema_name.as_str()),
-        ("table_name", table.name.as_str()),
-        ("name", name.as_str()),
-        ("description", table.description.as_str()),
-        ("guide", table.guide.as_str()),
-    ];
-    let mut matches = candidates
-        .into_iter()
-        .filter_map(|(field, value)| regex.is_match(value).then_some(field.to_string()))
-        .collect::<Vec<_>>();
-    if table
-        .required_filters
-        .iter()
-        .any(|filter| regex.is_match(filter))
-    {
-        matches.push("required_filters".to_string());
-    }
-    matches
 }
 
 fn column_matched_fields(column: &Column, regex: &regex::Regex) -> Vec<String> {
@@ -315,6 +318,53 @@ fn mock_validate_response() -> ValidateSourceResponse {
     }
 }
 
+fn mock_search_response() -> SearchResponse {
+    SearchResponse {
+        results: vec![
+            SearchResult {
+                r#type: SearchResultType::NativeSearchPath as i32,
+                payload: Some(search_result::Payload::NativeSearchPath(NativeSearchPath {
+                    table_function: Some(mock_search_function()),
+                    sql_call_example: "github.search_issues(q => '<q>')".to_string(),
+                    matched_fields: vec!["description".to_string()],
+                })),
+            },
+            SearchResult {
+                r#type: SearchResultType::ColumnHint as i32,
+                payload: Some(search_result::Payload::ColumnHint(ColumnHint {
+                    workspace: Some(workspace()),
+                    schema_name: "github".to_string(),
+                    surface_name: "issues".to_string(),
+                    surface_kind: SearchSurfaceKind::Table as i32,
+                    name: "title".to_string(),
+                    data_type: "Utf8".to_string(),
+                    required: false,
+                    description: "Issue title".to_string(),
+                    matched_fields: vec!["description".to_string()],
+                })),
+            },
+        ],
+        provider_statuses: vec![
+            SearchProviderStatus {
+                provider: SearchProvider::CatalogMetadata as i32,
+                state: SearchProviderState::ResultsFound as i32,
+                note: "2 results".to_string(),
+            },
+            SearchProviderStatus {
+                provider: SearchProvider::ObservedValues as i32,
+                state: SearchProviderState::NotEnabled as i32,
+                note: "observed-value index is not enabled".to_string(),
+            },
+        ],
+        truncation: Some(SearchResultTruncation {
+            truncated: false,
+            returned_count: 2,
+            max_results: 10,
+            note: String::new(),
+        }),
+    }
+}
+
 fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
     match name {
         "github" => Ok(SourceInfo {
@@ -430,6 +480,7 @@ impl<T> MockResult<T> {
 #[derive(Clone)]
 pub(crate) struct MockServerConfig {
     execute_sql_override: Option<MockResult<ExecuteSqlResponse>>,
+    search: MockResult<SearchResponse>,
     discover_sources: MockResult<DiscoverSourcesResponse>,
     list_sources: MockResult<ListSourcesResponse>,
     validate_source: MockResult<ValidateSourceResponse>,
@@ -440,6 +491,7 @@ impl Default for MockServerConfig {
     fn default() -> Self {
         Self {
             execute_sql_override: None,
+            search: MockResult::ok(mock_search_response()),
             discover_sources: MockResult::ok(mock_discover_response()),
             list_sources: MockResult::ok(ListSourcesResponse {
                 sources: vec![
@@ -487,6 +539,16 @@ impl MockServerConfig {
 
     pub(crate) fn with_execute_sql_error(mut self, code: Code, message: impl Into<String>) -> Self {
         self.execute_sql_override = Some(MockResult::err(code, message));
+        self
+    }
+
+    pub(crate) fn with_search_response(mut self, response: SearchResponse) -> Self {
+        self.search = MockResult::ok(response);
+        self
+    }
+
+    pub(crate) fn with_search_error(mut self, code: Code, message: impl Into<String>) -> Self {
+        self.search = MockResult::err(code, message);
         self
     }
 
@@ -558,8 +620,8 @@ fn list_catalog_response(request: &ListCatalogRequest) -> ListCatalogResponse {
 #[derive(Default)]
 struct Captured {
     execute_sql: Mutex<Vec<ExecuteSqlRequest>>,
+    search: Mutex<Vec<SearchRequest>>,
     list_catalog: Mutex<Vec<ListCatalogRequest>>,
-    search_catalog: Mutex<Vec<SearchCatalogRequest>>,
     describe_table: Mutex<Vec<DescribeTableRequest>>,
     list_columns: Mutex<Vec<ListColumnsRequest>>,
     discover_sources: Mutex<Vec<DiscoverSourcesRequest>>,
@@ -571,6 +633,29 @@ struct Captured {
     import_source: Mutex<Vec<ImportSourceRequest>>,
     delete_source: Mutex<Vec<DeleteSourceRequest>>,
     validate_source: Mutex<Vec<ValidateSourceRequest>>,
+}
+
+#[derive(Clone)]
+struct MockSearchService {
+    config: Arc<MockServerConfig>,
+    captured: Arc<Captured>,
+}
+
+#[tonic::async_trait]
+impl SearchService for MockSearchService {
+    async fn search(
+        &self,
+        request: Request<SearchRequest>,
+    ) -> Result<Response<SearchResponse>, Status> {
+        self.captured
+            .search
+            .lock()
+            .expect("search capture")
+            .push(request.into_inner());
+        Ok(Response::new(
+            self.config.search.clone().into_tonic_result()?,
+        ))
+    }
 }
 
 pub(crate) fn encode_arrow_ipc_stream(
@@ -655,49 +740,6 @@ impl CatalogService for MockCatalogService {
             .expect("list_catalog capture")
             .push(request.clone());
         Ok(Response::new(list_catalog_response(&request)))
-    }
-
-    async fn search_catalog(
-        &self,
-        request: Request<SearchCatalogRequest>,
-    ) -> Result<Response<SearchCatalogResponse>, Status> {
-        let request = request.into_inner();
-        self.captured
-            .search_catalog
-            .lock()
-            .expect("search_catalog capture")
-            .push(request.clone());
-        let pattern = regex::RegexBuilder::new(&request.pattern)
-            .case_insensitive(request.ignore_case)
-            .build()
-            .map_err(|error| Status::invalid_argument(format!("invalid regex pattern: {error}")))?;
-        let mut matches = Vec::new();
-        if request.kind == 0 || request.kind == 1 {
-            for table in mock_visible_tables().into_iter().filter(|table| {
-                request.schema_name.is_empty() || table.schema_name == request.schema_name
-            }) {
-                let matched_fields = table_matched_fields(&table, &pattern);
-                if !matched_fields.is_empty() {
-                    matches.push(CatalogSearchResult {
-                        item: Some(CatalogItem {
-                            item: Some(catalog_item::Item::Table(table_summary(&table))),
-                        }),
-                        matched_fields,
-                    });
-                }
-            }
-        }
-        let (items, pagination) = paginate(
-            matches,
-            request.pagination.unwrap_or(PaginationRequest {
-                limit: 20,
-                offset: 0,
-            }),
-        );
-        Ok(Response::new(SearchCatalogResponse {
-            items,
-            pagination: Some(pagination),
-        }))
     }
 
     async fn describe_table(
@@ -976,8 +1018,10 @@ impl MockServer {
         let captured = Arc::new(Captured::default());
         let query_captured = Arc::clone(&captured);
         let catalog_captured = Arc::clone(&captured);
+        let search_captured = Arc::clone(&captured);
         let source_captured = Arc::clone(&captured);
         let query_config = Arc::clone(&config);
+        let search_config = Arc::clone(&config);
         let task = tokio::spawn(async move {
             Server::builder()
                 .add_service(CatalogServiceServer::new(MockCatalogService {
@@ -986,6 +1030,10 @@ impl MockServer {
                 .add_service(QueryServiceServer::new(MockQueryService {
                     config: query_config,
                     captured: query_captured,
+                }))
+                .add_service(SearchServiceServer::new(MockSearchService {
+                    config: search_config,
+                    captured: search_captured,
                 }))
                 .add_service(SourceServiceServer::new(MockSourceService {
                     config,
@@ -1033,6 +1081,10 @@ impl MockServer {
             .clone()
     }
 
+    pub(crate) fn search_requests(&self) -> Vec<SearchRequest> {
+        self.captured.search.lock().expect("search capture").clone()
+    }
+
     pub(crate) fn discover_sources_requests(&self) -> Vec<DiscoverSourcesRequest> {
         self.captured
             .discover_sources
@@ -1054,14 +1106,6 @@ impl MockServer {
             .list_catalog
             .lock()
             .expect("list_catalog capture")
-            .clone()
-    }
-
-    pub(crate) fn search_catalog_requests(&self) -> Vec<SearchCatalogRequest> {
-        self.captured
-            .search_catalog
-            .lock()
-            .expect("search_catalog capture")
             .clone()
     }
 

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -262,8 +262,8 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .collect::<Vec<_>>(),
         vec![
             "sql",
+            "search",
             "list_catalog",
-            "search_catalog",
             "describe_table",
             "list_columns"
         ]
@@ -279,17 +279,16 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
         tools[1]
             .description
             .as_deref()
-            .expect("list_catalog description")
+            .expect("search description")
             .contains("3 table(s) and 0 table function(s) are currently visible")
     );
     assert!(
         tools[2]
             .description
             .as_deref()
-            .expect("search_catalog description")
+            .expect("list_catalog description")
             .contains("3 table(s) and 0 table function(s) are currently visible")
     );
-
     let resources = client.list_all_resources().await?;
     assert_eq!(
         resources
@@ -334,8 +333,8 @@ async fn mcp_stdio_enable_feedback_flag_lists_feedback_tool()
             .collect::<Vec<_>>(),
         vec![
             "sql",
+            "search",
             "list_catalog",
-            "search_catalog",
             "describe_table",
             "list_columns",
             "feedback"
@@ -576,7 +575,6 @@ async fn mcp_stdio_sql_and_catalog_tools_return_structured_content()
     let client = start_mcp_client(&server).await?;
 
     assert_list_catalog_tool(&client, &server).await?;
-    assert_search_catalog_tool(&client, &server).await?;
     assert_describe_table_tool(&client, &server).await?;
     assert_list_columns_tool(&client).await?;
     assert_sql_tool(&client).await?;
@@ -653,65 +651,6 @@ async fn assert_list_catalog_tool(
         )
         .await
         .expect_err("invalid catalog kind should fail");
-    Ok(())
-}
-
-async fn assert_search_catalog_tool(
-    client: &RunningService<RoleClient, ()>,
-    server: &MockServer,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let search = structured_tool_content(
-        client,
-        CallToolRequestParams::new("search_catalog").with_arguments(json_object(&json!({
-            "pattern": "fixture.*messages",
-            "schema": "local_messages",
-            "kind": "table",
-            "ignore_case": true
-        }))),
-    )
-    .await?;
-    assert_eq!(search["total"], 1);
-    assert_eq!(search["items"][0]["name"], "local_messages.messages");
-    assert_eq!(
-        search["items"][0]["sql_reference"],
-        "local_messages.messages"
-    );
-    assert!(
-        search["items"][0]["matched_fields"]
-            .as_array()
-            .expect("matched fields")
-            .iter()
-            .any(|field| field == "description")
-    );
-    let search_requests = server.search_catalog_requests();
-    let search_request = search_requests.last().expect("search catalog request");
-    assert_eq!(search_request.pattern, "fixture.*messages");
-    assert_eq!(search_request.schema_name, "local_messages");
-    assert_eq!(search_request.kind, 1);
-    let search_pagination = search_request
-        .pagination
-        .as_ref()
-        .expect("search pagination");
-    assert_eq!(search_pagination.limit, 20);
-    assert_eq!(search_pagination.offset, 0);
-    assert!(search_request.ignore_case);
-
-    let guide_search = structured_tool_content(
-        client,
-        CallToolRequestParams::new("search_catalog").with_arguments(json_object(&json!({
-            "pattern": "Query fixture messages",
-            "schema": "local_messages"
-        }))),
-    )
-    .await?;
-    assert_eq!(guide_search["total"], 1);
-    assert!(
-        guide_search["items"][0]["matched_fields"]
-            .as_array()
-            .expect("matched fields")
-            .iter()
-            .any(|field| field == "guide")
-    );
     Ok(())
 }
 

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -4,9 +4,11 @@ use coral_api::v1::Workspace;
 use coral_api::v1::catalog_service_client::CatalogServiceClient;
 use coral_api::v1::feedback_service_client::FeedbackServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
+use coral_api::v1::search_service_client::SearchServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
+    SEARCH_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint};
@@ -38,6 +40,9 @@ pub type CatalogClient = CatalogServiceClient<GrpcService>;
 /// Public SQL query gRPC client.
 pub type QueryClient = QueryServiceClient<GrpcService>;
 
+/// Public Universal Search gRPC client.
+pub type SearchClient = SearchServiceClient<GrpcService>;
+
 /// Public feedback-submission gRPC client.
 pub type FeedbackClient = FeedbackServiceClient<GrpcService>;
 
@@ -49,6 +54,7 @@ pub struct AppClient {
     source: SourceClient,
     catalog: CatalogClient,
     query: QueryClient,
+    search: SearchClient,
     feedback: FeedbackClient,
 }
 
@@ -72,11 +78,14 @@ impl AppClient {
             .max_decoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE);
         let query_client = QueryClient::new(grpc_service(channel.clone(), &grpc_endpoint))
             .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
+        let search_client = SearchClient::new(grpc_service(channel.clone(), &grpc_endpoint))
+            .max_decoding_message_size(SEARCH_RESPONSE_MAX_MESSAGE_SIZE);
         let feedback_client = FeedbackClient::new(grpc_service(channel, &grpc_endpoint));
         Ok(Self {
             source: source_client,
             catalog: catalog_client,
             query: query_client,
+            search: search_client,
             feedback: feedback_client,
         })
     }
@@ -97,6 +106,12 @@ impl AppClient {
     /// Returns a cloned query client.
     pub fn query_client(&self) -> QueryClient {
         self.query.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned Universal Search client.
+    pub fn search_client(&self) -> SearchClient {
+        self.search.clone()
     }
 
     #[must_use]

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -34,8 +34,8 @@ use coral_api::v1::ExecuteSqlResponse;
 use serde_json::Value;
 
 pub use client::{
-    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, QueryClient, SourceClient,
-    default_workspace,
+    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, QueryClient, SearchClient,
+    SourceClient, default_workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use sources::{SourceInputDecodeError, manifest_input_from_proto};

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -82,4 +82,8 @@ pub struct TableFunctionInfo {
     pub arguments: Vec<TableFunctionArgumentInfo>,
     /// Columns returned by the function.
     pub result_columns: Vec<TableFunctionResultColumnInfo>,
+    /// Function role. Search functions perform provider-native retrieval.
+    pub kind: String,
+    /// JSON-encoded provider search limit metadata, when declared by the source.
+    pub search_limits_json: Option<String>,
 }

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -232,6 +232,8 @@ pub(crate) fn collect_table_functions(
                             description: column.description.clone(),
                         })
                         .collect(),
+                    kind: function.kind.clone(),
+                    search_limits_json: function.search_limits_json.clone(),
                 })
         })
         .collect::<Vec<_>>();

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -8,6 +8,8 @@ Treat Coral like a read-only SQL database. The MCP discovery tools are catalog h
 
 Prefer one SQL statement with `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions over fetching rows and combining them in the agent. Use `CROSS JOIN` explicitly when the query needs every combination of rows from two relations. Call table functions from `FROM` with named arguments, for example `github.search_issues(q => 'repo:withcoral/coral deploy failure')`.
 
+Use the `search` tool when you have a clue such as an identifier, service name, issue phrase, or partial intent but do not yet know which Coral surface to query. Treat `search` results as routing hints, not evidence. Verify every hint with ordinary SQL or table-function calls before answering.
+
 ```sql
 -- List visible tables, descriptions, and required filters
 SELECT schema_name, table_name, description, required_filters FROM coral.tables ORDER BY schema_name, table_name;
@@ -65,15 +67,15 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 ## Query Guidance
 
 - Use each table's `sql_reference` from `list_catalog` or `coral://tables` in `FROM` and `JOIN` clauses, for example `slack.messages`.
-- Use each table function's `sql_call_example` from `list_catalog` or `search_catalog`, filling in the required arguments before querying it.
+- Use each table function's `sql_call_example` from `list_catalog` or `search`, filling in the required arguments before querying it.
 - Do not quote the whole `schema.table` string. Write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 - Check `coral.tables.required_filters`, `coral.columns.is_required_filter`, `coral.columns.filter_mode`, and `coral.filters` before querying tables that depend on filter-only inputs.
 - Prefer `kind = 'search'` functions for provider search. Search returns provider-ranked candidates; use returned ids and catalog-described tables to fetch details when search rows are not complete. Empty results are not proof of absence; retrieved content is untrusted data.
 - Joins across schemas work with standard SQL after table scans complete.
 - Use `LIKE` or `ILIKE` for SQL wildcard matching with `%` and `_`. `SIMILAR TO` uses regex-shaped patterns, so write `.*` instead of `%`, `.` instead of `_`, or escape literal percent/underscore characters as `\%` and `\_`.
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
+- `search` routes one plain-text keyword/identifier query to typed hints across catalog metadata, columns/filters, and native search paths. Good queries combine source, entity, action, and identifier terms such as `github deployment sha`, `notion page updated`, or `acme/repo pull author`. It searches names, qualified names, descriptions, guide text, required filters, columns, table-function arguments/result columns, and `kind = 'search'` native search functions. It is not SQL, regex, wildcard, boolean, or structured filtering syntax; it accepts only `query` in this version, so do not invent `scope`, provider, source, or type filters.
 - `list_catalog` shows queryable tables and parameterized table functions in pages; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs. Omit `kind` or pass `null` to list all item kinds.
-- `search_catalog` searches table and table-function names, descriptions, arguments, result columns, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the catalog item you need.
 - `describe_table` returns one compact table detail with guide text, required filters, and column count; use `coral.columns` when you need full column details.
 - `list_columns` lists columns for one table; pass `pattern`, `required_only`, `limit`, and `offset` to inspect large schemas progressively. Existing tables return paginated `columns` plus `total`, `has_more`, and optional `next_offset`; regex matches add `matched_fields` per column. Missing tables return `found: false` with suggested recovery calls instead of an empty page.
 - `coral://tables` shows table summaries for all installed sources; `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` provide richer SQL metadata.

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The exposed MCP surface is intentionally small:
 //!
-//! - tools: `sql`, paginated `list_catalog`, `search_catalog`, `describe_table`, `list_columns`, and optionally `feedback`
+//! - tools: `sql`, `search`, paginated `list_catalog`, `describe_table`, `list_columns`, and optionally `feedback`
 //! - resources: `coral://guide`, `coral://tables`
 //!
 //! Protocol lifecycle, initialization, and stdio transport behavior should stay

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -3,12 +3,12 @@
 use coral_api::v1::{
     CatalogItemKind as ProtoCatalogItemKind, DescribeTableRequest, DescribeTableResponse,
     ExecuteSqlRequest, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
-    ListSourcesRequest, PaginationRequest, SearchCatalogRequest, Source, SubmitFeedbackRequest,
+    ListSourcesRequest, PaginationRequest, SearchRequest, Source, SubmitFeedbackRequest,
     TableSummary as ProtoTableSummary, catalog_item,
 };
 use coral_client::{
-    AppClient, CatalogClient, FeedbackClient, QueryClient, SourceClient, batches_to_json_rows,
-    decode_execute_sql_response, default_workspace,
+    AppClient, CatalogClient, FeedbackClient, QueryClient, SearchClient, SourceClient,
+    batches_to_json_rows, decode_execute_sql_response, default_workspace,
 };
 use rmcp::{
     ErrorData, ServerHandler,
@@ -30,9 +30,9 @@ use crate::{
         describe_table_value, feedback_tool, guide_resource, guide_resource_content,
         initial_instructions, internal_status, list_catalog_arguments, list_catalog_tool,
         list_catalog_value, list_columns_arguments, list_columns_tool, list_columns_value,
-        required_string_argument, search_catalog_arguments, search_catalog_tool,
-        search_catalog_value, sql_tool, status_to_error_data, tables_resource,
-        tables_resource_content, tool_error_from_status, tool_error_result,
+        required_string_argument, search_arguments, search_tool, search_value, sql_tool,
+        status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
+        tool_error_result,
     },
     telemetry,
 };
@@ -82,6 +82,7 @@ pub(crate) struct CoralMcpServer {
     source: SourceClient,
     catalog: CatalogClient,
     query: QueryClient,
+    search: SearchClient,
     feedback: FeedbackClient,
     options: McpOptions,
 }
@@ -92,6 +93,7 @@ impl CoralMcpServer {
             source: app.source_client(),
             catalog: app.catalog_client(),
             query: app.query_client(),
+            search: app.search_client(),
             feedback: app.feedback_client(),
             options,
         }
@@ -285,33 +287,27 @@ impl CoralMcpServer {
         })
     }
 
-    async fn search_catalog_tool_result(
+    async fn search_tool_result(
         &self,
         request_arguments: Option<&Map<String, Value>>,
     ) -> Result<ToolCallOutcome, ErrorData> {
-        let arguments = search_catalog_arguments(request_arguments)?;
-        let mut catalog_client = self.catalog.clone();
-        match catalog_client
-            .search_catalog(Request::new(SearchCatalogRequest {
+        let arguments = search_arguments(request_arguments)?;
+        let mut search_client = self.search.clone();
+        match search_client
+            .search(Request::new(SearchRequest {
                 workspace: Some(default_workspace()),
-                pattern: arguments.pattern,
-                ignore_case: arguments.ignore_case,
-                schema_name: arguments.schema.unwrap_or_default(),
-                kind: catalog_item_kind_from_tool(arguments.kind) as i32,
-                pagination: Some(PaginationRequest {
-                    limit: arguments.pagination.limit,
-                    offset: arguments.pagination.offset,
-                }),
+                query: arguments.query,
+                limit: 0,
             }))
             .await
-            .map(|response| search_catalog_value(&response.into_inner()))
+            .map(|response| search_value(&response.into_inner()))
         {
             Ok(value) => Ok(ToolCallOutcome::Success(value)),
             Err(status) if status.code() == tonic::Code::InvalidArgument => {
                 Err(status_to_error_data(&status))
             }
             Err(status) => Ok(ToolCallOutcome::ToolError {
-                operation: "Catalog search",
+                operation: "Search",
                 status,
             }),
         }
@@ -374,12 +370,9 @@ impl CoralMcpServer {
                     self.execute_sql_value(&sql).await,
                 ))
             }
+            "search" => self.search_tool_result(request.arguments.as_ref()).await,
             "list_catalog" => {
                 self.list_catalog_tool_result(request.arguments.as_ref())
-                    .await
-            }
-            "search_catalog" => {
-                self.search_catalog_tool_result(request.arguments.as_ref())
                     .await
             }
             "describe_table" => {
@@ -486,8 +479,8 @@ impl ServerHandler for CoralMcpServer {
                 .map_err(|status| status_to_error_data(&status))?;
             let mut tools = vec![
                 sql_tool(&sources, visible_table_count),
+                search_tool(visible_table_count, visible_function_count),
                 list_catalog_tool(visible_table_count, visible_function_count),
-                search_catalog_tool(visible_table_count, visible_function_count),
                 describe_table_tool(),
                 list_columns_tool(),
             ];

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -1,6 +1,6 @@
 use coral_api::v1::{
     ColumnSearchResult, DescribeTableResponse, ListCatalogResponse, ListColumnsResponse,
-    SearchCatalogResponse, Table as ProtoTable, TableFunction as ProtoTableFunction,
+    Table as ProtoTable, TableFunction as ProtoTableFunction,
     TableFunctionArgument as ProtoTableFunctionArgument,
     TableFunctionResultColumn as ProtoTableFunctionResultColumn, TableSummary as ProtoTableSummary,
     catalog_item,
@@ -49,37 +49,14 @@ fn describe_missing_table_value(
         .iter()
         .map(missing_table_summary_value)
         .collect::<Vec<_>>();
-    let escaped_table = regex::escape(table);
-    let search_arguments = if same_schema_tables.is_empty() {
-        SuggestedCallArguments {
-            pattern: Some(escaped_table),
-            schema: None,
+    let suggested_calls = vec![SuggestedCall {
+        tool: "list_catalog",
+        arguments: SuggestedCallArguments {
+            schema: (!same_schema_tables.is_empty()).then_some(schema),
             kind: Some("table"),
-            limit: None,
-        }
-    } else {
-        SuggestedCallArguments {
-            pattern: Some(escaped_table),
-            schema: Some(schema),
-            kind: Some("table"),
-            limit: None,
-        }
-    };
-    let mut suggested_calls = vec![SuggestedCall {
-        tool: "search_catalog",
-        arguments: search_arguments,
+            limit: Some(10),
+        },
     }];
-    if !same_schema_tables.is_empty() {
-        suggested_calls.push(SuggestedCall {
-            tool: "list_catalog",
-            arguments: SuggestedCallArguments {
-                pattern: None,
-                schema: Some(schema),
-                kind: Some("table"),
-                limit: Some(10),
-            },
-        });
-    }
     serde_json::to_value(MissingTableValue {
         found: false,
         requested: RequestedTable { schema, table },
@@ -89,16 +66,6 @@ fn describe_missing_table_value(
         suggested_calls,
     })
     .expect("missing table value serializes")
-}
-
-pub(crate) fn search_catalog_value(response: &SearchCatalogResponse) -> Value {
-    let pagination = response.pagination.unwrap_or_default();
-    let items = response
-        .items
-        .iter()
-        .filter_map(catalog_search_result_value)
-        .collect::<Vec<_>>();
-    paged_collection_value("items", items, &pagination)
 }
 
 pub(crate) fn list_catalog_value(response: &ListCatalogResponse) -> Value {
@@ -111,7 +78,7 @@ pub(crate) fn list_catalog_value(response: &ListCatalogResponse) -> Value {
     paged_collection_value("items", items, &pagination)
 }
 
-fn catalog_item_value(item: &coral_api::v1::CatalogItem) -> Option<Value> {
+pub(crate) fn catalog_item_value(item: &coral_api::v1::CatalogItem) -> Option<Value> {
     match item.item.as_ref()? {
         catalog_item::Item::Table(table) => {
             serde_json::to_value(CatalogTableItemValue::from(table)).ok()
@@ -132,15 +99,6 @@ fn minimal_table_function_call_example(function: &ProtoTableFunction) -> String 
         .collect::<Vec<_>>()
         .join(", ");
     format!("{reference}({required_arguments})")
-}
-
-fn catalog_search_result_value(result: &coral_api::v1::CatalogSearchResult) -> Option<Value> {
-    let mut value = catalog_item_value(result.item.as_ref()?)?;
-    value.as_object_mut()?.insert(
-        "matched_fields".to_string(),
-        serde_json::to_value(&result.matched_fields).ok()?,
-    );
-    Some(value)
 }
 
 pub(crate) fn list_columns_value(
@@ -230,8 +188,6 @@ struct SuggestedCall<'a> {
 
 #[derive(Serialize)]
 struct SuggestedCallArguments<'a> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pattern: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     schema: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -4,13 +4,12 @@ mod catalog;
 mod discovery;
 mod errors;
 mod resources;
+mod search;
 mod tools;
 mod values;
 
-pub(crate) use catalog::{
-    describe_table_value, list_catalog_value, list_columns_value, search_catalog_value,
-};
-pub(crate) use discovery::{Pagination, parse_pagination, parse_pagination_with_limits};
+pub(crate) use catalog::{describe_table_value, list_catalog_value, list_columns_value};
+pub(crate) use discovery::{Pagination, parse_pagination};
 pub(crate) use errors::{
     internal_status, status_to_error_data, tool_error_from_status, tool_error_result,
 };
@@ -18,9 +17,9 @@ pub(crate) use resources::{
     guide_resource, guide_resource_content, initial_instructions, tables_resource,
     tables_resource_content,
 };
+pub(crate) use search::search_value;
 pub(crate) use tools::{
     CatalogToolKind, build_tool_result, describe_table_arguments, describe_table_tool,
     feedback_tool, list_catalog_arguments, list_catalog_tool, list_columns_arguments,
-    list_columns_tool, required_string_argument, search_catalog_arguments, search_catalog_tool,
-    sql_tool,
+    list_columns_tool, required_string_argument, search_arguments, search_tool, sql_tool,
 };

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use super::values::queryable_table_summary_values;
 
-static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral, a read-only SQL database. Treat exposed data as database schemas, tables, and table functions. Use `list_catalog` and `search_catalog` as catalog helpers, use `describe_table` and `list_columns` for table-specific metadata, use `sql` against `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` for deeper discovery, then answer with set-based SQL through `sql`. Prefer one SQL statement with joins, CROSS JOIN, CTEs, subqueries, and aggregates over row-by-row tool calls.";
+static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral, a read-only SQL database. Treat exposed data as database schemas, tables, and table functions. Use `search` and `list_catalog` as catalog helpers, use `describe_table` and `list_columns` for table-specific metadata, use `sql` against `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` for deeper discovery, then answer with set-based SQL through `sql`. Prefer one SQL statement with joins, CROSS JOIN, CTEs, subqueries, and aggregates over row-by-row tool calls.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
 pub(crate) fn initial_instructions() -> &'static str {

--- a/crates/coral-mcp/src/surface/search.rs
+++ b/crates/coral-mcp/src/surface/search.rs
@@ -1,0 +1,479 @@
+use std::sync::Arc;
+
+use coral_api::v1::search_result::Payload;
+use coral_api::v1::{
+    ColumnHint, NativeSearchPath, SearchProvider, SearchProviderState, SearchResponse,
+    SearchResult, SearchResultTruncation, SearchSurfaceKind,
+};
+use serde::Serialize;
+use serde_json::{Map, Value, json};
+
+use super::catalog::catalog_item_value;
+use super::values::format_schema_table_equivalent;
+
+pub(crate) fn search_value(response: &SearchResponse) -> Value {
+    serde_json::to_value(SearchValue {
+        provider_statuses: response
+            .provider_statuses
+            .iter()
+            .map(ProviderStatusValue::from)
+            .collect(),
+        truncation: response
+            .truncation
+            .as_ref()
+            .map(TruncationValue::from)
+            .unwrap_or_default(),
+        results: response
+            .results
+            .iter()
+            .filter_map(search_result_value)
+            .collect(),
+    })
+    .expect("search value serializes")
+}
+
+pub(crate) fn search_output_schema() -> Arc<Map<String, Value>> {
+    Arc::new(
+        json!({
+            "type": "object",
+            "required": ["provider_statuses", "truncation", "results"],
+            "additionalProperties": false,
+            "properties": {
+                "provider_statuses": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["provider", "state", "note"],
+                        "additionalProperties": false,
+                        "properties": {
+                            "provider": {
+                                "type": "string",
+                                "enum": ["catalog_metadata", "observed_values", "unknown"]
+                            },
+                            "state": {
+                                "type": "string",
+                                "enum": [
+                                    "results_found",
+                                    "empty",
+                                    "not_enabled",
+                                    "skipped",
+                                    "partial",
+                                    "error",
+                                    "unknown"
+                                ]
+                            },
+                            "note": { "type": "string" }
+                        }
+                    }
+                },
+                "truncation": {
+                    "type": "object",
+                    "required": ["truncated", "returned_count", "max_results", "note"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "truncated": { "type": "boolean" },
+                        "returned_count": { "type": "integer", "minimum": 0 },
+                        "max_results": { "type": "integer", "minimum": 1 },
+                        "note": { "type": "string" }
+                    }
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            catalog_item_result_schema(),
+                            column_hint_result_schema(),
+                            native_search_path_result_schema(),
+                            observed_value_result_schema()
+                        ]
+                    }
+                }
+            }
+        })
+        .as_object()
+        .cloned()
+        .expect("search output schema should be an object"),
+    )
+}
+
+#[derive(Serialize)]
+struct SearchValue<'a> {
+    provider_statuses: Vec<ProviderStatusValue<'a>>,
+    truncation: TruncationValue<'a>,
+    results: Vec<Value>,
+}
+
+#[derive(Serialize)]
+struct ProviderStatusValue<'a> {
+    provider: &'static str,
+    state: &'static str,
+    note: &'a str,
+}
+
+impl<'a> From<&'a coral_api::v1::SearchProviderStatus> for ProviderStatusValue<'a> {
+    fn from(status: &'a coral_api::v1::SearchProviderStatus) -> Self {
+        Self {
+            provider: provider_name(SearchProvider::try_from(status.provider).ok()),
+            state: provider_state(SearchProviderState::try_from(status.state).ok()),
+            note: &status.note,
+        }
+    }
+}
+
+#[derive(Default, Serialize)]
+struct TruncationValue<'a> {
+    truncated: bool,
+    returned_count: u32,
+    max_results: u32,
+    note: &'a str,
+}
+
+impl<'a> From<&'a SearchResultTruncation> for TruncationValue<'a> {
+    fn from(truncation: &'a SearchResultTruncation) -> Self {
+        Self {
+            truncated: truncation.truncated,
+            returned_count: truncation.returned_count,
+            max_results: truncation.max_results,
+            note: &truncation.note,
+        }
+    }
+}
+
+fn search_result_value(result: &SearchResult) -> Option<Value> {
+    match result.payload.as_ref()? {
+        Payload::CatalogItem(item) => catalog_item_result_value(item),
+        Payload::ColumnHint(hint) => Some(column_hint_value(hint)),
+        Payload::ObservedValue(value) => serde_json::to_value(ObservedValueResult {
+            r#type: "observed_value",
+            value: &value.value,
+            schema_name: &value.schema_name,
+            surface_name: &value.surface_name,
+            column_name: &value.column_name,
+        })
+        .ok(),
+        Payload::NativeSearchPath(path) => native_search_path_value(path),
+    }
+}
+
+fn catalog_item_result_value(item: &coral_api::v1::CatalogItem) -> Option<Value> {
+    let mut value = catalog_item_value(item)?;
+    value
+        .as_object_mut()?
+        .insert("type".to_string(), Value::from("catalog_item"));
+    Some(value)
+}
+
+fn column_hint_value(hint: &ColumnHint) -> Value {
+    serde_json::to_value(ColumnHintResult {
+        r#type: "column_hint",
+        schema_name: &hint.schema_name,
+        surface_name: &hint.surface_name,
+        surface_kind: surface_kind(SearchSurfaceKind::try_from(hint.surface_kind).ok()),
+        name: &hint.name,
+        data_type: &hint.data_type,
+        required: hint.required,
+        description: &hint.description,
+        matched_fields: &hint.matched_fields,
+    })
+    .expect("column hint value serializes")
+}
+
+fn native_search_path_value(path: &NativeSearchPath) -> Option<Value> {
+    let function = path.table_function.as_ref()?;
+    serde_json::to_value(NativeSearchPathResult {
+        r#type: "native_search_path",
+        schema_name: &function.schema_name,
+        name: format!("{}.{}", function.schema_name, function.name),
+        sql_reference: format_schema_table_equivalent(&function.schema_name, &function.name),
+        sql_call_example: &path.sql_call_example,
+        description: &function.description,
+        arguments: function
+            .arguments
+            .iter()
+            .map(FunctionArgumentValue::from)
+            .collect(),
+        result_columns: function
+            .result_columns
+            .iter()
+            .map(FunctionResultColumnValue::from)
+            .collect(),
+        matched_fields: &path.matched_fields,
+    })
+    .ok()
+}
+
+#[derive(Serialize)]
+struct ColumnHintResult<'a> {
+    r#type: &'static str,
+    schema_name: &'a str,
+    surface_name: &'a str,
+    surface_kind: &'static str,
+    name: &'a str,
+    data_type: &'a str,
+    required: bool,
+    description: &'a str,
+    matched_fields: &'a [String],
+}
+
+#[derive(Serialize)]
+struct ObservedValueResult<'a> {
+    r#type: &'static str,
+    value: &'a str,
+    schema_name: &'a str,
+    surface_name: &'a str,
+    column_name: &'a str,
+}
+
+#[derive(Serialize)]
+struct NativeSearchPathResult<'a> {
+    r#type: &'static str,
+    schema_name: &'a str,
+    name: String,
+    sql_reference: String,
+    sql_call_example: &'a str,
+    description: &'a str,
+    arguments: Vec<FunctionArgumentValue<'a>>,
+    result_columns: Vec<FunctionResultColumnValue<'a>>,
+    matched_fields: &'a [String],
+}
+
+#[derive(Serialize)]
+struct FunctionArgumentValue<'a> {
+    name: &'a str,
+    required: bool,
+    values: &'a [String],
+}
+
+impl<'a> From<&'a coral_api::v1::TableFunctionArgument> for FunctionArgumentValue<'a> {
+    fn from(argument: &'a coral_api::v1::TableFunctionArgument) -> Self {
+        Self {
+            name: &argument.name,
+            required: argument.required,
+            values: &argument.values,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct FunctionResultColumnValue<'a> {
+    column_name: &'a str,
+    data_type: &'a str,
+    is_nullable: bool,
+    description: &'a str,
+}
+
+impl<'a> From<&'a coral_api::v1::TableFunctionResultColumn> for FunctionResultColumnValue<'a> {
+    fn from(column: &'a coral_api::v1::TableFunctionResultColumn) -> Self {
+        Self {
+            column_name: &column.name,
+            data_type: &column.data_type,
+            is_nullable: column.nullable,
+            description: &column.description,
+        }
+    }
+}
+
+fn provider_name(provider: Option<SearchProvider>) -> &'static str {
+    match provider {
+        Some(SearchProvider::CatalogMetadata) => "catalog_metadata",
+        Some(SearchProvider::ObservedValues) => "observed_values",
+        Some(SearchProvider::Unspecified) | None => "unknown",
+    }
+}
+
+fn provider_state(state: Option<SearchProviderState>) -> &'static str {
+    match state {
+        Some(SearchProviderState::ResultsFound) => "results_found",
+        Some(SearchProviderState::Empty) => "empty",
+        Some(SearchProviderState::NotEnabled) => "not_enabled",
+        Some(SearchProviderState::Skipped) => "skipped",
+        Some(SearchProviderState::Partial) => "partial",
+        Some(SearchProviderState::Error) => "error",
+        Some(SearchProviderState::Unspecified) | None => "unknown",
+    }
+}
+
+fn surface_kind(kind: Option<SearchSurfaceKind>) -> &'static str {
+    match kind {
+        Some(SearchSurfaceKind::Table) => "table",
+        Some(SearchSurfaceKind::TableFunction) => "table_function",
+        Some(SearchSurfaceKind::Unspecified) | None => "unknown",
+    }
+}
+
+fn catalog_item_result_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["type", "kind", "schema_name", "name", "sql_reference", "description"],
+        "additionalProperties": true,
+        "properties": {
+            "type": { "enum": ["catalog_item"] },
+            "kind": { "type": "string", "enum": ["table", "table_function"] },
+            "schema_name": { "type": "string" },
+            "name": { "type": "string" },
+            "sql_reference": { "type": "string" },
+            "description": { "type": "string" }
+        }
+    })
+}
+
+fn column_hint_result_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": [
+            "type",
+            "schema_name",
+            "surface_name",
+            "surface_kind",
+            "name",
+            "data_type",
+            "required",
+            "description",
+            "matched_fields"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "type": { "enum": ["column_hint"] },
+            "schema_name": { "type": "string" },
+            "surface_name": { "type": "string" },
+            "surface_kind": {
+                "type": "string",
+                "enum": ["table", "table_function", "unknown"]
+            },
+            "name": { "type": "string" },
+            "data_type": { "type": "string" },
+            "required": { "type": "boolean" },
+            "description": { "type": "string" },
+            "matched_fields": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        }
+    })
+}
+
+fn native_search_path_result_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": [
+            "type",
+            "schema_name",
+            "name",
+            "sql_reference",
+            "sql_call_example",
+            "description",
+            "arguments",
+            "result_columns",
+            "matched_fields"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "type": { "enum": ["native_search_path"] },
+            "schema_name": { "type": "string" },
+            "name": { "type": "string" },
+            "sql_reference": { "type": "string" },
+            "sql_call_example": { "type": "string" },
+            "description": { "type": "string" },
+            "arguments": {
+                "type": "array",
+                "items": function_argument_schema()
+            },
+            "result_columns": {
+                "type": "array",
+                "items": result_column_schema()
+            },
+            "matched_fields": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        }
+    })
+}
+
+fn observed_value_result_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["type", "value", "schema_name", "surface_name", "column_name"],
+        "additionalProperties": false,
+        "properties": {
+            "type": { "enum": ["observed_value"] },
+            "value": { "type": "string" },
+            "schema_name": { "type": "string" },
+            "surface_name": { "type": "string" },
+            "column_name": { "type": "string" }
+        }
+    })
+}
+
+fn function_argument_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["name", "required", "values"],
+        "additionalProperties": false,
+        "properties": {
+            "name": { "type": "string" },
+            "required": { "type": "boolean" },
+            "values": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        }
+    })
+}
+
+fn result_column_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["column_name", "data_type", "is_nullable", "description"],
+        "additionalProperties": false,
+        "properties": {
+            "column_name": { "type": "string" },
+            "data_type": { "type": "string" },
+            "is_nullable": { "type": "boolean" },
+            "description": { "type": "string" }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use coral_api::v1::{
+        SearchProvider, SearchProviderState, SearchProviderStatus, SearchResponse,
+        SearchResultTruncation,
+    };
+    use serde_json::Value;
+
+    use super::search_value;
+
+    #[test]
+    fn search_value_renders_provider_status_names() {
+        let value = search_value(&SearchResponse {
+            results: Vec::new(),
+            provider_statuses: vec![SearchProviderStatus {
+                provider: SearchProvider::ObservedValues as i32,
+                state: SearchProviderState::NotEnabled as i32,
+                note: "disabled".to_string(),
+            }],
+            truncation: Some(SearchResultTruncation {
+                truncated: false,
+                returned_count: 0,
+                max_results: 10,
+                note: String::new(),
+            }),
+        });
+
+        let statuses = value
+            .get("provider_statuses")
+            .and_then(Value::as_array)
+            .expect("provider statuses");
+        let status = statuses.first().expect("first provider status");
+        assert_eq!(
+            status.get("provider").and_then(Value::as_str),
+            Some("observed_values")
+        );
+        assert_eq!(
+            status.get("state").and_then(Value::as_str),
+            Some("not_enabled")
+        );
+    }
+}

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -7,7 +7,8 @@ use rmcp::{
 };
 use serde_json::{Map, Value, json};
 
-use super::{Pagination, parse_pagination, parse_pagination_with_limits};
+use super::search::search_output_schema;
+use super::{Pagination, parse_pagination};
 
 pub(crate) struct ListCatalogArguments {
     pub(crate) schema: Option<String>,
@@ -15,12 +16,8 @@ pub(crate) struct ListCatalogArguments {
     pub(crate) pagination: Pagination,
 }
 
-pub(crate) struct SearchCatalogArguments {
-    pub(crate) pattern: String,
-    pub(crate) schema: Option<String>,
-    pub(crate) kind: Option<CatalogToolKind>,
-    pub(crate) ignore_case: bool,
-    pub(crate) pagination: Pagination,
+pub(crate) struct SearchArguments {
+    pub(crate) query: String,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -119,61 +116,27 @@ pub(crate) fn list_catalog_tool(visible_table_count: usize, visible_function_cou
     )
 }
 
-pub(crate) fn search_catalog_tool(
-    visible_table_count: usize,
-    visible_function_count: usize,
-) -> Tool {
+pub(crate) fn search_tool(visible_table_count: usize, visible_function_count: usize) -> Tool {
     Tool::new(
-        "search_catalog",
-        search_catalog_description(visible_table_count, visible_function_count),
+        "search",
+        format!(
+            "Search Coral discovery metadata with one plain-text keyword/identifier query. Use it before SQL when you know a domain concept, source name, table/function name, column/filter name, or native provider-search target but not the exact Coral surface. Good queries combine salient terms such as source, entity, action, and identifier names, for example `github deployment sha`, `notion page updated`, or `acme/repo pull author`. The search engine tokenizes common technical identifiers, including dotted, slashed, hyphenated, underscored, @, and # terms, and matches against schema names, table names, function names, qualified names, descriptions, guide text, required filters, column names/types/descriptions, table-function kind, arguments, allowed argument values, result columns, and `kind = 'search'` native search table functions. It is not SQL, regex, wildcard, boolean, or structured provider/type/scope filtering syntax; this tool accepts only `query`. Current release searches catalog metadata. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible. Results are ranked hints; verify them with list_catalog, describe_table, list_columns, and ordinary Coral SQL."
+        ),
         json_object_schema(&json!({
             "type": "object",
-            "required": ["pattern"],
+            "required": ["query"],
+            "additionalProperties": false,
             "properties": {
-                "pattern": {
+                "query": {
                     "type": "string",
-                    "description": "Rust regex pattern to match database catalog metadata."
-                },
-                "schema": {
-                    "type": "string",
-                    "description": "Optional exact SQL schema name to search."
-                },
-                "kind": {
-                    "description": "Optional item kind to search. Omit or pass null to search all catalog items.",
-                    "anyOf": [
-                        {
-                            "type": "string",
-                            "enum": ["table", "table_function"]
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "ignore_case": {
-                    "type": "boolean",
-                    "description": "Whether regex matching is case-insensitive. Defaults to true."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum catalog items to return, from 1 to 100. Defaults to 20.",
-                    "minimum": 1,
-                    "maximum": 100,
-                    "default": 20
-                },
-                "offset": {
-                    "type": "integer",
-                    "description": "Number of matching catalog items to skip. Defaults to 0.",
-                    "minimum": 0,
-                    "maximum": u32::MAX,
-                    "default": 0
+                    "description": "Plain-text keywords, phrases, or technical identifiers to match against Coral catalog metadata. Use source/table/function/column/filter names and domain nouns; do not pass SQL, regex, wildcards, or provider/type/scope filters."
                 }
             }
         })),
     )
-    .with_raw_output_schema(search_catalog_output_schema())
+    .with_raw_output_schema(search_output_schema())
     .with_annotations(
-        ToolAnnotations::with_title("Search Catalog")
+        ToolAnnotations::with_title("Search")
             .read_only(true)
             .destructive(false)
             .idempotent(true)
@@ -321,15 +284,11 @@ pub(crate) fn list_catalog_arguments(
     })
 }
 
-pub(crate) fn search_catalog_arguments(
+pub(crate) fn search_arguments(
     arguments: Option<&Map<String, Value>>,
-) -> Result<SearchCatalogArguments, ErrorData> {
-    Ok(SearchCatalogArguments {
-        pattern: required_string_argument(arguments, "pattern")?,
-        schema: optional_string_argument(arguments, "schema")?,
-        kind: optional_catalog_kind_argument(arguments)?,
-        ignore_case: optional_bool_argument(arguments, "ignore_case", true)?,
-        pagination: parse_pagination_with_limits(arguments, 20, 100)?,
+) -> Result<SearchArguments, ErrorData> {
+    Ok(SearchArguments {
+        query: required_string_argument(arguments, "query")?,
     })
 }
 
@@ -388,12 +347,6 @@ fn sql_tool_description(_sources: &[Source], visible_table_count: usize) -> Stri
             "Execute read-only SQL against the Coral database. {visible_table_count} table(s) are currently visible. Use JOIN, CROSS JOIN, CTEs, subqueries, and aggregates to combine tables in one statement."
         )
     }
-}
-
-fn search_catalog_description(visible_table_count: usize, visible_function_count: usize) -> String {
-    format!(
-        "Search database catalog metadata with a Rust regex. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible."
-    )
 }
 
 fn list_catalog_output_schema() -> Arc<Map<String, Value>> {
@@ -522,78 +475,6 @@ fn catalog_table_function_item_output_schema() -> Value {
     })
 }
 
-fn search_catalog_output_schema() -> Arc<Map<String, Value>> {
-    json_object_schema(&json!({
-        "type": "object",
-        "required": ["items", "total", "limit", "offset", "has_more"],
-        "additionalProperties": false,
-        "properties": {
-            "items": {
-                "type": "array",
-                "items": {
-                    "oneOf": [
-                        catalog_search_item_output_schema(catalog_table_item_output_schema()),
-                        catalog_search_item_output_schema(catalog_table_function_item_output_schema())
-                    ]
-                }
-            },
-            "total": {
-                "type": "integer",
-                "minimum": 0
-            },
-            "limit": {
-                "type": "integer",
-                "minimum": 1
-            },
-            "offset": {
-                "type": "integer",
-                "minimum": 0
-            },
-            "has_more": { "type": "boolean" },
-            "next_offset": {
-                "type": "integer",
-                "minimum": 0
-            }
-        }
-    }))
-}
-
-fn catalog_search_item_output_schema(mut schema: Value) -> Value {
-    let object = schema
-        .as_object_mut()
-        .expect("catalog item schema is an object");
-    object
-        .get_mut("required")
-        .and_then(Value::as_array_mut)
-        .expect("catalog item schema has required array")
-        .push(json!("matched_fields"));
-    object
-        .get_mut("properties")
-        .and_then(Value::as_object_mut)
-        .expect("catalog item schema has properties object")
-        .insert(
-            "matched_fields".to_string(),
-            json!({
-                "type": "array",
-                "items": {
-                    "type": "string",
-                    "enum": [
-                        "schema_name",
-                        "table_name",
-                        "function_name",
-                        "name",
-                        "description",
-                        "guide",
-                        "required_filters",
-                        "arguments",
-                        "result_columns"
-                    ]
-                }
-            }),
-        );
-    schema
-}
-
 fn list_columns_output_schema() -> Arc<Map<String, Value>> {
     json_object_schema(&json!({
         "type": "object",
@@ -706,7 +587,7 @@ fn missing_table_output_schema() -> Value {
                     "properties": {
                         "tool": {
                             "type": "string",
-                            "enum": ["search_catalog", "list_catalog"]
+                            "enum": ["list_catalog"]
                         },
                         "arguments": { "type": "object" }
                     }
@@ -802,7 +683,7 @@ fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
 mod tests {
     use serde_json::{Map, Value};
 
-    use super::{list_catalog_arguments, search_catalog_arguments};
+    use super::list_catalog_arguments;
 
     #[test]
     fn catalog_kind_argument_accepts_null_as_all_kinds() {
@@ -810,9 +691,5 @@ mod tests {
         arguments.insert("kind".to_string(), Value::Null);
         let list = list_catalog_arguments(Some(&arguments)).expect("list arguments");
         assert_eq!(list.kind, None);
-
-        arguments.insert("pattern".to_string(), Value::String("issue".to_string()));
-        let search = search_catalog_arguments(Some(&arguments)).expect("search arguments");
-        assert_eq!(search.kind, None);
     }
 }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -126,6 +126,11 @@ functions:
         type: Utf8
         description: Issue title
   - name: search_issues
+    kind: search
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
     description: Search issues
     args:
       - name: q
@@ -299,8 +304,8 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .collect::<Vec<_>>(),
         vec![
             "sql",
+            "search",
             "list_catalog",
-            "search_catalog",
             "describe_table",
             "list_columns"
         ]
@@ -312,6 +317,20 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .expect("sql description")
             .contains("No user tables are currently visible")
     );
+    assert!(
+        tool_by_name(&initial_tools, "search")
+            .description
+            .as_deref()
+            .expect("search description")
+            .contains("Results are ranked hints")
+    );
+    let search_tool_description = tool_by_name(&initial_tools, "search")
+        .description
+        .as_deref()
+        .expect("search description");
+    assert!(search_tool_description.contains("plain-text keyword/identifier query"));
+    assert!(search_tool_description.contains("not SQL, regex, wildcard, boolean"));
+    assert!(search_tool_description.contains("Current release searches catalog metadata"));
     for tool in &initial_tools {
         let Some(output_schema) = &tool.output_schema else {
             continue;
@@ -357,8 +376,8 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     add_demo_source(&mut session.source_client, manifest_yaml).await;
 
     let updated_tools = client.list_all_tools().await.expect("updated tools");
+    let search_tool = tool_by_name(&updated_tools, "search");
     let list_catalog_tool = tool_by_name(&updated_tools, "list_catalog");
-    let search_catalog_tool = tool_by_name(&updated_tools, "search_catalog");
     let list_columns_tool = tool_by_name(&updated_tools, "list_columns");
     assert!(
         updated_tools[0]
@@ -368,17 +387,17 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .contains("3 table(s) are currently visible")
     );
     assert!(
-        updated_tools[1]
+        list_catalog_tool
             .description
             .as_deref()
             .expect("catalog description")
             .contains("3 table(s) and 0 table function(s) are currently visible")
     );
     assert!(
-        updated_tools[2]
+        search_tool
             .description
             .as_deref()
-            .expect("catalog search description")
+            .expect("search description")
             .contains("3 table(s) and 0 table function(s) are currently visible")
     );
 
@@ -496,63 +515,6 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         .await
         .expect_err("invalid catalog kind should fail");
 
-    let search = client
-        .call_tool(
-            CallToolRequestParams::new("search_catalog").with_arguments(json_object(&json!({
-                "pattern": "^MESSAGES$",
-                "schema": "local_messages",
-                "kind": "table",
-                "ignore_case": true
-            }))),
-        )
-        .await
-        .expect("search catalog");
-    let search = search.structured_content.expect("structured content");
-    assert_eq!(search["total"], 1);
-    assert_eq!(search["items"][0]["name"], "local_messages.messages");
-    assert_eq!(
-        search["items"][0]["sql_reference"],
-        "local_messages.messages"
-    );
-    assert!(
-        search["items"][0]["table"]["guide"].is_string(),
-        "search results should always expose guide text, even when empty"
-    );
-    assert!(
-        search["items"][0]["matched_fields"]
-            .as_array()
-            .expect("matched fields")
-            .iter()
-            .any(|field| field == "table_name")
-    );
-    assert_matches_output_schema(search_catalog_tool, &search);
-
-    let search_page = client
-        .call_tool(
-            CallToolRequestParams::new("search_catalog").with_arguments(json_object(&json!({
-                "pattern": "Fixture",
-                "schema": "local_messages",
-                "limit": 2
-            }))),
-        )
-        .await
-        .expect("search table page");
-    let search_page = search_page.structured_content.expect("structured content");
-    assert_eq!(search_page["total"], 3);
-    assert_eq!(search_page["limit"], 2);
-    assert_eq!(search_page["has_more"], true);
-    assert_eq!(search_page["next_offset"], 2);
-    assert_matches_output_schema(search_catalog_tool, &search_page);
-
-    client
-        .call_tool(
-            CallToolRequestParams::new("search_catalog").with_arguments(json_object(&json!({
-                "pattern": "["
-            }))),
-        )
-        .await
-        .expect_err("invalid regex should fail");
-
     let described = client
         .call_tool(
             CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
@@ -593,14 +555,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         missing_table["suggestions"][0]["name"],
         "local_messages.events"
     );
-    assert_eq!(
-        missing_table["suggested_calls"][0]["tool"],
-        "search_catalog"
-    );
-    assert_eq!(
-        missing_table["suggested_calls"][0]["arguments"]["pattern"],
-        "missing"
-    );
+    assert_eq!(missing_table["suggested_calls"][0]["tool"], "list_catalog");
     assert_eq!(
         missing_table["suggested_calls"][0]["arguments"]["schema"],
         "local_messages"
@@ -620,13 +575,10 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         .structured_content
         .expect("structured content");
     assert_eq!(missing_schema["found"], false);
-    assert_eq!(
-        missing_schema["suggested_calls"][0]["arguments"]["pattern"],
-        r"missing\["
-    );
+    assert_eq!(missing_schema["suggested_calls"][0]["tool"], "list_catalog");
     assert!(
         missing_schema["suggested_calls"][0]["arguments"]["schema"].is_null(),
-        "search suggestion should not constrain a missing schema"
+        "catalog listing should not constrain a missing schema"
     );
 
     client
@@ -785,6 +737,10 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 }
 
 #[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "This end-to-end test keeps table-function listing, catalog search, and universal search assertions under one fixture."
+)]
 async fn list_catalog_surfaces_table_functions() {
     let temp = TempDir::new().expect("temp dir");
     let manifest_path = write_function_fixture_manifest(temp.path());
@@ -806,7 +762,7 @@ async fn list_catalog_surfaces_table_functions() {
     assert!(tools.iter().all(|tool| tool.name != "search_tables"));
 
     let catalog_tool = tool_by_name(&tools, "list_catalog");
-    let search_tool = tool_by_name(&tools, "search_catalog");
+    let universal_search_tool = tool_by_name(&tools, "search");
     let catalog = client
         .call_tool(CallToolRequestParams::new("list_catalog"))
         .await
@@ -856,28 +812,52 @@ async fn list_catalog_surfaces_table_functions() {
     );
     assert_matches_output_schema(catalog_tool, &functions);
 
-    let search = client
+    let universal_search = client
         .call_tool(
-            CallToolRequestParams::new("search_catalog").with_arguments(json_object(&json!({
-                "pattern": "hybrid",
-                "kind": "table_function"
+            CallToolRequestParams::new("search").with_arguments(json_object(&json!({
+                "query": "issue search title"
             }))),
         )
         .await
-        .expect("search table functions")
+        .expect("universal search")
         .structured_content
-        .expect("structured search");
-    assert_eq!(search["total"], 1);
-    assert_eq!(search["items"][0]["kind"], "table_function");
-    assert_eq!(search["items"][0]["name"], "searchy.search_issues");
+        .expect("structured universal search");
     assert!(
-        search["items"][0]["matched_fields"]
+        universal_search["provider_statuses"]
             .as_array()
-            .expect("matched fields")
+            .expect("provider statuses")
             .iter()
-            .any(|field| field == "arguments")
+            .any(|status| status["provider"] == "catalog_metadata"
+                && status["state"] == "results_found")
     );
-    assert_matches_output_schema(search_tool, &search);
+    assert!(
+        universal_search["provider_statuses"]
+            .as_array()
+            .expect("provider statuses")
+            .iter()
+            .any(|status| status["provider"] == "observed_values" && status["state"] == "empty")
+    );
+    assert!(
+        universal_search["results"]
+            .as_array()
+            .expect("search results")
+            .iter()
+            .any(|result| result["type"] == "native_search_path"
+                && result["name"] == "searchy.search_issues"
+                && result["sql_call_example"]
+                    .as_str()
+                    .is_some_and(|example| example.contains("q => '<q>'")))
+    );
+    assert!(
+        universal_search["results"]
+            .as_array()
+            .expect("search results")
+            .iter()
+            .any(|result| result["type"] == "column_hint"
+                && result["surface_name"] == "search_issues"
+                && result["name"] == "title")
+    );
+    assert_matches_output_schema(universal_search_tool, &universal_search);
 
     session.shutdown().await;
 }
@@ -903,14 +883,18 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             .collect::<Vec<_>>(),
         vec![
             "sql",
+            "search",
             "list_catalog",
-            "search_catalog",
             "describe_table",
             "list_columns",
             "feedback"
         ]
     );
-    let feedback_annotations = tools[5].annotations.as_ref().expect("feedback annotations");
+    let feedback_tool = tool_by_name(&tools, "feedback");
+    let feedback_annotations = feedback_tool
+        .annotations
+        .as_ref()
+        .expect("feedback annotations");
     assert_eq!(feedback_annotations.read_only_hint, Some(false));
     assert_eq!(feedback_annotations.destructive_hint, Some(false));
     assert_eq!(feedback_annotations.idempotent_hint, Some(false));

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -196,7 +196,7 @@ npx skills add withcoral/skills
 
 Available skills:
 
-- **`coral`** — teaches your agent the discovery-first MCP workflow for answering data questions through Coral, including how to use `list_catalog`, `search_catalog`, `coral.tables`, `coral.table_functions`, `coral.columns`, and `coral.inputs`.
+- **`coral`** — teaches your agent the discovery-first MCP workflow for answering data questions through Coral, including how to use `search`, `list_catalog`, `coral.tables`, `coral.table_functions`, `coral.columns`, and `coral.inputs`.
 - **`coral-create-source-spec`** — guides your agent through authoring or repairing a custom source spec YAML for `coral source add --file`, or adapting it into a bundled source.
 - **`coral-review-source-spec`** — guides source manifest and source PR reviews for correctness, query ergonomics, documentation quality, and consistency with existing Coral sources.
 

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -15,8 +15,8 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
 | Tool     | `sql`            | Execute read-only SQL against the Coral database        |
+| Tool     | `search`         | Route clues to likely catalog items, columns, filters, and native search paths |
 | Tool     | `list_catalog`   | List database tables and table functions with pagination |
-| Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
 | Tool     | `describe_table` | Show compact metadata for one database table            |
 | Tool     | `list_columns`   | List columns for one database table with pagination     |
 | Resource | `coral://guide`  | Database workflow guide for agents                     |
@@ -35,9 +35,12 @@ Agents should treat the discovery tools as catalog helpers, not as replacement p
 - For table functions, use `sql_call_example` and fill in the required arguments.
 - Do not quote the whole `schema.item` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 
-**`search_catalog`**: deterministic regex matching over database catalog metadata.
+**`search`**: one-query clue routing over Coral discovery metadata.
 
-- Arguments: required `pattern` plus optional `schema`, `kind`, `ignore_case`, `limit`, `offset`.
+- Arguments: required `query` only.
+- Returns typed hints such as `catalog_item`, `column_hint`, and `native_search_path`, plus provider-status and truncation metadata.
+- Use it when the agent has a clue but does not know which source, table, table function, column, or filter to try first.
+- Results are not evidence. Agents must verify useful hints with ordinary `sql` queries or explicit table-function calls before answering.
 
 **`describe_table`**: compact metadata for one table.
 
@@ -48,7 +51,7 @@ Agents should treat the discovery tools as catalog helpers, not as replacement p
 
 - Arguments: exact `schema` and `table`, plus optional `pattern`, `ignore_case`, `required_only`, `limit`, `offset`.
 - For existing tables, returns a `columns` page with `total`, `has_more`, and optional `next_offset`. When `pattern` is set, matching rows include `matched_fields` so clients can explain why a column matched.
-- When the requested table does not exist, returns `found: false` with recovery hints instead of an empty page. Clients should branch to `search_catalog` or `list_catalog` rather than pretending the table has zero columns.
+- When the requested table does not exist, returns `found: false` with recovery hints instead of an empty page. Clients should branch to `search` or `list_catalog` rather than pretending the table has zero columns.
 
 ### Richer metadata via SQL
 
@@ -234,7 +237,7 @@ Once your client is connected, ask the agent to list available tables or run a s
 
 > "Run a small Coral query against `coral.tables`."
 
-The agent should call `list_catalog`, `search_catalog`, or query `coral.tables` and `coral.table_functions` to return SQL schemas and catalog items, and use `describe_table` or `list_columns` for table-specific metadata. Large catalogs should be paged with `limit` and `offset`.
+The agent should call `search`, `list_catalog`, or query `coral.tables` and `coral.table_functions` to return SQL schemas and catalog items, and use `describe_table` or `list_columns` for table-specific metadata. Large catalogs should be paged with `limit` and `offset`.
 
 ## Troubleshooting
 

--- a/docs/project/architecture.mdx
+++ b/docs/project/architecture.mdx
@@ -68,6 +68,7 @@ The local server and core orchestrator.
 | Feedback persistence | Workspace-scoped blocked-agent feedback reports (`feedback/`) |
 | Query orchestration | Loads sources, builds the engine, executes SQL (`query/`) |
 | Catalog discovery | Lists/searches/describes query-visible tables and columns (`catalog/`) |
+| Universal Search | Routes clues to typed catalog, column, and native-search-path hints (`search/`) |
 
 This is the largest crate. It ties `coral-spec` and `coral-engine` together and manages all persistent local state.
 
@@ -103,7 +104,7 @@ The MCP stdio server.
 | --------------- | ------------------------------------------------------------------- |
 | MCP protocol    | Tool and resource handlers via the `rmcp` SDK (`server.rs`)         |
 | Surface shaping | Tool/resource/error helpers split across `surface/{mod,tools,resources,errors}.rs`; discovery semantics come from `coral-app` |
-| Tools           | `sql`, `list_catalog`, `search_catalog`, `describe_table`, `list_columns`, optional `feedback` |
+| Tools           | `sql`, `search`, `list_catalog`, `describe_table`, `list_columns`, optional `feedback` |
 | Resources       | `coral://guide`, `coral://tables`                                   |
 
 Uses `coral-client` to reach `coral-app`, same transport as the CLI.
@@ -114,7 +115,7 @@ The shared gRPC contract.
 
 | Owns                 | Details                                                                                |
 | -------------------- | -------------------------------------------------------------------------------------- |
-| Protobuf definitions | `proto/coral/v1/` — `query.proto`, `sources.proto`, `catalog.proto`, `resources.proto` |
+| Protobuf definitions | `proto/coral/v1/` — `query.proto`, `sources.proto`, `catalog.proto`, `search.proto`, `resources.proto` |
 | Generated bindings   | Tonic-generated Rust types and service traits                                          |
 
 All inter-crate communication between `coral-client` and `coral-app` goes through these generated types.

--- a/docs/project/security.mdx
+++ b/docs/project/security.mdx
@@ -25,7 +25,7 @@ This release is intended for single-user local use:
   server binds to loopback, and the MCP server uses stdio transport.
 
 Coral reduces data exposure by keeping execution local and by exposing a narrow
-MCP surface: `sql`, `list_catalog`, `search_catalog`, `describe_table`,
+MCP surface: `sql`, `search`, `list_catalog`, `describe_table`,
 `list_columns`, optional `feedback`, `coral://guide`, and `coral://tables`.
 Secret values are not returned through `coral.inputs`; secret rows show only
 whether a value is configured.

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -34,6 +34,25 @@ coral sql "<SQL>"
 
 JSON output is an array of row objects. Selected nullable columns are included with explicit `null` values when the row value is null.
 
+## `coral search`
+
+Route a clue to likely Coral catalog items, columns, filters, and provider-native search paths.
+
+```shellscript
+coral search "payments-api timeout"
+coral search --json "payments-api timeout"
+```
+
+The text output is compact and shows each result's type, name, and most useful payload detail. Treat results as routing hints; verify them with `coral sql` before using retrieved data as evidence.
+
+### Options
+
+| Option   | Type | Default | Description                 |
+| -------- | ---- | ------- | --------------------------- |
+| `--json` | flag | `false` | Emit structured JSON output |
+
+JSON output contains the same provider-status, truncation, and typed-result fields returned by the shared Search API.
+
 ## `coral source`
 
 Manage configured sources, either the bundled ones, or your custom source specs.
@@ -219,8 +238,8 @@ This server exposes:
 | Type     | Name             | Description                      |
 | -------- | ---------------- | -------------------------------- |
 | Tool     | `sql`            | Execute read-only SQL against the Coral database |
+| Tool     | `search`         | Route clues to likely catalog items, columns, filters, and native search paths |
 | Tool     | `list_catalog`   | List database tables and table functions |
-| Tool     | `search_catalog` | Search database catalog metadata by regex |
 | Tool     | `describe_table` | Show compact database table metadata |
 | Tool     | `list_columns`   | List columns for one database table |
 | Resource | `coral://guide`  | Database workflow guide for agents |

--- a/plugins/coral/skills/coral/SKILL.md
+++ b/plugins/coral/skills/coral/SKILL.md
@@ -23,8 +23,8 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 ## Workflow
 
 1. Identify the needed source, entity, and scope from the user request.
-2. Discover tables and table functions with `list_catalog` or `search_catalog`; page large catalogs and narrow by schema or kind when useful.
-3. Read `list_catalog` or `search_catalog` for `sql_reference`, `sql_call_example`, and `required_filters`; use `coral://guide` for query patterns and `coral://tables` for table summaries.
+2. Route ambiguous clues with `search`, and discover tables and table functions with `list_catalog`; page large catalogs and narrow by schema or kind when useful.
+3. Read `search` or `list_catalog` for `sql_reference`, `sql_call_example`, and `required_filters`; use `coral://guide` for query patterns and `coral://tables` for table summaries.
 4. Inspect `coral.columns` for table columns, required filters, virtual columns, and descriptions.
 5. Inspect `coral.table_functions` for source-scoped function arguments and result columns.
 6. Inspect `coral.inputs` when source configuration affects the answer.


### PR DESCRIPTION
## Summary
- compact the Universal Search work into one current-version PR based on current `main`
- expose the shared `search` API plus MCP and CLI search surfaces
- back catalog metadata and observed-value retrieval with a workspace-scoped Tantivy index
- refresh catalog metadata by building a replacement index directory and swapping it into place
- index observed values from successful SQL results with sidecar state for count and retention

## Replaces
Supersedes the old draft stack: #792, #793, #794, #868, #869, #929, #943.

## Validation
- `make rust-checks`