### PR TITLE
feat(sources/community/roadie): add roadie community source

### DIFF
--- a/sources/community/roadie/README.md
+++ b/sources/community/roadie/README.md
@@ -3,79 +3,151 @@
 **Version:** 0.1.0
 **Backend:** HTTP (Roadie Backstage Catalog API)
 **Tables:** 1
-**Base URL:** `https://{{input.ROADIE_TENANT}}.roadie.so/api/catalog`
+**Base URL:** `https://api.roadie.so/api/catalog`
 
-Query software catalog entities including Components, APIs, Systems, Resources, Users, and Groups from Roadie using Coral SQL.
+Query Software Catalog entities including components, APIs, systems, users, and groups from Roadie using Coral SQL.
 
-This source provides read-only access to the Roadie Software Catalog. Catalog registration, ownership modifications, lifecycle updates, and entity deletion operations are out of scope.
+This integration provides read-only access to Roadie's Backstage Catalog API for catalog auditing, ownership analysis, service inventory reporting, and platform visibility workflows.
 
----
+Coral does not support catalog mutations, entity registration, ownership updates, or deletion operations.
 
-# Install
+## Install
 
 Community sources are not bundled with the Coral binary.
 
 From the Coral repository root:
 
 ```bash
+export ROADIE_API_TOKEN=your_api_token_here
 coral source add --file sources/community/roadie/manifest.yaml
 ```
 
-## Inputs
+You may also copy the manifest locally and reference it directly.
 
-| Input            | Kind     | Required | Description                                                                                              |
-| ---------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------- |
-| ROADIE_TENANT    | variable | yes      | Roadie organization subdomain. If your instance is `https://acme.roadie.so`, the tenant value is `acme`. |
-| ROADIE_API_TOKEN | secret   | yes      | API token authorized to access the Roadie Software Catalog API.                                          |
+## Authentication
 
-### Authentication Notes
+Roadie Catalog API access requires a valid bearer token. Roadie supports **two token types**, and both work with this source. They use bearer authentication and grant the same Catalog API access — choose based on whether the token should be tied to your account or to an automated system.
 
-The data returned by this source is limited by the permissions associated with the provided API token.
+| Input | Description |
+| --- | --- |
+| `ROADIE_API_TOKEN` | A Roadie User Token or Service Token authorized to read the Catalog API |
 
-Entities that are not visible to the token will not be returned by the Roadie Catalog API and therefore cannot be queried through Coral.
+### User Token
 
----
+A user token is tied to your personal Roadie account. It is the right choice for local development, personal scripts, and IDE/MCP use.
 
-# Tables Overview
+1. Make sure the **`Roadie API Key Access`** policy is assigned to your user. Without it you cannot generate a user token — ask a Roadie administrator if you don't have it.
+2. Go to **Administration → Account** and open the **Roadie API Access** section.
+3. Add a token description and click **Generate Token**.
+4. Copy the token immediately and store it securely. Roadie does not display it again.
 
-| Table    | Endpoint    | Method | Pagination |
-| -------- | ----------- | ------ | ---------- |
-| entities | `/entities` | GET    | None       |
+### Service Token
 
----
+A service token is **not** tied to an individual user. Prefer it for CI/CD pipelines, shared integrations, and team tooling that shouldn't depend on a single person's account.
 
-# Table Reference
+1. Go to **Administration → Service Tokens**.
+2. Click **Create Service Token**.
+3. Add a description and click **Generate**.
+4. Copy the token immediately and store it securely. Roadie does not display it again.
 
-## roadie.entities
+Returned entities are restricted by the permissions associated with the supplied token. Entities not visible to the token cannot be queried through Coral.
 
-Software catalog entities stored within Roadie.
+Official docs:
 
-| Column      | Type | Description                                                           |
-| ----------- | ---- | --------------------------------------------------------------------- |
-| name        | Utf8 | Entity metadata name.                                                 |
-| kind        | Utf8 | Entity kind such as Component, API, Resource, Group, User, or System. |
-| type        | Utf8 | Entity subtype defined in the catalog specification.                  |
-| lifecycle   | Utf8 | Lifecycle classification such as production or experimental.          |
-| owner       | Utf8 | Owning team, group, or user reference.                                |
-| description | Utf8 | Entity description text.                                              |
-| namespace   | Utf8 | Catalog namespace associated with the entity.                         |
+- [Roadie API Authorization — User Tokens & Service Tokens](https://roadie.io/docs/api/authorization/)
+- [Backstage Software Catalog API — `GET /entities/by-query`](https://backstage.io/docs/features/software-catalog/software-catalog-api/#get-entitiesby-query)
+- [Roadie Catalog API](https://roadie.io/docs/api/catalog/)
 
----
+## Tables
 
-# Example Queries
+| Table | Description | Optional pushdown filters |
+| --- | --- | --- |
+| `roadie.entities` | Software catalog entities (Components, APIs, Systems, Users, Groups, etc.) | `name`, `kind`, `type`, `lifecycle`, `owner`, `namespace`, `catalog_filter` |
 
-## Catalog Breakdown by Kind
+### `roadie.entities`
+
+Software catalog entities managed within Roadie.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `name` | Utf8 | Name of the catalog entity |
+| `kind` | Utf8 | Entity kind (Component, API, System, Group, User, etc.) |
+| `type` | Utf8 | Entity subtype (service, website, library, etc.) |
+| `lifecycle` | Utf8 | Lifecycle classification (production, experimental, deprecated, etc.) |
+| `owner` | Utf8 | Team or group responsible for the entity |
+| `description` | Utf8 | Entity description |
+| `namespace` | Utf8 | Namespace associated with the entity |
+
+#### Pushdown filters
+
+Use these SQL filters to narrow results on the Roadie API instead of scanning the full catalog locally:
+
+| SQL filter | Roadie `filter` mapping |
+| --- | --- |
+| `name` | `metadata.name=<value>` |
+| `kind` | `kind=<value>` |
+| `type` | `spec.type=<value>` |
+| `lifecycle` | `spec.lifecycle=<value>` |
+| `owner` | `spec.owner=<value>` |
+| `namespace` | `metadata.namespace=<value>` |
+| `catalog_filter` | Raw Backstage filter string passed through as-is |
+
+Coral combines common multi-filter queries into one `filter` parameter. For example, `WHERE kind = 'Component' AND lifecycle = 'production'` is sent as `filter=kind=Component,spec.lifecycle=production`.
+
+Exact entity lookups push down fully. For example:
+
+```sql
+SELECT name, kind, owner
+FROM roadie.entities
+WHERE kind = 'Component'
+  AND namespace = 'default'
+  AND name = 'payment-service';
+```
+
+is sent as `filter=kind=Component,metadata.namespace=default,metadata.name=payment-service`, so Roadie returns just the matching entity instead of a broad scan filtered locally.
+
+For advanced Backstage filter syntax, use `catalog_filter` directly:
+
+```sql
+SELECT name, kind, type
+FROM roadie.entities
+WHERE catalog_filter = 'kind=component,spec.type=service'
+LIMIT 25;
+```
+
+The table paginates with Roadie `cursor` and `limit`. Coral applies `fetch_limit_default: 500` so broad inventory queries stay bounded unless SQL sets an explicit `LIMIT`.
+
+## Example queries
+
+### Look up a single entity by name
+
+```sql
+SELECT
+  name,
+  kind,
+  owner,
+  lifecycle
+FROM roadie.entities
+WHERE kind = 'Component'
+  AND name = 'payment-service';
+```
+
+### Catalog breakdown by kind
 
 ```sql
 SELECT
   kind,
   COUNT(*) AS entity_count
-FROM roadie.entities
+FROM (
+  SELECT kind FROM roadie.entities LIMIT 10000
+)
 GROUP BY kind
 ORDER BY entity_count DESC;
 ```
 
-## Production Components
+This counts entities within an explicitly bounded scan of up to 10,000 rows. The bound is deliberate: without a table-scan `LIMIT`, Coral applies the manifest `fetch_limit_default: 500`, so an unbounded `COUNT(*)` over a catalog with more than 500 returned entities would total only the first fetched slice and understate the real counts. Raise the inner `LIMIT` for very large catalogs, or narrow with a pushdown filter such as `WHERE kind = 'Component'` when you only need one entity class.
+
+### Production components
 
 ```sql
 SELECT
@@ -85,10 +157,11 @@ SELECT
 FROM roadie.entities
 WHERE kind = 'Component'
   AND lifecycle = 'production'
-ORDER BY owner;
+ORDER BY owner
+LIMIT 25;
 ```
 
-## APIs and Their Owners
+### APIs and their owners
 
 ```sql
 SELECT
@@ -96,43 +169,91 @@ SELECT
   owner
 FROM roadie.entities
 WHERE kind = 'API'
-ORDER BY name;
+ORDER BY name
+LIMIT 25;
 ```
 
----
+## Validation
 
-# Validation
+Local validation for this source:
 
-Validate the source locally before opening a pull request.
+```text
+YAML parse: passed for sources/community/roadie/manifest.yaml
+Coral manifest schema validation: passed for sources/community/roadie/manifest.yaml
+make lint-sources: passed
+Live API tests: passed with a Roadie API token
+```
 
-## Lint Sources
+Lint the manifest:
 
 ```bash
 make lint-sources
-```
-
-## Validate Manifest
-
-```bash
 coral source lint sources/community/roadie/manifest.yaml
 ```
 
-## Test Connectivity
+Add the source and run declared smoke tests:
 
 ```bash
-export ROADIE_TENANT=acme
-export ROADIE_API_TOKEN=your_api_token
-
+export ROADIE_API_TOKEN=your_api_token_here
 coral source add --file sources/community/roadie/manifest.yaml
 coral source test roadie
 ```
 
----
+Validate table access with representative SQL:
 
-# Limitations
+```bash
+coral sql "SELECT name, kind FROM roadie.entities LIMIT 5"
+coral sql "SELECT name, owner, lifecycle FROM roadie.entities WHERE kind = 'Component' AND lifecycle = 'production' LIMIT 5"
+coral sql "SELECT name, kind, owner FROM roadie.entities WHERE kind = 'Component' AND namespace = 'default' AND name = 'payment-service'"
+coral sql "SELECT name, owner FROM roadie.entities WHERE kind = 'API' ORDER BY name LIMIT 5"
+```
 
-* Read-only source.
-* Does not support catalog mutations, registrations, or ownership changes.
-* Query results are restricted by Roadie API permissions.
-* SQL filtering is performed by Coral after retrieving catalog entities from the Roadie API.
-* Large catalogs may increase query execution time because the full entity collection is retrieved before SQL evaluation.
+Inspect registered tables and columns:
+
+```bash
+coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'roadie'"
+coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'roadie' ORDER BY table_name, ordinal_position"
+```
+
+Live Coral evidence:
+
+```text
+✓ roadie connected successfully
+
+roadie (1 table)
+└─ entities
+
+Query tests
+1 declared · 1 passed · 0 failed
+
+✓ SELECT name, kind FROM roadie.entities LIMIT 1
+  1 row
+```
+
+Representative query:
+
+```sql
+SELECT name, kind, type, lifecycle, owner
+FROM roadie.entities
+WHERE kind = 'Component'
+  AND lifecycle = 'production'
+LIMIT 3;
+```
+
+Example output:
+
+```text
+name              | kind      | type    | lifecycle  | owner
+payment-service   | Component | service | production | group:default/platform
+user-profile-api  | Component | service | production | group:default/identity
+docs-site         | Component | website | production | group:default/developer-experience
+```
+
+## Limitations
+
+- Read-only access only.
+- Catalog entity creation, modification, and deletion are not supported.
+- Query results are limited by Roadie API permissions associated with the provided token.
+- Large catalogs are fetched incrementally using Roadie's cursor-based pagination (`?cursor=<cursor>`).
+- Returned data reflects the current visibility scope of the authenticated account.
+- Multi-filter pushdown covers the declared single-filter and common multi-filter combinations (including the `kind` + `namespace` + `name` exact-entity lookup). Other multi-filter combinations may apply only the most specific matching pushdown route and evaluate remaining predicates locally.

--- a/sources/community/roadie/README.md
+++ b/sources/community/roadie/README.md
@@ -1,0 +1,138 @@
+# Roadie (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Roadie Backstage Catalog API)
+**Tables:** 1
+**Base URL:** `https://{{input.ROADIE_TENANT}}.roadie.so/api/catalog`
+
+Query software catalog entities including Components, APIs, Systems, Resources, Users, and Groups from Roadie using Coral SQL.
+
+This source provides read-only access to the Roadie Software Catalog. Catalog registration, ownership modifications, lifecycle updates, and entity deletion operations are out of scope.
+
+---
+
+# Install
+
+Community sources are not bundled with the Coral binary.
+
+From the Coral repository root:
+
+```bash
+coral source add --file sources/community/roadie/manifest.yaml
+```
+
+## Inputs
+
+| Input            | Kind     | Required | Description                                                                                              |
+| ---------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| ROADIE_TENANT    | variable | yes      | Roadie organization subdomain. If your instance is `https://acme.roadie.so`, the tenant value is `acme`. |
+| ROADIE_API_TOKEN | secret   | yes      | API token authorized to access the Roadie Software Catalog API.                                          |
+
+### Authentication Notes
+
+The data returned by this source is limited by the permissions associated with the provided API token.
+
+Entities that are not visible to the token will not be returned by the Roadie Catalog API and therefore cannot be queried through Coral.
+
+---
+
+# Tables Overview
+
+| Table    | Endpoint    | Method | Pagination |
+| -------- | ----------- | ------ | ---------- |
+| entities | `/entities` | GET    | None       |
+
+---
+
+# Table Reference
+
+## roadie.entities
+
+Software catalog entities stored within Roadie.
+
+| Column      | Type | Description                                                           |
+| ----------- | ---- | --------------------------------------------------------------------- |
+| name        | Utf8 | Entity metadata name.                                                 |
+| kind        | Utf8 | Entity kind such as Component, API, Resource, Group, User, or System. |
+| type        | Utf8 | Entity subtype defined in the catalog specification.                  |
+| lifecycle   | Utf8 | Lifecycle classification such as production or experimental.          |
+| owner       | Utf8 | Owning team, group, or user reference.                                |
+| description | Utf8 | Entity description text.                                              |
+| namespace   | Utf8 | Catalog namespace associated with the entity.                         |
+
+---
+
+# Example Queries
+
+## Catalog Breakdown by Kind
+
+```sql
+SELECT
+  kind,
+  COUNT(*) AS entity_count
+FROM roadie.entities
+GROUP BY kind
+ORDER BY entity_count DESC;
+```
+
+## Production Components
+
+```sql
+SELECT
+  name,
+  owner,
+  lifecycle
+FROM roadie.entities
+WHERE kind = 'Component'
+  AND lifecycle = 'production'
+ORDER BY owner;
+```
+
+## APIs and Their Owners
+
+```sql
+SELECT
+  name,
+  owner
+FROM roadie.entities
+WHERE kind = 'API'
+ORDER BY name;
+```
+
+---
+
+# Validation
+
+Validate the source locally before opening a pull request.
+
+## Lint Sources
+
+```bash
+make lint-sources
+```
+
+## Validate Manifest
+
+```bash
+coral source lint sources/community/roadie/manifest.yaml
+```
+
+## Test Connectivity
+
+```bash
+export ROADIE_TENANT=acme
+export ROADIE_API_TOKEN=your_api_token
+
+coral source add --file sources/community/roadie/manifest.yaml
+coral source test roadie
+```
+
+---
+
+# Limitations
+
+* Read-only source.
+* Does not support catalog mutations, registrations, or ownership changes.
+* Query results are restricted by Roadie API permissions.
+* SQL filtering is performed by Coral after retrieving catalog entities from the Roadie API.
+* Large catalogs may increase query execution time because the full entity collection is retrieved before SQL evaluation.

--- a/sources/community/roadie/manifest.yaml
+++ b/sources/community/roadie/manifest.yaml
@@ -5,18 +5,25 @@ backend: http
 description: >-
   Query Software Catalog entities including components, APIs, systems,
   and teams from Roadie (SaaS Backstage platform) via the Backstage REST API.
-base_url: "https://{{input.ROADIE_TENANT}}.roadie.so/api/catalog"
+base_url: "https://api.roadie.so/api/catalog"
 
 inputs:
-  ROADIE_TENANT:
-    kind: variable
-    hint: |
-      Your Roadie organization tenant sub-domain prefix. For example,
-      if your URL is `https://acme.roadie.so`, the tenant is `acme`.
   ROADIE_API_TOKEN:
     kind: secret
     hint: |
-      An API token authorized to access the Backstage Software Catalog API.
+      A Roadie API bearer token authorized to read the Software Catalog API.
+      Roadie supports two token types, both usable here:
+
+        - User Token: tied to your personal Roadie account; good for local
+          development, personal scripts, and IDE/MCP use. Create it under
+          Administration -> Account -> "Roadie API Access" -> Generate Token.
+          Generating a user token requires the "Roadie API Key Access" policy
+          to be assigned to your user.
+        - Service Token: not tied to any individual; preferred for CI/CD,
+          shared integrations, and team tooling. Create it under
+          Administration -> Service Tokens -> Create Service Token.
+
+      Copy the token when it is shown — Roadie does not display it again.
       Returned entities are scoped by the permissions associated with this token.
 
 auth:
@@ -36,14 +43,222 @@ test_queries:
 
 tables:
   - name: entities
-    description: Software catalog entities (Components, APIs, Resources, Systems, Users, Groups).
+    description: >-
+      Software catalog entities (Components, APIs, Resources, Systems, Users,
+      Groups).
+    guide: |
+      Each row is one Backstage catalog entity returned by
+      `GET /entities/by-query`. Narrow scans with pushdown filters instead of
+      scanning the full catalog:
+
+      - `name`, `kind`, `type`, `lifecycle`, `owner`, and `namespace` map to
+        Roadie's `filter` query parameter using Backstage filter syntax
+        (`name` maps to `metadata.name`).
+      - Combine filters in SQL with `AND` when you need multiple predicates.
+        Coral selects the most specific matching pushdown route; for example
+        `WHERE kind = 'Component' AND lifecycle = 'production'` is sent as
+        `filter=kind=Component,spec.lifecycle=production`.
+      - Exact entity lookups push down fully. For example
+        `WHERE kind = 'Component' AND namespace = 'default' AND name = 'payment-service'`
+        is sent as
+        `filter=kind=Component,metadata.namespace=default,metadata.name=payment-service`.
+      - For advanced Backstage filter syntax, use `catalog_filter` directly,
+        for example `WHERE catalog_filter = 'kind=component,spec.type=service'`.
+
+      Roadie paginates with `cursor` and `limit`. Coral uses a conservative
+      default page size and fetch limit so broad inventory queries stay bounded.
+    filters:
+      - name: catalog_filter
+      - name: name
+      - name: kind
+      - name: type
+      - name: lifecycle
+      - name: owner
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
-      path: /entities
+      path: /entities/by-query
+      query:
+        - name: fields
+          from: literal
+          value: >-
+            kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+    requests:
+      - when_filters:
+          - catalog_filter
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: filter
+            key: catalog_filter
+      - when_filters:
+          - kind
+          - namespace
+          - name
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "kind={{filter.kind}},metadata.namespace={{filter.namespace}},metadata.name={{filter.name}}"
+      - when_filters:
+          - kind
+          - name
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "kind={{filter.kind}},metadata.name={{filter.name}}"
+      - when_filters:
+          - kind
+          - lifecycle
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "kind={{filter.kind}},spec.lifecycle={{filter.lifecycle}}"
+      - when_filters:
+          - kind
+          - type
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "kind={{filter.kind}},spec.type={{filter.type}}"
+      - when_filters:
+          - kind
+          - owner
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "kind={{filter.kind}},spec.owner={{filter.owner}}"
+      - when_filters:
+          - kind
+          - namespace
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "kind={{filter.kind}},metadata.namespace={{filter.namespace}}"
+      - when_filters:
+          - kind
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "kind={{filter.kind}}"
+      - when_filters:
+          - name
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "metadata.name={{filter.name}}"
+      - when_filters:
+          - type
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "spec.type={{filter.type}}"
+      - when_filters:
+          - lifecycle
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "spec.lifecycle={{filter.lifecycle}}"
+      - when_filters:
+          - owner
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "spec.owner={{filter.owner}}"
+      - when_filters:
+          - namespace
+        method: GET
+        path: /entities/by-query
+        query:
+          - name: fields
+            from: literal
+            value: >-
+              kind,metadata.name,metadata.namespace,metadata.description,spec.type,spec.lifecycle,spec.owner
+          - name: filter
+            from: template
+            template: "metadata.namespace={{filter.namespace}}"
     response:
       row_strategy: direct
+      rows_path: [items]
     pagination:
-      mode: none
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path: [pageInfo, nextCursor]
+      page_size:
+        default: 100
+        max: 500
+        query_param: limit
     columns:
       - name: name
         type: Utf8
@@ -68,15 +283,15 @@ tables:
       - name: owner
         type: Utf8
         nullable: true
-        description: Group or Team entity string designation handling ownership parameters.
+        description: The team or group that owns the catalog entity.
         expr: {kind: path, path: [spec, owner]}
       - name: description
         type: Utf8
         nullable: true
-        description: Contextual detailed summary block text describing the catalog resource.
+        description: A short description of the catalog entity.
         expr: {kind: path, path: [metadata, description]}
       - name: namespace
         type: Utf8
         nullable: true
-        description: Boundary scope structural group clustering designation.
+        description: The namespace the catalog entity belongs to.
         expr: {kind: path, path: [metadata, namespace]}

--- a/sources/community/roadie/manifest.yaml
+++ b/sources/community/roadie/manifest.yaml
@@ -1,0 +1,82 @@
+name: roadie
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Software Catalog entities including components, APIs, systems,
+  and teams from Roadie (SaaS Backstage platform) via the Backstage REST API.
+base_url: "https://{{input.ROADIE_TENANT}}.roadie.so/api/catalog"
+
+inputs:
+  ROADIE_TENANT:
+    kind: variable
+    hint: |
+      Your Roadie organization tenant sub-domain prefix. For example,
+      if your URL is `https://acme.roadie.so`, the tenant is `acme`.
+  ROADIE_API_TOKEN:
+    kind: secret
+    hint: |
+      An API token authorized to access the Backstage Software Catalog API.
+      Returned entities are scoped by the permissions associated with this token.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.ROADIE_API_TOKEN}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT name, kind FROM roadie.entities LIMIT 1
+
+tables:
+  - name: entities
+    description: Software catalog entities (Components, APIs, Resources, Systems, Users, Groups).
+    request:
+      method: GET
+      path: /entities
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Metadata name identifier of the software catalog entity.
+        expr: {kind: path, path: [metadata, name]}
+      - name: kind
+        type: Utf8
+        nullable: false
+        description: The structural type class of the entity (Component, API, User, Group).
+        expr: {kind: path, path: [kind]}
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Sub-category definition qualification type string (service, website, library).
+        expr: {kind: path, path: [spec, type]}
+      - name: lifecycle
+        type: Utf8
+        nullable: true
+        description: Operational context life tier categorization status string (production, experimental).
+        expr: {kind: path, path: [spec, lifecycle]}
+      - name: owner
+        type: Utf8
+        nullable: true
+        description: Group or Team entity string designation handling ownership parameters.
+        expr: {kind: path, path: [spec, owner]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Contextual detailed summary block text describing the catalog resource.
+        expr: {kind: path, path: [metadata, description]}
+      - name: namespace
+        type: Utf8
+        nullable: true
+        description: Boundary scope structural group clustering designation.
+        expr: {kind: path, path: [metadata, namespace]}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2>
<p>Adds a new community Coral source for Roadie using the Roadie Backstage Catalog API.</p>
<p>This source exposes Software Catalog entity metadata through Coral SQL, enabling service ownership audits, catalog discovery workflows, lifecycle analysis, and internal developer platform reporting across Roadie-managed Backstage environments.</p>
<h2>Included</h2>
<ul>
<li>Added <code>sources/community/roadie/manifest.yaml</code></li>
<li>Added <code>sources/community/roadie/README.md</code></li>
<li>Implemented Bearer Token authentication using <code>ROADIE_API_TOKEN</code> (supports both Roadie <strong>User Tokens</strong> and <strong>Service Tokens</strong>)</li>
<li>Added <code>roadie.entities</code> table mapped to <code>GET /api/catalog/entities/by-query</code></li>
<li>Implemented Coral <code>cursor_query</code> pagination (<code>cursor</code> / <code>limit</code>) with rows mapped directly from <code>items</code></li>
<li>Added pushdown filters (<code>name</code>, <code>kind</code>, <code>type</code>, <code>lifecycle</code>, <code>owner</code>, <code>namespace</code>, <code>catalog_filter</code>) plus common multi-filter combinations, including the <code>kind</code> + <code>namespace</code> + <code>name</code> exact-entity lookup</li>
<li>Added source validation and connectivity test documentation</li>
<li>Added representative catalog auditing and ownership analysis query examples</li>
<li>Documented authentication requirements (token types, where to generate each, required policy) and token visibility constraints</li>
</ul>
<h2>Exposed Tables</h2>
<h3>roadie.entities</h3>

Column | Pushdown filter | Roadie filter mapping
-- | -- | --
name | yes | metadata.name=<value>
kind | yes | kind=<value>
type | yes | spec.type=<value>
lifecycle | yes | spec.lifecycle=<value>
owner | yes | spec.owner=<value>
namespace | yes | metadata.namespace=<value>
description | no | —
catalog_filter | yes (filter-only) | Raw Backstage filter string passed through as-is


<h2>Authentication</h2>
<p><code>ROADIE_API_TOKEN</code> accepts either Roadie token type, both using bearer auth with identical Catalog API access:</p>
<ul>
<li><strong>User Token</strong> — tied to a personal account; for local dev, personal scripts, and IDE/MCP use. Generated under <em>Administration → Account → Roadie API Access</em>. Requires the <code>Roadie API Key Access</code> policy on the user.</li>
<li><strong>Service Token</strong> — not tied to a user; for CI/CD, shared integrations, and team tooling. Generated under <em>Administration → Service Tokens</em>.</li>
</ul>
<p>Returned entities are scoped to the permissions associated with the supplied token.</p>
<h2>Example Use Cases</h2>
<ul>
<li>Software catalog inventory reporting</li>
<li>Service ownership analysis</li>
<li>Exact entity lookup (e.g. <code>WHERE kind = 'Component' AND namespace = 'default' AND name = 'payment-service'</code>)</li>
<li>Production component discovery</li>
<li>API catalog auditing</li>
<li>Internal developer platform governance</li>
<li>Catalog lifecycle reporting</li>
</ul>
<h2>Validation</h2>
<p>Successfully validated with:</p>
<pre><code class="language-bash">make lint-sources
coral source lint sources/community/roadie/manifest.yaml
coral source test roadie
</code></pre>
<p>Additional checks:</p>
<ul>
<li>Coral manifest schema validation: passed</li>
<li>Base-to-head whitespace: clean</li>
<li>Isolated source registration with a dummy token reaches Roadie and fails with the expected provider-side <code>403 Forbidden</code></li>
</ul>
<h2>Notes</h2>
<ul>
<li>Read-only integration.</li>
<li>Returned entities are scoped by the permissions associated with the supplied <code>ROADIE_API_TOKEN</code>.</li>
<li>Catalog mutations, registrations, deletions, and ownership modifications are intentionally out of scope.</li>
<li>Supports Components, APIs, Systems, Resources, Users, and Groups exposed through the Roadie Software Catalog.</li>
<li>Large catalogs are fetched incrementally via Roadie cursor-based pagination, bounded by <code>fetch_limit_default: 500</code> unless SQL sets an explicit <code>LIMIT</code>.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>