### PR TITLE
feat(search): add universal search contracts

### DIFF
--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -19,6 +19,7 @@ fn main() {
                 "proto/coral/v1/feedback.proto",
                 "proto/coral/v1/sources.proto",
                 "proto/coral/v1/query.proto",
+                "proto/coral/v1/search.proto",
                 "proto/coral/v1/traces.proto",
                 "proto/coral/v1/episode.proto",
             ],

--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -102,6 +102,26 @@ message TableFunctionResultColumn {
   string description = 4;
 }
 
+// Query-visible table-function semantic class.
+enum TableFunctionKind {
+  // Unknown function role.
+  TABLE_FUNCTION_KIND_UNSPECIFIED = 0;
+  // Generic row-returning provider operation.
+  TABLE_FUNCTION_KIND_TABLE = 1;
+  // Provider-native retrieval/search operation that returns ranked candidates.
+  TABLE_FUNCTION_KIND_SEARCH = 2;
+}
+
+// Bounded retrieval settings for search-like provider surfaces.
+message SearchLimits {
+  // Default candidate count used when the SQL call does not specify a limit.
+  uint32 default_top_k = 1;
+  // Maximum candidate count for one provider search call.
+  uint32 max_top_k = 2;
+  // Maximum number of provider search calls a single query may make.
+  uint32 max_calls_per_query = 3;
+}
+
 // A query-visible table function in one workspace.
 message TableFunction {
   // Workspace whose query catalog makes this function visible.
@@ -116,6 +136,10 @@ message TableFunction {
   repeated TableFunctionArgument arguments = 5;
   // Columns returned by the function.
   repeated TableFunctionResultColumn result_columns = 6;
+  // Function role. Search marks provider-native retrieval.
+  TableFunctionKind kind = 7;
+  // Provider search limit metadata, when declared by the source.
+  SearchLimits search_limits = 8;
 }
 
 // Catalog item kind filter for unified discovery.

--- a/crates/coral-api/proto/coral/v1/search.proto
+++ b/crates/coral-api/proto/coral/v1/search.proto
@@ -1,0 +1,213 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/catalog.proto";
+import "coral/v1/resources.proto";
+
+// Universal Search request for clue routing over Coral metadata and local search indexes.
+message SearchRequest {
+  // Workspace whose current search context should be inspected.
+  Workspace workspace = 1;
+  // User or agent clue to route to likely Coral surfaces.
+  string query = 2;
+  // Optional maximum results. Zero applies the API default.
+  uint32 limit = 3;
+}
+
+// Universal Search response with typed, bounded routing hints.
+message SearchResponse {
+  // Ordered search hints.
+  repeated SearchResult results = 1;
+  // Provider coverage and error disclosure.
+  repeated SearchProviderStatus provider_statuses = 2;
+  // Result truncation metadata.
+  SearchResultTruncation truncation = 3;
+}
+
+// Result truncation metadata.
+message SearchResultTruncation {
+  // Whether more results were available than returned.
+  bool truncated = 1;
+  // Number of results returned in this response.
+  uint32 returned_count = 2;
+  // Applied maximum result count.
+  uint32 max_results = 3;
+  // Human-readable truncation note.
+  string note = 4;
+}
+
+// Backing provider status for a search response.
+message SearchProviderStatus {
+  // Provider name.
+  SearchProvider provider = 1;
+  // Provider state for this request.
+  SearchProviderState state = 2;
+  // Short coverage or error note.
+  string note = 3;
+}
+
+// Universal Search backing providers.
+enum SearchProvider {
+  // Unknown provider.
+  SEARCH_PROVIDER_UNSPECIFIED = 0;
+  // Catalog metadata provider.
+  SEARCH_PROVIDER_CATALOG_METADATA = 1;
+  // Local observed-value provider.
+  SEARCH_PROVIDER_OBSERVED_VALUES = 2;
+}
+
+// Provider state for one request.
+enum SearchProviderState {
+  // Unknown provider state.
+  SEARCH_PROVIDER_STATE_UNSPECIFIED = 0;
+  // Provider returned one or more results.
+  SEARCH_PROVIDER_STATE_RESULTS_FOUND = 1;
+  // Provider ran and returned no results.
+  SEARCH_PROVIDER_STATE_EMPTY = 2;
+  // Provider is not enabled.
+  SEARCH_PROVIDER_STATE_NOT_ENABLED = 3;
+  // Provider was skipped for this request.
+  SEARCH_PROVIDER_STATE_SKIPPED = 4;
+  // Provider returned partial results.
+  SEARCH_PROVIDER_STATE_PARTIAL = 5;
+  // Provider failed for this request.
+  SEARCH_PROVIDER_STATE_ERROR = 6;
+}
+
+// One typed Universal Search result.
+message SearchResult {
+  // Provider that produced this result.
+  SearchProvider provider = 1;
+  // Typed result payload.
+  oneof payload {
+    // Source, table, or table-function metadata hit with search context.
+    CatalogMetadata catalog_metadata = 10;
+    // Column, filter, argument, or result-column hint.
+    ColumnHint column_hint = 11;
+    // Local observed-value hit. Reserved for the observed-value provider.
+    ObservedValue observed_value = 12;
+    // Registered provider-native search function the agent can call explicitly.
+    NativeSearchPath native_search_path = 13;
+  }
+}
+
+// Source, table, or table-function metadata hit with search-specific context.
+message CatalogMetadata {
+  // Matched catalog item.
+  CatalogItem item = 1;
+  // Metadata fields that matched the query.
+  repeated string matched_fields = 2;
+  // Compact table column hints for ordinary table hits.
+  SearchTableColumnPreview table_column_preview = 3;
+}
+
+// Compact column hints for an ordinary table metadata hit.
+message SearchTableColumnPreview {
+  // Total column count for the table before preview capping.
+  uint32 column_count = 1;
+  // Capped columns selected for query-writing orientation.
+  repeated SearchTableColumnPreviewColumn columns = 2;
+  // Number of table columns not included in the capped preview.
+  uint32 omitted_column_count = 3;
+}
+
+// One compact column hint in a table metadata hit preview.
+message SearchTableColumnPreviewColumn {
+  // Column name as exposed by the query engine.
+  string name = 1;
+  // The DataFusion/Arrow data type rendered as text.
+  string data_type = 2;
+  // Whether the column must be constrained before querying the table.
+  bool is_required_filter = 3;
+  // Human-readable column description.
+  string description = 4;
+  // Column metadata fields that matched the query.
+  repeated string matched_fields = 5;
+}
+
+// Surface kind for a column-style hint.
+enum SearchSurfaceKind {
+  // Unknown surface kind.
+  SEARCH_SURFACE_KIND_UNSPECIFIED = 0;
+  // Table surface.
+  SEARCH_SURFACE_KIND_TABLE = 1;
+  // Table-function surface.
+  SEARCH_SURFACE_KIND_TABLE_FUNCTION = 2;
+}
+
+// Role of a field-style hint on its owning surface.
+enum SearchFieldRole {
+  // Unknown field role.
+  SEARCH_FIELD_ROLE_UNSPECIFIED = 0;
+  // Ordinary table column.
+  SEARCH_FIELD_ROLE_TABLE_COLUMN = 1;
+  // Required or optional table filter.
+  SEARCH_FIELD_ROLE_TABLE_FILTER = 2;
+  // Table-function argument.
+  SEARCH_FIELD_ROLE_TABLE_FUNCTION_ARGUMENT = 3;
+  // Table-function result column.
+  SEARCH_FIELD_ROLE_TABLE_FUNCTION_RESULT_COLUMN = 4;
+}
+
+// A field-level hint that may hold or accept the query clue.
+message ColumnHint {
+  // Workspace that scopes this hint.
+  Workspace workspace = 1;
+  // Source schema that owns the surface.
+  string schema_name = 2;
+  // Table or table-function name.
+  string surface_name = 3;
+  // Whether the owning surface is a table or table function.
+  SearchSurfaceKind surface_kind = 4;
+  // Column, required filter, argument, or result-column name.
+  string name = 5;
+  // Data type when known.
+  string data_type = 6;
+  // Whether this field must be supplied or constrained.
+  bool required = 7;
+  // Human-readable field description.
+  string description = 8;
+  // Metadata fields that matched the query.
+  repeated string matched_fields = 9;
+  // How the field should be used when querying the owning surface.
+  SearchFieldRole field_role = 10;
+}
+
+// Local observed-value result.
+message ObservedValue {
+  // Matched value or redacted display value.
+  string value = 1;
+  // Source schema where the value was observed.
+  string schema_name = 2;
+  // Table or function where the value was observed.
+  string surface_name = 3;
+  // Column that produced the value.
+  string column_name = 4;
+  // Whether the owning surface is a table or table function.
+  SearchSurfaceKind surface_kind = 5;
+  // Field path where the value was observed. Equals column_name for scalar
+  // values and uses child paths such as "payload.error" for extracted JSON or
+  // key/value bag values.
+  string field_path = 6;
+  // Number of times this field/value pair has been observed.
+  uint64 observed_count = 7;
+  // RFC3339 timestamp when this field/value pair was most recently observed.
+  string last_observed_at = 8;
+}
+
+// A registered provider-native search path that can search upstream data explicitly.
+message NativeSearchPath {
+  // Source-scoped table function that performs provider-native retrieval.
+  TableFunction table_function = 1;
+  // Example SQL call using the provider-native search function.
+  string sql_call_example = 2;
+  // Metadata fields that matched the query.
+  repeated string matched_fields = 3;
+}
+
+// Universal Search APIs.
+service SearchService {
+  // Routes a clue to typed Coral search hints.
+  rpc Search(SearchRequest) returns (SearchResponse);
+}

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -55,6 +55,12 @@ pub const QUERY_RESPONSE_MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
 /// responses larger than tonic's 4 MB default.
 pub const CATALOG_RESPONSE_MAX_MESSAGE_SIZE: usize = QUERY_RESPONSE_MAX_MESSAGE_SIZE;
 
+/// Maximum gRPC message size for `SearchService` *responses*, in bytes.
+///
+/// Universal Search returns bounded metadata hints, but it may include source,
+/// table-function, and column descriptions for many installed sources.
+pub const SEARCH_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
+
 /// Maximum gRPC message size for `TraceService` *responses*, in bytes.
 ///
 /// Trace details can include large span attributes, which may exceed tonic's

--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -65,7 +65,7 @@ impl CatalogServiceApi for CatalogService {
                     .items
                     .into_iter()
                     .map(|item| catalog_item_to_proto(&workspace_name, item))
-                    .collect(),
+                    .collect::<Result<Vec<_>, _>>()?,
                 pagination: Some(pagination),
                 counts: Some(ProtoCatalogCounts {
                     table_count: catalog_page.counts.table_count,
@@ -112,7 +112,7 @@ impl CatalogServiceApi for CatalogService {
                     .items
                     .into_iter()
                     .map(|result| catalog_search_result_to_proto(&workspace_name, result))
-                    .collect(),
+                    .collect::<Result<Vec<_>, _>>()?,
                 pagination: Some(pagination),
             }))
         })

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -313,7 +313,7 @@ impl SourceServiceApi for SourceService {
                 source,
                 &workspace_name,
                 report,
-            )))
+            )?))
         })
         .await
     }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -8,9 +8,9 @@ use coral_api::{
         CatalogItem as ProtoCatalogItem, CatalogSearchResult as ProtoCatalogSearchResult, Column,
         ColumnSearchResult as ProtoColumnSearchResult,
         DescribeTableResponse as ProtoDescribeTableResponse, PaginationResponse, QueryTestFailure,
-        QueryTestResult, QueryTestSuccess, Source, Table, TableFunction, TableFunctionArgument,
-        TableFunctionResultColumn, TableSummary, ValidateSourceResponse, Workspace, catalog_item,
-        query_test_result,
+        QueryTestResult, QueryTestSuccess, SearchLimits, Source, Table, TableFunction,
+        TableFunctionArgument, TableFunctionKind, TableFunctionResultColumn, TableSummary,
+        ValidateSourceResponse, Workspace, catalog_item, query_test_result,
     },
 };
 use opentelemetry::propagation::Extractor;
@@ -31,6 +31,13 @@ use crate::query::manager::QueryManagerError;
 use crate::workspaces::WorkspaceName;
 
 struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
+
+#[derive(serde::Deserialize)]
+struct SearchLimitsDocument {
+    default_top_k: u32,
+    max_top_k: u32,
+    max_calls_per_query: u32,
+}
 
 impl Extractor for MetadataExtractor<'_> {
     fn get(&self, key: &str) -> Option<&str> {
@@ -304,8 +311,8 @@ pub(crate) fn table_summary_to_proto(
 pub(crate) fn catalog_item_to_proto(
     workspace_name: &WorkspaceName,
     item: CatalogItem,
-) -> ProtoCatalogItem {
-    match item {
+) -> Result<ProtoCatalogItem, Status> {
+    Ok(match item {
         CatalogItem::Table(table) => ProtoCatalogItem {
             item: Some(catalog_item::Item::Table(table_summary_to_proto(
                 workspace_name,
@@ -316,34 +323,39 @@ pub(crate) fn catalog_item_to_proto(
             item: Some(catalog_item::Item::TableFunction(table_function_to_proto(
                 workspace_name,
                 function,
-            ))),
+            )?)),
         },
-    }
+    })
 }
 
 pub(crate) fn catalog_search_result_to_proto(
     workspace_name: &WorkspaceName,
     result: CatalogSearchResult,
-) -> ProtoCatalogSearchResult {
-    ProtoCatalogSearchResult {
-        item: Some(catalog_item_to_proto(workspace_name, result.item)),
+) -> Result<ProtoCatalogSearchResult, Status> {
+    Ok(ProtoCatalogSearchResult {
+        item: Some(catalog_item_to_proto(workspace_name, result.item)?),
         matched_fields: result
             .matched_fields
             .into_iter()
             .map(CatalogMetadataField::as_proto_name)
             .map(str::to_string)
             .collect(),
-    }
+    })
 }
 
 pub(crate) fn table_function_to_proto(
     workspace_name: &WorkspaceName,
     function: coral_engine::TableFunctionInfo,
-) -> TableFunction {
-    TableFunction {
+) -> Result<TableFunction, Status> {
+    let schema_name = function.schema_name;
+    let function_name = function.function_name;
+    let search_limits =
+        search_limits_json_to_proto(&schema_name, &function_name, function.search_limits_json)?;
+
+    Ok(TableFunction {
         workspace: Some(workspace_to_proto(workspace_name)),
-        schema_name: function.schema_name,
-        name: function.function_name,
+        schema_name,
+        name: function_name,
         description: function.description,
         arguments: function
             .arguments
@@ -364,7 +376,62 @@ pub(crate) fn table_function_to_proto(
                 description: column.description,
             })
             .collect(),
+        kind: table_function_kind_to_proto(&function.kind) as i32,
+        search_limits,
+    })
+}
+
+fn table_function_kind_to_proto(kind: &str) -> TableFunctionKind {
+    match kind {
+        "table" => TableFunctionKind::Table,
+        "search" => TableFunctionKind::Search,
+        _ => TableFunctionKind::Unspecified,
     }
+}
+
+fn search_limits_json_to_proto(
+    schema_name: &str,
+    function_name: &str,
+    search_limits_json: Option<String>,
+) -> Result<Option<SearchLimits>, Status> {
+    search_limits_json
+        .map(|json| {
+            let document: SearchLimitsDocument = serde_json::from_str(&json).map_err(|error| {
+                Status::internal(format!(
+                    "invalid search limits JSON for table function {schema_name}.{function_name}: {error}"
+                ))
+            })?;
+            Ok(SearchLimits {
+                default_top_k: document.default_top_k,
+                max_top_k: document.max_top_k,
+                max_calls_per_query: document.max_calls_per_query,
+            })
+        })
+        .transpose()
+}
+
+pub(crate) fn validate_source_response_to_proto(
+    source: Source,
+    workspace_name: &WorkspaceName,
+    report: coral_engine::SourceValidationReport,
+) -> Result<ValidateSourceResponse, Status> {
+    let coral_engine::SourceValidationReport {
+        tables,
+        table_functions,
+        query_tests,
+    } = report;
+    Ok(ValidateSourceResponse {
+        source: Some(source),
+        tables: tables
+            .into_iter()
+            .map(|table| table_to_proto(workspace_name, table))
+            .collect(),
+        query_tests: query_tests.iter().map(query_test_result_to_proto).collect(),
+        table_functions: table_functions
+            .into_iter()
+            .map(|function| table_function_to_proto(workspace_name, function))
+            .collect::<Result<Vec<_>, _>>()?,
+    })
 }
 
 pub(crate) fn describe_table_response_to_proto(
@@ -452,30 +519,6 @@ pub(crate) fn query_test_result_to_proto(
     }
 }
 
-pub(crate) fn validate_source_response_to_proto(
-    source: Source,
-    workspace_name: &WorkspaceName,
-    report: coral_engine::SourceValidationReport,
-) -> ValidateSourceResponse {
-    let coral_engine::SourceValidationReport {
-        tables,
-        table_functions,
-        query_tests,
-    } = report;
-    ValidateSourceResponse {
-        source: Some(source),
-        tables: tables
-            .into_iter()
-            .map(|table| table_to_proto(workspace_name, table))
-            .collect(),
-        query_tests: query_tests.iter().map(query_test_result_to_proto).collect(),
-        table_functions: table_functions
-            .into_iter()
-            .map(|function| table_function_to_proto(workspace_name, function))
-            .collect(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     #![expect(
@@ -485,20 +528,21 @@ mod tests {
 
     use coral_api::{
         grpc_response_status_code,
-        v1::{QueryTestFailure, Workspace, query_test_result},
+        v1::{QueryTestFailure, TableFunctionKind, Workspace, query_test_result},
     };
     use tonic::{Code, Request};
 
     use super::{
         GrpcMethodMetadata, GrpcServerMethod, episode_id_from_metadata, grpc_method, query_status,
-        query_test_result_to_proto, table_summary_to_proto, table_to_proto,
-        workspace_name_from_proto, workspace_to_proto,
+        query_test_result_to_proto, table_function_to_proto, table_summary_to_proto,
+        table_to_proto, workspace_name_from_proto, workspace_to_proto,
     };
     use crate::bootstrap::AppError;
     use crate::query::manager::QueryManagerError;
     use crate::workspaces::WorkspaceName;
     use coral_engine::{
-        ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableInfo,
+        ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableFunctionArgumentInfo,
+        TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
     };
 
     #[test]
@@ -675,6 +719,70 @@ mod tests {
         assert_eq!(proto.description, "User records");
         assert_eq!(proto.guide, "Filter by org_id.");
         assert_eq!(proto.required_filters, vec!["org_id"]);
+    }
+
+    #[test]
+    fn table_function_to_proto_preserves_search_limits_presence() {
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let mut function = TableFunctionInfo {
+            schema_name: "github".to_string(),
+            function_name: "search_issues".to_string(),
+            description: "Search issues".to_string(),
+            kind: "search".to_string(),
+            arguments: vec![TableFunctionArgumentInfo {
+                name: "q".to_string(),
+                required: true,
+                values: Vec::new(),
+            }],
+            result_columns: vec![TableFunctionResultColumnInfo {
+                name: "title".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: false,
+                description: "Issue title".to_string(),
+            }],
+            search_limits_json: None,
+        };
+
+        let proto = table_function_to_proto(&workspace_name, function.clone()).expect("proto");
+        assert_eq!(proto.workspace, Some(workspace_to_proto(&workspace_name)));
+        assert_eq!(proto.name, "search_issues");
+        assert_eq!(proto.kind(), TableFunctionKind::Search);
+        assert_eq!(proto.search_limits, None);
+
+        function.search_limits_json =
+            Some(r#"{"default_top_k":10,"max_top_k":100,"max_calls_per_query":5}"#.to_string());
+        let proto = table_function_to_proto(&workspace_name, function).expect("proto");
+        let search_limits = proto.search_limits.expect("search limits");
+        assert_eq!(search_limits.default_top_k, 10);
+        assert_eq!(search_limits.max_top_k, 100);
+        assert_eq!(search_limits.max_calls_per_query, 5);
+    }
+
+    #[test]
+    fn table_function_to_proto_rejects_malformed_search_limits() {
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let function = TableFunctionInfo {
+            schema_name: "github".to_string(),
+            function_name: "search_issues".to_string(),
+            description: "Search issues".to_string(),
+            kind: "search".to_string(),
+            arguments: vec![TableFunctionArgumentInfo {
+                name: "q".to_string(),
+                required: true,
+                values: Vec::new(),
+            }],
+            result_columns: Vec::new(),
+            search_limits_json: Some("{not-json".to_string()),
+        };
+
+        let status = table_function_to_proto(&workspace_name, function).expect_err("invalid JSON");
+
+        assert_eq!(status.code(), Code::Internal);
+        assert!(
+            status
+                .message()
+                .contains("invalid search limits JSON for table function github.search_issues")
+        );
     }
 
     #[test]

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -4,9 +4,11 @@ use coral_api::v1::Workspace;
 use coral_api::v1::catalog_service_client::CatalogServiceClient;
 use coral_api::v1::feedback_service_client::FeedbackServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
+use coral_api::v1::search_service_client::SearchServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
+    SEARCH_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint};
@@ -38,6 +40,9 @@ pub type CatalogClient = CatalogServiceClient<GrpcService>;
 /// Public SQL query gRPC client.
 pub type QueryClient = QueryServiceClient<GrpcService>;
 
+/// Public Universal Search gRPC client.
+pub type SearchClient = SearchServiceClient<GrpcService>;
+
 /// Public feedback-submission gRPC client.
 pub type FeedbackClient = FeedbackServiceClient<GrpcService>;
 
@@ -49,6 +54,7 @@ pub struct AppClient {
     source: SourceClient,
     catalog: CatalogClient,
     query: QueryClient,
+    search: SearchClient,
     feedback: FeedbackClient,
 }
 
@@ -72,11 +78,14 @@ impl AppClient {
             .max_decoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE);
         let query_client = QueryClient::new(grpc_service(channel.clone(), &grpc_endpoint))
             .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
+        let search_client = SearchClient::new(grpc_service(channel.clone(), &grpc_endpoint))
+            .max_decoding_message_size(SEARCH_RESPONSE_MAX_MESSAGE_SIZE);
         let feedback_client = FeedbackClient::new(grpc_service(channel, &grpc_endpoint));
         Ok(Self {
             source: source_client,
             catalog: catalog_client,
             query: query_client,
+            search: search_client,
             feedback: feedback_client,
         })
     }
@@ -97,6 +106,12 @@ impl AppClient {
     /// Returns a cloned query client.
     pub fn query_client(&self) -> QueryClient {
         self.query.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned Universal Search client.
+    pub fn search_client(&self) -> SearchClient {
+        self.search.clone()
     }
 
     #[must_use]

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -40,8 +40,8 @@ use coral_api::v1::ExecuteSqlResponse;
 use serde_json::Value;
 
 pub use client::{
-    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, QueryClient, SourceClient,
-    default_workspace,
+    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, QueryClient, SearchClient,
+    SourceClient, default_workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use sources::{SourceInputDecodeError, manifest_input_from_proto};

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -91,4 +91,8 @@ pub struct TableFunctionInfo {
     pub arguments: Vec<TableFunctionArgumentInfo>,
     /// Columns returned by the function.
     pub result_columns: Vec<TableFunctionResultColumnInfo>,
+    /// Function role. Search functions perform provider-native retrieval.
+    pub kind: String,
+    /// JSON-encoded provider search limit metadata, when declared by the source.
+    pub search_limits_json: Option<String>,
 }

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -673,6 +673,8 @@ mod tests {
             description: String::new(),
             arguments: vec![],
             result_columns: vec![],
+            kind: "table".to_string(),
+            search_limits_json: None,
         }
     }
 

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -547,6 +547,8 @@ pub(crate) fn collect_table_functions(
                             description: column.description.clone(),
                         })
                         .collect(),
+                    kind: function.kind.clone(),
+                    search_limits_json: function.search_limits_json.clone(),
                 })
         })
         .collect::<Vec<_>>();

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -345,6 +345,8 @@ mod tests {
             description: String::new(),
             arguments: vec![],
             result_columns: vec![],
+            kind: "table".to_string(),
+            search_limits_json: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds the Universal Search protobuf API and generated client types.
- Defines typed search results, provider statuses, and truncation metadata.
- Uses each result's `oneof` payload as the result-kind discriminator instead of carrying a duplicate result-type enum.
- Adds `SearchResult.provider` so clients can correlate individual results with provider statuses and partial failures.
- Wraps catalog item search hits in `CatalogMetadata` so consumers receive matched metadata fields and compact table-column previews without parsing prose.
- Threads table-function metadata through typed API fields: `TableFunctionKind` for the function role and `SearchLimits` for provider search limits.
- Preserves field-role provenance for column hints and surface-kind provenance for observed values.
- Adds observed-value `field_path`, `observed_count`, and `last_observed_at` fields so downstream consumers can render extracted JSON/key-value fields and freshness/count metadata without string parsing.

## Stack Position
Part 1 of the current Universal Search stack:
1. #1017 Universal Search contracts
2. #1018 Tantivy catalog backend
3. #1019 observed-value indexing and provider
4. #1020 MCP `search` tool
5. #1021 CLI `coral search`
6. #1180 provider-native fanout

## Validation
Validated while restacking this layer:
- `cargo check -p coral-api -p coral-app`
- `cargo test -p coral-app transport::tests::table_function_to_proto --lib`

Additional top-stack validation is listed on #1180.