### PR TITLE
feat(engine): add opt-in parallel HTTP pagination

### DIFF
--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use datafusion::error::{DataFusionError, Result};
+use futures::{StreamExt as _, stream};
 use serde_json::Value;
 
 use crate::backends::http::ProviderQueryError;
@@ -19,7 +20,9 @@ use crate::backends::http::url::{join_url, normalize_base_url};
 use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::response_rows::extract_rows;
 use crate::backends::shared::template::{RenderContext, render_template};
-use coral_spec::ValidatedPaginationMode;
+use coral_spec::{
+    RequestSpec, ValidatedPagination, ValidatedPaginationMode, ValidatedPaginationParallel,
+};
 
 const DEFAULT_MAX_PAGES: usize = 10_000;
 
@@ -28,6 +31,51 @@ struct FetchLimits {
     effective_limit: Option<usize>,
     page_size_limit: Option<usize>,
     max_search_calls: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FetchContext<'a> {
+    client: &'a HttpSourceClient,
+    target: &'a HttpFetchTarget,
+    filter_values: &'a HashMap<String, String>,
+    arg_values: &'a HashMap<String, String>,
+    active_request: &'a RequestSpec,
+}
+
+#[derive(Debug, Clone)]
+struct PageFetchRequest {
+    state: PageState,
+    extra_query_pairs: Vec<(String, String)>,
+}
+
+#[derive(Debug)]
+struct FetchedPage {
+    payload: Value,
+    next_url: Option<String>,
+    rows: Vec<Value>,
+    rows_on_page: usize,
+}
+
+#[derive(Debug)]
+struct ParallelPage {
+    index: usize,
+    rows: Vec<Value>,
+    rows_on_page: usize,
+}
+
+#[derive(Debug)]
+enum ParallelFetchPlan {
+    IndependentPages {
+        start: i64,
+        step: i64,
+        extra_page_param: Option<String>,
+        max_concurrency: usize,
+    },
+    IndependentOffsets {
+        start: i64,
+        step: i64,
+        max_concurrency: usize,
+    },
 }
 
 #[expect(
@@ -57,7 +105,13 @@ pub(super) async fn fetch_rows(
         })?;
     let page_size = resolve_page_size(pagination.page_size.as_ref(), limits.page_size_limit);
 
-    let active_request = target.resolved_request();
+    let context = FetchContext {
+        client,
+        target,
+        filter_values,
+        arg_values,
+        active_request: target.resolved_request(),
+    };
 
     let mut state = PageState {
         page: target.pagination().page_start,
@@ -71,6 +125,26 @@ pub(super) async fn fetch_rows(
     let mut page_count = 0usize;
     let max_pages = target.pagination().max_pages.unwrap_or(DEFAULT_MAX_PAGES);
 
+    if let Some(plan) = resolve_parallel_fetch_plan(
+        target,
+        &pagination,
+        &limits,
+        page_size,
+        sql_limit,
+        max_pages,
+        &client.source_schema,
+    )? {
+        return fetch_rows_parallel(
+            context,
+            limits,
+            &pagination,
+            page_size.expect("parallel plan requires page size"),
+            max_pages,
+            plan,
+        )
+        .await;
+    }
+
     loop {
         page_count += 1;
         if page_count > max_pages {
@@ -83,127 +157,22 @@ pub(super) async fn fetch_rows(
             }));
         }
 
-        let resolved_inputs = client.resolved_inputs_for_request().await?;
-        let state_values = pagination_state_values(&state);
-        let render_context = RenderContext::new(
-            filter_values,
-            arg_values,
-            &state_values,
-            resolved_inputs.as_ref(),
-        );
-        let base_url = render_template(&client.base_url, &render_context)?;
-        let base_url = normalize_base_url(&base_url);
-        let following_link_header = matches!(
-            pagination.mode,
-            ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto
-        ) && state.next_url.is_some();
-
-        let url = if matches!(
-            pagination.mode,
-            ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto
-        ) && let Some(next) = state.next_url.clone()
-        {
-            next
-        } else {
-            let rendered_path = render_template(&active_request.path, &render_context)?;
-            join_url(&base_url, &rendered_path)?
-        };
-
-        let (query_pairs, body) = if following_link_header {
-            (Vec::new(), None)
-        } else {
-            let mut query_pairs = build_query_pairs(active_request, &render_context)?;
-            apply_pagination_query_pairs(&mut query_pairs, target, &pagination, &state, page_size)
-                .map_err(|error| {
-                    pagination_error(
-                        &client.source_schema,
-                        target.name(),
-                        None,
-                        Some(&url),
-                        &error,
-                    )
-                })?;
-
-            let mut body = build_request_body(active_request, &render_context)?;
-            apply_pagination_body_fields(
-                &mut body,
-                &active_request.body,
-                target,
-                &pagination,
-                &state,
-                page_size,
-            )
-            .map_err(|error| {
-                pagination_error(
-                    &client.source_schema,
-                    target.name(),
-                    None,
-                    Some(&url),
-                    &error,
-                )
-            })?;
-            (query_pairs, body)
-        };
-
-        let request = execute_request(
-            &client.http,
-            client.request_timeout,
-            OutgoingHttpRequest {
-                auth: &client.auth,
-                request_headers: &client.request_headers,
-                request_authenticators: &client.request_authenticators,
-                table_headers: &active_request.headers,
-                table_name: target.name(),
-                method: active_request.method,
-                base_url: &base_url,
-                url: &url,
-                query_pairs: &query_pairs,
-                body: body.as_ref(),
-                response_format: target.response().format,
-                source_schema: &client.source_schema,
-                rate_limit: &client.rate_limit,
-                body_capture: client.body_capture,
-                render_context,
-                allow_404_empty: target.response().allow_404_empty,
-                link_header_require_results: pagination.link_header_require_results,
+        let Some(mut fetched_page) = fetch_page(
+            context,
+            &pagination,
+            page_size,
+            &PageFetchRequest {
+                state: state.clone(),
+                extra_query_pairs: Vec::new(),
             },
         )
-        .await?;
-
-        let Some((payload, next_url)) = request else {
+        .await?
+        else {
             break;
         };
 
-        if !target.response().ok_path.is_empty() {
-            let ok = get_path_value(&payload, &target.response().ok_path)
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
-            if !ok {
-                let err = if target.response().error_path.is_empty() {
-                    "unknown source API error".to_string()
-                } else {
-                    get_path_value(&payload, &target.response().error_path)
-                        .and_then(Value::as_str)
-                        .unwrap_or("unknown source API error")
-                        .to_string()
-                };
-                return Err(DataFusionError::External(Box::new(
-                    ProviderQueryError::ApiRequest {
-                        source_schema: client.source_schema.clone(),
-                        table: target.name().to_string(),
-                        status: None,
-                        method: None,
-                        url: None,
-                        filters: filter_values.clone(),
-                        detail: err,
-                    },
-                )));
-            }
-        }
-
-        let mut rows = extract_rows(target.response(), &payload);
-        let rows_on_page = rows.len();
-        all_rows.append(&mut rows);
+        let rows_on_page = fetched_page.rows_on_page;
+        all_rows.append(&mut fetched_page.rows);
 
         if let Some(limit) = limits.effective_limit
             && all_rows.len() >= limit
@@ -222,12 +191,14 @@ pub(super) async fn fetch_rows(
         match &pagination.mode {
             ValidatedPaginationMode::None => break,
             ValidatedPaginationMode::CursorQuery | ValidatedPaginationMode::CursorBody => {
-                let next_cursor =
-                    get_path_value(&payload, &target.pagination().response_cursor_path)
-                        .and_then(Value::as_str)
-                        .map(str::trim)
-                        .filter(|s| !s.is_empty())
-                        .map(ToOwned::to_owned);
+                let next_cursor = get_path_value(
+                    &fetched_page.payload,
+                    &target.pagination().response_cursor_path,
+                )
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned);
                 match next_cursor {
                     Some(cursor) => state.cursor = Some(cursor),
                     None => break,
@@ -256,14 +227,417 @@ pub(super) async fn fetch_rows(
                     })?;
                 state.offset = state.offset.saturating_add(step);
             }
-            ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto => match next_url {
-                Some(next) => state.next_url = Some(next),
-                None => break,
-            },
+            ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto => {
+                match fetched_page.next_url {
+                    Some(next) => state.next_url = Some(next),
+                    None => break,
+                }
+            }
         }
     }
 
     Ok(all_rows)
+}
+
+async fn fetch_rows_parallel(
+    context: FetchContext<'_>,
+    limits: FetchLimits,
+    pagination: &ValidatedPagination,
+    page_size: usize,
+    max_pages: usize,
+    plan: ParallelFetchPlan,
+) -> Result<Vec<Value>> {
+    let first_request = first_parallel_page_request(&plan);
+    let Some(mut first_page) =
+        fetch_page(context, pagination, Some(page_size), &first_request).await?
+    else {
+        return Ok(Vec::new());
+    };
+
+    let mut all_rows = Vec::new();
+    let first_rows_on_page = first_page.rows_on_page;
+    all_rows.append(&mut first_page.rows);
+    if let Some(limit) = limits.effective_limit
+        && all_rows.len() >= limit
+    {
+        all_rows.truncate(limit);
+        return Ok(all_rows);
+    }
+    if page_is_exhausted(first_rows_on_page, Some(page_size)) {
+        return Ok(all_rows);
+    }
+
+    let Some(limit) = limits.effective_limit else {
+        return Ok(all_rows);
+    };
+    let pages_needed = limit.div_ceil(page_size);
+    if pages_needed <= 1 {
+        all_rows.truncate(limit);
+        return Ok(all_rows);
+    }
+    if pages_needed > max_pages {
+        return Err(provider_error(ProviderQueryError::Pagination {
+            source_schema: context.client.source_schema.clone(),
+            table: context.target.name().to_string(),
+            method: None,
+            url: None,
+            detail: format!("exceeded pagination max_pages={max_pages}"),
+        }));
+    }
+
+    let requests = remaining_parallel_page_requests(&plan, pages_needed);
+    let max_concurrency = plan.max_concurrency();
+    let mut pages = stream::iter(requests)
+        .map(|(index, request)| async move {
+            let page = fetch_page(context, pagination, Some(page_size), &request).await?;
+            let Some(page) = page else {
+                return Ok::<_, DataFusionError>(ParallelPage {
+                    index,
+                    rows: Vec::new(),
+                    rows_on_page: 0,
+                });
+            };
+            Ok(ParallelPage {
+                index,
+                rows: page.rows,
+                rows_on_page: page.rows_on_page,
+            })
+        })
+        .buffer_unordered(max_concurrency)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
+
+    pages.sort_by_key(|page| page.index);
+    for mut page in pages {
+        if page.rows_on_page == 0 {
+            break;
+        }
+        let rows_on_page = page.rows_on_page;
+        all_rows.append(&mut page.rows);
+        if all_rows.len() >= limit {
+            break;
+        }
+        if page_is_exhausted(rows_on_page, Some(page_size)) {
+            break;
+        }
+    }
+    all_rows.truncate(limit);
+    Ok(all_rows)
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "One-page HTTP fetch keeps request rendering and response validation together"
+)]
+async fn fetch_page(
+    context: FetchContext<'_>,
+    pagination: &ValidatedPagination,
+    page_size: Option<usize>,
+    page_request: &PageFetchRequest,
+) -> Result<Option<FetchedPage>> {
+    let FetchContext {
+        client,
+        target,
+        filter_values,
+        arg_values,
+        active_request,
+    } = context;
+    let state = &page_request.state;
+    let resolved_inputs = client.resolved_inputs_for_request().await?;
+    let state_values = pagination_state_values(state);
+    let render_context = RenderContext::new(
+        filter_values,
+        arg_values,
+        &state_values,
+        resolved_inputs.as_ref(),
+    );
+    let base_url = render_template(&client.base_url, &render_context)?;
+    let base_url = normalize_base_url(&base_url);
+    let following_link_header = matches!(
+        pagination.mode,
+        ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto
+    ) && state.next_url.is_some();
+
+    let url = if matches!(
+        pagination.mode,
+        ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto
+    ) && let Some(next) = state.next_url.clone()
+    {
+        next
+    } else {
+        let rendered_path = render_template(&active_request.path, &render_context)?;
+        join_url(&base_url, &rendered_path)?
+    };
+
+    let (mut query_pairs, body) = if following_link_header {
+        (Vec::new(), None)
+    } else {
+        let mut query_pairs = build_query_pairs(active_request, &render_context)?;
+        apply_pagination_query_pairs(&mut query_pairs, target, pagination, state, page_size)
+            .map_err(|error| {
+                pagination_error(
+                    &client.source_schema,
+                    target.name(),
+                    None,
+                    Some(&url),
+                    &error,
+                )
+            })?;
+
+        let mut body = build_request_body(active_request, &render_context)?;
+        apply_pagination_body_fields(
+            &mut body,
+            &active_request.body,
+            target,
+            pagination,
+            state,
+            page_size,
+        )
+        .map_err(|error| {
+            pagination_error(
+                &client.source_schema,
+                target.name(),
+                None,
+                Some(&url),
+                &error,
+            )
+        })?;
+        (query_pairs, body)
+    };
+    query_pairs.extend(page_request.extra_query_pairs.iter().cloned());
+
+    let request = execute_request(
+        &client.http,
+        client.request_timeout,
+        OutgoingHttpRequest {
+            auth: &client.auth,
+            request_headers: &client.request_headers,
+            request_authenticators: &client.request_authenticators,
+            table_headers: &active_request.headers,
+            table_name: target.name(),
+            method: active_request.method,
+            base_url: &base_url,
+            url: &url,
+            query_pairs: &query_pairs,
+            body: body.as_ref(),
+            response_format: target.response().format,
+            source_schema: &client.source_schema,
+            rate_limit: &client.rate_limit,
+            body_capture: client.body_capture,
+            render_context,
+            allow_404_empty: target.response().allow_404_empty,
+            link_header_require_results: pagination.link_header_require_results,
+        },
+    )
+    .await?;
+
+    let Some((payload, next_url)) = request else {
+        return Ok(None);
+    };
+
+    validate_payload_ok(client, target, filter_values, &payload)?;
+    let rows = extract_rows(target.response(), &payload);
+    let rows_on_page = rows.len();
+    Ok(Some(FetchedPage {
+        payload,
+        next_url,
+        rows,
+        rows_on_page,
+    }))
+}
+
+fn validate_payload_ok(
+    client: &HttpSourceClient,
+    target: &HttpFetchTarget,
+    filter_values: &HashMap<String, String>,
+    payload: &Value,
+) -> Result<()> {
+    if target.response().ok_path.is_empty() {
+        return Ok(());
+    }
+    let ok = get_path_value(payload, &target.response().ok_path)
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if ok {
+        return Ok(());
+    }
+    let err = if target.response().error_path.is_empty() {
+        "unknown source API error".to_string()
+    } else {
+        get_path_value(payload, &target.response().error_path)
+            .and_then(Value::as_str)
+            .unwrap_or("unknown source API error")
+            .to_string()
+    };
+    Err(DataFusionError::External(Box::new(
+        ProviderQueryError::ApiRequest {
+            source_schema: client.source_schema.clone(),
+            table: target.name().to_string(),
+            status: None,
+            method: None,
+            url: None,
+            filters: filter_values.clone(),
+            detail: err,
+        },
+    )))
+}
+
+fn resolve_parallel_fetch_plan(
+    target: &HttpFetchTarget,
+    pagination: &ValidatedPagination,
+    limits: &FetchLimits,
+    page_size: Option<usize>,
+    sql_limit: Option<usize>,
+    max_pages: usize,
+    source_schema: &str,
+) -> Result<Option<ParallelFetchPlan>> {
+    if sql_limit.is_none() || limits.max_search_calls.is_some() {
+        return Ok(None);
+    }
+    let Some(page_size) = page_size else {
+        return Ok(None);
+    };
+    let Some(limit) = limits.effective_limit else {
+        return Ok(None);
+    };
+    if limit <= page_size {
+        return Ok(None);
+    }
+    if max_pages <= 1 {
+        return Ok(None);
+    }
+
+    match &pagination.parallel {
+        Some(ValidatedPaginationParallel::IndependentPages(page)) => {
+            let extra_page_param = if matches!(pagination.mode, ValidatedPaginationMode::LinkHeader)
+            {
+                Some(page.param.clone())
+            } else {
+                None
+            };
+            Ok(Some(ParallelFetchPlan::IndependentPages {
+                start: page.start,
+                step: page.step,
+                extra_page_param,
+                max_concurrency: page.max_concurrency,
+            }))
+        }
+        Some(ValidatedPaginationParallel::IndependentOffsets { max_concurrency }) => {
+            let ValidatedPaginationMode::Offset(offset) = &pagination.mode else {
+                return Err(provider_error(ProviderQueryError::Pagination {
+                    source_schema: source_schema.to_string(),
+                    table: target.name().to_string(),
+                    method: None,
+                    url: None,
+                    detail: "independent offset pagination requires offset mode".to_string(),
+                }));
+            };
+            let step = offset
+                .resolve_step(Some(page_size), source_schema, target.name())
+                .map_err(|error| {
+                    provider_error(ProviderQueryError::Pagination {
+                        source_schema: source_schema.to_string(),
+                        table: target.name().to_string(),
+                        method: None,
+                        url: None,
+                        detail: error.to_string(),
+                    })
+                })?;
+            Ok(Some(ParallelFetchPlan::IndependentOffsets {
+                start: offset.start,
+                step,
+                max_concurrency: *max_concurrency,
+            }))
+        }
+        None => Ok(None),
+    }
+}
+
+fn first_parallel_page_request(plan: &ParallelFetchPlan) -> PageFetchRequest {
+    match plan {
+        ParallelFetchPlan::IndependentPages {
+            start,
+            extra_page_param,
+            ..
+        } => {
+            let page = *start;
+            PageFetchRequest {
+                state: PageState {
+                    page,
+                    ..PageState::default()
+                },
+                extra_query_pairs: extra_page_param
+                    .iter()
+                    .map(|param| (param.clone(), page.to_string()))
+                    .collect(),
+            }
+        }
+        ParallelFetchPlan::IndependentOffsets { start, .. } => PageFetchRequest {
+            state: PageState {
+                offset: *start,
+                ..PageState::default()
+            },
+            extra_query_pairs: Vec::new(),
+        },
+    }
+}
+
+fn remaining_parallel_page_requests(
+    plan: &ParallelFetchPlan,
+    pages_needed: usize,
+) -> Vec<(usize, PageFetchRequest)> {
+    (1..pages_needed)
+        .map(|index| (index, parallel_page_request(plan, index)))
+        .collect()
+}
+
+fn parallel_page_request(plan: &ParallelFetchPlan, index: usize) -> PageFetchRequest {
+    match plan {
+        ParallelFetchPlan::IndependentPages {
+            start,
+            step,
+            extra_page_param,
+            ..
+        } => {
+            let index = i64::try_from(index).unwrap_or(i64::MAX);
+            let page = start.saturating_add(step.saturating_mul(index));
+            PageFetchRequest {
+                state: PageState {
+                    page,
+                    ..PageState::default()
+                },
+                extra_query_pairs: extra_page_param
+                    .iter()
+                    .map(|param| (param.clone(), page.to_string()))
+                    .collect(),
+            }
+        }
+        ParallelFetchPlan::IndependentOffsets { start, step, .. } => {
+            let index = i64::try_from(index).unwrap_or(i64::MAX);
+            PageFetchRequest {
+                state: PageState {
+                    offset: start.saturating_add(step.saturating_mul(index)),
+                    ..PageState::default()
+                },
+                extra_query_pairs: Vec::new(),
+            }
+        }
+    }
+}
+
+impl ParallelFetchPlan {
+    fn max_concurrency(&self) -> usize {
+        match self {
+            Self::IndependentPages {
+                max_concurrency, ..
+            }
+            | Self::IndependentOffsets {
+                max_concurrency, ..
+            } => *max_concurrency,
+        }
+    }
 }
 
 fn resolve_fetch_limits(target: &HttpFetchTarget, sql_limit: Option<usize>) -> FetchLimits {

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -1154,6 +1154,100 @@ async fn pagination_page_mode() {
 }
 
 #[tokio::test]
+async fn pagination_parallel_page_mode_preserves_order_and_limit() {
+    let server = MockServer::start().await;
+    let rows = users_rows();
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("page", "1"))
+        .and(query_param("per_page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": &rows[..2] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("page", "2"))
+        .and(query_param("per_page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": &rows[2..] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_parallel_page", &server.uri());
+    manifest["tables"][0]["pagination"] = json!({
+        "mode": "page",
+        "page_param": "page",
+        "page_start": 1,
+        "page_size": {
+            "default": 2,
+            "max": 2,
+            "query_param": "per_page"
+        },
+        "parallel": {
+            "strategy": "independent_pages",
+            "max_concurrency": 2
+        }
+    });
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT id, name, email FROM http_parallel_page.users LIMIT 3",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, users_rows());
+}
+
+#[tokio::test]
+async fn pagination_parallel_short_first_page_does_not_fetch_later_pages() {
+    let server = MockServer::start().await;
+    let rows = users_rows();
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("page", "1"))
+        .and(query_param("per_page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": &rows[..1] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_parallel_short", &server.uri());
+    manifest["tables"][0]["pagination"] = json!({
+        "mode": "page",
+        "page_param": "page",
+        "page_start": 1,
+        "page_size": {
+            "default": 2,
+            "max": 2,
+            "query_param": "per_page"
+        },
+        "parallel": {
+            "strategy": "independent_pages",
+            "max_concurrency": 2
+        }
+    });
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT id, name, email FROM http_parallel_short.users LIMIT 3",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, vec![users_rows()[0].clone()]);
+}
+
+#[tokio::test]
 async fn pagination_offset_mode() {
     let server = MockServer::start().await;
     let rows = users_rows();
@@ -1198,6 +1292,57 @@ async fn pagination_offset_mode() {
 }
 
 #[tokio::test]
+async fn pagination_parallel_offset_mode() {
+    let server = MockServer::start().await;
+    let rows = users_rows();
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("offset", "0"))
+        .and(query_param("limit", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": &rows[..2] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("offset", "2"))
+        .and(query_param("limit", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": &rows[2..] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_parallel_offset", &server.uri());
+    manifest["tables"][0]["pagination"] = json!({
+        "mode": "offset",
+        "offset_param": "offset",
+        "offset_start": 0,
+        "page_size": {
+            "default": 2,
+            "max": 2,
+            "query_param": "limit"
+        },
+        "parallel": {
+            "strategy": "independent_offsets",
+            "max_concurrency": 2
+        }
+    });
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT id, name, email FROM http_parallel_offset.users LIMIT 3",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, users_rows());
+}
+
+#[tokio::test]
 async fn pagination_link_header() {
     let server = MockServer::start().await;
     let rows = users_rows();
@@ -1229,6 +1374,58 @@ async fn pagination_link_header() {
             &[source],
             test_runtime(),
             "SELECT id, name, email FROM http_link.users ORDER BY id",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, users_rows());
+}
+
+#[tokio::test]
+async fn pagination_parallel_link_header_with_independent_page_param() {
+    let server = MockServer::start().await;
+    let rows = users_rows();
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("page", "1"))
+        .and(query_param("per_page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": &rows[..2] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("page", "2"))
+        .and(query_param("per_page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": &rows[2..] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_parallel_link", &server.uri());
+    manifest["tables"][0]["pagination"] = json!({
+        "mode": "link_header",
+        "page_size": {
+            "default": 2,
+            "max": 2,
+            "query_param": "per_page"
+        },
+        "parallel": {
+            "strategy": "independent_pages",
+            "page_param": "page",
+            "page_start": 1,
+            "page_step": 1,
+            "max_concurrency": 2
+        }
+    });
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT id, name, email FROM http_parallel_link.users LIMIT 3",
         )
         .await
         .expect("query should succeed"),

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -544,6 +544,8 @@ pub struct PaginationSpec {
     #[serde(default)]
     pub page_size: Option<PageSizeSpec>,
     #[serde(default)]
+    pub parallel: Option<PaginationParallelSpec>,
+    #[serde(default)]
     pub cursor_param: Option<String>,
     #[serde(default)]
     pub cursor_body_path: Vec<String>,
@@ -572,6 +574,7 @@ impl Default for PaginationSpec {
         Self {
             mode: PaginationMode::default(),
             page_size: None,
+            parallel: None,
             cursor_param: None,
             cursor_body_path: Vec::new(),
             response_cursor_path: Vec::new(),
@@ -592,6 +595,7 @@ impl Default for PaginationSpec {
 pub struct ValidatedPagination {
     pub mode: ValidatedPaginationMode,
     pub page_size: Option<PageSizeSpec>,
+    pub parallel: Option<ValidatedPaginationParallel>,
     pub link_header_require_results: bool,
 }
 
@@ -615,6 +619,45 @@ pub struct OffsetPagination {
     step: OffsetStep,
 }
 
+/// Declarative opt-in for pagination that can construct later pages without
+/// reading earlier responses.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct PaginationParallelSpec {
+    pub strategy: PaginationParallelStrategy,
+    #[serde(default = "default_parallel_max_concurrency")]
+    pub max_concurrency: usize,
+    #[serde(default)]
+    pub page_param: Option<String>,
+    #[serde(default)]
+    pub page_start: Option<i64>,
+    #[serde(default)]
+    pub page_step: Option<i64>,
+}
+
+/// Parallel pagination strategies supported by the source-spec DSL.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PaginationParallelStrategy {
+    IndependentPages,
+    IndependentOffsets,
+}
+
+/// Fully validated parallel pagination settings ready for engine use.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidatedPaginationParallel {
+    IndependentPages(IndependentPagePagination),
+    IndependentOffsets { max_concurrency: usize },
+}
+
+/// Validated independently addressable page-number settings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndependentPagePagination {
+    pub param: String,
+    pub start: i64,
+    pub step: i64,
+    pub max_concurrency: usize,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OffsetStep {
     Explicit(i64),
@@ -630,9 +673,11 @@ impl PaginationSpec {
     pub fn validated(&self, schema: &str, table: &str) -> Result<ValidatedPagination> {
         let page_size = self.validated_page_size(schema, table)?;
         let mode = self.validated_mode(schema, table, page_size.is_some())?;
+        let parallel = self.validated_parallel(schema, table, &mode, page_size.as_ref())?;
         Ok(ValidatedPagination {
             mode,
             page_size,
+            parallel,
             link_header_require_results: self.link_header_require_results,
         })
     }
@@ -738,6 +783,89 @@ impl PaginationSpec {
 
         Ok(Some(page_size.clone()))
     }
+
+    fn validated_parallel(
+        &self,
+        schema: &str,
+        table: &str,
+        mode: &ValidatedPaginationMode,
+        page_size: Option<&PageSizeSpec>,
+    ) -> Result<Option<ValidatedPaginationParallel>> {
+        let Some(parallel) = &self.parallel else {
+            return Ok(None);
+        };
+        if parallel.max_concurrency == 0 {
+            return Err(ManifestError::validation(format!(
+                "{schema}.{table} pagination.parallel.max_concurrency must be > 0"
+            )));
+        }
+        if page_size.is_none() {
+            return Err(ManifestError::validation(format!(
+                "{schema}.{table} pagination.parallel requires page_size"
+            )));
+        }
+
+        match parallel.strategy {
+            PaginationParallelStrategy::IndependentPages => {
+                let (param, start, step) = match mode {
+                    ValidatedPaginationMode::Page => {
+                        let param = self.page_param.clone().ok_or_else(|| {
+                            ManifestError::validation(format!(
+                                "{schema}.{table} pagination.parallel.strategy=independent_pages requires page_param"
+                            ))
+                        })?;
+                        (param, self.page_start, self.page_step)
+                    }
+                    ValidatedPaginationMode::LinkHeader => {
+                        let param = parallel.page_param.clone().ok_or_else(|| {
+                            ManifestError::validation(format!(
+                                "{schema}.{table} pagination.parallel.strategy=independent_pages with mode=link_header requires parallel.page_param"
+                            ))
+                        })?;
+                        let start = parallel.page_start.ok_or_else(|| {
+                            ManifestError::validation(format!(
+                                "{schema}.{table} pagination.parallel.strategy=independent_pages with mode=link_header requires parallel.page_start"
+                            ))
+                        })?;
+                        let step = parallel.page_step.ok_or_else(|| {
+                            ManifestError::validation(format!(
+                                "{schema}.{table} pagination.parallel.strategy=independent_pages with mode=link_header requires parallel.page_step"
+                            ))
+                        })?;
+                        (param, start, step)
+                    }
+                    _ => {
+                        return Err(ManifestError::validation(format!(
+                            "{schema}.{table} pagination.parallel.strategy=independent_pages requires pagination.mode=page or link_header"
+                        )));
+                    }
+                };
+                if step <= 0 {
+                    return Err(ManifestError::validation(format!(
+                        "{schema}.{table} pagination.parallel.page_step must be > 0"
+                    )));
+                }
+                Ok(Some(ValidatedPaginationParallel::IndependentPages(
+                    IndependentPagePagination {
+                        param,
+                        start,
+                        step,
+                        max_concurrency: parallel.max_concurrency,
+                    },
+                )))
+            }
+            PaginationParallelStrategy::IndependentOffsets => match mode {
+                ValidatedPaginationMode::Offset(_) => {
+                    Ok(Some(ValidatedPaginationParallel::IndependentOffsets {
+                        max_concurrency: parallel.max_concurrency,
+                    }))
+                }
+                _ => Err(ManifestError::validation(format!(
+                    "{schema}.{table} pagination.parallel.strategy=independent_offsets requires pagination.mode=offset"
+                ))),
+            },
+        }
+    }
 }
 
 impl OffsetPagination {
@@ -760,6 +888,10 @@ impl OffsetPagination {
 
 fn default_page_step() -> i64 {
     1
+}
+
+fn default_parallel_max_concurrency() -> usize {
+    4
 }
 
 /// Supported pagination modes in the source-spec DSL.
@@ -1263,6 +1395,161 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("demo.items pagination.mode=offset requires offset_step or page_size")
+        );
+    }
+
+    #[test]
+    fn pagination_parallel_accepts_independent_page_mode() {
+        let pagination = PaginationSpec {
+            mode: PaginationMode::Page,
+            page_param: Some("page".to_string()),
+            page_start: 1,
+            page_size: Some(PageSizeSpec {
+                default: 50,
+                max: 100,
+                query_param: Some("per_page".to_string()),
+                body_path: vec![],
+            }),
+            parallel: Some(PaginationParallelSpec {
+                strategy: PaginationParallelStrategy::IndependentPages,
+                max_concurrency: 3,
+                page_param: None,
+                page_start: None,
+                page_step: None,
+            }),
+            ..PaginationSpec::default()
+        };
+
+        let validated = pagination.validated("demo", "items").unwrap();
+
+        assert_eq!(
+            validated.parallel,
+            Some(ValidatedPaginationParallel::IndependentPages(
+                IndependentPagePagination {
+                    param: "page".to_string(),
+                    start: 1,
+                    step: 1,
+                    max_concurrency: 3,
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn pagination_parallel_accepts_link_header_with_explicit_page_coordinates() {
+        let pagination = PaginationSpec {
+            mode: PaginationMode::LinkHeader,
+            page_size: Some(PageSizeSpec {
+                default: 50,
+                max: 100,
+                query_param: Some("per_page".to_string()),
+                body_path: vec![],
+            }),
+            parallel: Some(PaginationParallelSpec {
+                strategy: PaginationParallelStrategy::IndependentPages,
+                max_concurrency: 2,
+                page_param: Some("page".to_string()),
+                page_start: Some(1),
+                page_step: Some(1),
+            }),
+            ..PaginationSpec::default()
+        };
+
+        let validated = pagination.validated("demo", "items").unwrap();
+
+        assert_eq!(
+            validated.parallel,
+            Some(ValidatedPaginationParallel::IndependentPages(
+                IndependentPagePagination {
+                    param: "page".to_string(),
+                    start: 1,
+                    step: 1,
+                    max_concurrency: 2,
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn pagination_parallel_rejects_cursor_mode() {
+        let pagination = PaginationSpec {
+            mode: PaginationMode::CursorQuery,
+            cursor_param: Some("cursor".to_string()),
+            response_cursor_path: vec!["next".to_string()],
+            page_size: Some(PageSizeSpec {
+                default: 50,
+                max: 100,
+                query_param: Some("limit".to_string()),
+                body_path: vec![],
+            }),
+            parallel: Some(PaginationParallelSpec {
+                strategy: PaginationParallelStrategy::IndependentPages,
+                max_concurrency: 2,
+                page_param: None,
+                page_start: None,
+                page_step: None,
+            }),
+            ..PaginationSpec::default()
+        };
+
+        let err = pagination.validated("demo", "items").unwrap_err();
+
+        assert!(
+            err.to_string().contains(
+                "demo.items pagination.parallel.strategy=independent_pages requires pagination.mode=page or link_header"
+            )
+        );
+    }
+
+    #[test]
+    fn pagination_parallel_rejects_missing_page_size() {
+        let pagination = PaginationSpec {
+            mode: PaginationMode::Page,
+            page_param: Some("page".to_string()),
+            parallel: Some(PaginationParallelSpec {
+                strategy: PaginationParallelStrategy::IndependentPages,
+                max_concurrency: 2,
+                page_param: None,
+                page_start: None,
+                page_step: None,
+            }),
+            ..PaginationSpec::default()
+        };
+
+        let err = pagination.validated("demo", "items").unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("demo.items pagination.parallel requires page_size")
+        );
+    }
+
+    #[test]
+    fn pagination_parallel_rejects_zero_concurrency() {
+        let pagination = PaginationSpec {
+            mode: PaginationMode::Page,
+            page_param: Some("page".to_string()),
+            page_size: Some(PageSizeSpec {
+                default: 50,
+                max: 100,
+                query_param: Some("per_page".to_string()),
+                body_path: vec![],
+            }),
+            parallel: Some(PaginationParallelSpec {
+                strategy: PaginationParallelStrategy::IndependentPages,
+                max_concurrency: 0,
+                page_param: None,
+                page_start: None,
+                page_step: None,
+            }),
+            ..PaginationSpec::default()
+        };
+
+        let err = pagination.validated("demo", "items").unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("demo.items pagination.parallel.max_concurrency must be > 0")
         );
     }
 }

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -94,11 +94,13 @@ pub use backends::mcp::{
 pub(crate) use common::validate_test_queries;
 pub use common::{
     BodyFieldSpec, BodySpec, ColumnSpec, DetailHintSpec, ExprSpec, FilterMode, FilterSpec,
-    FunctionArgBinding, HeaderSpec, HttpMethod, ManifestDataType, PageSizeSpec, PaginationMode,
+    FunctionArgBinding, HeaderSpec, HttpMethod, IndependentPagePagination, ManifestDataType,
+    PageSizeSpec, PaginationMode, PaginationParallelSpec, PaginationParallelStrategy,
     PaginationSpec, QueryParamSpec, RequestRouteSpec, RequestSpec, ResponseBodyFormat,
     ResponseSpec, RowStrategy, SearchLimitsSpec, SourceBackend, SourceManifestCommon,
     SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon, TableFunctionArgSpec,
-    TimestampInput, ValidatedPagination, ValidatedPaginationMode, ValueSourceSpec,
+    TimestampInput, ValidatedPagination, ValidatedPaginationMode, ValidatedPaginationParallel,
+    ValueSourceSpec,
 };
 pub use error::{ManifestError, Result};
 pub use inputs::{

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -1146,6 +1146,7 @@
           ]
         },
         "page_size": { "$ref": "#/$defs/page_size" },
+        "parallel": { "$ref": "#/$defs/pagination_parallel" },
         "cursor_param": { "type": "string", "minLength": 1 },
         "cursor_body_path": {
           "type": "array",
@@ -1163,6 +1164,21 @@
         "offset_step": { "type": "integer", "minimum": 1 },
         "link_header_require_results": { "type": "boolean" },
         "max_pages": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "pagination_parallel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["strategy"],
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["independent_pages", "independent_offsets"]
+        },
+        "max_concurrency": { "type": "integer", "minimum": 1 },
+        "page_param": { "type": "string", "minLength": 1 },
+        "page_start": { "type": "integer" },
+        "page_step": { "type": "integer", "minimum": 1 }
       }
     },
     "page_size": {

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -815,13 +815,26 @@ The `pagination` object controls how Coral fetches additional pages of results.
 | `cursor_body_path`            | list of strings | `[]`    | JSON path in the request body for the cursor (`cursor_body` mode)                                      |
 | `page_param`                  | string          | —       | Query parameter name for the page number (`page` mode)                                                 |
 | `page_start`                  | integer         | `0`     | Starting page number                                                                                   |
+| `page_step`                   | integer         | `1`     | Amount to add to the page number after each fetched page                                               |
 | `offset_param`                | string          | —       | Query parameter name for the offset (`offset` mode)                                                    |
 | `offset_start`                | integer         | `0`     | Starting offset value                                                                                  |
+| `offset_step`                 | integer         | —       | Amount to add to the offset after each fetched page; defaults to page size when `page_size` is present |
 | `page_size.default`           | integer         | —       | Default page size                                                                                      |
 | `page_size.max`               | integer         | —       | Maximum page size                                                                                      |
 | `page_size.query_param`       | string          | —       | Query parameter name for the page size                                                                 |
+| `parallel.strategy`           | string          | —       | Optional parallel pagination opt-in: `independent_pages` or `independent_offsets`                      |
+| `parallel.max_concurrency`    | integer         | `4`     | Maximum number of later pages to fetch concurrently                                                    |
+| `parallel.page_param`         | string          | —       | Explicit page query parameter for `link_header` endpoints that also accept independent page numbers    |
+| `parallel.page_start`         | integer         | —       | Explicit first page number for `link_header` parallel pagination                                       |
+| `parallel.page_step`          | integer         | —       | Explicit page step for `link_header` parallel pagination                                               |
 | `max_pages`                   | integer         | —       | Maximum number of pages to fetch                                                                       |
 | `link_header_require_results` | boolean         | `false` | For `link_header` mode, require non-empty results to continue                                          |
+
+By default Coral fetches pages sequentially. Add `parallel` only when the API
+can construct page N without reading the response for page N-1. Cursor
+pagination is sequential because the next cursor comes from the previous
+response. Parallel pagination is only used for finite SQL `LIMIT` queries;
+unbounded queries keep the sequential path.
 
 Example using cursor-based pagination:
 
@@ -862,6 +875,40 @@ pagination:
     default: 30
     max: 100
     query_param: per_page
+```
+
+Example using independently addressable page numbers:
+
+```yaml
+pagination:
+  mode: page
+  page_param: page
+  page_start: 1
+  page_size:
+    default: 100
+    max: 100
+    query_param: per_page
+  parallel:
+    strategy: independent_pages
+    max_concurrency: 4
+```
+
+Example using link headers for sequential pagination while declaring the
+explicit page parameter Coral may use for finite-limit parallel fetches:
+
+```yaml
+pagination:
+  mode: link_header
+  page_size:
+    default: 30
+    max: 100
+    query_param: per_page
+  parallel:
+    strategy: independent_pages
+    page_param: page
+    page_start: 1
+    page_step: 1
+    max_concurrency: 4
 ```
 
 ## Source inputs


### PR DESCRIPTION
## Intent

Add a source-spec contract and engine path for HTTP relations whose pages are independently addressable. Coral still defaults to sequential pagination; a manifest must opt in with `pagination.parallel` before the runtime will fetch later pages concurrently.

This is one PR for now per request, but it has a clean split point if review wants it:

- `coral-spec` schema/parser/validation/docs for the new `pagination.parallel` contract
- `coral-engine` fetch planner/executor and HTTP tests

## What changed

- Added `pagination.parallel.strategy` with two supported strategies:
  - `independent_pages`
  - `independent_offsets`
- Added validation so schema, parser, validator, docs, and runtime agree:
  - cursor modes cannot opt into parallel pagination
  - parallel pagination requires `page_size`
  - link-header parallel page mode requires explicit `parallel.page_param`, `parallel.page_start`, and `parallel.page_step`
  - `max_concurrency` must be greater than zero
- Refactored HTTP fetch so one-page request execution is shared by the existing sequential loop and the new bounded parallel path.
- Parallel execution only runs for finite SQL `LIMIT` queries. Unbounded queries stay sequential.
- Parallel execution fetches page 1 first, stops on a short first page, then fetches remaining pages up to the requested limit with bounded concurrency.
- Results are merged back in page order and truncated to the SQL limit.
- Documented the new source-spec fields and examples.

No bundled source is opted in in this PR. I tried GitHub `pulls` live because it was the clean benchmark target, but the live endpoint did not show a reliable win, so this PR leaves source opt-in to a later evidence-backed source change.

## Live smoke evidence

Installed current Coral vs this branch's release binary, same warmed MCP `tools/call sql` boundary, real GitHub endpoint:

| Query | Current installed | This branch | Result |
| --- | ---: | ---: | --- |
| `github.pulls LIMIT 100` | `1653.2 ms` avg | `1604.7 ms` avg | one-page noise-level difference |
| `github.pulls LIMIT 250` | `3808.7 ms` avg | `4398.4 ms` avg | branch was slower in this run |
| `github.pulls LIMIT 500` | `6553.0 ms` avg | `6582.5 ms` avg | effectively flat |

Interpretation: the generic engine capability works, but GitHub should not be opted in by default without stronger endpoint-specific evidence.

## Validation

- `cargo test -p coral-engine --test engine pagination_parallel --locked`
- `cargo test -p coral-engine --test engine pagination --locked`
- `cargo test -p coral-spec pagination --locked`
- `cargo clippy -p coral-engine -p coral-spec --all-targets --all-features --locked -- -D warnings`
- `make rust-checks`

`make rust-checks` passed workspace fmt, workspace clippy, 898 nextest tests, and rustdoc with warnings denied. Nextest reported 1 leaky test, with all tests passing.

## Notes for review

The contract is intentionally mechanism-specific, not source-specific. The spec says a relation has independently addressable pages or offsets; the engine never branches on provider name.

The runtime keeps cursor and opaque link traversal sequential. That is deliberate: page N cannot be constructed safely unless the manifest gives Coral enough information to build it without page N-1.
