### PR TITLE
feat(mcp): summarize unfiltered catalog listing

### DIFF
--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -280,7 +280,7 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .description
             .as_deref()
             .expect("list_catalog description")
-            .contains("3 table(s) and 0 table function(s) are currently visible")
+            .contains("With no schema and no kind, returns a compact schema summary")
     );
     assert!(
         tools[2]
@@ -592,21 +592,28 @@ async fn assert_list_catalog_tool(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let structured_catalog =
         structured_tool_content(client, CallToolRequestParams::new("list_catalog")).await?;
-    assert_eq!(structured_catalog["total"], 3);
+    assert_eq!(structured_catalog["view"], "schema_summary");
+    assert_eq!(structured_catalog["total_schemas"], 1);
+    assert_eq!(structured_catalog["total_items"], 3);
     assert_eq!(structured_catalog["limit"], 50);
     assert_eq!(structured_catalog["offset"], 0);
     assert_eq!(structured_catalog["has_more"], false);
     assert_eq!(
-        structured_catalog["items"][0]["name"],
+        structured_catalog["schemas"][0]["schema_name"],
+        "local_messages"
+    );
+    assert_eq!(structured_catalog["schemas"][0]["table_count"], 3);
+    assert_eq!(structured_catalog["schemas"][0]["table_function_count"], 0);
+    assert_eq!(
+        structured_catalog["schemas"][0]["sample_items"][0],
         "local_messages.events"
     );
-    assert_eq!(structured_catalog["items"][0]["kind"], "table");
     let requests = server.list_catalog_requests();
     let request = requests.last().expect("list catalog request");
     assert_eq!(request.schema_name, "");
     assert_eq!(request.kind, 0);
     let request_pagination = request.pagination.as_ref().expect("request pagination");
-    assert_eq!(request_pagination.limit, 50);
+    assert_eq!(request_pagination.limit, 0);
     assert_eq!(request_pagination.offset, 0);
 
     let all_kinds = structured_tool_content(
@@ -809,8 +816,8 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
         .await?;
     assert_eq!(catalog.is_error, Some(false));
     assert_eq!(
-        catalog.structured_content.expect("structured content")["items"][0]["name"],
-        "local_messages.events"
+        catalog.structured_content.expect("structured content")["schemas"][0]["schema_name"],
+        "local_messages"
     );
 
     client.cancel().await?;

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -72,7 +72,7 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 - Joins across schemas work with standard SQL after table scans complete.
 - Use `LIKE` or `ILIKE` for SQL wildcard matching with `%` and `_`. `SIMILAR TO` uses regex-shaped patterns, so write `.*` instead of `%`, `.` instead of `_`, or escape literal percent/underscore characters as `\%` and `\_`.
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
-- `list_catalog` shows queryable tables and parameterized table functions in pages; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs. Omit `kind` or pass `null` to list all item kinds.
+- `list_catalog` returns a compact schema summary when called without `schema` or `kind`. Pass `schema`, `kind`, `limit`, and `offset` for detailed pages of queryable tables and parameterized table functions. Omit `kind` or pass `null` with `schema` to list all item kinds in that schema.
 - `search_catalog` searches table and table-function names, descriptions, arguments, result columns, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the catalog item you need.
 - `describe_table` returns one compact table detail with guide text, required filters, and column count; use `coral.columns` when you need full column details.
 - `list_columns` lists columns for one table; pass `pattern`, `required_only`, `limit`, and `offset` to inspect large schemas progressively. Existing tables return paginated `columns` plus `total`, `has_more`, and optional `next_offset`; regex matches add `matched_fields` per column. Missing tables return `found: false` with suggested recovery calls instead of an empty page.

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -28,11 +28,12 @@ use crate::{
     surface::{
         CatalogToolKind, build_tool_result, describe_table_arguments, describe_table_tool,
         describe_table_value, feedback_tool, guide_resource, guide_resource_content,
-        initial_instructions, internal_status, list_catalog_arguments, list_catalog_tool,
-        list_catalog_value, list_columns_arguments, list_columns_tool, list_columns_value,
-        required_string_argument, search_catalog_arguments, search_catalog_tool,
-        search_catalog_value, sql_tool, status_to_error_data, tables_resource,
-        tables_resource_content, tool_error_from_status, tool_error_result,
+        initial_instructions, internal_status, list_catalog_arguments,
+        list_catalog_schema_summary_value, list_catalog_tool, list_catalog_value,
+        list_columns_arguments, list_columns_tool, list_columns_value, required_string_argument,
+        search_catalog_arguments, search_catalog_tool, search_catalog_value, sql_tool,
+        status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
+        tool_error_result,
     },
     telemetry,
 };
@@ -322,6 +323,24 @@ impl CoralMcpServer {
         request_arguments: Option<&Map<String, Value>>,
     ) -> Result<ToolCallOutcome, ErrorData> {
         let arguments = list_catalog_arguments(request_arguments)?;
+        if arguments.schema.is_none() && arguments.kind.is_none() {
+            let result = self
+                .load_catalog(
+                    None,
+                    CATALOG_KIND_ALL,
+                    PaginationRequest {
+                        limit: LIST_CATALOG_UNBOUNDED_LIMIT,
+                        offset: 0,
+                    },
+                )
+                .await
+                .map(|response| list_catalog_schema_summary_value(&response, arguments.pagination));
+            return Ok(ToolCallOutcome::from_value_result(
+                "Catalog schema summary",
+                result,
+            ));
+        }
+
         let mut catalog_client = self.catalog.clone();
         let result = catalog_client
             .list_catalog(Request::new(ListCatalogRequest {

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use coral_api::v1::{
     ColumnSearchResult, DescribeTableResponse, ListCatalogResponse, ListColumnsResponse,
     SearchCatalogResponse, Table as ProtoTable, TableFunction as ProtoTableFunction,
@@ -8,11 +10,13 @@ use coral_api::v1::{
 use serde::Serialize;
 use serde_json::{Map, Value};
 
+use super::Pagination;
 use super::values::{
     format_schema_table_equivalent, format_sql_identifier, insert_pagination_fields,
     missing_table_summary_value, paged_collection_value,
 };
 
+const SCHEMA_SAMPLE_ITEM_LIMIT: usize = 3;
 pub(crate) fn describe_table_value(
     schema: &str,
     table: &str,
@@ -111,6 +115,48 @@ pub(crate) fn list_catalog_value(response: &ListCatalogResponse) -> Value {
     paged_collection_value("items", items, &pagination)
 }
 
+pub(crate) fn list_catalog_schema_summary_value(
+    response: &ListCatalogResponse,
+    pagination: Pagination,
+) -> Value {
+    let mut summaries = BTreeMap::new();
+    for item in &response.items {
+        add_catalog_item_to_schema_summaries(item, &mut summaries);
+    }
+
+    let total_items = response.pagination.as_ref().map_or_else(
+        || u32::try_from(response.items.len()).unwrap_or(u32::MAX),
+        |pagination| pagination.total_count,
+    );
+    let schemas = summaries
+        .into_values()
+        .map(CatalogSchemaSummaryValue::from)
+        .collect::<Vec<_>>();
+    let total_schemas = u32::try_from(schemas.len()).unwrap_or(u32::MAX);
+    let offset = usize::try_from(pagination.offset).unwrap_or(usize::MAX);
+    let limit = usize::try_from(pagination.limit).unwrap_or(usize::MAX);
+    let page_schemas = schemas
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .collect::<Vec<_>>();
+    let returned_count = u32::try_from(page_schemas.len()).unwrap_or(u32::MAX);
+    let has_more = pagination.offset.saturating_add(returned_count) < total_schemas;
+    let next_offset = has_more.then_some(pagination.offset.saturating_add(returned_count));
+
+    serde_json::to_value(CatalogSchemaSummaryPageValue {
+        view: "schema_summary",
+        schemas: page_schemas,
+        total_schemas,
+        total_items,
+        limit: pagination.limit,
+        offset: pagination.offset,
+        has_more,
+        next_offset,
+    })
+    .expect("catalog schema summary value serializes")
+}
+
 fn catalog_item_value(item: &coral_api::v1::CatalogItem) -> Option<Value> {
     match item.item.as_ref()? {
         catalog_item::Item::Table(table) => {
@@ -175,6 +221,89 @@ fn column_search_result_value(result: &ColumnSearchResult) -> Option<Value> {
         );
     }
     Some(Value::Object(value))
+}
+
+fn add_catalog_item_to_schema_summaries(
+    item: &coral_api::v1::CatalogItem,
+    summaries: &mut BTreeMap<String, CatalogSchemaSummaryBuilder>,
+) {
+    let Some(item) = item.item.as_ref() else {
+        return;
+    };
+    match item {
+        catalog_item::Item::Table(table) => {
+            let entry = summaries
+                .entry(table.schema_name.clone())
+                .or_insert_with(|| CatalogSchemaSummaryBuilder::new(&table.schema_name));
+            entry.table_count += 1;
+            entry.push_sample_item(&table.name);
+        }
+        catalog_item::Item::TableFunction(function) => {
+            let entry = summaries
+                .entry(function.schema_name.clone())
+                .or_insert_with(|| CatalogSchemaSummaryBuilder::new(&function.schema_name));
+            entry.table_function_count += 1;
+            entry.push_sample_item(&function.name);
+        }
+    }
+}
+
+struct CatalogSchemaSummaryBuilder {
+    schema_name: String,
+    table_count: u32,
+    table_function_count: u32,
+    sample_items: Vec<String>,
+}
+
+impl CatalogSchemaSummaryBuilder {
+    fn new(schema_name: &str) -> Self {
+        Self {
+            schema_name: schema_name.to_string(),
+            table_count: 0,
+            table_function_count: 0,
+            sample_items: Vec::new(),
+        }
+    }
+
+    fn push_sample_item(&mut self, item_name: &str) {
+        if self.sample_items.len() >= SCHEMA_SAMPLE_ITEM_LIMIT {
+            return;
+        }
+        self.sample_items
+            .push(format!("{}.{}", self.schema_name, item_name));
+    }
+}
+
+#[derive(Serialize)]
+struct CatalogSchemaSummaryPageValue {
+    view: &'static str,
+    schemas: Vec<CatalogSchemaSummaryValue>,
+    total_schemas: u32,
+    total_items: u32,
+    limit: u32,
+    offset: u32,
+    has_more: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_offset: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct CatalogSchemaSummaryValue {
+    schema_name: String,
+    table_count: u32,
+    table_function_count: u32,
+    sample_items: Vec<String>,
+}
+
+impl From<CatalogSchemaSummaryBuilder> for CatalogSchemaSummaryValue {
+    fn from(builder: CatalogSchemaSummaryBuilder) -> Self {
+        Self {
+            schema_name: builder.schema_name,
+            table_count: builder.table_count,
+            table_function_count: builder.table_function_count,
+            sample_items: builder.sample_items,
+        }
+    }
 }
 
 #[derive(Serialize)]

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -8,7 +8,8 @@ mod tools;
 mod values;
 
 pub(crate) use catalog::{
-    describe_table_value, list_catalog_value, list_columns_value, search_catalog_value,
+    describe_table_value, list_catalog_schema_summary_value, list_catalog_value,
+    list_columns_value, search_catalog_value,
 };
 pub(crate) use discovery::{Pagination, parse_pagination, parse_pagination_with_limits};
 pub(crate) use errors::{

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -71,17 +71,17 @@ pub(crate) fn list_catalog_tool(visible_table_count: usize, visible_function_cou
     Tool::new(
         "list_catalog",
         format!(
-            "List database catalog items. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible."
+            "List database catalog schemas or items. With no schema and no kind, returns a compact schema summary for {visible_table_count} table(s) and {visible_function_count} table function(s). Pass schema or kind for detailed catalog items."
         ),
         json_object_schema(&json!({
             "type": "object",
             "properties": {
                 "schema": {
                     "type": "string",
-                    "description": "Optional exact SQL schema name to list."
+                    "description": "Optional exact SQL schema name to list detailed catalog items for."
                 },
                 "kind": {
-                    "description": "Optional item kind to list. Omit or pass null to list all catalog items.",
+                    "description": "Optional item kind to list. Omit or pass null with schema to list all item kinds. Omit both schema and kind to return a compact schema summary.",
                     "anyOf": [
                         {
                             "type": "string",
@@ -399,6 +399,16 @@ fn search_catalog_description(visible_table_count: usize, visible_function_count
 fn list_catalog_output_schema() -> Arc<Map<String, Value>> {
     json_object_schema(&json!({
         "type": "object",
+        "oneOf": [
+            list_catalog_items_output_schema(),
+            list_catalog_schema_summary_output_schema()
+        ]
+    }))
+}
+
+fn list_catalog_items_output_schema() -> Value {
+    json!({
+        "type": "object",
         "required": ["items", "total", "limit", "offset", "has_more"],
         "additionalProperties": false,
         "properties": {
@@ -429,7 +439,83 @@ fn list_catalog_output_schema() -> Arc<Map<String, Value>> {
                 "minimum": 0
             }
         }
-    }))
+    })
+}
+
+fn list_catalog_schema_summary_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": [
+            "view",
+            "schemas",
+            "total_schemas",
+            "total_items",
+            "limit",
+            "offset",
+            "has_more"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "view": { "enum": ["schema_summary"] },
+            "schemas": catalog_schema_summary_array_output_schema(),
+            "total_schemas": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "total_items": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1
+            },
+            "offset": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "has_more": { "type": "boolean" },
+            "next_offset": {
+                "type": "integer",
+                "minimum": 0
+            }
+        }
+    })
+}
+
+fn catalog_schema_summary_array_output_schema() -> Value {
+    json!({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "required": [
+                "schema_name",
+                "table_count",
+                "table_function_count",
+                "sample_items"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "schema_name": { "type": "string" },
+                "table_count": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "table_function_count": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "sample_items": catalog_schema_sample_items_output_schema()
+            }
+        }
+    })
+}
+
+fn catalog_schema_sample_items_output_schema() -> Value {
+    json!({
+        "type": "array",
+        "items": { "type": "string" }
+    })
 }
 
 fn catalog_table_item_output_schema() -> Value {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -372,7 +372,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .description
             .as_deref()
             .expect("catalog description")
-            .contains("3 table(s) and 0 table function(s) are currently visible")
+            .contains("With no schema and no kind, returns a compact schema summary")
     );
     assert!(
         updated_tools[2]
@@ -426,14 +426,16 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         .await
         .expect("list catalog");
     let catalog = catalog.structured_content.expect("structured catalog");
-    assert_eq!(catalog["total"], 3);
-    assert_eq!(catalog["items"][0]["kind"], "table");
-    assert_eq!(catalog["items"][0]["name"], "local_messages.events");
+    assert_eq!(catalog["view"], "schema_summary");
+    assert_eq!(catalog["total_schemas"], 1);
+    assert_eq!(catalog["total_items"], 3);
+    assert_eq!(catalog["schemas"][0]["schema_name"], "local_messages");
+    assert_eq!(catalog["schemas"][0]["table_count"], 3);
+    assert_eq!(catalog["schemas"][0]["table_function_count"], 0);
     assert_eq!(
-        catalog["items"][0]["sql_reference"],
+        catalog["schemas"][0]["sample_items"][0],
         "local_messages.events"
     );
-    assert_eq!(catalog["items"][0]["table"]["table_name"], "events");
     assert_matches_output_schema(list_catalog_tool, &catalog);
 
     let catalog_page = client
@@ -795,22 +797,64 @@ async fn list_catalog_surfaces_table_functions() {
     add_demo_source(&mut session.source_client, manifest_yaml).await;
 
     let tools = client.list_all_tools().await.expect("tools");
+    assert_table_function_catalog_tools(&tools);
+    let catalog_tool = tool_by_name(&tools, "list_catalog");
+    let search_tool = tool_by_name(&tools, "search_catalog");
+
+    assert_searchy_schema_summary(client, catalog_tool).await;
+    assert_searchy_catalog_items(client, catalog_tool).await;
+    assert_searchy_function_catalog_page(client, catalog_tool).await;
+    assert_searchy_catalog_search(client, search_tool).await;
+
+    session.shutdown().await;
+}
+
+fn assert_table_function_catalog_tools(tools: &[Tool]) {
     assert!(
-        tool_by_name(&tools, "list_catalog")
+        tool_by_name(tools, "list_catalog")
             .description
             .as_deref()
             .expect("catalog description")
-            .contains("1 table(s) and 2 table function(s) are currently visible")
+            .contains("With no schema and no kind, returns a compact schema summary")
     );
     assert!(tools.iter().all(|tool| tool.name != "list_tables"));
     assert!(tools.iter().all(|tool| tool.name != "search_tables"));
+}
 
-    let catalog_tool = tool_by_name(&tools, "list_catalog");
-    let search_tool = tool_by_name(&tools, "search_catalog");
-    let catalog = client
+async fn assert_searchy_schema_summary(
+    client: &RunningService<RoleClient, ()>,
+    catalog_tool: &Tool,
+) {
+    let catalog_summary = client
         .call_tool(CallToolRequestParams::new("list_catalog"))
         .await
         .expect("list catalog")
+        .structured_content
+        .expect("structured catalog summary");
+    assert_eq!(catalog_summary["view"], "schema_summary");
+    assert_eq!(catalog_summary["total_schemas"], 1);
+    assert_eq!(catalog_summary["schemas"][0]["schema_name"], "searchy");
+    assert_eq!(catalog_summary["schemas"][0]["table_count"], 1);
+    assert_eq!(catalog_summary["schemas"][0]["table_function_count"], 2);
+    assert_eq!(
+        catalog_summary["schemas"][0]["sample_items"][0],
+        "searchy.lookup_issue"
+    );
+    assert_matches_output_schema(catalog_tool, &catalog_summary);
+}
+
+async fn assert_searchy_catalog_items(
+    client: &RunningService<RoleClient, ()>,
+    catalog_tool: &Tool,
+) {
+    let catalog = client
+        .call_tool(
+            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
+                "schema": "searchy"
+            }))),
+        )
+        .await
+        .expect("list searchy catalog")
         .structured_content
         .expect("structured catalog");
     assert_eq!(catalog["total"], 3);
@@ -832,7 +876,12 @@ async fn list_catalog_surfaces_table_functions() {
     assert_eq!(catalog["items"][1]["kind"], "table");
     assert_eq!(catalog["items"][1]["name"], "searchy.placeholder");
     assert_matches_output_schema(catalog_tool, &catalog);
+}
 
+async fn assert_searchy_function_catalog_page(
+    client: &RunningService<RoleClient, ()>,
+    catalog_tool: &Tool,
+) {
     let functions = client
         .call_tool(
             CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
@@ -855,7 +904,12 @@ async fn list_catalog_surfaces_table_functions() {
         "searchy.search_issues(q => '<value>')"
     );
     assert_matches_output_schema(catalog_tool, &functions);
+}
 
+async fn assert_searchy_catalog_search(
+    client: &RunningService<RoleClient, ()>,
+    search_tool: &Tool,
+) {
     let search = client
         .call_tool(
             CallToolRequestParams::new("search_catalog").with_arguments(json_object(&json!({
@@ -878,8 +932,6 @@ async fn list_catalog_surfaces_table_functions() {
             .any(|field| field == "arguments")
     );
     assert_matches_output_schema(search_tool, &search);
-
-    session.shutdown().await;
 }
 
 #[tokio::test]
@@ -1067,12 +1119,8 @@ async fn mcp_tool_error_does_not_end_session() {
         .structured_content
         .expect("structured content");
     assert_eq!(
-        structured_catalog_after_error["items"][0]["name"],
-        "local_messages.events"
-    );
-    assert_eq!(
-        structured_catalog_after_error["items"][0]["sql_reference"],
-        "local_messages.events"
+        structured_catalog_after_error["schemas"][0]["schema_name"],
+        "local_messages"
     );
     assert_eq!(catalog_after_error.is_error, Some(false));
 

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -15,7 +15,7 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
 | Tool     | `sql`            | Execute read-only SQL against the Coral database        |
-| Tool     | `list_catalog`   | List database tables and table functions with pagination |
+| Tool     | `list_catalog`   | List schemas, tables, and table functions                |
 | Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
 | Tool     | `describe_table` | Show compact metadata for one database table            |
 | Tool     | `list_columns`   | List columns for one database table with pagination     |
@@ -28,9 +28,11 @@ Agents should treat the discovery tools as catalog helpers, not as replacement p
 
 ### Discovery tools
 
-**`list_catalog`**: paginated list of database tables and parameterized table functions.
+**`list_catalog`**: schema summary or paginated list of database tables and parameterized table functions.
 
-- Arguments: optional `schema`, `kind`, `limit`, `offset`. Omit `kind` (or pass `null`) to include both `"table"` and `"table_function"` items.
+- Arguments: optional `schema`, `kind`, `limit`, `offset`.
+- With no `schema` and no `kind`, returns a compact schema summary with counts and sample item names.
+- Pass `schema` or `kind` to return detailed catalog items. Omit `kind` (or pass `null`) with `schema` to include both `"table"` and `"table_function"` items.
 - For tables, use `sql_reference` in `FROM` and `JOIN` clauses.
 - For table functions, use `sql_call_example` and fill in the required arguments.
 - Do not quote the whole `schema.item` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
@@ -234,7 +236,7 @@ Once your client is connected, ask the agent to list available tables or run a s
 
 > "Run a small Coral query against `coral.tables`."
 
-The agent should call `list_catalog`, `search_catalog`, or query `coral.tables` and `coral.table_functions` to return SQL schemas and catalog items, and use `describe_table` or `list_columns` for table-specific metadata. Large catalogs should be paged with `limit` and `offset`.
+The agent should call `list_catalog`, `search_catalog`, or query `coral.tables` and `coral.table_functions` to return SQL schemas and catalog items, and use `describe_table` or `list_columns` for table-specific metadata. Use no-argument `list_catalog` for a compact schema summary; pass `schema` or `kind` when you need detailed catalog items. Large detailed catalogs should be paged with `limit` and `offset`.
 
 ## Troubleshooting
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -223,7 +223,7 @@ This server exposes:
 | Type     | Name             | Description                      |
 | -------- | ---------------- | -------------------------------- |
 | Tool     | `sql`            | Execute read-only SQL against the Coral database |
-| Tool     | `list_catalog`   | List database tables and table functions |
+| Tool     | `list_catalog`   | List schemas, tables, and table functions |
 | Tool     | `search_catalog` | Search database catalog metadata by regex |
 | Tool     | `describe_table` | Show compact database table metadata |
 | Tool     | `list_columns`   | List columns for one database table |


### PR DESCRIPTION
## Status

Benchmark result: this did **not** validate as a Codex efficiency fix. Keep this draft as an artifact for discussion, not as a merge-ready solution.

Pinned Coral builder tag tested:

```text
0c140c5f3a3fd58c66ce98216e4bd3746d6f131b-0c140c5
```

## Benchmark Readout

| Builder | Runner | Behavioral pass | Efficiency | Discovery calls | SQL calls | Unfiltered `list_catalog` |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| baseline `main-fa121e4` | Opus | `40/50` | `87/90` | `70`, avg `1.40` | `95`, avg `1.90` | `0` |
| baseline `main-fa121e4` | Codex | `23/50` | `66/90` | `141`, avg `2.82` | `198`, avg `3.96` | `5` |
| PR #937 | Opus | `34/50` | `80/90` | `84`, avg `1.68` | `83`, avg `1.66` | `0` |
| PR #937 | Codex | `22/50` | `66/90` | `148`, avg `2.96` | `200`, avg `4.00` | `6` |
| PR #1037 | Opus | `40/50` | `86/90` | `72`, avg `1.44` | `92`, avg `1.84` | `1` |
| PR #1037 | Codex | `24/50` | `67/90` | `172`, avg `3.44` | `196`, avg `3.92` | `23` |

Codex first Coral call was unfiltered `list_catalog` in `18/50` traces on this PR, versus `2/50` on the baseline/PR #937 runs. Opus stayed search-first in `50/50` traces.

## Interpretation

Compact no-filter `list_catalog` is not enough. It made broad orientation cheaper-looking, and Codex used it more often. The common bad path became:

```text
unfiltered list_catalog summary -> schema listing -> list_columns/describe_table
```

rather than:

```text
intent-shaped search_catalog -> query
```

## Current Change Shape

- MCP `list_catalog` with no `schema` and no `kind` returns a compact `schema_summary` view instead of the first detailed catalog item page.
- Filtered `list_catalog` calls still return detailed table/table-function catalog items.
- The summary is factual only: schema name, table/function counts, sample item names, total item count, and schema pagination metadata.
- There is intentionally no per-schema `next` or `next_hint` field because the search-versus-listing heuristic was not solid enough for the output contract.

## Boundaries

This is MCP-surface only. It does not change the gRPC/proto catalog contract, app catalog discovery, `search_catalog` ranking, or SQL catalog tables.

## Likely Next Direction

- Stronger steering toward `search_catalog` for clear-intent tasks.
- Consider making detailed `list_catalog` require `schema`, `kind`, or another narrowing argument.
- Make no-filter output explicitly non-rewarding for broad orientation.
- Make `search_catalog` results rich enough that agents do not feel forced into schema-wide listing plus column scans.

## Verification

- `cargo test -p coral-mcp list_catalog_surfaces_table_functions -- --nocapture`
- `cargo test -p coral-cli --features cli-test-server --test mcp mcp_stdio_sql_and_catalog_tools_return_structured_content -- --nocapture`
- `make docs-check`
- `make rust-checks`