### PR TITLE
feat: add Docker Engine API source spec

### DIFF
--- a/sources/community/docker/README.md
+++ b/sources/community/docker/README.md
@@ -1,0 +1,149 @@
+# Docker
+
+**Version:** 0.2.0
+**Backend:** HTTP
+**Tables:** 2
+**Base URL:** `http://localhost:2375` (configurable)
+
+Query Docker container metadata as SQL via the [Docker Engine HTTP API](https://docs.docker.com/reference/api/engine/). No authentication required for local use.
+
+```bash
+coral source add --file sources/community/docker/manifest.yaml
+```
+
+## Tables
+
+| Table | Description |
+|---|---|
+| `containers` | All containers including stopped, exited, paused, and dead ones |
+| `running` | Only currently running containers |
+
+---
+
+### `containers`
+
+All containers on the Docker host. Equivalent to `docker ps --all`.
+
+#### Columns
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Full 64-character container ID |
+| `image` | Utf8 | Image name and tag (e.g. `nginx:latest`) |
+| `status` | Utf8 | Human-readable status string (e.g. `Exited (255) 2 days ago`) |
+| `state` | Utf8 | Machine-readable state: `running`, `exited`, `dead`, `paused`, `restarting` |
+| `created_epoch` | Int64 | Container creation time as Unix epoch seconds |
+| `command` | Utf8 | Entrypoint command string |
+
+---
+
+### `running`
+
+Only currently running containers. Equivalent to `docker ps`.
+
+#### Columns
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Full 64-character container ID |
+| `image` | Utf8 | Image name and tag |
+| `status` | Utf8 | Human-readable status string |
+| `state` | Utf8 | Machine-readable state |
+| `created_epoch` | Int64 | Container creation time as Unix epoch seconds |
+
+---
+
+## Setup
+
+### Option 1 — Local via socat (recommended)
+
+Proxy the Unix socket over TCP without exposing a network port:
+
+```bash
+socat TCP-LISTEN:2375,reuseaddr,fork UNIX-CLIENT:/var/run/docker.sock
+```
+
+Set `DOCKER_API_BASE=http://localhost:2375`.
+
+### Option 2 — Docker Desktop (Windows / macOS)
+
+Docker Desktop → Settings → General → **"Expose daemon on tcp://localhost:2375 without TLS"**
+
+> ⚠️ Only enable on trusted local machines. Never expose port 2375 on a network interface.
+
+### Option 3 — Remote daemon with TLS
+
+Follow Docker's [remote access guide](https://docs.docker.com/engine/daemon/remote-access/) to configure TLS certificates, then set:
+
+```
+DOCKER_API_BASE=https://your-docker-host:2376
+```
+
+---
+
+## Quick start
+
+```bash
+# Confirm connectivity
+coral sql "SELECT id, image, status, state FROM docker.containers LIMIT 1"
+
+# List all containers with their state
+coral sql "SELECT id, image, status, state FROM docker.containers LIMIT 20"
+
+# Find only exited containers
+coral sql "SELECT id, image, status FROM docker.containers WHERE state = 'exited' LIMIT 10"
+
+# List running containers
+coral sql "SELECT id, image, status FROM docker.running LIMIT 20"
+
+# Cross-source JOIN with GitHub to correlate container crashes with recent deploys
+coral sql "
+  SELECT
+    dc.id,
+    dc.image,
+    dc.status,
+    gp.title        AS last_pr,
+    gp.user__login  AS deployed_by,
+    gp.merged_at    AS deploy_time
+  FROM docker.containers dc
+  LEFT JOIN github.pulls gp
+    ON gp.owner = 'your-owner'
+    AND gp.repo  = 'your-repo'
+    AND gp.state = 'closed'
+  WHERE dc.state != 'running'
+  LIMIT 10
+"
+```
+
+---
+
+## Live evidence
+
+```
+$ coral source add --file sources/community/docker/manifest.yaml
+Added source docker
+  ✓ docker connected successfully
+    docker (2 tables)
+    ├─ containers
+    └─ running
+    Query tests
+    1 declared · 1 passed · 0 failed
+    ✓ SELECT id, image, status, state FROM docker.containers LIMIT 1
+      1 row
+
+$ coral sql "SELECT id, image, status, state FROM docker.containers LIMIT 3"
++------------------------------------------------------------------+---------------------------------+-------------------------+--------+
+| id                                                               | image                           | status                  | state  |
++------------------------------------------------------------------+---------------------------------+-------------------------+--------+
+| 6d0f1aa827b5b4efbebf3047e65a509a1ded2ef6ad4d4ba3d0ca20d999a23188 | jaegertracing/all-in-one:latest | Exited (255) 2 days ago | exited |
++------------------------------------------------------------------+---------------------------------+-------------------------+--------+
+```
+
+---
+
+## Notes
+
+- The Docker Engine API does not support server-side filtering by arbitrary fields. `WHERE` clauses on `state`, `image`, etc. are evaluated locally by Coral after fetching the full container list.
+- `created_epoch` is a Unix timestamp (seconds). Use your environment's date functions to convert if needed.
+- Container logs and per-container stats require separate API calls (`/containers/{id}/logs`, `/containers/{id}/stats`) and are not included in these tables.
+- The Docker Engine API version targeted is v1.43+ (Docker 24.0+). Older versions may differ in field availability.

--- a/sources/community/docker/manifest.yaml
+++ b/sources/community/docker/manifest.yaml
@@ -1,0 +1,89 @@
+name: docker
+version: 0.2.0
+dsl_version: 3
+backend: http
+description: >
+  Query Docker container metadata as SQL via the Docker Engine HTTP API.
+  Exposes running and all containers as tables, with snake_case columns
+  for ergonomic queries. Supports local Unix socket proxy or remote TLS-secured daemon.
+
+inputs:
+  DOCKER_API_BASE:
+    kind: variable
+    default: http://localhost:2375
+    hint: >
+      Docker Engine HTTP API base URL.
+      For local use: expose via socat or SSH tunnel rather than raw TCP.
+      For remote use: always secure with TLS (see README).
+
+base_url: "{{input.DOCKER_API_BASE}}"
+
+test_queries:
+  - SELECT id, image, status, state FROM docker.containers LIMIT 1
+
+tables:
+  - name: containers
+    description: >
+      All containers including stopped, exited, paused, and dead ones.
+      Equivalent to: docker ps --all
+    request:
+      method: GET
+      path: /containers/json?all=true
+    response:
+      rows_path: []
+    columns:
+      - name: id
+        path: Id
+        type: Utf8
+        description: Full 64-character container ID
+      - name: image
+        path: Image
+        type: Utf8
+        description: Image name and tag (e.g. nginx:latest)
+      - name: status
+        path: Status
+        type: Utf8
+        description: Human-readable status string (e.g. "Exited (255) 2 days ago")
+      - name: state
+        path: State
+        type: Utf8
+        description: Machine-readable state (running, exited, dead, paused, restarting)
+      - name: created_epoch
+        path: Created
+        type: Int64
+        description: Container creation time as Unix epoch seconds
+      - name: command
+        path: Command
+        type: Utf8
+        description: Entrypoint command string
+
+  - name: running
+    description: >
+      Only currently running containers.
+      Equivalent to: docker ps
+    request:
+      method: GET
+      path: /containers/json
+    response:
+      rows_path: []
+    columns:
+      - name: id
+        path: Id
+        type: Utf8
+        description: Full 64-character container ID
+      - name: image
+        path: Image
+        type: Utf8
+        description: Image name and tag
+      - name: status
+        path: Status
+        type: Utf8
+        description: Human-readable status string
+      - name: state
+        path: State
+        type: Utf8
+        description: Machine-readable state
+      - name: created_epoch
+        path: Created
+        type: Int64
+        description: Container creation time as Unix epoch seconds


### PR DESCRIPTION
## Docker Engine HTTP API Source

This source spec enables querying Docker container metadata as SQL using Coral.

### What it does
Connects to the Docker Engine HTTP API (default: `http://localhost:2375`) and exposes two tables:
- `docker.containers` — all containers including stopped/exited ones
- `docker.running` — only currently running containers

### Example queries
```sql
-- List all containers
SELECT id, image, status, state FROM docker.containers LIMIT 20;

-- Find exited containers
SELECT id, image, status FROM docker.containers WHERE state = 'exited' LIMIT 10;

-- Cross-source JOIN with GitHub to correlate deploys with crashes
SELECT
  dc.id,
  dc.image,
  dc.status,
  gp.title        AS last_pr,
  gp.user__login  AS deployed_by
FROM docker.containers dc
LEFT JOIN github.pulls gp
  ON gp.owner = 'your-owner'
  AND gp.repo  = 'your-repo'
  AND gp.state = 'closed'
WHERE dc.state != 'running'
LIMIT 10;
```

### Setup
See README.md for three setup options: socat proxy (recommended for local use), Docker Desktop, and remote TLS-secured daemon.

### Tables

| Table | Description |
|---|---|
| `containers` | All containers (`/containers/json?all=true`) |
| `running` | Running containers only (`/containers/json`) |

### Columns

| Column | Type | Description |
|---|---|---|
| `id` | Utf8 | Full 64-character container ID |
| `image` | Utf8 | Image name and tag |
| `status` | Utf8 | Human-readable status (e.g. `Exited (255) 2 days ago`) |
| `state` | Utf8 | Machine-readable state: `running`, `exited`, `dead`, `paused`, `restarting` |
| `created_epoch` | Int64 | Unix timestamp of creation |
| `command` | Utf8 | Entrypoint command |