### PR TITLE
feat(sources/community/couchdb): add CouchDB community source

### DIFF
--- a/sources/community/couchdb/README.md
+++ b/sources/community/couchdb/README.md
@@ -1,0 +1,137 @@
+# CouchDB
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+**Base URL:** your CouchDB HTTP endpoint (set via `COUCHDB_URL`)
+
+Inspect a CouchDB instance's server info, per-database document counts and
+sizes, running background tasks, and replication scheduler jobs through
+CouchDB's HTTP-native REST API.
+
+This source is **observability only**. It maps read-only REST endpoints to
+queryable tables and never reads or writes documents or modifies design
+documents.
+
+## Setup
+
+### Requirements
+
+- Network access to a CouchDB HTTP endpoint (default port `5984`).
+- A CouchDB user. The `server` table only needs valid credentials, but the
+  `databases`, `active_tasks`, and `scheduler` tables read server-level
+  metadata endpoints that require **server-admin** access (or a user granted
+  the relevant role).
+- The `databases` table uses the bodyless `GET /_dbs_info`, which requires
+  **CouchDB 3.2 or newer**.
+
+### Add the source
+
+```bash
+export COUCHDB_URL=http://localhost:5984
+export COUCHDB_USERNAME=admin
+export COUCHDB_PASSWORD=password
+coral source add --file sources/community/couchdb/manifest.yaml
+```
+
+Run from the repo root. Or interactively:
+
+```bash
+coral source add --file sources/community/couchdb/manifest.yaml --interactive
+```
+
+Inputs:
+
+- `COUCHDB_URL` — base URL including scheme and port, e.g.
+  `http://localhost:5984`. No trailing slash.
+- `COUCHDB_USERNAME` — CouchDB username.
+- `COUCHDB_PASSWORD` — password for the user.
+
+## Authentication
+
+This source uses HTTP **Basic authentication** (`Authorization: Basic ...`),
+the standard CouchDB credential scheme. Provide a server admin for full
+coverage, or a less-privileged user if you only need the `server` table. See
+the [CouchDB authentication docs](https://docs.couchdb.org/en/stable/api/server/authn.html).
+
+## Tables
+
+| Table | Description | Endpoint |
+|---|---|---|
+| `server` | Server welcome banner, version, and vendor info | `GET /` |
+| `databases` | Per-database document counts and storage sizes | `GET /_dbs_info` |
+| `active_tasks` | Running indexing, replication, and compaction tasks | `GET /_active_tasks` |
+| `scheduler` | Replication scheduler jobs and their current state | `GET /_scheduler/jobs` |
+
+No table requires or accepts SQL filters; filter with a `WHERE` clause after
+fetching. `scheduler` uses `skip`/`limit` page-based pagination; the other
+tables return all results in a single request.
+
+## Notes
+
+- `databases` sizes: `disk_size` is the on-disk file size, `active_size` is the
+  live data and index size, and `external_size` is the uncompressed JSON size.
+  A large `disk_size` relative to `active_size` indicates space reclaimable by
+  compaction.
+- `active_tasks` returns an empty result on an idle node. Columns like
+  `source`, `target`, `docs_read`, and `docs_written` are populated only for
+  replication tasks; `design_document` only for indexer tasks.
+- `scheduler.history` is ordered most-recent-first, so `latest_event` and
+  `latest_event_at` reflect each job's current state (`started`, `crashed`,
+  `added`, etc.). Live progress is in the `info` JSON column.
+- `started_on`/`updated_on` (active tasks) and `start_time`/`latest_event_at`
+  (scheduler) are real `Timestamp` columns.
+
+## Example Queries
+
+### Confirm connectivity and version
+
+```sql
+SELECT couchdb, version, vendor_name
+FROM couchdb.server
+```
+
+### Largest databases by document count
+
+```sql
+SELECT name, doc_count, doc_del_count, disk_size, active_size
+FROM couchdb.databases
+ORDER BY doc_count DESC
+LIMIT 20
+```
+
+### Databases with reclaimable space (compaction candidates)
+
+```sql
+SELECT name, disk_size, active_size, disk_size - active_size AS reclaimable
+FROM couchdb.databases
+WHERE disk_size > active_size
+ORDER BY reclaimable DESC
+```
+
+### What is the node doing right now?
+
+```sql
+SELECT type, database, progress, changes_done, total_changes
+FROM couchdb.active_tasks
+ORDER BY progress ASC
+```
+
+### Replication jobs that are not healthy
+
+```sql
+SELECT doc_id, source, target, node, latest_event, latest_event_at
+FROM couchdb.scheduler
+WHERE latest_event <> 'started'
+ORDER BY latest_event_at DESC
+```
+
+### Replication progress
+
+```sql
+SELECT doc_id,
+       json_get_int(info, 'docs_read') AS docs_read,
+       json_get_int(info, 'docs_written') AS docs_written,
+       json_get_int(info, 'changes_pending') AS changes_pending
+FROM couchdb.scheduler
+```

--- a/sources/community/couchdb/README.md
+++ b/sources/community/couchdb/README.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.1.0
 **Backend:** HTTP
-**Tables:** 4
+**Tables:** 5
 **Base URL:** your CouchDB HTTP endpoint (set via `COUCHDB_URL`)
 
 Inspect a CouchDB instance's server info, per-database document counts and
@@ -61,11 +61,26 @@ the [CouchDB authentication docs](https://docs.couchdb.org/en/stable/api/server/
 | `server` | Server welcome banner, version, and vendor info | `GET /` |
 | `databases` | Per-database document counts and storage sizes | `GET /_dbs_info` |
 | `active_tasks` | Running indexing, replication, and compaction tasks | `GET /_active_tasks` |
-| `scheduler` | Replication scheduler jobs and their current state | `GET /_scheduler/jobs` |
+| `scheduler` | Currently active replication scheduler jobs | `GET /_scheduler/jobs` |
+| `scheduler_docs` | Replication documents and their full lifecycle state | `GET /_scheduler/docs` |
 
 No table requires or accepts SQL filters; filter with a `WHERE` clause after
-fetching. `scheduler` uses `skip`/`limit` page-based pagination; the other
-tables return all results in a single request.
+fetching. `databases`, `scheduler`, and `scheduler_docs` page through results
+with `skip`/`limit`, which Coral drives automatically; `server` and
+`active_tasks` return all results in a single request.
+
+### `scheduler` vs `scheduler_docs`
+
+`scheduler` (`/_scheduler/jobs`) lists only the replication jobs the scheduler
+currently holds in memory — running or recently active. It does **not** include
+finished, failed, or not-yet-scheduled replications, so it is not a complete
+picture of replication health.
+
+`scheduler_docs` (`/_scheduler/docs`) is the authoritative view: one row per
+replication document with a `state` covering the whole lifecycle
+(`initializing`, `running`, `pending`, `crashing`, `error`, `failed`,
+`completed`) plus `error_count`. Use this table to find unhealthy
+replications.
 
 ## Notes
 
@@ -77,10 +92,12 @@ tables return all results in a single request.
   `source`, `target`, `docs_read`, and `docs_written` are populated only for
   replication tasks; `design_document` only for indexer tasks.
 - `scheduler.history` is ordered most-recent-first, so `latest_event` and
-  `latest_event_at` reflect each job's current state (`started`, `crashed`,
-  `added`, etc.). Live progress is in the `info` JSON column.
-- `started_on`/`updated_on` (active tasks) and `start_time`/`latest_event_at`
-  (scheduler) are real `Timestamp` columns.
+  `latest_event_at` reflect each job's latest scheduler event (`started`,
+  `crashed`, `added`, etc.). For authoritative replication state use
+  `scheduler_docs.state` instead. Live progress is in the `info` JSON column.
+- `started_on`/`updated_on` (active tasks), `start_time`/`latest_event_at`
+  (scheduler), and `last_updated`/`start_time` (scheduler_docs) are real
+  `Timestamp` columns.
 
 ## Example Queries
 
@@ -117,21 +134,30 @@ FROM couchdb.active_tasks
 ORDER BY progress ASC
 ```
 
-### Replication jobs that are not healthy
+### Replications that are not healthy
 
 ```sql
-SELECT doc_id, source, target, node, latest_event, latest_event_at
-FROM couchdb.scheduler
-WHERE latest_event <> 'started'
-ORDER BY latest_event_at DESC
+SELECT doc_id, database, state, error_count, source, target, last_updated
+FROM couchdb.scheduler_docs
+WHERE state NOT IN ('running', 'completed')
+ORDER BY error_count DESC, last_updated DESC
 ```
 
 ### Replication progress
 
 ```sql
-SELECT doc_id,
+SELECT doc_id, state,
        json_get_int(info, 'docs_read') AS docs_read,
        json_get_int(info, 'docs_written') AS docs_written,
        json_get_int(info, 'changes_pending') AS changes_pending
+FROM couchdb.scheduler_docs
+WHERE state = 'running'
+```
+
+### Currently active scheduler jobs
+
+```sql
+SELECT doc_id, source, target, node, latest_event, latest_event_at
 FROM couchdb.scheduler
+ORDER BY latest_event_at DESC
 ```

--- a/sources/community/couchdb/README.md
+++ b/sources/community/couchdb/README.md
@@ -19,11 +19,15 @@ documents.
 
 - Network access to a CouchDB HTTP endpoint (default port `5984`).
 - A CouchDB user. The `server` table only needs valid credentials, but the
-  `databases`, `active_tasks`, and `scheduler` tables read server-level
-  metadata endpoints that require **server-admin** access (or a user granted
-  the relevant role).
+  `databases`, `active_tasks`, `scheduler`, and `scheduler_docs` tables read
+  server-level metadata endpoints that require **server-admin** access (or a
+  user granted the relevant role).
 - The `databases` table uses the bodyless `GET /_dbs_info`, which requires
   **CouchDB 3.2 or newer**.
+- `scheduler_docs` reads `GET /_scheduler/docs`. On a cluster that has never
+  run a replication, CouchDB returns HTTP 404 because the `_replicator`
+  database does not exist yet; the table reports this as empty (zero rows)
+  rather than an error.
 
 ### Add the source
 
@@ -90,7 +94,9 @@ replications.
   compaction.
 - `active_tasks` returns an empty result on an idle node. Columns like
   `source`, `target`, `docs_read`, and `docs_written` are populated only for
-  replication tasks; `design_document` only for indexer tasks.
+  replication tasks; `design_document` only for indexer tasks. Use
+  `process_status` (e.g. `running`, `waiting`) for the live status on CouchDB
+  2.x/3.x; the documented `task` and `status` fields are null there.
 - `scheduler.history` is ordered most-recent-first, so `latest_event` and
   `latest_event_at` reflect each job's latest scheduler event (`started`,
   `crashed`, `added`, etc.). For authoritative replication state use

--- a/sources/community/couchdb/manifest.yaml
+++ b/sources/community/couchdb/manifest.yaml
@@ -87,12 +87,13 @@ tables:
     description: Per-database document counts and storage sizes.
     guide: |
       Returns one row per database from `GET /_dbs_info`, which reports the same
-      metadata as `GET /{db}` for every database in one request. Requires
-      CouchDB 3.2 or newer (the bodyless `GET /_dbs_info`) and server-admin
-      access. `disk_size` is the on-disk file size; `active_size` is the live
-      data size; the difference indicates reclaimable space from compaction.
-      `update_seq` and `purge_seq` are opaque sequence strings on clustered
-      CouchDB and are exposed as text.
+      metadata as `GET /{db}` for every database. Requires CouchDB 3.2 or newer
+      (the bodyless `GET /_dbs_info`) and server-admin access. The endpoint is
+      paginated with `skip`/`limit`, which Coral drives automatically so large
+      instances are not fetched in one expensive request. `disk_size` is the
+      on-disk file size; `active_size` is the live data size; the difference
+      indicates reclaimable space from compaction. `update_seq` and `purge_seq`
+      are opaque sequence strings on clustered CouchDB and are exposed as text.
     request:
       method: GET
       path: /_dbs_info
@@ -100,7 +101,13 @@ tables:
       rows_path: []
       row_strategy: direct
     pagination:
-      mode: none
+      mode: offset
+      offset_param: skip
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
     columns:
       - name: name
         type: Utf8
@@ -279,24 +286,21 @@ tables:
           expr: {kind: path, path: [updated_on]}
 
   - name: scheduler
-    description: Replication scheduler jobs and their current state.
+    description: Currently active replication scheduler jobs.
     guide: |
-      Returns one row per replication job from `GET /_scheduler/jobs`. Requires
-      server-admin access. Each job's `history` is ordered most-recent-first,
-      so `latest_event` and `latest_event_at` reflect the job's current state
-      (e.g. `started`, `crashed`, `added`). `info` carries live replication
-      progress (docs read/written, pending changes). Use page-based pagination
-      via `skip`/`limit`.
+      Returns one row per replication job the scheduler currently holds in
+      memory (running or recently active) from `GET /_scheduler/jobs`. Requires
+      server-admin access. This is NOT a complete view of replication health:
+      finished, failed, or not-yet-started replications are not listed here —
+      query the `scheduler_docs` table for full replication-document state.
+      Each job's `history` is ordered most-recent-first, so `latest_event` and
+      `latest_event_at` reflect the job's latest scheduler event (e.g.
+      `started`, `crashed`, `added`). `info` carries live replication progress
+      (docs read/written, pending changes). The endpoint is paginated with
+      `skip`/`limit`, which Coral drives automatically.
     request:
       method: GET
       path: /_scheduler/jobs
-      query:
-        - name: skip
-          from: literal
-          value: 0
-        - name: limit
-          from: literal
-          value: 100
     response:
       rows_path:
         - jobs
@@ -381,3 +385,98 @@ tables:
         nullable: true
         description: Job event history, most recent first
         expr: {kind: path, path: [history]}
+
+  - name: scheduler_docs
+    description: Replication documents and their current scheduler state.
+    guide: |
+      Returns one row per replication document across all replicator databases
+      from `GET /_scheduler/docs`. Requires server-admin access. Unlike the
+      `scheduler` table (which only lists jobs the scheduler currently holds in
+      memory), this is the authoritative view of replication health: `state`
+      covers the full lifecycle — `initializing`, `running`, `pending`,
+      `crashing`, `error`, `failed`, and `completed`. Use `error_count` and
+      `error_msg` to triage failing replications. `info` carries live progress
+      for running replications or the error reason for failed ones. The
+      endpoint is paginated with `skip`/`limit`, which Coral drives
+      automatically.
+    request:
+      method: GET
+      path: /_scheduler/docs
+    response:
+      rows_path:
+        - docs
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: skip
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 500
+        query_param: limit
+    columns:
+      - name: doc_id
+        type: Utf8
+        nullable: true
+        description: ID of the replication document
+        expr: {kind: path, path: [doc_id]}
+      - name: database
+        type: Utf8
+        nullable: true
+        description: Replicator database holding the replication document
+        expr: {kind: path, path: [database]}
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Internal replication job ID (null until the job is scheduled)
+        expr: {kind: path, path: [id]}
+      - name: state
+        type: Utf8
+        nullable: true
+        description: >-
+          Replication state: initializing, running, pending, crashing, error,
+          failed, or completed
+        expr: {kind: path, path: [state]}
+      - name: error_count
+        type: Int64
+        nullable: true
+        description: Consecutive error count for this replication
+        expr: {kind: path, path: [error_count]}
+      - name: source
+        type: Utf8
+        nullable: true
+        description: Replication source endpoint
+        expr: {kind: path, path: [source]}
+      - name: target
+        type: Utf8
+        nullable: true
+        description: Replication target endpoint
+        expr: {kind: path, path: [target]}
+      - name: node
+        type: Utf8
+        nullable: true
+        description: Cluster node running the replication, if scheduled
+        expr: {kind: path, path: [node]}
+      - name: last_updated
+        type: Timestamp
+        nullable: true
+        description: When the replication state was last updated
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [last_updated]}
+      - name: start_time
+        type: Timestamp
+        nullable: true
+        description: When the replication started
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [start_time]}
+      - name: info
+        type: Json
+        nullable: true
+        description: >-
+          Live replication progress for running jobs, or the error reason for
+          failed ones
+        expr: {kind: path, path: [info]}

--- a/sources/community/couchdb/manifest.yaml
+++ b/sources/community/couchdb/manifest.yaml
@@ -1,0 +1,383 @@
+name: couchdb
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Inspect a CouchDB instance's server info, per-database document counts and
+  sizes, running background tasks, and replication scheduler jobs through the
+  HTTP-native REST API.
+inputs:
+  COUCHDB_URL:
+    kind: variable
+    default: http://localhost:5984
+    hint: |
+      Base URL of your CouchDB HTTP endpoint, including scheme and port, e.g.
+      `http://localhost:5984` or `https://couchdb.example.com`. Do not include
+      a trailing slash.
+  COUCHDB_USERNAME:
+    kind: variable
+    hint: |
+      CouchDB username. Server-level metadata endpoints (`/_dbs_info`,
+      `/_active_tasks`, `/_scheduler/jobs`) require a server admin or a user
+      with the relevant role. See
+      https://docs.couchdb.org/en/stable/api/server/authn.html
+  COUCHDB_PASSWORD:
+    kind: secret
+    hint: Password for the CouchDB user.
+base_url: "{{input.COUCHDB_URL}}"
+auth:
+  type: BasicAuth
+  username: "{{input.COUCHDB_USERNAME}}"
+  password: "{{input.COUCHDB_PASSWORD}}"
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT * FROM couchdb.server LIMIT 1
+
+tables:
+  - name: server
+    description: Server welcome banner, version, and vendor information from the root endpoint.
+    guide: >
+      Returns a single row from `GET /`. Good first query to confirm
+      connectivity and check the CouchDB version. `features` lists enabled
+      server capabilities (e.g. scheduler, partitioned) as a JSON array.
+    request:
+      method: GET
+      path: /
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: couchdb
+        type: Utf8
+        nullable: true
+        description: Welcome message (always "Welcome" on a healthy node)
+        expr: {kind: path, path: [couchdb]}
+      - name: version
+        type: Utf8
+        nullable: true
+        description: CouchDB server version
+        expr: {kind: path, path: [version]}
+      - name: git_sha
+        type: Utf8
+        nullable: true
+        description: Git commit the server was built from
+        expr: {kind: path, path: [git_sha]}
+      - name: uuid
+        type: Utf8
+        nullable: true
+        description: Server instance UUID
+        expr: {kind: path, path: [uuid]}
+      - name: vendor_name
+        type: Utf8
+        nullable: true
+        description: Distribution vendor name
+        expr: {kind: path, path: [vendor, name]}
+      - name: features
+        type: Json
+        nullable: true
+        description: Enabled server features as a JSON array of strings
+        expr: {kind: path, path: [features]}
+
+  - name: databases
+    description: Per-database document counts and storage sizes.
+    guide: |
+      Returns one row per database from `GET /_dbs_info`, which reports the same
+      metadata as `GET /{db}` for every database in one request. Requires
+      CouchDB 3.2 or newer (the bodyless `GET /_dbs_info`) and server-admin
+      access. `disk_size` is the on-disk file size; `active_size` is the live
+      data size; the difference indicates reclaimable space from compaction.
+      `update_seq` and `purge_seq` are opaque sequence strings on clustered
+      CouchDB and are exposed as text.
+    request:
+      method: GET
+      path: /_dbs_info
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Database name
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [key]}
+            - {kind: path, path: [info, db_name]}
+      - name: doc_count
+        type: Int64
+        nullable: true
+        description: Number of live (non-deleted) documents
+        expr: {kind: path, path: [info, doc_count]}
+      - name: doc_del_count
+        type: Int64
+        nullable: true
+        description: Number of deleted documents (tombstones)
+        expr: {kind: path, path: [info, doc_del_count]}
+      - name: disk_size
+        type: Int64
+        nullable: true
+        description: On-disk size of the database file, in bytes
+        expr: {kind: path, path: [info, sizes, file]}
+      - name: external_size
+        type: Int64
+        nullable: true
+        description: Uncompressed size of the JSON data, in bytes
+        expr: {kind: path, path: [info, sizes, external]}
+      - name: active_size
+        type: Int64
+        nullable: true
+        description: Size of live data and indexes, in bytes
+        expr: {kind: path, path: [info, sizes, active]}
+      - name: update_seq
+        type: Utf8
+        nullable: true
+        description: Current update sequence for the database
+        expr: {kind: path, path: [info, update_seq]}
+      - name: purge_seq
+        type: Utf8
+        nullable: true
+        description: Current purge sequence for the database
+        expr: {kind: path, path: [info, purge_seq]}
+      - name: compact_running
+        type: Boolean
+        nullable: true
+        description: Whether a compaction is currently running on the database
+        expr: {kind: path, path: [info, compact_running]}
+      - name: disk_format_version
+        type: Int64
+        nullable: true
+        description: On-disk format version of the database file
+        expr: {kind: path, path: [info, disk_format_version]}
+      - name: cluster_q
+        type: Int64
+        nullable: true
+        description: Number of shards (q) for the database
+        expr: {kind: path, path: [info, cluster, q]}
+      - name: cluster_n
+        type: Int64
+        nullable: true
+        description: Number of replicas (n) of each shard
+        expr: {kind: path, path: [info, cluster, n]}
+      - name: cluster_w
+        type: Int64
+        nullable: true
+        description: Write quorum (w) for the database
+        expr: {kind: path, path: [info, cluster, w]}
+      - name: cluster_r
+        type: Int64
+        nullable: true
+        description: Read quorum (r) for the database
+        expr: {kind: path, path: [info, cluster, r]}
+      - name: instance_start_time
+        type: Utf8
+        nullable: true
+        description: Database instance start time (always "0" on CouchDB 2.x+)
+        expr: {kind: path, path: [info, instance_start_time]}
+
+  - name: active_tasks
+    description: Running background tasks such as indexing, replication, and compaction.
+    guide: |
+      Returns one row per running task from `GET /_active_tasks`. Requires
+      server-admin access. Returns an empty result when the node is idle.
+      `type` identifies the task kind (e.g. `indexer`, `replication`,
+      `database_compaction`, `view_compaction`). `progress` is a 0-100 percent
+      value. Many columns are populated only for specific task types: `source`,
+      `target`, `docs_read`, and `docs_written` for replication;
+      `design_document` for indexing.
+    request:
+      method: GET
+      path: /_active_tasks
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: type
+        type: Utf8
+        nullable: true
+        description: "Task type: indexer, replication, database_compaction, etc."
+        expr: {kind: path, path: [type]}
+      - name: database
+        type: Utf8
+        nullable: true
+        description: Database the task is operating on
+        expr: {kind: path, path: [database]}
+      - name: node
+        type: Utf8
+        nullable: true
+        description: Cluster node running the task
+        expr: {kind: path, path: [node]}
+      - name: pid
+        type: Utf8
+        nullable: true
+        description: Erlang process ID handling the task
+        expr: {kind: path, path: [pid]}
+      - name: progress
+        type: Int64
+        nullable: true
+        description: Task completion percentage (0-100)
+        expr: {kind: path, path: [progress]}
+      - name: changes_done
+        type: Int64
+        nullable: true
+        description: Number of changes processed so far
+        expr: {kind: path, path: [changes_done]}
+      - name: total_changes
+        type: Int64
+        nullable: true
+        description: Total number of changes to process
+        expr: {kind: path, path: [total_changes]}
+      - name: design_document
+        type: Utf8
+        nullable: true
+        description: Design document being indexed (indexer tasks)
+        expr: {kind: path, path: [design_document]}
+      - name: source
+        type: Utf8
+        nullable: true
+        description: Replication source (replication tasks)
+        expr: {kind: path, path: [source]}
+      - name: target
+        type: Utf8
+        nullable: true
+        description: Replication target (replication tasks)
+        expr: {kind: path, path: [target]}
+      - name: docs_read
+        type: Int64
+        nullable: true
+        description: Documents read so far (replication tasks)
+        expr: {kind: path, path: [docs_read]}
+      - name: docs_written
+        type: Int64
+        nullable: true
+        description: Documents written so far (replication tasks)
+        expr: {kind: path, path: [docs_written]}
+      - name: started_on
+        type: Timestamp
+        nullable: true
+        description: When the task started
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [started_on]}
+      - name: updated_on
+        type: Timestamp
+        nullable: true
+        description: When the task status was last updated
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [updated_on]}
+
+  - name: scheduler
+    description: Replication scheduler jobs and their current state.
+    guide: |
+      Returns one row per replication job from `GET /_scheduler/jobs`. Requires
+      server-admin access. Each job's `history` is ordered most-recent-first,
+      so `latest_event` and `latest_event_at` reflect the job's current state
+      (e.g. `started`, `crashed`, `added`). `info` carries live replication
+      progress (docs read/written, pending changes). Use page-based pagination
+      via `skip`/`limit`.
+    request:
+      method: GET
+      path: /_scheduler/jobs
+      query:
+        - name: skip
+          from: literal
+          value: 0
+        - name: limit
+          from: literal
+          value: 100
+    response:
+      rows_path:
+        - jobs
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: skip
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 500
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Internal replication job ID
+        expr: {kind: path, path: [id]}
+      - name: database
+        type: Utf8
+        nullable: true
+        description: Replicator database holding the replication document
+        expr: {kind: path, path: [database]}
+      - name: doc_id
+        type: Utf8
+        nullable: true
+        description: ID of the replication document
+        expr: {kind: path, path: [doc_id]}
+      - name: source
+        type: Utf8
+        nullable: true
+        description: Replication source endpoint
+        expr: {kind: path, path: [source]}
+      - name: target
+        type: Utf8
+        nullable: true
+        description: Replication target endpoint
+        expr: {kind: path, path: [target]}
+      - name: node
+        type: Utf8
+        nullable: true
+        description: Cluster node running the job
+        expr: {kind: path, path: [node]}
+      - name: pid
+        type: Utf8
+        nullable: true
+        description: Erlang process ID running the job
+        expr: {kind: path, path: [pid]}
+      - name: user
+        type: Utf8
+        nullable: true
+        description: User that owns the replication, if any
+        expr: {kind: path, path: [user]}
+      - name: latest_event
+        type: Utf8
+        nullable: true
+        description: Most recent history event type, reflecting current state
+        expr: {kind: path, path: [history, "0", type]}
+      - name: latest_event_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp of the most recent history event
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [history, "0", timestamp]}
+      - name: start_time
+        type: Timestamp
+        nullable: true
+        description: When the job started
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [start_time]}
+      - name: info
+        type: Json
+        nullable: true
+        description: Live replication progress (docs read/written, pending changes)
+        expr: {kind: path, path: [info]}
+      - name: history
+        type: Json
+        nullable: true
+        description: Job event history, most recent first
+        expr: {kind: path, path: [history]}

--- a/sources/community/couchdb/manifest.yaml
+++ b/sources/community/couchdb/manifest.yaml
@@ -394,11 +394,11 @@ tables:
       `scheduler` table (which only lists jobs the scheduler currently holds in
       memory), this is the authoritative view of replication health: `state`
       covers the full lifecycle — `initializing`, `running`, `pending`,
-      `crashing`, `error`, `failed`, and `completed`. Use `error_count` and
-      `error_msg` to triage failing replications. `info` carries live progress
-      for running replications or the error reason for failed ones. The
-      endpoint is paginated with `skip`/`limit`, which Coral drives
-      automatically.
+      `crashing`, `error`, `failed`, and `completed`. Use `error_count` and the
+      `info` column to triage failing replications: `info` carries live progress
+      for running replications (e.g. `docs_read`, `docs_written`) or the error
+      reason for failed ones (e.g. `json_get_str(info, 'error')`). The endpoint
+      is paginated with `skip`/`limit`, which Coral drives automatically.
     request:
       method: GET
       path: /_scheduler/docs

--- a/sources/community/couchdb/manifest.yaml
+++ b/sources/community/couchdb/manifest.yaml
@@ -18,8 +18,8 @@ inputs:
     kind: variable
     hint: |
       CouchDB username. Server-level metadata endpoints (`/_dbs_info`,
-      `/_active_tasks`, `/_scheduler/jobs`) require a server admin or a user
-      with the relevant role. See
+      `/_active_tasks`, `/_scheduler/jobs`, `/_scheduler/docs`) require a
+      server admin or a user with the relevant role. See
       https://docs.couchdb.org/en/stable/api/server/authn.html
   COUCHDB_PASSWORD:
     kind: secret
@@ -35,6 +35,10 @@ request_headers:
     value: application/json
 test_queries:
   - SELECT * FROM couchdb.server LIMIT 1
+  - SELECT * FROM couchdb.databases LIMIT 1
+  - SELECT * FROM couchdb.active_tasks LIMIT 1
+  - SELECT * FROM couchdb.scheduler LIMIT 1
+  - SELECT * FROM couchdb.scheduler_docs LIMIT 1
 
 tables:
   - name: server
@@ -196,9 +200,11 @@ tables:
       server-admin access. Returns an empty result when the node is idle.
       `type` identifies the task kind (e.g. `indexer`, `replication`,
       `database_compaction`, `view_compaction`). `progress` is a 0-100 percent
-      value. Many columns are populated only for specific task types: `source`,
-      `target`, `docs_read`, and `docs_written` for replication;
-      `design_document` for indexing.
+      value, and `process_status` (e.g. `running`, `waiting`) is the live
+      status signal on CouchDB 2.x/3.x — the documented `task` and `status`
+      fields are null there. Many columns are populated only for specific task
+      types: `source`, `target`, `docs_read`, and `docs_written` for
+      replication; `design_document` for indexing.
     request:
       method: GET
       path: /_active_tasks
@@ -213,6 +219,30 @@ tables:
         nullable: true
         description: "Task type: indexer, replication, database_compaction, etc."
         expr: {kind: path, path: [type]}
+      - name: task
+        type: Utf8
+        nullable: true
+        description: >-
+          Human-readable task label from CouchDB's documented active-task
+          schema. Populated on older CouchDB releases; null on CouchDB 3.x,
+          which reports liveness through process_status plus the type-specific
+          fields below.
+        expr: {kind: path, path: [task]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Human-readable status line from CouchDB's documented active-task
+          schema. Like task, this is null on CouchDB 3.x — use process_status
+          there.
+        expr: {kind: path, path: [status]}
+      - name: process_status
+        type: Utf8
+        nullable: true
+        description: >-
+          Live Erlang process status of the task on CouchDB 2.x/3.x (e.g.
+          running, waiting) — the current "what is it doing" signal.
+        expr: {kind: path, path: [process_status]}
       - name: database
         type: Utf8
         nullable: true
@@ -398,7 +428,10 @@ tables:
       `info` column to triage failing replications: `info` carries live progress
       for running replications (e.g. `docs_read`, `docs_written`) or the error
       reason for failed ones (e.g. `json_get_str(info, 'error')`). The endpoint
-      is paginated with `skip`/`limit`, which Coral drives automatically.
+      is paginated with `skip`/`limit`, which Coral drives automatically. On a
+      cluster that has never run a replication the `_replicator` database may
+      not exist yet, so CouchDB returns HTTP 404 for this endpoint; Coral treats
+      that as an empty result rather than an error.
     request:
       method: GET
       path: /_scheduler/docs
@@ -406,6 +439,7 @@ tables:
       rows_path:
         - docs
       row_strategy: direct
+      allow_404_empty: true
     pagination:
       mode: offset
       offset_param: skip


### PR DESCRIPTION
Add a read-only HTTP community source for CouchDB that maps its HTTP-native REST endpoints to queryable tables. Exposes four observability tables:

- server: welcome banner, version, and vendor info (GET /)
- databases: per-database document counts and storage sizes (GET /_dbs_info)
- active_tasks: running indexing, replication, and compaction tasks
- scheduler: replication scheduler jobs and their current state

Authentication uses HTTP Basic auth. Observability only: no document read/write and no design-document modification.

Closes #601

--- 

# Fresh instance (no _replicator yet) — scheduler_docs 404 handled as empty:
$ coral source add --file sources/community/couchdb/manifest.yaml
    couchdb (5 tables): active_tasks, databases, scheduler, scheduler_docs, server
    5 declared · 5 passed · 0 failed
    ✓ SELECT * FROM couchdb.server LIMIT 1         — 1 row
    ✓ SELECT * FROM couchdb.databases LIMIT 1      — 0 rows
    ✓ SELECT * FROM couchdb.active_tasks LIMIT 1   — 0 rows
    ✓ SELECT * FROM couchdb.scheduler LIMIT 1      — 0 rows
    ✓ SELECT * FROM couchdb.scheduler_docs LIMIT 1 — 0 rows   ← was a 404 error before

# After creating _replicator + replications + data:
$ coral sql "SELECT name, doc_count, disk_size, active_size FROM couchdb.databases WHERE name NOT LIKE '\_%' ORDER BY name"
+-----------------+-----------+-----------+-------------+
| name            | doc_count | disk_size | active_size |
+-----------------+-----------+-----------+-------------+
| orders          | 3         | 29012     | 606         |
| products        | 12006     | 2011567   | 1952365     |
| products-backup | 12006     | 2097577   | 1954552     |
+-----------------+-----------+-----------+-------------+

$ coral sql "SELECT type, database, process_status, progress FROM couchdb.active_tasks"
+-------------+-------------------------------------------------+----------------+----------+
| type        | database                                        | process_status | progress |
+-------------+-------------------------------------------------+----------------+----------+
| replication | shards/80000000-ffffffff/_replicator.1780210962 | waiting        |          |
+-------------+-------------------------------------------------+----------------+----------+

$ coral sql "SELECT doc_id, state, error_count, source, target FROM couchdb.scheduler_docs ORDER BY doc_id"
+---------------+----------+-------------+---------------------------------------+----------------------------------------+
| doc_id        | state    | error_count | source                                | target                                 |
+---------------+----------+-------------+---------------------------------------+----------------------------------------+
| repl-broken   | crashing | 9           | http://localhost:5984/does-not-exist/ | http://localhost:5984/nope/            |
| repl-products | running  | 0           | http://localhost:5984/products/       | http://localhost:5984/products-backup/ |
+---------------+----------+-------------+---------------------------------------+----------------------------------------+

$ coral sql "SELECT doc_id, database, latest_event FROM couchdb.scheduler ORDER BY doc_id"
+---------------+-------------+--------------+
| doc_id        | database    | latest_event |
+---------------+-------------+--------------+
| repl-broken   | _replicator | crashed      |
| repl-products | _replicator | started      |
+---------------+-------------+--------------+
