### PR TITLE
feat(sources/community/cockroachdb): add CockroachDB community source

### DIFF
--- a/sources/community/cockroachdb/README.md
+++ b/sources/community/cockroachdb/README.md
@@ -33,9 +33,9 @@ targets the **Cluster API v2**, because:
 ### Requirements
 
 - Network access to a CockroachDB node's HTTP interface (default port `8080`).
-- A Cluster API session token (secure clusters). The login user needs a role
-  with the `VIEWCLUSTERMETADATA` and `VIEWACTIVITY` system privileges, or
-  membership in `admin`.
+- A Cluster API session token (secure clusters). The Cluster API v2 only
+  authenticates SQL users that are members of the `admin` role and have a
+  password and the `LOGIN` privilege.
 
 ### Get a session token (secure clusters)
 
@@ -88,26 +88,29 @@ method this source uses.
 
 | Table | Description | Endpoint |
 |---|---|---|
-| `health` | Per-node liveness/readiness from the node-liveness map | `/api/v2/nodes/` |
+| `health` | Per-node liveness/readiness (`liveness_status`) | `/api/v2/nodes/` |
 | `nodes` | Per-node status, addresses, and build information | `/api/v2/nodes/` |
 | `databases` | Databases known to the cluster | `/api/v2/databases/` |
-| `metrics` | Selected per-node metrics plus the full metrics map | `/api/v2/nodes/` |
+| `metrics` | Selected per-node metrics plus the full metrics maps | `/api/v2/nodes/` |
 
 No table requires or accepts SQL filters; filter with a `WHERE` clause after
-fetching. Result sets are cluster-scale (one row per node or database) and are
-returned in a single request.
+fetching. `/api/v2/nodes/` returns all nodes in a single response, so `health`,
+`nodes`, and `metrics` are not paginated; `databases` pages through results with
+`limit`/`offset`, which Coral drives automatically.
 
 ## Notes
 
-- `health.liveness` is CockroachDB's `NodeLivenessStatus`, vended either as an
-  enum name (e.g. `LIVE`) or its numeric code: `0` UNKNOWN, `1` DEAD,
-  `2` UNAVAILABLE, `3` LIVE, `4` DECOMMISSIONING, `5` DECOMMISSIONED.
+- `health.liveness_status` is CockroachDB's `NodeLivenessStatus` numeric code:
+  `0` UNKNOWN, `1` DEAD, `2` UNAVAILABLE, `3` LIVE, `4` DECOMMISSIONING,
+  `5` DECOMMISSIONED. The same column is also on the `nodes` table.
 - `nodes.started_at` and `nodes.updated_at` are epoch **nanoseconds**
   (Int64). Divide by 1,000,000,000 for Unix seconds.
-- `metrics` named columns cover common health signals. Metric keys vary across
-  major versions, so a named column may be NULL while the value is still
-  present in the `metrics` JSON column — read any gauge with
-  `json_get_float(metrics, 'sql.conns')`.
+- `metrics` named columns cover common node-level health signals. Metric keys
+  vary across major versions, so a named column may be NULL while the value is
+  still present in the `metrics` JSON column — read any gauge with
+  `json_get_float(metrics, 'sql.conns')`. Per-store gauges (ranges, replicas,
+  capacity, livebytes) are in the `store_metrics` JSON column keyed by store ID,
+  e.g. `json_get_float(store_metrics, '1', 'ranges')`.
 - `databases` lists names only. The Cluster API does not return per-database
   sizes; use a SQL client and `SHOW DATABASES` for storage details.
 
@@ -116,7 +119,7 @@ returned in a single request.
 ### Cluster membership and liveness
 
 ```sql
-SELECT node_id, liveness
+SELECT node_id, liveness_status
 FROM cockroachdb.health
 ORDER BY node_id
 ```
@@ -151,6 +154,17 @@ ORDER BY sql_conns DESC
 SELECT node_id,
        json_get_float(metrics, 'sys.uptime') AS uptime_seconds,
        json_get_float(metrics, 'sql.txn.commit.count') AS txn_commits
+FROM cockroachdb.metrics
+ORDER BY node_id
+```
+
+### Per-store ranges, replicas, and capacity (store ID 1)
+
+```sql
+SELECT node_id,
+       json_get_float(store_metrics, '1', 'ranges') AS ranges,
+       json_get_float(store_metrics, '1', 'replicas') AS replicas,
+       json_get_float(store_metrics, '1', 'capacity.available') AS capacity_available
 FROM cockroachdb.metrics
 ORDER BY node_id
 ```

--- a/sources/community/cockroachdb/README.md
+++ b/sources/community/cockroachdb/README.md
@@ -108,9 +108,13 @@ fetching. `/api/v2/nodes/` returns all nodes in a single response, so `health`,
 - `metrics` named columns cover common node-level health signals. Metric keys
   vary across major versions, so a named column may be NULL while the value is
   still present in the `metrics` JSON column — read any gauge with
-  `json_get_float(metrics, 'sql.conns')`. Per-store gauges (ranges, replicas,
-  capacity, livebytes) are in the `store_metrics` JSON column keyed by store ID,
-  e.g. `json_get_float(store_metrics, '1', 'ranges')`.
+  `json_get_float(metrics, 'sql.conns')`.
+- `store_metrics` is a **best-effort** column. It carries per-store gauges
+  (ranges, replicas, capacity, livebytes) keyed by store ID, e.g.
+  `json_get_float(store_metrics, '1', 'ranges')`, but it is **not** part of the
+  documented [Cluster API v2 response schema](https://www.cockroachlabs.com/docs/api/cluster/v2.html)
+  (which guarantees the node `metrics` map). Treat it as nullable and
+  version-dependent; it may be absent on some CockroachDB versions.
 - `databases` lists names only. The Cluster API does not return per-database
   sizes; use a SQL client and `SHOW DATABASES` for storage details.
 

--- a/sources/community/cockroachdb/README.md
+++ b/sources/community/cockroachdb/README.md
@@ -1,0 +1,164 @@
+# CockroachDB
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+**Base URL:** your CockroachDB node's HTTP interface (set via `COCKROACHDB_URL`)
+
+Inspect a self-hosted CockroachDB cluster's node liveness, per-node status and
+build information, known databases, and selected node metrics through the
+read-only [Cluster API v2](https://www.cockroachlabs.com/docs/stable/cluster-api)
+(`/api/v2`).
+
+This source is **observability only**. It uses the documented HTTP Cluster API
+and never runs SQL — it does not connect over the Postgres wire protocol and
+does not expose `crdb_internal` tables.
+
+## Why the Cluster API v2
+
+The original design proposal (#600) suggested the `/_status` and `/_admin/v1`
+endpoints plus the `/_status/vars` Prometheus endpoint. This source instead
+targets the **Cluster API v2**, because:
+
+- `/api/v2/nodes/`, `/api/v2/databases/`, and `/api/v2/health/` are the
+  documented, **stable** HTTP endpoints; `/_status/*` and `/_admin/v1/*` are
+  internal and explicitly undocumented
+  ([cockroachdb/docs#8602](https://github.com/cockroachdb/docs/issues/8602)).
+- `/_status/vars` returns Prometheus text, which Coral's JSON mapper cannot
+  read. The `metrics` table instead reads the per-node `metrics` map that the
+  v2 nodes endpoint already returns as JSON.
+
+## Setup
+
+### Requirements
+
+- Network access to a CockroachDB node's HTTP interface (default port `8080`).
+- A Cluster API session token (secure clusters). The login user needs a role
+  with the `VIEWCLUSTERMETADATA` and `VIEWACTIVITY` system privileges, or
+  membership in `admin`.
+
+### Get a session token (secure clusters)
+
+```bash
+curl -k --data "username=<user>&password=<password>" \
+  https://localhost:8080/api/v2/login/
+# => {"session":"<token>"}
+```
+
+Copy the `session` value. Tokens are revoked on logout and expire per the
+cluster's `server.web_session_timeout` setting.
+
+### Add the source
+
+```bash
+export COCKROACHDB_URL=https://localhost:8080
+export COCKROACHDB_SESSION=<token>
+coral source add --file sources/community/cockroachdb/manifest.yaml
+```
+
+Run from the repo root. Or interactively:
+
+```bash
+coral source add --file sources/community/cockroachdb/manifest.yaml --interactive
+```
+
+Inputs:
+
+- `COCKROACHDB_URL` — base URL including scheme and port, e.g.
+  `https://localhost:8080`. No trailing slash and no `/api/v2` suffix; Coral
+  appends the API path.
+- `COCKROACHDB_SESSION` — session token sent in the `X-Cockroach-API-Session`
+  header.
+
+## Authentication
+
+The Cluster API v2 authenticates with a **session token** in the
+`X-Cockroach-API-Session` header (created via `/api/v2/login/`). That is the
+method this source uses.
+
+- **Secure clusters**: set `COCKROACHDB_SESSION` to a real token.
+- **Insecure clusters**: the Cluster API is served without authentication and
+  ignores the header, so set `COCKROACHDB_SESSION` to any non-empty placeholder
+  value (Coral requires a non-empty secret).
+- **TLS**: secure clusters serve the HTTP API over TLS. The node's HTTP
+  certificate must be trusted by the host running Coral, or front the cluster
+  with a proxy that terminates TLS with a trusted certificate.
+
+## Tables
+
+| Table | Description | Endpoint |
+|---|---|---|
+| `health` | Per-node liveness/readiness from the node-liveness map | `/api/v2/nodes/` |
+| `nodes` | Per-node status, addresses, and build information | `/api/v2/nodes/` |
+| `databases` | Databases known to the cluster | `/api/v2/databases/` |
+| `metrics` | Selected per-node metrics plus the full metrics map | `/api/v2/nodes/` |
+
+No table requires or accepts SQL filters; filter with a `WHERE` clause after
+fetching. Result sets are cluster-scale (one row per node or database) and are
+returned in a single request.
+
+## Notes
+
+- `health.liveness` is CockroachDB's `NodeLivenessStatus`, vended either as an
+  enum name (e.g. `LIVE`) or its numeric code: `0` UNKNOWN, `1` DEAD,
+  `2` UNAVAILABLE, `3` LIVE, `4` DECOMMISSIONING, `5` DECOMMISSIONED.
+- `nodes.started_at` and `nodes.updated_at` are epoch **nanoseconds**
+  (Int64). Divide by 1,000,000,000 for Unix seconds.
+- `metrics` named columns cover common health signals. Metric keys vary across
+  major versions, so a named column may be NULL while the value is still
+  present in the `metrics` JSON column — read any gauge with
+  `json_get_float(metrics, 'sql.conns')`.
+- `databases` lists names only. The Cluster API does not return per-database
+  sizes; use a SQL client and `SHOW DATABASES` for storage details.
+
+## Example Queries
+
+### Cluster membership and liveness
+
+```sql
+SELECT node_id, liveness
+FROM cockroachdb.health
+ORDER BY node_id
+```
+
+### Node inventory with versions
+
+```sql
+SELECT node_id, address, sql_address, build_tag, num_cpus, total_system_memory
+FROM cockroachdb.nodes
+ORDER BY node_id
+```
+
+### Nodes not running the expected version
+
+```sql
+SELECT node_id, build_tag
+FROM cockroachdb.nodes
+WHERE build_tag <> 'v24.1.0'
+```
+
+### Open SQL connections per node
+
+```sql
+SELECT node_id, sql_conns, sql_query_count, sys_goroutines
+FROM cockroachdb.metrics
+ORDER BY sql_conns DESC
+```
+
+### Read an arbitrary gauge from the raw metrics map
+
+```sql
+SELECT node_id,
+       json_get_float(metrics, 'sys.uptime') AS uptime_seconds,
+       json_get_float(metrics, 'sql.txn.commit.count') AS txn_commits
+FROM cockroachdb.metrics
+ORDER BY node_id
+```
+
+### List databases
+
+```sql
+SELECT name
+FROM cockroachdb.databases
+ORDER BY name
+```

--- a/sources/community/cockroachdb/manifest.yaml
+++ b/sources/community/cockroachdb/manifest.yaml
@@ -20,17 +20,16 @@ inputs:
     kind: secret
     hint: |
       Cluster API session token, sent in the `X-Cockroach-API-Session` header.
-      On a secure cluster, obtain one by logging in:
+      The Cluster API v2 only authenticates SQL users that are members of the
+      `admin` role and have a password and the LOGIN privilege. On a secure
+      cluster, create a session token with:
 
         curl -k --data "username=<user>&password=<password>" \
           https://localhost:8080/api/v2/login/
 
-      and copy the `session` value from the JSON response. The login user
-      needs a SQL role with the `VIEWCLUSTERMETADATA` and `VIEWACTIVITY`
-      system privileges (or `admin` membership) to read the nodes and
-      databases endpoints. Insecure clusters serve the Cluster API without
-      authentication and ignore this header, so any non-empty placeholder
-      value works there.
+      and copy the `session` value from the JSON response. Insecure clusters
+      serve the Cluster API without authentication and ignore this header, so
+      any non-empty placeholder value works there.
 base_url: "{{input.COCKROACHDB_URL}}"
 auth:
   type: HeaderAuth
@@ -48,58 +47,51 @@ test_queries:
 
 tables:
   - name: health
-    description: Per-node liveness/readiness derived from the cluster's node-liveness map.
+    description: Per-node liveness/readiness status.
     guide: |
-      Returns one row per node from the `liveness_by_node_id` map on
-      `/api/v2/nodes/`. `liveness` is CockroachDB's NodeLivenessStatus, vended
-      either as an enum name (e.g. `LIVE`) or its numeric code:
-      `0` UNKNOWN, `1` DEAD, `2` UNAVAILABLE, `3` LIVE, `4` DECOMMISSIONING,
-      `5` DECOMMISSIONED. Anything other than `LIVE`/`3` on a node you expect
-      to be up signals a readiness or membership problem. This is the first
-      query to run to confirm connectivity and cluster membership.
+      Returns one row per node from `GET /api/v2/nodes/`, projecting each
+      node's `liveness_status`. The status is CockroachDB's NodeLivenessStatus
+      enum code: `0` UNKNOWN, `1` DEAD, `2` UNAVAILABLE, `3` LIVE,
+      `4` DECOMMISSIONING, `5` DECOMMISSIONED. Anything other than `3` (LIVE)
+      on a node you expect to be up signals a readiness or membership problem.
+      This is the first query to run to confirm connectivity and cluster
+      membership. The endpoint returns all nodes in a single response.
     request:
       method: GET
       path: /api/v2/nodes/
-      query:
-        - name: limit
-          from: literal
-          value: 1000
     response:
       rows_path:
-        - liveness_by_node_id
-      row_strategy: dict_entries
+        - nodes
+      row_strategy: direct
     pagination:
       mode: none
     columns:
       - name: node_id
         type: Int64
         nullable: false
-        description: Node ID this liveness entry refers to
-        expr: {kind: path, path: [_key]}
-      - name: liveness
-        type: Utf8
+        description: Node ID
+        expr: {kind: path, path: [node_id]}
+      - name: liveness_status
+        type: Int64
         nullable: true
         description: >-
-          NodeLivenessStatus name or numeric code (0 UNKNOWN, 1 DEAD,
-          2 UNAVAILABLE, 3 LIVE, 4 DECOMMISSIONING, 5 DECOMMISSIONED)
-        expr: {kind: path, path: [_value]}
+          NodeLivenessStatus code (0 UNKNOWN, 1 DEAD, 2 UNAVAILABLE, 3 LIVE,
+          4 DECOMMISSIONING, 5 DECOMMISSIONED)
+        expr: {kind: path, path: [liveness_status]}
 
   - name: nodes
     description: Per-node status, network addresses, and build information.
     guide: |
-      Returns one row per node from `/api/v2/nodes/`. Use `node_id` to join
+      Returns one row per node from `GET /api/v2/nodes/`. Use `node_id` to join
       against the `health` and `metrics` tables. `started_at` and `updated_at`
       are epoch **nanoseconds** (CockroachDB vends these as nanosecond counts),
       exposed as Int64; divide by 1e9 for seconds. `address` and `sql_address`
-      are host:port strings. `build_info`, `locality`, and `attrs` are returned
-      as JSON for querying with `json_get_*`.
+      are host:port strings. `server_version`, `locality`, and `attrs` are
+      returned as JSON for querying with `json_get_*`. The endpoint returns all
+      nodes in a single response.
     request:
       method: GET
       path: /api/v2/nodes/
-      query:
-        - name: limit
-          from: literal
-          value: 1000
     response:
       rows_path:
         - nodes
@@ -111,144 +103,94 @@ tables:
         type: Int64
         nullable: false
         description: Unique node ID within the cluster
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [desc, node_id]}
-            - {kind: path, path: [desc, nodeId]}
+        expr: {kind: path, path: [node_id]}
       - name: address
         type: Utf8
         nullable: true
         description: RPC address (host:port) advertised by the node
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [desc, address, address_field]}
-            - {kind: path, path: [desc, address, addressField]}
+        expr: {kind: path, path: [address, address_field]}
       - name: sql_address
         type: Utf8
         nullable: true
         description: SQL address (host:port) advertised by the node
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [desc, sql_address, address_field]}
-            - {kind: path, path: [desc, sql_address, addressField]}
+        expr: {kind: path, path: [sql_address, address_field]}
       - name: build_tag
         type: Utf8
         nullable: true
-        description: CockroachDB version tag the node is running (e.g. v24.1.0)
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [desc, build_tag]}
-            - {kind: path, path: [desc, buildTag]}
-            - {kind: path, path: [build_info, tag]}
-            - {kind: path, path: [buildInfo, tag]}
-      - name: go_version
-        type: Utf8
+        description: CockroachDB version tag the node is running (e.g. v24.1.5)
+        expr: {kind: path, path: [build_tag]}
+      - name: liveness_status
+        type: Int64
         nullable: true
-        description: Go runtime version the binary was built with
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [build_info, go_version]}
-            - {kind: path, path: [buildInfo, goVersion]}
-      - name: platform
-        type: Utf8
-        nullable: true
-        description: Build platform (e.g. linux amd64)
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [build_info, platform]}
-            - {kind: path, path: [buildInfo, platform]}
-      - name: distribution
-        type: Utf8
-        nullable: true
-        description: Build distribution (OSS or CCL)
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [build_info, distribution]}
-            - {kind: path, path: [buildInfo, distribution]}
+        description: >-
+          NodeLivenessStatus code (3 LIVE; see the health table for the full
+          mapping)
+        expr: {kind: path, path: [liveness_status]}
       - name: started_at
         type: Int64
         nullable: true
         description: Node process start time as epoch nanoseconds
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [started_at]}
-            - {kind: path, path: [startedAt]}
+        expr: {kind: path, path: [started_at]}
       - name: updated_at
         type: Int64
         nullable: true
         description: Time this node status was last updated, as epoch nanoseconds
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [updated_at]}
-            - {kind: path, path: [updatedAt]}
+        expr: {kind: path, path: [updated_at]}
       - name: num_cpus
         type: Int64
         nullable: true
         description: Number of logical CPUs visible to the node
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [num_cpus]}
-            - {kind: path, path: [numCpus]}
+        expr: {kind: path, path: [num_cpus]}
       - name: total_system_memory
         type: Int64
         nullable: true
         description: Total system memory available to the node, in bytes
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [total_system_memory]}
-            - {kind: path, path: [totalSystemMemory]}
+        expr: {kind: path, path: [total_system_memory]}
+      - name: cluster_name
+        type: Utf8
+        nullable: true
+        description: Configured cluster name, if any
+        expr: {kind: path, path: [cluster_name]}
+      - name: server_version
+        type: Json
+        nullable: true
+        description: Server version object (major, minor, patch, internal)
+        expr: {kind: path, path: [ServerVersion]}
       - name: locality
         type: Json
         nullable: true
         description: Locality tiers (region/zone) configured for the node
-        expr: {kind: path, path: [desc, locality]}
+        expr: {kind: path, path: [locality]}
       - name: attrs
         type: Json
         nullable: true
         description: Store/node attributes advertised by the node
-        expr: {kind: path, path: [desc, attrs]}
-      - name: build_info
-        type: Json
-        nullable: true
-        description: Full build metadata (tag, revision, time, channel, type)
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [build_info]}
-            - {kind: path, path: [buildInfo]}
+        expr: {kind: path, path: [attrs]}
 
   - name: databases
     description: Databases known to the cluster.
     guide: |
-      Returns one row per database name from `/api/v2/databases/`. This is the
-      catalog of databases the cluster knows about, including system databases
-      such as `system`, `defaultdb`, and `postgres`. The Cluster API does not
-      return per-database sizes here; use a SQL client and `SHOW DATABASES`
-      with size details if you need storage figures.
+      Returns one row per database name from `GET /api/v2/databases/`. This is
+      the catalog of databases the cluster knows about, including system
+      databases such as `system`, `defaultdb`, and `postgres`. The endpoint is
+      paginated with `limit`/`offset`, which Coral drives automatically. The
+      Cluster API does not return per-database sizes here; use a SQL client and
+      `SHOW DATABASES` with size details if you need storage figures.
     request:
       method: GET
       path: /api/v2/databases/
-      query:
-        - name: limit
-          from: literal
-          value: 1000
     response:
       rows_path:
         - databases
       row_strategy: direct
     pagination:
-      mode: none
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
     columns:
       - name: name
         type: Utf8
@@ -257,23 +199,21 @@ tables:
         expr: {kind: path, path: []}
 
   - name: metrics
-    description: Selected per-node operational metrics plus the full metrics map.
+    description: Selected per-node operational metrics plus the full metrics maps.
     guide: |
       Returns one row per node with a curated set of node-level metrics pulled
-      from each node's `metrics` map on `/api/v2/nodes/`. The named columns
-      cover the most common health signals; the `metrics` JSON column contains
-      the complete map so you can read any other gauge with
-      `json_get_float(metrics, 'sql.conns')`. Metric values are doubles. Some
-      metric keys differ across major CockroachDB versions, so a named column
-      may be NULL while the value is still present under a slightly different
-      key in the `metrics` map.
+      from each node's `metrics` map on `GET /api/v2/nodes/`. The named columns
+      cover common health signals; the `metrics` JSON column contains the
+      complete node-level map and `store_metrics` contains per-store gauges
+      (ranges, replicas, capacity, livebytes, ...) keyed by store ID, so you
+      can read any other value with `json_get_float(metrics, 'sql.conns')`.
+      Metric values are doubles. Some metric keys differ across major
+      CockroachDB versions, so a named column may be NULL while the value is
+      still present under a slightly different key in the maps. The endpoint
+      returns all nodes in a single response.
     request:
       method: GET
       path: /api/v2/nodes/
-      query:
-        - name: limit
-          from: literal
-          value: 1000
     response:
       rows_path:
         - nodes
@@ -285,11 +225,7 @@ tables:
         type: Int64
         nullable: false
         description: Node ID these metrics belong to
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [desc, node_id]}
-            - {kind: path, path: [desc, nodeId]}
+        expr: {kind: path, path: [node_id]}
       - name: sql_conns
         type: Float64
         nullable: true
@@ -328,5 +264,10 @@ tables:
       - name: metrics
         type: Json
         nullable: true
-        description: Complete node metrics map (metric name to double value)
+        description: Complete node-level metrics map (metric name to double value)
         expr: {kind: path, path: [metrics]}
+      - name: store_metrics
+        type: Json
+        nullable: true
+        description: Per-store metrics keyed by store ID (ranges, replicas, capacity, ...)
+        expr: {kind: path, path: [store_metrics]}

--- a/sources/community/cockroachdb/manifest.yaml
+++ b/sources/community/cockroachdb/manifest.yaml
@@ -1,0 +1,332 @@
+name: cockroachdb
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Inspect a self-hosted CockroachDB cluster's node liveness, per-node status and
+  build information, known databases, and selected node metrics through the
+  documented, read-only Cluster API v2 (/api/v2).
+inputs:
+  COCKROACHDB_URL:
+    kind: variable
+    default: https://localhost:8080
+    hint: |
+      Base URL of a CockroachDB node's HTTP interface, including scheme and
+      port. Default is `https://localhost:8080`. Secure clusters serve the
+      HTTP API over TLS (the node's HTTP certificate must be trusted by the
+      host running Coral); insecure clusters use `http://`. Do not include a
+      trailing slash or the `/api/v2` path — Coral appends the API path.
+  COCKROACHDB_SESSION:
+    kind: secret
+    hint: |
+      Cluster API session token, sent in the `X-Cockroach-API-Session` header.
+      On a secure cluster, obtain one by logging in:
+
+        curl -k --data "username=<user>&password=<password>" \
+          https://localhost:8080/api/v2/login/
+
+      and copy the `session` value from the JSON response. The login user
+      needs a SQL role with the `VIEWCLUSTERMETADATA` and `VIEWACTIVITY`
+      system privileges (or `admin` membership) to read the nodes and
+      databases endpoints. Insecure clusters serve the Cluster API without
+      authentication and ignore this header, so any non-empty placeholder
+      value works there.
+base_url: "{{input.COCKROACHDB_URL}}"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: X-Cockroach-API-Session
+      from: input
+      key: COCKROACHDB_SESSION
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT * FROM cockroachdb.databases LIMIT 1
+  - SELECT * FROM cockroachdb.nodes LIMIT 1
+
+tables:
+  - name: health
+    description: Per-node liveness/readiness derived from the cluster's node-liveness map.
+    guide: |
+      Returns one row per node from the `liveness_by_node_id` map on
+      `/api/v2/nodes/`. `liveness` is CockroachDB's NodeLivenessStatus, vended
+      either as an enum name (e.g. `LIVE`) or its numeric code:
+      `0` UNKNOWN, `1` DEAD, `2` UNAVAILABLE, `3` LIVE, `4` DECOMMISSIONING,
+      `5` DECOMMISSIONED. Anything other than `LIVE`/`3` on a node you expect
+      to be up signals a readiness or membership problem. This is the first
+      query to run to confirm connectivity and cluster membership.
+    request:
+      method: GET
+      path: /api/v2/nodes/
+      query:
+        - name: limit
+          from: literal
+          value: 1000
+    response:
+      rows_path:
+        - liveness_by_node_id
+      row_strategy: dict_entries
+    pagination:
+      mode: none
+    columns:
+      - name: node_id
+        type: Int64
+        nullable: false
+        description: Node ID this liveness entry refers to
+        expr: {kind: path, path: [_key]}
+      - name: liveness
+        type: Utf8
+        nullable: true
+        description: >-
+          NodeLivenessStatus name or numeric code (0 UNKNOWN, 1 DEAD,
+          2 UNAVAILABLE, 3 LIVE, 4 DECOMMISSIONING, 5 DECOMMISSIONED)
+        expr: {kind: path, path: [_value]}
+
+  - name: nodes
+    description: Per-node status, network addresses, and build information.
+    guide: |
+      Returns one row per node from `/api/v2/nodes/`. Use `node_id` to join
+      against the `health` and `metrics` tables. `started_at` and `updated_at`
+      are epoch **nanoseconds** (CockroachDB vends these as nanosecond counts),
+      exposed as Int64; divide by 1e9 for seconds. `address` and `sql_address`
+      are host:port strings. `build_info`, `locality`, and `attrs` are returned
+      as JSON for querying with `json_get_*`.
+    request:
+      method: GET
+      path: /api/v2/nodes/
+      query:
+        - name: limit
+          from: literal
+          value: 1000
+    response:
+      rows_path:
+        - nodes
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: node_id
+        type: Int64
+        nullable: false
+        description: Unique node ID within the cluster
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [desc, node_id]}
+            - {kind: path, path: [desc, nodeId]}
+      - name: address
+        type: Utf8
+        nullable: true
+        description: RPC address (host:port) advertised by the node
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [desc, address, address_field]}
+            - {kind: path, path: [desc, address, addressField]}
+      - name: sql_address
+        type: Utf8
+        nullable: true
+        description: SQL address (host:port) advertised by the node
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [desc, sql_address, address_field]}
+            - {kind: path, path: [desc, sql_address, addressField]}
+      - name: build_tag
+        type: Utf8
+        nullable: true
+        description: CockroachDB version tag the node is running (e.g. v24.1.0)
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [desc, build_tag]}
+            - {kind: path, path: [desc, buildTag]}
+            - {kind: path, path: [build_info, tag]}
+            - {kind: path, path: [buildInfo, tag]}
+      - name: go_version
+        type: Utf8
+        nullable: true
+        description: Go runtime version the binary was built with
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [build_info, go_version]}
+            - {kind: path, path: [buildInfo, goVersion]}
+      - name: platform
+        type: Utf8
+        nullable: true
+        description: Build platform (e.g. linux amd64)
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [build_info, platform]}
+            - {kind: path, path: [buildInfo, platform]}
+      - name: distribution
+        type: Utf8
+        nullable: true
+        description: Build distribution (OSS or CCL)
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [build_info, distribution]}
+            - {kind: path, path: [buildInfo, distribution]}
+      - name: started_at
+        type: Int64
+        nullable: true
+        description: Node process start time as epoch nanoseconds
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [started_at]}
+            - {kind: path, path: [startedAt]}
+      - name: updated_at
+        type: Int64
+        nullable: true
+        description: Time this node status was last updated, as epoch nanoseconds
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [updated_at]}
+            - {kind: path, path: [updatedAt]}
+      - name: num_cpus
+        type: Int64
+        nullable: true
+        description: Number of logical CPUs visible to the node
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [num_cpus]}
+            - {kind: path, path: [numCpus]}
+      - name: total_system_memory
+        type: Int64
+        nullable: true
+        description: Total system memory available to the node, in bytes
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [total_system_memory]}
+            - {kind: path, path: [totalSystemMemory]}
+      - name: locality
+        type: Json
+        nullable: true
+        description: Locality tiers (region/zone) configured for the node
+        expr: {kind: path, path: [desc, locality]}
+      - name: attrs
+        type: Json
+        nullable: true
+        description: Store/node attributes advertised by the node
+        expr: {kind: path, path: [desc, attrs]}
+      - name: build_info
+        type: Json
+        nullable: true
+        description: Full build metadata (tag, revision, time, channel, type)
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [build_info]}
+            - {kind: path, path: [buildInfo]}
+
+  - name: databases
+    description: Databases known to the cluster.
+    guide: |
+      Returns one row per database name from `/api/v2/databases/`. This is the
+      catalog of databases the cluster knows about, including system databases
+      such as `system`, `defaultdb`, and `postgres`. The Cluster API does not
+      return per-database sizes here; use a SQL client and `SHOW DATABASES`
+      with size details if you need storage figures.
+    request:
+      method: GET
+      path: /api/v2/databases/
+      query:
+        - name: limit
+          from: literal
+          value: 1000
+    response:
+      rows_path:
+        - databases
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Database name
+        expr: {kind: path, path: []}
+
+  - name: metrics
+    description: Selected per-node operational metrics plus the full metrics map.
+    guide: |
+      Returns one row per node with a curated set of node-level metrics pulled
+      from each node's `metrics` map on `/api/v2/nodes/`. The named columns
+      cover the most common health signals; the `metrics` JSON column contains
+      the complete map so you can read any other gauge with
+      `json_get_float(metrics, 'sql.conns')`. Metric values are doubles. Some
+      metric keys differ across major CockroachDB versions, so a named column
+      may be NULL while the value is still present under a slightly different
+      key in the `metrics` map.
+    request:
+      method: GET
+      path: /api/v2/nodes/
+      query:
+        - name: limit
+          from: literal
+          value: 1000
+    response:
+      rows_path:
+        - nodes
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: node_id
+        type: Int64
+        nullable: false
+        description: Node ID these metrics belong to
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [desc, node_id]}
+            - {kind: path, path: [desc, nodeId]}
+      - name: sql_conns
+        type: Float64
+        nullable: true
+        description: Number of open SQL connections to the node
+        expr: {kind: path, path: [metrics, "sql.conns"]}
+      - name: sql_query_count
+        type: Float64
+        nullable: true
+        description: Cumulative count of SQL queries executed on the node
+        expr: {kind: path, path: [metrics, "sql.query.count"]}
+      - name: sys_cpu_user_percent
+        type: Float64
+        nullable: true
+        description: Fraction of CPU time spent in user space (0.0-1.0 per core)
+        expr: {kind: path, path: [metrics, "sys.cpu.user.percent"]}
+      - name: sys_cpu_sys_percent
+        type: Float64
+        nullable: true
+        description: Fraction of CPU time spent in kernel space (0.0-1.0 per core)
+        expr: {kind: path, path: [metrics, "sys.cpu.sys.percent"]}
+      - name: sys_rss_bytes
+        type: Float64
+        nullable: true
+        description: Resident set size of the node process, in bytes
+        expr: {kind: path, path: [metrics, "sys.rss"]}
+      - name: sys_goroutines
+        type: Float64
+        nullable: true
+        description: Current number of goroutines in the node process
+        expr: {kind: path, path: [metrics, "sys.goroutines"]}
+      - name: sys_uptime_seconds
+        type: Float64
+        nullable: true
+        description: Node process uptime, in seconds
+        expr: {kind: path, path: [metrics, "sys.uptime"]}
+      - name: metrics
+        type: Json
+        nullable: true
+        description: Complete node metrics map (metric name to double value)
+        expr: {kind: path, path: [metrics]}

--- a/sources/community/cockroachdb/manifest.yaml
+++ b/sources/community/cockroachdb/manifest.yaml
@@ -204,12 +204,14 @@ tables:
       Returns one row per node with a curated set of node-level metrics pulled
       from each node's `metrics` map on `GET /api/v2/nodes/`. The named columns
       cover common health signals; the `metrics` JSON column contains the
-      complete node-level map and `store_metrics` contains per-store gauges
-      (ranges, replicas, capacity, livebytes, ...) keyed by store ID, so you
-      can read any other value with `json_get_float(metrics, 'sql.conns')`.
-      Metric values are doubles. Some metric keys differ across major
-      CockroachDB versions, so a named column may be NULL while the value is
-      still present under a slightly different key in the maps. The endpoint
+      complete node-level map, so you can read any other value with
+      `json_get_float(metrics, 'sql.conns')`. Metric values are doubles. Some
+      metric keys differ across major CockroachDB versions, so a named column
+      may be NULL while the value is still present under a slightly different
+      key in the map. `store_metrics` is a best-effort extra: it carries
+      per-store gauges (ranges, replicas, capacity, livebytes, ...) keyed by
+      store ID, but it is NOT part of the documented Cluster API v2 response
+      schema, so treat it as nullable and version-dependent. The endpoint
       returns all nodes in a single response.
     request:
       method: GET
@@ -269,5 +271,8 @@ tables:
       - name: store_metrics
         type: Json
         nullable: true
-        description: Per-store metrics keyed by store ID (ranges, replicas, capacity, ...)
+        description: >-
+          Best-effort per-store metrics keyed by store ID (ranges, replicas,
+          capacity, livebytes, ...). Not part of the documented Cluster API v2
+          schema; may be NULL on some CockroachDB versions.
         expr: {kind: path, path: [store_metrics]}


### PR DESCRIPTION
Closes #600

Add a read-only HTTP community source for self-hosted CockroachDB built on the documented, stable Cluster API v2 (/api/v2). Exposes four observability tables:

- health: per-node liveness/readiness from each node's liveness_status
- nodes: per-node status, network addresses, and build information
- databases: databases known to the cluster
- metrics: selected per-node metrics plus the full metrics map

Authentication uses a Cluster API session token in the X-Cockroach-API-Session header. Observability only: no SQL execution and no crdb_internal tables.

---
$ coral source add --file sources/community/cockroachdb/manifest.yaml
Added source cockroachdb
  ✓ cockroachdb connected successfully
    cockroachdb (4 tables): databases, health, metrics, nodes
    2 declared · 2 passed · 0 failed
    ✓ SELECT * FROM cockroachdb.databases LIMIT 1 — 1 row
    ✓ SELECT * FROM cockroachdb.nodes LIMIT 1 — 1 row

$ coral sql "SELECT node_id, address, sql_address, build_tag, liveness_status, num_cpus, total_system_memory FROM cockroachdb.nodes ORDER BY node_id"
+---------+-----------------+-----------------+-----------+-----------------+----------+---------------------+
| node_id | address         | sql_address     | build_tag | liveness_status | num_cpus | total_system_memory |
+---------+-----------------+-----------------+-----------+-----------------+----------+---------------------+
| 1       | 127.0.0.1:26257 | 127.0.0.1:26257 | v24.1.5   | 3               | 6        | 16624766976         |
+---------+-----------------+-----------------+-----------+-----------------+----------+---------------------+

$ coral sql "SELECT node_id, sql_conns, sql_query_count, sys_goroutines, sys_uptime_seconds, json_get_float(store_metrics, '1', 'ranges') AS ranges FROM cockroachdb.metrics"
+---------+-----------+-----------------+----------------+--------------------+--------+
| node_id | sql_conns | sql_query_count | sys_goroutines | sys_uptime_seconds | ranges |
+---------+-----------+-----------------+----------------+--------------------+--------+
| 1       | 0.0       | 3.0             | 388.0          | 560.0              | 54.0   |
+---------+-----------+-----------------+----------------+--------------------+--------+

$ coral sql "SELECT name FROM cockroachdb.databases ORDER BY name"   -- offset pagination, all pages
+-----------+
| name      |
+-----------+
| analytics |
| defaultdb |
| myapp     |
| postgres  |
| system    |
+-----------+

<img width="1436" height="669" alt="image" src="https://github.com/user-attachments/assets/17be4bd1-d159-4dde-a9b2-cf22672cf009" />

