### PR TITLE
feat(sources/community/knock): add Knock notification source

### DIFF
--- a/sources/community/knock/README.md
+++ b/sources/community/knock/README.md
@@ -1,0 +1,185 @@
+# Knock
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+**Base URL:** `https://api.knock.app`
+
+Query notification messages, users, tenants, and schedules from Knock — the notification infrastructure platform for in-app, email, SMS, push, and chat notifications.
+
+## Authentication
+
+Requires a `KNOCK_API_KEY`. Find it in the Knock dashboard:
+**Platform → API Keys → copy secret key**
+
+Secret keys start with `sk_test_` (test environment) or `sk_live_` (production environment). Use the key matching the environment you want to query.
+
+> **Environment note:** Knock API keys are environment-scoped. A `sk_test_` key only returns data from your test environment; a `sk_live_` key only returns production data.
+
+```bash
+coral source add --file sources/community/knock/manifest.yaml
+```
+
+You will be prompted to enter your API key interactively.
+
+API docs: https://docs.knock.app/api-reference/overview
+
+## Tables
+
+| Table | Description | Required filters | Optional filters |
+|---|---|---|---|
+| `messages` | Notification delivery records with status tracking | — | `channel_id`, `workflow`, `tenant`, `status` |
+| `users` | Notification recipients/subscribers | — | — |
+| `tenants` | Multi-tenant organization records | — | `tenant_id` |
+| `schedules` | Scheduled workflow notification runs | — | `workflow`, `tenant` |
+
+### Key design notes
+
+- **All tables use cursor pagination.** Knock uses `page_info.after` cursors
+  with a max page size of 50. The source handles pagination automatically.
+- **`messages` is the core table.** It tracks delivery status (`queued`,
+  `sent`, `delivered`, `undelivered`, `not_sent`) and engagement timestamps
+  (`read_at`, `seen_at`, `archived_at`).
+- **`users` are flat objects.** Standard fields (name, email, phone_number)
+  are columns; custom properties synced to Knock are not exposed as fixed
+  columns.
+- **`tenants` enable multi-tenant scoping.** Join `messages.tenant` with
+  `tenants.id` to enrich notification data with tenant metadata.
+
+```text
+messages   → notification delivery records with engagement tracking
+users      → recipients/subscribers with contact details
+tenants    → multi-tenant organization records
+schedules  → scheduled workflow notification runs
+```
+
+### Not included in v1
+
+- **`message_events`, `message_activities`, `delivery_logs`** — require a
+  `message_id` path parameter (sub-resource pattern). Deferred to v2.
+- **`workflows`** — workflow definitions live on the Knock Management API
+  (`control.knock.app`) which uses separate Service Token authentication,
+  not the standard API secret key.
+- **`objects`** — require a `collection` path parameter. Deferred to v2.
+
+### messages filter values
+
+| Filter | Description |
+|---|---|
+| `channel_id` | Filter by channel ID (e.g. a specific email or push channel) |
+| `workflow` | Filter by workflow key (e.g. `welcome-email`) |
+| `tenant` | Filter by tenant ID |
+| `status` | Filter by delivery status (`queued`, `sent`, `delivered`, `undelivered`, `not_sent`) |
+
+### schedules filter values
+
+| Filter | Description |
+|---|---|
+| `workflow` | Filter by workflow key |
+| `tenant` | Filter by tenant ID |
+
+## Quick start
+
+```bash
+# Step 1 — list recent notification messages
+coral sql "
+  SELECT id, status, workflow, tenant, inserted_at
+  FROM knock.messages
+  LIMIT 20
+"
+
+# Step 2 — list all users
+coral sql "
+  SELECT id, name, email, timezone
+  FROM knock.users
+  LIMIT 20
+"
+
+# Step 3 — list all tenants
+coral sql "
+  SELECT id, name, created_at
+  FROM knock.tenants
+"
+
+# Step 4 — list schedules for a specific workflow
+coral sql "
+  SELECT id, workflow, tenant, inserted_at
+  FROM knock.schedules
+  WHERE workflow = 'welcome-series'
+"
+```
+
+## Example queries
+
+### List recent messages with status
+
+```sql
+SELECT
+  id,
+  status,
+  workflow,
+  channel_id,
+  tenant,
+  inserted_at
+FROM knock.messages
+ORDER BY inserted_at DESC
+LIMIT 50;
+```
+
+### Find undelivered messages by workflow
+
+```sql
+SELECT
+  id,
+  workflow,
+  channel_id,
+  tenant,
+  status,
+  inserted_at
+FROM knock.messages
+WHERE status = 'undelivered'
+LIMIT 50;
+```
+
+### List all users in the workspace
+
+```sql
+SELECT
+  id,
+  name,
+  email,
+  phone_number,
+  timezone,
+  created_at
+FROM knock.users
+LIMIT 100;
+```
+
+### List schedules for a specific workflow
+
+```sql
+SELECT
+  id,
+  workflow,
+  tenant,
+  inserted_at,
+  updated_at
+FROM knock.schedules
+WHERE workflow = 'digest-daily'
+LIMIT 50;
+```
+
+### Join messages with users on recipient
+
+```sql
+SELECT
+  m.id AS message_id,
+  m.status,
+  m.workflow,
+  m.inserted_at,
+  u.name AS recipient_name,
+  u.email AS recipient_email
+FROM knock.messages m
+JOIN knock.users u ON m.tenant = u.id
+LIMIT 50;
+```

--- a/sources/community/knock/manifest.yaml
+++ b/sources/community/knock/manifest.yaml
@@ -1,0 +1,467 @@
+dsl_version: 3
+name: knock
+version: 0.1.0
+backend: http
+description: >-
+  Query Knock notification messages, users, tenants, and schedules
+  as SQL tables. Inspect delivery statuses, recipient rosters,
+  multi-tenant configurations, and scheduled notifications.
+  Join with Novu, Resend, or Postmark for cross-source notification
+  intelligence.
+base_url: https://api.knock.app
+
+inputs:
+  KNOCK_API_KEY:
+    kind: secret
+    hint: |
+      Your Knock secret API key (starts with sk_test_ or sk_live_).
+      Find it in the Knock dashboard under Platform → API Keys.
+      See https://docs.knock.app/api-reference/overview/api-keys
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.KNOCK_API_KEY}}
+
+rate_limit:
+  extra_statuses:
+    - 429
+  retry_after_header: Retry-After
+
+test_queries:
+  - SELECT id, status, workflow, tenant, inserted_at FROM knock.messages LIMIT 5
+  - SELECT id, name, email, timezone FROM knock.users LIMIT 5
+  - SELECT id, name, created_at FROM knock.tenants LIMIT 5
+  - SELECT id, workflow, tenant, inserted_at FROM knock.schedules LIMIT 5
+
+tables:
+
+  # ------------------------------------------------------------------
+  # knock.messages — notification delivery records
+  # GET /v1/messages
+  # Cursor pagination via page_info.after, entries wrapper.
+  # ------------------------------------------------------------------
+  - name: messages
+    description: >-
+      Notification messages delivered through Knock workflows. Each row
+      is one message with its delivery status, channel, workflow origin,
+      tenant scope, and engagement timestamps. Use this table to audit
+      notification history, track delivery rates, and diagnose failures.
+    guide: |
+      No required filters — returns all messages across all workflows.
+      Optionally filter by channel_id, workflow, tenant, or status.
+
+      status values: queued, sent, delivered, undelivered, not_sent.
+      read_at, seen_at, archived_at track recipient engagement.
+
+      Example:
+        SELECT id, status, workflow, tenant, inserted_at
+        FROM knock.messages
+        WHERE status = 'delivered'
+        ORDER BY inserted_at DESC
+        LIMIT 50
+    filters:
+      - name: channel_id
+      - name: workflow
+      - name: tenant
+      - name: status
+    request:
+      method: GET
+      path: /v1/messages
+      query:
+        - name: channel_id
+          from: filter
+          key: channel_id
+        - name: workflow
+          from: filter
+          key: workflow
+        - name: tenant
+          from: filter
+          key: tenant
+        - name: status
+          from: filter
+          key: status
+    response:
+      rows_path:
+        - entries
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path:
+        - page_info
+        - after
+      page_size:
+        default: 50
+        max: 50
+        query_param: page_size
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique message identifier.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: channel_id
+        type: Utf8
+        nullable: true
+        description: Channel used for delivery (e.g. email, push, in-app).
+        expr:
+          kind: path
+          path:
+            - channel_id
+      - name: workflow
+        type: Utf8
+        nullable: true
+        description: Workflow key that triggered this message.
+        expr:
+          kind: path
+          path:
+            - workflow
+      - name: tenant
+        type: Utf8
+        nullable: true
+        description: Tenant ID if multi-tenant notifications are used.
+        expr:
+          kind: path
+          path:
+            - tenant
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Delivery status: queued, sent, delivered, undelivered, or
+          not_sent.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: source
+        type: Utf8
+        nullable: true
+        description: Source information for the message.
+        expr:
+          kind: path
+          path:
+            - source
+      - name: inserted_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the message was created.
+        expr:
+          kind: path
+          path:
+            - inserted_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the message was last updated.
+        expr:
+          kind: path
+          path:
+            - updated_at
+      - name: read_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the recipient read the message.
+        expr:
+          kind: path
+          path:
+            - read_at
+      - name: seen_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the recipient saw the message.
+        expr:
+          kind: path
+          path:
+            - seen_at
+      - name: archived_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the message was archived.
+        expr:
+          kind: path
+          path:
+            - archived_at
+
+  # ------------------------------------------------------------------
+  # knock.users — notification recipients
+  # GET /v1/users
+  # Cursor pagination via page_info.after, entries wrapper.
+  # ------------------------------------------------------------------
+  - name: users
+    description: >-
+      Users (recipients) registered in the Knock environment. Each row
+      is one user with their contact details and locale settings. Users
+      are the recipients of notifications sent through workflows.
+    guide: |
+      No required filters. Returns all users in the environment.
+
+      id is your application's identifier for the user.
+      Custom properties synced to Knock are merged into the user object
+      but are not exposed as fixed columns here.
+
+      Example:
+        SELECT id, name, email, phone_number, created_at
+        FROM knock.users
+        LIMIT 50
+    request:
+      method: GET
+      path: /v1/users
+    response:
+      rows_path:
+        - entries
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path:
+        - page_info
+        - after
+      page_size:
+        default: 50
+        max: 50
+        query_param: page_size
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Customer-defined user identifier.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: User full name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address.
+        expr:
+          kind: path
+          path:
+            - email
+      - name: phone_number
+        type: Utf8
+        nullable: true
+        description: User phone number.
+        expr:
+          kind: path
+          path:
+            - phone_number
+      - name: avatar
+        type: Utf8
+        nullable: true
+        description: URL to user avatar image.
+        expr:
+          kind: path
+          path:
+            - avatar
+      - name: timezone
+        type: Utf8
+        nullable: true
+        description: User timezone (e.g. America/New_York).
+        expr:
+          kind: path
+          path:
+            - timezone
+      - name: locale
+        type: Utf8
+        nullable: true
+        description: User locale (e.g. en, fr, de).
+        expr:
+          kind: path
+          path:
+            - locale
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the user was created.
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the user was last updated.
+        expr:
+          kind: path
+          path:
+            - updated_at
+
+  # ------------------------------------------------------------------
+  # knock.tenants — multi-tenant organization records
+  # GET /v1/tenants
+  # Cursor pagination via page_info.after, entries wrapper.
+  # ------------------------------------------------------------------
+  - name: tenants
+    description: >-
+      Tenants configured in the Knock environment. Tenants represent
+      organizations, teams, or accounts in multi-tenant applications.
+      Use tenant IDs to scope notifications and join with the messages
+      table on the tenant column.
+    guide: |
+      No required filters. Returns all tenants in the environment.
+
+      Tenants are system-level objects in Knock. Custom properties and
+      branding overrides stored on tenants are available in the
+      properties and settings fields but are not exposed as fixed
+      columns here.
+
+      Example:
+        SELECT id, name, created_at
+        FROM knock.tenants
+        LIMIT 50
+    filters:
+      - name: tenant_id
+    request:
+      method: GET
+      path: /v1/tenants
+      query:
+        - name: tenant_id
+          from: filter
+          key: tenant_id
+    response:
+      rows_path:
+        - entries
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path:
+        - page_info
+        - after
+      page_size:
+        default: 50
+        max: 50
+        query_param: page_size
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Tenant identifier.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Tenant display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the tenant was created.
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the tenant was last updated.
+        expr:
+          kind: path
+          path:
+            - updated_at
+
+  # ------------------------------------------------------------------
+  # knock.schedules — scheduled workflow notifications
+  # GET /v1/schedules
+  # Cursor pagination via page_info.after, entries wrapper.
+  # ------------------------------------------------------------------
+  - name: schedules
+    description: >-
+      Scheduled notifications in the Knock environment. Each row is one
+      schedule entry linking a workflow to its scheduled execution.
+      Use this table for operational visibility into upcoming and
+      recurring notification deliveries.
+    guide: |
+      No required filters. Returns all schedules in the environment.
+      Optionally filter by workflow key or tenant.
+
+      Example:
+        SELECT id, workflow, tenant, inserted_at
+        FROM knock.schedules
+        WHERE workflow = 'welcome-series'
+        LIMIT 50
+    filters:
+      - name: workflow
+      - name: tenant
+    request:
+      method: GET
+      path: /v1/schedules
+      query:
+        - name: workflow
+          from: filter
+          key: workflow
+        - name: tenant
+          from: filter
+          key: tenant
+    response:
+      rows_path:
+        - entries
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path:
+        - page_info
+        - after
+      page_size:
+        default: 50
+        max: 50
+        query_param: page_size
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Schedule identifier.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: workflow
+        type: Utf8
+        nullable: true
+        description: Workflow key this schedule is associated with.
+        expr:
+          kind: path
+          path:
+            - workflow
+      - name: tenant
+        type: Utf8
+        nullable: true
+        description: Tenant ID scoping this schedule.
+        expr:
+          kind: path
+          path:
+            - tenant
+      - name: inserted_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the schedule was created.
+        expr:
+          kind: path
+          path:
+            - inserted_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the schedule was last updated.
+        expr:
+          kind: path
+          path:
+            - updated_at


### PR DESCRIPTION
Closes #636

## Summary

Adds a new community source for [Knock](https://knock.app) — the notification infrastructure platform for in-app, email, SMS, push, and chat notifications.

## What's included

| File | Purpose |
|---|---|
| `sources/community/knock/manifest.yaml` | Source spec — 4 tables, Bearer auth, cursor pagination |
| `sources/community/knock/README.md` | Setup guide, table docs, filter reference, 5 example queries |

## Tables

| Table | Endpoint | Filters | Description |
|---|---|---|---|
| `messages` | `GET /v1/messages` | `channel_id`, `workflow`, `tenant`, `status` | Notification delivery records with engagement tracking |
| `users` | `GET /v1/users` | — | Notification recipients with contact details |
| `tenants` | `GET /v1/tenants` | `tenant_id` | Multi-tenant organization records |
| `schedules` | `GET /v1/schedules` | `workflow`, `tenant` | Scheduled workflow notification runs |

## Design decisions

- **Auth:** `Bearer sk_*` secret key via `HeaderAuth`. No OAuth — Knock uses static API keys only.
- **Pagination:** All 4 tables use `cursor_query` with `page_info.after` and `entries` wrapper (max page size 50).
- **Rate limiting:** `rate_limit` block with `429` status + `Retry-After` header, matching the pattern from `novu`, `auth0`, and `vercel` sources.
- **Read-only:** All endpoints are GET. No write operations.

## Intentionally excluded from v1

| Resource | Reason |
|---|---|
| `message_events`, `delivery_logs` | Require `message_id` path param (sub-resource pattern) |
| `objects` | Require `collection` path param |
| `workflows` | Live on Management API (`control.knock.app`) with separate Service Token auth |

These are good candidates for a v2 follow-up with required filters.


## Example usage

```sql
-- Recent undelivered messages
SELECT id, workflow, channel_id, status, inserted_at
FROM knock.messages
WHERE status = 'undelivered'
LIMIT 50;

-- All users with contact info
SELECT id, name, email, phone_number, timezone
FROM knock.users
LIMIT 100;
