### PR TITLE
feat(sources/community/productboard): add Productboard community source

### DIFF
--- a/sources/community/productboard/README.md
+++ b/sources/community/productboard/README.md
@@ -1,0 +1,137 @@
+# Productboard (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Productboard API v2)
+**Tables:** 4
+**Base URL:** `https://api.productboard.com`
+
+Query notes, features, members, and teams from Productboard. Designed for 
+product roadmap visibility, feedback analysis, and cross-source joins with 
+bundled sources like **Slack**, **Intercom**, and **Jira**.
+
+## Install
+
+Community sources are not bundled with the Coral binary. Add the manifest from
+this directory:
+
+```bash
+coral source add --file sources/community/productboard/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to
+`coral source add --file`.
+
+Reference the linked GitHub issue in your PR so maintainers can connect the
+contribution to the prior discussion.
+
+## Authentication and setup
+
+Requires `PRODUCTBOARD_ACCESS_TOKEN` (Personal Access Token).
+
+1. In Productboard, go to **Workspace Settings → Integrations → Public APIs**.
+2. Click **Add Token** (requires at least a Pro plan).
+3. Ensure the token has the `members:pii:read` scope if you need to query actual names and emails.
+4. Copy the access token.
+
+```bash
+export PRODUCTBOARD_ACCESS_TOKEN=eyJhb...
+coral source add --file sources/community/productboard/manifest.yaml
+```
+
+See [Productboard API Token Documentation](https://developer.productboard.com/reference/api-token).
+
+## Table categories
+
+### Product data
+
+| Table | Description |
+| --- | --- |
+| `notes` | Feedback and conversations. Primary join key `owner_id`. |
+| `features` | Product features and roadmap items. |
+| `members` | Workspace members. |
+| `teams` | Workspace teams. |
+
+## Filters and pagination
+
+- List tables (`notes`, `features`, `members`, `teams`) use Productboard cursor pagination (`pageCursor`). Always use `LIMIT` on large workspaces.
+- **Note on pagination limitations**: Productboard API v2 returns full URLs in `links.next`. Pagination might experience issues until Coral engine parses these out natively, so use `LIMIT` to keep query bounds small for now.
+- `features` restricts results strictly to entities where `type=feature`. Other entities like components or objectives are not currently exposed in this v1 source.
+
+## Example relationships
+
+```text
+productboard.notes.owner_id
+  → productboard.members.id
+
+productboard.members.email
+  → slack.users.email
+  → intercom.contacts.email
+```
+
+## Example queries
+
+### Notes and owners
+
+```sql
+SELECT n.id, n.name, n.created_at, m.email AS owner_email
+FROM productboard.notes n
+LEFT JOIN productboard.members m ON n.owner_id = m.id
+WHERE n.archived = false
+LIMIT 20;
+```
+
+### Search features by status
+
+```sql
+SELECT id, name, status_name, timeframe_start
+FROM productboard.features
+WHERE status_name = 'In Progress'
+LIMIT 10;
+```
+
+### Cross-tool member join (requires Slack)
+
+```sql
+SELECT p.name AS pb_name, p.role, s.name AS slack_name
+FROM productboard.members p
+JOIN slack.users s ON LOWER(p.email) = LOWER(s.profile_email)
+WHERE p.disabled = false
+LIMIT 20;
+```
+
+### Pipeline summary
+
+```sql
+SELECT status_name, COUNT(*) AS feature_count
+FROM productboard.features
+GROUP BY status_name
+ORDER BY feature_count DESC;
+```
+
+## Validation
+
+```bash
+# YAML style (requires: cargo install ryl --locked)
+make lint-sources
+
+# Manifest structure and smoke queries (requires Coral CLI)
+coral source lint sources/community/productboard/manifest.yaml
+export PRODUCTBOARD_ACCESS_TOKEN=eyJhb...
+coral source add --file sources/community/productboard/manifest.yaml
+coral source test productboard
+```
+
+## Limitations
+
+- **Read-only** v1 (no creates/updates).
+- **Entities scoping**: The `features` table only exposes features (not components, objectives, or products).
+- **PII redaction**: Without the `members:pii:read` scope, the `members` table will return `[redacted]` for `name` and `email` fields.
+- **Content field**: The `notes.content` field is typed as `Json` because its schema is polymorphic (can be a string for `textNote` or an array for `conversationNote`).
+- **Pagination gap**: Productboard returns a full URL in `links.next` instead of a raw cursor. This may require future DSL enhancements in Coral to fully support native fetching of >100 records.
+- Community sources are maintained separately from bundled core sources.
+
+## Contributing
+
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md): discuss on the issue first,
+sign the CLA if this is your first contribution, run `make lint-sources`, and
+open a focused PR titled `feat(sources/community/productboard): add productboard community source`.

--- a/sources/community/productboard/manifest.yaml
+++ b/sources/community/productboard/manifest.yaml
@@ -1,0 +1,453 @@
+name: productboard
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query notes, features, members, and teams from Productboard. Join with
+  bundled sources like Slack, Intercom, or Jira.
+inputs:
+  PRODUCTBOARD_ACCESS_TOKEN:
+    kind: secret
+    required: true
+    hint: |
+      Your Productboard Personal Access Token (Bearer).
+      Generate from: Workspace Settings → Integrations → Public APIs → Add Token.
+      Requires at least a Pro plan.
+      Note: member name and email fields return [redacted] without
+      the members:pii:read scope on your token.
+      Docs: https://developer.productboard.com/reference/api-token
+base_url: https://api.productboard.com
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.PRODUCTBOARD_ACCESS_TOKEN}}
+test_queries:
+  - SELECT * FROM productboard.notes LIMIT 5
+  - SELECT id, name, status_name, created_at FROM productboard.features LIMIT 10
+  - SELECT id, name, email, role FROM productboard.members LIMIT 10
+  - SELECT id, name, handle FROM productboard.teams LIMIT 10
+  - SELECT id, name FROM productboard.notes WHERE archived = false LIMIT 10
+tables:
+  - name: notes
+    description: Productboard notes (feedback and conversations).
+    guide: |
+      Query customer feedback and notes. Use `archived` or `processed` filters
+      to narrow down results. The `content` column contains the raw note body.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /v2/notes
+      query:
+        - name: archived
+          from: filter_bool
+          key: archived
+        - name: processed
+          from: filter_bool
+          key: processed
+        - name: createdFrom
+          from: filter
+          key: created_from
+        - name: createdTo
+          from: filter
+          key: created_to
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: pageCursor
+      response_cursor_path:
+        - links
+        - next
+      page_size:
+        default: 100
+        max: 100
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the note.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Type of the note (e.g. textNote, conversationNote).
+        expr:
+          kind: path
+          path:
+            - type
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Title or subject of the note.
+        expr:
+          kind: path
+          path:
+            - fields
+            - name
+      - name: content
+        type: Json
+        nullable: true
+        description: Content payload (can be text or an array of messages).
+        expr:
+          kind: path
+          path:
+            - fields
+            - content
+      - name: owner_id
+        type: Utf8
+        nullable: true
+        description: User ID of the note owner. Join to productboard.members.id.
+        expr:
+          kind: path
+          path:
+            - fields
+            - owner
+            - id
+      - name: processed
+        type: Boolean
+        nullable: true
+        description: Whether the note has been processed.
+        expr:
+          kind: path
+          path:
+            - fields
+            - processed
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the note is archived.
+        expr:
+          kind: path
+          path:
+            - fields
+            - archived
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Note creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Note last update timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+      - name: created_from
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Filter for notes created after this date (ISO 8601).
+      - name: created_to
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Filter for notes created before this date (ISO 8601).
+  - name: features
+    description: Productboard features.
+    guide: |
+      Query product features. Due to API structure, we query the `entities`
+      endpoint with a hardcoded `type=feature` filter. Status names are
+      workspace-specific.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /v2/entities
+      query:
+        - name: type
+          from: literal
+          value: feature
+        - name: status[name]
+          from: filter
+          key: status_name
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: pageCursor
+      response_cursor_path:
+        - links
+        - next
+      page_size:
+        default: 100
+        max: 100
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the feature.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Name of the feature.
+        expr:
+          kind: path
+          path:
+            - fields
+            - name
+      - name: status_id
+        type: Utf8
+        nullable: true
+        description: Internal ID of the feature's status.
+        expr:
+          kind: path
+          path:
+            - fields
+            - status
+            - id
+      - name: status_name
+        type: Utf8
+        nullable: true
+        description: Human-readable status name (e.g., In Progress).
+        expr:
+          kind: path
+          path:
+            - fields
+            - status
+            - name
+      - name: timeframe_start
+        type: Utf8
+        nullable: true
+        description: Target start date of the feature timeframe.
+        expr:
+          kind: path
+          path:
+            - fields
+            - timeframe
+            - startDate
+      - name: timeframe_end
+        type: Utf8
+        nullable: true
+        description: Target end date of the feature timeframe.
+        expr:
+          kind: path
+          path:
+            - fields
+            - timeframe
+            - endDate
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Feature creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Feature last update timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+  - name: members
+    description: Productboard workspace members.
+    guide: |
+      Query workspace members. Requires the `members:pii:read` scope on your
+      token, otherwise `name` and `email` fields will return `[redacted]`.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /v2/members
+      query:
+        - name: query
+          from: filter
+          key: query
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: pageCursor
+      response_cursor_path:
+        - links
+        - next
+      page_size:
+        default: 100
+        max: 100
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the member.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Full name of the member.
+        expr:
+          kind: path
+          path:
+            - fields
+            - name
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Email address of the member.
+        expr:
+          kind: path
+          path:
+            - fields
+            - email
+      - name: role
+        type: Utf8
+        nullable: true
+        description: Member role (e.g. maker, contributor, viewer).
+        expr:
+          kind: path
+          path:
+            - fields
+            - role
+      - name: disabled
+        type: Boolean
+        nullable: true
+        description: Whether the member account is disabled.
+        expr:
+          kind: path
+          path:
+            - fields
+            - disabled
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Member creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Member last update timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+  - name: teams
+    description: Productboard workspace teams.
+    guide: |
+      Query workspace teams. Use team IDs to group or analyze features and notes.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /v2/teams
+      query: []
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: pageCursor
+      response_cursor_path:
+        - links
+        - next
+      page_size:
+        default: 100
+        max: 100
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the team.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Name of the team.
+        expr:
+          kind: path
+          path:
+            - fields
+            - name
+      - name: handle
+        type: Utf8
+        nullable: true
+        description: Internal handle for the team.
+        expr:
+          kind: path
+          path:
+            - fields
+            - handle
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Description of the team.
+        expr:
+          kind: path
+          path:
+            - fields
+            - description
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Team creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Team last update timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt


### PR DESCRIPTION
## Summary

Fixes #635

Add a new `productboard` community source that lets Coral query
Productboard workspace data through SQL using the Productboard
REST API v2. This makes notes, features, members, and teams
queryable via standard SQL — enabling product-engineering joins
like "which GitHub PRs relate to our top-requested features?"
or "which Asana tasks map to open Productboard notes?"

This change is manifest-only and uses Coral's existing HTTP
source-spec model. It adds read-only Productboard visibility
without changing CLI, MCP, config, runtime, or bundled-source
contracts.

## What changed

Added:
- `sources/community/productboard/manifest.yaml`
- `sources/community/productboard/README.md`

## Source scope

Inputs:
- `PRODUCTBOARD_ACCESS_TOKEN` — static Bearer token (secret),
  generated from Workspace Settings → Integrations →
  Public APIs → Add Token (requires Pro plan or above)

Tables:
- `productboard.notes`
  - `GET /v2/notes`
  - lists user feedback notes ordered by creation date
  - optional filters: `archived` (filter_bool), `processed`
    (filter_bool), `created_from`, `created_to` (virtual
    time range filters bound to `createdFrom`/`createdTo`)
  - `content` kept as `Json` — polymorphic field that returns
    a string for `textNote` and an array for `conversationNote`
  - cursor pagination via `pageCursor` /
    `response_cursor_path: [links, next]`

- `productboard.features`
  - `GET /v2/entities`
  - uses unified entities endpoint with hardcoded
    `type=feature` query param
  - exposes feature name, status, and timeframe dates
  - cursor pagination via `pageCursor` /
    `response_cursor_path: [links, next]`

- `productboard.members`
  - `GET /v2/members`
  - lists workspace members with role and status
  - optional `query` filter for name/email search
  - ⚠️ name and email fields return `[redacted]` without the
    `members:pii:read` scope on the access token
  - cursor pagination via `pageCursor`

- `productboard.teams`
  - `GET /v2/teams`
  - lists workspace teams with name, handle, and description
  - cursor pagination via `pageCursor`

## Implementation notes

- uses Productboard REST API **v2** — the next-generation API
  launched in 2025. No version header required — auth is
  `Authorization: Bearer {{input.PRODUCTBOARD_ACCESS_TOKEN}}`
- all 4 endpoints wrap responses in `{"data": [...],
  "links": {"next": "...?"}}` → `rows_path: [data]`
- cursor pagination uses `cursor_param: pageCursor` with
  `response_cursor_path: [links, next]` — Coral extracts the
  `pageCursor` token from the full next URL automatically
- `type[]` bracket notation is NOT used — confirmed absent
  from all existing Coral source manifests. Features table
  uses plain `type` query param with value `feature`
- `content` on notes is `Json` to handle the polymorphic
  schema difference between `textNote` (string) and
  `conversationNote` (array of message objects)
- all timestamps are ISO 8601 strings — uses
  `format_timestamp: iso8601` throughout
- nested field paths use multi-level `path` arrays
  (e.g. `[fields, name]`, `[fields, status, id]`) to
  navigate Productboard v2's `fields` wrapper object

## Out of scope

Not included in v1:
- `initiatives`, `components`, `objectives` entity types
  (can be added as additional tables using same entities
  endpoint with different `type` param)
- note relationships and product links
- plugin integrations and webhook subscriptions
- write operations of any kind
- OAuth authentication (PAT only for v1)