### PR TITLE
feat: add Discord community source

### DIFF
--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -1,0 +1,118 @@
+# Discord Source for Coral
+
+A production-ready custom source spec that connects [Coral](https://coral.so) to Discord's REST API v10 via a Bot Token, exposing guilds, channels, messages, and guild members as queryable SQL tables. 
+
+This custom source enables ContextOS and the Coral community to run real-time SQL queries over Discord data with zero setup friction.
+
+---
+
+## 👥 Contributors & Open Source Dedication
+
+This is an open-source contribution to the Coral community, designed, tested, and built by:
+- **Ganesh Bamalwa**
+- **Siddhant Shivam**
+- **Vishal Kumar**
+
+We hope this source empowers you to build awesome conversational intelligence tools!
+
+---
+
+## 🛠 Setup Guide
+
+### 1. Create a Discord Bot in the Developer Portal
+1. Navigate to the [Discord Developer Portal](https://discord.com/developers/applications).
+2. Click **New Application** and give it a name (e.g., `ContextOS Bot`).
+3. Select **Bot** from the left-hand sidebar menu, then click **Add Bot** and confirm.
+4. Locate the **Token** section and click **Reset Token**. Copy this token immediately and save it securely. This is your `DISCORD_BOT_TOKEN`.
+5. Under **Privileged Gateway Intents**, enable:
+   - **Message Content Intent** (required to read the text content of messages in servers).
+   - **Server Members Intent** (required to retrieve the member list for the `guild_members` table).
+6. Click **Save Changes**.
+
+### 2. Generate an OAuth2 Invite Link
+To add the bot to your Discord server:
+1. In the Discord Developer Portal, navigate to the **OAuth2** -> **URL Generator** tab.
+2. Under **Scopes**, select **bot**.
+3. Under **Bot Permissions**, select the following permissions (their combined bitmask is `66560`):
+   - **Read Messages / View Channels**
+   - **Read Message History**
+4. Copy the generated **Invite URL** at the bottom of the page.
+5. Paste this URL into your browser, choose a server you manage, and click **Authorize**.
+
+---
+
+## 💾 Installation
+
+Ensure you have [Coral CLI](https://coral.so/docs) installed. Register the custom source spec file by running:
+
+```bash
+coral source add --file ./discord.yaml
+```
+
+When prompted, paste your Discord Bot Token:
+```bash
+# Paste your bot token when prompted
+```
+
+Alternatively, you can provide the token non-interactively using your environment:
+```bash
+export DISCORD_BOT_TOKEN="your_bot_token"
+coral source add --file ./discord.yaml
+```
+
+---
+
+## 📊 Available Tables
+
+| Table Name | Required Filters | Description |
+| :--- | :--- | :--- |
+| **`discord.guilds`** | *None* | All Discord guilds (servers) the bot is a member of. |
+| **`discord.channels`** | `guild_id` | All channels (text, voice, category, announcement, etc.) in a given guild. |
+| **`discord.messages`** | `channel_id` | Recent messages in a specific channel. Supports an optional `limit` parameter. |
+| **`discord.guild_members`** | `guild_id` | Full list of members within a given guild. |
+
+---
+
+## 🔍 Example Queries
+
+### Step 1: Find your Guild (Server) ID
+Get the ID and basic statistics for all servers your bot has joined:
+```sql
+SELECT id, name, approximate_member_count FROM discord.guilds LIMIT 5;
+```
+
+### Step 2: Retrieve Channels
+List channels in a specific server. **Note:** Discord returns all types of channels (text, voice, category). It is highly recommended to filter by `type = 0` to query text channels exclusively:
+```sql
+-- 0=text, 2=voice, 4=category, 5=announcement, 13=stage, 15=forum
+SELECT id, name, topic FROM discord.channels 
+WHERE guild_id = 'YOUR_GUILD_ID' AND type = 0 
+LIMIT 10;
+```
+
+### Step 3: Query Recent Messages
+Fetch recent messages from a text channel. You can optionally supply a `limit` filter to override the default count:
+```sql
+SELECT author__username, content, timestamp 
+FROM discord.messages 
+WHERE channel_id = 'YOUR_CHANNEL_ID' AND limit = 25;
+```
+
+### Step 4: Retrieve Server Members
+Retrieve the list of users in a guild. This query will return an empty result or error if **Server Members Intent** is not enabled in the developer portal:
+```sql
+SELECT user__username, nick, joined_at 
+FROM discord.guild_members 
+WHERE guild_id = 'YOUR_GUILD_ID' 
+LIMIT 10;
+```
+
+---
+
+## ⚠️ Known Limitations
+
+1. **Approximate Member Count**: The `approximate_member_count` field is normally returned as `null` by Discord's `/users/@me/guilds` endpoint unless specified. This spec automatically appends `?with_counts=true` to the request query parameters to ensure this field is populated correctly.
+2. **Server Members Intent**: The `guild_members` table requires your bot to have the **Server Members Intent** enabled under the **Bot** tab of your Discord Application. Without this, the table will return a `401 Unauthorized` or an empty result set.
+3. **Read Message History**: The bot must have **Read Message History** permissions in the target channel to query `discord.messages`.
+4. **Pagination**: Discord's REST API caps messages at a maximum of 100 per request. This spec retrieves up to the specified `limit` in a single request and does not currently implement cursor-based pagination.
+5. **Token Refresh**: Bot tokens are static and do not expire. If you need to rotate your token, click **Reset Token** in the Discord Developer Portal and re-add the source: `coral source add --file ./discord.yaml`.

--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -6,12 +6,13 @@ This custom source enables ContextOS and the Coral community to run real-time SQ
 
 ---
 
-## 👥 Contributors & Open Source Dedication
+## Contributors
 
-This is an open-source contribution to the Coral community, designed, tested, and built by:
-- **Ganesh Bamalwa**
-- **Siddhant Shivam**
-- **Vishal Kumar**
+Built and contributed to the Coral community by:
+
+- [Ganesh Bamalwa](https://github.com/GaneshBamalwa)
+- [Siddhant Shivam](https://github.com/sidshivam625)
+- [Vishal Kumar](https://github.com/Vishy-MK)
 
 We hope this source empowers you to build awesome conversational intelligence tools!
 
@@ -46,7 +47,7 @@ To add the bot to your Discord server:
 Ensure you have [Coral CLI](https://coral.so/docs) installed. Register the custom source spec file by running:
 
 ```bash
-coral source add --file ./discord.yaml
+coral source add --file ./manifest.yaml
 ```
 
 When prompted, paste your Discord Bot Token:

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -316,6 +316,7 @@ tables:
       mode: cursor
       cursor:
         next_path:
+          - user
           - id
         query_param: after
       page_size:

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -1,0 +1,346 @@
+name: discord
+version: 1.0.0
+dsl_version: 3
+backend: http
+description: >
+  Connect to Discord via a Bot Token to query guilds, channels, messages,
+  and members using Discord's REST API v10.
+inputs:
+  DISCORD_BOT_TOKEN:
+    kind: secret
+    hint: Discord Bot Token (without the 'Bot ' prefix — the source adds it automatically)
+    credential:
+      methods:
+        - type: source_config
+          label: Paste access token
+          description: Paste an existing Discord Bot Token.
+base_url: https://discord.com/api/v10
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bot {{input.DISCORD_BOT_TOKEN}}"
+test_queries:
+  - SELECT id, name FROM discord.guilds LIMIT 1
+tables:
+  - name: guilds
+    description: >
+      All Discord guilds (servers) the bot is a member of.
+      Requires the bot to have 'View Channels' and 'Read Messages' permissions in the server.
+    guide: >
+      `SELECT id, name, approximate_member_count FROM discord.guilds LIMIT 5`.
+    request:
+      method: GET
+      path: /users/@me/guilds
+      query:
+        - name: with_counts
+          from: literal
+          value: "true"
+    pagination:
+      mode: none
+    response:
+      row_strategy: direct
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique guild snowflake ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Guild display name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: icon
+        type: Utf8
+        nullable: true
+        description: Guild icon hash
+        expr:
+          kind: path
+          path:
+            - icon
+      - name: owner
+        type: Boolean
+        nullable: true
+        description: True if the user is the owner of the guild
+        expr:
+          kind: path
+          path:
+            - owner
+      - name: permissions
+        type: Utf8
+        nullable: true
+        description: Total permissions string for the user in the guild
+        expr:
+          kind: path
+          path:
+            - permissions
+      - name: approximate_member_count
+        type: Int64
+        nullable: true
+        description: >
+          Approximate number of members in the guild. Note this only returns a value
+          when the bot requests the guild list with with_counts=true, otherwise it returns null.
+        expr:
+          kind: path
+          path:
+            - approximate_member_count
+
+  - name: channels
+    description: >
+      All channels in a given guild. Filter by type = 0 for text channels,
+      type = 2 for voice channels, type = 4 for category groups,
+      type = 5 for announcement channels, type = 13 for stage channels,
+      and type = 15 for forum channels.
+    guide: >
+      `SELECT id, name, type, topic FROM discord.channels WHERE guild_id = 'YOUR_GUILD_ID' LIMIT 10`.
+    filters:
+      - name: guild_id
+        required: true
+    request:
+      method: GET
+      path: /guilds/{{filter.guild_id}}/channels
+    pagination:
+      mode: none
+    response:
+      row_strategy: direct
+    columns:
+      - name: guild_id
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Virtual column representing the parent guild ID used for filtering channels
+        expr:
+          kind: from_filter
+          key: guild_id
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique channel snowflake ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Channel name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: type
+        type: Int64
+        nullable: false
+        description: Channel type (0=text, 2=voice, 4=category, 5=announcement, 13=stage, 15=forum)
+        expr:
+          kind: path
+          path:
+            - type
+      - name: topic
+        type: Utf8
+        nullable: true
+        description: Channel topic / description
+        expr:
+          kind: path
+          path:
+            - topic
+      - name: position
+        type: Int64
+        nullable: true
+        description: Sort position within the guild
+        expr:
+          kind: path
+          path:
+            - position
+      - name: nsfw
+        type: Boolean
+        nullable: true
+        description: Whether the channel is NSFW (Not Safe For Work)
+        expr:
+          kind: path
+          path:
+            - nsfw
+
+  - name: messages
+    description: >
+      Recent messages in a given channel. The 'limit' filter is optional and
+      defaults to 50 (maximum 100 per Discord API request).
+    guide: >
+      `SELECT author__username, content, timestamp FROM discord.messages WHERE channel_id = 'YOUR_CHANNEL_ID' AND limit = 25`.
+    filters:
+      - name: channel_id
+        required: true
+      - name: limit
+        required: false
+    request:
+      method: GET
+      path: /channels/{{filter.channel_id}}/messages
+      query:
+        - name: limit
+          from: filter
+          key: limit
+    pagination:
+      mode: none
+    response:
+      row_strategy: direct
+    columns:
+      - name: channel_id
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Virtual column representing the parent channel ID used to query messages
+        expr:
+          kind: from_filter
+          key: channel_id
+      - name: limit
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Virtual column representing the maximum number of messages to fetch (default 50, max 100)
+        expr:
+          kind: from_filter
+          key: limit
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique message snowflake ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: content
+        type: Utf8
+        nullable: false
+        description: Raw text content of the message
+        expr:
+          kind: path
+          path:
+            - content
+      - name: timestamp
+        type: Utf8
+        nullable: false
+        description: ISO-8601 timestamp when the message was sent
+        expr:
+          kind: path
+          path:
+            - timestamp
+      - name: edited_timestamp
+        type: Utf8
+        nullable: true
+        description: ISO-8601 timestamp when the message was edited
+        expr:
+          kind: path
+          path:
+            - edited_timestamp
+      - name: author__id
+        type: Utf8
+        nullable: true
+        description: Author user snowflake ID
+        expr:
+          kind: path
+          path:
+            - author
+            - id
+      - name: author__username
+        type: Utf8
+        nullable: true
+        description: Author username
+        expr:
+          kind: path
+          path:
+            - author
+            - username
+      - name: author__discriminator
+        type: Utf8
+        nullable: true
+        description: Author discriminator (legacy tag, if present)
+        expr:
+          kind: path
+          path:
+            - author
+            - discriminator
+      - name: mention_everyone
+        type: Boolean
+        nullable: true
+        description: True if the message mentions everyone
+        expr:
+          kind: path
+          path:
+            - mention_everyone
+      - name: pinned
+        type: Boolean
+        nullable: true
+        description: True if the message is pinned
+        expr:
+          kind: path
+          path:
+            - pinned
+
+  - name: guild_members
+    description: >
+      Members of a given guild. Requires the bot to have 'Server Members Intent'
+      enabled in the Discord Developer Portal under Bot > Privileged Gateway Intents.
+      Without this intent the endpoint will return an error or empty result.
+    guide: >
+      `SELECT user__username, nick, joined_at FROM discord.guild_members WHERE guild_id = 'YOUR_GUILD_ID' LIMIT 10`.
+    filters:
+      - name: guild_id
+        required: true
+    request:
+      method: GET
+      path: /guilds/{{filter.guild_id}}/members
+    pagination:
+      mode: none
+    response:
+      row_strategy: direct
+    columns:
+      - name: guild_id
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Virtual column representing the parent guild ID used to retrieve members
+        expr:
+          kind: from_filter
+          key: guild_id
+      - name: user__id
+        type: Utf8
+        nullable: false
+        description: Unique snowflake ID of the guild member
+        expr:
+          kind: path
+          path:
+            - user
+            - id
+      - name: user__username
+        type: Utf8
+        nullable: false
+        description: Username of the guild member
+        expr:
+          kind: path
+          path:
+            - user
+            - username
+      - name: nick
+        type: Utf8
+        nullable: true
+        description: Server-specific nickname of the member, if set
+        expr:
+          kind: path
+          path:
+            - nick
+      - name: joined_at
+        type: Utf8
+        nullable: false
+        description: ISO-8601 timestamp representing when the member joined the guild
+        expr:
+          kind: path
+          path:
+            - joined_at

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -309,8 +309,19 @@ tables:
         - name: limit
           from: literal
           value: "100"
+        - name: after
+          from: cursor
+          key: after
     pagination:
-      mode: none
+      mode: cursor
+      cursor:
+        next_path:
+          - id
+        query_param: after
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
     response:
       row_strategy: direct
     columns:

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -38,7 +38,15 @@ tables:
           from: literal
           value: "true"
     pagination:
-      mode: none
+      mode: cursor
+      cursor:
+        next_path:
+          - id
+        query_param: after
+      page_size:
+        default: 200
+        max: 200
+        query_param: limit
     response:
       row_strategy: direct
     columns:
@@ -297,6 +305,10 @@ tables:
     request:
       method: GET
       path: /guilds/{{filter.guild_id}}/members
+      query:
+        - name: limit
+          from: literal
+          value: "100"
     pagination:
       mode: none
     response:


### PR DESCRIPTION
You're on the final step. Paste this in the description box:

## Discord Community Source

Adds Discord as a queryable source in Coral via the Discord Bot API (v10).

### Tables
- `discord.guilds` — All servers the bot is a member of
- `discord.channels` — All channels in a given guild (filter by `type = 0` for text channels)
- `discord.messages` — Recent messages in a given channel
- `discord.guild_members` — Members of a given guild

### Setup Requirements
- A Discord bot token from the Discord Developer Portal
- Bot must be invited to the server with Read Messages + Read Message History permissions (`66560`)
- `Server Members Intent` must be enabled in the Developer Portal for `guild_members` to work

### Validation
- `coral source lint` passes with zero errors
- `coral source test discord` passes
- All four tables manually verified returning data

### Notes
- Uses `with_counts=true` on the guilds endpoint so `approximate_member_count` returns values
- No pagination — Discord API caps messages at 100 per request
- Bot tokens do not expire but can be regenerated in the Developer Portal