### PR TITLE
fix(plugin): stop enabling feedback at startup

### DIFF
--- a/plugins/coral/.mcp.json
+++ b/plugins/coral/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "Coral": {
       "command": "coral",
-      "args": ["mcp-stdio", "--enable-feedback"]
+      "args": ["mcp-stdio"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Remove the plugin MCP startup argument that enabled feedback by default.

Feedback is now a runtime feature and should be enabled explicitly with:

```sh
coral features enable feedback
```

## Validation

- `jq . plugins/coral/.mcp.json >/dev/null`
- `rg --hidden --line-number -- '--enable-feedback' plugins/coral` returned no matches
