### PR TITLE
feat(sources/community/aws_cost_explorer): add AWS Cost Explorer source

### DIFF
--- a/sources/community/aws_cost_explorer/README.md
+++ b/sources/community/aws_cost_explorer/README.md
@@ -33,8 +33,17 @@ Create a policy with the following permissions (all read-only):
 }
 ```
 
-Cost Explorer IAM actions only support `Resource: "*"` — resource-level
-scoping is not available.
+The example policy uses `Resource: "*"` for simplicity, which works for
+every action this source calls. Some Cost Explorer actions also support
+resource-level scoping and tag-based conditions if you want to tighten the
+policy: `ce:GetCostAndUsage` and `ce:GetCostForecast` support the
+`billingview` resource type, `ce:GetAnomalies` is scoped to the
+`anomalymonitor` resource type, and these actions accept the
+`aws:ResourceTag/${TagKey}` condition key. `ce:GetRightsizingRecommendation`
+and `ce:GetSavingsPlansCoverage` have no resource type and require
+`Resource: "*"`. See the
+[Cost Explorer service authorization reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awscostexplorerservice.html)
+for the full action-to-resource mapping.
 
 ### Step 2 — Enable Cost Explorer
 
@@ -74,6 +83,16 @@ and AWS GovCloud (US) does not expose a Cost Explorer endpoint. Coral
 does not read your AWS CLI profile, AWS SSO cache, or `AWS_PROFILE` —
 credentials must be supplied via the four environment variables above
 (or `coral source add --interactive`).
+
+> **Billable API.** Cost Explorer API requests are billed by AWS at
+> $0.01 per paginated request ([pricing](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/pricing/)),
+> independent of the free Cost Explorer console. Coral follows
+> `NextPageToken`/`NextToken` until the result set is exhausted, so a
+> single broad query can issue many billable requests: `cost_by_service`
+> and `cost_by_tag` page up to 100 requests, `anomalies` and
+> `savings_plans_coverage` up to 50, and `rightsizing_recommendations` up
+> to 20. Narrow the time window, filter, or add `LIMIT` to keep wide scans
+> from fanning out into dozens of charges.
 
 ## Tables
 
@@ -121,7 +140,7 @@ WHERE time_period_start = '2026-05-01'
   AND time_period_end   = '2026-06-01'
 ```
 
-To work with individual services, use `json_get_json` on the `groups` column:
+To inspect a single element, use `json_get_json` on the `groups` column:
 
 ```sql
 SELECT
@@ -133,6 +152,32 @@ FROM aws_cost_explorer.cost_by_service
 WHERE time_period_start = '2026-05-01'
   AND time_period_end   = '2026-06-01'
 ```
+
+To analyze **all** services rather than just the first element, expand the
+`groups` array into one row per service with
+`unnest(json_get_array(groups))`, then project the fields you need. This is
+how you answer questions like "top services by spend":
+
+```sql
+SELECT
+    json_get_str(g, 'Keys', 0)                              AS service,
+    CAST(json_get_str(g, 'Metrics', 'UnblendedCost', 'Amount') AS DOUBLE) AS cost_usd
+FROM (
+    SELECT unnest(json_get_array(groups)) AS g
+    FROM aws_cost_explorer.cost_by_service
+    WHERE time_period_start = '2026-05-01'
+      AND time_period_end   = '2026-06-01'
+)
+ORDER BY cost_usd DESC
+LIMIT 10
+```
+
+`json_get_array(groups)` returns the array as a list, `unnest` explodes it to
+one row per element, and `json_get_str(g, 'Keys', 0)` / `json_get_str(g,
+'Metrics', '<metric>', 'Amount')` read each element. Match the metric key to
+the `metric` filter you bound (e.g. `'AmortizedCost'` when
+`metric = 'AmortizedCost'`); it defaults to `UnblendedCost`. Wrap the
+extracted amount in `CAST(... AS DOUBLE)` before sorting or aggregating.
 
 ### `aws_cost_explorer.cost_by_tag`
 
@@ -152,6 +197,26 @@ FROM aws_cost_explorer.cost_by_tag
 WHERE time_period_start = '2026-05-01'
   AND time_period_end   = '2026-06-01'
   AND tag_key           = 'aws:cloudformation:stack-name'
+```
+
+To rank all tag values by spend, expand the `groups` array the same way as
+`cost_by_service` — `unnest(json_get_array(groups))` gives one row per tag
+value. Resources with no value for the tag appear with an empty string as
+the `Keys` value:
+
+```sql
+SELECT
+    json_get_str(g, 'Keys', 0)                              AS tag_value,
+    CAST(json_get_str(g, 'Metrics', 'UnblendedCost', 'Amount') AS DOUBLE) AS cost_usd
+FROM (
+    SELECT unnest(json_get_array(groups)) AS g
+    FROM aws_cost_explorer.cost_by_tag
+    WHERE time_period_start = '2026-05-01'
+      AND time_period_end   = '2026-06-01'
+      AND tag_key           = 'aws:cloudformation:stack-name'
+)
+ORDER BY cost_usd DESC
+LIMIT 10
 ```
 
 ### `aws_cost_explorer.anomalies`
@@ -210,8 +275,11 @@ a prediction beyond. Supported metrics are narrower than `cost_by_service`
 `NET_AMORTIZED_COST`, and `NET_UNBLENDED_COST`.
 
 ```sql
--- Forecast from yesterday through end of next month. Use yesterday's
--- date as the start because earlier starts are rejected by AWS.
+-- Forecast from yesterday through the end of next month. Replace the
+-- dates below with your own run: time_period_start must be "yesterday"
+-- (AWS rejects earlier starts), and time_period_end is exclusive. The
+-- literals here are illustrative for a run on 2026-05-31; substitute the
+-- current yesterday/next-month-start when you query.
 SELECT
     period_start,
     CAST(mean_value AS DOUBLE)                       AS expected_usd,
@@ -223,6 +291,15 @@ WHERE time_period_start         = '2026-05-30'
   AND metric                    = 'UNBLENDED_COST'
   AND prediction_interval_level = 80
 ```
+
+The filters also accept computed expressions, so you can avoid hand-editing
+dates — for example
+`time_period_start = CAST(current_date - INTERVAL '1 day' AS VARCHAR)`.
+Note that "yesterday" is evaluated against AWS's service clock: if the host
+clock lags UTC, a computed `current_date - 1 day` can land one day before
+AWS's earliest supported start and return
+`ValidationException ("Earliest supported Start is …")`. If that happens,
+use the date from the error message (AWS's "yesterday") as the start.
 
 ### `aws_cost_explorer.rightsizing_recommendations`
 
@@ -276,6 +353,11 @@ ORDER BY CAST(on_demand_cost AS DOUBLE) DESC
 
 ## Notes
 
+- **Billable requests:** Cost Explorer API calls cost $0.01 per paginated
+  request. Broad queries paginate (up to 100 requests for `cost_by_service`
+  and `cost_by_tag`), so narrow the window or add `LIMIT` to avoid
+  unexpected charges. See the billable-API note under
+  [Authentication](#authentication).
 - **Data lag:** Cost Explorer data has a ~24-hour lag. The current open month
   is marked `estimated = true`.
 - **End date is exclusive:** `time_period_end = '2026-06-01'` includes all of

--- a/sources/community/aws_cost_explorer/README.md
+++ b/sources/community/aws_cost_explorer/README.md
@@ -46,6 +46,16 @@ After activation, the API becomes available within 24 hours.
 
 Attach the policy to an IAM user and generate an access key pair.
 
+> **Long-term IAM keys only.** This source signs requests with the
+> `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` pair as-is. Temporary
+> credentials that require a session token — STS `AssumeRole`, IAM
+> Identity Center / SSO, EC2 instance roles, EKS / IRSA — are **not
+> supported** because `AWS_SESSION_TOKEN` is not threaded through the
+> SigV4 authenticator yet. Access keys whose ID starts with `ASIA` are
+> session-scoped and will fail with `InvalidClientTokenId` or
+> `SignatureDoesNotMatch`. Use a long-term IAM user key (the ID starts
+> with `AKIA`).
+
 ### Step 4 — Add the source
 
 ```sh

--- a/sources/community/aws_cost_explorer/README.md
+++ b/sources/community/aws_cost_explorer/README.md
@@ -1,0 +1,277 @@
+# AWS Cost Explorer
+
+Query AWS billing data including cost by service, cost by resource tag,
+detected cost anomalies, cost forecasts, EC2 rightsizing recommendations, and
+Savings Plans coverage from
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/).
+
+## Authentication
+
+AWS Cost Explorer uses AWS Signature Version 4. You need an IAM user with
+read-only Cost Explorer permissions.
+
+### Step 1 — Create an IAM policy
+
+Create a policy with the following permissions (all read-only):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ce:GetCostAndUsage",
+        "ce:GetAnomalies",
+        "ce:GetCostForecast",
+        "ce:GetRightsizingRecommendation",
+        "ce:GetSavingsPlansCoverage"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Cost Explorer IAM actions only support `Resource: "*"` — resource-level
+scoping is not available.
+
+### Step 2 — Enable Cost Explorer
+
+Cost Explorer must be activated before the API returns data. In the AWS
+console, go to **Billing and Cost Management → Cost Explorer → Enable**.
+After activation, the API becomes available within 24 hours.
+
+### Step 3 — Create access keys
+
+Attach the policy to an IAM user and generate an access key pair.
+
+### Step 4 — Add the source
+
+```sh
+export AWS_ACCESS_KEY_ID="AKIA..."
+export AWS_SECRET_ACCESS_KEY="..."
+# Optional — defaults shown:
+export AWS_REGION="us-east-1"             # us-gov-west-1 for GovCloud, cn-northwest-1 for China
+export AWS_ENDPOINT_SUFFIX="amazonaws.com"  # amazonaws.com.cn for China
+coral source add --file sources/community/aws_cost_explorer/manifest.yaml
+```
+
+`AWS_REGION` and `AWS_ENDPOINT_SUFFIX` default to `us-east-1` and
+`amazonaws.com`. Override them only for AWS GovCloud (US) or the China
+partition. Coral does not read your AWS CLI profile, AWS SSO cache, or
+`AWS_PROFILE` — credentials must be supplied via the four environment
+variables above (or `coral source add --interactive`).
+
+## Tables
+
+| Table | Description | Required filters |
+|---|---|---|
+| `aws_cost_explorer.cost_by_service` | Spend grouped by AWS service | `time_period_start`, `time_period_end` |
+| `aws_cost_explorer.cost_by_tag` | Spend grouped by a resource tag key | `time_period_start`, `time_period_end`, `tag_key` |
+| `aws_cost_explorer.anomalies` | Cost anomalies detected by AWS's ML models | `date_interval_start`, `date_interval_end` |
+| `aws_cost_explorer.cost_forecast` | Projected cost for a future or in-progress period | `time_period_start`, `time_period_end`, `granularity`, `metric` |
+| `aws_cost_explorer.rightsizing_recommendations` | EC2 downsize/terminate recommendations | — |
+| `aws_cost_explorer.savings_plans_coverage` | Savings Plans coverage by service | `time_period_start`, `time_period_end` |
+
+`cost_by_service` and `cost_by_tag` accept an optional `metric` filter
+(`UNBLENDED_COST`, `BLENDED_COST`, `AMORTIZED_COST`, `NET_AMORTIZED_COST`,
+`NET_UNBLENDED_COST`, `USAGE_QUANTITY`, `NORMALIZED_USAGE_AMOUNT`) and an
+optional `granularity` filter (`MONTHLY`, `DAILY`, `HOURLY`). Both default to
+`UNBLENDED_COST` and `MONTHLY` when omitted. `HOURLY` is opt-in on the AWS
+account and limited to the last 14 days. Per-metric typed columns
+(`unblended_cost`, `blended_cost`, `amortized_cost`, `net_amortized_cost`,
+`net_unblended_cost`, `usage_quantity`, `normalized_usage_amount`) are
+populated only for the requested `metric`; the other six are NULL on the
+same row. `period_total_cost` and `unit` always reflect the requested
+metric.
+
+For example, `metric = 'AMORTIZED_COST'` produces:
+
+| period_start | period_total_cost | amortized_cost | unblended_cost | blended_cost |
+|---|---|---|---|---|
+| 2026-04-01   | 3421.78           | 3421.78        | NULL           | NULL         |
+
+`unblended_cost` and the other five metric columns return NULL because the
+API only returns the metric you asked for. Use the typed column matching
+your filter, or the always-populated `period_total_cost`.
+
+### `aws_cost_explorer.cost_by_service`
+
+Returns one row per billing period with the aggregate cost and a `groups` JSON
+array containing the per-service breakdown. `time_period_end` is **exclusive**
+— use the first day of the following month to include all days of the target month.
+
+```sql
+SELECT
+    period_start,
+    period_total_cost,
+    estimated,
+    groups
+FROM aws_cost_explorer.cost_by_service
+WHERE time_period_start = '2026-05-01'
+  AND time_period_end   = '2026-06-01'
+```
+
+To work with individual services, use `json_get_json` on the `groups` column:
+
+```sql
+SELECT
+    period_start,
+    json_get_json(groups, 0)                                                    AS first_service_json,
+    json_get_str(json_get_json(groups, 0), 'Keys', 0)                          AS first_service_name,
+    json_get_str(json_get_json(groups, 0), 'Metrics', 'UnblendedCost', 'Amount') AS first_service_cost
+FROM aws_cost_explorer.cost_by_service
+WHERE time_period_start = '2026-05-01'
+  AND time_period_end   = '2026-06-01'
+```
+
+### `aws_cost_explorer.cost_by_tag`
+
+Returns one row per billing period with the aggregate cost and a `groups` JSON
+array containing the per-tag-value breakdown. The AWS-managed tag
+`aws:cloudformation:stack-name` is automatically activated — use it to
+attribute costs to CloudFormation stacks.
+
+```sql
+SELECT
+    period_start,
+    groups
+FROM aws_cost_explorer.cost_by_tag
+WHERE time_period_start = '2026-05-01'
+  AND time_period_end   = '2026-06-01'
+  AND tag_key           = 'aws:cloudformation:stack-name'
+```
+
+### `aws_cost_explorer.anomalies`
+
+Returns cost anomalies detected by AWS's ML baseline. AWS retains anomalies
+for up to 90 days. `anomaly_end_date` is `NULL` for ongoing spikes.
+Optional filters: `total_impact_min` (whole-dollar threshold),
+`feedback` (`YES`, `NO`, `PLANNED_ACTIVITY` — user-supplied classification),
+and `monitor_arn` (restrict to a specific Cost Anomaly Monitor).
+
+```sql
+SELECT
+    anomaly_start_date,
+    dimension_value AS service,
+    CAST(total_impact AS DOUBLE) AS impact_usd,
+    CAST(total_impact_percentage AS DOUBLE) AS pct_above_expected
+FROM aws_cost_explorer.anomalies
+WHERE date_interval_start = '2026-04-01'
+  AND date_interval_end   = '2026-05-29'
+  AND total_impact_min    = 50
+ORDER BY CAST(total_impact AS DOUBLE) DESC
+```
+
+To inspect root causes, drill into the `root_causes` JSON array:
+
+```sql
+SELECT
+    anomaly_id,
+    json_get_str(json_get_json(root_causes, 0), 'Service')     AS top_root_service,
+    json_get_str(json_get_json(root_causes, 0), 'Region')      AS top_root_region,
+    json_get_str(json_get_json(root_causes, 0), 'UsageType')   AS top_root_usage_type
+FROM aws_cost_explorer.anomalies
+WHERE date_interval_start = '2026-04-01'
+  AND date_interval_end   = '2026-05-29'
+```
+
+### `aws_cost_explorer.cost_forecast`
+
+Projects cost for a future or in-progress period. `time_period_start` must be
+today or later — past dates return `ValidationException`. `DAILY` allows up
+to 3 months ahead; `MONTHLY` up to 18 months. Supported metrics are narrower
+than `cost_by_service` — only `UNBLENDED_COST`, `BLENDED_COST`,
+`AMORTIZED_COST`, `NET_AMORTIZED_COST`, and `NET_UNBLENDED_COST`.
+
+```sql
+SELECT
+    period_start,
+    CAST(mean_value AS DOUBLE)                       AS expected_usd,
+    CAST(prediction_interval_upper_bound AS DOUBLE)  AS conservative_usd
+FROM aws_cost_explorer.cost_forecast
+WHERE time_period_start         = '2026-05-29'
+  AND time_period_end           = '2026-06-01'
+  AND granularity               = 'DAILY'
+  AND metric                    = 'UNBLENDED_COST'
+  AND prediction_interval_level = 80
+```
+
+### `aws_cost_explorer.rightsizing_recommendations`
+
+Returns EC2 instances AWS recommends downsizing or terminating based on 14
+days of CloudWatch CPU data. Memory-based recommendations require the
+CloudWatch agent.
+
+```sql
+SELECT
+    instance_id,
+    instance_type,
+    CAST(monthly_cost AS DOUBLE)             AS current_monthly_usd,
+    recommendation_type,
+    target_instance_type,
+    CAST(estimated_monthly_savings AS DOUBLE) AS savings_usd
+FROM aws_cost_explorer.rightsizing_recommendations
+WHERE recommendation_type = 'MODIFY'
+ORDER BY CAST(estimated_monthly_savings AS DOUBLE) DESC
+```
+
+### `aws_cost_explorer.savings_plans_coverage`
+
+Shows how much eligible on-demand spend is covered by an active Savings
+Plan. Coverage below 80% with significant `on_demand_cost` is a strong
+signal to review commitment purchases. Returns
+`DataUnavailableException` from AWS when the account has no Savings Plans
+in the requested period — that is account state, not a query error.
+
+`coverage_pct` is computed by AWS as
+`spend_covered_by_savings_plans / total_cost * 100`, where
+`total_cost = on_demand_cost + spend_covered_by_savings_plans`.
+
+```sql
+SELECT
+    service,
+    CAST(coverage_pct AS DOUBLE)                     AS coverage_pct,
+    CAST(on_demand_cost AS DOUBLE)                   AS uncovered_usd,
+    CAST(spend_covered_by_savings_plans AS DOUBLE)   AS covered_usd,
+    CAST(total_cost AS DOUBLE)                       AS total_usd
+FROM aws_cost_explorer.savings_plans_coverage
+WHERE time_period_start = '2026-04-01'
+  AND time_period_end   = '2026-05-01'
+  AND CAST(coverage_pct AS DOUBLE) < 80
+ORDER BY CAST(on_demand_cost AS DOUBLE) DESC
+```
+
+## Notes
+
+- **Data lag:** Cost Explorer data has a ~24-hour lag. The current open month
+  is marked `estimated = true`.
+- **End date is exclusive:** `time_period_end = '2026-06-01'` includes all of
+  May 2026 but no June data.
+- **Data retention:** `cost_by_service` and `cost_by_tag` keep 14 months of
+  daily data by default and up to 38 months of monthly data when the
+  multi-year opt-in is enabled. `savings_plans_coverage` requires the
+  start date to be within the last 13 months. `anomalies` retains up to
+  90 days. `cost_forecast` requires `time_period_start` to be today or
+  later. The example dates above stay valid as long as the underlying
+  retention window includes them — refresh the dates if you re-run after
+  a long gap.
+- **String columns to cast:** every numeric-looking column on every table
+  in this source is `Utf8` and must be cast before arithmetic. This
+  includes all `*_cost` and `*_amount` columns, `period_total_cost`,
+  `mean_value`, `prediction_interval_lower_bound`,
+  `prediction_interval_upper_bound`, `total_impact`,
+  `total_impact_percentage`, `max_impact`, `total_actual_spend`,
+  `total_expected_spend`, `monthly_cost`, `estimated_monthly_savings`,
+  `coverage_pct`, `cpu_utilization_pct`, `memory_utilization_pct`, and
+  `usage_quantity` / `normalized_usage_amount`. Use
+  `CAST(<column> AS DOUBLE)` before any comparison or arithmetic.
+  Boolean (`actions_enabled`, `estimated`), Float64
+  (`current_score`, `max_score`), and Int64 columns project as their
+  declared types.
+- **Tag activation:** User-defined tags must be activated under
+  **Billing → Cost allocation tags** before they appear in `cost_by_tag`.
+  The `aws:cloudformation:stack-name` tag is auto-activated.
+- **Cost Explorer must be enabled:** The API returns `OptInRequired` if Cost
+  Explorer has never been activated in the account.

--- a/sources/community/aws_cost_explorer/README.md
+++ b/sources/community/aws_cost_explorer/README.md
@@ -50,11 +50,11 @@ Attach the policy to an IAM user and generate an access key pair.
 > `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` pair as-is. Temporary
 > credentials that require a session token — STS `AssumeRole`, IAM
 > Identity Center / SSO, EC2 instance roles, EKS / IRSA — are **not
-> supported** because `AWS_SESSION_TOKEN` is not threaded through the
-> SigV4 authenticator yet. Access keys whose ID starts with `ASIA` are
-> session-scoped and will fail with `InvalidClientTokenId` or
-> `SignatureDoesNotMatch`. Use a long-term IAM user key (the ID starts
-> with `AKIA`).
+> supported** because there is no manifest path to thread
+> `AWS_SESSION_TOKEN` through the SigV4 authenticator yet. Access keys
+> whose ID starts with `ASIA` are session-scoped and will fail with
+> `InvalidClientTokenId` or `SignatureDoesNotMatch`. Use a long-term IAM
+> user key (the ID starts with `AKIA`).
 
 ### Step 4 — Add the source
 
@@ -62,16 +62,18 @@ Attach the policy to an IAM user and generate an access key pair.
 export AWS_ACCESS_KEY_ID="AKIA..."
 export AWS_SECRET_ACCESS_KEY="..."
 # Optional — defaults shown:
-export AWS_REGION="us-east-1"             # us-gov-west-1 for GovCloud, cn-northwest-1 for China
-export AWS_ENDPOINT_SUFFIX="amazonaws.com"  # amazonaws.com.cn for China
+export AWS_REGION="us-east-1"             # cn-northwest-1 for the China partition
+export AWS_ENDPOINT_SUFFIX="amazonaws.com"  # amazonaws.com.cn for the China partition
 coral source add --file sources/community/aws_cost_explorer/manifest.yaml
 ```
 
 `AWS_REGION` and `AWS_ENDPOINT_SUFFIX` default to `us-east-1` and
-`amazonaws.com`. Override them only for AWS GovCloud (US) or the China
-partition. Coral does not read your AWS CLI profile, AWS SSO cache, or
-`AWS_PROFILE` — credentials must be supplied via the four environment
-variables above (or `coral source add --interactive`).
+`amazonaws.com`. Override them only for the China partition. Cost
+Explorer is a global service with one regional endpoint per partition,
+and AWS GovCloud (US) does not expose a Cost Explorer endpoint. Coral
+does not read your AWS CLI profile, AWS SSO cache, or `AWS_PROFILE` —
+credentials must be supplied via the four environment variables above
+(or `coral source add --interactive`).
 
 ## Tables
 
@@ -80,42 +82,38 @@ variables above (or `coral source add --interactive`).
 | `aws_cost_explorer.cost_by_service` | Spend grouped by AWS service | `time_period_start`, `time_period_end` |
 | `aws_cost_explorer.cost_by_tag` | Spend grouped by a resource tag key | `time_period_start`, `time_period_end`, `tag_key` |
 | `aws_cost_explorer.anomalies` | Cost anomalies detected by AWS's ML models | `date_interval_start`, `date_interval_end` |
-| `aws_cost_explorer.cost_forecast` | Projected cost for a future or in-progress period | `time_period_start`, `time_period_end`, `granularity`, `metric` |
+| `aws_cost_explorer.cost_forecast` | Projected cost for an in-progress or future period | `time_period_start`, `time_period_end`, `granularity`, `metric` |
 | `aws_cost_explorer.rightsizing_recommendations` | EC2 downsize/terminate recommendations | — |
 | `aws_cost_explorer.savings_plans_coverage` | Savings Plans coverage by service | `time_period_start`, `time_period_end` |
 
 `cost_by_service` and `cost_by_tag` accept an optional `metric` filter
-(`UNBLENDED_COST`, `BLENDED_COST`, `AMORTIZED_COST`, `NET_AMORTIZED_COST`,
-`NET_UNBLENDED_COST`, `USAGE_QUANTITY`, `NORMALIZED_USAGE_AMOUNT`) and an
+(`UnblendedCost`, `BlendedCost`, `AmortizedCost`, `NetAmortizedCost`,
+`NetUnblendedCost`, `UsageQuantity`, `NormalizedUsageAmount`) and an
 optional `granularity` filter (`MONTHLY`, `DAILY`, `HOURLY`). Both default to
-`UNBLENDED_COST` and `MONTHLY` when omitted. `HOURLY` is opt-in on the AWS
-account and limited to the last 14 days. Per-metric typed columns
-(`unblended_cost`, `blended_cost`, `amortized_cost`, `net_amortized_cost`,
-`net_unblended_cost`, `usage_quantity`, `normalized_usage_amount`) are
-populated only for the requested `metric`; the other six are NULL on the
-same row. `period_total_cost` and `unit` always reflect the requested
-metric.
+`UnblendedCost` and `MONTHLY` when omitted. `HOURLY` is opt-in at the
+AWS payer-account level and limited to the last 14 days; it also
+requires `time_period_start` and `time_period_end` to be passed as
+ISO-8601 timestamps (e.g. `'2026-05-29T00:00:00Z'`) rather than
+`YYYY-MM-DD` dates, or AWS will reject the request with
+`ValidationException` (`"Time period is invalid. Valid format is
+yyyy-MM-ddThh:mm:ssZ."`).
 
-For example, `metric = 'AMORTIZED_COST'` produces:
-
-| period_start | period_total_cost | amortized_cost | unblended_cost | blended_cost |
-|---|---|---|---|---|
-| 2026-04-01   | 3421.78           | 3421.78        | NULL           | NULL         |
-
-`unblended_cost` and the other five metric columns return NULL because the
-API only returns the metric you asked for. Use the typed column matching
-your filter, or the always-populated `period_total_cost`.
+Both tables hardcode a `GroupBy` on the request — `SERVICE` for
+`cost_by_service`, the supplied `tag_key` for `cost_by_tag` — and AWS
+returns the response `Total` block as an empty object whenever a
+`GroupBy` is set. The cost values therefore live exclusively under the
+`groups` JSON array; there is no scalar period-total column. Sum across
+the entries in `groups` to compute a period-level aggregate.
 
 ### `aws_cost_explorer.cost_by_service`
 
-Returns one row per billing period with the aggregate cost and a `groups` JSON
-array containing the per-service breakdown. `time_period_end` is **exclusive**
-— use the first day of the following month to include all days of the target month.
+Returns one row per billing period with a `groups` JSON array containing the
+per-service breakdown. `time_period_end` is **exclusive** — use the first day
+of the following month to include all days of the target month.
 
 ```sql
 SELECT
     period_start,
-    period_total_cost,
     estimated,
     groups
 FROM aws_cost_explorer.cost_by_service
@@ -138,10 +136,13 @@ WHERE time_period_start = '2026-05-01'
 
 ### `aws_cost_explorer.cost_by_tag`
 
-Returns one row per billing period with the aggregate cost and a `groups` JSON
-array containing the per-tag-value breakdown. The AWS-managed tag
-`aws:cloudformation:stack-name` is automatically activated — use it to
-attribute costs to CloudFormation stacks.
+Returns one row per billing period with a `groups` JSON array containing the
+per-tag-value breakdown. To attribute costs to CloudFormation stacks, group
+by the AWS-generated tag `aws:cloudformation:stack-name`. Both user-defined
+tags and AWS-generated tags must be activated under
+**Billing → Cost Allocation Tags** before they return any rows. Activation
+is non-retroactive (older billing periods stay empty) and only the
+management account can activate tags in AWS Organizations.
 
 ```sql
 SELECT
@@ -157,6 +158,9 @@ WHERE time_period_start = '2026-05-01'
 
 Returns cost anomalies detected by AWS's ML baseline. AWS retains anomalies
 for up to 90 days. `anomaly_end_date` is `NULL` for ongoing spikes.
+`date_interval_end` has an upper bound of "yesterday" — AWS rejects
+end dates of today or later with `ValidationException` (the live error
+reads `"Latest supported detectionDate for GetRecentAnomalies is …"`).
 Optional filters: `total_impact_min` (whole-dollar threshold),
 `feedback` (`YES`, `NO`, `PLANNED_ACTIVITY` — user-supplied classification),
 and `monitor_arn` (restrict to a specific Cost Anomaly Monitor).
@@ -189,20 +193,32 @@ WHERE date_interval_start = '2026-04-01'
 
 ### `aws_cost_explorer.cost_forecast`
 
-Projects cost for a future or in-progress period. `time_period_start` must be
-today or later — past dates return `ValidationException`. `DAILY` allows up
-to 3 months ahead; `MONTHLY` up to 18 months. Supported metrics are narrower
-than `cost_by_service` — only `UNBLENDED_COST`, `BLENDED_COST`,
-`AMORTIZED_COST`, `NET_AMORTIZED_COST`, and `NET_UNBLENDED_COST`.
+Projects cost for an in-progress or future period. `time_period_start` has
+a hard lower bound of "yesterday" — AWS rejects earlier starts with
+`ValidationException` (`"Earliest supported Start is …"`). Future starts
+are accepted in practice even though AWS docs say the start "must be equal
+to or no later than the current date"; in live tests AWS returns
+`DataUnavailableException` ("Insufficient amount of historical data")
+rather than rejecting the start date itself when there is no history to
+forecast from. `time_period_end` has its own ceiling: AWS rejects ends
+more than ~3 months ahead at `DAILY` granularity (or ~18 months ahead
+at `MONTHLY`) with `ValidationException`
+(`"Latest supported End is …"`). The forecast covers `time_period_start`
+through `time_period_end` exclusive; AWS blends actuals up to today with
+a prediction beyond. Supported metrics are narrower than `cost_by_service`
+— only `UNBLENDED_COST`, `BLENDED_COST`, `AMORTIZED_COST`,
+`NET_AMORTIZED_COST`, and `NET_UNBLENDED_COST`.
 
 ```sql
+-- Forecast from yesterday through end of next month. Use yesterday's
+-- date as the start because earlier starts are rejected by AWS.
 SELECT
     period_start,
     CAST(mean_value AS DOUBLE)                       AS expected_usd,
     CAST(prediction_interval_upper_bound AS DOUBLE)  AS conservative_usd
 FROM aws_cost_explorer.cost_forecast
-WHERE time_period_start         = '2026-05-29'
-  AND time_period_end           = '2026-06-01'
+WHERE time_period_start         = '2026-05-30'
+  AND time_period_end           = '2026-07-01'
   AND granularity               = 'DAILY'
   AND metric                    = 'UNBLENDED_COST'
   AND prediction_interval_level = 80
@@ -231,9 +247,14 @@ ORDER BY CAST(estimated_monthly_savings AS DOUBLE) DESC
 
 Shows how much eligible on-demand spend is covered by an active Savings
 Plan. Coverage below 80% with significant `on_demand_cost` is a strong
-signal to review commitment purchases. Returns
-`DataUnavailableException` from AWS when the account has no Savings Plans
-in the requested period — that is account state, not a query error.
+signal to review commitment purchases. AWS returns
+`DataUnavailableException` (HTTP 400) when the account has no Savings
+Plans in the requested period; this surfaces as a query error rather
+than zero rows. Treat that error as account state, not a manifest
+problem. `time_period_end` is exclusive and AWS rejects end dates after
+today with `ValidationException`
+(`"end date should NOT be after [today]"`); use today's date for an
+in-progress month.
 
 `coverage_pct` is computed by AWS as
 `spend_covered_by_savings_plans / total_cost * 100`, where
@@ -262,26 +283,34 @@ ORDER BY CAST(on_demand_cost AS DOUBLE) DESC
 - **Data retention:** `cost_by_service` and `cost_by_tag` keep 14 months of
   daily data by default and up to 38 months of monthly data when the
   multi-year opt-in is enabled. `savings_plans_coverage` requires the
-  start date to be within the last 13 months. `anomalies` retains up to
-  90 days. `cost_forecast` requires `time_period_start` to be today or
-  later. The example dates above stay valid as long as the underlying
-  retention window includes them — refresh the dates if you re-run after
-  a long gap.
+  start date to be within the last 13 months and the end date to be
+  today or earlier (AWS rejects future end dates). `anomalies` retains
+  up to 90 days and `date_interval_end` is bounded at "yesterday" by
+  AWS. `cost_forecast` requires `time_period_start` to be yesterday or
+  later — AWS rejects earlier starts. The example dates above stay
+  valid as long as the underlying retention window includes them —
+  refresh the dates if you re-run after a long gap.
 - **String columns to cast:** every numeric-looking column on every table
   in this source is `Utf8` and must be cast before arithmetic. This
-  includes all `*_cost` and `*_amount` columns, `period_total_cost`,
-  `mean_value`, `prediction_interval_lower_bound`,
+  includes `mean_value`, `prediction_interval_lower_bound`,
   `prediction_interval_upper_bound`, `total_impact`,
   `total_impact_percentage`, `max_impact`, `total_actual_spend`,
   `total_expected_spend`, `monthly_cost`, `estimated_monthly_savings`,
-  `coverage_pct`, `cpu_utilization_pct`, `memory_utilization_pct`, and
-  `usage_quantity` / `normalized_usage_amount`. Use
-  `CAST(<column> AS DOUBLE)` before any comparison or arithmetic.
-  Boolean (`actions_enabled`, `estimated`), Float64
+  `cpu_utilization_pct`, `memory_utilization_pct`, `coverage_pct`,
+  `on_demand_cost`, `spend_covered_by_savings_plans`, and `total_cost`.
+  Per-period totals on `cost_by_service` and `cost_by_tag` live inside
+  the `groups` JSON array — extract with `json_get_str` and cast the
+  result the same way. Use `CAST(<column> AS DOUBLE)` before any
+  comparison or arithmetic. Boolean (`estimated`), Float64
   (`current_score`, `max_score`), and Int64 columns project as their
   declared types.
-- **Tag activation:** User-defined tags must be activated under
-  **Billing → Cost allocation tags** before they appear in `cost_by_tag`.
-  The `aws:cloudformation:stack-name` tag is auto-activated.
-- **Cost Explorer must be enabled:** The API returns `OptInRequired` if Cost
-  Explorer has never been activated in the account.
+- **Tag activation:** Both user-defined and AWS-generated cost allocation
+  tags (including `aws:cloudformation:stack-name`) must be activated under
+  **Billing → Cost Allocation Tags** before they appear in `cost_by_tag`.
+  Activation is non-retroactive — older billing periods stay empty even
+  after activation. In AWS Organizations, only the management account can
+  activate cost allocation tags.
+- **Cost Explorer must be enabled:** queries fail with an
+  `AccessDeniedException` referencing `ce:GetCostAndUsage` (or whichever
+  operation the table calls) until Cost Explorer is activated for the
+  account in **Billing → Cost Explorer**.

--- a/sources/community/aws_cost_explorer/manifest.yaml
+++ b/sources/community/aws_cost_explorer/manifest.yaml
@@ -1,0 +1,1151 @@
+dsl_version: 3
+name: aws_cost_explorer
+version: 0.1.0
+backend: http
+description: >-
+  Query AWS Cost Explorer for cost and usage data, rightsizing recommendations,
+  and Savings Plans coverage. Uses AWS Signature Version 4 authentication.
+  Cost Explorer is a global service; for standard AWS partitions requests
+  go to us-east-1.
+inputs:
+  AWS_REGION:
+    kind: variable
+    default: us-east-1
+    hint: |
+      AWS region for Cost Explorer API requests. Cost Explorer is a global
+      service — keep `us-east-1` for standard AWS partitions. Use
+      `us-gov-west-1` for AWS GovCloud (US) or `cn-northwest-1` for the
+      China partition.
+  AWS_ENDPOINT_SUFFIX:
+    kind: variable
+    default: amazonaws.com
+    hint: |
+      AWS endpoint DNS suffix. Keep `amazonaws.com` for standard AWS
+      regions. Use `amazonaws.com.cn` for the China partition.
+  AWS_ACCESS_KEY_ID:
+    kind: secret
+    hint: |
+      AWS access key ID. Attach a policy with at least:
+      ce:GetCostAndUsage, ce:GetAnomalies, ce:GetCostForecast,
+      ce:GetRightsizingRecommendation, ce:GetSavingsPlansCoverage.
+  AWS_SECRET_ACCESS_KEY:
+    kind: secret
+    hint: |
+      AWS secret access key paired with AWS_ACCESS_KEY_ID.
+      Coral does not read your AWS CLI profile, AWS SSO cache, or
+      `AWS_PROFILE` at query time for this source.
+base_url: https://ce.{{input.AWS_REGION}}.{{input.AWS_ENDPOINT_SUFFIX}}
+auth:
+  type: CustomAuth
+  authenticator: aws_sigv4
+  service: ce
+  region: "{{input.AWS_REGION}}"
+  access_key_id: "{{input.AWS_ACCESS_KEY_ID}}"
+  secret_access_key: "{{input.AWS_SECRET_ACCESS_KEY}}"
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+  - name: Content-Type
+    from: literal
+    value: application/x-amz-json-1.1
+test_queries:
+  - SELECT instance_id, instance_type, recommendation_type, monthly_cost FROM aws_cost_explorer.rightsizing_recommendations LIMIT 5
+  - SELECT period_start, period_total_cost, estimated FROM aws_cost_explorer.cost_by_service WHERE time_period_start = '2026-04-01' AND time_period_end = '2026-05-01' LIMIT 1
+tables:
+  - name: cost_by_service
+    description: >-
+      AWS cost per billing period grouped by service, returned by GetCostAndUsage.
+      Each row represents one time period. The groups column contains the full
+      per-service breakdown as a JSON array — use json_get_json to extract it.
+      Use period_total_cost for the aggregate cost across all services in the period.
+    guide: |
+      Requires time_period_start and time_period_end (YYYY-MM-DD, end is exclusive —
+      use the first day of the following month to include the full month).
+      granularity defaults to MONTHLY. Cost Explorer data lags ~24 hours;
+      the current open month is marked estimated = true.
+      Each row is one time period. groups is a JSON array of
+      {"Keys":["<service>"],"Metrics":{"UnblendedCost":{"Amount":"...","Unit":"USD"}}}
+      objects — one entry per AWS service. Use json_get_json(groups, 0)
+      to get the first service element, then json_get_str on the result
+      to extract 'Keys' and 'Metrics' fields.
+    filters:
+      - name: time_period_start
+        required: true
+        description: >-
+          Start of the billing period, inclusive. Format YYYY-MM-DD.
+          Example: '2026-05-01'.
+      - name: time_period_end
+        required: true
+        description: >-
+          End of the billing period, exclusive. Use the first day of the next
+          month to include all days. Example: '2026-06-01' for all of May.
+      - name: granularity
+        description: >-
+          Aggregation period. MONTHLY (default) or DAILY. HOURLY is limited
+          to the last 14 days and requires the hourly-granularity opt-in
+          on the AWS account.
+      - name: metric
+        description: >-
+          Cost metric to retrieve. UNBLENDED_COST (default), AMORTIZED_COST,
+          BLENDED_COST, NET_UNBLENDED_COST, NET_AMORTIZED_COST,
+          USAGE_QUANTITY, NORMALIZED_USAGE_AMOUNT.
+          Use AMORTIZED_COST when the account uses Reserved Instances or
+          Savings Plans — UNBLENDED_COST understates amortized commitment costs.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: AWSInsightsIndexService.GetCostAndUsage
+      body:
+        - path: [TimePeriod, Start]
+          from: filter
+          key: time_period_start
+        - path: [TimePeriod, End]
+          from: filter
+          key: time_period_end
+        - path: [Granularity]
+          from: filter
+          key: granularity
+          default: MONTHLY
+        - path: [GroupBy, "0", Type]
+          from: literal
+          value: DIMENSION
+        - path: [GroupBy, "0", Key]
+          from: literal
+          value: SERVICE
+        - path: [Metrics, "0"]
+          from: filter
+          key: metric
+          default: UNBLENDED_COST
+    response:
+      rows_path: [ResultsByTime]
+    pagination:
+      mode: none
+    columns:
+      - name: time_period_start
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Billing period start date filter.
+        expr: {kind: from_filter, key: time_period_start}
+      - name: time_period_end
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Billing period end date filter.
+        expr: {kind: from_filter, key: time_period_end}
+      - name: period_start
+        type: Utf8
+        nullable: true
+        description: Actual start date of this billing period returned by the API.
+        expr: {kind: path, path: [TimePeriod, Start]}
+      - name: period_end
+        type: Utf8
+        nullable: true
+        description: Actual end date of this billing period returned by the API.
+        expr: {kind: path, path: [TimePeriod, End]}
+      - name: period_total_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total cost across all services for the period, projected from
+          the response key matching the metric the caller requested. When
+          metric = 'AMORTIZED_COST', this reflects Total.AmortizedCost.Amount;
+          when metric = 'UNBLENDED_COST' (the default), this reflects
+          Total.UnblendedCost.Amount; and so on for the other documented
+          metric values. Cast to Float64 before arithmetic:
+          CAST(period_total_cost AS DOUBLE). Use metric = 'AMORTIZED_COST'
+          for accounts with Reserved Instances or Savings Plans.
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [Total, UnblendedCost, Amount]}
+            - {kind: path, path: [Total, AmortizedCost, Amount]}
+            - {kind: path, path: [Total, BlendedCost, Amount]}
+            - {kind: path, path: [Total, NetUnblendedCost, Amount]}
+            - {kind: path, path: [Total, NetAmortizedCost, Amount]}
+            - {kind: path, path: [Total, UsageQuantity, Amount]}
+            - {kind: path, path: [Total, NormalizedUsageAmount, Amount]}
+      - name: unit
+        type: Utf8
+        nullable: true
+        description: >-
+          Currency or usage unit returned by the API for the metric the
+          caller requested. Typically 'USD' for cost metrics; 'Hrs' or
+          similar for USAGE_QUANTITY; unit-less or service-specific for
+          NORMALIZED_USAGE_AMOUNT.
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [Total, UnblendedCost, Unit]}
+            - {kind: path, path: [Total, AmortizedCost, Unit]}
+            - {kind: path, path: [Total, BlendedCost, Unit]}
+            - {kind: path, path: [Total, NetUnblendedCost, Unit]}
+            - {kind: path, path: [Total, NetAmortizedCost, Unit]}
+            - {kind: path, path: [Total, UsageQuantity, Unit]}
+            - {kind: path, path: [Total, NormalizedUsageAmount, Unit]}
+      - name: estimated
+        type: Boolean
+        nullable: true
+        description: >-
+          True when the period includes the current open month whose billing is
+          not yet finalised.
+        expr: {kind: path, path: [Estimated]}
+      - name: groups
+        type: Json
+        nullable: true
+        description: >-
+          Full per-service cost breakdown as a JSON array. Each element has
+          Keys (service name) and Metrics keyed by the metric the caller
+          requested (e.g. Metrics.AmortizedCost.Amount when
+          metric = 'AMORTIZED_COST'). Use json_get_json(groups, 0) to read
+          the first element, then json_get_str(first_element, 'Keys', 0) for
+          the service name. Per-metric typed columns (`amortized_cost`,
+          `blended_cost`, …) are also available alongside `groups` for the
+          row-level total without `json_get_str` navigation.
+        expr: {kind: path, path: [Groups]}
+      - name: unblended_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total UNBLENDED_COST for the period as a string. Non-NULL only
+          when metric is unset (default) or metric = 'UNBLENDED_COST';
+          NULL when the caller selected a different metric.
+          Cast to Float64 before arithmetic.
+        expr: {kind: path, path: [Total, UnblendedCost, Amount]}
+      - name: amortized_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total AMORTIZED_COST for the period as a string. Non-NULL only
+          when metric = 'AMORTIZED_COST'. Use this metric for accounts
+          with Reserved Instances or Savings Plans — UNBLENDED_COST
+          understates amortized commitment costs.
+        expr: {kind: path, path: [Total, AmortizedCost, Amount]}
+      - name: blended_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total BLENDED_COST for the period as a string. Non-NULL only
+          when metric = 'BLENDED_COST'. Cast to Float64 before arithmetic.
+        expr: {kind: path, path: [Total, BlendedCost, Amount]}
+      - name: net_unblended_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total NET_UNBLENDED_COST for the period as a string (unblended
+          cost net of credits and refunds). Non-NULL only when
+          metric = 'NET_UNBLENDED_COST'. Cast to Float64 before arithmetic.
+        expr: {kind: path, path: [Total, NetUnblendedCost, Amount]}
+      - name: net_amortized_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total NET_AMORTIZED_COST for the period as a string (amortized
+          cost net of credits and refunds). Non-NULL only when
+          metric = 'NET_AMORTIZED_COST'. Cast to Float64 before arithmetic.
+        expr: {kind: path, path: [Total, NetAmortizedCost, Amount]}
+      - name: usage_quantity
+        type: Utf8
+        nullable: true
+        description: >-
+          Total USAGE_QUANTITY for the period as a string. Non-NULL only
+          when metric = 'USAGE_QUANTITY'. The aggregate value is unit-less
+          because the API sums quantities across services with different
+          natural units (EC2 hours, S3 GB, DynamoDB request counts) — the
+          companion `unit` column returns 'N/A' for this metric. To get
+          comparable usage figures, query a tag- or service-scoped slice
+          rather than the cross-service aggregate.
+        expr: {kind: path, path: [Total, UsageQuantity, Amount]}
+      - name: normalized_usage_amount
+        type: Utf8
+        nullable: true
+        description: >-
+          Total NORMALIZED_USAGE_AMOUNT for the period as a string,
+          normalized for instance-size-flexibility comparisons across
+          Reserved Instance families. Non-NULL only when
+          metric = 'NORMALIZED_USAGE_AMOUNT'.
+        expr: {kind: path, path: [Total, NormalizedUsageAmount, Amount]}
+      - name: metric
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Cost metric filter used for this query. UNBLENDED_COST (default),
+          AMORTIZED_COST, BLENDED_COST, NET_UNBLENDED_COST,
+          NET_AMORTIZED_COST, USAGE_QUANTITY, NORMALIZED_USAGE_AMOUNT.
+          Bind via WHERE metric = '<value>' to retrieve a non-default metric.
+        expr: {kind: from_filter, key: metric}
+      - name: granularity
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Aggregation period filter. MONTHLY (default), DAILY, or HOURLY
+          (last 14 days, opt-in). Bind via WHERE granularity = '<value>'.
+        expr: {kind: from_filter, key: granularity}
+
+  - name: cost_by_tag
+    description: >-
+      AWS cost per billing period grouped by a resource tag key, returned by GetCostAndUsage.
+      Each row represents one time period. The groups column contains the full per-tag-value
+      breakdown as a JSON array. Use tag_key = 'aws:cloudformation:stack-name' to attribute
+      cost to CloudFormation stacks and correlate with deployment events.
+    guide: |
+      Requires time_period_start, time_period_end (YYYY-MM-DD, end exclusive),
+      and tag_key. The tag key must be activated as a cost allocation tag in the
+      AWS Billing console. The AWS-managed tag 'aws:cloudformation:stack-name'
+      is automatically activated and does not require manual activation.
+      Each row is one time period. groups is a JSON array where each element has
+      Keys (the tag value) and Metrics.UnblendedCost.Amount. Resources with no
+      value for that tag appear with an empty string as the tag value.
+      Use json_get_json(groups, 0) to read the first element.
+    filters:
+      - name: time_period_start
+        required: true
+        description: Start of the billing period, inclusive. Format YYYY-MM-DD.
+      - name: time_period_end
+        required: true
+        description: End of the billing period, exclusive. Format YYYY-MM-DD.
+      - name: tag_key
+        required: true
+        description: >-
+          The AWS tag key to group costs by. Use 'aws:cloudformation:stack-name'
+          to attribute costs to CloudFormation stacks. User-defined tags must be
+          activated in Billing → Cost allocation tags first.
+      - name: granularity
+        description: >-
+          Aggregation period. MONTHLY (default) or DAILY. HOURLY is limited
+          to the last 14 days and requires the hourly-granularity opt-in
+          on the AWS account.
+      - name: metric
+        description: >-
+          Cost metric to retrieve. UNBLENDED_COST (default), AMORTIZED_COST,
+          BLENDED_COST, NET_UNBLENDED_COST, NET_AMORTIZED_COST,
+          USAGE_QUANTITY, NORMALIZED_USAGE_AMOUNT.
+          Use AMORTIZED_COST when the account uses Reserved Instances or
+          Savings Plans — UNBLENDED_COST understates amortized commitment costs.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: AWSInsightsIndexService.GetCostAndUsage
+      body:
+        - path: [TimePeriod, Start]
+          from: filter
+          key: time_period_start
+        - path: [TimePeriod, End]
+          from: filter
+          key: time_period_end
+        - path: [Granularity]
+          from: filter
+          key: granularity
+          default: MONTHLY
+        - path: [GroupBy, "0", Type]
+          from: literal
+          value: TAG
+        - path: [GroupBy, "0", Key]
+          from: filter
+          key: tag_key
+        - path: [Metrics, "0"]
+          from: filter
+          key: metric
+          default: UNBLENDED_COST
+    response:
+      rows_path: [ResultsByTime]
+    pagination:
+      mode: none
+    columns:
+      - name: time_period_start
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Billing period start date filter.
+        expr: {kind: from_filter, key: time_period_start}
+      - name: time_period_end
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Billing period end date filter.
+        expr: {kind: from_filter, key: time_period_end}
+      - name: tag_key
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Tag key filter used to group costs.
+        expr: {kind: from_filter, key: tag_key}
+      - name: period_start
+        type: Utf8
+        nullable: true
+        description: Actual start date of this billing period returned by the API.
+        expr: {kind: path, path: [TimePeriod, Start]}
+      - name: period_end
+        type: Utf8
+        nullable: true
+        description: Actual end date of this billing period returned by the API.
+        expr: {kind: path, path: [TimePeriod, End]}
+      - name: period_total_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total cost across all tag values for the period, projected from
+          the response key matching the metric the caller requested. When
+          metric = 'AMORTIZED_COST', this reflects Total.AmortizedCost.Amount;
+          when metric = 'UNBLENDED_COST' (the default), this reflects
+          Total.UnblendedCost.Amount; and so on for the other documented
+          metric values. Cast to Float64 before arithmetic:
+          CAST(period_total_cost AS DOUBLE). Use metric = 'AMORTIZED_COST'
+          for accounts with Reserved Instances or Savings Plans.
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [Total, UnblendedCost, Amount]}
+            - {kind: path, path: [Total, AmortizedCost, Amount]}
+            - {kind: path, path: [Total, BlendedCost, Amount]}
+            - {kind: path, path: [Total, NetUnblendedCost, Amount]}
+            - {kind: path, path: [Total, NetAmortizedCost, Amount]}
+            - {kind: path, path: [Total, UsageQuantity, Amount]}
+            - {kind: path, path: [Total, NormalizedUsageAmount, Amount]}
+      - name: unit
+        type: Utf8
+        nullable: true
+        description: >-
+          Currency or usage unit returned by the API for the metric the
+          caller requested. Typically 'USD' for cost metrics; 'Hrs' or
+          similar for USAGE_QUANTITY; unit-less or service-specific for
+          NORMALIZED_USAGE_AMOUNT.
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [Total, UnblendedCost, Unit]}
+            - {kind: path, path: [Total, AmortizedCost, Unit]}
+            - {kind: path, path: [Total, BlendedCost, Unit]}
+            - {kind: path, path: [Total, NetUnblendedCost, Unit]}
+            - {kind: path, path: [Total, NetAmortizedCost, Unit]}
+            - {kind: path, path: [Total, UsageQuantity, Unit]}
+            - {kind: path, path: [Total, NormalizedUsageAmount, Unit]}
+      - name: estimated
+        type: Boolean
+        nullable: true
+        description: True when billing for the period is not yet finalised.
+        expr: {kind: path, path: [Estimated]}
+      - name: groups
+        type: Json
+        nullable: true
+        description: >-
+          Full per-tag-value cost breakdown as a JSON array. Each element has
+          Keys (the tag value) and Metrics keyed by the metric the caller
+          requested (e.g. Metrics.AmortizedCost.Amount when
+          metric = 'AMORTIZED_COST'). Use json_get_json(groups, 0) to read
+          the first element, then json_get_str(first_element, 'Keys', 0) for
+          the tag value. Per-metric typed columns (`amortized_cost`,
+          `blended_cost`, …) are also available alongside `groups` for the
+          row-level total without `json_get_str` navigation.
+        expr: {kind: path, path: [Groups]}
+      - name: unblended_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total UNBLENDED_COST for the tag value group as a string. Non-NULL
+          only when metric is unset (default) or metric = 'UNBLENDED_COST';
+          NULL when the caller selected a different metric.
+          Cast to Float64 before arithmetic.
+        expr: {kind: path, path: [Total, UnblendedCost, Amount]}
+      - name: amortized_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total AMORTIZED_COST for the tag value group as a string. Non-NULL
+          only when metric = 'AMORTIZED_COST'. Use this metric for accounts
+          with Reserved Instances or Savings Plans — UNBLENDED_COST
+          understates amortized commitment costs.
+        expr: {kind: path, path: [Total, AmortizedCost, Amount]}
+      - name: blended_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total BLENDED_COST for the tag value group as a string. Non-NULL
+          only when metric = 'BLENDED_COST'. Cast to Float64 before arithmetic.
+        expr: {kind: path, path: [Total, BlendedCost, Amount]}
+      - name: net_unblended_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total NET_UNBLENDED_COST for the tag value group as a string
+          (unblended cost net of credits and refunds). Non-NULL only when
+          metric = 'NET_UNBLENDED_COST'. Cast to Float64 before arithmetic.
+        expr: {kind: path, path: [Total, NetUnblendedCost, Amount]}
+      - name: net_amortized_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total NET_AMORTIZED_COST for the tag value group as a string
+          (amortized cost net of credits and refunds). Non-NULL only when
+          metric = 'NET_AMORTIZED_COST'. Cast to Float64 before arithmetic.
+        expr: {kind: path, path: [Total, NetAmortizedCost, Amount]}
+      - name: usage_quantity
+        type: Utf8
+        nullable: true
+        description: >-
+          Total USAGE_QUANTITY for the tag value group as a string. Non-NULL
+          only when metric = 'USAGE_QUANTITY'. The aggregate value is
+          unit-less because the API sums quantities across services with
+          different natural units (EC2 hours, S3 GB, DynamoDB request
+          counts) — the companion `unit` column returns 'N/A' for this
+          metric. To get comparable usage figures, query a service-scoped
+          slice rather than the cross-service aggregate.
+        expr: {kind: path, path: [Total, UsageQuantity, Amount]}
+      - name: normalized_usage_amount
+        type: Utf8
+        nullable: true
+        description: >-
+          Total NORMALIZED_USAGE_AMOUNT for the tag value group as a string,
+          normalized for instance-size-flexibility comparisons across
+          Reserved Instance families. Non-NULL only when
+          metric = 'NORMALIZED_USAGE_AMOUNT'.
+        expr: {kind: path, path: [Total, NormalizedUsageAmount, Amount]}
+      - name: metric
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Cost metric filter used for this query. UNBLENDED_COST (default),
+          AMORTIZED_COST, BLENDED_COST, NET_UNBLENDED_COST,
+          NET_AMORTIZED_COST, USAGE_QUANTITY, NORMALIZED_USAGE_AMOUNT.
+          Bind via WHERE metric = '<value>' to retrieve a non-default metric.
+        expr: {kind: from_filter, key: metric}
+      - name: granularity
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Aggregation period filter. MONTHLY (default), DAILY, or HOURLY
+          (last 14 days, opt-in). Bind via WHERE granularity = '<value>'.
+        expr: {kind: from_filter, key: granularity}
+
+  - name: anomalies
+    description: >-
+      Cost anomalies detected by AWS Cost Explorer's ML models, returned by
+      GetAnomalies. Each row is one detected spending spike with the impacted
+      dimension (service or linked account), the dollar impact, and the
+      detection window. Use as the entry point for cost-spike investigation —
+      AWS accounts for seasonality and growth trends in its baseline model,
+      which makes this more reliable than manual month-over-month comparisons.
+    guide: |
+      Requires date_interval_start and date_interval_end (YYYY-MM-DD).
+      Anomalies are retained for up to 90 days. Newer accounts (less than ~5
+      weeks of billing history) may return no results because AWS needs that
+      minimum baseline to detect spikes.
+      anomaly_end_date is null for anomalies that are still active (the spike
+      has not ended). Use IS NULL to find ongoing anomalies.
+      total_impact is the dollar difference between actual and expected
+      spend — use ORDER BY CAST(total_impact AS DOUBLE) DESC to rank spikes
+      by severity. Use total_impact_min to suppress low-value noise.
+      root_causes is a JSON array. Each element has Service, Region,
+      UsageType, LinkedAccount, LinkedAccountName, and Impact.Contribution.
+      Use json_get_json(root_causes, 0) for the highest-contribution root
+      cause, then json_get_str on the result.
+    filters:
+      - name: date_interval_start
+        required: true
+        description: >-
+          Start of the window to search for detected anomalies. Format
+          YYYY-MM-DD. The returned anomaly's AnomalyEndDate falls within
+          this window. Use the first day of the month to scan the full
+          billing period.
+      - name: date_interval_end
+        required: true
+        description: End of the anomaly search window. Format YYYY-MM-DD.
+      - name: total_impact_min
+        description: >-
+          Minimum total dollar impact to include. Filters out low-value
+          noise. Whole-dollar integer (e.g. 100 to suppress anomalies under
+          $100).
+      - name: feedback
+        description: >-
+          Filter by user-supplied feedback. YES (confirmed anomaly), NO
+          (false positive), PLANNED_ACTIVITY (expected spend increase).
+      - name: monitor_arn
+        description: >-
+          Restrict to anomalies detected by a specific Cost Anomaly Monitor
+          ARN.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: AWSInsightsIndexService.GetAnomalies
+      body:
+        - path: [DateInterval, StartDate]
+          from: filter
+          key: date_interval_start
+        - path: [DateInterval, EndDate]
+          from: filter
+          key: date_interval_end
+        - path: [TotalImpact, NumericOperator]
+          from: literal
+          value: GREATER_THAN_OR_EQUAL
+        - path: [TotalImpact, StartValue]
+          from: filter_int
+          key: total_impact_min
+          default: 0
+        - path: [Feedback]
+          from: filter
+          key: feedback
+        - path: [MonitorArn]
+          from: filter
+          key: monitor_arn
+        - path: [MaxResults]
+          from: literal
+          value: 100
+    response:
+      rows_path: [Anomalies]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextPageToken]
+      response_cursor_path: [NextPageToken]
+      max_pages: 50
+    columns:
+      - name: date_interval_start
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Anomaly search window start date filter.
+        expr: {kind: from_filter, key: date_interval_start}
+      - name: date_interval_end
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Anomaly search window end date filter.
+        expr: {kind: from_filter, key: date_interval_end}
+      - name: anomaly_id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the anomaly assigned by AWS.
+        expr: {kind: path, path: [AnomalyId]}
+      - name: anomaly_start_date
+        type: Utf8
+        nullable: true
+        description: >-
+          Date the anomaly was first detected (YYYY-MM-DD). Use as the
+          window start when querying cost_by_tag to identify the
+          responsible stack.
+        expr: {kind: path, path: [AnomalyStartDate]}
+      - name: anomaly_end_date
+        type: Utf8
+        nullable: true
+        description: >-
+          Date the anomaly ended (YYYY-MM-DD). Null when the spike is
+          still active. Use IS NULL to find ongoing anomalies.
+        expr: {kind: path, path: [AnomalyEndDate]}
+      - name: dimension_value
+        type: Utf8
+        nullable: true
+        description: >-
+          The monitor dimension that triggered the alert — typically an AWS
+          service name (e.g. 'AWS Lambda') or linked account ID, depending
+          on the anomaly monitor type.
+        expr: {kind: path, path: [DimensionValue]}
+      - name: total_actual_spend
+        type: Utf8
+        nullable: true
+        description: >-
+          Total actual spend during the anomaly window. Cast to Float64:
+          CAST(total_actual_spend AS DOUBLE).
+        expr: {kind: path, path: [Impact, TotalActualSpend]}
+      - name: total_expected_spend
+        type: Utf8
+        nullable: true
+        description: >-
+          What AWS predicted spend would be without the anomaly. Cast to
+          Float64 before arithmetic.
+        expr: {kind: path, path: [Impact, TotalExpectedSpend]}
+      - name: total_impact
+        type: Utf8
+        nullable: true
+        description: >-
+          Dollar difference between actual and expected spend — the size of
+          the spike. Cast to Float64 and ORDER BY CAST(total_impact AS
+          DOUBLE) DESC to rank spikes by severity.
+        expr: {kind: path, path: [Impact, TotalImpact]}
+      - name: total_impact_percentage
+        type: Utf8
+        nullable: true
+        description: >-
+          Anomaly size as a percentage above expected spend. Cast to
+          Float64 for comparisons.
+        expr: {kind: path, path: [Impact, TotalImpactPercentage]}
+      - name: max_impact
+        type: Utf8
+        nullable: true
+        description: >-
+          Single-day peak dollar impact during the anomaly window. Cast to
+          Float64 before arithmetic.
+        expr: {kind: path, path: [Impact, MaxImpact]}
+      - name: current_score
+        type: Float64
+        nullable: true
+        description: >-
+          AWS's current anomaly confidence score. Higher means more
+          confident that the spike is anomalous.
+        expr: {kind: path, path: [AnomalyScore, CurrentScore]}
+      - name: max_score
+        type: Float64
+        nullable: true
+        description: Maximum anomaly score reached during the spike.
+        expr: {kind: path, path: [AnomalyScore, MaxScore]}
+      - name: root_causes
+        type: Json
+        nullable: true
+        description: >-
+          JSON array of root-cause objects identified by AWS. Each element
+          has Service, Region, UsageType, LinkedAccount, LinkedAccountName,
+          and Impact.Contribution (the share of total_impact attributable
+          to that root cause). Multiple root causes appear in order of
+          descending contribution. Use json_get_json(root_causes, 0) to
+          read the first root cause.
+        expr: {kind: path, path: [RootCauses]}
+      - name: feedback
+        type: Utf8
+        nullable: true
+        description: >-
+          User feedback on this anomaly: YES (confirmed), NO (false
+          positive), PLANNED_ACTIVITY (expected). Null when no feedback has
+          been submitted.
+        expr: {kind: path, path: [Feedback]}
+      - name: monitor_arn
+        type: Utf8
+        nullable: true
+        description: ARN of the Cost Anomaly Monitor that detected this anomaly.
+        expr: {kind: path, path: [MonitorArn]}
+      - name: total_impact_min
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Minimum total impact filter applied to this query.
+        expr: {kind: from_filter, key: total_impact_min}
+
+  - name: cost_forecast
+    description: >-
+      Projected cost for a future or in-progress billing period, returned by
+      GetCostForecast. Returns a mean prediction with a configurable
+      confidence interval per sub-period. Use to project end-of-month
+      spend, size the impact of a recent infrastructure change, or answer
+      'are we going to exceed budget?' in an agent session.
+    guide: |
+      Requires time_period_start, time_period_end, granularity, and metric.
+      time_period_start must be today or a future date — past dates return
+      ValidationException. To forecast the remainder of the current month,
+      set time_period_start to today and time_period_end to the first of
+      next month.
+      The supported metric set is narrower than cost_by_service /
+      cost_by_tag: only AMORTIZED_COST, BLENDED_COST, NET_AMORTIZED_COST,
+      NET_UNBLENDED_COST, and UNBLENDED_COST. USAGE_QUANTITY and
+      NORMALIZED_USAGE_AMOUNT are not supported by the forecast API.
+      DAILY granularity allows up to 3 months ahead; MONTHLY allows up to
+      18 months ahead.
+      mean_value is the point estimate. prediction_interval_lower_bound and
+      prediction_interval_upper_bound bracket the mean at the confidence
+      level chosen by prediction_interval_level (default 80, range 51-99) —
+      higher levels widen the interval.
+    filters:
+      - name: time_period_start
+        required: true
+        description: >-
+          Start of the forecast period. Must be today or a future date.
+          Format YYYY-MM-DD. Use today's date to forecast the rest of the
+          current month.
+      - name: time_period_end
+        required: true
+        description: >-
+          End of the forecast period, exclusive. Format YYYY-MM-DD.
+      - name: granularity
+        required: true
+        description: >-
+          Forecast resolution. DAILY (one row per day, up to 3 months
+          ahead) or MONTHLY (one row per month, up to 18 months ahead).
+          DAILY is more useful for near-term spend pacing; MONTHLY for
+          budget headroom checks.
+      - name: metric
+        required: true
+        description: >-
+          Cost metric to forecast. AMORTIZED_COST, BLENDED_COST,
+          NET_AMORTIZED_COST, NET_UNBLENDED_COST, or UNBLENDED_COST.
+          USAGE_QUANTITY and NORMALIZED_USAGE_AMOUNT are not supported by
+          the forecast API.
+      - name: prediction_interval_level
+        description: >-
+          Confidence level for the prediction interval bounds. Integer
+          51-99, defaults to 80. Higher confidence widens the interval.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: AWSInsightsIndexService.GetCostForecast
+      body:
+        - path: [TimePeriod, Start]
+          from: filter
+          key: time_period_start
+        - path: [TimePeriod, End]
+          from: filter
+          key: time_period_end
+        - path: [Granularity]
+          from: filter
+          key: granularity
+        - path: [Metric]
+          from: filter
+          key: metric
+        - path: [PredictionIntervalLevel]
+          from: filter_int
+          key: prediction_interval_level
+          default: 80
+    response:
+      rows_path: [ForecastResultsByTime]
+    pagination:
+      mode: none
+    columns:
+      - name: time_period_start
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Forecast period start date filter.
+        expr: {kind: from_filter, key: time_period_start}
+      - name: time_period_end
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Forecast period end date filter.
+        expr: {kind: from_filter, key: time_period_end}
+      - name: granularity
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Forecast granularity filter (DAILY or MONTHLY).
+        expr: {kind: from_filter, key: granularity}
+      - name: metric
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Cost metric filter used for this forecast.
+        expr: {kind: from_filter, key: metric}
+      - name: period_start
+        type: Utf8
+        nullable: true
+        description: Start of this forecast sub-period (YYYY-MM-DD).
+        expr: {kind: path, path: [TimePeriod, Start]}
+      - name: period_end
+        type: Utf8
+        nullable: true
+        description: End of this forecast sub-period, exclusive (YYYY-MM-DD).
+        expr: {kind: path, path: [TimePeriod, End]}
+      - name: mean_value
+        type: Utf8
+        nullable: true
+        description: >-
+          Point estimate of predicted cost for this sub-period. Cast to
+          Float64: CAST(mean_value AS DOUBLE). Sum across rows for the
+          total forecast when using DAILY granularity.
+        expr: {kind: path, path: [MeanValue]}
+      - name: prediction_interval_lower_bound
+        type: Utf8
+        nullable: true
+        description: >-
+          Lower bound of the prediction interval at the requested
+          confidence level. Cast to Float64 before arithmetic.
+        expr: {kind: path, path: [PredictionIntervalLowerBound]}
+      - name: prediction_interval_upper_bound
+        type: Utf8
+        nullable: true
+        description: >-
+          Upper bound of the prediction interval at the requested
+          confidence level. Cast to Float64 — use this as the conservative
+          estimate when checking budget headroom.
+        expr: {kind: path, path: [PredictionIntervalUpperBound]}
+      - name: prediction_interval_level
+        type: Int64
+        nullable: true
+        virtual: true
+        description: >-
+          Confidence level filter (51-99, default 80) used for this
+          forecast's interval bounds.
+        expr: {kind: from_filter, key: prediction_interval_level}
+
+  - name: rightsizing_recommendations
+    description: >-
+      EC2 rightsizing recommendations from AWS Cost Explorer, based on a
+      14-day CloudWatch utilisation lookback. Returns instances that are
+      over-provisioned (MODIFY) or idle (TERMINATE).
+    guide: |
+      No required filters. Recommendations are computed by AWS daily using
+      CloudWatch metrics from the last 14 days. Memory utilisation requires
+      the CloudWatch agent on the instance; without it `memory_utilization_pct`
+      is NULL and the recommendation is driven by CPU only.
+      Recommendations are cached for 24 hours.
+      Set recommendation_target = 'CROSS_INSTANCE_FAMILY' to surface
+      cross-family downsizes (e.g. m5.large → t3.medium) which often yield
+      larger savings but may change network and CPU performance and require
+      application testing.
+      `estimated_monthly_savings` reflects the MODIFY target's first option
+      OR the TERMINATE detail, depending on `recommendation_type`. When
+      `recommendation_type = 'TERMINATE'`, `target_instance_type` is NULL
+      because there is no replacement instance.
+    filters:
+      - name: recommendation_target
+        description: >-
+          Recommendation scope. SAME_INSTANCE_FAMILY (default) restricts
+          target instances to the same family as the source. CROSS_INSTANCE_FAMILY
+          allows cross-family suggestions which often yield larger savings
+          but may change network or CPU characteristics.
+      - name: benefits_considered
+        description: >-
+          Whether AWS factors existing Savings Plans / RI benefits into the
+          savings calculation. true (default) gives net-of-commitments
+          savings; false ignores commitments.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: AWSInsightsIndexService.GetRightsizingRecommendation
+      body:
+        - path: [Service]
+          from: literal
+          value: AmazonEC2
+        - path: [Configuration, RecommendationTarget]
+          from: filter
+          key: recommendation_target
+          default: SAME_INSTANCE_FAMILY
+        - path: [Configuration, BenefitsConsidered]
+          from: filter_bool
+          key: benefits_considered
+          default: true
+        - path: [PageSize]
+          from: literal
+          value: 100
+    response:
+      rows_path: [RightsizingRecommendations]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextPageToken]
+      response_cursor_path: [NextPageToken]
+      max_pages: 20
+    columns:
+      - name: instance_id
+        type: Utf8
+        nullable: true
+        description: EC2 instance ID, e.g. 'i-0abc123'.
+        expr: {kind: path, path: [CurrentInstance, ResourceId]}
+      - name: instance_name
+        type: Utf8
+        nullable: true
+        description: EC2 instance name tag value.
+        expr: {kind: path, path: [CurrentInstance, InstanceName]}
+      - name: instance_type
+        type: Utf8
+        nullable: true
+        description: Current EC2 instance type, e.g. 'm5.large'.
+        expr:
+          {kind: path, path: [CurrentInstance, ResourceDetails, EC2ResourceDetails, InstanceType]}
+      - name: region
+        type: Utf8
+        nullable: true
+        description: AWS region where the instance runs.
+        expr:
+          {kind: path, path: [CurrentInstance, ResourceDetails, EC2ResourceDetails, Region]}
+      - name: monthly_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Current estimated monthly cost as a string. Cast to Float64 before
+          arithmetic: CAST(monthly_cost AS DOUBLE).
+        expr: {kind: path, path: [CurrentInstance, MonthlyCost]}
+      - name: recommendation_type
+        type: Utf8
+        nullable: true
+        description: 'MODIFY (downsize) or TERMINATE (shut down — zero recent usage).'
+        expr: {kind: path, path: [RightsizingType]}
+      - name: estimated_monthly_savings
+        type: Utf8
+        nullable: true
+        description: >-
+          Estimated monthly savings if the recommendation is applied, as a
+          string. For MODIFY recommendations, reflects the first
+          (highest-savings) target instance only — AWS may return multiple
+          options. For TERMINATE recommendations, reflects the full
+          terminate savings (the entire instance cost). Cast to Float64
+          before arithmetic.
+        expr:
+          kind: coalesce
+          exprs:
+            - {kind: path, path: [ModifyRecommendationDetail, TargetInstances, "0", EstimatedMonthlySavings]}
+            - {kind: path, path: [TerminateRecommendationDetail, EstimatedMonthlySavings]}
+      - name: cpu_utilization_pct
+        type: Utf8
+        nullable: true
+        description: >-
+          Maximum CPU utilisation percentage observed over the 14-day
+          lookback window. Available on every recommendation regardless of
+          whether the CloudWatch agent is installed.
+        expr:
+          kind: path
+          path: [CurrentInstance, ResourceUtilization, EC2ResourceUtilization, MaxCpuUtilizationPercentage]
+      - name: memory_utilization_pct
+        type: Utf8
+        nullable: true
+        description: >-
+          Maximum memory utilisation percentage observed over the 14-day
+          lookback window. NULL unless the CloudWatch agent is installed
+          on the instance — basic CloudWatch monitoring does not surface
+          memory metrics.
+        expr:
+          kind: path
+          path: [CurrentInstance, ResourceUtilization, EC2ResourceUtilization, MaxMemoryUtilizationPercentage]
+      - name: target_instance_type
+        type: Utf8
+        nullable: true
+        description: >-
+          Recommended target instance type for MODIFY recommendations.
+          NULL for TERMINATE recommendations (no replacement instance).
+          Reflects the first (primary) target option — AWS may return
+          multiple candidates.
+        expr:
+          {kind: path, path: [ModifyRecommendationDetail, TargetInstances, "0", ResourceDetails, EC2ResourceDetails, InstanceType]}
+      - name: recommendation_target
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Recommendation scope filter. SAME_INSTANCE_FAMILY (default) or
+          CROSS_INSTANCE_FAMILY. Bind via WHERE recommendation_target = '<value>'.
+        expr: {kind: from_filter, key: recommendation_target}
+      - name: benefits_considered
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: >-
+          Filter controlling whether AWS factors existing Savings Plans / RI
+          benefits into savings (default true). Bind via WHERE benefits_considered = false.
+        expr: {kind: from_filter, key: benefits_considered}
+
+  - name: savings_plans_coverage
+    description: >-
+      Savings Plans coverage by AWS service, returned by GetSavingsPlansCoverage.
+      Shows what fraction of eligible on-demand spend is covered by a Savings Plan.
+      Coverage below 100% represents on-demand spend that could be reduced by
+      purchasing or expanding a Savings Plan.
+    guide: |
+      Requires time_period_start and time_period_end (YYYY-MM-DD, end exclusive).
+      The Start date must be within the last 13 months. coverage_pct below 80
+      with significant on_demand_cost is a strong signal to review commitment
+      purchases. New Savings Plans take up to 72 hours to fully appear in
+      coverage data.
+      total_cost is the sum of on_demand_cost and spend_covered_by_savings_plans
+      for the row's service grouping; use it to compute absolute coverage in
+      dollars instead of just coverage_pct.
+    filters:
+      - name: time_period_start
+        required: true
+        description: Start of the coverage period, inclusive. Format YYYY-MM-DD.
+      - name: time_period_end
+        required: true
+        description: End of the coverage period, exclusive. Format YYYY-MM-DD.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: AWSInsightsIndexService.GetSavingsPlansCoverage
+      body:
+        - path: [TimePeriod, Start]
+          from: filter
+          key: time_period_start
+        - path: [TimePeriod, End]
+          from: filter
+          key: time_period_end
+        - path: [Granularity]
+          from: literal
+          value: MONTHLY
+        - path: [GroupBy, "0", Type]
+          from: literal
+          value: DIMENSION
+        - path: [GroupBy, "0", Key]
+          from: literal
+          value: SERVICE
+        - path: [MaxResults]
+          from: literal
+          value: 100
+    response:
+      rows_path: [SavingsPlansCoverages]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextToken]
+      response_cursor_path: [NextToken]
+      max_pages: 50
+    columns:
+      - name: time_period_start
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Coverage period start date filter.
+        expr: {kind: from_filter, key: time_period_start}
+      - name: time_period_end
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Coverage period end date filter.
+        expr: {kind: from_filter, key: time_period_end}
+      - name: period_start
+        type: Utf8
+        nullable: true
+        description: Actual start date of this coverage period returned by the API.
+        expr: {kind: path, path: [TimePeriod, Start]}
+      - name: period_end
+        type: Utf8
+        nullable: true
+        description: Actual end date of this coverage period returned by the API (exclusive).
+        expr: {kind: path, path: [TimePeriod, End]}
+      - name: service
+        type: Utf8
+        nullable: true
+        description: AWS service name.
+        expr: {kind: path, path: [Attributes, SERVICE]}
+      - name: coverage_pct
+        type: Utf8
+        nullable: true
+        description: >-
+          Percentage of on-demand hours covered by Savings Plans, as a string.
+          Cast to Float64: CAST(coverage_pct AS DOUBLE). Values below 80 indicate
+          significant uncovered spend.
+        expr: {kind: path, path: [Coverage, CoverageHours, CoverageHoursPercentage]}
+      - name: on_demand_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          On-demand spend not covered by any Savings Plan, as a string.
+          Cast to Float64 for calculations.
+        expr: {kind: path, path: [Coverage, CoverageCost, OnDemandCost]}
+      - name: spend_covered_by_savings_plans
+        type: Utf8
+        nullable: true
+        description: >-
+          Spend covered by an active Savings Plan, as a string.
+          Cast to Float64: CAST(spend_covered_by_savings_plans AS DOUBLE).
+          Sum with on_demand_cost to get total compute spend.
+        expr: {kind: path, path: [Coverage, CoverageCost, SpendCoveredBySavingsPlans]}
+      - name: total_cost
+        type: Utf8
+        nullable: true
+        description: >-
+          Total compute spend (on_demand_cost + spend_covered_by_savings_plans)
+          for this service grouping, as a string. Cast to Float64 for calculations.
+        expr: {kind: path, path: [Coverage, CoverageCost, TotalCost]}

--- a/sources/community/aws_cost_explorer/manifest.yaml
+++ b/sources/community/aws_cost_explorer/manifest.yaml
@@ -3,25 +3,29 @@ name: aws_cost_explorer
 version: 0.1.0
 backend: http
 description: >-
-  Query AWS Cost Explorer for cost and usage data, rightsizing recommendations,
-  and Savings Plans coverage. Uses AWS Signature Version 4 authentication.
-  Cost Explorer is a global service; for standard AWS partitions requests
-  go to us-east-1.
+  Query AWS Cost Explorer for historical cost and usage, cost anomalies,
+  cost forecasts, EC2 rightsizing recommendations, and Savings Plans
+  coverage. Uses AWS Signature Version 4 authentication. Cost Explorer is
+  a global service with one regional endpoint per partition — use
+  us-east-1 for the standard AWS partition or cn-northwest-1 for the
+  China partition. AWS GovCloud (US) does not expose a Cost Explorer
+  endpoint.
 inputs:
   AWS_REGION:
     kind: variable
     default: us-east-1
     hint: |
-      AWS region for Cost Explorer API requests. Cost Explorer is a global
-      service — keep `us-east-1` for standard AWS partitions. Use
-      `us-gov-west-1` for AWS GovCloud (US) or `cn-northwest-1` for the
-      China partition.
+      AWS region for Cost Explorer API requests. Cost Explorer is a
+      global service with one regional endpoint per partition — keep
+      `us-east-1` for the standard AWS partition or use `cn-northwest-1`
+      for the China partition. AWS GovCloud (US) does not expose a Cost
+      Explorer endpoint.
   AWS_ENDPOINT_SUFFIX:
     kind: variable
     default: amazonaws.com
     hint: |
-      AWS endpoint DNS suffix. Keep `amazonaws.com` for standard AWS
-      regions. Use `amazonaws.com.cn` for the China partition.
+      AWS endpoint DNS suffix. Keep `amazonaws.com` for the standard AWS
+      partition. Use `amazonaws.com.cn` for the China partition.
   AWS_ACCESS_KEY_ID:
     kind: secret
     hint: |
@@ -50,15 +54,26 @@ request_headers:
     from: literal
     value: application/x-amz-json-1.1
 test_queries:
-  - SELECT instance_id, instance_type, recommendation_type, monthly_cost FROM aws_cost_explorer.rightsizing_recommendations LIMIT 5
-  - SELECT period_start, period_total_cost, estimated FROM aws_cost_explorer.cost_by_service WHERE time_period_start = '2026-04-01' AND time_period_end = '2026-05-01' LIMIT 1
+  - >-
+    SELECT instance_id, instance_type, recommendation_type, monthly_cost
+    FROM aws_cost_explorer.rightsizing_recommendations
+    LIMIT 5
 tables:
+  # AWS Cost Explorer is a JSON-RPC service. Per the public service
+  # model (botocore: data/ce/2017-10-25/service-2.json) the documented
+  # `targetPrefix` is `AWSInsightsIndexService`, which is the value the
+  # AWS SDKs send in `X-Amz-Target`. The prefix is internal-looking and
+  # doesn't appear in the user-facing API reference; do not "fix" it to
+  # something like `AWSCostExplorer` — the wire contract requires this
+  # exact value.
   - name: cost_by_service
     description: >-
       AWS cost per billing period grouped by service, returned by GetCostAndUsage.
       Each row represents one time period. The groups column contains the full
       per-service breakdown as a JSON array — use json_get_json to extract it.
-      Use period_total_cost for the aggregate cost across all services in the period.
+      Because the request always sets a SERVICE GroupBy, AWS returns the
+      response Total block as an empty object, so all per-period totals must
+      come from the per-service entries inside `groups`.
     guide: |
       Requires time_period_start and time_period_end (YYYY-MM-DD, end is exclusive —
       use the first day of the following month to include the full month).
@@ -82,16 +97,20 @@ tables:
           month to include all days. Example: '2026-06-01' for all of May.
       - name: granularity
         description: >-
-          Aggregation period. MONTHLY (default) or DAILY. HOURLY is limited
-          to the last 14 days and requires the hourly-granularity opt-in
-          on the AWS account.
+          Aggregation period. MONTHLY (default) or DAILY. HOURLY is
+          opt-in at the AWS payer-account level and limited to the last
+          14 days; HOURLY also requires time_period_start and
+          time_period_end to be passed as ISO-8601 timestamps
+          (e.g. '2026-05-29T00:00:00Z') instead of YYYY-MM-DD dates,
+          otherwise AWS rejects the request with ValidationException
+          ("Time period is invalid. Valid format is yyyy-MM-ddThh:mm:ssZ.").
       - name: metric
         description: >-
-          Cost metric to retrieve. UNBLENDED_COST (default), AMORTIZED_COST,
-          BLENDED_COST, NET_UNBLENDED_COST, NET_AMORTIZED_COST,
-          USAGE_QUANTITY, NORMALIZED_USAGE_AMOUNT.
-          Use AMORTIZED_COST when the account uses Reserved Instances or
-          Savings Plans — UNBLENDED_COST understates amortized commitment costs.
+          Cost metric to retrieve. UnblendedCost (default), AmortizedCost,
+          BlendedCost, NetUnblendedCost, NetAmortizedCost,
+          UsageQuantity, NormalizedUsageAmount.
+          Use AmortizedCost when the account uses Reserved Instances or
+          Savings Plans — UnblendedCost understates amortized commitment costs.
     request:
       method: POST
       path: /
@@ -119,7 +138,7 @@ tables:
         - path: [Metrics, "0"]
           from: filter
           key: metric
-          default: UNBLENDED_COST
+          default: UnblendedCost
     response:
       rows_path: [ResultsByTime]
     pagination:
@@ -150,46 +169,6 @@ tables:
         nullable: true
         description: Actual end date of this billing period returned by the API.
         expr: {kind: path, path: [TimePeriod, End]}
-      - name: period_total_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total cost across all services for the period, projected from
-          the response key matching the metric the caller requested. When
-          metric = 'AMORTIZED_COST', this reflects Total.AmortizedCost.Amount;
-          when metric = 'UNBLENDED_COST' (the default), this reflects
-          Total.UnblendedCost.Amount; and so on for the other documented
-          metric values. Cast to Float64 before arithmetic:
-          CAST(period_total_cost AS DOUBLE). Use metric = 'AMORTIZED_COST'
-          for accounts with Reserved Instances or Savings Plans.
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [Total, UnblendedCost, Amount]}
-            - {kind: path, path: [Total, AmortizedCost, Amount]}
-            - {kind: path, path: [Total, BlendedCost, Amount]}
-            - {kind: path, path: [Total, NetUnblendedCost, Amount]}
-            - {kind: path, path: [Total, NetAmortizedCost, Amount]}
-            - {kind: path, path: [Total, UsageQuantity, Amount]}
-            - {kind: path, path: [Total, NormalizedUsageAmount, Amount]}
-      - name: unit
-        type: Utf8
-        nullable: true
-        description: >-
-          Currency or usage unit returned by the API for the metric the
-          caller requested. Typically 'USD' for cost metrics; 'Hrs' or
-          similar for USAGE_QUANTITY; unit-less or service-specific for
-          NORMALIZED_USAGE_AMOUNT.
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [Total, UnblendedCost, Unit]}
-            - {kind: path, path: [Total, AmortizedCost, Unit]}
-            - {kind: path, path: [Total, BlendedCost, Unit]}
-            - {kind: path, path: [Total, NetUnblendedCost, Unit]}
-            - {kind: path, path: [Total, NetAmortizedCost, Unit]}
-            - {kind: path, path: [Total, UsageQuantity, Unit]}
-            - {kind: path, path: [Total, NormalizedUsageAmount, Unit]}
       - name: estimated
         type: Boolean
         nullable: true
@@ -204,82 +183,21 @@ tables:
           Full per-service cost breakdown as a JSON array. Each element has
           Keys (service name) and Metrics keyed by the metric the caller
           requested (e.g. Metrics.AmortizedCost.Amount when
-          metric = 'AMORTIZED_COST'). Use json_get_json(groups, 0) to read
+          metric = 'AmortizedCost'). Use json_get_json(groups, 0) to read
           the first element, then json_get_str(first_element, 'Keys', 0) for
-          the service name. Per-metric typed columns (`amortized_cost`,
-          `blended_cost`, …) are also available alongside `groups` for the
-          row-level total without `json_get_str` navigation.
+          the service name. Per-period totals are not exposed as scalar
+          columns because AWS returns the response Total block empty
+          whenever a GroupBy is set; sum across the per-service entries
+          here to compute a period-level aggregate.
         expr: {kind: path, path: [Groups]}
-      - name: unblended_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total UNBLENDED_COST for the period as a string. Non-NULL only
-          when metric is unset (default) or metric = 'UNBLENDED_COST';
-          NULL when the caller selected a different metric.
-          Cast to Float64 before arithmetic.
-        expr: {kind: path, path: [Total, UnblendedCost, Amount]}
-      - name: amortized_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total AMORTIZED_COST for the period as a string. Non-NULL only
-          when metric = 'AMORTIZED_COST'. Use this metric for accounts
-          with Reserved Instances or Savings Plans — UNBLENDED_COST
-          understates amortized commitment costs.
-        expr: {kind: path, path: [Total, AmortizedCost, Amount]}
-      - name: blended_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total BLENDED_COST for the period as a string. Non-NULL only
-          when metric = 'BLENDED_COST'. Cast to Float64 before arithmetic.
-        expr: {kind: path, path: [Total, BlendedCost, Amount]}
-      - name: net_unblended_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total NET_UNBLENDED_COST for the period as a string (unblended
-          cost net of credits and refunds). Non-NULL only when
-          metric = 'NET_UNBLENDED_COST'. Cast to Float64 before arithmetic.
-        expr: {kind: path, path: [Total, NetUnblendedCost, Amount]}
-      - name: net_amortized_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total NET_AMORTIZED_COST for the period as a string (amortized
-          cost net of credits and refunds). Non-NULL only when
-          metric = 'NET_AMORTIZED_COST'. Cast to Float64 before arithmetic.
-        expr: {kind: path, path: [Total, NetAmortizedCost, Amount]}
-      - name: usage_quantity
-        type: Utf8
-        nullable: true
-        description: >-
-          Total USAGE_QUANTITY for the period as a string. Non-NULL only
-          when metric = 'USAGE_QUANTITY'. The aggregate value is unit-less
-          because the API sums quantities across services with different
-          natural units (EC2 hours, S3 GB, DynamoDB request counts) — the
-          companion `unit` column returns 'N/A' for this metric. To get
-          comparable usage figures, query a tag- or service-scoped slice
-          rather than the cross-service aggregate.
-        expr: {kind: path, path: [Total, UsageQuantity, Amount]}
-      - name: normalized_usage_amount
-        type: Utf8
-        nullable: true
-        description: >-
-          Total NORMALIZED_USAGE_AMOUNT for the period as a string,
-          normalized for instance-size-flexibility comparisons across
-          Reserved Instance families. Non-NULL only when
-          metric = 'NORMALIZED_USAGE_AMOUNT'.
-        expr: {kind: path, path: [Total, NormalizedUsageAmount, Amount]}
       - name: metric
         type: Utf8
         nullable: true
         virtual: true
         description: >-
-          Cost metric filter used for this query. UNBLENDED_COST (default),
-          AMORTIZED_COST, BLENDED_COST, NET_UNBLENDED_COST,
-          NET_AMORTIZED_COST, USAGE_QUANTITY, NORMALIZED_USAGE_AMOUNT.
+          Cost metric filter used for this query. UnblendedCost (default),
+          AmortizedCost, BlendedCost, NetUnblendedCost,
+          NetAmortizedCost, UsageQuantity, NormalizedUsageAmount.
           Bind via WHERE metric = '<value>' to retrieve a non-default metric.
         expr: {kind: from_filter, key: metric}
       - name: granularity
@@ -288,7 +206,8 @@ tables:
         virtual: true
         description: >-
           Aggregation period filter. MONTHLY (default), DAILY, or HOURLY
-          (last 14 days, opt-in). Bind via WHERE granularity = '<value>'.
+          (opt-in, last 14 days, requires ISO-8601 timestamps for
+          time_period_start/end). Bind via WHERE granularity = '<value>'.
         expr: {kind: from_filter, key: granularity}
 
   - name: cost_by_tag
@@ -296,12 +215,24 @@ tables:
       AWS cost per billing period grouped by a resource tag key, returned by GetCostAndUsage.
       Each row represents one time period. The groups column contains the full per-tag-value
       breakdown as a JSON array. Use tag_key = 'aws:cloudformation:stack-name' to attribute
-      cost to CloudFormation stacks and correlate with deployment events.
+      cost to CloudFormation stacks and correlate with deployment events. Because the
+      request always sets a TAG GroupBy, AWS returns the response Total block as an
+      empty object, so all per-period totals must come from the per-tag-value entries
+      inside `groups`.
     guide: |
       Requires time_period_start, time_period_end (YYYY-MM-DD, end exclusive),
-      and tag_key. The tag key must be activated as a cost allocation tag in the
-      AWS Billing console. The AWS-managed tag 'aws:cloudformation:stack-name'
-      is automatically activated and does not require manual activation.
+      and tag_key. The tag key must be activated as a cost allocation tag in
+      the AWS Billing and Cost Management console under Cost Allocation Tags
+      before it appears here. This applies to both user-defined tags
+      (under "User-Defined Cost Allocation Tags") and AWS-generated tags like
+      'aws:cloudformation:stack-name' (under "AWS-Generated Cost Allocation
+      Tags") — neither type is active by default.
+      Activation is non-retroactive: costs incurred before the tag was
+      activated do not get tagged after the fact, so a freshly activated
+      tag will show empty values for older billing periods.
+      In AWS Organizations, only the management account can activate cost
+      allocation tags; member-account credentials querying this table will
+      return empty tag values until the org owner activates the key.
       Each row is one time period. groups is a JSON array where each element has
       Keys (the tag value) and Metrics.UnblendedCost.Amount. Resources with no
       value for that tag appear with an empty string as the tag value.
@@ -316,21 +247,29 @@ tables:
       - name: tag_key
         required: true
         description: >-
-          The AWS tag key to group costs by. Use 'aws:cloudformation:stack-name'
-          to attribute costs to CloudFormation stacks. User-defined tags must be
-          activated in Billing → Cost allocation tags first.
+          The AWS tag key to group costs by. Use
+          'aws:cloudformation:stack-name' to attribute costs to
+          CloudFormation stacks. Both user-defined and AWS-generated
+          (`aws:` prefix) tag keys must be activated under
+          Billing → Cost Allocation Tags before they return any data
+          here, and only the management account can activate them in
+          AWS Organizations.
       - name: granularity
         description: >-
-          Aggregation period. MONTHLY (default) or DAILY. HOURLY is limited
-          to the last 14 days and requires the hourly-granularity opt-in
-          on the AWS account.
+          Aggregation period. MONTHLY (default) or DAILY. HOURLY is
+          opt-in at the AWS payer-account level and limited to the last
+          14 days; HOURLY also requires time_period_start and
+          time_period_end to be passed as ISO-8601 timestamps
+          (e.g. '2026-05-29T00:00:00Z') instead of YYYY-MM-DD dates,
+          otherwise AWS rejects the request with ValidationException
+          ("Time period is invalid. Valid format is yyyy-MM-ddThh:mm:ssZ.").
       - name: metric
         description: >-
-          Cost metric to retrieve. UNBLENDED_COST (default), AMORTIZED_COST,
-          BLENDED_COST, NET_UNBLENDED_COST, NET_AMORTIZED_COST,
-          USAGE_QUANTITY, NORMALIZED_USAGE_AMOUNT.
-          Use AMORTIZED_COST when the account uses Reserved Instances or
-          Savings Plans — UNBLENDED_COST understates amortized commitment costs.
+          Cost metric to retrieve. UnblendedCost (default), AmortizedCost,
+          BlendedCost, NetUnblendedCost, NetAmortizedCost,
+          UsageQuantity, NormalizedUsageAmount.
+          Use AmortizedCost when the account uses Reserved Instances or
+          Savings Plans — UnblendedCost understates amortized commitment costs.
     request:
       method: POST
       path: /
@@ -358,7 +297,7 @@ tables:
         - path: [Metrics, "0"]
           from: filter
           key: metric
-          default: UNBLENDED_COST
+          default: UnblendedCost
     response:
       rows_path: [ResultsByTime]
     pagination:
@@ -395,46 +334,6 @@ tables:
         nullable: true
         description: Actual end date of this billing period returned by the API.
         expr: {kind: path, path: [TimePeriod, End]}
-      - name: period_total_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total cost across all tag values for the period, projected from
-          the response key matching the metric the caller requested. When
-          metric = 'AMORTIZED_COST', this reflects Total.AmortizedCost.Amount;
-          when metric = 'UNBLENDED_COST' (the default), this reflects
-          Total.UnblendedCost.Amount; and so on for the other documented
-          metric values. Cast to Float64 before arithmetic:
-          CAST(period_total_cost AS DOUBLE). Use metric = 'AMORTIZED_COST'
-          for accounts with Reserved Instances or Savings Plans.
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [Total, UnblendedCost, Amount]}
-            - {kind: path, path: [Total, AmortizedCost, Amount]}
-            - {kind: path, path: [Total, BlendedCost, Amount]}
-            - {kind: path, path: [Total, NetUnblendedCost, Amount]}
-            - {kind: path, path: [Total, NetAmortizedCost, Amount]}
-            - {kind: path, path: [Total, UsageQuantity, Amount]}
-            - {kind: path, path: [Total, NormalizedUsageAmount, Amount]}
-      - name: unit
-        type: Utf8
-        nullable: true
-        description: >-
-          Currency or usage unit returned by the API for the metric the
-          caller requested. Typically 'USD' for cost metrics; 'Hrs' or
-          similar for USAGE_QUANTITY; unit-less or service-specific for
-          NORMALIZED_USAGE_AMOUNT.
-        expr:
-          kind: coalesce
-          exprs:
-            - {kind: path, path: [Total, UnblendedCost, Unit]}
-            - {kind: path, path: [Total, AmortizedCost, Unit]}
-            - {kind: path, path: [Total, BlendedCost, Unit]}
-            - {kind: path, path: [Total, NetUnblendedCost, Unit]}
-            - {kind: path, path: [Total, NetAmortizedCost, Unit]}
-            - {kind: path, path: [Total, UsageQuantity, Unit]}
-            - {kind: path, path: [Total, NormalizedUsageAmount, Unit]}
       - name: estimated
         type: Boolean
         nullable: true
@@ -447,92 +346,21 @@ tables:
           Full per-tag-value cost breakdown as a JSON array. Each element has
           Keys (the tag value) and Metrics keyed by the metric the caller
           requested (e.g. Metrics.AmortizedCost.Amount when
-          metric = 'AMORTIZED_COST'). Use json_get_json(groups, 0) to read
+          metric = 'AmortizedCost'). Use json_get_json(groups, 0) to read
           the first element, then json_get_str(first_element, 'Keys', 0) for
-          the tag value. Per-metric typed columns (`amortized_cost`,
-          `blended_cost`, …) are also available alongside `groups` for the
-          row-level total without `json_get_str` navigation.
+          the tag value. Per-period totals are not exposed as scalar
+          columns because AWS returns the response Total block empty
+          whenever a GroupBy is set; sum across the per-tag-value entries
+          here to compute a period-level aggregate.
         expr: {kind: path, path: [Groups]}
-      - name: unblended_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total UNBLENDED_COST for the period across all tag values, as a
-          string. Non-NULL only when metric is unset (default) or
-          metric = 'UNBLENDED_COST'; NULL when the caller selected a
-          different metric. For per-tag-value breakdowns use the `groups`
-          JSON column. Cast to Float64 before arithmetic.
-        expr: {kind: path, path: [Total, UnblendedCost, Amount]}
-      - name: amortized_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total AMORTIZED_COST for the period across all tag values, as a
-          string. Non-NULL only when metric = 'AMORTIZED_COST'. For
-          per-tag-value breakdowns use the `groups` JSON column. Use this
-          metric for accounts with Reserved Instances or Savings Plans —
-          UNBLENDED_COST understates amortized commitment costs.
-        expr: {kind: path, path: [Total, AmortizedCost, Amount]}
-      - name: blended_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total BLENDED_COST for the period across all tag values, as a
-          string. Non-NULL only when metric = 'BLENDED_COST'. For
-          per-tag-value breakdowns use the `groups` JSON column. Cast to
-          Float64 before arithmetic.
-        expr: {kind: path, path: [Total, BlendedCost, Amount]}
-      - name: net_unblended_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total NET_UNBLENDED_COST for the period across all tag values
-          (unblended cost net of credits and refunds), as a string. Non-NULL
-          only when metric = 'NET_UNBLENDED_COST'. For per-tag-value
-          breakdowns use the `groups` JSON column. Cast to Float64 before
-          arithmetic.
-        expr: {kind: path, path: [Total, NetUnblendedCost, Amount]}
-      - name: net_amortized_cost
-        type: Utf8
-        nullable: true
-        description: >-
-          Total NET_AMORTIZED_COST for the period across all tag values
-          (amortized cost net of credits and refunds), as a string. Non-NULL
-          only when metric = 'NET_AMORTIZED_COST'. For per-tag-value
-          breakdowns use the `groups` JSON column. Cast to Float64 before
-          arithmetic.
-        expr: {kind: path, path: [Total, NetAmortizedCost, Amount]}
-      - name: usage_quantity
-        type: Utf8
-        nullable: true
-        description: >-
-          Total USAGE_QUANTITY for the period across all tag values, as a
-          string. Non-NULL only when metric = 'USAGE_QUANTITY'. The
-          aggregate value is unit-less because the API sums quantities
-          across services with different natural units (EC2 hours, S3 GB,
-          DynamoDB request counts) — the companion `unit` column returns
-          'N/A' for this metric. To get comparable usage figures, query a
-          service-scoped slice rather than the cross-service aggregate.
-          For per-tag-value breakdowns use the `groups` JSON column.
-        expr: {kind: path, path: [Total, UsageQuantity, Amount]}
-      - name: normalized_usage_amount
-        type: Utf8
-        nullable: true
-        description: >-
-          Total NORMALIZED_USAGE_AMOUNT for the period across all tag
-          values, as a string, normalized for instance-size-flexibility
-          comparisons across Reserved Instance families. Non-NULL only when
-          metric = 'NORMALIZED_USAGE_AMOUNT'. For per-tag-value breakdowns
-          use the `groups` JSON column.
-        expr: {kind: path, path: [Total, NormalizedUsageAmount, Amount]}
       - name: metric
         type: Utf8
         nullable: true
         virtual: true
         description: >-
-          Cost metric filter used for this query. UNBLENDED_COST (default),
-          AMORTIZED_COST, BLENDED_COST, NET_UNBLENDED_COST,
-          NET_AMORTIZED_COST, USAGE_QUANTITY, NORMALIZED_USAGE_AMOUNT.
+          Cost metric filter used for this query. UnblendedCost (default),
+          AmortizedCost, BlendedCost, NetUnblendedCost,
+          NetAmortizedCost, UsageQuantity, NormalizedUsageAmount.
           Bind via WHERE metric = '<value>' to retrieve a non-default metric.
         expr: {kind: from_filter, key: metric}
       - name: granularity
@@ -541,7 +369,8 @@ tables:
         virtual: true
         description: >-
           Aggregation period filter. MONTHLY (default), DAILY, or HOURLY
-          (last 14 days, opt-in). Bind via WHERE granularity = '<value>'.
+          (opt-in, last 14 days, requires ISO-8601 timestamps for
+          time_period_start/end). Bind via WHERE granularity = '<value>'.
         expr: {kind: from_filter, key: granularity}
 
   - name: anomalies
@@ -557,6 +386,11 @@ tables:
       Anomalies are retained for up to 90 days. Newer accounts (less than ~5
       weeks of billing history) may return no results because AWS needs that
       minimum baseline to detect spikes.
+      date_interval_end has an upper bound of "yesterday" — AWS rejects
+      end dates of today or later with ValidationException ("Latest
+      supported detectionDate for GetRecentAnomalies is …"). Use the
+      previous day's date as the inclusive upper edge of the search
+      window.
       anomaly_end_date is null for anomalies that are still active (the spike
       has not ended). Use IS NULL to find ongoing anomalies.
       total_impact is the dollar difference between actual and expected
@@ -576,7 +410,11 @@ tables:
           billing period.
       - name: date_interval_end
         required: true
-        description: End of the anomaly search window. Format YYYY-MM-DD.
+        description: >-
+          End of the anomaly search window. Format YYYY-MM-DD. Must be
+          yesterday or earlier — AWS rejects today/future end dates with
+          ValidationException ("Latest supported detectionDate for
+          GetRecentAnomalies is …").
       - name: total_impact_min
         description: >-
           Minimum total dollar impact to include. Filters out low-value
@@ -617,6 +455,9 @@ tables:
         - path: [MonitorArn]
           from: filter
           key: monitor_arn
+        # GetAnomalies MaxResults is the PageSize integer (no documented
+        # max). 100 is an arbitrary page-size choice within the legal
+        # range; pagination chases NextPageToken until exhaustion.
         - path: [MaxResults]
           from: literal
           value: 100
@@ -749,17 +590,29 @@ tables:
 
   - name: cost_forecast
     description: >-
-      Projected cost for a future or in-progress billing period, returned by
+      Projected cost for an in-progress or future billing period, returned by
       GetCostForecast. Returns a mean prediction with a configurable
       confidence interval per sub-period. Use to project end-of-month
       spend, size the impact of a recent infrastructure change, or answer
       'are we going to exceed budget?' in an agent session.
     guide: |
       Requires time_period_start, time_period_end, granularity, and metric.
-      time_period_start must be today or a future date — past dates return
-      ValidationException. To forecast the remainder of the current month,
-      set time_period_start to today and time_period_end to the first of
-      next month.
+      time_period_start has a hard lower bound of "yesterday" — AWS
+      rejects earlier start dates with ValidationException ("Earliest
+      supported Start is …"). Future start dates are accepted in practice
+      even though AWS docs say the start "must be equal to or no later
+      than the current date"; in live tests, AWS returns
+      DataUnavailableException ("Insufficient amount of historical
+      data") rather than rejecting the start date itself when there is
+      no history to forecast from. The forecast covers
+      time_period_start through time_period_end exclusive; AWS blends
+      actuals up to today with a prediction beyond.
+      time_period_end has its own ceiling: AWS rejects ends more than ~3
+      months ahead at DAILY granularity (or ~18 months ahead at MONTHLY)
+      with ValidationException ("Latest supported End is …").
+      To forecast the full current month from yesterday onward, set
+      time_period_start to yesterday and time_period_end to the first
+      of next month.
       The supported metric set is narrower than cost_by_service /
       cost_by_tag: only AMORTIZED_COST, BLENDED_COST, NET_AMORTIZED_COST,
       NET_UNBLENDED_COST, and UNBLENDED_COST. USAGE_QUANTITY and
@@ -774,13 +627,20 @@ tables:
       - name: time_period_start
         required: true
         description: >-
-          Start of the forecast period. Must be today or a future date.
-          Format YYYY-MM-DD. Use today's date to forecast the rest of the
-          current month.
+          Start of the forecast period, inclusive. Must be yesterday or
+          later — AWS rejects earlier starts with ValidationException
+          ("Earliest supported Start is …"). Future starts are accepted
+          in practice (AWS returns DataUnavailableException when there
+          is no data to forecast). Format YYYY-MM-DD. Use yesterday's
+          date to forecast from the most recent settled day, or a
+          future date to forecast a future window.
       - name: time_period_end
         required: true
         description: >-
           End of the forecast period, exclusive. Format YYYY-MM-DD.
+          AWS caps the end date at today + ~3 months for DAILY (or
+          today + ~18 months for MONTHLY) and rejects later dates with
+          ValidationException ("Latest supported End is …").
       - name: granularity
         required: true
         description: >-
@@ -910,7 +770,10 @@ tables:
       larger savings but may change network and CPU performance and require
       application testing.
       `estimated_monthly_savings` reflects the MODIFY target's first option
-      OR the TERMINATE detail, depending on `recommendation_type`. When
+      in the response array OR the TERMINATE detail, depending on
+      `recommendation_type`. AWS may return multiple modify candidates and
+      flags the recommended one with `DefaultTargetInstance`, but this
+      manifest currently surfaces only the array's first element. When
       `recommendation_type = 'TERMINATE'`, `target_instance_type` is NULL
       because there is no replacement instance.
     filters:
@@ -944,6 +807,9 @@ tables:
           from: filter_bool
           key: benefits_considered
           default: true
+        # GetRightsizingRecommendation PageSize is RecommendationsPageSize
+        # (max 6000). 100 keeps per-call payloads small; pagination
+        # chases NextPageToken until exhaustion.
         - path: [PageSize]
           from: literal
           value: 100
@@ -994,10 +860,12 @@ tables:
         nullable: true
         description: >-
           Estimated monthly savings if the recommendation is applied, as a
-          string. For MODIFY recommendations, reflects the first
-          (highest-savings) target instance only — AWS may return multiple
-          options. For TERMINATE recommendations, reflects the full
-          terminate savings (the entire instance cost). Cast to Float64
+          string. For MODIFY recommendations, reflects the first target
+          instance returned by AWS — AWS marks the recommended option with
+          `DefaultTargetInstance: true`, but this column projects the
+          array's first element regardless of that flag. For TERMINATE
+          recommendations, reflects the full terminate savings (the entire
+          instance cost). Cast to Float64
           before arithmetic.
         expr:
           kind: coalesce
@@ -1031,8 +899,10 @@ tables:
         description: >-
           Recommended target instance type for MODIFY recommendations.
           NULL for TERMINATE recommendations (no replacement instance).
-          Reflects the first (primary) target option — AWS may return
-          multiple candidates.
+          Reflects the first target instance returned by AWS — AWS marks
+          the recommended option with `DefaultTargetInstance: true`, but
+          this column projects the array's first element regardless of
+          that flag.
         expr:
           {kind: path, path: [ModifyRecommendationDetail, TargetInstances, "0", ResourceDetails, EC2ResourceDetails, InstanceType]}
       - name: recommendation_target
@@ -1060,8 +930,11 @@ tables:
       purchasing or expanding a Savings Plan.
     guide: |
       Requires time_period_start and time_period_end (YYYY-MM-DD, end exclusive).
-      The Start date must be within the last 13 months. coverage_pct below 80
-      with significant on_demand_cost is a strong signal to review commitment
+      The Start date must be within the last 13 months. time_period_end
+      is exclusive and AWS rejects end dates after today with
+      ValidationException ("end date should NOT be after [today]"); use
+      today's date for an in-progress month. coverage_pct below 80 with
+      significant on_demand_cost is a strong signal to review commitment
       purchases. New Savings Plans take up to 72 hours to fully appear in
       coverage data.
       total_cost is the sum of on_demand_cost and spend_covered_by_savings_plans
@@ -1073,7 +946,10 @@ tables:
         description: Start of the coverage period, inclusive. Format YYYY-MM-DD.
       - name: time_period_end
         required: true
-        description: End of the coverage period, exclusive. Format YYYY-MM-DD.
+        description: >-
+          End of the coverage period, exclusive. Format YYYY-MM-DD. Must
+          be today or earlier — AWS rejects end dates after today with
+          ValidationException ("end date should NOT be after [today]").
     request:
       method: POST
       path: /
@@ -1094,6 +970,9 @@ tables:
         - path: [GroupBy, "0", Key]
           from: literal
           value: SERVICE
+        # GetSavingsPlansCoverage MaxResults is MaxResults (min 1, no
+        # documented max; AWS default is 20). 100 keeps round-trips
+        # bounded; pagination chases NextToken until exhaustion.
         - path: [MaxResults]
           from: literal
           value: 100
@@ -1136,17 +1015,18 @@ tables:
         type: Utf8
         nullable: true
         description: >-
-          Percentage of on-demand hours covered by Savings Plans, as a string.
-          Cast to Float64: CAST(coverage_pct AS DOUBLE). Values below 80 indicate
-          significant uncovered spend.
-        expr: {kind: path, path: [Coverage, CoverageHours, CoverageHoursPercentage]}
+          Percentage of eligible Savings Plans usage covered by an active
+          Savings Plan, as a string. Cast to Float64:
+          CAST(coverage_pct AS DOUBLE). Values below 80 indicate significant
+          uncovered spend.
+        expr: {kind: path, path: [Coverage, CoveragePercentage]}
       - name: on_demand_cost
         type: Utf8
         nullable: true
         description: >-
           On-demand spend not covered by any Savings Plan, as a string.
           Cast to Float64 for calculations.
-        expr: {kind: path, path: [Coverage, CoverageCost, OnDemandCost]}
+        expr: {kind: path, path: [Coverage, OnDemandCost]}
       - name: spend_covered_by_savings_plans
         type: Utf8
         nullable: true
@@ -1154,11 +1034,11 @@ tables:
           Spend covered by an active Savings Plan, as a string.
           Cast to Float64: CAST(spend_covered_by_savings_plans AS DOUBLE).
           Sum with on_demand_cost to get total compute spend.
-        expr: {kind: path, path: [Coverage, CoverageCost, SpendCoveredBySavingsPlans]}
+        expr: {kind: path, path: [Coverage, SpendCoveredBySavingsPlans]}
       - name: total_cost
         type: Utf8
         nullable: true
         description: >-
           Total compute spend (on_demand_cost + spend_covered_by_savings_plans)
           for this service grouping, as a string. Cast to Float64 for calculations.
-        expr: {kind: path, path: [Coverage, CoverageCost, TotalCost]}
+        expr: {kind: path, path: [Coverage, TotalCost]}

--- a/sources/community/aws_cost_explorer/manifest.yaml
+++ b/sources/community/aws_cost_explorer/manifest.yaml
@@ -82,8 +82,14 @@ tables:
       Each row is one time period. groups is a JSON array of
       {"Keys":["<service>"],"Metrics":{"UnblendedCost":{"Amount":"...","Unit":"USD"}}}
       objects — one entry per AWS service. Use json_get_json(groups, 0)
-      to get the first service element, then json_get_str on the result
-      to extract 'Keys' and 'Metrics' fields.
+      to inspect the first service element, then json_get_str on the result
+      to extract 'Keys' and 'Metrics' fields. To analyze ALL services
+      (e.g. "top services by spend"), expand the array into one row per
+      service with unnest(json_get_array(groups)) in a subquery, then
+      project json_get_str(g, 'Keys', 0) for the service and
+      json_get_str(g, 'Metrics', '<metric>', 'Amount') for the cost
+      (match '<metric>' to the bound metric filter; default UnblendedCost).
+      See the README cost_by_service examples for the full query.
     filters:
       - name: time_period_start
         required: true
@@ -185,7 +191,9 @@ tables:
           requested (e.g. Metrics.AmortizedCost.Amount when
           metric = 'AmortizedCost'). Use json_get_json(groups, 0) to read
           the first element, then json_get_str(first_element, 'Keys', 0) for
-          the service name. Per-period totals are not exposed as scalar
+          the service name. To analyze all services in one query, expand
+          with unnest(json_get_array(groups)) in a subquery (see README).
+          Per-period totals are not exposed as scalar
           columns because AWS returns the response Total block empty
           whenever a GroupBy is set; sum across the per-service entries
           here to compute a period-level aggregate.
@@ -195,19 +203,23 @@ tables:
         nullable: true
         virtual: true
         description: >-
-          Cost metric filter used for this query. UnblendedCost (default),
-          AmortizedCost, BlendedCost, NetUnblendedCost,
-          NetAmortizedCost, UsageQuantity, NormalizedUsageAmount.
-          Bind via WHERE metric = '<value>' to retrieve a non-default metric.
+          Cost metric filter used for this query. Defaults to UnblendedCost
+          in the request, but this column is NULL unless you bind it
+          explicitly via WHERE metric = '<value>' — it echoes the bound
+          filter, not the applied default. Other values: AmortizedCost,
+          BlendedCost, NetUnblendedCost, NetAmortizedCost, UsageQuantity,
+          NormalizedUsageAmount.
         expr: {kind: from_filter, key: metric}
       - name: granularity
         type: Utf8
         nullable: true
         virtual: true
         description: >-
-          Aggregation period filter. MONTHLY (default), DAILY, or HOURLY
-          (opt-in, last 14 days, requires ISO-8601 timestamps for
-          time_period_start/end). Bind via WHERE granularity = '<value>'.
+          Aggregation period filter. Defaults to MONTHLY in the request, but
+          this column is NULL unless you bind it explicitly via WHERE
+          granularity = '<value>' — it echoes the bound filter, not the
+          applied default. Other values: DAILY, or HOURLY (opt-in, last 14
+          days, requires ISO-8601 timestamps for time_period_start/end).
         expr: {kind: from_filter, key: granularity}
 
   - name: cost_by_tag
@@ -236,7 +248,13 @@ tables:
       Each row is one time period. groups is a JSON array where each element has
       Keys (the tag value) and Metrics.UnblendedCost.Amount. Resources with no
       value for that tag appear with an empty string as the tag value.
-      Use json_get_json(groups, 0) to read the first element.
+      Use json_get_json(groups, 0) to inspect the first element. To rank ALL
+      tag values by spend, expand the array into one row per tag value with
+      unnest(json_get_array(groups)) in a subquery, then project
+      json_get_str(g, 'Keys', 0) for the tag value and
+      json_get_str(g, 'Metrics', '<metric>', 'Amount') for the cost
+      (match '<metric>' to the bound metric filter; default UnblendedCost).
+      See the README cost_by_tag examples for the full query.
     filters:
       - name: time_period_start
         required: true
@@ -348,7 +366,9 @@ tables:
           requested (e.g. Metrics.AmortizedCost.Amount when
           metric = 'AmortizedCost'). Use json_get_json(groups, 0) to read
           the first element, then json_get_str(first_element, 'Keys', 0) for
-          the tag value. Per-period totals are not exposed as scalar
+          the tag value. To rank all tag values in one query, expand
+          with unnest(json_get_array(groups)) in a subquery (see README).
+          Per-period totals are not exposed as scalar
           columns because AWS returns the response Total block empty
           whenever a GroupBy is set; sum across the per-tag-value entries
           here to compute a period-level aggregate.
@@ -358,19 +378,23 @@ tables:
         nullable: true
         virtual: true
         description: >-
-          Cost metric filter used for this query. UnblendedCost (default),
-          AmortizedCost, BlendedCost, NetUnblendedCost,
-          NetAmortizedCost, UsageQuantity, NormalizedUsageAmount.
-          Bind via WHERE metric = '<value>' to retrieve a non-default metric.
+          Cost metric filter used for this query. Defaults to UnblendedCost
+          in the request, but this column is NULL unless you bind it
+          explicitly via WHERE metric = '<value>' — it echoes the bound
+          filter, not the applied default. Other values: AmortizedCost,
+          BlendedCost, NetUnblendedCost, NetAmortizedCost, UsageQuantity,
+          NormalizedUsageAmount.
         expr: {kind: from_filter, key: metric}
       - name: granularity
         type: Utf8
         nullable: true
         virtual: true
         description: >-
-          Aggregation period filter. MONTHLY (default), DAILY, or HOURLY
-          (opt-in, last 14 days, requires ISO-8601 timestamps for
-          time_period_start/end). Bind via WHERE granularity = '<value>'.
+          Aggregation period filter. Defaults to MONTHLY in the request, but
+          this column is NULL unless you bind it explicitly via WHERE
+          granularity = '<value>' — it echoes the bound filter, not the
+          applied default. Other values: DAILY, or HOURLY (opt-in, last 14
+          days, requires ISO-8601 timestamps for time_period_start/end).
         expr: {kind: from_filter, key: granularity}
 
   - name: anomalies

--- a/sources/community/aws_cost_explorer/manifest.yaml
+++ b/sources/community/aws_cost_explorer/manifest.yaml
@@ -123,7 +123,10 @@ tables:
     response:
       rows_path: [ResultsByTime]
     pagination:
-      mode: none
+      mode: cursor_body
+      cursor_body_path: [NextPageToken]
+      response_cursor_path: [NextPageToken]
+      max_pages: 100
     columns:
       - name: time_period_start
         type: Utf8
@@ -359,7 +362,10 @@ tables:
     response:
       rows_path: [ResultsByTime]
     pagination:
-      mode: none
+      mode: cursor_body
+      cursor_body_path: [NextPageToken]
+      response_cursor_path: [NextPageToken]
+      max_pages: 100
     columns:
       - name: time_period_start
         type: Utf8
@@ -451,63 +457,73 @@ tables:
         type: Utf8
         nullable: true
         description: >-
-          Total UNBLENDED_COST for the tag value group as a string. Non-NULL
-          only when metric is unset (default) or metric = 'UNBLENDED_COST';
-          NULL when the caller selected a different metric.
-          Cast to Float64 before arithmetic.
+          Total UNBLENDED_COST for the period across all tag values, as a
+          string. Non-NULL only when metric is unset (default) or
+          metric = 'UNBLENDED_COST'; NULL when the caller selected a
+          different metric. For per-tag-value breakdowns use the `groups`
+          JSON column. Cast to Float64 before arithmetic.
         expr: {kind: path, path: [Total, UnblendedCost, Amount]}
       - name: amortized_cost
         type: Utf8
         nullable: true
         description: >-
-          Total AMORTIZED_COST for the tag value group as a string. Non-NULL
-          only when metric = 'AMORTIZED_COST'. Use this metric for accounts
-          with Reserved Instances or Savings Plans — UNBLENDED_COST
-          understates amortized commitment costs.
+          Total AMORTIZED_COST for the period across all tag values, as a
+          string. Non-NULL only when metric = 'AMORTIZED_COST'. For
+          per-tag-value breakdowns use the `groups` JSON column. Use this
+          metric for accounts with Reserved Instances or Savings Plans —
+          UNBLENDED_COST understates amortized commitment costs.
         expr: {kind: path, path: [Total, AmortizedCost, Amount]}
       - name: blended_cost
         type: Utf8
         nullable: true
         description: >-
-          Total BLENDED_COST for the tag value group as a string. Non-NULL
-          only when metric = 'BLENDED_COST'. Cast to Float64 before arithmetic.
+          Total BLENDED_COST for the period across all tag values, as a
+          string. Non-NULL only when metric = 'BLENDED_COST'. For
+          per-tag-value breakdowns use the `groups` JSON column. Cast to
+          Float64 before arithmetic.
         expr: {kind: path, path: [Total, BlendedCost, Amount]}
       - name: net_unblended_cost
         type: Utf8
         nullable: true
         description: >-
-          Total NET_UNBLENDED_COST for the tag value group as a string
-          (unblended cost net of credits and refunds). Non-NULL only when
-          metric = 'NET_UNBLENDED_COST'. Cast to Float64 before arithmetic.
+          Total NET_UNBLENDED_COST for the period across all tag values
+          (unblended cost net of credits and refunds), as a string. Non-NULL
+          only when metric = 'NET_UNBLENDED_COST'. For per-tag-value
+          breakdowns use the `groups` JSON column. Cast to Float64 before
+          arithmetic.
         expr: {kind: path, path: [Total, NetUnblendedCost, Amount]}
       - name: net_amortized_cost
         type: Utf8
         nullable: true
         description: >-
-          Total NET_AMORTIZED_COST for the tag value group as a string
-          (amortized cost net of credits and refunds). Non-NULL only when
-          metric = 'NET_AMORTIZED_COST'. Cast to Float64 before arithmetic.
+          Total NET_AMORTIZED_COST for the period across all tag values
+          (amortized cost net of credits and refunds), as a string. Non-NULL
+          only when metric = 'NET_AMORTIZED_COST'. For per-tag-value
+          breakdowns use the `groups` JSON column. Cast to Float64 before
+          arithmetic.
         expr: {kind: path, path: [Total, NetAmortizedCost, Amount]}
       - name: usage_quantity
         type: Utf8
         nullable: true
         description: >-
-          Total USAGE_QUANTITY for the tag value group as a string. Non-NULL
-          only when metric = 'USAGE_QUANTITY'. The aggregate value is
-          unit-less because the API sums quantities across services with
-          different natural units (EC2 hours, S3 GB, DynamoDB request
-          counts) — the companion `unit` column returns 'N/A' for this
-          metric. To get comparable usage figures, query a service-scoped
-          slice rather than the cross-service aggregate.
+          Total USAGE_QUANTITY for the period across all tag values, as a
+          string. Non-NULL only when metric = 'USAGE_QUANTITY'. The
+          aggregate value is unit-less because the API sums quantities
+          across services with different natural units (EC2 hours, S3 GB,
+          DynamoDB request counts) — the companion `unit` column returns
+          'N/A' for this metric. To get comparable usage figures, query a
+          service-scoped slice rather than the cross-service aggregate.
+          For per-tag-value breakdowns use the `groups` JSON column.
         expr: {kind: path, path: [Total, UsageQuantity, Amount]}
       - name: normalized_usage_amount
         type: Utf8
         nullable: true
         description: >-
-          Total NORMALIZED_USAGE_AMOUNT for the tag value group as a string,
-          normalized for instance-size-flexibility comparisons across
-          Reserved Instance families. Non-NULL only when
-          metric = 'NORMALIZED_USAGE_AMOUNT'.
+          Total NORMALIZED_USAGE_AMOUNT for the period across all tag
+          values, as a string, normalized for instance-size-flexibility
+          comparisons across Reserved Instance families. Non-NULL only when
+          metric = 'NORMALIZED_USAGE_AMOUNT'. For per-tag-value breakdowns
+          use the `groups` JSON column.
         expr: {kind: path, path: [Total, NormalizedUsageAmount, Amount]}
       - name: metric
         type: Utf8
@@ -1072,9 +1088,6 @@ tables:
         - path: [TimePeriod, End]
           from: filter
           key: time_period_end
-        - path: [Granularity]
-          from: literal
-          value: MONTHLY
         - path: [GroupBy, "0", Type]
           from: literal
           value: DIMENSION


### PR DESCRIPTION
# feat(sources/community/aws_cost_explorer): add Cost Explorer source

Adds a new read-only community source for AWS Cost Explorer under `sources/community/aws_cost_explorer/`, exposing cost and usage metrics, rightsizing recommendations, Savings Plans coverage, anomaly detection, and cost forecasting via the Cost Explorer API.

## What's included

`manifest.yaml` — six tables, all using the `aws_sigv4` authenticator with `service: ce`, the same auth pattern as `cloudwatch_logs` and `cloudwatch_metrics`:

| Table | Purpose | API call |
|---|---|---|
| `cost_by_service` | Per-billing-period cost grouped by AWS service | `GetCostAndUsage` (group by `SERVICE`) |
| `cost_by_tag` | Per-billing-period cost grouped by a resource tag value | `GetCostAndUsage` (group by `TAG`) |
| `rightsizing_recommendations` | EC2 downsize / terminate recommendations | `GetRightsizingRecommendation` |
| `savings_plans_coverage` | Savings Plans coverage by service | `GetSavingsPlansCoverage` |
| `anomalies` | ML-detected cost spikes with root-cause breakdown | `GetAnomalies` |
| `cost_forecast` | Projected spend with prediction-interval bounds | `GetCostForecast` |

`README.md` walks the user through:

1. **Authentication setup** — IAM policy with the five required `ce:*` actions (read-only, `Resource: "*"` because Cost Explorer doesn't support resource-level scoping).
2. **Enabling Cost Explorer in the console** — required because the API returns `OptInRequired` until activated, with up to 24 hours of activation lag.
3. **Generating IAM access keys** for an IAM user with the policy attached.
4. **Adding the source** — `coral source add --file sources/community/aws_cost_explorer/manifest.yaml` with environment variables, including partition-aware `AWS_REGION` and `AWS_ENDPOINT_SUFFIX` overrides for GovCloud and China.

The README also documents:
- A summary table of every table's required filters.
- The per-metric NULL contract (`metric = 'AMORTIZED_COST'` populates `amortized_cost` and leaves `unblended_cost` NULL on the same row, etc.) with a concrete example.
- One worked SQL example per table, plus `json_get_json` patterns for the `groups` and `root_causes` JSON arrays.
- A "Notes" section covering data lag, the exclusive-end-date convention, retention windows per table, the Utf8 cast contract, tag activation, and the Cost Explorer enable requirement.

## Implementation notes

- **Region pinning.** Cost Explorer is global but routed through `us-east-1` for standard partitions. The manifest defaults `AWS_REGION` to `us-east-1` and `AWS_ENDPOINT_SUFFIX` to `amazonaws.com`, with the README documenting `us-gov-west-1` / `cn-northwest-1` overrides.
- **Per-metric typed columns on `cost_by_service` / `cost_by_tag`.** AWS keys the response under the requested metric (`Total.UnblendedCost.Amount`, `Total.AmortizedCost.Amount`, etc.). The source exposes seven typed columns (`unblended_cost`, `amortized_cost`, `blended_cost`, `net_unblended_cost`, `net_amortized_cost`, `usage_quantity`, `normalized_usage_amount`) plus a coalesced `period_total_cost`. Whichever metric the caller filters on populates its matching column; the other six are NULL on the same row. `period_total_cost` and `unit` always reflect the requested metric.
- **Filter-bound metric / granularity.** `metric` and `granularity` are filter-bound with virtual columns on `cost_by_service` and `cost_by_tag`, so `WHERE metric = 'AMORTIZED_COST'` routes the value into `Metrics[0]` of the request body. Defaults are `UNBLENDED_COST` and `MONTHLY` to match the AWS CLI canon. AWS rejects lowercase enums, so values are documented in upper case.
- **`rightsizing_recommendations` projections.** `cpu_utilization_pct` and `memory_utilization_pct` project from `CurrentInstance.ResourceUtilization.EC2ResourceUtilization.{Max…UtilizationPercentage}`. `estimated_monthly_savings` coalesces `ModifyRecommendationDetail.TargetInstances[0].EstimatedMonthlySavings` with `TerminateRecommendationDetail.EstimatedMonthlySavings` so TERMINATE recommendations expose savings instead of NULL. `recommendation_target` and `benefits_considered` are filter-bound for queries like `WHERE recommendation_target = 'CROSS_INSTANCE_FAMILY'`.
- **`savings_plans_coverage`.** Exposes `spend_covered_by_savings_plans`, `total_cost`, `period_start`, `period_end` alongside `coverage_pct` and `on_demand_cost`. Pagination is `cursor_body` over `NextToken` with `MaxResults: 100` to avoid the server-side default of 20.
- **Required-filter enforcement.** All seven required filters across the six tables surface `MISSING_REQUIRED_FILTER` from the engine before any HTTP request reaches AWS.
- **Unit-less aggregates.** `usage_quantity` and `normalized_usage_amount` aggregates are unit-less by AWS design (the API sums quantities across services with different natural units), so `unit` returns `'N/A'` for those metrics. Documented on the column descriptions and in the README Notes section.
- **Retention.** 14 months daily / 38 months monthly retention is documented in the README. Queries with `time_period_start` older than the retention window surface AWS's `ValidationException` cleanly.

## Verification

`coral source add`:

```text
Added source aws_cost_explorer (secrets: keychain)
✓ aws_cost_explorer connected successfully
Secrets: keychain
aws_cost_explorer (6 tables)
├─ anomalies
├─ cost_by_service
├─ cost_by_tag
├─ cost_forecast
├─ rightsizing_recommendations
└─ savings_plans_coverage
Query tests
1 declared · 1 passed · 0 failed
✓ SELECT instance_id, instance_type, recommendation_type, monthly_cost FROM aws_cost_explorer.rightsizing_recommendations LIMIT 5
0 rows
```

`coral source test`:

```text
✓ aws_cost_explorer connected successfully
Secrets: keychain
aws_cost_explorer (6 tables)
├─ anomalies
├─ cost_by_service
├─ cost_by_tag
├─ cost_forecast
├─ rightsizing_recommendations
└─ savings_plans_coverage
Query tests
1 declared · 1 passed · 0 failed
```

**Live query — per-metric NULL contract on `cost_by_service`:**

```sql
SELECT period_total_cost, unit, amortized_cost, unblended_cost
FROM aws_cost_explorer.cost_by_service
WHERE time_period_start = '2025-09-01'
  AND time_period_end   = '2025-10-01'
  AND metric            = 'AMORTIZED_COST'
```

| period_total_cost | unit | amortized_cost | unblended_cost |
|---|---|---|---|
| 0 | USD | 0 | NULL |

Switching to the default metric (no `metric` filter) populates `unblended_cost` and leaves `amortized_cost` NULL — same row shape, opposite NULL pattern.

**Live query — DAILY granularity row multiplication:**

```sql
SELECT period_start, period_end, unblended_cost
FROM aws_cost_explorer.cost_by_service
WHERE time_period_start = '2025-09-01'
  AND time_period_end   = '2025-09-04'
  AND granularity       = 'DAILY'
```

| period_start | period_end | unblended_cost |
|---|---|---|
| 2025-09-01 | 2025-09-02 | 0 |
| 2025-09-02 | 2025-09-03 | 0 |
| 2025-09-03 | 2025-09-04 | 0 |

**Live query — `recommendation_target` filter binding:**

```sql
SELECT instance_id, recommendation_target
FROM aws_cost_explorer.rightsizing_recommendations
WHERE recommendation_target = 'CROSS_INSTANCE_FAMILY'
LIMIT 5
```

Empty (test account has no EC2). The same query with an invalid value surfaces AWS's enum validation:

```text
ValidationException: 1 validation error detected: Value 'NOT_A_REAL_VALUE' at 'configuration.recommendationTarget'
failed to satisfy constraint: Member must satisfy enum value set: [CROSS_INSTANCE_FAMILY, SAME_INSTANCE_FAMILY]
```

Confirms the new filter binding routes through the request body.

**Required-filter enforcement (Coral-side, before HTTP):**

```text
Error: aws_cost_explorer.cost_forecast requires `WHERE granularity = <constant>`
Detail: aws_cost_explorer.cost_forecast requires a constant equality filter on granularity
```

**12-month retention boundary (AWS-side validation surfaced cleanly):**

```sql
SELECT period_total_cost
FROM aws_cost_explorer.cost_by_service
WHERE time_period_start = '2020-01-01'
  AND time_period_end   = '2020-02-01'
```

```text
Source rejected the request (400)
Detail: ValidationException: You haven't enabled historical data beyond 14 months.
```

**`anomalies` cartesian — 8 combinations of optional filters** (`feedback ∈ {YES, NO, PLANNED_ACTIVITY}` × `total_impact_min` × `monitor_arn`), plus invalid-feedback rejection by AWS:

```text
ValidationException: 1 validation error detected: Value 'BOGUS' at 'feedback' failed to satisfy constraint:
Member must satisfy enum value set: [NO, YES, PLANNED_ACTIVITY]
```

**`cost_forecast` cartesian — 5 valid metrics × {DAILY, MONTHLY} = 10 round-trips.** All reach AWS. All return `DataUnavailableException` on this test account because it lacks historical data, but the 10 identical errors prove uniform filter binding across the metric × granularity matrix. `NORMALIZED_USAGE_AMOUNT` is rejected with the documented "does not support requests for NORMALIZED_USAGE_AMOUNT" message; `HOURLY` granularity is rejected with "Forecast requests not currently supported for HOURLY".

## Acknowledged limitation: temporary AWS credentials

This source supports only **long-term IAM user access keys** (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`). It cannot authenticate with temporary credentials from `aws sts assume-role`, IAM Identity Center / SSO, EKS IRSA, EC2 instance roles, or GitHub Actions OIDC.

The signer side already supports session tokens — `AwsSigV4Authenticator` accepts an optional `session_token: ParsedTemplate` and forwards it to `aws-sigv4`'s `Credentials::new`. The blocker is in the renderer: declaring `AWS_SESSION_TOKEN` as `kind: secret, required: false` and threading it into `auth.session_token` fails at `coral source add` with:

```text
custom authenticator 'aws_sigv4' failed: missing source input 'AWS_SESSION_TOKEN' for template token
```

`required: false` on a secret input is correctly accepted by `coral_spec::resolve_inputs`, but `render_input_template` in the SigV4 authenticator treats every `{{input.X}}` reference as mandatory regardless of how the input was declared. So "configured but absent" and "not configured" are indistinguishable to the renderer.

The same gap affects `cloudwatch_logs` and `cloudwatch_metrics`. Reproduction and design discussion in **#1045**. Once the renderer fix lands, all three AWS sources can add `AWS_SESSION_TOKEN` as `required: false` in a single follow-up PR — no schema changes here would need to be revisited.

This PR ships the long-term-keys path because it's the existing supported pattern across the bundled AWS sources; deferring the source until #1045 resolves would block usable Cost Explorer querying on a discussion that may take a while to settle. The README documents the IAM-user setup explicitly so users aren't surprised when assume-role / SSO doesn't work today.

## Why ship this now vs. wait for #1045

- The renderer gap is repo-wide, not Cost-Explorer-specific. Two existing bundled sources (`cloudwatch_logs`, `cloudwatch_metrics`) ship with the same limitation.
- The chosen direction in #1045 (relax renderer vs. typed value sources vs. `aws-config` chain) is a maintainer call with follow-on implications for `CustomAuth` more broadly. Whichever direction wins, the manifest in this PR remains valid — only the input declaration and `auth.session_token` line would be added.
- Users running on long-term keys (still common for Cost Explorer specifically, since Cost Explorer is often consumed from an admin-only billing IAM user) are unblocked today.
