### PR TITLE
feat(sources/community/windmill): add Windmill source

### DIFF
--- a/sources/community/windmill/README.md
+++ b/sources/community/windmill/README.md
@@ -3,16 +3,25 @@
 Query Windmill scripts, flows, apps, and schedules through Coral SQL using the
 [Windmill HTTP API](https://app.windmill.dev/openapi.html).
 
-This source is read-only and metadata-only. It intentionally excludes workflow
-payloads and secret-bearing values.
+This source exposes read-only SQL tables with selected metadata columns. The
+configured Windmill list endpoints may still transfer unmapped operational
+fields to Coral before projection, including script source, flow definitions,
+and schedule arguments.
 
 ## Setup
 
 ### 1. Create a Windmill token
 
-Create a [Windmill user token](https://www.windmill.dev/docs/core_concepts/user_tokens)
-or service token with the minimum workspace read permissions needed to list
-scripts, flows, apps, and schedules.
+Create a [Windmill user token](https://www.windmill.dev/docs/core_concepts/user_tokens).
+Enable **Limit token permissions** and the read-only token restriction, then
+grant these scopes:
+
+- `scripts:read`
+- `flows:read`
+- `apps:read`
+- `schedules:read`
+
+These permissions were validated against all four tables in this source.
 
 ### 2. Add the source
 
@@ -45,11 +54,13 @@ coral source test windmill
 
 ### `windmill.scripts`
 
-List script inventory without script source code.
+List selected script metadata columns. Script source code is not exposed as a
+SQL column.
 
 | Column | Type | Description |
 |---|---|---|
 | `path` | Utf8 | Workspace-relative script path |
+| `hash` | Utf8 | Stable script version identifier |
 | `summary` | Utf8 | Script summary |
 | `description` | Utf8 | Script description |
 | `language` | Utf8 | Script language |
@@ -65,7 +76,8 @@ List script inventory without script source code.
 
 ### `windmill.flows`
 
-List flow inventory without raw flow definitions.
+List selected flow metadata columns. Raw flow definitions are not exposed as
+SQL columns.
 
 | Column | Type | Description |
 |---|---|---|
@@ -86,7 +98,8 @@ List flow inventory without raw flow definitions.
 
 ### `windmill.apps`
 
-List app inventory without raw app definitions.
+List selected app metadata columns. Raw app definitions are not exposed as SQL
+columns.
 
 | Column | Type | Description |
 |---|---|---|
@@ -105,7 +118,8 @@ List app inventory without raw app definitions.
 
 ### `windmill.schedules`
 
-List schedule inventory without arguments or permission maps.
+List selected schedule metadata columns. Arguments and permission maps are not
+exposed as SQL columns.
 
 | Column | Type | Description |
 |---|---|---|
@@ -156,7 +170,7 @@ coral source lint sources/community/windmill/manifest.yaml
 coral source add --file sources/community/windmill/manifest.yaml
 coral source test windmill
 coral sql "SELECT * FROM coral.tables WHERE schema_name = 'windmill'"
-coral sql "SELECT path, language, created_at FROM windmill.scripts LIMIT 5"
+coral sql "SELECT path, hash, language, created_at FROM windmill.scripts LIMIT 5"
 coral sql "SELECT path, script_path, enabled FROM windmill.schedules LIMIT 5"
 ```
 
@@ -164,15 +178,20 @@ coral sql "SELECT path, script_path, enabled FROM windmill.schedules LIMIT 5"
 
 - **Read-only.** This source does not create, update, execute, archive, or
   delete Windmill resources.
-- **Metadata-only.** Raw script source, raw flow definitions, app definitions,
-  schedule args, permission maps, errors, email fields, resource values,
-  variable values, job history, logs, and result payloads are not exposed.
+- **Selected metadata columns only.** Raw script source, raw flow definitions,
+  app definitions, schedule args, permission maps, errors, email fields,
+  resource values, variable values, job history, logs, and result payloads are
+  not exposed as SQL columns.
+- **Provider responses may contain unmapped fields.** Windmill list endpoints
+  may still transfer workflow definitions, schedule arguments, and other
+  operational fields to Coral before unmapped fields are discarded.
 - **Metadata may still be sensitive.** Paths, descriptions, labels, editor
   identities, and schedule targets can reveal operational details.
 - **Workspace-scoped.** Configure one `WINDMILL_WORKSPACE` per Coral source
   registration.
-- **Minimum privileges recommended.** Use a token scoped to the workspace
-  metadata that Coral needs to inspect.
+- **Minimum privileges recommended.** Enable Windmill's read-only token
+  restriction and grant only `scripts:read`, `flows:read`, `apps:read`, and
+  `schedules:read`.
 
 ## Out of scope for v1
 

--- a/sources/community/windmill/README.md
+++ b/sources/community/windmill/README.md
@@ -1,0 +1,183 @@
+# Windmill Community Source
+
+Query Windmill scripts, flows, apps, and schedules through Coral SQL using the
+[Windmill HTTP API](https://app.windmill.dev/openapi.html).
+
+This source is read-only and metadata-only. It intentionally excludes workflow
+payloads and secret-bearing values.
+
+## Setup
+
+### 1. Create a Windmill token
+
+Create a [Windmill user token](https://www.windmill.dev/docs/core_concepts/user_tokens)
+or service token with the minimum workspace read permissions needed to list
+scripts, flows, apps, and schedules.
+
+### 2. Add the source
+
+For Windmill Cloud:
+
+```powershell
+$env:WINDMILL_BASE_URL = "https://app.windmill.dev"
+$env:WINDMILL_WORKSPACE = "example-workspace"
+$env:WINDMILL_TOKEN = "replace-with-read-only-token"
+coral source add --file sources/community/windmill/manifest.yaml
+```
+
+For self-hosted Windmill, set `WINDMILL_BASE_URL` to your instance URL without
+a trailing slash. The official Docker Compose setup is available at
+`http://localhost`.
+
+Interactive setup is also supported:
+
+```powershell
+coral source add --interactive --file sources/community/windmill/manifest.yaml
+```
+
+### 3. Verify
+
+```powershell
+coral source test windmill
+```
+
+## Tables
+
+### `windmill.scripts`
+
+List script inventory without script source code.
+
+| Column | Type | Description |
+|---|---|---|
+| `path` | Utf8 | Workspace-relative script path |
+| `summary` | Utf8 | Script summary |
+| `description` | Utf8 | Script description |
+| `language` | Utf8 | Script language |
+| `created_by` | Utf8 | User who created the script version |
+| `created_at` | Timestamp | Time the script version was created |
+| `archived` | Boolean | Whether the script is archived |
+| `starred` | Boolean | Whether the script is starred |
+| `draft_only` | Boolean | Whether only a draft version exists |
+| `dedicated_worker` | Boolean | Whether the script uses a dedicated worker |
+| `labels` | Json | Script labels |
+
+**Optional filter:** `path`
+
+### `windmill.flows`
+
+List flow inventory without raw flow definitions.
+
+| Column | Type | Description |
+|---|---|---|
+| `path` | Utf8 | Workspace-relative flow path |
+| `summary` | Utf8 | Flow summary |
+| `description` | Utf8 | Flow description |
+| `edited_by` | Utf8 | User who last edited the flow |
+| `edited_at` | Timestamp | Time the flow was last edited |
+| `archived` | Boolean | Whether the flow is archived |
+| `starred` | Boolean | Whether the flow is starred |
+| `draft_only` | Boolean | Whether only a draft version exists |
+| `tag` | Utf8 | Flow worker tag |
+| `dedicated_worker` | Boolean | Whether the flow uses a dedicated worker |
+| `timeout` | Float64 | Flow timeout in seconds |
+| `labels` | Json | Flow labels |
+
+**Optional filter:** `path`
+
+### `windmill.apps`
+
+List app inventory without raw app definitions.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Int64 | App ID |
+| `workspace_id` | Utf8 | Workspace containing the app |
+| `path` | Utf8 | Workspace-relative app path |
+| `summary` | Utf8 | App summary |
+| `version` | Int64 | Current app version |
+| `starred` | Boolean | Whether the app is starred |
+| `edited_at` | Timestamp | Time the app was last edited |
+| `execution_mode` | Utf8 | App execution mode |
+| `raw_app` | Boolean | Whether the app uses the raw-app format |
+| `labels` | Json | App labels |
+
+**Optional filter:** `path`
+
+### `windmill.schedules`
+
+List schedule inventory without arguments or permission maps.
+
+| Column | Type | Description |
+|---|---|---|
+| `path` | Utf8 | Workspace-relative schedule path |
+| `edited_by` | Utf8 | User who last edited the schedule |
+| `edited_at` | Timestamp | Time the schedule was last edited |
+| `schedule` | Utf8 | Cron schedule expression |
+| `timezone` | Utf8 | Schedule timezone |
+| `enabled` | Boolean | Whether the schedule is enabled |
+| `script_path` | Utf8 | Script or flow path invoked by the schedule |
+| `is_flow` | Boolean | Whether the schedule invokes a flow |
+
+**Optional filters:** `path`, `script_path`, `is_flow`
+
+For schedules, `path` filters the schedule record path and `script_path`
+filters the script or flow invoked by the schedule.
+
+## Example queries
+
+```sql
+-- Review scripts that changed recently
+SELECT path, language, summary, created_at
+FROM windmill.scripts
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+```sql
+-- Review enabled schedules and their targets
+SELECT path, enabled, schedule, timezone, script_path, is_flow
+FROM windmill.schedules
+WHERE enabled = true
+ORDER BY path;
+```
+
+```sql
+-- Review starred apps
+SELECT path, summary, execution_mode, edited_at
+FROM windmill.apps
+WHERE starred = true
+ORDER BY edited_at DESC;
+```
+
+## Validation
+
+```powershell
+coral source lint sources/community/windmill/manifest.yaml
+coral source add --file sources/community/windmill/manifest.yaml
+coral source test windmill
+coral sql "SELECT * FROM coral.tables WHERE schema_name = 'windmill'"
+coral sql "SELECT path, language, created_at FROM windmill.scripts LIMIT 5"
+coral sql "SELECT path, script_path, enabled FROM windmill.schedules LIMIT 5"
+```
+
+## Limitations
+
+- **Read-only.** This source does not create, update, execute, archive, or
+  delete Windmill resources.
+- **Metadata-only.** Raw script source, raw flow definitions, app definitions,
+  schedule args, permission maps, errors, email fields, resource values,
+  variable values, job history, logs, and result payloads are not exposed.
+- **Metadata may still be sensitive.** Paths, descriptions, labels, editor
+  identities, and schedule targets can reveal operational details.
+- **Workspace-scoped.** Configure one `WINDMILL_WORKSPACE` per Coral source
+  registration.
+- **Minimum privileges recommended.** Use a token scoped to the workspace
+  metadata that Coral needs to inspect.
+
+## Out of scope for v1
+
+- Queued and completed job metadata
+- Job logs and result payloads
+- Resource and variable metadata or values
+- Script, flow, app, or schedule mutations
+- User and permission management

--- a/sources/community/windmill/manifest.yaml
+++ b/sources/community/windmill/manifest.yaml
@@ -1,0 +1,516 @@
+---
+name: windmill
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Windmill scripts, flows, apps, and schedules through Coral SQL using
+  the Windmill HTTP API. Read-only and metadata-only; workflow payloads and
+  secret-bearing values are intentionally not exposed.
+
+inputs:
+  WINDMILL_BASE_URL:
+    kind: variable
+    default: http://localhost
+    hint: >-
+      Base URL for the Windmill instance, without a trailing slash.
+      For Windmill Cloud use https://app.windmill.dev.
+  WINDMILL_WORKSPACE:
+    kind: variable
+    required: true
+    hint: Windmill workspace id or slug used in workspace-scoped API paths.
+  WINDMILL_TOKEN:
+    kind: secret
+    required: true
+    hint: Windmill user token or service token with read access to metadata.
+
+base_url: "{{input.WINDMILL_BASE_URL}}/api"
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.WINDMILL_TOKEN}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT path, language, created_at FROM windmill.scripts LIMIT 5
+  - SELECT path, edited_at FROM windmill.flows LIMIT 5
+  - SELECT path, execution_mode, edited_at FROM windmill.apps LIMIT 5
+  - SELECT path, script_path, enabled FROM windmill.schedules LIMIT 5
+
+tables:
+  - name: scripts
+    description: Windmill scripts without script source code.
+    guide: |
+      Each row is one script visible in the configured workspace. Use
+      `path` to narrow the upstream request. This table intentionally omits
+      script source code and permission maps.
+    filters:
+      - name: path
+    request:
+      method: GET
+      path: /w/{{input.WINDMILL_WORKSPACE}}/scripts/list
+      query:
+        - name: path_exact
+          from: filter
+          key: path
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+      link_header_require_results: false
+    columns:
+      - name: path
+        type: Utf8
+        nullable: false
+        description: Workspace-relative script path.
+        expr:
+          kind: path
+          path:
+            - path
+      - name: summary
+        type: Utf8
+        nullable: true
+        description: Script summary.
+        expr:
+          kind: path
+          path:
+            - summary
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Script description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: language
+        type: Utf8
+        nullable: true
+        description: Script language.
+        expr:
+          kind: path
+          path:
+            - language
+      - name: created_by
+        type: Utf8
+        nullable: true
+        description: User who created the script version.
+        expr:
+          kind: path
+          path:
+            - created_by
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Time the script version was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the script is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: starred
+        type: Boolean
+        nullable: true
+        description: Whether the script is starred.
+        expr:
+          kind: path
+          path:
+            - starred
+      - name: draft_only
+        type: Boolean
+        nullable: true
+        description: Whether only a draft version exists.
+        expr:
+          kind: path
+          path:
+            - draft_only
+      - name: dedicated_worker
+        type: Boolean
+        nullable: true
+        description: Whether the script uses a dedicated worker.
+        expr:
+          kind: path
+          path:
+            - dedicated_worker
+      - name: labels
+        type: Json
+        nullable: true
+        description: Script labels.
+        expr:
+          kind: path
+          path:
+            - labels
+
+  - name: flows
+    description: Windmill flow inventory without raw flow definitions.
+    guide: |
+      Each row is one flow visible in the configured workspace. Use
+      `path` to narrow the upstream request. This table intentionally omits raw
+      flow definitions and permission maps.
+    filters:
+      - name: path
+    request:
+      method: GET
+      path: /w/{{input.WINDMILL_WORKSPACE}}/flows/list
+      query:
+        - name: path_exact
+          from: filter
+          key: path
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+      link_header_require_results: false
+    columns:
+      - name: path
+        type: Utf8
+        nullable: false
+        description: Workspace-relative flow path.
+        expr:
+          kind: path
+          path:
+            - path
+      - name: summary
+        type: Utf8
+        nullable: true
+        description: Flow summary.
+        expr:
+          kind: path
+          path:
+            - summary
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Flow description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: edited_by
+        type: Utf8
+        nullable: true
+        description: User who last edited the flow.
+        expr:
+          kind: path
+          path:
+            - edited_by
+      - name: edited_at
+        type: Timestamp
+        nullable: true
+        description: Time the flow was last edited.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - edited_at
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the flow is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: starred
+        type: Boolean
+        nullable: true
+        description: Whether the flow is starred.
+        expr:
+          kind: path
+          path:
+            - starred
+      - name: draft_only
+        type: Boolean
+        nullable: true
+        description: Whether only a draft version exists.
+        expr:
+          kind: path
+          path:
+            - draft_only
+      - name: tag
+        type: Utf8
+        nullable: true
+        description: Flow worker tag.
+        expr:
+          kind: path
+          path:
+            - tag
+      - name: dedicated_worker
+        type: Boolean
+        nullable: true
+        description: Whether the flow uses a dedicated worker.
+        expr:
+          kind: path
+          path:
+            - dedicated_worker
+      - name: timeout
+        type: Float64
+        nullable: true
+        description: Flow timeout in seconds.
+        expr:
+          kind: path
+          path:
+            - timeout
+      - name: labels
+        type: Json
+        nullable: true
+        description: Flow labels.
+        expr:
+          kind: path
+          path:
+            - labels
+
+  - name: apps
+    description: Windmill app inventory without raw app definitions.
+    guide: |
+      Each row is one app visible in the configured workspace. Use
+      `path` to narrow the upstream request. This table intentionally omits raw
+      app definitions and permission maps.
+    filters:
+      - name: path
+    request:
+      method: GET
+      path: /w/{{input.WINDMILL_WORKSPACE}}/apps/list
+      query:
+        - name: path_exact
+          from: filter
+          key: path
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+      link_header_require_results: false
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: App ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: workspace_id
+        type: Utf8
+        nullable: false
+        description: Workspace containing the app.
+        expr:
+          kind: path
+          path:
+            - workspace_id
+      - name: path
+        type: Utf8
+        nullable: false
+        description: Workspace-relative app path.
+        expr:
+          kind: path
+          path:
+            - path
+      - name: summary
+        type: Utf8
+        nullable: true
+        description: App summary.
+        expr:
+          kind: path
+          path:
+            - summary
+      - name: version
+        type: Int64
+        nullable: true
+        description: Current app version.
+        expr:
+          kind: path
+          path:
+            - version
+      - name: starred
+        type: Boolean
+        nullable: true
+        description: Whether the app is starred.
+        expr:
+          kind: path
+          path:
+            - starred
+      - name: edited_at
+        type: Timestamp
+        nullable: true
+        description: Time the app was last edited.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - edited_at
+      - name: execution_mode
+        type: Utf8
+        nullable: true
+        description: App execution mode.
+        expr:
+          kind: path
+          path:
+            - execution_mode
+      - name: raw_app
+        type: Boolean
+        nullable: true
+        description: Whether the app uses the raw-app format.
+        expr:
+          kind: path
+          path:
+            - raw_app
+      - name: labels
+        type: Json
+        nullable: true
+        description: App labels.
+        expr:
+          kind: path
+          path:
+            - labels
+
+  - name: schedules
+    description: Windmill schedules without args or permission maps.
+    guide: |
+      Each row is one schedule visible in the configured workspace. Use `path`
+      to filter the schedule record path, `script_path` to filter the target
+      script or flow path, or `is_flow` to filter the target kind. This table
+      intentionally omits args, permission maps, errors, email fields, and
+      callback arguments.
+    filters:
+      - name: path
+      - name: script_path
+      - name: is_flow
+    request:
+      method: GET
+      path: /w/{{input.WINDMILL_WORKSPACE}}/schedules/list
+      query:
+        - name: schedule_path
+          from: filter
+          key: path
+        - name: path
+          from: filter
+          key: script_path
+        - name: is_flow
+          from: filter_bool
+          key: is_flow
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+      link_header_require_results: false
+    columns:
+      - name: path
+        type: Utf8
+        nullable: false
+        description: Workspace-relative schedule path.
+        expr:
+          kind: path
+          path:
+            - path
+      - name: edited_by
+        type: Utf8
+        nullable: true
+        description: User who last edited the schedule.
+        expr:
+          kind: path
+          path:
+            - edited_by
+      - name: edited_at
+        type: Timestamp
+        nullable: true
+        description: Time the schedule was last edited.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - edited_at
+      - name: schedule
+        type: Utf8
+        nullable: false
+        description: Cron schedule expression.
+        expr:
+          kind: path
+          path:
+            - schedule
+      - name: timezone
+        type: Utf8
+        nullable: false
+        description: Schedule timezone.
+        expr:
+          kind: path
+          path:
+            - timezone
+      - name: enabled
+        type: Boolean
+        nullable: false
+        description: Whether the schedule is enabled.
+        expr:
+          kind: path
+          path:
+            - enabled
+      - name: script_path
+        type: Utf8
+        nullable: false
+        description: Script or flow path invoked by the schedule.
+        expr:
+          kind: path
+          path:
+            - script_path
+      - name: is_flow
+        type: Boolean
+        nullable: false
+        description: Whether the schedule invokes a flow.
+        expr:
+          kind: path
+          path:
+            - is_flow

--- a/sources/community/windmill/manifest.yaml
+++ b/sources/community/windmill/manifest.yaml
@@ -5,8 +5,9 @@ dsl_version: 3
 backend: http
 description: >-
   Query Windmill scripts, flows, apps, and schedules through Coral SQL using
-  the Windmill HTTP API. Read-only and metadata-only; workflow payloads and
-  secret-bearing values are intentionally not exposed.
+  the Windmill HTTP API. Read-only SQL tables expose selected metadata columns.
+  Windmill API list responses may still transfer unmapped operational fields to
+  Coral before they are discarded.
 
 inputs:
   WINDMILL_BASE_URL:
@@ -22,7 +23,9 @@ inputs:
   WINDMILL_TOKEN:
     kind: secret
     required: true
-    hint: Windmill user token or service token with read access to metadata.
+    hint: >-
+      Windmill user token with read-only enabled and scripts:read, flows:read,
+      apps:read, and schedules:read scopes.
 
 base_url: "{{input.WINDMILL_BASE_URL}}/api"
 
@@ -39,18 +42,19 @@ request_headers:
     value: application/json
 
 test_queries:
-  - SELECT path, language, created_at FROM windmill.scripts LIMIT 5
+  - SELECT path, hash, language, created_at FROM windmill.scripts LIMIT 5
   - SELECT path, edited_at FROM windmill.flows LIMIT 5
   - SELECT path, execution_mode, edited_at FROM windmill.apps LIMIT 5
   - SELECT path, script_path, enabled FROM windmill.schedules LIMIT 5
 
 tables:
   - name: scripts
-    description: Windmill scripts without script source code.
+    description: Windmill script metadata columns.
     guide: |
       Each row is one script visible in the configured workspace. Use
       `path` to narrow the upstream request. This table intentionally omits
-      script source code and permission maps.
+      script source code and permission maps from the SQL table. Windmill's API
+      response may still transfer unmapped fields to Coral before projection.
     filters:
       - name: path
     request:
@@ -82,6 +86,14 @@ tables:
           kind: path
           path:
             - path
+      - name: hash
+        type: Utf8
+        nullable: false
+        description: Stable script version identifier.
+        expr:
+          kind: path
+          path:
+            - hash
       - name: summary
         type: Utf8
         nullable: true
@@ -167,11 +179,12 @@ tables:
             - labels
 
   - name: flows
-    description: Windmill flow inventory without raw flow definitions.
+    description: Windmill flow metadata columns.
     guide: |
       Each row is one flow visible in the configured workspace. Use
       `path` to narrow the upstream request. This table intentionally omits raw
-      flow definitions and permission maps.
+      flow definitions and permission maps from the SQL table. Windmill's API
+      response may still transfer unmapped fields to Coral before projection.
     filters:
       - name: path
     request:
@@ -296,11 +309,12 @@ tables:
             - labels
 
   - name: apps
-    description: Windmill app inventory without raw app definitions.
+    description: Windmill app metadata columns.
     guide: |
       Each row is one app visible in the configured workspace. Use
       `path` to narrow the upstream request. This table intentionally omits raw
-      app definitions and permission maps.
+      app definitions and permission maps from the SQL table. Windmill's API
+      response may still transfer unmapped fields to Coral before projection.
     filters:
       - name: path
     request:
@@ -409,13 +423,14 @@ tables:
             - labels
 
   - name: schedules
-    description: Windmill schedules without args or permission maps.
+    description: Windmill schedule metadata columns.
     guide: |
       Each row is one schedule visible in the configured workspace. Use `path`
       to filter the schedule record path, `script_path` to filter the target
       script or flow path, or `is_flow` to filter the target kind. This table
       intentionally omits args, permission maps, errors, email fields, and
-      callback arguments.
+      callback arguments from the SQL table. Windmill's API response may still
+      transfer unmapped fields to Coral before projection.
     filters:
       - name: path
       - name: script_path


### PR DESCRIPTION
Closes #1055

## Summary

Adds a new **Windmill** community source under `sources/community/windmill/`.

This source exposes read-only, metadata-only SQL access to scripts, flows, apps, and schedules from a configured Windmill workspace. Workflow payloads, secret-bearing values, permission maps, job logs, and result payloads are intentionally excluded.

## What's included

| File | Purpose |
|---|---|
| `sources/community/windmill/manifest.yaml` | Source spec with 4 workspace-scoped tables, bearer authentication, pagination, and filter pushdown |
| `sources/community/windmill/README.md` | Setup guide, table documentation, example queries, validation commands, and limitations |

## Tables

| Table | Endpoint | Optional filters |
|---|---|---|
| `windmill.scripts` | `GET /api/w/{workspace}/scripts/list` | `path` |
| `windmill.flows` | `GET /api/w/{workspace}/flows/list` | `path` |
| `windmill.apps` | `GET /api/w/{workspace}/apps/list` | `path` |
| `windmill.schedules` | `GET /api/w/{workspace}/schedules/list` | `path`, `script_path`, `is_flow` |

## Authentication

The source requires:

- `WINDMILL_BASE_URL` - Windmill instance URL, defaulting to `http://localhost`
- `WINDMILL_WORKSPACE` - workspace id or slug
- `WINDMILL_TOKEN` - bearer token stored as `kind: secret`

Use a scoped Windmill user token with the minimum read permissions required for scripts, flows, apps, and schedules.

## Design decisions

- **Metadata-only surface** - excludes raw script source, flow definitions, app definitions, schedule arguments, permission maps, resource values, variable values, job history, logs, and results.
- **Workspace-scoped API paths** - each source registration targets one Windmill workspace.
- **Normalized schedule filters** - SQL `path` maps to Windmill `schedule_path`, while SQL `script_path` maps to Windmill `path`, matching the API semantics.
- **Page pagination** - list endpoints use Windmill's `page` and `per_page` parameters.
- **Sensitive metadata warning** - the README documents that paths, descriptions, labels, editor identities, and schedule targets may still expose operational details.

## Validation

Validated against a disposable self-hosted Windmill Community Edition instance using the official Docker Compose setup.

```text
$ coral source lint sources/community/windmill/manifest.yaml
Manifest is valid
```

```text
$ coral source test windmill
✓ windmill connected successfully

  windmill (4 tables)
  ├─ apps
  ├─ flows
  ├─ schedules
  └─ scripts

  Query tests
  4 declared · 4 passed · 0 failed
```

Representative schedule query:

```sql
SELECT path, schedule, timezone, enabled, script_path, is_flow
FROM windmill.schedules
WHERE path = 'u/admin/coral_validation_schedule'
LIMIT 5;
```

Returned the expected schedule row and target script path.

## Proof screenshots

<!-- Drag the lint and source-test screenshot into the GitHub PR editor here. -->
#### Windmill manifest lint and source test
<img width="1063" height="655" alt="image" src="https://github.com/user-attachments/assets/eedbd6cf-da27-4d5e-8027-d949b44d27fb" />


<!-- Drag the scripts query screenshot into the GitHub PR editor here. -->
##### Windmill scripts metadata query
<img width="1237" height="201" alt="image" src="https://github.com/user-attachments/assets/def7d39b-5b4f-415d-a841-c7dab99b02bb" />


<!-- Drag the schedules query screenshot into the GitHub PR editor here. -->
#### Windmill schedules metadata query 
<img width="1133" height="191" alt="image" src="https://github.com/user-attachments/assets/2ceb352b-69fd-4639-ae4f-68d3988fb619" />


## User-visible impact

New opt-in community source only. Existing sources and runtime behavior are unchanged.

## Known limitations

- Read-only and metadata-only.
- One configured workspace per Coral source registration.
- No raw workflow definitions, secret values, resource values, variable values, job history, logs, or results.
- Metadata may still reveal operational details; least-privilege tokens are recommended.