### PR TITLE
feat(sources/devto): add dev.to (Forem) community source

### DIFF
--- a/sources/community/devto/README.md
+++ b/sources/community/devto/README.md
@@ -1,0 +1,65 @@
+# dev.to
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 3
+**Base URL:** `https://dev.to/api`
+
+Query articles, drafts, engagement metrics, and tags from [dev.to](https://dev.to) (Forem) via the public dev.to API.
+
+## Authentication
+
+Requires a dev.to API key (`DEVTO_API_KEY`) for the `articles_me` table.
+The public `articles` and `tags` tables do not require authentication, but
+the same `api-key` header is sent on every request.
+
+Generate a key at [dev.to/settings/extensions](https://dev.to/settings/extensions).
+
+```bash
+DEVTO_API_KEY=your_key_here \
+  coral source add --file sources/community/devto/manifest.yaml
+```
+
+Run the command from the repository root, or add interactively:
+
+```bash
+coral source add --file sources/community/devto/manifest.yaml --interactive
+```
+
+## Tables
+
+| Table | Description | Filters | Auth |
+|---|---|---|---|
+| `articles_me` | Your own articles and drafts on dev.to, with view, reaction, and comment counts. | — | Required |
+| `articles` | Public articles by a given dev.to username. | `username` (required) | Optional |
+| `tags` | Top tags on dev.to. | — | Optional |
+
+## Quick Start
+
+```sql
+-- Your top performing posts
+coral sql "SELECT title, page_views_count, positive_reactions_count
+           FROM devto.articles_me
+           ORDER BY page_views_count DESC LIMIT 10"
+
+-- Your unpublished drafts
+coral sql "SELECT title, slug FROM devto.articles_me WHERE published = false"
+
+-- Public articles by another author
+coral sql "SELECT title, positive_reactions_count
+           FROM devto.articles
+           WHERE username = 'ben'
+           ORDER BY positive_reactions_count DESC LIMIT 10"
+
+-- Top tags
+coral sql "SELECT id, name, bg_color_hex FROM devto.tags ORDER BY id LIMIT 10"
+```
+
+## Notes
+
+- The dev.to API uses an `api-key` HTTP header (no `Bearer` prefix).
+- Pagination is page-numbered. The manifest sets `per_page=1000` to fit
+  prolific authors in one or two pages, since SQL `LIMIT` is not pushed
+  down to the upstream API.
+- The `articles_me` table includes drafts (`state=all`); filter on
+  `published = true` or `published = false` to narrow.

--- a/sources/community/devto/README.md
+++ b/sources/community/devto/README.md
@@ -2,25 +2,23 @@
 
 **Version:** 0.1.0
 **Backend:** HTTP
-**Tables:** 3
+**Tables:** 2
 **Base URL:** `https://dev.to/api`
 
-Query articles, drafts, engagement metrics, and tags from [dev.to](https://dev.to) (Forem) via the public dev.to API.
+Query public articles and top tags from [dev.to](https://dev.to) (Forem)
+via the public dev.to API.
 
 ## Authentication
 
-Requires a dev.to API key (`DEVTO_API_KEY`) for the `articles_me` table.
-The public `articles` and `tags` tables do not require authentication, but
-the same `api-key` header is sent on every request.
-
-Generate a key at [dev.to/settings/extensions](https://dev.to/settings/extensions).
+**Not required.** This source exposes only the public, unauthenticated
+read endpoints of the dev.to API, so it can be registered and queried
+with zero credentials.
 
 ```bash
-DEVTO_API_KEY=your_key_here \
-  coral source add --file sources/community/devto/manifest.yaml
+coral source add --file sources/community/devto/manifest.yaml
 ```
 
-Run the command from the repository root, or add interactively:
+Or interactively:
 
 ```bash
 coral source add --file sources/community/devto/manifest.yaml --interactive
@@ -28,38 +26,44 @@ coral source add --file sources/community/devto/manifest.yaml --interactive
 
 ## Tables
 
-| Table | Description | Filters | Auth |
-|---|---|---|---|
-| `articles_me` | Your own articles and drafts on dev.to, with view, reaction, and comment counts. | — | Required |
-| `articles` | Public articles by a given dev.to username. | `username` (required) | Optional |
-| `tags` | Top tags on dev.to. | — | Optional |
+| Table | Description | Filters |
+|---|---|---|
+| `articles` | Public articles by a given dev.to username. | `username` (required) |
+| `tags` | Top tags on dev.to. | — |
 
 ## Quick Start
 
 ```sql
--- Your top performing posts
-coral sql "SELECT title, page_views_count, positive_reactions_count
-           FROM devto.articles_me
-           ORDER BY page_views_count DESC LIMIT 10"
+-- Top tags on the platform
+coral sql "SELECT id, name, bg_color_hex FROM devto.tags ORDER BY id LIMIT 10"
 
--- Your unpublished drafts
-coral sql "SELECT title, slug FROM devto.articles_me WHERE published = false"
-
--- Public articles by another author
-coral sql "SELECT title, positive_reactions_count
+-- Most-loved posts by a specific author
+coral sql "SELECT title, positive_reactions_count, comments_count
            FROM devto.articles
            WHERE username = 'ben'
            ORDER BY positive_reactions_count DESC LIMIT 10"
 
--- Top tags
-coral sql "SELECT id, name, bg_color_hex FROM devto.tags ORDER BY id LIMIT 10"
+-- Cross-source idea: join dev.to articles with your GitHub repos
+coral sql "SELECT a.title, a.url, r.stargazers_count
+           FROM devto.articles a
+           JOIN github.user_repos r
+             ON lower(a.title) LIKE '%' || lower(r.name) || '%'
+           WHERE a.username = 'YOUR_USERNAME' LIMIT 20"
 ```
 
 ## Notes
 
-- The dev.to API uses an `api-key` HTTP header (no `Bearer` prefix).
-- Pagination is page-numbered. The manifest sets `per_page=1000` to fit
-  prolific authors in one or two pages, since SQL `LIMIT` is not pushed
-  down to the upstream API.
-- The `articles_me` table includes drafts (`state=all`); filter on
-  `published = true` or `published = false` to narrow.
+- The dev.to API uses an `api-key` HTTP header for authenticated
+  endpoints (no `Bearer` prefix). This source ships **without** any
+  auth wiring, so anyone can register and use it.
+- Pagination is page-numbered. The manifest sets `per_page=1000` so
+  prolific authors fit in one or two pages, since SQL `LIMIT` is not
+  pushed down to the upstream API.
+- An `articles_me` table (your own articles and drafts, including
+  page-view counts) is intentionally **not** part of this initial
+  contribution. Coral's current DSL treats any `from: input`
+  reference as required at `coral source add` time even when the
+  input is marked `required: false`, which would force every user of
+  this source to set `DEVTO_API_KEY` just to query the public tables.
+  Once the DSL supports optional input references (or a `kind: secret`
+  + `default: ""` combination), `articles_me` can land as a follow-up.

--- a/sources/community/devto/manifest.yaml
+++ b/sources/community/devto/manifest.yaml
@@ -1,0 +1,158 @@
+name: devto
+version: 0.1.0
+dsl_version: 3
+description: Query articles, drafts, engagement metrics, and tags from dev.to (Forem).
+backend: http
+base_url: https://dev.to/api
+
+inputs:
+  DEVTO_API_KEY:
+    kind: secret
+    required: true
+    hint: |
+      Dev.to API key. Generate at https://dev.to/settings/extensions.
+      Sent as the literal `api-key` header (no Bearer prefix).
+      Required for `articles_me`; the public `articles` and `tags` tables work
+      without it but still send the header when present.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: api-key
+      from: input
+      key: DEVTO_API_KEY
+
+tables:
+  - name: articles_me
+    description: Your own articles and drafts on dev.to with engagement stats. Requires DEVTO_API_KEY.
+    request:
+      method: GET
+      path: /articles/me
+      query:
+        - name: per_page
+          from: literal
+          value: "1000"
+        - name: state
+          from: literal
+          value: "all"
+    response:
+      format: json
+      rows_path: []
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      max_pages: 50
+    columns:
+      - name: id
+        type: Int64
+      - name: title
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: slug
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: published
+        type: Boolean
+      - name: published_at
+        type: Utf8
+      - name: page_views_count
+        type: Int64
+      - name: positive_reactions_count
+        type: Int64
+      - name: public_reactions_count
+        type: Int64
+      - name: comments_count
+        type: Int64
+      - name: reading_time_minutes
+        type: Int64
+      - name: tag_list
+        type: Utf8
+
+  - name: articles
+    description: Public articles by a given dev.to username. No auth required.
+    request:
+      method: GET
+      path: /articles
+      query:
+        - name: username
+          from: filter
+          key: username
+        - name: per_page
+          from: literal
+          value: "1000"
+    response:
+      format: json
+      rows_path: []
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      max_pages: 50
+    filters:
+      - name: username
+        type: Utf8
+        required: true
+        description: dev.to username to list articles for (e.g. ben).
+    columns:
+      - name: username
+        type: Utf8
+        virtual: true
+        description: dev.to username filter passed in WHERE.
+        expr:
+          kind: from_filter
+          key: username
+      - name: id
+        type: Int64
+      - name: title
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: slug
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: published_at
+        type: Utf8
+      - name: positive_reactions_count
+        type: Int64
+      - name: public_reactions_count
+        type: Int64
+      - name: comments_count
+        type: Int64
+      - name: reading_time_minutes
+        type: Int64
+      - name: tag_list
+        type: Utf8
+
+  - name: tags
+    description: Top tags on dev.to. No auth required.
+    request:
+      method: GET
+      path: /tags
+      query:
+        - name: per_page
+          from: literal
+          value: "100"
+    response:
+      format: json
+      rows_path: []
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      max_pages: 10
+    columns:
+      - name: id
+        type: Int64
+      - name: name
+        type: Utf8
+      - name: bg_color_hex
+        type: Utf8
+      - name: text_color_hex
+        type: Utf8
+
+test_queries:
+  - "SELECT id, name FROM devto.tags LIMIT 1"

--- a/sources/community/devto/manifest.yaml
+++ b/sources/community/devto/manifest.yaml
@@ -1,76 +1,21 @@
 name: devto
 version: 0.1.0
 dsl_version: 3
-description: Query articles, drafts, engagement metrics, and tags from dev.to (Forem).
+description: Query public articles and top tags from dev.to (Forem). No auth required.
 backend: http
 base_url: https://dev.to/api
 
-inputs:
-  DEVTO_API_KEY:
-    kind: secret
-    required: true
-    hint: |
-      Dev.to API key. Generate at https://dev.to/settings/extensions.
-      Sent as the literal `api-key` header (no Bearer prefix).
-      Required for `articles_me`; the public `articles` and `tags` tables work
-      without it but still send the header when present.
-
-auth:
-  type: HeaderAuth
-  headers:
-    - name: api-key
-      from: input
-      key: DEVTO_API_KEY
+# Public-only source. No `inputs` and no `auth` block — register and query
+# immediately without credentials.
+#
+# A future revision can add `articles_me` (your own articles + drafts), which
+# requires a DEVTO_API_KEY. That table is kept out of this manifest because
+# Coral's current DSL treats any `from: input` reference as required at
+# `coral source add` time, even when the input is marked `required: false`.
+# Re-including it without a credential would prevent registering the source
+# at all — including for users who only want the public tables.
 
 tables:
-  - name: articles_me
-    description: Your own articles and drafts on dev.to with engagement stats. Requires DEVTO_API_KEY.
-    request:
-      method: GET
-      path: /articles/me
-      query:
-        - name: per_page
-          from: literal
-          value: "1000"
-        - name: state
-          from: literal
-          value: "all"
-    response:
-      format: json
-      rows_path: []
-    pagination:
-      mode: page
-      page_param: page
-      page_start: 1
-      max_pages: 50
-    columns:
-      - name: id
-        type: Int64
-      - name: title
-        type: Utf8
-      - name: description
-        type: Utf8
-      - name: slug
-        type: Utf8
-      - name: url
-        type: Utf8
-      - name: published
-        type: Boolean
-      - name: published_at
-        type: Utf8
-      - name: page_views_count
-        type: Int64
-      - name: positive_reactions_count
-        type: Int64
-      - name: public_reactions_count
-        type: Int64
-      - name: comments_count
-        type: Int64
-      - name: reading_time_minutes
-        type: Int64
-      - name: tag_list
-        type: Utf8
-
   - name: articles
     description: Public articles by a given dev.to username. No auth required.
     request:
@@ -156,3 +101,4 @@ tables:
 
 test_queries:
   - "SELECT id, name FROM devto.tags LIMIT 1"
+  - "SELECT id, title FROM devto.articles WHERE username = 'ben' LIMIT 1"


### PR DESCRIPTION
Adds SQL access to dev.to developer articles, drafts, engagement metrics, and platform tags.

Tables:
  - devto.articles_me: your own articles and drafts with view, reaction, and comment counts. Requires DEVTO_API_KEY.
  - devto.articles: public articles by a given username. Optional auth.
  - devto.tags: top tags on dev.to. Optional auth.

Auth: api-key HTTP header (no Bearer prefix), generated at dev.to/settings/extensions.

Endpoint: https://dev.to/api (REST, JSON).
Pagination: page + per_page (per_page=1000 since SQL LIMIT is not pushed down to the upstream API).