### PR TITLE
feat(sources/devpost): add Devpost community source

### DIFF
--- a/sources/community/devpost/README.md
+++ b/sources/community/devpost/README.md
@@ -1,0 +1,82 @@
+# Devpost
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 1 table + 1 search function
+**Base URL:** `https://devpost.com`
+
+Query public hackathons from [Devpost](https://devpost.com) via its public JSON
+API (`/api/hackathons`). No authentication required.
+
+```bash
+coral source add --file sources/community/devpost/manifest.yaml
+coral source test devpost
+```
+
+## Tables & functions
+
+| Name | Kind | Description | Filters / Args |
+|---|---|---|---|
+| `events` | table | Browse hackathons in Devpost's default ranking | `status` |
+| `search` | search function | Keyword search, preserving provider ranking | `q` (required), `status` |
+
+---
+
+### `events`
+
+Browse the hackathon catalog. Results paginate 9 per page, so always use a
+`LIMIT` (default fetch limit is 100). Avoid an unbounded `ORDER BY`, which would
+force fetching the entire ~13k-row catalog; for ranked keyword results use
+`search()` instead.
+
+#### Filters
+
+| Filter | Type | Description |
+|---|---|---|
+| `status` | string | `open`, `upcoming`, or `ended`, mapped to `?status[]=` |
+
+### `search`
+
+```sql
+SELECT title, organizer, prize_amount_raw, registrations_count
+FROM devpost.search(q => 'ai')
+ORDER BY registrations_count DESC
+LIMIT 10;
+```
+
+#### Arguments
+
+| Arg | Required | Description |
+|---|---|---|
+| `q` | yes | Keyword query, mapped to `?search=` |
+| `status` | no | Optional `open` / `upcoming` / `ended` |
+
+## Columns (both surfaces)
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Int64 | Devpost numeric hackathon id |
+| `title` | Utf8 | Hackathon title |
+| `url` | Utf8 | Canonical hackathon URL |
+| `organizer` | Utf8 | Hosting organization name |
+| `location` | Utf8 | Displayed location (e.g. "Online") |
+| `status` | Utf8 | Open state (open/upcoming/ended) |
+| `tracks` | Utf8 | Comma-joined theme names |
+| `registrations_count` | Int64 | Number of registered participants |
+| `featured` | Boolean | Whether Devpost features this hackathon |
+| `invite_only` | Boolean | Whether participation is invite-only |
+| `prize_amount_raw` | Utf8 | Raw prize markup (HTML); parse downstream |
+| `submission_period_dates_raw` | Utf8 | Human-readable window; parse downstream |
+| `time_left_to_submission` | Utf8 | Human-readable time remaining |
+| `thumbnail_url` | Utf8 | Thumbnail image URL |
+| `submission_gallery_url` | Utf8 | Project submission gallery URL |
+
+## Notes
+
+Two fields are returned un-normalized by Devpost and exposed as `_raw`:
+
+- `prize_amount_raw` — HTML, e.g. `"$<span data-currency-value>60,000</span>"`.
+- `submission_period_dates_raw` — text, e.g. `"May 05 - Jun 11, 2026"`.
+
+They are left raw because Coral's `format_timestamp` helper only accepts
+epoch/ISO-8601 inputs; parse them in your own layer.

--- a/sources/community/devpost/manifest.yaml
+++ b/sources/community/devpost/manifest.yaml
@@ -1,0 +1,145 @@
+name: devpost
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query public hackathons from Devpost. Browse the catalog or run keyword
+  search; no authentication required.
+base_url: https://devpost.com
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT id, title FROM devpost.events LIMIT 1
+  - SELECT id, title FROM devpost.search(q => 'ai') LIMIT 1
+tables:
+  - name: events
+    description: >-
+      Browse public hackathons listed on Devpost in the provider's default
+      ranking. Use a LIMIT (results are paginated 9 per page); avoid unbounded
+      ORDER BY, which forces fetching the entire catalog. For keyword retrieval
+      use the devpost.search() function instead.
+    fetch_limit_default: 100
+    filters:
+      - name: status
+        type: Utf8
+        description: Open state filter, mapped to ?status[]= (e.g. 'open', 'upcoming', 'ended').
+    request:
+      method: GET
+      path: /api/hackathons
+      query:
+        - name: "status[]"
+          from: filter
+          key: status
+    response:
+      rows_path: [hackathons]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      max_pages: 25
+    columns: &event_columns
+      - name: id
+        type: Int64
+        description: Devpost numeric hackathon id.
+      - name: title
+        type: Utf8
+        description: Hackathon title.
+      - name: url
+        type: Utf8
+        description: Canonical hackathon URL.
+      - name: organizer
+        type: Utf8
+        description: Hosting organization name.
+        expr:
+          kind: path
+          path: [organization_name]
+      - name: location
+        type: Utf8
+        description: Displayed location (e.g. "Online" or a city).
+        expr:
+          kind: path
+          path: [displayed_location, location]
+      - name: status
+        type: Utf8
+        description: Open state (open/upcoming/ended).
+        expr:
+          kind: path
+          path: [open_state]
+      - name: tracks
+        type: Utf8
+        description: Comma-joined theme names (e.g. "Machine Learning/AI,Databases").
+        expr:
+          kind: join_array_path
+          path: [themes]
+          item_path: [name]
+          separator: ","
+      - name: registrations_count
+        type: Int64
+        description: Number of registered participants.
+      - name: featured
+        type: Boolean
+        description: Whether Devpost features this hackathon.
+      - name: invite_only
+        type: Boolean
+        description: Whether participation is invite-only.
+      - name: prize_amount_raw
+        type: Utf8
+        description: Raw prize markup from Devpost (HTML, e.g. "$<span ...>60,000</span>"); parse downstream.
+        expr:
+          kind: path
+          path: [prize_amount]
+      - name: submission_period_dates_raw
+        type: Utf8
+        description: Human-readable submission window (e.g. "May 05 - Jun 11, 2026"); parse downstream.
+        expr:
+          kind: path
+          path: [submission_period_dates]
+      - name: time_left_to_submission
+        type: Utf8
+        description: Human-readable time remaining (e.g. "12 days left").
+      - name: thumbnail_url
+        type: Utf8
+        description: Thumbnail image URL.
+      - name: submission_gallery_url
+        type: Utf8
+        description: URL of the project submission gallery.
+functions:
+  - name: search
+    kind: search
+    description: >-
+      Keyword search across Devpost hackathons, preserving Devpost's provider
+      ranking. Call as devpost.search(q => 'ai'). Optionally pass status.
+    search_limits:
+      default_top_k: 25
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+      - name: status
+        bind:
+          arg: status
+    request:
+      method: GET
+      path: /api/hackathons
+      query:
+        - name: search
+          from: arg
+          key: q
+        - name: "status[]"
+          from: arg
+          key: status
+    response:
+      rows_path: [hackathons]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      max_pages: 12
+    columns: *event_columns


### PR DESCRIPTION
## What changed
Adds a new community source spec for **Devpost** under `sources/community/devpost/` (manifest + README).

## Why
Devpost exposes a clean, public, no-auth JSON API (`/api/hackathons`) that isn't represented in the catalog yet. Hackathon discovery is a common use case and this makes it queryable as SQL.

## Surface
- `devpost.events` — browse table, filter by `status` (`open`/`upcoming`/`ended`).
- `devpost.search(q => '...')` — a `kind: search` function that preserves Devpost's provider ranking, bounded by `search_limits`.

## Example
```sql
SELECT title, organizer, registrations_count
FROM devpost.search(q => 'ai')
ORDER BY registrations_count DESC
LIMIT 10;
```

## Validation
- `coral source lint` passes; `coral source test devpost` passes both declared `test_queries` against the live API.
- Manifest passes `yamllint` with the repo `.yamllint.yaml`.

## Known limitations
Two Devpost fields are returned un-normalized and are intentionally exposed as `_raw` strings (HTML prize markup, human-readable date range) because `format_timestamp` only accepts epoch/ISO inputs. Documented in the README.

Made with [Cursor](https://cursor.com)