### PR TITLE
feat(sources/hackerearth): add HackerEarth community source

### DIFF
--- a/sources/community/hackerearth/README.md
+++ b/sources/community/hackerearth/README.md
@@ -1,0 +1,47 @@
+# HackerEarth
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 1
+**Base URL:** `https://www.hackerearth.com`
+
+Query hackathons and coding challenges from [HackerEarth](https://www.hackerearth.com)
+via its public events feed (`/chrome-extension/events/`). No authentication required.
+
+```bash
+coral source add --file sources/community/hackerearth/manifest.yaml
+coral source test hackerearth
+```
+
+## Tables
+
+| Table | Description | Filters |
+|---|---|---|
+| `events` | Current hackathons and challenges feed | — |
+
+---
+
+### `events`
+
+Returns the full current events feed in a single request (no pagination).
+
+```sql
+SELECT title, status, start_utc, end_utc
+FROM hackerearth.events
+WHERE status = 'ONGOING'
+LIMIT 20;
+```
+
+#### Columns
+
+| Column | Type | Description |
+|---|---|---|
+| `title` | Utf8 | Event title |
+| `description` | Utf8 | Short description |
+| `url` | Utf8 | Full URL to the challenge |
+| `status` | Utf8 | `ONGOING` or `UPCOMING` |
+| `college` | Boolean | Whether the event is college-restricted |
+| `challenge_type` | Utf8 | e.g. "Monthly Challenges", "Hiring Challenge" |
+| `start_utc` | Utf8 | Start time, UTC (e.g. `2026-04-27 04:30:00+00:00`) |
+| `end_utc` | Utf8 | End time, UTC |
+| `thumbnail` | Utf8 | Thumbnail image URL |

--- a/sources/community/hackerearth/manifest.yaml
+++ b/sources/community/hackerearth/manifest.yaml
@@ -1,0 +1,56 @@
+name: hackerearth
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query hackathons and coding challenges from HackerEarth's public events feed.
+  No authentication required.
+base_url: https://www.hackerearth.com
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT title FROM hackerearth.events LIMIT 1
+tables:
+  - name: events
+    description: >-
+      Hackathons and coding challenges from HackerEarth's public events feed.
+      Returns the full current feed in a single request (no pagination).
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /chrome-extension/events/
+    response:
+      rows_path: [response]
+      row_strategy: direct
+    columns:
+      - name: title
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: status
+        type: Utf8
+        description: HackerEarth status (ONGOING / UPCOMING).
+      - name: college
+        type: Boolean
+        description: Whether the event is college-restricted.
+      - name: challenge_type
+        type: Utf8
+        description: e.g. "Monthly Challenges", "Hiring Challenge".
+      - name: start_utc
+        type: Utf8
+        description: Start time, UTC ("2026-04-27 04:30:00+00:00"); parsed downstream.
+        expr:
+          kind: path
+          path: [start_utc_tz]
+      - name: end_utc
+        type: Utf8
+        description: End time, UTC ("2026-05-31 18:29:00+00:00"); parsed downstream.
+        expr:
+          kind: path
+          path: [end_utc_tz]
+      - name: thumbnail
+        type: Utf8


### PR DESCRIPTION
## What changed
Adds a new community source spec for **HackerEarth** under `sources/community/hackerearth/` (manifest + README).

## Why
HackerEarth publishes its current hackathons and coding challenges through a public, no-auth JSON feed (`/chrome-extension/events/`) not yet in the catalog.

## Surface
- `hackerearth.events` — the full current events feed in a single request (no pagination), with ISO UTC start/end timestamps.

## Example
```sql
SELECT title, status, start_utc, end_utc
FROM hackerearth.events
WHERE status = 'ONGOING'
LIMIT 20;
```

## Validation
- `coral source lint` passes; `coral source test hackerearth` passes the declared `test_query` against the live feed.
- Manifest passes `yamllint` with the repo `.yamllint.yaml`.

## Known limitations
The feed has no prize field and exposes UTC datetimes as strings (`2026-04-27 04:30:00+00:00`); documented in the README.

Made with [Cursor](https://cursor.com)