### PR TITLE
feat(sources/community/arxiv): add arxiv preprint search source

### DIFF
--- a/sources/community/arxiv/README.md
+++ b/sources/community/arxiv/README.md
@@ -1,0 +1,56 @@
+# arXiv Source
+
+Search arXiv papers, preprints, and research metadata.
+
+Under the hood, this source queries the open-access [OpenAlex API](https://openalex.org/), which indexes the entire arXiv preprint repository. This approach allows Coral to fetch and parse paper metadata in native JSON format, bypassing the XML-only limitation of the official arXiv API.
+
+## Rate Limits & Usage
+
+OpenAlex is free and open to the public without requiring an API key.
+- **Default limit:** 10 requests per second.
+- **Polite pool:** If you wish to identify your application and receive faster, prioritized rate limits (up to 100 requests per second), OpenAlex recommends adding a `mailto` parameter to requests. Since this community source uses a fully anonymous setup, you can optionally modify the manifest's `base_url` to append your email, e.g. `https://api.openalex.org?mailto=your-email@example.com`.
+
+## Setup
+
+Add the source directly using the CLI:
+
+```bash
+coral source add --file sources/community/arxiv/manifest.yaml
+```
+
+## Functions
+
+### `search(q)`
+Perform a full-text search across arXiv preprint titles, abstracts, authors, and concepts. Requires the `q` argument.
+
+**Example:**
+```sql
+SELECT title, publication_year, cited_by_count
+FROM arxiv.search(q => 'quantum computing')
+LIMIT 5;
+```
+
+## Tables
+
+### `papers`
+Query papers indexed in arXiv. You can list all papers or filter by specific identifiers:
+- `openalex_id` (e.g. `'W2781738013'`)
+- `doi` (e.g. `'https://doi.org/10.22331/q-2018-08-06-79'`)
+- `arxiv_id` (e.g. `'1706.03762'`)
+- `landing_page_url` (e.g. `'http://arxiv.org/abs/cond-mat/0410550'`)
+- `publication_year` (e.g. `2024`)
+
+**Examples:**
+```sql
+-- Retrieve a specific paper by its arXiv ID
+SELECT title, publication_year, cited_by_count, pdf_url
+FROM arxiv.papers
+WHERE arxiv_id = '1706.03762'
+LIMIT 1;
+
+-- List preprints from a specific publication year
+SELECT title, publication_date, cited_by_count
+FROM arxiv.papers
+WHERE publication_year = 2025
+LIMIT 5;
+```

--- a/sources/community/arxiv/README.md
+++ b/sources/community/arxiv/README.md
@@ -6,11 +6,17 @@ Under the hood, this source queries the open-access [OpenAlex API](https://opena
 
 ## Rate Limits & Usage
 
-OpenAlex is free and open to the public without requiring an API key.
-- **Default limit:** 10 requests per second.
-- **Polite pool:** If you wish to identify your application and receive faster, prioritized rate limits (up to 100 requests per second), OpenAlex recommends adding a `mailto` parameter to requests. Since this community source uses a fully anonymous setup, you can optionally modify the manifest's `base_url` to append your email, e.g. `https://api.openalex.org?mailto=your-email@example.com`.
+OpenAlex is free and open to the public, but requires a free API key to get access to higher rate limits (up to 100 requests per second) and faster response times.
+- **Rate limit:** 100 requests per second with an API key.
+- Get a free key by visiting the [OpenAlex Settings Page](https://openalex.org/settings/api).
 
 ## Setup
+
+Configure the `OPENALEX_API_KEY` credential in your environment:
+
+```bash
+export OPENALEX_API_KEY="your_free_api_key"
+```
 
 Add the source directly using the CLI:
 
@@ -21,11 +27,11 @@ coral source add --file sources/community/arxiv/manifest.yaml
 ## Functions
 
 ### `search(q)`
-Perform a full-text search across arXiv preprint titles, abstracts, authors, and concepts. Requires the `q` argument.
+Perform a full-text search across arXiv preprint titles, abstracts, and full text. Requires the `q` argument.
 
 **Example:**
 ```sql
-SELECT title, publication_year, cited_by_count
+SELECT title, publication_year, cited_by_count, arxiv_id
 FROM arxiv.search(q => 'quantum computing')
 LIMIT 5;
 ```
@@ -40,16 +46,21 @@ Query papers indexed in arXiv. You can list all papers or filter by specific ide
 - `landing_page_url` (e.g. `'http://arxiv.org/abs/cond-mat/0410550'`)
 - `publication_year` (e.g. `2024`)
 
+#### Output Columns of Interest
+- `arxiv_id`: The raw arXiv identifier (e.g., `'1706.03762'`), extracted dynamically from the locations array.
+- `best_oa_landing_page_url` / `best_oa_pdf_url`: The best Open Access URLs for the paper (which may point to a publisher page or arXiv).
+- `locations`: JSON array of all hosted copies/repositories. Inspect this to find explicit arXiv links or other versions.
+
 **Examples:**
 ```sql
 -- Retrieve a specific paper by its arXiv ID
-SELECT title, publication_year, cited_by_count, pdf_url
+SELECT title, publication_year, cited_by_count, best_oa_pdf_url, arxiv_id
 FROM arxiv.papers
 WHERE arxiv_id = '1706.03762'
 LIMIT 1;
 
 -- List preprints from a specific publication year
-SELECT title, publication_date, cited_by_count
+SELECT title, publication_date, cited_by_count, best_oa_landing_page_url
 FROM arxiv.papers
 WHERE publication_year = 2025
 LIMIT 5;

--- a/sources/community/arxiv/README.md
+++ b/sources/community/arxiv/README.md
@@ -31,7 +31,7 @@ Perform a full-text search across arXiv preprint titles, abstracts, and full tex
 
 **Example:**
 ```sql
-SELECT title, publication_year, cited_by_count, arxiv_id
+SELECT title, publication_year, cited_by_count, best_oa_arxiv_id
 FROM arxiv.search(q => 'quantum computing')
 LIMIT 5;
 ```
@@ -47,14 +47,14 @@ Query papers indexed in arXiv. You can list all papers or filter by specific ide
 - `publication_year` (e.g. `2024`)
 
 #### Output Columns of Interest
-- `arxiv_id`: The raw arXiv identifier (e.g., `'1706.03762'`), extracted dynamically from the locations array.
+- `best_oa_arxiv_id`: The arXiv identifier of the work derived from the best open access location (e.g. `'1706.03762'`). Note that `best_oa_arxiv_id` may be null or contain a non-arXiv URL if the best open access location for a paper is a publisher page, journal, or DOI link rather than arxiv.org.
 - `best_oa_landing_page_url` / `best_oa_pdf_url`: The best Open Access URLs for the paper (which may point to a publisher page or arXiv).
 - `locations`: JSON array of all hosted copies/repositories. Inspect this to find explicit arXiv links or other versions.
 
 **Examples:**
 ```sql
 -- Retrieve a specific paper by its arXiv ID
-SELECT title, publication_year, cited_by_count, best_oa_pdf_url, arxiv_id
+SELECT title, publication_year, cited_by_count, best_oa_pdf_url, best_oa_arxiv_id
 FROM arxiv.papers
 WHERE arxiv_id = '1706.03762'
 LIMIT 1;

--- a/sources/community/arxiv/README.md
+++ b/sources/community/arxiv/README.md
@@ -1,8 +1,8 @@
 # arXiv Source
 
-Search arXiv papers, preprints, and research metadata.
+A convenience wrapper around OpenAlex's `/works?filter=indexed_in:arxiv` endpoint. Pre-applies the arXiv scope filter to simplify queries. Not a direct arXiv API integration.
 
-Under the hood, this source queries the open-access [OpenAlex API](https://openalex.org/), which indexes the entire arXiv preprint repository. This approach allows Coral to fetch and parse paper metadata in native JSON format, bypassing the XML-only limitation of the official arXiv API.
+Under the hood, this source queries the open-access [OpenAlex API](https://openalex.org/) rather than the official arXiv API. This provides a streamlined interface focused solely on arXiv preprints, pre-applying the arXiv scope filter, and mapping filters and search terms directly to OpenAlex's structured database. This approach allows Coral to fetch and parse paper metadata in native JSON format with high rate limits, bypassing the XML-only limitation of the official arXiv API.
 
 ## Rate Limits & Usage
 
@@ -31,7 +31,7 @@ Perform a full-text search across arXiv preprint titles, abstracts, and full tex
 
 **Example:**
 ```sql
-SELECT title, publication_year, cited_by_count, best_oa_arxiv_id
+SELECT title, publication_year, cited_by_count, best_oa_landing_page_url
 FROM arxiv.search(q => 'quantum computing')
 LIMIT 5;
 ```
@@ -42,19 +42,18 @@ LIMIT 5;
 Query papers indexed in arXiv. You can list all papers or filter by specific identifiers:
 - `openalex_id` (e.g. `'W2781738013'`)
 - `doi` (e.g. `'https://doi.org/10.22331/q-2018-08-06-79'`)
-- `arxiv_id` (e.g. `'1706.03762'`)
+- `arxiv_id` (e.g. `'1706.03762'`) — **Note:** Supports unversioned arXiv ID lookup only (e.g. `'1706.03762'`, not `'1706.03762v7'`). Versioned IDs are not supported.
 - `landing_page_url` (e.g. `'http://arxiv.org/abs/cond-mat/0410550'`)
 - `publication_year` (e.g. `2024`)
 
 #### Output Columns of Interest
-- `best_oa_arxiv_id`: The arXiv identifier of the work derived from the best open access location (e.g. `'1706.03762'`). Note that `best_oa_arxiv_id` may be null or contain a non-arXiv URL if the best open access location for a paper is a publisher page, journal, or DOI link rather than arxiv.org.
 - `best_oa_landing_page_url` / `best_oa_pdf_url`: The best Open Access URLs for the paper (which may point to a publisher page or arXiv).
-- `locations`: JSON array of all hosted copies/repositories. Inspect this to find explicit arXiv links or other versions.
+- `locations`: JSON array of all hosted copies/repositories. To find original, specific, or versioned arXiv identifiers/URLs, inspect this array.
 
 **Examples:**
 ```sql
 -- Retrieve a specific paper by its arXiv ID
-SELECT title, publication_year, cited_by_count, best_oa_pdf_url, best_oa_arxiv_id
+SELECT title, publication_year, cited_by_count, best_oa_pdf_url, best_oa_landing_page_url
 FROM arxiv.papers
 WHERE arxiv_id = '1706.03762'
 LIMIT 1;

--- a/sources/community/arxiv/manifest.yaml
+++ b/sources/community/arxiv/manifest.yaml
@@ -185,7 +185,7 @@ tables:
         query:
           - name: filter
             from: template
-            template: openalex:{{filter.openalex_id}}
+            template: indexed_in:arxiv,openalex:{{filter.openalex_id}}
       - when_filters:
           - doi
         method: GET
@@ -193,7 +193,7 @@ tables:
         query:
           - name: filter
             from: template
-            template: doi:{{filter.doi}}
+            template: indexed_in:arxiv,doi:{{filter.doi}}
       - when_filters:
           - landing_page_url
         method: GET
@@ -201,7 +201,7 @@ tables:
         query:
           - name: filter
             from: template
-            template: locations.landing_page_url:{{filter.landing_page_url}}
+            template: indexed_in:arxiv,locations.landing_page_url:{{filter.landing_page_url}}
       - when_filters:
           - arxiv_id
         method: GET
@@ -209,7 +209,7 @@ tables:
         query:
           - name: filter
             from: template
-            template: locations.landing_page_url:http://arxiv.org/abs/{{filter.arxiv_id}}|https://arxiv.org/abs/{{filter.arxiv_id}}
+            template: indexed_in:arxiv,locations.landing_page_url:http://arxiv.org/abs/{{filter.arxiv_id}}|https://arxiv.org/abs/{{filter.arxiv_id}}
       - when_filters:
           - publication_year
         method: GET

--- a/sources/community/arxiv/manifest.yaml
+++ b/sources/community/arxiv/manifest.yaml
@@ -119,12 +119,13 @@ functions:
         expr:
           kind: path
           path: [cited_by_count]
-      - name: arxiv_id
+      - name: best_oa_arxiv_id
         type: Utf8
         nullable: true
         description: >-
-          The arXiv identifier of the work (e.g. 1706.03762). If null or not matching,
-          users can inspect the `locations` JSON column to retrieve the arXiv-specific identifier.
+          The arXiv identifier of the work derived from the best open access location (e.g. 1706.03762).
+          This may be null or contain a non-arXiv URL if the best open access location for a paper
+          is a publisher page, journal, or DOI link rather than arxiv.org.
         expr:
           kind: replace
           from: "https://arxiv.org/abs/"
@@ -303,9 +304,18 @@ tables:
       - name: arxiv_id
         type: Utf8
         nullable: true
+        virtual: true
+        description: Filter column to query by arXiv ID.
+        expr:
+          kind: from_filter
+          key: arxiv_id
+      - name: best_oa_arxiv_id
+        type: Utf8
+        nullable: true
         description: >-
-          The arXiv identifier of the work (e.g. 1706.03762). If null or not matching,
-          users can inspect the `locations` JSON column to retrieve the arXiv-specific identifier.
+          The arXiv identifier of the work derived from the best open access location (e.g. 1706.03762).
+          This may be null or contain a non-arXiv URL if the best open access location for a paper
+          is a publisher page, journal, or DOI link rather than arxiv.org.
         expr:
           kind: replace
           from: "https://arxiv.org/abs/"

--- a/sources/community/arxiv/manifest.yaml
+++ b/sources/community/arxiv/manifest.yaml
@@ -4,8 +4,16 @@ dsl_version: 3
 backend: http
 description: >-
   Search arXiv papers, preprints, and research metadata via the OpenAlex API.
-  No authentication required.
+  Requires a free OpenAlex API key.
 base_url: https://api.openalex.org
+
+inputs:
+  OPENALEX_API_KEY:
+    kind: secret
+    hint: >-
+      API key for OpenAlex. Get a free key at https://openalex.org/settings/api.
+      The key provides a free allowance and higher rate limits. The key is passed
+      as the api_key query parameter.
 
 test_queries:
   - SELECT title, publication_year, cited_by_count FROM arxiv.search(q => 'quantum computing') LIMIT 5
@@ -17,12 +25,12 @@ functions:
   - name: search
     kind: search
     description: |
-      Search arXiv papers and preprints by title, abstract, authors, or concepts.
+      Search arXiv papers and preprints by title, abstract, or full text.
       Returns ranked results matching the search term.
     fetch_limit_default: 25
     search_limits:
       default_top_k: 25
-      max_top_k: 200
+      max_top_k: 100
       max_calls_per_query: 5
     args:
       - name: q
@@ -39,6 +47,9 @@ functions:
         - name: search
           from: arg
           key: q
+        - name: api_key
+          from: input
+          key: OPENALEX_API_KEY
     response:
       rows_path:
         - results
@@ -49,7 +60,7 @@ functions:
       page_step: 1
       page_size:
         default: 25
-        max: 200
+        max: 100
         query_param: per_page
     columns:
       - name: id
@@ -108,20 +119,44 @@ functions:
         expr:
           kind: path
           path: [cited_by_count]
-      - name: landing_page_url
+      - name: arxiv_id
         type: Utf8
         nullable: true
-        description: Landing page URL of the preprint.
+        description: >-
+          The arXiv identifier of the work (e.g. 1706.03762). If null or not matching,
+          users can inspect the `locations` JSON column to retrieve the arXiv-specific identifier.
+        expr:
+          kind: replace
+          from: "https://arxiv.org/abs/"
+          to: ""
+          expr:
+            kind: replace
+            from: "http://arxiv.org/abs/"
+            to: ""
+            expr:
+              kind: path
+              path: [best_oa_location, landing_page_url]
+      - name: best_oa_landing_page_url
+        type: Utf8
+        nullable: true
+        description: Best open access landing page URL.
         expr:
           kind: path
           path: [best_oa_location, landing_page_url]
-      - name: pdf_url
+      - name: best_oa_pdf_url
         type: Utf8
         nullable: true
-        description: PDF URL of the preprint.
+        description: Best open access PDF URL.
         expr:
           kind: path
           path: [best_oa_location, pdf_url]
+      - name: locations
+        type: Json
+        nullable: true
+        description: JSON array of all locations (repositories, journals) hosting this work.
+        expr:
+          kind: path
+          path: [locations]
       - name: authorships
         type: Json
         nullable: true
@@ -177,6 +212,9 @@ tables:
         - name: filter
           from: literal
           value: indexed_in:arxiv
+        - name: api_key
+          from: input
+          key: OPENALEX_API_KEY
     requests:
       - when_filters:
           - openalex_id
@@ -186,6 +224,9 @@ tables:
           - name: filter
             from: template
             template: indexed_in:arxiv,openalex:{{filter.openalex_id}}
+          - name: api_key
+            from: input
+            key: OPENALEX_API_KEY
       - when_filters:
           - doi
         method: GET
@@ -194,6 +235,9 @@ tables:
           - name: filter
             from: template
             template: indexed_in:arxiv,doi:{{filter.doi}}
+          - name: api_key
+            from: input
+            key: OPENALEX_API_KEY
       - when_filters:
           - landing_page_url
         method: GET
@@ -202,6 +246,9 @@ tables:
           - name: filter
             from: template
             template: indexed_in:arxiv,locations.landing_page_url:{{filter.landing_page_url}}
+          - name: api_key
+            from: input
+            key: OPENALEX_API_KEY
       - when_filters:
           - arxiv_id
         method: GET
@@ -210,6 +257,9 @@ tables:
           - name: filter
             from: template
             template: indexed_in:arxiv,locations.landing_page_url:http://arxiv.org/abs/{{filter.arxiv_id}}|https://arxiv.org/abs/{{filter.arxiv_id}}
+          - name: api_key
+            from: input
+            key: OPENALEX_API_KEY
       - when_filters:
           - publication_year
         method: GET
@@ -218,6 +268,9 @@ tables:
           - name: filter
             from: template
             template: indexed_in:arxiv,publication_year:{{filter.publication_year}}
+          - name: api_key
+            from: input
+            key: OPENALEX_API_KEY
     response:
       rows_path:
         - results
@@ -226,9 +279,10 @@ tables:
       page_param: page
       page_start: 1
       page_step: 1
+      max_pages: 100
       page_size:
         default: 25
-        max: 200
+        max: 100
         query_param: per_page
     columns:
       - name: id
@@ -249,11 +303,20 @@ tables:
       - name: arxiv_id
         type: Utf8
         nullable: true
-        virtual: true
-        description: Filter column to query by arXiv ID.
+        description: >-
+          The arXiv identifier of the work (e.g. 1706.03762). If null or not matching,
+          users can inspect the `locations` JSON column to retrieve the arXiv-specific identifier.
         expr:
-          kind: from_filter
-          key: arxiv_id
+          kind: replace
+          from: "https://arxiv.org/abs/"
+          to: ""
+          expr:
+            kind: replace
+            from: "http://arxiv.org/abs/"
+            to: ""
+            expr:
+              kind: path
+              path: [best_oa_location, landing_page_url]
       - name: title
         type: Utf8
         nullable: true
@@ -303,20 +366,27 @@ tables:
         expr:
           kind: path
           path: [cited_by_count]
-      - name: landing_page_url
+      - name: best_oa_landing_page_url
         type: Utf8
         nullable: true
-        description: Landing page URL of the preprint.
+        description: Best open access landing page URL.
         expr:
           kind: path
           path: [best_oa_location, landing_page_url]
-      - name: pdf_url
+      - name: best_oa_pdf_url
         type: Utf8
         nullable: true
-        description: PDF URL of the preprint.
+        description: Best open access PDF URL.
         expr:
           kind: path
           path: [best_oa_location, pdf_url]
+      - name: locations
+        type: Json
+        nullable: true
+        description: JSON array of all locations (repositories, journals) hosting this work.
+        expr:
+          kind: path
+          path: [locations]
       - name: authorships
         type: Json
         nullable: true

--- a/sources/community/arxiv/manifest.yaml
+++ b/sources/community/arxiv/manifest.yaml
@@ -1,0 +1,354 @@
+name: arxiv
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Search arXiv papers, preprints, and research metadata via the OpenAlex API.
+  No authentication required.
+base_url: https://api.openalex.org
+
+test_queries:
+  - SELECT title, publication_year, cited_by_count FROM arxiv.search(q => 'quantum computing') LIMIT 5
+  - SELECT title, publication_year, cited_by_count FROM arxiv.papers WHERE openalex_id = 'W2781738013' LIMIT 1
+  - SELECT title, publication_year, cited_by_count FROM arxiv.papers WHERE arxiv_id = '1706.03762' LIMIT 1
+  - SELECT title, publication_year, cited_by_count FROM arxiv.papers WHERE doi = 'https://doi.org/10.22331/q-2018-08-06-79' LIMIT 1
+
+functions:
+  - name: search
+    kind: search
+    description: |
+      Search arXiv papers and preprints by title, abstract, authors, or concepts.
+      Returns ranked results matching the search term.
+    fetch_limit_default: 25
+    search_limits:
+      default_top_k: 25
+      max_top_k: 200
+      max_calls_per_query: 5
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+    request:
+      method: GET
+      path: /works
+      query:
+        - name: filter
+          from: literal
+          value: indexed_in:arxiv
+        - name: search
+          from: arg
+          key: q
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 25
+        max: 200
+        query_param: per_page
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: OpenAlex URL ID (e.g. https://openalex.org/W2781738013).
+        expr:
+          kind: path
+          path: [id]
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Title of the paper.
+        expr:
+          kind: path
+          path: [title]
+      - name: doi
+        type: Utf8
+        nullable: true
+        description: Document Object Identifier (DOI) URL.
+        expr:
+          kind: path
+          path: [doi]
+      - name: publication_year
+        type: Int64
+        nullable: true
+        description: Publication year.
+        expr:
+          kind: path
+          path: [publication_year]
+      - name: publication_date
+        type: Utf8
+        nullable: true
+        description: Publication date (YYYY-MM-DD).
+        expr:
+          kind: path
+          path: [publication_date]
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Work type (e.g. article, preprint).
+        expr:
+          kind: path
+          path: [type]
+      - name: language
+        type: Utf8
+        nullable: true
+        description: Primary language code (e.g. en).
+        expr:
+          kind: path
+          path: [language]
+      - name: cited_by_count
+        type: Int64
+        nullable: true
+        description: Number of citations received.
+        expr:
+          kind: path
+          path: [cited_by_count]
+      - name: landing_page_url
+        type: Utf8
+        nullable: true
+        description: Landing page URL of the preprint.
+        expr:
+          kind: path
+          path: [best_oa_location, landing_page_url]
+      - name: pdf_url
+        type: Utf8
+        nullable: true
+        description: PDF URL of the preprint.
+        expr:
+          kind: path
+          path: [best_oa_location, pdf_url]
+      - name: authorships
+        type: Json
+        nullable: true
+        description: JSON array containing authors and their affiliations.
+        expr:
+          kind: path
+          path: [authorships]
+      - name: topics
+        type: Json
+        nullable: true
+        description: JSON array of topics associated with the work.
+        expr:
+          kind: path
+          path: [topics]
+      - name: referenced_works
+        type: Json
+        nullable: true
+        description: JSON array of OpenAlex IDs referenced by this work.
+        expr:
+          kind: path
+          path: [referenced_works]
+      - name: related_works
+        type: Json
+        nullable: true
+        description: JSON array of related OpenAlex work IDs.
+        expr:
+          kind: path
+          path: [related_works]
+      - name: abstract_inverted_index
+        type: Json
+        nullable: true
+        description: Inverted index mapping words to positions in the abstract.
+        expr:
+          kind: path
+          path: [abstract_inverted_index]
+
+tables:
+  - name: papers
+    description: |
+      Query arXiv papers. You can list all papers or filter by specific identifiers
+      such as `openalex_id`, `doi`, `landing_page_url`, `arxiv_id`, or `publication_year`.
+    fetch_limit_default: 25
+    filters:
+      - name: openalex_id
+      - name: doi
+      - name: landing_page_url
+      - name: arxiv_id
+      - name: publication_year
+    request:
+      method: GET
+      path: /works
+      query:
+        - name: filter
+          from: literal
+          value: indexed_in:arxiv
+    requests:
+      - when_filters:
+          - openalex_id
+        method: GET
+        path: /works
+        query:
+          - name: filter
+            from: template
+            template: openalex:{{filter.openalex_id}}
+      - when_filters:
+          - doi
+        method: GET
+        path: /works
+        query:
+          - name: filter
+            from: template
+            template: doi:{{filter.doi}}
+      - when_filters:
+          - landing_page_url
+        method: GET
+        path: /works
+        query:
+          - name: filter
+            from: template
+            template: locations.landing_page_url:{{filter.landing_page_url}}
+      - when_filters:
+          - arxiv_id
+        method: GET
+        path: /works
+        query:
+          - name: filter
+            from: template
+            template: locations.landing_page_url:http://arxiv.org/abs/{{filter.arxiv_id}}|https://arxiv.org/abs/{{filter.arxiv_id}}
+      - when_filters:
+          - publication_year
+        method: GET
+        path: /works
+        query:
+          - name: filter
+            from: template
+            template: indexed_in:arxiv,publication_year:{{filter.publication_year}}
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 25
+        max: 200
+        query_param: per_page
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: OpenAlex URL ID (e.g. https://openalex.org/W2781738013).
+        expr:
+          kind: path
+          path: [id]
+      - name: openalex_id
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Filter column to query by OpenAlex ID.
+        expr:
+          kind: from_filter
+          key: openalex_id
+      - name: arxiv_id
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Filter column to query by arXiv ID.
+        expr:
+          kind: from_filter
+          key: arxiv_id
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Title of the paper.
+        expr:
+          kind: path
+          path: [title]
+      - name: doi
+        type: Utf8
+        nullable: true
+        description: Document Object Identifier (DOI) URL.
+        expr:
+          kind: path
+          path: [doi]
+      - name: publication_year
+        type: Int64
+        nullable: true
+        description: Publication year.
+        expr:
+          kind: path
+          path: [publication_year]
+      - name: publication_date
+        type: Utf8
+        nullable: true
+        description: Publication date (YYYY-MM-DD).
+        expr:
+          kind: path
+          path: [publication_date]
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Work type (e.g. article, preprint).
+        expr:
+          kind: path
+          path: [type]
+      - name: language
+        type: Utf8
+        nullable: true
+        description: Primary language code (e.g. en).
+        expr:
+          kind: path
+          path: [language]
+      - name: cited_by_count
+        type: Int64
+        nullable: true
+        description: Number of citations received.
+        expr:
+          kind: path
+          path: [cited_by_count]
+      - name: landing_page_url
+        type: Utf8
+        nullable: true
+        description: Landing page URL of the preprint.
+        expr:
+          kind: path
+          path: [best_oa_location, landing_page_url]
+      - name: pdf_url
+        type: Utf8
+        nullable: true
+        description: PDF URL of the preprint.
+        expr:
+          kind: path
+          path: [best_oa_location, pdf_url]
+      - name: authorships
+        type: Json
+        nullable: true
+        description: JSON array containing authors and their affiliations.
+        expr:
+          kind: path
+          path: [authorships]
+      - name: topics
+        type: Json
+        nullable: true
+        description: JSON array of topics associated with the work.
+        expr:
+          kind: path
+          path: [topics]
+      - name: referenced_works
+        type: Json
+        nullable: true
+        description: JSON array of OpenAlex IDs referenced by this work.
+        expr:
+          kind: path
+          path: [referenced_works]
+      - name: related_works
+        type: Json
+        nullable: true
+        description: JSON array of related OpenAlex work IDs.
+        expr:
+          kind: path
+          path: [related_works]
+      - name: abstract_inverted_index
+        type: Json
+        nullable: true
+        description: Inverted index mapping words to positions in the abstract.
+        expr:
+          kind: path
+          path: [abstract_inverted_index]

--- a/sources/community/arxiv/manifest.yaml
+++ b/sources/community/arxiv/manifest.yaml
@@ -3,7 +3,8 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Search arXiv papers, preprints, and research metadata via the OpenAlex API.
+  A convenience wrapper around OpenAlex's /works?filter=indexed_in:arxiv endpoint.
+  Pre-applies the arXiv scope filter to simplify queries. Not a direct arXiv API integration.
   Requires a free OpenAlex API key.
 base_url: https://api.openalex.org
 
@@ -119,24 +120,7 @@ functions:
         expr:
           kind: path
           path: [cited_by_count]
-      - name: best_oa_arxiv_id
-        type: Utf8
-        nullable: true
-        description: >-
-          The arXiv identifier of the work derived from the best open access location (e.g. 1706.03762).
-          This may be null or contain a non-arXiv URL if the best open access location for a paper
-          is a publisher page, journal, or DOI link rather than arxiv.org.
-        expr:
-          kind: replace
-          from: "https://arxiv.org/abs/"
-          to: ""
-          expr:
-            kind: replace
-            from: "http://arxiv.org/abs/"
-            to: ""
-            expr:
-              kind: path
-              path: [best_oa_location, landing_page_url]
+
       - name: best_oa_landing_page_url
         type: Utf8
         nullable: true
@@ -305,28 +289,12 @@ tables:
         type: Utf8
         nullable: true
         virtual: true
-        description: Filter column to query by arXiv ID.
+        description: >-
+          Filter column to query by arXiv ID. Unversioned arXiv ID lookup only (e.g. '1706.03762', not '1706.03762v7').
+          Matches against OpenAlex landing page URLs. Versioned IDs are not supported.
         expr:
           kind: from_filter
           key: arxiv_id
-      - name: best_oa_arxiv_id
-        type: Utf8
-        nullable: true
-        description: >-
-          The arXiv identifier of the work derived from the best open access location (e.g. 1706.03762).
-          This may be null or contain a non-arXiv URL if the best open access location for a paper
-          is a publisher page, journal, or DOI link rather than arxiv.org.
-        expr:
-          kind: replace
-          from: "https://arxiv.org/abs/"
-          to: ""
-          expr:
-            kind: replace
-            from: "http://arxiv.org/abs/"
-            to: ""
-            expr:
-              kind: path
-              path: [best_oa_location, landing_page_url]
       - name: title
         type: Utf8
         nullable: true


### PR DESCRIPTION
This PR adds a new community source for `arxiv` preprints and papers. Under the hood, this source uses the OpenAlex API (which indexes arXiv preprints in native JSON, bypassing the official arXiv API's XML restriction).

### Proposed Changes

- **Added `sources/community/arxiv/manifest.yaml`**:
  - Implements the `arxiv.search(q)` search function (marked `kind: search`) which queries `/works?filter=indexed_in:arxiv&search={{q}}`.
  - Implements the `arxiv.papers` table which lists preprints.
  - Utilizes multiple request routing (`requests` block) to target specific endpoint query filters when filters are present in the SQL query:
    - `openalex_id` -> `filter=openalex:{{filter.openalex_id}}`
    - `doi` -> `filter=doi:{{filter.doi}}`
    - `landing_page_url` -> `filter=locations.landing_page_url:{{filter.landing_page_url}}`
    - `arxiv_id` -> `filter=locations.landing_page_url:http://arxiv.org/abs/{{filter.arxiv_id}}|https://arxiv.org/abs/{{filter.arxiv_id}}` (uses OR logic `|` to match both http and https landing pages)
    - `publication_year` -> `filter=indexed_in:arxiv,publication_year:{{filter.publication_year}}`
  - Defines virtual columns `openalex_id` and `arxiv_id` using `kind: from_filter` expressions so DataFusion recognizes them during filter pushdown.
  - Implements page-based pagination.
- **Added `sources/community/arxiv/README.md`**:
  - Documents how the source works, rate limits, installation, and example SQL queries for both search and papers.

---

### Verification

Tested with `coral source add --file sources/community/arxiv/manifest.yaml` and all 4 query validation checks passed successfully:

```text
    arxiv (1 table)
    └─ papers
    Query tests
    4 declared · 4 passed · 0 failed

    ✓ SELECT title, publication_year, cited_by_count FROM arxiv.search(q => 'quantum computing') LIMIT 5
      5 rows

    ✓ SELECT title, publication_year, cited_by_count FROM arxiv.papers WHERE openalex_id = 'W2781738013' LIMIT 1
      1 row

    ✓ SELECT title, publication_year, cited_by_count FROM arxiv.papers WHERE arxiv_id = '1706.03762' LIMIT 1
      1 row

    ✓ SELECT title, publication_year, cited_by_count FROM arxiv.papers WHERE doi = 'https://doi.org/10.22331/q-2018-08-06-79' LIMIT 1
      1 row
```

Closes #1075
