### PR TITLE
feat(sources/community/vapi): add Vapi Voice AI source

### DIFF
--- a/sources/community/vapi/README.md
+++ b/sources/community/vapi/README.md
@@ -1,0 +1,147 @@
+# Vapi
+
+Query [Vapi](https://vapi.ai) Voice AI data — call logs, assistants, and phone numbers — using SQL.
+
+## Tables
+
+| Table | Endpoint | Description |
+|---|---|---|
+| `vapi.calls` | `GET /call` | Call logs with status, cost, transcript, and AI analysis |
+| `vapi.assistants` | `GET /assistant` | Configured voice AI assistants |
+| `vapi.phone_numbers` | `GET /phone-number` | Provisioned phone numbers |
+
+## Setup
+
+1. Go to [https://dashboard.vapi.ai/org/api-keys](https://dashboard.vapi.ai/org/api-keys).
+2. Create or copy an existing API key. Any key with read access works.
+3. Set the environment variable:
+
+```sh
+export VAPI_API_KEY=<your-api-key>
+```
+
+4. Add the source:
+
+```sh
+coral source add vapi
+```
+
+## Example Queries
+
+### Recent calls
+
+```sql
+SELECT id, type, status, cost, created_at
+FROM vapi.calls
+LIMIT 20;
+```
+
+### Calls in a time window (date-cursor pagination)
+
+Vapi uses date-cursor pagination. Use `created_at_lt` and `created_at_gt` to page
+through large call histories:
+
+```sql
+-- Calls from the last 7 days
+SELECT id, type, status, cost, started_at, ended_at
+FROM vapi.calls
+WHERE created_at_gt = '2025-01-01T00:00:00Z'
+  AND created_at_lt = '2025-01-08T00:00:00Z'
+LIMIT 100;
+```
+
+To page forward, set `created_at_lt` to the `created_at` of the oldest row in the
+previous result.
+
+### Calls by assistant
+
+```sql
+SELECT c.id, c.status, c.cost, a.name AS assistant_name
+FROM vapi.calls c
+JOIN vapi.assistants a ON c.assistant_id = a.id
+LIMIT 20;
+```
+
+### Call transcripts
+
+```sql
+SELECT id, status, artifact__transcript
+FROM vapi.calls
+WHERE artifact__transcript IS NOT NULL
+LIMIT 5;
+```
+
+### Assistants and their models
+
+```sql
+SELECT id, name, model__provider, model__model, voice__provider
+FROM vapi.assistants;
+```
+
+### Phone numbers
+
+```sql
+SELECT id, name, number, assistant_id
+FROM vapi.phone_numbers;
+```
+
+### Calls per phone number
+
+```sql
+SELECT p.number, COUNT(*) AS call_count
+FROM vapi.calls c
+JOIN vapi.phone_numbers p ON c.phone_number_id = p.id
+GROUP BY p.number
+ORDER BY call_count DESC;
+```
+
+## Key Columns
+
+### vapi.calls
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | Utf8 | Unique call ID |
+| `type` | Utf8 | `inboundPhoneCall`, `outboundPhoneCall`, or `webCall` |
+| `status` | Utf8 | `queued`, `ringing`, `in-progress`, `forwarding`, or `ended` |
+| `ended_reason` | Utf8 | Why the call ended |
+| `cost` | Float64 | Total cost in USD |
+| `assistant_id` | Utf8 | Links to `vapi.assistants.id` |
+| `phone_number_id` | Utf8 | Links to `vapi.phone_numbers.id` |
+| `analysis__summary` | Utf8 | AI-generated call summary (may be null) |
+| `artifact__transcript` | Utf8 | Full transcript (may be null) |
+| `created_at_gt` | virtual filter | Lower bound for date-cursor pagination |
+| `created_at_lt` | virtual filter | Upper bound for date-cursor pagination |
+
+### vapi.assistants
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | Utf8 | Unique assistant ID |
+| `name` | Utf8 | Human-readable name |
+| `model__provider` | Utf8 | LLM provider (e.g. `openai`, `anthropic`) |
+| `model__model` | Utf8 | LLM model name (e.g. `gpt-4o`) |
+| `voice__provider` | Utf8 | TTS provider (e.g. `11labs`, `deepgram`) |
+
+### vapi.phone_numbers
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | Utf8 | Unique phone number ID |
+| `number` | Utf8 | E.164 format (e.g. `+14155552671`) |
+| `assistant_id` | Utf8 | Default assistant for inbound calls |
+
+## Pagination
+
+Vapi does not use standard offset or cursor pagination. Instead, it accepts
+`createdAtGt` and `createdAtLt` query parameters to bound results by creation
+time. The maximum page size is 1000 rows.
+
+To page through a large call history:
+
+1. Query with `created_at_lt = <end>` and `created_at_gt = <start>`.
+2. Take the `created_at` of the last (oldest) row as the new `created_at_lt`.
+3. Repeat until fewer than the requested number of rows are returned.
+
+This source sets `pagination: mode: none` because Coral cannot drive this
+date-cursor pattern automatically. Callers control pagination via WHERE filters.

--- a/sources/community/vapi/README.md
+++ b/sources/community/vapi/README.md
@@ -53,6 +53,16 @@ LIMIT 100;
 To page forward, set `created_at_lt` to the `created_at` of the oldest row in the
 previous result.
 
+### Calls by phone number
+
+```sql
+-- Scope calls to a specific phone number without scanning all calls
+SELECT id, type, status, cost, created_at
+FROM vapi.calls
+WHERE phone_number_id_filter = '<your-phone-number-id>'
+LIMIT 50;
+```
+
 ### Calls by assistant
 
 ```sql
@@ -75,14 +85,29 @@ LIMIT 5;
 
 ```sql
 SELECT id, name, model__provider, model__model, voice__provider
-FROM vapi.assistants;
+FROM vapi.assistants
+LIMIT 100;
+```
+
+### All assistants (page through large accounts)
+
+```sql
+-- First page
+SELECT id, name, created_at FROM vapi.assistants LIMIT 100;
+
+-- Next page: use the created_at of the last row as created_at_lt
+SELECT id, name, created_at
+FROM vapi.assistants
+WHERE created_at_lt = '<created_at of last row>'
+LIMIT 100;
 ```
 
 ### Phone numbers
 
 ```sql
 SELECT id, name, number, assistant_id
-FROM vapi.phone_numbers;
+FROM vapi.phone_numbers
+LIMIT 100;
 ```
 
 ### Calls per phone number
@@ -102,8 +127,8 @@ ORDER BY call_count DESC;
 | Column | Type | Notes |
 |---|---|---|
 | `id` | Utf8 | Unique call ID |
-| `type` | Utf8 | `inboundPhoneCall`, `outboundPhoneCall`, or `webCall` |
-| `status` | Utf8 | `queued`, `ringing`, `in-progress`, `forwarding`, or `ended` |
+| `type` | Utf8 | Known values include `inboundPhoneCall`, `outboundPhoneCall`, `webCall`, `vapi.websocketCall`; Vapi may add more |
+| `status` | Utf8 | Known values include `queued`, `ringing`, `in-progress`, `forwarding`, `ended`; additional non-happy-path values exist |
 | `ended_reason` | Utf8 | Why the call ended |
 | `cost` | Float64 | Total cost in USD |
 | `assistant_id` | Utf8 | Links to `vapi.assistants.id` |
@@ -112,6 +137,9 @@ ORDER BY call_count DESC;
 | `artifact__transcript` | Utf8 | Full transcript (may be null) |
 | `created_at_gt` | virtual filter | Lower bound for date-cursor pagination |
 | `created_at_lt` | virtual filter | Upper bound for date-cursor pagination |
+| `assistant_id_filter` | virtual filter | Filter by assistant ID |
+| `phone_number_id_filter` | virtual filter | Filter by phone number ID |
+| `limit` | virtual filter | Max rows (default 100, max 1000) |
 
 ### vapi.assistants
 
@@ -122,6 +150,9 @@ ORDER BY call_count DESC;
 | `model__provider` | Utf8 | LLM provider (e.g. `openai`, `anthropic`) |
 | `model__model` | Utf8 | LLM model name (e.g. `gpt-4o`) |
 | `voice__provider` | Utf8 | TTS provider (e.g. `11labs`, `deepgram`) |
+| `created_at_gt` | virtual filter | Lower bound for pagination |
+| `created_at_lt` | virtual filter | Upper bound for pagination |
+| `limit` | virtual filter | Max rows (default 100, max 1000) |
 
 ### vapi.phone_numbers
 
@@ -130,18 +161,24 @@ ORDER BY call_count DESC;
 | `id` | Utf8 | Unique phone number ID |
 | `number` | Utf8 | E.164 format (e.g. `+14155552671`) |
 | `assistant_id` | Utf8 | Default assistant for inbound calls |
+| `created_at_gt` | virtual filter | Lower bound for pagination |
+| `created_at_lt` | virtual filter | Upper bound for pagination |
+| `limit` | virtual filter | Max rows (default 100, max 1000) |
 
 ## Pagination
 
 Vapi does not use standard offset or cursor pagination. Instead, it accepts
 `createdAtGt` and `createdAtLt` query parameters to bound results by creation
-time. The maximum page size is 1000 rows.
+time. All three list endpoints default to **100 rows** per request and accept up
+to **1000** via the `limit` filter.
 
 To page through a large call history:
 
 1. Query with `created_at_lt = <end>` and `created_at_gt = <start>`.
 2. Take the `created_at` of the last (oldest) row as the new `created_at_lt`.
 3. Repeat until fewer than the requested number of rows are returned.
+
+The same pattern applies to `vapi.assistants` and `vapi.phone_numbers`.
 
 This source sets `pagination: mode: none` because Coral cannot drive this
 date-cursor pattern automatically. Callers control pagination via WHERE filters.

--- a/sources/community/vapi/README.md
+++ b/sources/community/vapi/README.md
@@ -23,7 +23,7 @@ export VAPI_API_KEY=<your-api-key>
 4. Add the source:
 
 ```sh
-coral source add vapi
+coral source add --file sources/community/vapi/manifest.yaml
 ```
 
 ## Example Queries

--- a/sources/community/vapi/manifest.yaml
+++ b/sources/community/vapi/manifest.yaml
@@ -1,5 +1,5 @@
 name: vapi
-version: 0.1.0
+version: 0.2.0
 dsl_version: 3
 backend: http
 description: Query calls, assistants, and phone_numbers from Vapi Voice AI.
@@ -30,12 +30,19 @@ tables:
   - name: calls
     description: Call logs from Vapi, including status, cost, transcript, and AI analysis results.
     guide: |
-      The `type` column is one of: inboundPhoneCall, outboundPhoneCall, webCall.
-      The `status` column is one of: queued, ringing, in-progress, forwarding, ended.
+      The `type` column includes values such as inboundPhoneCall, outboundPhoneCall,
+      webCall, and vapi.websocketCall. Vapi may add further types; do not filter with
+      a closed IN list.
+      The `status` column includes values such as queued, ringing, in-progress,
+      forwarding, and ended. Additional non-happy-path statuses exist; avoid closed
+      enum filters.
       Use `created_at_lt` and `created_at_gt` filters for time-windowed queries and
-      manual date-cursor pagination (Vapi returns up to 1000 rows per request).
+      manual date-cursor pagination. Vapi defaults to 100 rows and accepts up to 1000
+      per request via the `limit` filter.
       `analysis__summary` and `artifact__transcript` are null for in-progress or
       very short calls. Join to vapi.assistants on assistant_id = id.
+      Use `phone_number_id_filter` to scope calls to a specific phone number without
+      scanning the full call history.
     filters:
       - name: created_at_gt
         description: Return calls created after this ISO 8601 timestamp (maps to createdAtGt).
@@ -43,8 +50,10 @@ tables:
         description: Return calls created before this ISO 8601 timestamp (maps to createdAtLt).
       - name: assistant_id_filter
         description: Filter calls by assistant ID (maps to assistantId query param).
+      - name: phone_number_id_filter
+        description: Filter calls by phone number ID (maps to phoneNumberId query param).
       - name: limit
-        description: Maximum number of calls to return. Vapi maximum is 1000.
+        description: Maximum number of calls to return. Vapi defaults to 100, maximum is 1000.
     request:
       method: GET
       path: /call
@@ -58,6 +67,9 @@ tables:
         - name: assistantId
           from: filter
           key: assistant_id_filter
+        - name: phoneNumberId
+          from: filter
+          key: phone_number_id_filter
         - name: limit
           from: filter
           key: limit
@@ -107,7 +119,7 @@ tables:
       - name: type
         type: Utf8
         nullable: true
-        description: "Call type: inboundPhoneCall, outboundPhoneCall, or webCall."
+        description: "Call type: inboundPhoneCall, outboundPhoneCall, webCall, vapi.websocketCall, and others."
         expr:
           kind: path
           path:
@@ -115,7 +127,7 @@ tables:
       - name: status
         type: Utf8
         nullable: true
-        description: "Call status: queued, ringing, in-progress, forwarding, or ended."
+        description: "Call status: queued, ringing, in-progress, forwarding, ended, and other non-happy-path values."
         expr:
           kind: path
           path:
@@ -216,9 +228,28 @@ tables:
       `model__provider` identifies the LLM provider (e.g. openai, anthropic, google).
       `voice__provider` identifies the TTS provider (e.g. 11labs, deepgram, playht).
       Join to vapi.calls on id = assistant_id to see calls handled by each assistant.
+      Vapi defaults to 100 rows per request. Use `limit`, `created_at_gt`, and
+      `created_at_lt` to page through large assistant lists.
+    filters:
+      - name: created_at_gt
+        description: Return assistants created after this ISO 8601 timestamp (maps to createdAtGt).
+      - name: created_at_lt
+        description: Return assistants created before this ISO 8601 timestamp (maps to createdAtLt).
+      - name: limit
+        description: Maximum number of assistants to return. Vapi defaults to 100, maximum is 1000.
     request:
       method: GET
       path: /assistant
+      query:
+        - name: createdAtGt
+          from: filter
+          key: created_at_gt
+        - name: createdAtLt
+          from: filter
+          key: created_at_lt
+        - name: limit
+          from: filter
+          key: limit
     response:
       row_strategy: direct
     pagination:
@@ -321,9 +352,28 @@ tables:
       `number` is in E.164 format (e.g. +14155552671).
       Join to vapi.calls on id = phone_number_id to see calls made through each number.
       `assistant_id` links to the default assistant assigned to inbound calls on this number.
+      Vapi defaults to 100 rows per request. Use `limit`, `created_at_gt`, and
+      `created_at_lt` to page through large phone number lists.
+    filters:
+      - name: created_at_gt
+        description: Return phone numbers created after this ISO 8601 timestamp (maps to createdAtGt).
+      - name: created_at_lt
+        description: Return phone numbers created before this ISO 8601 timestamp (maps to createdAtLt).
+      - name: limit
+        description: Maximum number of phone numbers to return. Vapi defaults to 100, maximum is 1000.
     request:
       method: GET
       path: /phone-number
+      query:
+        - name: createdAtGt
+          from: filter
+          key: created_at_gt
+        - name: createdAtLt
+          from: filter
+          key: created_at_lt
+        - name: limit
+          from: filter
+          key: limit
     response:
       row_strategy: direct
     pagination:

--- a/sources/community/vapi/manifest.yaml
+++ b/sources/community/vapi/manifest.yaml
@@ -1,0 +1,393 @@
+name: vapi
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Query calls, assistants, and phone_numbers from Vapi Voice AI.
+base_url: https://api.vapi.ai
+
+inputs:
+  VAPI_API_KEY:
+    kind: secret
+    required: true
+    hint: >
+      API key for the Vapi Voice AI platform. Generate one at
+      https://dashboard.vapi.ai/org/api-keys — any key with read access is
+      sufficient. The key is sent as a Bearer token on every request.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.VAPI_API_KEY}}"
+
+test_queries:
+  - SELECT id, type, status, cost, created_at FROM vapi.calls LIMIT 5
+  - SELECT id, name, model__provider, voice__provider FROM vapi.assistants LIMIT 5
+  - SELECT id, name, number, assistant_id FROM vapi.phone_numbers LIMIT 5
+
+tables:
+  - name: calls
+    description: Call logs from Vapi, including status, cost, transcript, and AI analysis results.
+    guide: |
+      The `type` column is one of: inboundPhoneCall, outboundPhoneCall, webCall.
+      The `status` column is one of: queued, ringing, in-progress, forwarding, ended.
+      Use `created_at_lt` and `created_at_gt` filters for time-windowed queries and
+      manual date-cursor pagination (Vapi returns up to 1000 rows per request).
+      `analysis__summary` and `artifact__transcript` are null for in-progress or
+      very short calls. Join to vapi.assistants on assistant_id = id.
+    filters:
+      - name: created_at_gt
+        description: Return calls created after this ISO 8601 timestamp (maps to createdAtGt).
+      - name: created_at_lt
+        description: Return calls created before this ISO 8601 timestamp (maps to createdAtLt).
+      - name: assistant_id_filter
+        description: Filter calls by assistant ID (maps to assistantId query param).
+      - name: limit
+        description: Maximum number of calls to return. Vapi maximum is 1000.
+    request:
+      method: GET
+      path: /call
+      query:
+        - name: createdAtGt
+          from: filter
+          key: created_at_gt
+        - name: createdAtLt
+          from: filter
+          key: created_at_lt
+        - name: assistantId
+          from: filter
+          key: assistant_id_filter
+        - name: limit
+          from: filter
+          key: limit
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique call identifier.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: org_id
+        type: Utf8
+        nullable: true
+        description: Organization ID that owns this call.
+        expr:
+          kind: path
+          path:
+            - orgId
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: When the call record was created (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: When the call record was last updated (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+      - name: type
+        type: Utf8
+        nullable: true
+        description: "Call type: inboundPhoneCall, outboundPhoneCall, or webCall."
+        expr:
+          kind: path
+          path:
+            - type
+      - name: status
+        type: Utf8
+        nullable: true
+        description: "Call status: queued, ringing, in-progress, forwarding, or ended."
+        expr:
+          kind: path
+          path:
+            - status
+      - name: ended_reason
+        type: Utf8
+        nullable: true
+        description: Reason the call ended (e.g. customer-ended-call, assistant-ended-call).
+        expr:
+          kind: path
+          path:
+            - endedReason
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: When the call was answered (ISO 8601); null if not yet started.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - startedAt
+      - name: ended_at
+        type: Timestamp
+        nullable: true
+        description: When the call ended (ISO 8601); null if still in progress.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - endedAt
+      - name: cost
+        type: Float64
+        nullable: true
+        description: Total cost of the call in USD.
+        expr:
+          kind: path
+          path:
+            - cost
+      - name: assistant_id
+        type: Utf8
+        nullable: true
+        description: ID of the assistant that handled the call. Join to vapi.assistants on id.
+        expr:
+          kind: path
+          path:
+            - assistantId
+      - name: phone_number_id
+        type: Utf8
+        nullable: true
+        description: ID of the phone number used. Join to vapi.phone_numbers on id.
+        expr:
+          kind: path
+          path:
+            - phoneNumberId
+      - name: analysis__summary
+        type: Utf8
+        nullable: true
+        description: AI-generated summary of the call. Null for in-progress or short calls.
+        expr:
+          kind: path
+          path:
+            - analysis
+            - summary
+      - name: analysis__success_evaluation
+        type: Utf8
+        nullable: true
+        description: AI evaluation of whether the call achieved its goal.
+        expr:
+          kind: path
+          path:
+            - analysis
+            - successEvaluation
+      - name: artifact__transcript
+        type: Utf8
+        nullable: true
+        description: Full call transcript. Null for in-progress or very short calls.
+        expr:
+          kind: path
+          path:
+            - artifact
+            - transcript
+      - name: cost_breakdown
+        type: Json
+        nullable: true
+        description: Detailed cost breakdown by component (LLM, TTS, STT, etc.).
+        expr:
+          kind: path
+          path:
+            - costBreakdown
+
+  - name: assistants
+    description: Configured Vapi voice AI assistants, including model and voice provider settings.
+    guide: |
+      `model__provider` identifies the LLM provider (e.g. openai, anthropic, google).
+      `voice__provider` identifies the TTS provider (e.g. 11labs, deepgram, playht).
+      Join to vapi.calls on id = assistant_id to see calls handled by each assistant.
+    request:
+      method: GET
+      path: /assistant
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique assistant identifier.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: org_id
+        type: Utf8
+        nullable: true
+        description: Organization ID that owns this assistant.
+        expr:
+          kind: path
+          path:
+            - orgId
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Human-readable name for the assistant.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: When the assistant was created (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: When the assistant was last updated (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+      - name: model__provider
+        type: Utf8
+        nullable: true
+        description: LLM provider for this assistant (e.g. openai, anthropic, google).
+        expr:
+          kind: path
+          path:
+            - model
+            - provider
+      - name: model__model
+        type: Utf8
+        nullable: true
+        description: Specific LLM model name (e.g. gpt-4o, claude-3-5-sonnet).
+        expr:
+          kind: path
+          path:
+            - model
+            - model
+      - name: voice__provider
+        type: Utf8
+        nullable: true
+        description: TTS provider for this assistant (e.g. 11labs, deepgram, playht).
+        expr:
+          kind: path
+          path:
+            - voice
+            - provider
+      - name: voice__voice_id
+        type: Utf8
+        nullable: true
+        description: Voice ID within the TTS provider.
+        expr:
+          kind: path
+          path:
+            - voice
+            - voiceId
+      - name: first_message
+        type: Utf8
+        nullable: true
+        description: The opening message the assistant speaks when a call connects.
+        expr:
+          kind: path
+          path:
+            - firstMessage
+
+  - name: phone_numbers
+    description: Provisioned Vapi phone numbers and their associated assistants.
+    guide: |
+      `number` is in E.164 format (e.g. +14155552671).
+      Join to vapi.calls on id = phone_number_id to see calls made through each number.
+      `assistant_id` links to the default assistant assigned to inbound calls on this number.
+    request:
+      method: GET
+      path: /phone-number
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique phone number identifier.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: org_id
+        type: Utf8
+        nullable: true
+        description: Organization ID that owns this phone number.
+        expr:
+          kind: path
+          path:
+            - orgId
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Human-readable label for the phone number.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: number
+        type: Utf8
+        nullable: true
+        description: Phone number in E.164 format (e.g. +14155552671).
+        expr:
+          kind: path
+          path:
+            - number
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: When the phone number was provisioned (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: When the phone number record was last updated (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+      - name: assistant_id
+        type: Utf8
+        nullable: true
+        description: Default assistant for inbound calls. Join to vapi.assistants on id.
+        expr:
+          kind: path
+          path:
+            - assistantId


### PR DESCRIPTION
## Summary

Adds a community source for [Vapi](https://vapi.ai), a developer platform for building voice AI phone agents.

## Why this source

Vapi is widely used by developers building AI-powered phone agents. There is no existing Coral source for it. This source lets users query their Vapi account data — call logs, assistant configs, and phone numbers — using SQL, enabling cross-source joins and cost analysis that would otherwise require custom API glue code.

## How it works

The source connects to `https://api.vapi.ai` using a Bearer token (`VAPI_API_KEY`). All three endpoints return root JSON arrays, so each table uses `row_strategy: direct`. Vapi uses date-cursor pagination (`createdAtGt` / `createdAtLt`) rather than standard offset/cursor pagination, so `pagination: mode: none` is set and virtual filter columns expose the date bounds to callers.

## Tables

| Table | Endpoint | Description |
|---|---|---|
| `vapi.calls` | `GET /call` | Call logs with status, cost, transcript, and AI analysis |
| `vapi.assistants` | `GET /assistant` | Configured voice AI assistants |
| `vapi.phone_numbers` | `GET /phone-number` | Provisioned phone numbers |

## Auth

Single Bearer token (`VAPI_API_KEY`) from the [Vapi dashboard](https://dashboard.vapi.ai/org/api-keys). No OAuth required.

## Key design decisions

- All three endpoints return root JSON arrays → `row_strategy: direct`
- Vapi uses date-cursor pagination (`createdAtGt` / `createdAtLt`) rather than standard offset/cursor → `pagination: mode: none` with virtual filter columns `created_at_gt` and `created_at_lt` for callers to drive manually
- Nested fields (`analysis.summary`, `artifact.transcript`, `model.provider`, `voice.voiceId`) flattened with `__` separator using multi-element `path` exprs
- All timestamp columns use `format_timestamp` with `input: iso8601`; all nullable to handle in-progress calls

## Validation

```
coral source lint sources/community/vapi/manifest.yaml
→ Manifest is valid

coral source test vapi
→ ✓ vapi connected successfully
→ 3 declared · 3 passed · 0 failed
→ ✓ SELECT id, type, status, cost, created_at FROM vapi.calls LIMIT 5        0 rows
→ ✓ SELECT id, name, model__provider, voice__provider FROM vapi.assistants LIMIT 5   1 row
→ ✓ SELECT id, name, number, assistant_id FROM vapi.phone_numbers LIMIT 5    0 rows
```

## Example query

```sql
SELECT c.id, c.status, c.cost, a.name AS assistant_name
FROM vapi.calls c
JOIN vapi.assistants a ON c.assistant_id = a.id
LIMIT 20;
```