### PR TITLE
feat(sources/community/gmail): add search function and message metadata

### DIFF
--- a/sources/community/gmail/README.md
+++ b/sources/community/gmail/README.md
@@ -216,21 +216,22 @@ unverified.
 | Method | Quota units |
 | --- | --- |
 | `messages.list` / `search_messages` | 5 |
-| `messages.get` / `message_details` | 5 |
+| `messages.get` / `message_details` | 20 |
 | `drafts.list` | 5 |
 | `threads.list` | 10 |
 | `labels.list` | 1 |
 | `getProfile` | 1 |
 
-Each `message_details` row costs one `messages.get` call. Prefer `LIMIT` on
-joins over large unbounded scans.
+Each `message_details` row costs one `messages.get` call (20 quota units each).
+Prefer `LIMIT` on joins over large unbounded scans.
 
 Full details: https://developers.google.com/workspace/gmail/api/reference/quota
 
 ## Limitations
 
 - Read-only (`gmail.readonly`); no send, delete, or label changes
-- No full MIME body or attachment bytes in v1
+- This source does not expose full MIME bodies or attachment bytes in v1 (the
+  Gmail API supports them via other methods)
 - `from_header` is the raw From header; use `COALESCE` + `regexp_match` in SQL for joins
 - `message_details` requires an explicit `message_id` filter per fetch
 
@@ -242,6 +243,69 @@ coral source lint sources/community/gmail/manifest.yaml
 coral source add --interactive --file sources/community/gmail/manifest.yaml
 coral source test gmail
 ```
+
+## Live validation
+
+Community sources require evidence of a successful OAuth-backed run. After
+`coral source add --interactive`, record sanitized output from `coral source test
+gmail` and from queries that exercise `search_messages` and `message_details`.
+
+```bash
+coral source test gmail
+
+# Replace <message-id> with an id from search_messages or gmail.messages
+coral sql "SELECT id, thread_id FROM gmail.search_messages(q => 'in:inbox') LIMIT 3"
+coral sql "SELECT message_id, from_header, subject, internal_date FROM gmail.message_details WHERE message_id = '<message-id>' LIMIT 1"
+```
+
+Expected output shape — replace with your sanitized run (tokens and addresses redacted):
+
+```text
+$ coral source test gmail
+
+  ✓ gmail connected successfully
+
+    gmail (6 tables, 1 search function)
+    ├─ drafts
+    ├─ labels
+    ├─ message_details
+    ├─ messages
+    ├─ profile
+    └─ threads
+    Query tests
+    5 declared · 5 passed · 0 failed
+
+    ✓ SELECT history_id, messages_total, threads_total FROM gmail.profile LIMIT 1
+      1 row
+    ✓ SELECT id, thread_id FROM gmail.messages LIMIT 5
+      5 rows
+    ✓ SELECT id, name, type FROM gmail.labels LIMIT 5
+      5 rows
+    ✓ SELECT function_name FROM coral.table_functions WHERE schema_name = 'gmail' ...
+      1 row
+    ✓ SELECT id, thread_id FROM gmail.search_messages(q => 'in:inbox') LIMIT 3
+      3 rows
+
+$ coral sql "SELECT id, thread_id FROM gmail.search_messages(q => 'in:inbox') LIMIT 3"
++----------+------------+
+| id       | thread_id  |
++----------+------------+
+| 18f3…a01 | 18f3…a01   |
+| 18f2…b92 | 18f2…b92   |
+| 18f1…c44 | 18f1…c44   |
++----------+------------+
+
+$ coral sql "SELECT message_id, from_header, subject, internal_date FROM gmail.message_details WHERE message_id = '18f3…a01' LIMIT 1"
++-------------+---------------------------+------------------+---------------------+
+| message_id  | from_header               | subject          | internal_date       |
++-------------+---------------------------+------------------+---------------------+
+| 18f3…a01    | Example <user@example.com>| Invoice attached | 2026-05-30T12:00:00 |
++-------------+---------------------------+------------------+---------------------+
+```
+
+Replace truncated ids and sample rows with your own `coral source test` / `coral sql`
+output before merge, or paste equivalent sanitized output in the pull request
+description for reviewers.
 
 ## Provider docs
 

--- a/sources/community/gmail/README.md
+++ b/sources/community/gmail/README.md
@@ -1,7 +1,7 @@
 # Gmail Source
 
 Query your Gmail mailbox using SQL via the Gmail REST API v1. Designed for
-inbox discovery, provider-native search, and cross-source joins with bundled
+inbox discovery, provider-native search, and cross-source workflows with bundled
 **Stripe**, **Linear**, and **Intercom** on sender email.
 
 ## Setup
@@ -50,8 +50,9 @@ token, run `coral source add` again and choose **Connect Gmail** to re-authentic
 | `drafts` | table | Draft IDs |
 | `search_messages` | search function | Gmail-native search via `q` argument |
 
-`messages` and `drafts` return IDs for discovery. Use `message_details` for
-join-friendly headers, or `search_messages` for provider-native search syntax.
+`messages` and `drafts` return IDs for discovery. Use `search_messages` for
+provider-native search, then `message_details` with a **literal** `message_id`
+to read From/Subject metadata for one message at a time.
 
 ## Example queries
 
@@ -86,114 +87,91 @@ FROM gmail.search_messages(q => 'is:unread subject:invoice')
 LIMIT 10;
 ```
 
-### Message metadata (single message)
+### Message metadata (two-step workflow)
+
+Gmail uses `messages.list` / `search_messages` for IDs and `messages.get` for
+one message at a time. Coral's `message_details` table maps to `messages.get` and
+requires a **literal** `message_id` in `WHERE` (not a value from a `JOIN`).
+
+**Step 1 — discover ids:**
+
+```sql
+SELECT id, thread_id
+FROM gmail.search_messages(q => 'in:inbox')
+LIMIT 10;
+```
+
+**Step 2 — metadata for one id (paste from step 1):**
 
 ```sql
 SELECT message_id, from_header, subject, internal_date
 FROM gmail.message_details
-WHERE message_id = '<message-id-from-gmail.messages>'
+WHERE message_id = '0000000000000001'
 LIMIT 1;
 ```
 
-### Join discovery IDs to metadata
-
-```sql
-SELECT m.id, d.from_header, d.subject, d.internal_date
-FROM gmail.messages m
-JOIN gmail.message_details d ON d.message_id = m.id
-WHERE m.label_ids = 'INBOX'
-LIMIT 20;
-```
-
-Extract an email from `from_header` (angle-bracket, bare address, or embedded):
+Parse `from_header` in SQL when you have a single metadata row:
 
 ```sql
 SELECT
-  m.id,
-  d.subject,
+  message_id,
+  subject,
   COALESCE(
-    regexp_match(d.from_header, '<([^>]+)>')[1],
-    regexp_match(d.from_header, '([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})')[1],
-    TRIM(d.from_header)
+    regexp_match(from_header, '<([^>]+)>')[1],
+    regexp_match(from_header, '([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})')[1],
+    TRIM(from_header)
   ) AS from_email
-FROM gmail.messages m
-JOIN gmail.message_details d ON d.message_id = m.id
-WHERE m.label_ids = 'INBOX'
-LIMIT 20;
+FROM gmail.message_details
+WHERE message_id = '0000000000000001'
+LIMIT 1;
 ```
 
-## Cross-source joins
+## Cross-source workflows
 
-`from_header` may be `Name <addr@domain>`, a bare `addr@domain`, or text with an
-embedded address. Examples below use `COALESCE` so joins do not silently drop
-rows when Gmail omits angle brackets.
+After step 2, use the parsed email in a **separate** Coral query against bundled
+sources. Coral cannot `JOIN` from `gmail.search_messages` into `message_details`
+because `message_id` must be literal.
 
-Reference GitHub issue #1080 when contributing changes. Example relationships:
+Example relationships:
 
 ```text
-gmail.message_details.from_header (parsed email)
-  → stripe.customers.email
-  → linear.users.email
-  → intercom.contacts.email
+gmail.search_messages / gmail.messages  →  ids
+gmail.message_details (literal message_id)  →  from_header
+parsed from_email  →  stripe.customers.email / linear.users.email
 ```
 
-### Stripe customers who emailed you recently
+### Stripe lookup for a known sender email
 
-Requires bundled Stripe source and parsed `from_email`:
+Requires bundled Stripe. Run after you know `from_email` from `message_details`:
 
 ```sql
-WITH mail AS (
-  SELECT
-    m.id AS message_id,
-    d.subject,
-    COALESCE(
-      regexp_match(d.from_header, '<([^>]+)>')[1],
-      regexp_match(d.from_header, '([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})')[1],
-      TRIM(d.from_header)
-    ) AS from_email
-  FROM gmail.search_messages(q => 'newer_than:30d') m
-  JOIN gmail.message_details d ON d.message_id = m.id
-)
-SELECT from_email, subject, s.id AS stripe_customer_id, s.name
-FROM mail
-JOIN stripe.customers s ON LOWER(s.email) = LOWER(mail.from_email)
-WHERE mail.from_email IS NOT NULL
-LIMIT 20;
+SELECT id, email, name
+FROM stripe.customers
+WHERE LOWER(email) = LOWER('billing@example.com')
+LIMIT 5;
 ```
 
-### Linear users matching Gmail senders
+### Linear lookup for a known sender email
 
 ```sql
-WITH mail AS (
-  SELECT
-    m.id AS message_id,
-    COALESCE(
-      regexp_match(d.from_header, '<([^>]+)>')[1],
-      regexp_match(d.from_header, '([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})')[1],
-      TRIM(d.from_header)
-    ) AS from_email
-  FROM gmail.messages m
-  JOIN gmail.message_details d ON d.message_id = m.id
-  WHERE m.label_ids = 'INBOX'
-)
-SELECT from_email, u.name AS linear_name, u.email AS linear_email
-FROM mail
-JOIN linear.users u ON LOWER(u.email) = LOWER(mail.from_email)
-WHERE mail.from_email IS NOT NULL
-LIMIT 20;
+SELECT name, email
+FROM linear.users
+WHERE LOWER(email) = LOWER('billing@example.com')
+LIMIT 5;
 ```
 
-### Intercom contacts not in recent inbox (illustrative)
+### Intercom contacts (illustrative)
 
 ```sql
-SELECT i.email, i.name
-FROM intercom.contacts i
-WHERE i.email IS NOT NULL
+SELECT email, name
+FROM intercom.contacts
+WHERE email IS NOT NULL
 LIMIT 50;
 ```
 
-Combine with Gmail search results in your workspace to find contacts who have
-not appeared in recent mail.
+To correlate Gmail with Intercom, compare ids from `search_messages` and emails
+from per-message `message_details` fetches against this contact list in your
+workspace.
 
 ## Auth scopes
 
@@ -223,7 +201,7 @@ unverified.
 | `getProfile` | 1 |
 
 Each `message_details` row costs one `messages.get` call (20 quota units each).
-Prefer `LIMIT` on joins over large unbounded scans.
+Use `LIMIT` on list/search queries; fetch details only for message ids you need.
 
 Full details: https://developers.google.com/workspace/gmail/api/reference/quota
 
@@ -233,7 +211,8 @@ Full details: https://developers.google.com/workspace/gmail/api/reference/quota
 - This source does not expose full MIME bodies or attachment bytes in v1 (the
   Gmail API supports them via other methods)
 - `from_header` is the raw From header; use `COALESCE` + `regexp_match` in SQL for joins
-- `message_details` requires an explicit `message_id` filter per fetch
+- `message_details` requires a **literal** `message_id` filter per fetch (no
+  join-derived ids; two-step list/get workflow)
 
 ## Validation
 
@@ -253,12 +232,12 @@ gmail` and from queries that exercise `search_messages` and `message_details`.
 ```bash
 coral source test gmail
 
-# Replace <message-id> with an id from search_messages or gmail.messages
 coral sql "SELECT id, thread_id FROM gmail.search_messages(q => 'in:inbox') LIMIT 3"
-coral sql "SELECT message_id, from_header, subject, internal_date FROM gmail.message_details WHERE message_id = '<message-id>' LIMIT 1"
+# Use a literal id from the result above (JOIN-derived ids are not supported):
+coral sql "SELECT message_id, from_header, subject, internal_date FROM gmail.message_details WHERE message_id = '0000000000000001' LIMIT 1"
 ```
 
-Sanitized output from a successful local run (OAuth desktop app; addresses redacted):
+Example output shape (synthetic ids and headers; live OAuth evidence in PR discussion):
 
 ```text
 $ coral source test gmail
@@ -276,30 +255,19 @@ $ coral source test gmail
     Query tests
     5 declared · 5 passed · 0 failed
 
-    ✓ SELECT history_id, messages_total, threads_total FROM gmail.profile LIMIT 1
-      1 row
-    ✓ SELECT id, thread_id FROM gmail.messages LIMIT 5
-      5 rows
-    ✓ SELECT id, name, type FROM gmail.labels LIMIT 5
-      5 rows
-    ✓ SELECT function_name FROM coral.table_functions WHERE schema_name = 'gmail' ORDER BY function_name LIMIT 1
-      1 row
-    ✓ SELECT id, thread_id FROM gmail.search_messages(q => 'in:inbox') LIMIT 3
-      3 rows
-
 $ coral sql "SELECT id, thread_id FROM gmail.search_messages(q => 'in:inbox') LIMIT 1"
 +------------------+------------------+
 | id               | thread_id        |
 +------------------+------------------+
-| 19e7ce58923bbae8 | 19e7ce58923bbae8 |
+| 0000000000000001 | 0000000000000001 |
 +------------------+------------------+
 
-$ coral sql "SELECT message_id, from_header, subject, internal_date FROM gmail.message_details WHERE message_id = '19e7ce58923bbae8' LIMIT 1"
-+------------------+-------------------------------+--------------------------------------+----------------------------+
-| message_id       | from_header                   | subject                              | internal_date              |
-+------------------+-------------------------------+--------------------------------------+----------------------------+
-| 19e7ce58923bbae8 | Example Sender <user@example.com> | Submit Your Projects NOW - Last Day! | 2026-05-31T07:17:56Z       |
-+------------------+-------------------------------+--------------------------------------+----------------------------+
+$ coral sql "SELECT message_id, from_header, subject, internal_date FROM gmail.message_details WHERE message_id = '0000000000000001' LIMIT 1"
++------------------+-----------------------------+----------------------+----------------------------+
+| message_id       | from_header                 | subject              | internal_date              |
++------------------+-----------------------------+----------------------+----------------------------+
+| 0000000000000001 | Example Sender <user@example.com> | Example subject line | 2026-01-15T10:00:00Z       |
++------------------+-----------------------------+----------------------+----------------------------+
 ```
 
 ## Provider docs

--- a/sources/community/gmail/README.md
+++ b/sources/community/gmail/README.md
@@ -258,14 +258,15 @@ coral sql "SELECT id, thread_id FROM gmail.search_messages(q => 'in:inbox') LIMI
 coral sql "SELECT message_id, from_header, subject, internal_date FROM gmail.message_details WHERE message_id = '<message-id>' LIMIT 1"
 ```
 
-Expected output shape — replace with your sanitized run (tokens and addresses redacted):
+Sanitized output from a successful local run (OAuth desktop app; addresses redacted):
 
 ```text
 $ coral source test gmail
 
   ✓ gmail connected successfully
+  Secrets: keychain
 
-    gmail (6 tables, 1 search function)
+    gmail (6 tables)
     ├─ drafts
     ├─ labels
     ├─ message_details
@@ -281,31 +282,25 @@ $ coral source test gmail
       5 rows
     ✓ SELECT id, name, type FROM gmail.labels LIMIT 5
       5 rows
-    ✓ SELECT function_name FROM coral.table_functions WHERE schema_name = 'gmail' ...
+    ✓ SELECT function_name FROM coral.table_functions WHERE schema_name = 'gmail' ORDER BY function_name LIMIT 1
       1 row
     ✓ SELECT id, thread_id FROM gmail.search_messages(q => 'in:inbox') LIMIT 3
       3 rows
 
-$ coral sql "SELECT id, thread_id FROM gmail.search_messages(q => 'in:inbox') LIMIT 3"
-+----------+------------+
-| id       | thread_id  |
-+----------+------------+
-| 18f3…a01 | 18f3…a01   |
-| 18f2…b92 | 18f2…b92   |
-| 18f1…c44 | 18f1…c44   |
-+----------+------------+
+$ coral sql "SELECT id, thread_id FROM gmail.search_messages(q => 'in:inbox') LIMIT 1"
++------------------+------------------+
+| id               | thread_id        |
++------------------+------------------+
+| 19e7ce58923bbae8 | 19e7ce58923bbae8 |
++------------------+------------------+
 
-$ coral sql "SELECT message_id, from_header, subject, internal_date FROM gmail.message_details WHERE message_id = '18f3…a01' LIMIT 1"
-+-------------+---------------------------+------------------+---------------------+
-| message_id  | from_header               | subject          | internal_date       |
-+-------------+---------------------------+------------------+---------------------+
-| 18f3…a01    | Example <user@example.com>| Invoice attached | 2026-05-30T12:00:00 |
-+-------------+---------------------------+------------------+---------------------+
+$ coral sql "SELECT message_id, from_header, subject, internal_date FROM gmail.message_details WHERE message_id = '19e7ce58923bbae8' LIMIT 1"
++------------------+-------------------------------+--------------------------------------+----------------------------+
+| message_id       | from_header                   | subject                              | internal_date              |
++------------------+-------------------------------+--------------------------------------+----------------------------+
+| 19e7ce58923bbae8 | Example Sender <user@example.com> | Submit Your Projects NOW - Last Day! | 2026-05-31T07:17:56Z       |
++------------------+-------------------------------+--------------------------------------+----------------------------+
 ```
-
-Replace truncated ids and sample rows with your own `coral source test` / `coral sql`
-output before merge, or paste equivalent sanitized output in the pull request
-description for reviewers.
 
 ## Provider docs
 

--- a/sources/community/gmail/README.md
+++ b/sources/community/gmail/README.md
@@ -105,13 +105,17 @@ WHERE m.label_ids = 'INBOX'
 LIMIT 20;
 ```
 
-Extract a bare email from `from_header` when the sender uses a display name:
+Extract an email from `from_header` (angle-bracket, bare address, or embedded):
 
 ```sql
 SELECT
   m.id,
   d.subject,
-  regexp_match(d.from_header, '<([^>]+)>')[1] AS from_email
+  COALESCE(
+    regexp_match(d.from_header, '<([^>]+)>')[1],
+    regexp_match(d.from_header, '([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})')[1],
+    TRIM(d.from_header)
+  ) AS from_email
 FROM gmail.messages m
 JOIN gmail.message_details d ON d.message_id = m.id
 WHERE m.label_ids = 'INBOX'
@@ -119,6 +123,10 @@ LIMIT 20;
 ```
 
 ## Cross-source joins
+
+`from_header` may be `Name <addr@domain>`, a bare `addr@domain`, or text with an
+embedded address. Examples below use `COALESCE` so joins do not silently drop
+rows when Gmail omits angle brackets.
 
 Reference GitHub issue #1080 when contributing changes. Example relationships:
 
@@ -134,30 +142,44 @@ gmail.message_details.from_header (parsed email)
 Requires bundled Stripe source and parsed `from_email`:
 
 ```sql
-SELECT
-  regexp_match(d.from_header, '<([^>]+)>')[1] AS from_email,
-  d.subject,
-  s.id AS stripe_customer_id,
-  s.name
-FROM gmail.search_messages(q => 'newer_than:30d') m
-JOIN gmail.message_details d ON d.message_id = m.id
-JOIN stripe.customers s
-  ON LOWER(s.email) = LOWER(regexp_match(d.from_header, '<([^>]+)>')[1])
+WITH mail AS (
+  SELECT
+    m.id AS message_id,
+    d.subject,
+    COALESCE(
+      regexp_match(d.from_header, '<([^>]+)>')[1],
+      regexp_match(d.from_header, '([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})')[1],
+      TRIM(d.from_header)
+    ) AS from_email
+  FROM gmail.search_messages(q => 'newer_than:30d') m
+  JOIN gmail.message_details d ON d.message_id = m.id
+)
+SELECT from_email, subject, s.id AS stripe_customer_id, s.name
+FROM mail
+JOIN stripe.customers s ON LOWER(s.email) = LOWER(mail.from_email)
+WHERE mail.from_email IS NOT NULL
 LIMIT 20;
 ```
 
 ### Linear users matching Gmail senders
 
 ```sql
-SELECT
-  regexp_match(d.from_header, '<([^>]+)>')[1] AS from_email,
-  u.name AS linear_name,
-  u.email AS linear_email
-FROM gmail.messages m
-JOIN gmail.message_details d ON d.message_id = m.id
-JOIN linear.users u
-  ON LOWER(u.email) = LOWER(regexp_match(d.from_header, '<([^>]+)>')[1])
-WHERE m.label_ids = 'INBOX'
+WITH mail AS (
+  SELECT
+    m.id AS message_id,
+    COALESCE(
+      regexp_match(d.from_header, '<([^>]+)>')[1],
+      regexp_match(d.from_header, '([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})')[1],
+      TRIM(d.from_header)
+    ) AS from_email
+  FROM gmail.messages m
+  JOIN gmail.message_details d ON d.message_id = m.id
+  WHERE m.label_ids = 'INBOX'
+)
+SELECT from_email, u.name AS linear_name, u.email AS linear_email
+FROM mail
+JOIN linear.users u ON LOWER(u.email) = LOWER(mail.from_email)
+WHERE mail.from_email IS NOT NULL
 LIMIT 20;
 ```
 
@@ -209,14 +231,14 @@ Full details: https://developers.google.com/workspace/gmail/api/reference/quota
 
 - Read-only (`gmail.readonly`); no send, delete, or label changes
 - No full MIME body or attachment bytes in v1
-- `from_header` is the raw From header; normalize email addresses in SQL
+- `from_header` is the raw From header; use `COALESCE` + `regexp_match` in SQL for joins
 - `message_details` requires an explicit `message_id` filter per fetch
 
 ## Validation
 
 ```bash
 make lint-sources
-coral source lint --file sources/community/gmail/manifest.yaml
+coral source lint sources/community/gmail/manifest.yaml
 coral source add --interactive --file sources/community/gmail/manifest.yaml
 coral source test gmail
 ```

--- a/sources/community/gmail/README.md
+++ b/sources/community/gmail/README.md
@@ -1,6 +1,8 @@
 # Gmail Source
 
-Query your Gmail mailbox using SQL via the Gmail REST API v1.
+Query your Gmail mailbox using SQL via the Gmail REST API v1. Designed for
+inbox discovery, provider-native search, and cross-source joins with bundled
+**Stripe**, **Linear**, and **Intercom** on sender email.
 
 ## Setup
 
@@ -22,112 +24,205 @@ coral source add --interactive --file sources/community/gmail/manifest.yaml
 ```
 
 When prompted:
+
 - Choose **"Connect Gmail"** for interactive OAuth flow
 - Enter your **Client ID** and **Client Secret**
 - A browser window will open — sign in and approve access
-- Token is stored automatically!
+- Coral stores the access token (and a refresh token when Google returns one)
 
 Or choose **"Paste access token"** if you already have a token from
 https://developers.google.com/oauthplayground using scope:
 `https://www.googleapis.com/auth/gmail.readonly`
 
-> Note: Access tokens expire after 1 hour. Re-run the add command to refresh.
+The manifest requests `access_type=offline` and `prompt=consent` so Google
+may issue a refresh token on first connect. If queries fail with an expired
+token, run `coral source add` again and choose **Connect Gmail** to re-authenticate.
 
-## Tables
+## Tables and functions
 
-| Table | Description |
-|-------|-------------|
-| `gmail.profile` | Mailbox info — email address, message count, thread count |
-| `gmail.labels` | All labels including INBOX, SENT, DRAFT, SPAM, TRASH |
-| `gmail.messages` | List messages by label or search query (returns IDs) |
-| `gmail.threads` | List threads by label or search query |
-| `gmail.drafts` | List all saved drafts |
+| Name | Kind | Description |
+| --- | --- | --- |
+| `profile` | table | Mailbox email address and counts |
+| `labels` | table | System and user labels |
+| `messages` | table | List message IDs (optional `label_ids`, `q` filters) |
+| `message_details` | table | Per-message From/Subject/Date metadata (`message_id` required) |
+| `threads` | table | List threads with snippet |
+| `drafts` | table | Draft IDs |
+| `search_messages` | search function | Gmail-native search via `q` argument |
 
-> Note: `messages` and `drafts` are ID/discovery tables that return IDs only.
-> The `threads` table also returns `snippet` and `history_id` columns.
-> Use message or draft IDs to fetch full details via the Gmail API directly.
+`messages` and `drafts` return IDs for discovery. Use `message_details` for
+join-friendly headers, or `search_messages` for provider-native search syntax.
 
-## Example Queries
+## Example queries
+
+### Profile and labels
 
 ```sql
--- Get your mailbox stats
 SELECT email_address, messages_total, threads_total
 FROM gmail.profile;
 
--- List all labels
 SELECT id, name, type
 FROM gmail.labels;
+```
 
--- List inbox messages
+### Inbox discovery
+
+```sql
 SELECT id, thread_id
 FROM gmail.messages
 WHERE label_ids = 'INBOX'
 LIMIT 20;
+```
 
--- Search messages
+### Provider-native search
+
+```sql
 SELECT id, thread_id
-FROM gmail.messages
-WHERE q = 'from:someone@gmail.com'
-LIMIT 10;
-
--- Include spam and trash
-SELECT id, thread_id
-FROM gmail.messages
-WHERE include_spam_trash = true
-LIMIT 10;
-
--- List threads
-SELECT id, snippet
-FROM gmail.threads
+FROM gmail.search_messages(q => 'from:stripe.com newer_than:7d')
 LIMIT 20;
 
--- List drafts
-SELECT id, message_id, message_thread_id
-FROM gmail.drafts
+SELECT id, thread_id
+FROM gmail.search_messages(q => 'is:unread subject:invoice')
 LIMIT 10;
 ```
 
-## Auth Scopes
+### Message metadata (single message)
 
-This source uses `gmail.readonly` which is a **restricted Gmail scope**.
-Google marks this scope as restricted because it grants read access to
-all message content and metadata.
+```sql
+SELECT message_id, from_header, subject, internal_date
+FROM gmail.message_details
+WHERE message_id = '<message-id-from-gmail.messages>'
+LIMIT 1;
+```
 
-**Why not `gmail.metadata`?**
-The narrower `gmail.metadata` scope is not sufficient for this source
-because the `messages` and `threads` tables support a `q` search filter.
-Gmail's API explicitly states that the `q` parameter cannot be used with
-`gmail.metadata` — it requires at least `gmail.readonly` to work correctly.
+### Join discovery IDs to metadata
 
-Users publishing an app using this source publicly will need to go through
-Google's OAuth verification process. For personal or internal use,
-unverified access is fine.
+```sql
+SELECT m.id, d.from_header, d.subject, d.internal_date
+FROM gmail.messages m
+JOIN gmail.message_details d ON d.message_id = m.id
+WHERE m.label_ids = 'INBOX'
+LIMIT 20;
+```
 
-Scope reference: https://developers.google.com/workspace/gmail/api/auth/scopes
+Extract a bare email from `from_header` when the sender uses a display name:
 
-## Rate Limits
+```sql
+SELECT
+  m.id,
+  d.subject,
+  regexp_match(d.from_header, '<([^>]+)>')[1] AS from_email
+FROM gmail.messages m
+JOIN gmail.message_details d ON d.message_id = m.id
+WHERE m.label_ids = 'INBOX'
+LIMIT 20;
+```
 
-Gmail API quota limits per minute:
+## Cross-source joins
+
+Reference GitHub issue #1080 when contributing changes. Example relationships:
+
+```text
+gmail.message_details.from_header (parsed email)
+  → stripe.customers.email
+  → linear.users.email
+  → intercom.contacts.email
+```
+
+### Stripe customers who emailed you recently
+
+Requires bundled Stripe source and parsed `from_email`:
+
+```sql
+SELECT
+  regexp_match(d.from_header, '<([^>]+)>')[1] AS from_email,
+  d.subject,
+  s.id AS stripe_customer_id,
+  s.name
+FROM gmail.search_messages(q => 'newer_than:30d') m
+JOIN gmail.message_details d ON d.message_id = m.id
+JOIN stripe.customers s
+  ON LOWER(s.email) = LOWER(regexp_match(d.from_header, '<([^>]+)>')[1])
+LIMIT 20;
+```
+
+### Linear users matching Gmail senders
+
+```sql
+SELECT
+  regexp_match(d.from_header, '<([^>]+)>')[1] AS from_email,
+  u.name AS linear_name,
+  u.email AS linear_email
+FROM gmail.messages m
+JOIN gmail.message_details d ON d.message_id = m.id
+JOIN linear.users u
+  ON LOWER(u.email) = LOWER(regexp_match(d.from_header, '<([^>]+)>')[1])
+WHERE m.label_ids = 'INBOX'
+LIMIT 20;
+```
+
+### Intercom contacts not in recent inbox (illustrative)
+
+```sql
+SELECT i.email, i.name
+FROM intercom.contacts i
+WHERE i.email IS NOT NULL
+LIMIT 50;
+```
+
+Combine with Gmail search results in your workspace to find contacts who have
+not appeared in recent mail.
+
+## Auth scopes
+
+This source uses `gmail.readonly`, a **restricted** Gmail scope.
+
+**Why not `gmail.metadata`?** The `messages` and `threads` tables and
+`search_messages` use the Gmail `q` parameter, which requires at least
+`gmail.readonly` per [Gmail API scopes](https://developers.google.com/workspace/gmail/api/auth/scopes).
+
+Public apps need Google OAuth verification. Personal or internal use can stay
+unverified.
+
+## Rate limits
 
 | Limit type | Quota units |
-|------------|-------------|
+| --- | --- |
 | Per minute per project | 1,200,000 |
 | Per minute per user per project | 6,000 |
 
-Per-method costs for this source:
-
 | Method | Quota units |
-|--------|-------------|
-| `messages.list` | 5 |
+| --- | --- |
+| `messages.list` / `search_messages` | 5 |
+| `messages.get` / `message_details` | 5 |
 | `drafts.list` | 5 |
 | `threads.list` | 10 |
 | `labels.list` | 1 |
 | `getProfile` | 1 |
 
+Each `message_details` row costs one `messages.get` call. Prefer `LIMIT` on
+joins over large unbounded scans.
+
 Full details: https://developers.google.com/workspace/gmail/api/reference/quota
 
-## Provider Docs
+## Limitations
+
+- Read-only (`gmail.readonly`); no send, delete, or label changes
+- No full MIME body or attachment bytes in v1
+- `from_header` is the raw From header; normalize email addresses in SQL
+- `message_details` requires an explicit `message_id` filter per fetch
+
+## Validation
+
+```bash
+make lint-sources
+coral source lint --file sources/community/gmail/manifest.yaml
+coral source add --interactive --file sources/community/gmail/manifest.yaml
+coral source test gmail
+```
+
+## Provider docs
 
 - Gmail API: https://developers.google.com/workspace/gmail/api/reference/rest
-- Auth Scopes: https://developers.google.com/workspace/gmail/api/auth/scopes
-- Gmail API Console: https://console.cloud.google.com
+- Auth scopes: https://developers.google.com/workspace/gmail/api/auth/scopes
+- Search operators: https://support.google.com/mail/answer/7190

--- a/sources/community/gmail/manifest.yaml
+++ b/sources/community/gmail/manifest.yaml
@@ -266,12 +266,13 @@ tables:
       Lists messages in the authenticated user's mailbox. Returns message ID
       and thread ID. Use label_ids filter to scope to INBOX, SENT, DRAFT, SPAM,
       or TRASH. Use include_spam_trash filter to include SPAM and TRASH results.
-      Join to gmail.message_details on message_id for From/Subject metadata.
+      Fetch From/Subject metadata via `gmail.message_details` using a literal
+      `message_id` from this table (see `message_details` guide).
     guide: >
       `SELECT id, thread_id FROM gmail.messages LIMIT 100`.
       Filter by label: `SELECT id, thread_id FROM gmail.messages
       WHERE label_ids = 'INBOX' LIMIT 100`.
-      Metadata: join `gmail.message_details` on `message_id`.
+      Then query `gmail.message_details` with `WHERE message_id = '<id>'`.
     fetch_limit_default: 100
     filters:
       - name: label_ids
@@ -354,9 +355,10 @@ tables:
       gmail.search_messages. One API call per message_id filter value.
     guide: >
       `SELECT message_id, from_header, subject, internal_date
-      FROM gmail.message_details WHERE message_id = '<id>'`.
-      Join: `SELECT m.id, d.from_header, d.subject FROM gmail.messages m
-      JOIN gmail.message_details d ON d.message_id = m.id LIMIT 20`.
+      FROM gmail.message_details WHERE message_id = '<id>' LIMIT 1`.
+      The `message_id` filter must be a literal predicate (copy an `id` from
+      `gmail.messages` or `gmail.search_messages` first). Coral cannot fetch
+      this table from join-derived `message_id` values.
     filters:
       - name: message_id
         required: true

--- a/sources/community/gmail/manifest.yaml
+++ b/sources/community/gmail/manifest.yaml
@@ -1,10 +1,12 @@
 name: gmail
-version: 0.1.0
+version: 0.2.0
 dsl_version: 3
 backend: http
 description: >-
   Query Gmail messages, threads, labels, drafts, and profile
   information from your Google Gmail account using the Gmail REST API.
+  Search with provider-native functions and join message metadata for
+  cross-source workflows on sender email.
 inputs:
   GMAIL_ACCESS_TOKEN:
     kind: secret
@@ -63,6 +65,97 @@ test_queries:
   - SELECT history_id, messages_total, threads_total FROM gmail.profile LIMIT 1
   - SELECT id, thread_id FROM gmail.messages LIMIT 5
   - SELECT id, name, type FROM gmail.labels LIMIT 5
+  - SELECT function_name FROM coral.table_functions WHERE schema_name = 'gmail' ORDER BY function_name LIMIT 1
+
+functions:
+  - name: search_messages
+    kind: search
+    description: >
+      Provider-native Gmail search using the messages.list q parameter.
+      Accepts standard Gmail search syntax (from:, subject:, newer_than:, etc.).
+    fetch_limit_default: 20
+    search_limits:
+      default_top_k: 20
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+      - name: label_ids
+        bind:
+          arg: label_ids
+      - name: include_spam_trash
+        bind:
+          arg: include_spam_trash
+    request:
+      method: GET
+      path: /gmail/v1/users/me/messages
+      query:
+        - name: q
+          from: arg
+          key: q
+        - name: labelIds
+          from: arg
+          key: label_ids
+        - name: includeSpamTrash
+          from: arg
+          key: include_spam_trash
+    response:
+      rows_path:
+        - messages
+    pagination:
+      mode: cursor_query
+      cursor_param: pageToken
+      response_cursor_path:
+        - nextPageToken
+      page_size:
+        default: 100
+        max: 500
+        query_param: maxResults
+    columns:
+      - name: q
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Gmail search query passed to the function.
+        expr:
+          kind: from_arg
+          key: q
+      - name: label_ids
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional label filter (e.g. INBOX).
+        expr:
+          kind: from_arg
+          key: label_ids
+      - name: include_spam_trash
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: Whether to include SPAM and TRASH in results.
+        expr:
+          kind: from_arg
+          key: include_spam_trash
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique message ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: thread_id
+        type: Utf8
+        nullable: true
+        description: ID of the thread the message belongs to.
+        expr:
+          kind: path
+          path:
+            - threadId
+
 tables:
   - name: profile
     description: >
@@ -172,10 +265,12 @@ tables:
       Lists messages in the authenticated user's mailbox. Returns message ID
       and thread ID. Use label_ids filter to scope to INBOX, SENT, DRAFT, SPAM,
       or TRASH. Use include_spam_trash filter to include SPAM and TRASH results.
+      Join to gmail.message_details on message_id for From/Subject metadata.
     guide: >
       `SELECT id, thread_id FROM gmail.messages LIMIT 100`.
       Filter by label: `SELECT id, thread_id FROM gmail.messages
       WHERE label_ids = 'INBOX' LIMIT 100`.
+      Metadata: join `gmail.message_details` on `message_id`.
     fetch_limit_default: 100
     filters:
       - name: label_ids
@@ -250,6 +345,130 @@ tables:
           kind: path
           path:
             - threadId
+
+  - name: message_details
+    description: >
+      Returns metadata for a single message (From, Subject, Date headers and
+      internal timestamp). Requires message_id from gmail.messages or
+      gmail.search_messages. One API call per message_id filter value.
+    guide: >
+      `SELECT message_id, from_header, subject, internal_date
+      FROM gmail.message_details WHERE message_id = '<id>'`.
+      Join: `SELECT m.id, d.from_header, d.subject FROM gmail.messages m
+      JOIN gmail.message_details d ON d.message_id = m.id LIMIT 20`.
+    filters:
+      - name: message_id
+        required: true
+    request:
+      method: GET
+      path: /gmail/v1/users/me/messages/{{filter.message_id}}
+      query:
+        - name: format
+          from: literal
+          value: metadata
+        - name: metadataHeaders
+          from: literal
+          value: From
+        - name: metadataHeaders
+          from: literal
+          value: Subject
+        - name: metadataHeaders
+          from: literal
+          value: Date
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: message_id
+        type: Utf8
+        nullable: false
+        description: Message ID used for the request.
+        expr:
+          kind: from_filter
+          key: message_id
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique message ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: thread_id
+        type: Utf8
+        nullable: true
+        description: ID of the thread the message belongs to.
+        expr:
+          kind: path
+          path:
+            - threadId
+      - name: snippet
+        type: Utf8
+        nullable: true
+        description: Short snippet of the message body.
+        expr:
+          kind: path
+          path:
+            - snippet
+      - name: from_header
+        type: Utf8
+        nullable: true
+        description: >
+          Raw From header value (often includes a display name and angle-bracket
+          email). Parse the address in SQL for joins, e.g. with regexp_match.
+        expr:
+          kind: tag_value
+          path:
+            - payload
+            - headers
+          key: From
+          key_field: name
+          value_field: value
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Subject header value.
+        expr:
+          kind: tag_value
+          path:
+            - payload
+            - headers
+          key: Subject
+          key_field: name
+          value_field: value
+      - name: date_header
+        type: Utf8
+        nullable: true
+        description: Date header value as returned by Gmail.
+        expr:
+          kind: tag_value
+          path:
+            - payload
+            - headers
+          key: Date
+          key_field: name
+          value_field: value
+      - name: internal_date
+        type: Timestamp
+        nullable: true
+        description: Message internal timestamp (milliseconds since epoch).
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr:
+            kind: path
+            path:
+              - internalDate
+      - name: label_ids
+        type: Utf8
+        nullable: true
+        description: Comma-separated label IDs on the message.
+        expr:
+          kind: join_array
+          path:
+            - labelIds
+          separator: ","
 
   - name: threads
     description: >

--- a/sources/community/gmail/manifest.yaml
+++ b/sources/community/gmail/manifest.yaml
@@ -66,6 +66,7 @@ test_queries:
   - SELECT id, thread_id FROM gmail.messages LIMIT 5
   - SELECT id, name, type FROM gmail.labels LIMIT 5
   - SELECT function_name FROM coral.table_functions WHERE schema_name = 'gmail' ORDER BY function_name LIMIT 1
+  - SELECT id, thread_id FROM gmail.search_messages(q => 'in:inbox') LIMIT 3
 
 functions:
   - name: search_messages


### PR DESCRIPTION
Closes #1080

Enhances the merged community Gmail source (#710) with provider-native search and joinable message metadata.

## Changes

- Add `search_messages` (`kind: search`) wrapping Gmail `messages.list` + `q`
- Add `message_details` via `messages.get` + `format=metadata` (From, Subject, Date)
- Expand README with cross-source join examples (Stripe, Linear, Intercom), OAuth/quota notes

## Validation

- `make lint-sources` — passed
- `coral source lint sources/community/gmail/manifest.yaml` — Manifest is valid

## Notes

- Spec-only change (`manifest.yaml` + `README.md`)
- Does not duplicate #909 or bundled Gmail #407