### PR TITLE
feat(sources/community/npm): add npm registry source spec

### DIFF
--- a/sources/community/npm/README.md
+++ b/sources/community/npm/README.md
@@ -1,12 +1,14 @@
 # npm (npm)
 
-**Version:** 0.1.0
+**Version:** 0.2.0
 **Backend:** HTTP
-**Tables:** 1
+**Tables:** 2
 **Base URL:** `https://registry.npmjs.org`
 
 Query the [public npm registry REST API](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md)
-to search for packages and retrieve search-result summary data (such as latest version, publisher, downloads, and quality scores).
+to search for packages (`npm.search`) and retrieve full metadata for a single
+package by name (`npm.packages`) — latest version, repository, publish
+timestamps, maintainers, license, README and more.
 
 ```bash
 coral source add --file sources/community/npm/manifest.yaml

--- a/sources/community/npm/README.md
+++ b/sources/community/npm/README.md
@@ -18,9 +18,17 @@ This source does not require any authentication or input configuration. The npm 
 
 ## Tables
 
-| Table        | Description                                            | Key filters               |
-| ------------ | ------------------------------------------------------ | ------------------------- |
-| `npm.search` | Search npm packages by keyword, ranked by popularity   | `text` (**required**)     |
+| Table          | Description                                            | Key filters                   |
+| -------------- | ------------------------------------------------------ | ----------------------------- |
+| `npm.search`   | Search npm packages by keyword, ranked by popularity   | `text` (**required**)         |
+| `npm.packages` | Full metadata for one package, fetched by name         | `package_name` (**required**) |
+
+The `packages` table returns one row per package via `GET /{package_name}`
+(scoped packages like `@types/node` supported): canonical name, `latest_version`
+(`dist-tags.latest`), `repository__url`, `time__created`/`time__modified` (real
+`Timestamp` columns), maintainers, keywords, dist-tags, license, bugs URL, README
+and a `raw` column with the full document. For download counts, use the separate
+`npm_downloads` source.
 
 ## Example queries
 
@@ -50,6 +58,16 @@ SELECT name, license, publisher_username, publisher_email
 FROM npm.search
 WHERE text = 'webpack'
 LIMIT 10;
+
+-- Full metadata for a single package by name
+SELECT name, latest_version, time__modified, repository__url, license
+FROM npm.packages
+WHERE package_name = 'react';
+
+-- Scoped package
+SELECT name, latest_version
+FROM npm.packages
+WHERE package_name = '@types/node';
 ```
 
 ## Pagination

--- a/sources/community/npm/manifest.yaml
+++ b/sources/community/npm/manifest.yaml
@@ -1,10 +1,12 @@
 name: npm
-version: 0.1.0
+version: 0.2.0
 dsl_version: 3
 backend: http
 description: >-
-  Search the npm package registry and retrieve search-result summary data via
-  the public npm registry REST API. No authentication required.
+  Query the public npm registry REST API (registry.npmjs.org). The `search`
+  table returns ranked search-result summaries; the `packages` table returns
+  full metadata for a single package by name (versions, repository, publish
+  timestamps, maintainers, license, README). No authentication required.
 base_url: https://registry.npmjs.org
 
 test_queries:
@@ -14,6 +16,9 @@ test_queries:
   - >-
     SELECT name, version, description
     FROM npm.search WHERE text = 'react' LIMIT 1
+  - >-
+    SELECT name, latest_version
+    FROM npm.packages WHERE package_name = 'react' LIMIT 1
 
 tables:
   - name: search
@@ -314,3 +319,155 @@ tables:
         expr:
           kind: from_filter
           key: maintenance_weight
+
+  - name: packages
+    description: >
+      Full metadata for a single npm package, fetched by name. One row per
+      package. Filter on package_name (required). Scoped packages like
+      @types/node are supported.
+    guide: >
+      Look up a single npm package's metadata by name. Requires package_name
+      and maps to GET /{package_name} on registry.npmjs.org. Scoped packages
+      such as @types/node are supported (the slash is part of the name).
+      Returns exactly one row. Use repository__url to bridge to a git host, and
+      time__modified to gauge how recently the package was published. For
+      download counts use the separate npm_downloads source.
+    filters:
+      - name: package_name
+        required: true
+    request:
+      method: GET
+      path: "/{{filter.package_name}}"
+    response:
+      rows_path: []
+      row_strategy: direct
+    columns:
+      - name: package_name
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Package name queried (echoes the WHERE filter).
+        expr:
+          kind: from_filter
+          key: package_name
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Canonical package name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Package description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: latest_version
+        type: Utf8
+        nullable: true
+        description: Version currently tagged 'latest'.
+        expr:
+          kind: path
+          path:
+            - dist-tags
+            - latest
+      - name: homepage
+        type: Utf8
+        nullable: true
+        description: Project homepage URL.
+        expr:
+          kind: path
+          path:
+            - homepage
+      - name: repository__url
+        type: Utf8
+        nullable: true
+        description: Repository URL (typically git+https://github.com/owner/repo).
+        expr:
+          kind: path
+          path:
+            - repository
+            - url
+      - name: time__created
+        type: Timestamp
+        nullable: true
+        description: First-publish timestamp (RFC3339).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - time
+              - created
+      - name: time__modified
+        type: Timestamp
+        nullable: true
+        description: Most-recent-publish timestamp, any version (RFC3339).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - time
+              - modified
+      - name: maintainers
+        type: Json
+        nullable: true
+        description: Array of maintainer {name,email} objects.
+        expr:
+          kind: path
+          path:
+            - maintainers
+      - name: keywords
+        type: Json
+        nullable: true
+        description: Array of keyword strings.
+        expr:
+          kind: path
+          path:
+            - keywords
+      - name: dist_tags
+        type: Json
+        nullable: true
+        description: Object of {tag -> version}.
+        expr:
+          kind: path
+          path:
+            - dist-tags
+      - name: license
+        type: Utf8
+        nullable: true
+        description: SPDX license string.
+        expr:
+          kind: path
+          path:
+            - license
+      - name: bugs__url
+        type: Utf8
+        nullable: true
+        description: Issue tracker URL.
+        expr:
+          kind: path
+          path:
+            - bugs
+            - url
+      - name: readme
+        type: Utf8
+        nullable: true
+        description: README markdown for the latest published version.
+        expr:
+          kind: path
+          path:
+            - readme
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw npm registry document.
+        expr:
+          kind: current_row


### PR DESCRIPTION
## Summary

Adds a community source spec for the **npm registry** (`registry.npmjs.org`) — package metadata over the public, no-auth API.

- `sources/community/npm/manifest.yaml` — `packages` table (GET `/{package_name}`)
- `sources/community/npm/README.md`

One row per package, filtered by `package_name` (scoped packages like `@types/node` supported). Surfaces canonical name, `latest_version` (`dist-tags.latest`), `repository__url`, first/last publish timestamps, maintainers, keywords, dist-tags, license, bugs URL and README.

Nested fields use explicit `expr: { kind: path }` (the `__` convention isn't auto-applied).

> Download counts live on a different host (`api.npmjs.org`) and are submitted as a separate spec, `npm_downloads`.

## Test

```sql
SELECT name, latest_version FROM npm.packages WHERE package_name = 'react' LIMIT 1;
```

Built during the Pirates of the Coral-bean hackathon (powers a dependency-risk auditor that JOINs OSV + npm + npm downloads in one query).