### PR TITLE
feat(sources/community/npm_downloads): add npm downloads source spec

### DIFF
--- a/sources/community/npm_downloads/README.md
+++ b/sources/community/npm_downloads/README.md
@@ -4,8 +4,15 @@ Query the public **npm downloads API** (`api.npmjs.org`) for package download
 counts over the trailing week and month. No authentication required.
 
 > Package metadata (versions, repository, maintainers…) lives on a different
-> host (`registry.npmjs.org`) and is provided by the separate
-> [`npm`](../npm) source spec.
+> host (`registry.npmjs.org`) and is provided by the separate `npm` source spec.
+
+## Setup
+
+```bash
+coral source add --file sources/community/npm_downloads/manifest.yaml
+```
+
+No authentication required.
 
 ## Tables
 
@@ -21,13 +28,13 @@ Both tables expose the same columns:
 
 | Column | Type | Notes |
 |---|---|---|
-| `package_name` | Utf8 | Echoes the `WHERE` filter |
+| `package_name` | Utf8 | Virtual — echoes the `WHERE` filter |
 | `package` | Utf8 | Canonical package name from the API |
 | `downloads` | Int64 | Total downloads in the period |
 | `start` | Utf8 | First day of the window (YYYY-MM-DD) |
 | `end` | Utf8 | Last day of the window (YYYY-MM-DD) |
 
-## Examples
+## Example queries
 
 ```sql
 -- Monthly popularity
@@ -47,4 +54,6 @@ WHERE m.package_name = 'express' AND w.package_name = 'express';
 |---|---|---|
 | `NPM_DOWNLOADS_BASE` | `https://api.npmjs.org` | Base URL for the npm download-counts API |
 
-No authentication required.
+## References
+
+- npm download counts API: https://github.com/npm/registry/blob/main/docs/download-counts.md

--- a/sources/community/npm_downloads/README.md
+++ b/sources/community/npm_downloads/README.md
@@ -34,6 +34,13 @@ Both tables expose the same columns:
 | `start` | Utf8 | First day of the window (YYYY-MM-DD) |
 | `end` | Utf8 | Last day of the window (YYYY-MM-DD) |
 
+> **One package per query.** Both tables map to npm's *single-package* point
+> endpoint and return one row. npm also exposes a comma-separated *bulk* point
+> endpoint whose response is a differently-shaped object keyed by package name —
+> that shape is **not** modeled here, so a comma-separated value like
+> `package_name = 'npm,express'` returns a single row with `null`
+> `package`/`downloads`/`start`/`end`. Query one package at a time.
+
 ## Example queries
 
 ```sql
@@ -53,6 +60,38 @@ WHERE m.package_name = 'express' AND w.package_name = 'express';
 | Input | Default | Description |
 |---|---|---|
 | `NPM_DOWNLOADS_BASE` | `https://api.npmjs.org` | Base URL for the npm download-counts API |
+
+## Validation
+
+Captured live against the public API with Coral 0.2.0:
+
+```text
+$ coral source add --file sources/community/npm_downloads/manifest.yaml
+Added source npm_downloads
+
+  ✓ npm_downloads connected successfully
+
+    npm_downloads (2 tables)
+    ├─ downloads_last_month
+    └─ downloads_last_week
+    Query tests
+    2 declared · 2 passed · 0 failed
+
+    ✓ SELECT downloads FROM npm_downloads.downloads_last_month WHERE package_name = 'lodash' LIMIT 1
+      1 row
+    ✓ SELECT downloads FROM npm_downloads.downloads_last_week WHERE package_name = 'lodash' LIMIT 1
+      1 row
+```
+
+```text
+$ coral sql "SELECT package_name, package, downloads, start, \"end\"
+             FROM npm_downloads.downloads_last_month WHERE package_name = 'express'"
++--------------+---------+-----------+------------+------------+
+| package_name | package | downloads | start      | end        |
++--------------+---------+-----------+------------+------------+
+| express      | express | 425540092 | 2026-05-02 | 2026-05-31 |
++--------------+---------+-----------+------------+------------+
+```
 
 ## References
 

--- a/sources/community/npm_downloads/README.md
+++ b/sources/community/npm_downloads/README.md
@@ -1,0 +1,50 @@
+# npm_downloads
+
+Query the public **npm downloads API** (`api.npmjs.org`) for package download
+counts over the trailing week and month. No authentication required.
+
+> Package metadata (versions, repository, maintainers…) lives on a different
+> host (`registry.npmjs.org`) and is provided by the separate
+> [`npm`](../npm) source spec.
+
+## Tables
+
+### `downloads_last_month`
+Total downloads in the trailing 30 days. One row per package; filter on
+`package_name` (required).
+
+### `downloads_last_week`
+Total downloads in the trailing 7 days. One row per package; filter on
+`package_name` (required). Useful for short-term trend detection.
+
+Both tables expose the same columns:
+
+| Column | Type | Notes |
+|---|---|---|
+| `package_name` | Utf8 | Echoes the `WHERE` filter |
+| `package` | Utf8 | Canonical package name from the API |
+| `downloads` | Int64 | Total downloads in the period |
+| `start` | Utf8 | First day of the window (YYYY-MM-DD) |
+| `end` | Utf8 | Last day of the window (YYYY-MM-DD) |
+
+## Examples
+
+```sql
+-- Monthly popularity
+SELECT downloads FROM npm_downloads.downloads_last_month
+WHERE package_name = 'lodash';
+
+-- Short-term trend: compare a week (×4) against the month
+SELECT m.downloads AS month, w.downloads AS week
+FROM npm_downloads.downloads_last_month m
+JOIN npm_downloads.downloads_last_week  w ON 1 = 1
+WHERE m.package_name = 'express' AND w.package_name = 'express';
+```
+
+## Configuration
+
+| Input | Default | Description |
+|---|---|---|
+| `NPM_DOWNLOADS_BASE` | `https://api.npmjs.org` | Base URL for the npm download-counts API |
+
+No authentication required.

--- a/sources/community/npm_downloads/manifest.yaml
+++ b/sources/community/npm_downloads/manifest.yaml
@@ -8,6 +8,10 @@ description: >-
   per package, filtered by `package_name`. No authentication required. Useful
   for popularity and short-term trend detection. Package metadata lives on a
   different host (registry.npmjs.org) and is a separate source spec, `npm`.
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
 
 inputs:
   NPM_DOWNLOADS_BASE:
@@ -26,6 +30,11 @@ tables:
     description: >
       Total downloads in the trailing 30 days for a package. One row per
       package. Filter on package_name (required).
+    guide: >
+      Total downloads over the trailing 30 days. Requires package_name and maps
+      to GET /downloads/point/last-month/{package_name} on api.npmjs.org.
+      Returns one row. Pair with downloads_last_week to estimate a trend
+      (week * 4 vs month).
     filters:
       - name: package_name
         required: true
@@ -38,24 +47,46 @@ tables:
     columns:
       - name: package_name
         type: Utf8
-        description: Package name queried (echoes the WHERE filter)
+        nullable: true
+        virtual: true
+        description: Package name queried (echoes the WHERE filter).
+        expr:
+          kind: from_filter
+          key: package_name
       - name: package
         type: Utf8
-        description: Canonical package name returned by the API
+        description: Canonical package name returned by the API.
+        expr:
+          kind: path
+          path: [package]
       - name: downloads
         type: Int64
-        description: Total downloads in the period
+        description: Total downloads in the period.
+        expr:
+          kind: path
+          path: [downloads]
       - name: start
         type: Utf8
-        description: First day of the counted window (YYYY-MM-DD)
+        description: First day of the counted window (YYYY-MM-DD).
+        expr:
+          kind: path
+          path: [start]
       - name: end
         type: Utf8
-        description: Last day of the counted window (YYYY-MM-DD)
+        description: Last day of the counted window (YYYY-MM-DD).
+        expr:
+          kind: path
+          path: [end]
 
   - name: downloads_last_week
     description: >
       Total downloads in the trailing 7 days for a package. One row per
       package. Useful for short-term trend detection.
+    guide: >
+      Total downloads over the trailing 7 days. Requires package_name and maps
+      to GET /downloads/point/last-week/{package_name} on api.npmjs.org.
+      Returns one row. A week's count multiplied by ~4 and compared against
+      downloads_last_month is a cheap momentum signal.
     filters:
       - name: package_name
         required: true
@@ -68,12 +99,33 @@ tables:
     columns:
       - name: package_name
         type: Utf8
-        description: Package name queried (echoes the WHERE filter)
+        nullable: true
+        virtual: true
+        description: Package name queried (echoes the WHERE filter).
+        expr:
+          kind: from_filter
+          key: package_name
       - name: package
         type: Utf8
+        description: Canonical package name returned by the API.
+        expr:
+          kind: path
+          path: [package]
       - name: downloads
         type: Int64
+        description: Total downloads in the period.
+        expr:
+          kind: path
+          path: [downloads]
       - name: start
         type: Utf8
+        description: First day of the counted window (YYYY-MM-DD).
+        expr:
+          kind: path
+          path: [start]
       - name: end
         type: Utf8
+        description: Last day of the counted window (YYYY-MM-DD).
+        expr:
+          kind: path
+          path: [end]

--- a/sources/community/npm_downloads/manifest.yaml
+++ b/sources/community/npm_downloads/manifest.yaml
@@ -34,7 +34,11 @@ tables:
       Total downloads over the trailing 30 days. Requires package_name and maps
       to GET /downloads/point/last-month/{package_name} on api.npmjs.org.
       Returns one row. Pair with downloads_last_week to estimate a trend
-      (week * 4 vs month).
+      (week * 4 vs month). Exactly ONE package name is supported per query.
+      npm's comma-separated bulk point endpoint returns a differently-shaped
+      object keyed by package name and is not modeled here; passing a
+      comma-separated value (e.g. 'npm,express') yields a single row with null
+      package/downloads/start/end. Query one package at a time.
     filters:
       - name: package_name
         required: true
@@ -86,7 +90,10 @@ tables:
       Total downloads over the trailing 7 days. Requires package_name and maps
       to GET /downloads/point/last-week/{package_name} on api.npmjs.org.
       Returns one row. A week's count multiplied by ~4 and compared against
-      downloads_last_month is a cheap momentum signal.
+      downloads_last_month is a cheap momentum signal. Exactly ONE package name
+      is supported per query; npm's comma-separated bulk point endpoint returns
+      a differently-shaped object keyed by package name and is not modeled here
+      (a comma-separated value yields null fields). Query one package at a time.
     filters:
       - name: package_name
         required: true

--- a/sources/community/npm_downloads/manifest.yaml
+++ b/sources/community/npm_downloads/manifest.yaml
@@ -1,0 +1,79 @@
+name: npm_downloads
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Download counts from the public npm downloads API (api.npmjs.org): total
+  downloads over the trailing week and the trailing month for a package, one row
+  per package, filtered by `package_name`. No authentication required. Useful
+  for popularity and short-term trend detection. Package metadata lives on a
+  different host (registry.npmjs.org) and is a separate source spec, `npm`.
+
+inputs:
+  NPM_DOWNLOADS_BASE:
+    kind: variable
+    default: https://api.npmjs.org
+    hint: Base URL for the npm download-counts API
+
+base_url: "{{input.NPM_DOWNLOADS_BASE}}"
+
+test_queries:
+  - SELECT downloads FROM npm_downloads.downloads_last_month WHERE package_name = 'lodash' LIMIT 1
+  - SELECT downloads FROM npm_downloads.downloads_last_week WHERE package_name = 'lodash' LIMIT 1
+
+tables:
+  - name: downloads_last_month
+    description: >
+      Total downloads in the trailing 30 days for a package. One row per
+      package. Filter on package_name (required).
+    filters:
+      - name: package_name
+        required: true
+    request:
+      method: GET
+      path: "/downloads/point/last-month/{{filter.package_name}}"
+    response:
+      rows_path: []
+      row_strategy: direct
+    columns:
+      - name: package_name
+        type: Utf8
+        description: Package name queried (echoes the WHERE filter)
+      - name: package
+        type: Utf8
+        description: Canonical package name returned by the API
+      - name: downloads
+        type: Int64
+        description: Total downloads in the period
+      - name: start
+        type: Utf8
+        description: First day of the counted window (YYYY-MM-DD)
+      - name: end
+        type: Utf8
+        description: Last day of the counted window (YYYY-MM-DD)
+
+  - name: downloads_last_week
+    description: >
+      Total downloads in the trailing 7 days for a package. One row per
+      package. Useful for short-term trend detection.
+    filters:
+      - name: package_name
+        required: true
+    request:
+      method: GET
+      path: "/downloads/point/last-week/{{filter.package_name}}"
+    response:
+      rows_path: []
+      row_strategy: direct
+    columns:
+      - name: package_name
+        type: Utf8
+        description: Package name queried (echoes the WHERE filter)
+      - name: package
+        type: Utf8
+      - name: downloads
+        type: Int64
+      - name: start
+        type: Utf8
+      - name: end
+        type: Utf8


### PR DESCRIPTION
## Summary

Adds a community source spec for the **npm downloads API** (`api.npmjs.org`) — package download counts over the public, no-auth API.

- `sources/community/npm_downloads/manifest.yaml` — two tables:
  - `downloads_last_month` — total downloads, trailing 30 days
  - `downloads_last_week` — total downloads, trailing 7 days
- `sources/community/npm_downloads/README.md`

One row per package, filtered by `package_name`. Useful for popularity and short-term trend detection (compare a week ×4 against the month).

> This is intentionally separate from the `npm` registry spec: download counts live on `api.npmjs.org` while metadata lives on `registry.npmjs.org`, and a Coral source has a single `base_url`.

## Test

```sql
SELECT downloads FROM npm_downloads.downloads_last_month WHERE package_name = 'lodash' LIMIT 1;
SELECT downloads FROM npm_downloads.downloads_last_week  WHERE package_name = 'lodash' LIMIT 1;
```

Built during the Pirates of the Coral-bean hackathon (powers a dependency-risk auditor that JOINs OSV + npm + npm downloads in one query).