### PR TITLE
feat(sources/community): add obsidian and onepiece source specs

### DIFF
--- a/sources/community/obsidian/README.md
+++ b/sources/community/obsidian/README.md
@@ -1,8 +1,8 @@
 # Obsidian Local REST API (obsidian)
 
-**Version:** 0.1.0
+**Version:** 0.2.0
 **Backend:** HTTP
-**Tables:** 4
+**Tables:** 3
 **Functions:** 2
 **Base URL:** `https://127.0.0.1:27124`
 
@@ -23,13 +23,13 @@ coral source add --file sources/community/obsidian/manifest.yaml
 |-------|-------------|
 | `commands` | Available Obsidian command palette actions |
 | `tags` | Tags across the vault with usage counts |
-| `search_simple` | Fuzzy search results from the vault |
 | `vault_files` | Files and folders at the vault root |
 
-## Table Functions
+## Functions
 
 | Function | Description |
 |----------|-------------|
+| `search(query)` | Fuzzy search notes by keyword (returns ranked results with scores) |
 | `read_note(path)` | Read a note as structured JSON with content, tags, and frontmatter |
 | `list_directory(path)` | List files and folders in a vault directory |
 
@@ -50,7 +50,7 @@ SELECT tag, count FROM obsidian.tags ORDER BY count DESC
 ### Search notes
 
 ```sql
-SELECT filename, score FROM obsidian.search_simple WHERE query = 'project notes'
+SELECT filename, score FROM obsidian.search(query => 'project notes') LIMIT 10
 ```
 
 ### List files at vault root
@@ -87,7 +87,7 @@ coral sql "SELECT id, name FROM obsidian.commands LIMIT 1"
 coral sql "SELECT tag, count FROM obsidian.tags ORDER BY count DESC LIMIT 10"
 
 # Search for notes about a topic
-coral sql "SELECT filename, score FROM obsidian.search_simple WHERE query = 'meeting'"
+coral sql "SELECT filename, score FROM obsidian.search(query => 'meeting') LIMIT 10"
 
 # Read a specific note
 coral sql "SELECT content FROM obsidian.read_note(path => 'projects/README.md')"

--- a/sources/community/obsidian/README.md
+++ b/sources/community/obsidian/README.md
@@ -1,0 +1,101 @@
+# Obsidian Local REST API (obsidian)
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+**Functions:** 2
+**Base URL:** `https://127.0.0.1:27124`
+
+Query notes, commands, tags, and search results from your Obsidian vault via the [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) plugin.
+
+```bash
+coral source add --file sources/community/obsidian/manifest.yaml
+```
+
+## Requirements
+
+- Obsidian with the [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) plugin installed and enabled
+- The plugin's API key (found in Settings → Local REST API)
+
+## Tables
+
+| Table | Description |
+|-------|-------------|
+| `commands` | Available Obsidian command palette actions |
+| `tags` | Tags across the vault with usage counts |
+| `search_simple` | Fuzzy search results from the vault |
+| `vault_files` | Files and folders at the vault root |
+
+## Table Functions
+
+| Function | Description |
+|----------|-------------|
+| `read_note(path)` | Read a note as structured JSON with content, tags, and frontmatter |
+| `list_directory(path)` | List files and folders in a vault directory |
+
+## Example Queries
+
+### List available commands
+
+```sql
+SELECT id, name FROM obsidian.commands LIMIT 20
+```
+
+### List all tags with usage counts
+
+```sql
+SELECT tag, count FROM obsidian.tags ORDER BY count DESC
+```
+
+### Search notes
+
+```sql
+SELECT filename, score FROM obsidian.search_simple WHERE query = 'project notes'
+```
+
+### List files at vault root
+
+```sql
+SELECT name FROM obsidian.vault_files
+```
+
+### List files in a subdirectory
+
+```sql
+SELECT name FROM obsidian.list_directory(path => 'projects')
+```
+
+### Read a note by path
+
+```sql
+SELECT content FROM obsidian.read_note(path => 'daily/2024-01-15.md')
+```
+
+### Read note metadata
+
+```sql
+SELECT path, tags, frontmatter FROM obsidian.read_note(path => 'meeting-notes.md')
+```
+
+## Quick start
+
+```bash
+# Confirm connectivity
+coral sql "SELECT id, name FROM obsidian.commands LIMIT 1"
+
+# List all tags in your vault
+coral sql "SELECT tag, count FROM obsidian.tags ORDER BY count DESC LIMIT 10"
+
+# Search for notes about a topic
+coral sql "SELECT filename, score FROM obsidian.search_simple WHERE query = 'meeting'"
+
+# Read a specific note
+coral sql "SELECT content FROM obsidian.read_note(path => 'projects/README.md')"
+```
+
+## Notes
+
+- The API runs locally on your machine. Use `http://127.0.0.1:27123` for HTTP or `https://127.0.0.1:27124` for HTTPS.
+- If HTTPS fails due to the self-signed certificate, use the HTTP URL instead.
+- The API key grants full access to your vault. Use a dedicated vault if needed.
+- See the [API documentation](https://coddingtonbear.github.io/obsidian-local-rest-api/) for full details.

--- a/sources/community/obsidian/manifest.yaml
+++ b/sources/community/obsidian/manifest.yaml
@@ -1,5 +1,5 @@
 name: obsidian
-version: 0.1.0
+version: 0.2.0
 dsl_version: 3
 backend: http
 description: "Query notes, searches, tags, and commands from the Obsidian Local REST API (self-hosted)."
@@ -76,46 +76,6 @@ tables:
           kind: path
           path:
             - count
-  - name: search_simple
-    description: "Fuzzy search results from the vault."
-    guide: |
-      Provide a query string using the query filter.
-    filters:
-      - name: query
-        description: Full-text query string for Obsidian search.
-    request:
-      method: POST
-      path: /search/simple/
-      query:
-        - name: query
-          from: filter
-          key: query
-    response:
-      rows_path: []
-    columns:
-      - name: filename
-        type: Utf8
-        nullable: true
-        description: Matching note filename
-        expr:
-          kind: path
-          path:
-            - filename
-      - name: score
-        type: Float64
-        nullable: true
-        description: Match score
-        expr:
-          kind: path
-          path:
-            - score
-      - name: query
-        type: Utf8
-        virtual: true
-        description: Search query filter.
-        expr:
-          kind: from_filter
-          key: query
   - name: vault_files
     description: "Files and folders at the vault root."
     request:
@@ -132,6 +92,48 @@ tables:
         expr:
           kind: current_row
 functions:
+  - name: search
+    kind: search
+    description: "Fuzzy search results from the vault."
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    request:
+      method: POST
+      path: /search/simple/
+      query:
+        - name: query
+          from: arg
+          key: query
+    response:
+      rows_path: []
+    columns:
+      - name: query
+        type: Utf8
+        expr: {kind: from_arg, key: query}
+      - name: filename
+        type: Utf8
+        nullable: true
+        description: Matching note filename
+        expr:
+          kind: path
+          path:
+            - filename
+      - name: score
+        type: Float64
+        nullable: true
+        description: Match score
+        expr:
+          kind: path
+          path:
+            - score
   - name: read_note
     description: "Read a note as structured JSON including content, tags, and frontmatter."
     args:
@@ -205,4 +207,4 @@ test_queries:
   - "SELECT id, name FROM obsidian.commands LIMIT 1"
   - "SELECT tag, count FROM obsidian.tags LIMIT 1"
   - "SELECT name FROM obsidian.vault_files LIMIT 1"
-  - "SELECT filename, score FROM obsidian.search_simple WHERE query = 'test'"
+  - "SELECT filename, score FROM obsidian.search(query => 'test') LIMIT 5"

--- a/sources/community/obsidian/manifest.yaml
+++ b/sources/community/obsidian/manifest.yaml
@@ -1,0 +1,208 @@
+name: obsidian
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: "Query notes, searches, tags, and commands from the Obsidian Local REST API (self-hosted)."
+base_url: "{{input.OBSIDIAN_BASE_URL}}"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.OBSIDIAN_API_KEY}}"
+inputs:
+  OBSIDIAN_BASE_URL:
+    kind: variable
+    default: "https://127.0.0.1:27124"
+    hint: |
+      Base URL for the Obsidian Local REST API.
+      Use https://127.0.0.1:27124 for HTTPS or http://127.0.0.1:27123 for HTTP.
+      If HTTPS fails due to the self-signed certificate, switch to the HTTP URL.
+  OBSIDIAN_API_KEY:
+    kind: secret
+    hint: |
+      API key for the Obsidian Local REST API plugin.
+      Find it in Obsidian Settings → Local REST API after enabling the plugin.
+      This key grants full access to your vault; use a dedicated vault if needed.
+      Docs: https://coddingtonbear.github.io/obsidian-local-rest-api/
+tables:
+  - name: commands
+    description: "Available Obsidian command palette actions."
+    request:
+      method: GET
+      path: /commands/
+    response:
+      rows_path:
+        - commands
+    columns:
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Command identifier
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Command display name
+        expr:
+          kind: path
+          path:
+            - name
+  - name: tags
+    description: "Tags across the vault with usage counts."
+    request:
+      method: GET
+      path: /tags/
+    response:
+      rows_path:
+        - tags
+    columns:
+      - name: tag
+        type: Utf8
+        nullable: true
+        description: Tag value
+        expr:
+          kind: path
+          path:
+            - tag
+      - name: count
+        type: Int64
+        nullable: true
+        description: Number of notes with the tag
+        expr:
+          kind: path
+          path:
+            - count
+  - name: search_simple
+    description: "Fuzzy search results from the vault."
+    guide: |
+      Provide a query string using the query filter.
+    filters:
+      - name: query
+        description: Full-text query string for Obsidian search.
+    request:
+      method: POST
+      path: /search/simple/
+      query:
+        - name: query
+          from: filter
+          key: query
+    response:
+      rows_path: []
+    columns:
+      - name: filename
+        type: Utf8
+        nullable: true
+        description: Matching note filename
+        expr:
+          kind: path
+          path:
+            - filename
+      - name: score
+        type: Float64
+        nullable: true
+        description: Match score
+        expr:
+          kind: path
+          path:
+            - score
+      - name: query
+        type: Utf8
+        virtual: true
+        description: Search query filter.
+        expr:
+          kind: from_filter
+          key: query
+  - name: vault_files
+    description: "Files and folders at the vault root."
+    request:
+      method: GET
+      path: /vault/
+    response:
+      rows_path:
+        - files
+    columns:
+      - name: name
+        type: Utf8
+        nullable: true
+        description: File or folder name
+        expr:
+          kind: current_row
+functions:
+  - name: read_note
+    description: "Read a note as structured JSON including content, tags, and frontmatter."
+    args:
+      - name: path
+        required: true
+        bind:
+          arg: path
+    request:
+      method: GET
+      path: /vault/{{arg.path}}
+      headers:
+        - name: Accept
+          from: literal
+          value: application/vnd.olrapi.note+json
+    response:
+      rows_path: []
+    columns:
+      - name: path
+        type: Utf8
+        nullable: true
+        description: Note path
+        expr:
+          kind: path
+          path:
+            - path
+      - name: content
+        type: Utf8
+        nullable: true
+        description: Note content
+        expr:
+          kind: path
+          path:
+            - content
+      - name: tags
+        type: Utf8
+        nullable: true
+        description: Tags found in the note
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: frontmatter
+        type: Utf8
+        nullable: true
+        description: Frontmatter properties as JSON
+        expr:
+          kind: path
+          path:
+            - frontmatter
+  - name: list_directory
+    description: "List files and folders in a vault directory."
+    args:
+      - name: path
+        required: false
+        bind:
+          arg: path
+    request:
+      method: GET
+      path: /vault/{{arg.path}}/
+    response:
+      rows_path:
+        - files
+    columns:
+      - name: name
+        type: Utf8
+        nullable: true
+        description: File or folder name
+        expr:
+          kind: current_row
+test_queries:
+  - "SELECT id, name FROM obsidian.commands LIMIT 1"
+  - "SELECT tag, count FROM obsidian.tags LIMIT 1"
+  - "SELECT name FROM obsidian.vault_files LIMIT 1"
+  - "SELECT filename, score FROM obsidian.search_simple WHERE query = 'test'"

--- a/sources/community/onepiece/README.md
+++ b/sources/community/onepiece/README.md
@@ -1,0 +1,75 @@
+# One Piece API (onepiece)
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 1
+**Base URL:** `https://api.api-onepiece.com/v2`
+
+Query Devil Fruits from the One Piece API. No authentication required.
+
+```bash
+coral source add --file sources/community/onepiece/manifest.yaml
+```
+
+## Tables
+
+| Table | Description |
+|-------|-------------|
+| `fruits` | Devil Fruits catalog entries with names, types, and descriptions |
+
+### `fruits`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | Int64 | Devil Fruit identifier |
+| `name` | Utf8 | Localized Devil Fruit name |
+| `description` | Utf8 | Devil Fruit description text |
+| `roman_name` | Utf8 | Romanized Devil Fruit name |
+| `type` | Utf8 | Fruit type (Paramecia, Logia, Zoan, etc.) |
+| `image_url` | Utf8 | Public image URL for the Devil Fruit |
+
+## Example Queries
+
+### List all Devil Fruits
+
+```sql
+SELECT id, name, type FROM onepiece.fruits LIMIT 10
+```
+
+### Find fruits by type
+
+```sql
+SELECT name, roman_name, description
+FROM onepiece.fruits
+WHERE type = 'Logia'
+```
+
+### Get fruit details
+
+```sql
+SELECT name, description, image_url
+FROM onepiece.fruits
+WHERE id = 1
+```
+
+### List all fruit types
+
+```sql
+SELECT DISTINCT type FROM onepiece.fruits
+```
+
+## Quick start
+
+```bash
+# List all Devil Fruits
+coral sql "SELECT name, type FROM onepiece.fruits LIMIT 5"
+
+# Find all Paramecia fruits
+coral sql "SELECT name, roman_name FROM onepiece.fruits WHERE type = 'Paramecia' LIMIT 10"
+```
+
+## Notes
+
+- The API is a fan-maintained service and may not be stable.
+- Some fields like `description`, `roman_name`, `type`, and `image_url` may be null.
+- No authentication is required to use this API.

--- a/sources/community/onepiece/manifest.yaml
+++ b/sources/community/onepiece/manifest.yaml
@@ -1,0 +1,67 @@
+name: onepiece
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: "Query Devil Fruits from the One Piece API."
+inputs: {}
+base_url: "https://api.api-onepiece.com/v2"
+tables:
+  - name: fruits
+    description: "Devil Fruits catalog entries from the One Piece API."
+    request:
+      method: GET
+      path: /fruits/en
+    response:
+      rows_path: []
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Devil Fruit identifier
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Localized Devil Fruit name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Devil Fruit description text
+        expr:
+          kind: path
+          path:
+            - description
+      - name: roman_name
+        type: Utf8
+        nullable: true
+        description: Romanized Devil Fruit name
+        expr:
+          kind: path
+          path:
+            - roman_name
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Fruit type (Paramecia, Logia, Zoan, etc.)
+        expr:
+          kind: path
+          path:
+            - type
+      - name: image_url
+        type: Utf8
+        nullable: true
+        description: Public image URL for the Devil Fruit
+        expr:
+          kind: path
+          path:
+            - filename
+test_queries:
+  - "SELECT name, type FROM onepiece.fruits LIMIT 1"
+  - "SELECT id, roman_name FROM onepiece.fruits LIMIT 1"


### PR DESCRIPTION
## What changed
Added two new community source specs:
- **obsidian**: Query notes, commands, tags, and search from the Obsidian Local REST API plugin
- **onepiece**: Query Devil Fruits from the One Piece API (no auth required)
## Why it changed
Community contribution to expand the source catalog with two new integrations.
## User-visible impact
- New `coral source add` options for users who want to query their Obsidian vault or One Piece data
- `onepiece` source is ready to use with `coral sql "SELECT ... FROM onepiece.fruits"`
- `obsidian` source requires the Local REST API plugin installed in Obsidian
## Notes
- Added comprehensive READMEs with setup instructions and example queries