### PR TITLE
feat(sources/community/cohere_ai): add Cohere AI community source

### DIFF
--- a/sources/community/cohere_ai/README.md
+++ b/sources/community/cohere_ai/README.md
@@ -1,0 +1,366 @@
+# Cohere AI Source
+
+Query Cohere model metadata and run bounded live chat-completion and embedding checks through Coral SQL.
+
+## Summary
+
+This source lets Coral query Cohere for model catalog metadata, run one bounded non-streaming single-turn chat request, and generate one text embedding vector through SQL. It preserves top-level live response metadata, including response IDs, assistant message objects, embedding response metadata, usage objects, and billed token counts where Cohere returns them.
+
+## Provider docs
+
+- Cohere API overview: https://docs.cohere.com/v2/reference/about
+- Models: https://docs.cohere.com/v2/reference/list-models
+- Chat: https://docs.cohere.com/v2/reference/chat
+- Embeddings: https://docs.cohere.com/v2/reference/embed
+- Model guide: https://docs.cohere.com/v2/docs/models
+- API keys: https://dashboard.cohere.com/api-keys
+
+## Authentication
+
+Create a Cohere API key in the Cohere dashboard, then add the community source:
+
+```bash
+coral source add --interactive --file sources/community/cohere_ai/manifest.yaml
+```
+
+For scripted setup, provide the key as an environment variable:
+
+```bash
+COHERE_API_KEY=... coral source add --file sources/community/cohere_ai/manifest.yaml
+```
+
+The key is stored locally by Coral and sent as a Bearer token to Cohere's API.
+
+## Live request costs
+
+`cohere_ai.chat_completions` and `cohere_ai.embeddings` are live Cohere API calls. Selecting from these tables can consume API credits, quota, and rate limits. Use small prompts and positive token bounds for validation queries.
+
+## Source shape
+
+- `cohere_ai.models` lists model catalog rows from `GET /v1/models`.
+- `cohere_ai.chat_completions` runs one bounded synchronous non-streaming chat request with required `model`, `prompt`, and `max_tokens` filters.
+- `cohere_ai.embeddings` generates one text embedding vector with required `model`, `input`, and `input_type` filters.
+
+## Source scope
+
+- Targets Cohere's hosted API at `https://api.cohere.com`.
+- Requires `COHERE_API_KEY` bearer authentication.
+- `cohere_ai.models` is a metadata read.
+- `cohere_ai.chat_completions` and `cohere_ai.embeddings` perform live Cohere API calls when selected, so they can consume API credits, quota, or rate limits.
+- Chat calls require a positive `max_tokens` filter so examples and validation are bounded.
+- Chat is single-turn and non-streaming in this first version.
+- Embeddings use one text input and request `float` embeddings.
+- Embeddings require a text `input_type` such as `search_query`, `search_document`, `classification`, or `clustering`, matching Cohere's requirement for Embed v3 and newer models.
+
+## Limitations
+
+- Streaming chat is intentionally omitted because the source returns final SQL rows.
+- Tool calls, documents, citations, JSON schema response formats, safety controls, logprob requests, and reasoning configuration are not requested by this first version.
+- The nullable `tool_calls` and `logprobs` columns only preserve metadata if Cohere returns those fields for a request shape supported later.
+- Embeddings accept one text input in this first version. Batch text arrays, image embeddings, image `input_type`, and non-float embedding types are intentionally omitted.
+- Rerank, classify, tokenize, detokenize, audio transcriptions, fine-tuning, datasets, connectors, and evaluation endpoints are intentionally out of scope.
+- Model detail lookup is intentionally omitted because the list endpoint already provides useful metadata without needing path-sensitive model IDs.
+
+## Tables
+
+### `cohere_ai.models`
+
+Lists Cohere models visible to the API key.
+
+```sql
+SELECT name, endpoints, context_length, features
+FROM cohere_ai.models
+LIMIT 10;
+```
+
+Useful columns:
+
+| Column | Notes |
+|---|---|
+| `name` | Model name to use in chat or embedding requests |
+| `endpoints` | Comma-separated supported endpoint names |
+| `context_length` | Context length returned by Cohere |
+| `features` | Comma-separated feature flags when returned |
+
+### `cohere_ai.chat_completions`
+
+Runs one bounded single-turn chat request.
+
+```sql
+SELECT content, finish_reason, max_tokens, billed_input_tokens, billed_output_tokens
+FROM cohere_ai.chat_completions
+WHERE model = 'command-a-03-2025'
+  AND prompt = 'Reply with exactly: Coral Cohere works'
+  AND max_tokens = 20
+LIMIT 1;
+```
+
+This table preserves the raw assistant `message`, `usage`, response `id`, and token counts where Cohere returns them.
+
+### `cohere_ai.embeddings`
+
+Generates one text embedding vector.
+
+```sql
+SELECT id, response_type, api_version, billed_input_tokens,
+       substr(CAST(float_embedding AS VARCHAR), 1, 80) AS embedding_preview
+FROM cohere_ai.embeddings
+WHERE model = 'embed-v4.0'
+  AND input = 'Coral Cohere source validation'
+  AND input_type = 'search_query'
+LIMIT 1;
+```
+
+This table preserves the raw `embeddings` object, raw `meta` object, response `id`, API version metadata, and billed token counts where Cohere returns them.
+
+## Live validation output
+
+```bash
+$ coral source lint sources/community/cohere_ai/manifest.yaml
+Manifest is valid
+```
+
+```bash
+$ coral source add --file sources/community/cohere_ai/manifest.yaml
+Added source cohere_ai
+
+  PASS cohere_ai connected successfully
+
+    cohere_ai (3 tables)
+    - chat_completions
+    - embeddings
+    - models
+    Query tests
+    1 declared - 1 passed - 0 failed
+
+    PASS SELECT name, endpoints, context_length FROM cohere_ai.models LIMIT 5
+      5 rows
+```
+
+```bash
+$ coral source test cohere_ai
+  PASS cohere_ai connected successfully
+
+    cohere_ai (3 tables)
+    - chat_completions
+    - embeddings
+    - models
+    Query tests
+    1 declared - 1 passed - 0 failed
+
+    PASS SELECT name, endpoints, context_length FROM cohere_ai.models LIMIT 5
+      5 rows
+```
+
+```sql
+SELECT table_name
+FROM coral.tables
+WHERE schema_name = 'cohere_ai'
+ORDER BY table_name;
+```
+
+```text
++------------------+
+| table_name       |
++------------------+
+| chat_completions |
+| embeddings       |
+| models           |
++------------------+
+```
+
+```sql
+SELECT table_name, column_name, data_type
+FROM coral.columns
+WHERE schema_name = 'cohere_ai'
+ORDER BY table_name, ordinal_position;
+```
+
+```text
++------------------+----------------------+-----------+
+| table_name       | column_name          | data_type |
++------------------+----------------------+-----------+
+| chat_completions | model                | Utf8      |
+| chat_completions | prompt               | Utf8      |
+| chat_completions | max_tokens           | Int64     |
+| chat_completions | id                   | Utf8      |
+| chat_completions | finish_reason        | Utf8      |
+| chat_completions | message              | Json      |
+| chat_completions | message_role         | Utf8      |
+| chat_completions | content_type         | Utf8      |
+| chat_completions | content              | Utf8      |
+| chat_completions | tool_calls           | Json      |
+| chat_completions | usage                | Json      |
+| chat_completions | billed_input_tokens  | Int64     |
+| chat_completions | billed_output_tokens | Int64     |
+| chat_completions | input_tokens         | Int64     |
+| chat_completions | output_tokens        | Int64     |
+| chat_completions | cached_tokens        | Int64     |
+| chat_completions | logprobs             | Json      |
+| embeddings       | model                | Utf8      |
+| embeddings       | input                | Utf8      |
+| embeddings       | input_type           | Utf8      |
+| embeddings       | id                   | Utf8      |
+| embeddings       | response_type        | Utf8      |
+| embeddings       | texts                | Json      |
+| embeddings       | returned_text        | Utf8      |
+| embeddings       | embeddings           | Json      |
+| embeddings       | float_embedding      | Json      |
+| embeddings       | meta                 | Json      |
+| embeddings       | api_version          | Utf8      |
+| embeddings       | billed_input_tokens  | Int64     |
+| embeddings       | billed_image_tokens  | Int64     |
+| models           | name                 | Utf8      |
+| models           | is_deprecated        | Boolean   |
+| models           | endpoints            | Utf8      |
+| models           | finetuned            | Boolean   |
+| models           | context_length       | Int64     |
+| models           | tokenizer_url        | Utf8      |
+| models           | default_endpoints    | Utf8      |
+| models           | features             | Utf8      |
+| models           | sampling_defaults    | Json      |
++------------------+----------------------+-----------+
+```
+
+```sql
+SELECT key, kind, required
+FROM coral.inputs
+WHERE schema_name = 'cohere_ai'
+ORDER BY key;
+```
+
+```text
++----------------+--------+----------+
+| key            | kind   | required |
++----------------+--------+----------+
+| COHERE_API_KEY | secret | true     |
++----------------+--------+----------+
+```
+
+```sql
+SELECT name, endpoints, context_length, features
+FROM cohere_ai.models
+LIMIT 5;
+```
+
+```text
++---------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
+| name                      | endpoints      | context_length | features                                                                                            |
++---------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
+| c4ai-aya-expanse-32b      | generate, chat | 128000         |                                                                                                     |
+| c4ai-aya-vision-32b       | chat           | 16384          | logprobs, vision                                                                                    |
+| cohere-transcribe-03-2026 | transcriptions | 32768          |                                                                                                     |
+| command-a-03-2025         | chat           | 288000         | json_mode, json_schema, strict_tools, safety_modes, tools, tool_choice                              |
+| command-a-plus-05-2026    | generate, chat | 128000         | logprobs, json_mode, json_schema, strict_tools, safety_modes, tools, reasoning, vision, tool_images |
++---------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
+```
+
+```sql
+SELECT content, finish_reason, max_tokens, billed_input_tokens, billed_output_tokens
+FROM cohere_ai.chat_completions
+WHERE model = 'command-a-03-2025'
+  AND prompt = 'Reply with exactly: Coral Cohere works'
+  AND max_tokens = 20
+LIMIT 1;
+```
+
+```text
++--------------------+---------------+------------+---------------------+----------------------+
+| content            | finish_reason | max_tokens | billed_input_tokens | billed_output_tokens |
++--------------------+---------------+------------+---------------------+----------------------+
+| Coral Cohere works | COMPLETE      | 20         | 8                   | 5                    |
++--------------------+---------------+------------+---------------------+----------------------+
+```
+
+```sql
+SELECT id, message_role, content_type, input_tokens, output_tokens, cached_tokens
+FROM cohere_ai.chat_completions
+WHERE model = 'command-a-03-2025'
+  AND prompt = 'Reply with exactly: Coral Cohere works'
+  AND max_tokens = 20
+LIMIT 1;
+```
+
+```text
++--------------------------------------+--------------+--------------+--------------+---------------+---------------+
+| id                                   | message_role | content_type | input_tokens | output_tokens | cached_tokens |
++--------------------------------------+--------------+--------------+--------------+---------------+---------------+
+| 82b54c19-22f9-45cf-96fb-6e9efd8c6286 | assistant    | text         | 503          | 7             | 0             |
++--------------------------------------+--------------+--------------+--------------+---------------+---------------+
+```
+
+```sql
+SELECT id, response_type, api_version, billed_input_tokens,
+       substr(CAST(float_embedding AS VARCHAR), 1, 80) AS embedding_preview
+FROM cohere_ai.embeddings
+WHERE model = 'embed-v4.0'
+  AND input = 'Coral Cohere source validation'
+  AND input_type = 'search_query'
+LIMIT 1;
+```
+
+```text
++--------------------------------------+--------------------+-------------+---------------------+----------------------------------------------------------------------------------+
+| id                                   | response_type      | api_version | billed_input_tokens | embedding_preview                                                                |
++--------------------------------------+--------------------+-------------+---------------------+----------------------------------------------------------------------------------+
+| 24077dda-cc0a-4844-9beb-2cabf72347cc | embeddings_by_type | 2           | 6                   | [-0.006427452,0.01688568,-0.0004800163,-0.043575946,-0.04074351,-0.004929529,-0. |
++--------------------------------------+--------------------+-------------+---------------------+----------------------------------------------------------------------------------+
+```
+
+## Validation checklist
+
+```bash
+coral source lint sources/community/cohere_ai/manifest.yaml
+coral source add --file sources/community/cohere_ai/manifest.yaml
+coral source test cohere_ai
+```
+
+Then inspect the registered schema:
+
+```sql
+SELECT table_name
+FROM coral.tables
+WHERE schema_name = 'cohere_ai'
+ORDER BY table_name;
+```
+
+```sql
+SELECT table_name, column_name, data_type
+FROM coral.columns
+WHERE schema_name = 'cohere_ai'
+ORDER BY table_name, ordinal_position;
+```
+
+```sql
+SELECT key, kind, required
+FROM coral.inputs
+WHERE schema_name = 'cohere_ai'
+ORDER BY key;
+```
+
+Run representative live queries:
+
+```sql
+SELECT name, endpoints, context_length, features
+FROM cohere_ai.models
+LIMIT 10;
+```
+
+```sql
+SELECT content, finish_reason, max_tokens, billed_input_tokens, billed_output_tokens
+FROM cohere_ai.chat_completions
+WHERE model = 'command-a-03-2025'
+  AND prompt = 'Reply with exactly: Coral Cohere works'
+  AND max_tokens = 20
+LIMIT 1;
+```
+
+```sql
+SELECT id, response_type, api_version, billed_input_tokens,
+       substr(CAST(float_embedding AS VARCHAR), 1, 80) AS embedding_preview
+FROM cohere_ai.embeddings
+WHERE model = 'embed-v4.0'
+  AND input = 'Coral Cohere source validation'
+  AND input_type = 'search_query'
+LIMIT 1;
+```

--- a/sources/community/cohere_ai/README.md
+++ b/sources/community/cohere_ai/README.md
@@ -13,6 +13,7 @@ This source lets Coral query Cohere for model catalog metadata, run one bounded 
 - Chat: https://docs.cohere.com/v2/reference/chat
 - Embeddings: https://docs.cohere.com/v2/reference/embed
 - Model guide: https://docs.cohere.com/v2/docs/models
+- Rate limits: https://docs.cohere.com/v2/docs/rate-limits
 - API keys: https://dashboard.cohere.com/api-keys
 
 ## Authentication
@@ -70,6 +71,7 @@ Lists Cohere models visible to the API key.
 ```sql
 SELECT name, endpoints, context_length, features
 FROM cohere_ai.models
+WHERE endpoint = 'chat'
 LIMIT 10;
 ```
 
@@ -78,7 +80,7 @@ Useful columns:
 | Column | Notes |
 |---|---|
 | `name` | Model name to use in chat or embedding requests |
-| `endpoints` | Comma-separated supported endpoint names |
+| `endpoints` | Comma-separated supported endpoint names; use the optional `endpoint` filter to find chat or embed models |
 | `context_length` | Context length returned by Cohere |
 | `features` | Comma-separated feature flags when returned |
 
@@ -102,7 +104,7 @@ This table preserves the raw assistant `message`, `usage`, response `id`, and to
 Generates one text embedding vector.
 
 ```sql
-SELECT id, response_type, api_version, billed_input_tokens,
+SELECT id, api_version, billed_input_tokens,
        substr(CAST(float_embedding AS VARCHAR), 1, 80) AS embedding_preview
 FROM cohere_ai.embeddings
 WHERE model = 'embed-v4.0'
@@ -201,7 +203,6 @@ ORDER BY table_name, ordinal_position;
 | embeddings       | input                | Utf8      |
 | embeddings       | input_type           | Utf8      |
 | embeddings       | id                   | Utf8      |
-| embeddings       | response_type        | Utf8      |
 | embeddings       | texts                | Json      |
 | embeddings       | returned_text        | Utf8      |
 | embeddings       | embeddings           | Json      |
@@ -210,6 +211,8 @@ ORDER BY table_name, ordinal_position;
 | embeddings       | api_version          | Utf8      |
 | embeddings       | billed_input_tokens  | Int64     |
 | embeddings       | billed_image_tokens  | Int64     |
+| models           | endpoint             | Utf8      |
+| models           | default_only         | Boolean   |
 | models           | name                 | Utf8      |
 | models           | is_deprecated        | Boolean   |
 | models           | endpoints            | Utf8      |
@@ -240,19 +243,20 @@ ORDER BY key;
 ```sql
 SELECT name, endpoints, context_length, features
 FROM cohere_ai.models
+WHERE endpoint = 'chat'
 LIMIT 5;
 ```
 
 ```text
-+---------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
-| name                      | endpoints      | context_length | features                                                                                            |
-+---------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
-| c4ai-aya-expanse-32b      | generate, chat | 128000         |                                                                                                     |
-| c4ai-aya-vision-32b       | chat           | 16384          | logprobs, vision                                                                                    |
-| cohere-transcribe-03-2026 | transcriptions | 32768          |                                                                                                     |
-| command-a-03-2025         | chat           | 288000         | json_mode, json_schema, strict_tools, safety_modes, tools, tool_choice                              |
-| command-a-plus-05-2026    | generate, chat | 128000         | logprobs, json_mode, json_schema, strict_tools, safety_modes, tools, reasoning, vision, tool_images |
-+---------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
++-----------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
+| name                        | endpoints      | context_length | features                                                                                            |
++-----------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
+| c4ai-aya-expanse-32b        | generate, chat | 128000         |                                                                                                     |
+| c4ai-aya-vision-32b         | chat           | 16384          | logprobs, vision                                                                                    |
+| command-a-03-2025           | chat           | 288000         | json_mode, json_schema, strict_tools, safety_modes, tools, tool_choice                              |
+| command-a-plus-05-2026      | generate, chat | 128000         | logprobs, json_mode, json_schema, strict_tools, safety_modes, tools, reasoning, vision, tool_images |
+| command-a-reasoning-08-2025 | chat           | 288768         | json_mode, json_schema, strict_tools, safety_modes, tools, reasoning                                |
++-----------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
 ```
 
 ```sql
@@ -285,12 +289,12 @@ LIMIT 1;
 +--------------------------------------+--------------+--------------+--------------+---------------+---------------+
 | id                                   | message_role | content_type | input_tokens | output_tokens | cached_tokens |
 +--------------------------------------+--------------+--------------+--------------+---------------+---------------+
-| 82b54c19-22f9-45cf-96fb-6e9efd8c6286 | assistant    | text         | 503          | 7             | 0             |
+| 48463565-9a32-44e9-8ab9-2cad9ef98c51 | assistant    | text         | 503          | 7             | 0             |
 +--------------------------------------+--------------+--------------+--------------+---------------+---------------+
 ```
 
 ```sql
-SELECT id, response_type, api_version, billed_input_tokens,
+SELECT id, api_version, billed_input_tokens,
        substr(CAST(float_embedding AS VARCHAR), 1, 80) AS embedding_preview
 FROM cohere_ai.embeddings
 WHERE model = 'embed-v4.0'
@@ -300,11 +304,11 @@ LIMIT 1;
 ```
 
 ```text
-+--------------------------------------+--------------------+-------------+---------------------+----------------------------------------------------------------------------------+
-| id                                   | response_type      | api_version | billed_input_tokens | embedding_preview                                                                |
-+--------------------------------------+--------------------+-------------+---------------------+----------------------------------------------------------------------------------+
-| 24077dda-cc0a-4844-9beb-2cabf72347cc | embeddings_by_type | 2           | 6                   | [-0.006427452,0.01688568,-0.0004800163,-0.043575946,-0.04074351,-0.004929529,-0. |
-+--------------------------------------+--------------------+-------------+---------------------+----------------------------------------------------------------------------------+
++--------------------------------------+-------------+---------------------+----------------------------------------------------------------------------------+
+| id                                   | api_version | billed_input_tokens | embedding_preview                                                                |
++--------------------------------------+-------------+---------------------+----------------------------------------------------------------------------------+
+| 1a911b6d-e340-47f3-9b7c-b19a0867f72d | 2           | 6                   | [-0.0059665833,0.017109653,-0.0004938097,-0.043809433,-0.040975988,-0.0053672004 |
++--------------------------------------+-------------+---------------------+----------------------------------------------------------------------------------+
 ```
 
 ## Validation checklist
@@ -343,6 +347,7 @@ Run representative live queries:
 ```sql
 SELECT name, endpoints, context_length, features
 FROM cohere_ai.models
+WHERE endpoint = 'chat'
 LIMIT 10;
 ```
 
@@ -356,7 +361,7 @@ LIMIT 1;
 ```
 
 ```sql
-SELECT id, response_type, api_version, billed_input_tokens,
+SELECT id, api_version, billed_input_tokens,
        substr(CAST(float_embedding AS VARCHAR), 1, 80) AS embedding_preview
 FROM cohere_ai.embeddings
 WHERE model = 'embed-v4.0'

--- a/sources/community/cohere_ai/manifest.yaml
+++ b/sources/community/cohere_ai/manifest.yaml
@@ -26,9 +26,19 @@ tables:
   - name: models
     description: Cohere models available to the API key from GET /v1/models.
     fetch_limit_default: 100
+    filters:
+      - name: endpoint
+      - name: default_only
     request:
       method: GET
       path: /v1/models
+      query:
+        - name: endpoint
+          from: filter
+          key: endpoint
+        - name: default_only
+          from: filter_bool
+          key: default_only
     response:
       rows_path:
         - models
@@ -42,6 +52,22 @@ tables:
         max: 1000
         query_param: page_size
     columns:
+      - name: endpoint
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional Cohere endpoint filter supplied in SQL, such as chat or embed.
+        expr:
+          kind: from_filter
+          key: endpoint
+      - name: default_only
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: Optional Cohere default_only filter supplied in SQL.
+        expr:
+          kind: from_filter
+          key: default_only
       - name: name
         type: Utf8
         nullable: false
@@ -342,10 +368,6 @@ tables:
         type: Utf8
         nullable: true
         description: Cohere embedding response ID.
-      - name: response_type
-        type: Utf8
-        nullable: true
-        description: Embedding response type returned by Cohere.
       - name: texts
         type: Json
         nullable: true

--- a/sources/community/cohere_ai/manifest.yaml
+++ b/sources/community/cohere_ai/manifest.yaml
@@ -1,0 +1,409 @@
+name: cohere_ai
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Query Cohere model metadata and run bounded chat-completion and embedding checks through SQL.
+base_url: https://api.cohere.com
+inputs:
+  COHERE_API_KEY:
+    kind: secret
+    hint: |
+      Cohere API key.
+
+      Create or copy an API key from:
+      https://dashboard.cohere.com/api-keys
+
+      The key is sent as a Bearer token to Cohere's API.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.COHERE_API_KEY}}"
+test_queries:
+  - SELECT name, endpoints, context_length FROM cohere_ai.models LIMIT 5
+tables:
+  - name: models
+    description: Cohere models available to the API key from GET /v1/models.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /v1/models
+    response:
+      rows_path:
+        - models
+    pagination:
+      mode: cursor_query
+      cursor_param: page_token
+      response_cursor_path:
+        - next_page_token
+      page_size:
+        default: 100
+        max: 1000
+        query_param: page_size
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Cohere model name used in API requests.
+      - name: is_deprecated
+        type: Boolean
+        nullable: true
+        description: Whether Cohere marks the model as deprecated.
+      - name: endpoints
+        type: Utf8
+        nullable: true
+        description: Comma-separated endpoint names supported by the model.
+        expr:
+          kind: join_array
+          path:
+            - endpoints
+          separator: ", "
+      - name: finetuned
+        type: Boolean
+        nullable: true
+        description: Whether the row represents a fine-tuned model.
+      - name: context_length
+        type: Int64
+        nullable: true
+        description: Model context length when returned by Cohere.
+      - name: tokenizer_url
+        type: Utf8
+        nullable: true
+        description: URL for the model tokenizer metadata when returned.
+      - name: default_endpoints
+        type: Utf8
+        nullable: true
+        description: Comma-separated default endpoints for the model.
+        expr:
+          kind: join_array
+          path:
+            - default_endpoints
+          separator: ", "
+      - name: features
+        type: Utf8
+        nullable: true
+        description: Comma-separated feature flags returned for the model.
+        expr:
+          kind: join_array
+          path:
+            - features
+          separator: ", "
+      - name: sampling_defaults
+        type: Json
+        nullable: true
+        description: Model sampling defaults when returned by Cohere.
+
+  - name: chat_completions
+    description: Run one non-streaming, single-turn Cohere Chat API request with a required positive max_tokens bound.
+    filters:
+      - name: model
+        required: true
+      - name: prompt
+        required: true
+      - name: max_tokens
+        required: true
+    request:
+      method: POST
+      path: /v2/chat
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
+      body:
+        - path:
+            - model
+          from: filter
+          key: model
+        - path:
+            - messages
+            - "0"
+            - role
+          from: literal
+          value: user
+        - path:
+            - messages
+            - "0"
+            - content
+          from: filter
+          key: prompt
+        - path:
+            - max_tokens
+          from: filter_int
+          key: max_tokens
+        - path:
+            - stream
+          from: literal
+          value: false
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: model
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Model supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: model
+      - name: prompt
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Prompt supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: prompt
+      - name: max_tokens
+        type: Int64
+        nullable: false
+        virtual: true
+        description: Positive max_tokens value supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: max_tokens
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Cohere response ID.
+      - name: finish_reason
+        type: Utf8
+        nullable: true
+        description: Cohere finish reason for the chat request.
+      - name: message
+        type: Json
+        nullable: true
+        description: Raw assistant message object.
+      - name: message_role
+        type: Utf8
+        nullable: true
+        description: Assistant message role.
+        expr:
+          kind: path
+          path:
+            - message
+            - role
+      - name: content_type
+        type: Utf8
+        nullable: true
+        description: First assistant content item type.
+        expr:
+          kind: path
+          path:
+            - message
+            - content
+            - "0"
+            - type
+      - name: content
+        type: Utf8
+        nullable: true
+        description: First assistant text content item.
+        expr:
+          kind: path
+          path:
+            - message
+            - content
+            - "0"
+            - text
+      - name: tool_calls
+        type: Json
+        nullable: true
+        description: Assistant tool-call metadata when Cohere returns it.
+        expr:
+          kind: path
+          path:
+            - message
+            - tool_calls
+      - name: usage
+        type: Json
+        nullable: true
+        description: Raw usage object returned by Cohere.
+      - name: billed_input_tokens
+        type: Int64
+        nullable: true
+        description: Billed input token count.
+        expr:
+          kind: path
+          path:
+            - usage
+            - billed_units
+            - input_tokens
+      - name: billed_output_tokens
+        type: Int64
+        nullable: true
+        description: Billed output token count.
+        expr:
+          kind: path
+          path:
+            - usage
+            - billed_units
+            - output_tokens
+      - name: input_tokens
+        type: Int64
+        nullable: true
+        description: Total input token count when returned.
+        expr:
+          kind: path
+          path:
+            - usage
+            - tokens
+            - input_tokens
+      - name: output_tokens
+        type: Int64
+        nullable: true
+        description: Total output token count when returned.
+        expr:
+          kind: path
+          path:
+            - usage
+            - tokens
+            - output_tokens
+      - name: cached_tokens
+        type: Int64
+        nullable: true
+        description: Cached token count when returned.
+        expr:
+          kind: path
+          path:
+            - usage
+            - cached_tokens
+      - name: logprobs
+        type: Json
+        nullable: true
+        description: Log probability metadata when requested and returned.
+
+  - name: embeddings
+    description: Generate one Cohere text embedding vector with required model, input, and text input_type filters.
+    filters:
+      - name: model
+        required: true
+      - name: input
+        required: true
+      - name: input_type
+        required: true
+    request:
+      method: POST
+      path: /v2/embed
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
+      body:
+        - path:
+            - model
+          from: filter
+          key: model
+        - path:
+            - texts
+            - "0"
+          from: filter
+          key: input
+        - path:
+            - input_type
+          from: filter
+          key: input_type
+        - path:
+            - embedding_types
+            - "0"
+          from: literal
+          value: float
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: model
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Model supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: model
+      - name: input
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Input text supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: input
+      - name: input_type
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Cohere text input_type supplied in SQL filter, such as search_query or search_document.
+        expr:
+          kind: from_filter
+          key: input_type
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Cohere embedding response ID.
+      - name: response_type
+        type: Utf8
+        nullable: true
+        description: Embedding response type returned by Cohere.
+      - name: texts
+        type: Json
+        nullable: true
+        description: Text array echoed by Cohere.
+      - name: returned_text
+        type: Utf8
+        nullable: true
+        description: First text value echoed by Cohere.
+        expr:
+          kind: path
+          path:
+            - texts
+            - "0"
+      - name: embeddings
+        type: Json
+        nullable: true
+        description: Raw embeddings object returned by Cohere.
+      - name: float_embedding
+        type: Json
+        nullable: true
+        description: First float embedding vector.
+        expr:
+          kind: path
+          path:
+            - embeddings
+            - float
+            - "0"
+      - name: meta
+        type: Json
+        nullable: true
+        description: Raw meta object returned by Cohere.
+      - name: api_version
+        type: Utf8
+        nullable: true
+        description: Cohere API version metadata.
+        expr:
+          kind: path
+          path:
+            - meta
+            - api_version
+            - version
+      - name: billed_input_tokens
+        type: Int64
+        nullable: true
+        description: Billed input token count.
+        expr:
+          kind: path
+          path:
+            - meta
+            - billed_units
+            - input_tokens
+      - name: billed_image_tokens
+        type: Int64
+        nullable: true
+        description: Billed image token count when returned.
+        expr:
+          kind: path
+          path:
+            - meta
+            - billed_units
+            - image_tokens


### PR DESCRIPTION
﻿## Summary

Closes #1097.

This source lets Coral query Cohere for model catalog metadata, run one bounded non-streaming single-turn chat request, and generate one text embedding vector through SQL.

## Latest update

- Removed undocumented `response_type` from `cohere_ai.embeddings`.
- Added optional Cohere model filters: `endpoint` and `default_only`.
- Added Cohere rate-limit docs link.
- Refreshed README/PR validation output against the current source shape.

## Why this source

Cohere is a widely used hosted AI API for chat and embedding models. Coral does not currently include a Cohere source under `sources/core` or `sources/community`, so this community source adds a focused SQL surface for model discovery and small live validation workflows.

This source helps users:

- Discover Cohere models and endpoint capability metadata.
- Run bounded single-turn chat-completion smoke tests through SQL.
- Generate one text embedding vector through SQL with response metadata preserved.
- Inspect response IDs, assistant message objects, embedding response metadata, usage objects, and billed token counts where Cohere returns them.

## Provider docs

- Cohere API overview: https://docs.cohere.com/v2/reference/about
- Models: https://docs.cohere.com/v2/reference/list-models
- Chat: https://docs.cohere.com/v2/reference/chat
- Embeddings: https://docs.cohere.com/v2/reference/embed
- Model guide: https://docs.cohere.com/v2/docs/models
- Rate limits: https://docs.cohere.com/v2/docs/rate-limits
- API keys: https://dashboard.cohere.com/api-keys

## Source shape

- `cohere_ai.models` lists model catalog rows from `GET /v1/models`, with optional `endpoint` and `default_only` filters.
- `cohere_ai.chat_completions` runs one bounded synchronous non-streaming chat request with required `model`, `prompt`, and `max_tokens` filters.
- `cohere_ai.embeddings` generates one text embedding vector with required `model`, `input`, and text `input_type` filters.

## Source scope

- Targets Cohere's hosted API at `https://api.cohere.com`.
- Requires `COHERE_API_KEY` bearer authentication.
- `cohere_ai.models` is a metadata read.
- `cohere_ai.chat_completions` and `cohere_ai.embeddings` perform live Cohere API calls when selected, so they can consume API credits, quota, or rate limits.
- Chat calls require a positive `max_tokens` bound.
- Chat is single-turn, synchronous, and non-streaming in this first version.
- Embeddings use one text input, require a text `input_type`, and request `float` embeddings.
- Batch text arrays, image embeddings, image `input_type`, non-float embedding types, streaming chat, tool-request configuration, rerank, classify, tokenize, detokenize, audio, fine-tuning, datasets, connectors, and evaluation endpoints are intentionally out of scope.

## Validation

Validated against Cohere with a valid API key.

### 1. Lint

```bash
$ coral source lint sources/community/cohere_ai/manifest.yaml
Manifest is valid
```

### 2. Add source

```bash
$ coral source add --file sources/community/cohere_ai/manifest.yaml
Added source cohere_ai

  PASS cohere_ai connected successfully

    cohere_ai (3 tables)
    - chat_completions
    - embeddings
    - models
    Query tests
    1 declared - 1 passed - 0 failed

    PASS SELECT name, endpoints, context_length FROM cohere_ai.models LIMIT 5
      5 rows
```

### 3. Inspect tables

```bash
$ coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'cohere_ai' ORDER BY table_name"
+------------------+
| table_name       |
+------------------+
| chat_completions |
| embeddings       |
| models           |
+------------------+
```

### 4. Inspect columns

```bash
$ coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'cohere_ai' ORDER BY table_name, ordinal_position"
+------------------+----------------------+-----------+
| table_name       | column_name          | data_type |
+------------------+----------------------+-----------+
| chat_completions | model                | Utf8      |
| chat_completions | prompt               | Utf8      |
| chat_completions | max_tokens           | Int64     |
| chat_completions | id                   | Utf8      |
| chat_completions | finish_reason        | Utf8      |
| chat_completions | message              | Json      |
| chat_completions | message_role         | Utf8      |
| chat_completions | content_type         | Utf8      |
| chat_completions | content              | Utf8      |
| chat_completions | tool_calls           | Json      |
| chat_completions | usage                | Json      |
| chat_completions | billed_input_tokens  | Int64     |
| chat_completions | billed_output_tokens | Int64     |
| chat_completions | input_tokens         | Int64     |
| chat_completions | output_tokens        | Int64     |
| chat_completions | cached_tokens        | Int64     |
| chat_completions | logprobs             | Json      |
| embeddings       | model                | Utf8      |
| embeddings       | input                | Utf8      |
| embeddings       | input_type           | Utf8      |
| embeddings       | id                   | Utf8      |
| embeddings       | texts                | Json      |
| embeddings       | returned_text        | Utf8      |
| embeddings       | embeddings           | Json      |
| embeddings       | float_embedding      | Json      |
| embeddings       | meta                 | Json      |
| embeddings       | api_version          | Utf8      |
| embeddings       | billed_input_tokens  | Int64     |
| embeddings       | billed_image_tokens  | Int64     |
| models           | endpoint             | Utf8      |
| models           | default_only         | Boolean   |
| models           | name                 | Utf8      |
| models           | is_deprecated        | Boolean   |
| models           | endpoints            | Utf8      |
| models           | finetuned            | Boolean   |
| models           | context_length       | Int64     |
| models           | tokenizer_url        | Utf8      |
| models           | default_endpoints    | Utf8      |
| models           | features             | Utf8      |
| models           | sampling_defaults    | Json      |
+------------------+----------------------+-----------+
```

### 5. Inspect inputs

```bash
$ coral sql "SELECT key, kind, required FROM coral.inputs WHERE schema_name = 'cohere_ai' ORDER BY key"
+----------------+--------+----------+
| key            | kind   | required |
+----------------+--------+----------+
| COHERE_API_KEY | secret | true     |
+----------------+--------+----------+
```

### 6. Source test

```bash
$ coral source test cohere_ai
  PASS cohere_ai connected successfully

    cohere_ai (3 tables)
    - chat_completions
    - embeddings
    - models
    Query tests
    1 declared - 1 passed - 0 failed

    PASS SELECT name, endpoints, context_length FROM cohere_ai.models LIMIT 5
      5 rows
```

### 7. Filtered model inventory query

```bash
$ coral sql "SELECT name, endpoints, context_length, features FROM cohere_ai.models WHERE endpoint = 'chat' LIMIT 5"
+-----------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
| name                        | endpoints      | context_length | features                                                                                            |
+-----------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
| c4ai-aya-expanse-32b        | generate, chat | 128000         |                                                                                                     |
| c4ai-aya-vision-32b         | chat           | 16384          | logprobs, vision                                                                                    |
| command-a-03-2025           | chat           | 288000         | json_mode, json_schema, strict_tools, safety_modes, tools, tool_choice                              |
| command-a-plus-05-2026      | generate, chat | 128000         | logprobs, json_mode, json_schema, strict_tools, safety_modes, tools, reasoning, vision, tool_images |
| command-a-reasoning-08-2025 | chat           | 288768         | json_mode, json_schema, strict_tools, safety_modes, tools, reasoning                                |
+-----------------------------+----------------+----------------+-----------------------------------------------------------------------------------------------------+
```

### 8. Bounded chat-completion query

```bash
$ coral sql "SELECT content, finish_reason, max_tokens, billed_input_tokens, billed_output_tokens FROM cohere_ai.chat_completions WHERE model = 'command-a-03-2025' AND prompt = 'Reply with exactly: Coral Cohere works' AND max_tokens = 20 LIMIT 1"
+--------------------+---------------+------------+---------------------+----------------------+
| content            | finish_reason | max_tokens | billed_input_tokens | billed_output_tokens |
+--------------------+---------------+------------+---------------------+----------------------+
| Coral Cohere works | COMPLETE      | 20         | 8                   | 5                    |
+--------------------+---------------+------------+---------------------+----------------------+
```

### 9. Chat metadata query

```bash
$ coral sql "SELECT id, message_role, content_type, input_tokens, output_tokens, cached_tokens FROM cohere_ai.chat_completions WHERE model = 'command-a-03-2025' AND prompt = 'Reply with exactly: Coral Cohere works' AND max_tokens = 20 LIMIT 1"
+--------------------------------------+--------------+--------------+--------------+---------------+---------------+
| id                                   | message_role | content_type | input_tokens | output_tokens | cached_tokens |
+--------------------------------------+--------------+--------------+--------------+---------------+---------------+
| 48463565-9a32-44e9-8ab9-2cad9ef98c51 | assistant    | text         | 503          | 7             | 0             |
+--------------------------------------+--------------+--------------+--------------+---------------+---------------+
```

### 10. Embedding query

```bash
$ coral sql "SELECT id, api_version, billed_input_tokens, substr(CAST(float_embedding AS VARCHAR), 1, 80) AS embedding_preview FROM cohere_ai.embeddings WHERE model = 'embed-v4.0' AND input = 'Coral Cohere source validation' AND input_type = 'search_query' LIMIT 1"
+--------------------------------------+-------------+---------------------+----------------------------------------------------------------------------------+
| id                                   | api_version | billed_input_tokens | embedding_preview                                                                |
+--------------------------------------+-------------+---------------------+----------------------------------------------------------------------------------+
| 1a911b6d-e340-47f3-9b7c-b19a0867f72d | 2           | 6                   | [-0.0059665833,0.017109653,-0.0004938097,-0.043809433,-0.040975988,-0.0053672004 |
+--------------------------------------+-------------+---------------------+----------------------------------------------------------------------------------+
```





## Proof screenshots

![Cohere AI proof 1](https://raw.githubusercontent.com/FiscalMindset/coral/cohere-ai-proof-assets/output_proof/cohere_ai/01.png)

![Cohere AI proof 2](https://raw.githubusercontent.com/FiscalMindset/coral/cohere-ai-proof-assets/output_proof/cohere_ai/02.png)

![Cohere AI proof 3](https://raw.githubusercontent.com/FiscalMindset/coral/cohere-ai-proof-assets/output_proof/cohere_ai/03.png)

![Cohere AI proof 4](https://raw.githubusercontent.com/FiscalMindset/coral/cohere-ai-proof-assets/output_proof/cohere_ai/04.png)

![Cohere AI proof 5](https://raw.githubusercontent.com/FiscalMindset/coral/cohere-ai-proof-assets/output_proof/cohere_ai/05.png)

![Cohere AI proof 6](https://raw.githubusercontent.com/FiscalMindset/coral/cohere-ai-proof-assets/output_proof/cohere_ai/06.png)

![Cohere AI proof 7](https://raw.githubusercontent.com/FiscalMindset/coral/cohere-ai-proof-assets/output_proof/cohere_ai/07.png)

![Cohere AI proof 8](https://raw.githubusercontent.com/FiscalMindset/coral/cohere-ai-proof-assets/output_proof/cohere_ai/08.png)

![Cohere AI proof 9](https://raw.githubusercontent.com/FiscalMindset/coral/cohere-ai-proof-assets/output_proof/cohere_ai/09.png)

![Cohere AI proof 10](https://raw.githubusercontent.com/FiscalMindset/coral/cohere-ai-proof-assets/output_proof/cohere_ai/10.png)
