### PR TITLE
feat(cli): add basic TUI viewer for query results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -504,7 +504,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -530,7 +530,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -936,6 +936,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,9 +1093,23 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1121,7 +1150,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1243,9 +1272,10 @@ dependencies = [
  "coral-client",
  "coral-mcp",
  "coral-spec",
- "crossterm",
+ "crossterm 0.29.0",
  "dialoguer",
  "jsonschema",
+ "ratatui",
  "regex",
  "rmcp",
  "rust-embed",
@@ -1413,6 +1443,22 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -1422,7 +1468,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1579,7 +1625,7 @@ dependencies = [
  "datafusion-sql",
  "flate2",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "liblzma",
  "log",
  "object_store",
@@ -1613,7 +1659,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
@@ -1638,7 +1684,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object_store",
 ]
@@ -1656,7 +1702,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "log",
  "object_store",
@@ -1703,7 +1749,7 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
- "itertools",
+ "itertools 0.14.0",
  "liblzma",
  "log",
  "object_store",
@@ -1733,7 +1779,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "object_store",
  "tokio",
 ]
@@ -1807,7 +1853,7 @@ dependencies = [
  "datafusion-pruning",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
@@ -1860,7 +1906,7 @@ dependencies = [
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "paste",
  "recursive",
  "serde_json",
@@ -1876,7 +1922,7 @@ dependencies = [
  "arrow",
  "datafusion-common",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "paste",
 ]
 
@@ -1900,7 +1946,7 @@ dependencies = [
  "datafusion-expr-common",
  "datafusion-macros",
  "hex",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "md-5",
  "memchr",
@@ -1978,7 +2024,7 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr-common",
  "hashbrown 0.16.1",
- "itertools",
+ "itertools 0.14.0",
  "itoa",
  "log",
  "paste",
@@ -2052,7 +2098,7 @@ dependencies = [
  "datafusion-expr-common",
  "datafusion-physical-expr",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "recursive",
  "regex",
@@ -2075,7 +2121,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
  "paste",
  "petgraph",
@@ -2095,7 +2141,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "itertools",
+ "itertools 0.14.0",
 ]
 
 [[package]]
@@ -2111,7 +2157,7 @@ dependencies = [
  "datafusion-expr-common",
  "hashbrown 0.16.1",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
 ]
 
@@ -2130,7 +2176,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-pruning",
- "itertools",
+ "itertools 0.14.0",
  "recursive",
 ]
 
@@ -2158,7 +2204,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "num-traits",
  "parking_lot",
@@ -2179,7 +2225,7 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools",
+ "itertools 0.14.0",
  "log",
 ]
 
@@ -2231,7 +2277,7 @@ dependencies = [
  "similar",
  "tracing",
  "tracing-futures",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2738,6 +2784,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3113,6 +3161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,6 +3189,19 @@ dependencies = [
  "once_cell",
  "similar",
  "tempfile",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3159,6 +3229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -3359,6 +3438,12 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -3389,6 +3474,15 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -3642,7 +3736,7 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
@@ -3963,7 +4057,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4083,7 +4177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -4104,7 +4198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4412,6 +4506,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "recursive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4637,6 +4752,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4644,7 +4772,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -5079,10 +5207,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -5163,7 +5319,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5685,10 +5841,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -6469,7 +6642,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,9 @@ opentelemetry-otlp = "0.31.0"
 opentelemetry_sdk = "0.31.0"
 parquet = { version = "58.1.0", features = ["arrow"] }
 prost = "0.14.1"
-reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "json", "rustls-tls-native-roots", "system-proxy"] }
+ratatui = "0.29.0"
 regex = "1"
+reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "json", "rustls-tls-native-roots", "system-proxy"] }
 rmcp = { version = "1.6.0", features = ["client", "transport-child-process"] }
 rusqlite = { version = "0.37", features = ["bundled"] }
 rust-embed = { version = "8", features = ["mime-guess"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,8 @@ urlencoding = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
 walkdir = "2"
 wiremock = "0.6"
-
+scopeguard = "1.2.0"
+unicode-width = "0.2"
 coral-api = { path = "crates/coral-api" }
 coral-app = { path = "crates/coral-app" }
 coral-cli = { path = "crates/coral-cli" }

--- a/crates/coral-cli/Cargo.toml
+++ b/crates/coral-cli/Cargo.toml
@@ -24,6 +24,7 @@ clap.workspace = true
 clap_complete.workspace = true
 crossterm.workspace = true
 dialoguer.workspace = true
+ratatui.workspace = true
 rust-embed = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/coral-cli/Cargo.toml
+++ b/crates/coral-cli/Cargo.toml
@@ -30,6 +30,8 @@ thiserror.workspace = true
 tokio.workspace = true
 tonic.workspace = true
 url.workspace = true
+scopeguard.workspace = true
+unicode-width.workspace = true
 
 coral-api.workspace = true
 coral-app.workspace = true

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -16,6 +16,7 @@ pub mod env;
 mod onboard;
 mod query_error;
 mod source_ops;
+mod tui_viewer;
 
 use std::borrow::Cow;
 use std::path::PathBuf;
@@ -295,6 +296,7 @@ enum SourceCommand {
 enum OutputFormat {
     Table,
     Json,
+    Tui,
 }
 
 /// Typed CLI error whose stderr rendering and exit code are owned by the binary.
@@ -682,11 +684,11 @@ fn print_batches(
     batches: &[arrow::record_batch::RecordBatch],
     format: OutputFormat,
 ) -> Result<(), anyhow::Error> {
-    let output = match format {
-        OutputFormat::Table => format_batches_table(batches)?,
-        OutputFormat::Json => format_batches_json(batches)?,
-    };
-    println!("{output}");
+    match format {
+        OutputFormat::Table => println!("{}", format_batches_table(batches)?),
+        OutputFormat::Json => println!("{}", format_batches_json(batches)?),
+        OutputFormat::Tui => tui_viewer::run_tui_viewer(batches)?,
+    }
     Ok(())
 }
 

--- a/crates/coral-cli/src/tui_viewer.rs
+++ b/crates/coral-cli/src/tui_viewer.rs
@@ -12,19 +12,27 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
     Terminal,
 };
+use unicode_width::UnicodeWidthStr;
 use coral_client::format_batches_table;
 
 pub(crate) fn run_tui_viewer(batches: &[RecordBatch]) -> Result<(), anyhow::Error> {
     // Generate the formatted table string
     let table_string = format_batches_table(batches)?;
     let lines: Vec<&str> = table_string.lines().collect();
-    let max_y = lines.len().saturating_sub(1) as u16;
-    let max_x = lines.iter().map(|l| l.len()).max().unwrap_or(0) as u16;
+    let max_y = u16::try_from(lines.len().saturating_sub(1)).unwrap_or(u16::MAX);
+    let max_x = u16::try_from(lines.iter().map(|l| l.width()).max().unwrap_or(0)).unwrap_or(u16::MAX);
 
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
+    
+    // Ensure terminal state is safely restored on all exit paths
+    scopeguard::defer! {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -96,10 +104,7 @@ pub(crate) fn run_tui_viewer(batches: &[RecordBatch]) -> Result<(), anyhow::Erro
         }
     }
 
-    // Teardown
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    terminal.show_cursor()?;
+    // Teardown is handled automatically by scopeguard::defer
 
     Ok(())
 }

--- a/crates/coral-cli/src/tui_viewer.rs
+++ b/crates/coral-cli/src/tui_viewer.rs
@@ -1,0 +1,105 @@
+use std::io;
+use arrow::record_batch::RecordBatch;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::Alignment,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Terminal,
+};
+use coral_client::format_batches_table;
+
+pub(crate) fn run_tui_viewer(batches: &[RecordBatch]) -> Result<(), anyhow::Error> {
+    // Generate the formatted table string
+    let table_string = format_batches_table(batches)?;
+    let lines: Vec<&str> = table_string.lines().collect();
+    let max_y = lines.len().saturating_sub(1) as u16;
+    let max_x = lines.iter().map(|l| l.len()).max().unwrap_or(0) as u16;
+
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut scroll_y: u16 = 0;
+    let mut scroll_x: u16 = 0;
+
+    loop {
+        terminal.draw(|f| {
+            let area = f.area();
+            
+            // Adjust max scroll bounds based on terminal size
+            let visible_y = area.height.saturating_sub(2); // Subtract borders
+            let visible_x = area.width.saturating_sub(2);
+            
+            let clamped_y = scroll_y.min(max_y.saturating_sub(visible_y));
+            let clamped_x = scroll_x.min(max_x.saturating_sub(visible_x));
+
+            let paragraph = Paragraph::new(table_string.as_str())
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(" Coral SQL Results (q to quit, arrows to scroll) ")
+                        .border_style(Style::default().fg(Color::Cyan)),
+                )
+                .alignment(Alignment::Left)
+                .scroll((clamped_y, clamped_x));
+
+            f.render_widget(paragraph, area);
+            
+            // Sync back the clamped values
+            scroll_y = clamped_y;
+            scroll_x = clamped_x;
+        })?;
+
+        if let Event::Key(key) = event::read()? {
+            if key.kind == KeyEventKind::Press {
+                match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => break,
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        scroll_y = scroll_y.saturating_add(1);
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        scroll_y = scroll_y.saturating_sub(1);
+                    }
+                    KeyCode::Right | KeyCode::Char('l') => {
+                        scroll_x = scroll_x.saturating_add(3);
+                    }
+                    KeyCode::Left | KeyCode::Char('h') => {
+                        scroll_x = scroll_x.saturating_sub(3);
+                    }
+                    KeyCode::PageDown => {
+                        let visible = terminal.size().map(|s| s.height).unwrap_or(10).saturating_sub(2);
+                        scroll_y = scroll_y.saturating_add(visible);
+                    }
+                    KeyCode::PageUp => {
+                        let visible = terminal.size().map(|s| s.height).unwrap_or(10).saturating_sub(2);
+                        scroll_y = scroll_y.saturating_sub(visible);
+                    }
+                    KeyCode::Home => {
+                        scroll_y = 0;
+                        scroll_x = 0;
+                    }
+                    KeyCode::End => {
+                        scroll_y = max_y;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    // Teardown
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    Ok(())
+}

--- a/mock_data/manifest.yaml
+++ b/mock_data/manifest.yaml
@@ -8,7 +8,7 @@ tables:
     description: "Users dataset"
     format: jsonl
     source:
-      location: "file:///C:/Users/THRISHAL/coral/mock_data/users.jsonl"
+      location: "file://~/coral/mock_data/users.jsonl"
     columns:
       - name: id
         type: Int64
@@ -24,7 +24,7 @@ tables:
     description: "Products dataset"
     format: jsonl
     source:
-      location: "file:///C:/Users/THRISHAL/coral/mock_data/products.jsonl"
+      location: "file://~/coral/mock_data/products.jsonl"
     columns:
       - name: product_id
         type: Int64
@@ -40,7 +40,7 @@ tables:
     description: "Orders dataset"
     format: jsonl
     source:
-      location: "file:///C:/Users/THRISHAL/coral/mock_data/orders.jsonl"
+      location: "file://~/coral/mock_data/orders.jsonl"
     columns:
       - name: order_id
         type: Int64

--- a/mock_data/manifest.yaml
+++ b/mock_data/manifest.yaml
@@ -1,0 +1,56 @@
+dsl_version: 3
+name: mock_data
+version: 0.1.0
+description: "Mock data for testing TUI and SQL"
+backend: file
+tables:
+  - name: users
+    description: "Users dataset"
+    format: jsonl
+    source:
+      location: "file:///C:/Users/THRISHAL/coral/mock_data/users.jsonl"
+    columns:
+      - name: id
+        type: Int64
+      - name: name
+        type: Utf8
+      - name: email
+        type: Utf8
+      - name: tier
+        type: Utf8
+      - name: joined
+        type: Utf8
+  - name: products
+    description: "Products dataset"
+    format: jsonl
+    source:
+      location: "file:///C:/Users/THRISHAL/coral/mock_data/products.jsonl"
+    columns:
+      - name: product_id
+        type: Int64
+      - name: name
+        type: Utf8
+      - name: category
+        type: Utf8
+      - name: price
+        type: Float64
+      - name: stock
+        type: Int64
+  - name: orders
+    description: "Orders dataset"
+    format: jsonl
+    source:
+      location: "file:///C:/Users/THRISHAL/coral/mock_data/orders.jsonl"
+    columns:
+      - name: order_id
+        type: Int64
+      - name: user_id
+        type: Int64
+      - name: product_id
+        type: Int64
+      - name: quantity
+        type: Int64
+      - name: status
+        type: Utf8
+      - name: order_date
+        type: Utf8

--- a/mock_data/orders.jsonl
+++ b/mock_data/orders.jsonl
@@ -1,0 +1,12 @@
+{"order_id": 1001, "user_id": 1, "product_id": 101, "quantity": 1, "status": "Delivered", "order_date": "2024-02-01T10:00:00Z"}
+{"order_id": 1002, "user_id": 1, "product_id": 106, "quantity": 2, "status": "Delivered", "order_date": "2024-02-05T14:30:00Z"}
+{"order_id": 1003, "user_id": 2, "product_id": 105, "quantity": 1, "status": "Shipped", "order_date": "2024-02-15T09:15:00Z"}
+{"order_id": 1004, "user_id": 3, "product_id": 103, "quantity": 1, "status": "Delivered", "order_date": "2024-03-05T11:45:00Z"}
+{"order_id": 1005, "user_id": 3, "product_id": 104, "quantity": 1, "status": "Delivered", "order_date": "2024-03-05T11:45:00Z"}
+{"order_id": 1006, "user_id": 4, "product_id": 102, "quantity": 1, "status": "Processing", "order_date": "2024-03-20T16:20:00Z"}
+{"order_id": 1007, "user_id": 5, "product_id": 109, "quantity": 1, "status": "Delivered", "order_date": "2024-04-10T08:00:00Z"}
+{"order_id": 1008, "user_id": 6, "product_id": 110, "quantity": 2, "status": "Shipped", "order_date": "2024-04-15T13:10:00Z"}
+{"order_id": 1009, "user_id": 7, "product_id": 101, "quantity": 5, "status": "Delivered", "order_date": "2024-05-25T10:30:00Z"}
+{"order_id": 1010, "user_id": 8, "product_id": 107, "quantity": 1, "status": "Processing", "order_date": "2024-06-05T09:00:00Z"}
+{"order_id": 1011, "user_id": 9, "product_id": 108, "quantity": 2, "status": "Delivered", "order_date": "2024-06-20T14:45:00Z"}
+{"order_id": 1012, "user_id": 10, "product_id": 109, "quantity": 3, "status": "Shipped", "order_date": "2024-07-10T11:20:00Z"}

--- a/mock_data/products.jsonl
+++ b/mock_data/products.jsonl
@@ -1,0 +1,10 @@
+{"product_id": 101, "name": "Mechanical Keyboard", "category": "Electronics", "price": 120.50, "stock": 45}
+{"product_id": 102, "name": "Wireless Mouse", "category": "Electronics", "price": 45.99, "stock": 120}
+{"product_id": 103, "name": "Standing Desk", "category": "Furniture", "price": 350.00, "stock": 15}
+{"product_id": 104, "name": "Ergonomic Chair", "category": "Furniture", "price": 280.00, "stock": 25}
+{"product_id": 105, "name": "Noise Cancelling Headphones", "category": "Electronics", "price": 250.00, "stock": 60}
+{"product_id": 106, "name": "USB-C Hub", "category": "Accessories", "price": 35.50, "stock": 200}
+{"product_id": 107, "name": "Laptop Stand", "category": "Accessories", "price": 40.00, "stock": 80}
+{"product_id": 108, "name": "Monitor Arm", "category": "Accessories", "price": 75.00, "stock": 40}
+{"product_id": 109, "name": "Coffee Maker", "category": "Appliances", "price": 150.00, "stock": 30}
+{"product_id": 110, "name": "Smart Mug", "category": "Appliances", "price": 95.00, "stock": 50}

--- a/mock_data/users.jsonl
+++ b/mock_data/users.jsonl
@@ -1,0 +1,10 @@
+{"id": 1, "name": "Alice Smith", "email": "alice@example.com", "tier": "Premium", "joined": "2024-01-15T08:30:00Z"}
+{"id": 2, "name": "Bob Jones", "email": "bob@example.com", "tier": "Free", "joined": "2024-02-10T14:45:00Z"}
+{"id": 3, "name": "Charlie Brown", "email": "charlie@example.com", "tier": "Enterprise", "joined": "2024-03-01T09:00:00Z"}
+{"id": 4, "name": "Diana Prince", "email": "diana@example.com", "tier": "Premium", "joined": "2024-03-15T11:20:00Z"}
+{"id": 5, "name": "Evan Wright", "email": "evan@example.com", "tier": "Free", "joined": "2024-04-05T16:10:00Z"}
+{"id": 6, "name": "Fiona Gallagher", "email": "fiona@example.com", "tier": "Premium", "joined": "2024-04-12T10:05:00Z"}
+{"id": 7, "name": "George Miller", "email": "george@example.com", "tier": "Enterprise", "joined": "2024-05-20T13:30:00Z"}
+{"id": 8, "name": "Hannah Abbott", "email": "hannah@example.com", "tier": "Free", "joined": "2024-06-01T08:15:00Z"}
+{"id": 9, "name": "Ian Malcolm", "email": "ian@example.com", "tier": "Premium", "joined": "2024-06-15T15:45:00Z"}
+{"id": 10, "name": "Julia Child", "email": "julia@example.com", "tier": "Enterprise", "joined": "2024-07-04T12:00:00Z"}


### PR DESCRIPTION
## Summary
This PR introduces an interactive Terminal User Interface (TUI) format for visualizing SQL query results, greatly improving the developer experience when analyzing large datasets locally. 
Previously, the `coral sql` command dumped all table outputs directly to stdout, which made horizontal scrolling and dataset inspection difficult on smaller screens. By leveraging the `ratatui` and `crossterm` crates, users can now opt into a fully interactive 2D scrollable data grid.
## What's Included
- **New Output Format**: Added a `--format tui` option to the `coral sql` CLI router.
- **TUI Viewer Engine**: Created `tui_viewer.rs`, implementing a raw-mode terminal loop with smooth keyboard navigation (Arrow keys, `hjkl`, `PageUp/Down`, `Home/End`).
- **Dependencies**: Integrated `ratatui` (workspace v0.29.0) and `crossterm` into the `coral-cli` crate.
- **Mock Data**: Added a local `mock_data` testing suite containing a source `manifest.yaml` and `.jsonl` files (Users, Orders, Products) to allow for robust end-to-end testing of advanced CLI queries without requiring external API credentials.
## Why It Helps
As Coral agents extract increasingly complex relational data, developers need a native way to quickly explore the data shape without piping to external pager utilities (like `less -S`). The TUI viewer provides an immediate, out-of-the-box solution to inspect wide tables without layout breaking or line wrapping, laying the foundation for future features like inline-search, column sorting, and dynamic resizing.