### PR TITLE
fix(engine): reject lossy JSON Int64 coercion

### DIFF
--- a/crates/coral-engine/src/backends/shared/mapping.rs
+++ b/crates/coral-engine/src/backends/shared/mapping.rs
@@ -393,17 +393,11 @@ fn is_json_text(value: &str) -> bool {
     serde_json::from_str::<Value>(value).is_ok()
 }
 
-#[expect(
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    reason = "JSON numeric coercion intentionally accepts lossy conversions into i64 for downstream consumers"
-)]
 fn to_i64(value: Option<Value>) -> Option<i64> {
     match value? {
         Value::Number(v) => v
             .as_i64()
-            .or_else(|| v.as_f64().map(|f| f as i64))
-            .or_else(|| v.as_u64().map(|u| u as i64)),
+            .or_else(|| v.as_u64().and_then(|u| i64::try_from(u).ok())),
         Value::String(v) => v.parse::<i64>().ok(),
         Value::Bool(v) => Some(i64::from(v)),
         Value::Null | Value::Array(_) | Value::Object(_) => None,
@@ -447,7 +441,9 @@ mod tests {
     use coral_spec::{
         ExprSpec, ParsedTemplate, RequestSpec, TimestampInput, parse_source_manifest_value,
     };
-    use datafusion::arrow::array::{Array, BooleanArray, StringArray, TimestampMicrosecondArray};
+    use datafusion::arrow::array::{
+        Array, BooleanArray, Int64Array, StringArray, TimestampMicrosecondArray,
+    };
     use serde_json::{Value, json};
     use std::collections::HashMap;
 
@@ -810,6 +806,64 @@ mod tests {
         assert!(col.is_null(2));
         assert!(col.is_null(3));
         assert!(col.is_null(4));
+    }
+
+    #[test]
+    fn int64_columns_reject_lossy_json_numbers() {
+        let table = table_with_expr(
+            "id",
+            "Int64",
+            &ExprSpec::Path {
+                path: vec!["id".into()],
+            },
+        );
+        let schema = schema_from_columns(table.columns(), "test", table.name()).unwrap();
+        let items = vec![
+            serde_json::from_str(r#"{"id": 1.9}"#).unwrap(),
+            serde_json::from_str(r#"{"id": -1.9}"#).unwrap(),
+            serde_json::from_str(r#"{"id": 1.0}"#).unwrap(),
+            serde_json::from_str(r#"{"id": 1e3}"#).unwrap(),
+            serde_json::from_str(r#"{"id": 1.0000000000000001}"#).unwrap(),
+            json!({"id": i64::MAX}),
+            json!({"id": 9_223_372_036_854_775_808_u64}),
+            json!({"id": u64::MAX}),
+            json!({"id": i64::MAX.to_string()}),
+            json!({"id": "9223372036854775808"}),
+        ];
+
+        let batch = convert_items(
+            table.columns(),
+            schema,
+            &HashMap::new(),
+            &HashMap::new(),
+            &items,
+        )
+        .unwrap();
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+
+        let expected = [
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(i64::MAX),
+            None,
+            None,
+            Some(i64::MAX),
+            None,
+        ];
+        assert_eq!(col.len(), expected.len());
+        for (idx, expected) in expected.into_iter().enumerate() {
+            match expected {
+                Some(value) => assert_eq!(col.value(idx), value, "row {idx}"),
+                None => assert!(col.is_null(idx), "row {idx} should be null"),
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Tighten JSON-to-`Int64` row mapping so Coral no longer silently truncates fractional JSON numbers or accepts unsigned values outside the signed 64-bit range.
- Treat decimal/exponent JSON numeric forms as non-integral for `Int64` because `serde_json` has already rounded them by the time row mapping runs.
- Add regression coverage for fractional values, rounded decimal input, signed bounds, unsigned overflow, and string parsing.

## Why

`Int64` columns currently accept lossy JSON numeric coercions. That can corrupt IDs and counters before later rendering layers, including the MCP-safe JSON serialization path, ever see the value. The engine mapping should reject values it cannot represent exactly instead of manufacturing a plausible but wrong integer.

The mapping layer receives parsed `serde_json::Value`, not the original numeric token text. That means values like `1.0000000000000001` are already indistinguishable from `1.0`; the only reliable integer-path contract here is `Number::as_i64` / checked `as_u64`, plus exact string parsing.

## Test Plan

- [x] `cargo fmt --check`
- [x] `cargo test -p coral-engine --lib backends::shared::mapping::tests::int64_columns_reject_lossy_json_numbers`
- [x] `cargo clippy -p coral-engine --lib --tests --no-deps -- -D warnings`
- [x] `TMPDIR=/home/james/.codex/worktrees/4f7a/coral/target/test-tmp cargo test -p coral-engine --lib`
- [x] `/home/james/src/openclaw/agent-skills/skills/autoreview/scripts/autoreview --mode local`
