### PR TITLE
fix(ui): align source management layout (superseded)

### DIFF
--- a/ui/src/lib/source-categories.ts
+++ b/ui/src/lib/source-categories.ts
@@ -1,0 +1,48 @@
+export interface SourceCategory {
+  key: string
+  label: string
+}
+
+export const SOURCE_CATEGORY_ORDER: SourceCategory[] = [
+  { key: 'observability', label: 'Observability' },
+  { key: 'incident-management', label: 'Incident Management' },
+  { key: 'developer-tools', label: 'Developer Tools' },
+  { key: 'communication', label: 'Communication' },
+  { key: 'project-management', label: 'Project Management' },
+  { key: 'knowledge', label: 'Knowledge & Docs' },
+  { key: 'analytics', label: 'Analytics' },
+  { key: 'business', label: 'Business' },
+  { key: 'ai-ml', label: 'AI/ML' },
+]
+
+const SOURCE_CATEGORY: Record<string, string> = {
+  clickup: 'project-management',
+  claude: 'ai-ml',
+  cloudwatch_logs: 'observability',
+  cloudwatch_metrics: 'observability',
+  codex: 'ai-ml',
+  confluence: 'knowledge',
+  datadog: 'observability',
+  github: 'developer-tools',
+  gitlab: 'developer-tools',
+  google_calendar: 'communication',
+  grafana: 'observability',
+  incident_io: 'incident-management',
+  intercom: 'communication',
+  jira: 'project-management',
+  launchdarkly: 'developer-tools',
+  linear: 'project-management',
+  notion: 'knowledge',
+  openobserve: 'observability',
+  pagerduty: 'incident-management',
+  posthog: 'analytics',
+  sentry: 'observability',
+  slack: 'communication',
+  statusgator: 'observability',
+  stripe: 'business',
+  wandb: 'ai-ml',
+}
+
+export function getCategoryForSource(source: string): string {
+  return SOURCE_CATEGORY[source] ?? 'other'
+}

--- a/ui/src/views/sources/source-detail.css.ts
+++ b/ui/src/views/sources/source-detail.css.ts
@@ -65,6 +65,23 @@ export const section = style({
   gap: 8,
 })
 
+export const fieldGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 14,
+})
+
+export const fieldItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+})
+
+export const fieldLabel = style({
+  color: theme.content.primary,
+  fontWeight: 500,
+})
+
 export const bindingList = style({
   background: theme.surface.onMainContent,
   border: `1px solid ${theme.stroke.secondary}`,

--- a/ui/src/views/sources/source-detail.css.ts
+++ b/ui/src/views/sources/source-detail.css.ts
@@ -82,29 +82,6 @@ export const fieldLabel = style({
   fontWeight: 500,
 })
 
-export const bindingList = style({
-  background: theme.surface.onMainContent,
-  border: `1px solid ${theme.stroke.secondary}`,
-  borderRadius: 8,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 6,
-  padding: 12,
-})
-
-export const bindingRow = style({
-  alignItems: 'center',
-  display: 'grid',
-  gap: 10,
-  gridTemplateColumns: 'minmax(120px, max-content) 1fr',
-})
-
-export const keyLabel = style({
-  color: theme.content.secondary,
-  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-  fontSize: 12,
-})
-
 export const alertError = style({
   alignItems: 'center',
   background: theme.pill.red.background,

--- a/ui/src/views/sources/source-detail.tsx
+++ b/ui/src/views/sources/source-detail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import type { Source } from '@/generated/coral/v1/sources_pb'
+import type { Source, SourceInfo, SourceInputSpec } from '@/generated/coral/v1/sources_pb'
 
 import { Container as ButtonContainer } from '@/wax/components/button/container'
 import { Icon as ButtonIcon } from '@/wax/components/button/icon'
@@ -11,19 +11,26 @@ import { TextInput } from '@/wax/components/inputs/text'
 import { addToast } from '@/wax/components/toast'
 import { Typography } from '@/wax/components/typography'
 
+import { Markdown } from '@/components/markdown'
 import { providerIcon } from '@/lib/provider-icons'
 import {
   createBundledSource,
   deleteSource,
+  getBundledSourceInfo,
   getInstalledSource,
   originLabel,
   type InstallInput,
   type SourceOriginLabel,
 } from '@/lib/sources'
+import { toSentenceCase } from '@/utils/to-sentence-case'
 
 import * as styles from './source-detail.css'
 
 const SECRET_PLACEHOLDER = '••••••••'
+
+function formatFieldName(key: string): string {
+  return toSentenceCase(key.replace(/_/g, ' '))
+}
 
 export function SourceDetailDialog({
   name,
@@ -65,6 +72,7 @@ function SourceDetailDialogContent({
   onRemoved: (name: string) => void
 }) {
   const [source, setSource] = useState<Source | null>(null)
+  const [sourceInfo, setSourceInfo] = useState<SourceInfo | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [confirmingRemove, setConfirmingRemove] = useState(false)
   const [deleting, setDeleting] = useState(false)
@@ -74,9 +82,15 @@ function SourceDetailDialogContent({
   const refresh = useCallback(async () => {
     try {
       const installed = await getInstalledSource(name)
+      const info =
+        originLabel(installed.origin) === 'bundled' ? (await getBundledSourceInfo(name)).info : null
       setSource(installed)
+      setSourceInfo(info)
       setDrafts({})
+      setLoadError(null)
     } catch (e) {
+      setSource(null)
+      setSourceInfo(null)
       setLoadError(e instanceof Error ? e.message : String(e))
     }
   }, [name])
@@ -102,6 +116,20 @@ function SourceDetailDialogContent({
 
   const hasChanges = useMemo(() => {
     if (!source) return false
+    if (sourceInfo) {
+      const variables = new Map(source.variables.map((v) => [v.key, v.value]))
+      for (const input of sourceInfo.inputs) {
+        if (input.input.case === 'variable') {
+          const draft = drafts[`var:${input.key}`]
+          const current = variables.get(input.key) ?? input.input.value.defaultValue ?? ''
+          if (draft !== undefined && draft !== current) return true
+        } else if (input.input.case === 'secret') {
+          const draft = drafts[`sec:${input.key}`]
+          if (draft !== undefined && draft.trim().length > 0) return true
+        }
+      }
+      return false
+    }
     for (const v of source.variables) {
       const draft = drafts[`var:${v.key}`]
       if (draft !== undefined && draft !== v.value) return true
@@ -111,23 +139,49 @@ function SourceDetailDialogContent({
       if (draft !== undefined && draft.trim().length > 0) return true
     }
     return false
-  }, [drafts, source])
+  }, [drafts, source, sourceInfo])
 
   async function save() {
     if (!source) return
     setSaving(true)
     try {
-      const bindings: InstallInput[] = source.variables.map((v) => ({
-        key: v.key,
-        value: drafts[`var:${v.key}`] ?? v.value,
-        secret: false,
-      }))
-      for (const s of source.secrets) {
-        const draft = drafts[`sec:${s.key}`]
-        if (draft === undefined) continue
-        const trimmed = draft.trim()
-        if (trimmed.length > 0) {
-          bindings.push({ key: s.key, value: trimmed, secret: true })
+      const bindings: InstallInput[] = []
+      if (sourceInfo) {
+        const variables = new Map(source.variables.map((v) => [v.key, v.value]))
+        for (const input of sourceInfo.inputs) {
+          if (input.input.case === 'variable') {
+            const value = (
+              drafts[`var:${input.key}`] ??
+              variables.get(input.key) ??
+              input.input.value.defaultValue ??
+              ''
+            ).trim()
+            if (value.length > 0) bindings.push({ key: input.key, value, secret: false })
+            continue
+          }
+          if (input.input.case !== 'secret') continue
+          const draft = drafts[`sec:${input.key}`]
+          if (draft === undefined) continue
+          const trimmed = draft.trim()
+          if (trimmed.length > 0) {
+            bindings.push({ key: input.key, value: trimmed, secret: true })
+          }
+        }
+      } else {
+        bindings.push(
+          ...source.variables.map((v) => ({
+            key: v.key,
+            value: drafts[`var:${v.key}`] ?? v.value,
+            secret: false,
+          })),
+        )
+        for (const s of source.secrets) {
+          const draft = drafts[`sec:${s.key}`]
+          if (draft === undefined) continue
+          const trimmed = draft.trim()
+          if (trimmed.length > 0) {
+            bindings.push({ key: s.key, value: trimmed, secret: true })
+          }
         }
       }
       await createBundledSource(name, bindings)
@@ -177,7 +231,31 @@ function SourceDetailDialogContent({
 
       {!source && !loadError ? (
         <Typography.BodySmall variant="tertiary">Loading…</Typography.BodySmall>
-      ) : !source ? null : source.variables.length === 0 && source.secrets.length === 0 ? (
+      ) : !source ? null : sourceInfo ? (
+        <SourceInfoBindings
+          disabled={!editable || saving}
+          drafts={drafts}
+          onSecretBlur={(key) => {
+            const draftKey = `sec:${key}`
+            if (drafts[draftKey] !== '') return
+            setDrafts((previous) => {
+              const next = { ...previous }
+              delete next[draftKey]
+              return next
+            })
+          }}
+          onSecretFocus={(key) => {
+            const draftKey = `sec:${key}`
+            if (drafts[draftKey] !== undefined) return
+            setDrafts((previous) => ({ ...previous, [draftKey]: '' }))
+          }}
+          onValueChange={(key, value, secret) =>
+            setDrafts((previous) => ({ ...previous, [`${secret ? 'sec' : 'var'}:${key}`]: value }))
+          }
+          source={source}
+          sourceInfo={sourceInfo}
+        />
+      ) : source.variables.length === 0 && source.secrets.length === 0 ? (
         <section className={styles.section}>
           <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
           <Typography.BodySmall variant="tertiary">No bindings recorded.</Typography.BodySmall>
@@ -278,6 +356,117 @@ function SourceDetailDialogContent({
         </Dialog.Portal>
       </Dialog.Root>
     </>
+  )
+}
+
+function SourceInfoBindings({
+  disabled,
+  drafts,
+  onSecretBlur,
+  onSecretFocus,
+  onValueChange,
+  source,
+  sourceInfo,
+}: {
+  disabled: boolean
+  drafts: Record<string, string>
+  onSecretBlur: (key: string) => void
+  onSecretFocus: (key: string) => void
+  onValueChange: (key: string, value: string, secret: boolean) => void
+  source: Source
+  sourceInfo: SourceInfo
+}) {
+  const variables = useMemo(() => new Map(source.variables.map((v) => [v.key, v.value])), [source])
+  const configuredSecrets = useMemo(() => new Set(source.secrets.map((s) => s.key)), [source])
+
+  if (sourceInfo.inputs.length === 0) {
+    return (
+      <section className={styles.section}>
+        <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
+        <Typography.BodySmall variant="tertiary">No bindings recorded.</Typography.BodySmall>
+      </section>
+    )
+  }
+
+  return (
+    <section className={styles.section}>
+      <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
+      <div className={styles.fieldGroup}>
+        {sourceInfo.inputs.map((input) => (
+          <SourceInfoInputRow
+            key={input.key}
+            configuredSecret={configuredSecrets.has(input.key)}
+            disabled={disabled}
+            draft={drafts[`${input.input.case === 'secret' ? 'sec' : 'var'}:${input.key}`]}
+            input={input}
+            onSecretBlur={onSecretBlur}
+            onSecretFocus={onSecretFocus}
+            onValueChange={onValueChange}
+            value={variables.get(input.key)}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function SourceInfoInputRow({
+  configuredSecret,
+  disabled,
+  draft,
+  input,
+  onSecretBlur,
+  onSecretFocus,
+  onValueChange,
+  value,
+}: {
+  configuredSecret: boolean
+  disabled: boolean
+  draft: string | undefined
+  input: SourceInputSpec
+  onSecretBlur: (key: string) => void
+  onSecretFocus: (key: string) => void
+  onValueChange: (key: string, value: string, secret: boolean) => void
+  value: string | undefined
+}) {
+  if (input.input.case === 'variable') {
+    const resolved = value ?? input.input.value.defaultValue ?? ''
+    return (
+      <Field input={input}>
+        <TextInput
+          value={draft ?? resolved}
+          onChange={(next) => onValueChange(input.key, next, false)}
+          placeholder={resolved || formatFieldName(input.key)}
+          disabled={disabled}
+        />
+      </Field>
+    )
+  }
+
+  if (input.input.case !== 'secret') return null
+
+  return (
+    <Field input={input}>
+      <TextInput
+        type="password"
+        value={draft ?? (configuredSecret ? SECRET_PLACEHOLDER : '')}
+        onBlur={() => onSecretBlur(input.key)}
+        onChange={(next) => onValueChange(input.key, next, true)}
+        onFocus={() => onSecretFocus(input.key)}
+        placeholder={formatFieldName(input.key)}
+        disabled={disabled}
+      />
+    </Field>
+  )
+}
+
+function Field({ input, children }: { input: SourceInputSpec; children: React.ReactNode }) {
+  return (
+    <div className={styles.fieldItem}>
+      <Typography.Body className={styles.fieldLabel}>{formatFieldName(input.key)}</Typography.Body>
+      {children}
+      {input.hint ? <Markdown>{input.hint}</Markdown> : null}
+    </div>
   )
 }
 

--- a/ui/src/views/sources/source-detail.tsx
+++ b/ui/src/views/sources/source-detail.tsx
@@ -261,46 +261,15 @@ function SourceDetailDialogContent({
           <Typography.BodySmall variant="tertiary">No bindings recorded.</Typography.BodySmall>
         </section>
       ) : (
-        <section className={styles.section}>
-          <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
-          {!editable ? (
-            <Typography.BodySmall variant="tertiary">
-              Imported sources can't be edited here yet — re-import the source spec to change its
-              credentials.
-            </Typography.BodySmall>
-          ) : null}
-          <div className={styles.bindingList}>
-            {source.variables.map((v) => {
-              const draftKey = `var:${v.key}`
-              return (
-                <div key={draftKey} className={styles.bindingRow}>
-                  <span className={styles.keyLabel}>{v.key}</span>
-                  <TextInput
-                    value={drafts[draftKey] ?? v.value}
-                    onChange={(value) => setDrafts((p) => ({ ...p, [draftKey]: value }))}
-                    placeholder={v.key}
-                    disabled={!editable || saving}
-                  />
-                </div>
-              )
-            })}
-            {source.secrets.map((s) => {
-              const draftKey = `sec:${s.key}`
-              return (
-                <div key={draftKey} className={styles.bindingRow}>
-                  <span className={styles.keyLabel}>{s.key}</span>
-                  <TextInput
-                    type="password"
-                    value={drafts[draftKey] ?? ''}
-                    onChange={(value) => setDrafts((p) => ({ ...p, [draftKey]: value }))}
-                    placeholder={SECRET_PLACEHOLDER}
-                    disabled={!editable || saving}
-                  />
-                </div>
-              )
-            })}
-          </div>
-        </section>
+        <FallbackBindings
+          disabled={!editable || saving}
+          drafts={drafts}
+          editable={editable}
+          onValueChange={(draftKey, value) =>
+            setDrafts((previous) => ({ ...previous, [draftKey]: value }))
+          }
+          source={source}
+        />
       )}
 
       <Dialog.Actions>
@@ -356,6 +325,67 @@ function SourceDetailDialogContent({
         </Dialog.Portal>
       </Dialog.Root>
     </>
+  )
+}
+
+function FallbackBindings({
+  disabled,
+  drafts,
+  editable,
+  onValueChange,
+  source,
+}: {
+  disabled: boolean
+  drafts: Record<string, string>
+  editable: boolean
+  onValueChange: (draftKey: string, value: string) => void
+  source: Source
+}) {
+  return (
+    <section className={styles.section}>
+      <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
+      {!editable ? (
+        <Typography.BodySmall variant="tertiary">
+          Imported sources can't be edited here yet — re-import the source spec to change its
+          credentials.
+        </Typography.BodySmall>
+      ) : null}
+      <div className={styles.fieldGroup}>
+        {source.variables.map((v) => {
+          const draftKey = `var:${v.key}`
+          return (
+            <div key={draftKey} className={styles.fieldItem}>
+              <Typography.Body className={styles.fieldLabel}>
+                {formatFieldName(v.key)}
+              </Typography.Body>
+              <TextInput
+                value={drafts[draftKey] ?? v.value}
+                onChange={(value) => onValueChange(draftKey, value)}
+                placeholder={formatFieldName(v.key)}
+                disabled={disabled}
+              />
+            </div>
+          )
+        })}
+        {source.secrets.map((s) => {
+          const draftKey = `sec:${s.key}`
+          return (
+            <div key={draftKey} className={styles.fieldItem}>
+              <Typography.Body className={styles.fieldLabel}>
+                {formatFieldName(s.key)}
+              </Typography.Body>
+              <TextInput
+                type="password"
+                value={drafts[draftKey] ?? ''}
+                onChange={(value) => onValueChange(draftKey, value)}
+                placeholder={SECRET_PLACEHOLDER}
+                disabled={disabled}
+              />
+            </div>
+          )
+        })}
+      </div>
+    </section>
   )
 }
 

--- a/ui/src/views/sources/sources-index.css.ts
+++ b/ui/src/views/sources/sources-index.css.ts
@@ -150,8 +150,23 @@ export const cardFooter = style({
   alignItems: 'center',
   color: theme.content.tertiary,
   display: 'flex',
+  gap: 8,
   justifyContent: 'space-between',
   marginBlockStart: 'auto',
+})
+
+export const connectedPill = style({
+  alignItems: 'center',
+  background: theme.pill.green.background,
+  border: `1px solid ${theme.pill.green.stroke}`,
+  borderRadius: 999,
+  color: theme.pill.green.color,
+  display: 'inline-flex',
+  flexShrink: 0,
+  fontSize: 11,
+  fontWeight: 600,
+  gap: 4,
+  padding: '2px 8px',
 })
 
 export const originPill = style({

--- a/ui/src/views/sources/sources-index.tsx
+++ b/ui/src/views/sources/sources-index.tsx
@@ -6,6 +6,7 @@ import { Typography } from '@/wax/components/typography'
 
 import { ErrorBanner } from '@/components/error-banner'
 import { providerIcon } from '@/lib/provider-icons'
+import { SOURCE_CATEGORY_ORDER, getCategoryForSource } from '@/lib/source-categories'
 import {
   discoverBundled,
   listInstalledSources,
@@ -101,8 +102,26 @@ export function SourcesIndex() {
     )
   }, [allEntries, search])
 
-  const connected = useMemo(() => filtered.filter((entry) => entry.installed), [filtered])
-  const available = useMemo(() => filtered.filter((entry) => !entry.installed), [filtered])
+  const sections = useMemo(() => {
+    const grouped = new Map<string, IndexEntry[]>()
+    for (const entry of filtered) {
+      const category = getCategoryForSource(entry.name)
+      const group = grouped.get(category)
+      if (group) {
+        group.push(entry)
+      } else {
+        grouped.set(category, [entry])
+      }
+    }
+
+    const ordered = SOURCE_CATEGORY_ORDER.map((category) => ({
+      ...category,
+      entries: grouped.get(category.key) ?? [],
+    })).filter((category) => category.entries.length > 0)
+    const other = grouped.get('other')
+    if (other?.length) ordered.push({ key: 'other', label: 'Other', entries: other })
+    return ordered
+  }, [filtered])
 
   const onPick = (entry: IndexEntry) => {
     if (entry.installed) {
@@ -171,10 +190,10 @@ export function SourcesIndex() {
           </div>
         ) : null}
 
-        {connected.length > 0 ? (
-          <Section title="Connected" count={connected.length}>
+        {sections.map((section) => (
+          <Section key={section.key} title={section.label} count={section.entries.length}>
             <div className={styles.cardGrid}>
-              {connected.map((entry) => (
+              {section.entries.map((entry) => (
                 <SourceCard
                   key={`${entry.origin}:${entry.name}`}
                   entry={entry}
@@ -183,21 +202,9 @@ export function SourcesIndex() {
               ))}
             </div>
           </Section>
-        ) : null}
+        ))}
 
-        {available.length > 0 ? (
-          <Section title="Available" count={available.length}>
-            <div className={styles.cardGrid}>
-              {available.map((entry) => (
-                <SourceCard
-                  key={`${entry.origin}:${entry.name}`}
-                  entry={entry}
-                  onClick={() => onPick(entry)}
-                />
-              ))}
-            </div>
-          </Section>
-        ) : !loading && !error && allEntries.length > 0 ? (
+        {sections.length === 0 && !loading && !error && allEntries.length > 0 ? (
           <Typography.BodySmall variant="tertiary">
             No sources match your search.
           </Typography.BodySmall>
@@ -275,6 +282,12 @@ function SourceCard({ entry, onClick }: { entry: IndexEntry; onClick: () => void
         <Typography.BodySmall variant="tertiary">
           v{entry.installedVersion ?? entry.version}
         </Typography.BodySmall>
+        {entry.installed ? (
+          <span className={styles.connectedPill}>
+            <Icon name="CircleCheck" size="14" color="inherit" />
+            Connected
+          </span>
+        ) : null}
       </div>
     </button>
   )

--- a/ui/src/wax/components/inputs/text/text-input.tsx
+++ b/ui/src/wax/components/inputs/text/text-input.tsx
@@ -13,6 +13,7 @@ export interface TextInputProps {
   name?: string
   onBlur?: () => void
   onChange?: (value: string) => void
+  onFocus?: () => void
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
   placeholder?: string
   ref?: React.Ref<HTMLInputElement>
@@ -28,6 +29,7 @@ export function TextInput({
   name,
   onBlur,
   onChange,
+  onFocus,
   onKeyDown,
   placeholder,
   ref,
@@ -55,6 +57,7 @@ export function TextInput({
           name={name}
           onBlur={onBlur}
           onChange={handleChange}
+          onFocus={onFocus}
           onKeyDown={onKeyDown}
           placeholder={placeholder}
           ref={ref}

--- a/ui/tests/ui/sources.spec.ts
+++ b/ui/tests/ui/sources.spec.ts
@@ -71,7 +71,7 @@ test('installs a core source via paste, edits a binding, and removes it', async 
   )
   const detailDialog = page.getByRole('dialog', { name: /Linear/i })
   await expect(detailDialog.getByRole('heading', { name: 'Configuration' })).toBeVisible()
-  await expect(detailDialog.getByText('LINEAR_API_TOKEN')).toBeVisible()
+  await expect(detailDialog.getByText('Linear api token', { exact: true })).toBeVisible()
   await review.pause()
 
   await review.chapter(
@@ -95,6 +95,44 @@ test('installs a core source via paste, edits a binding, and removes it', async 
 
   await expect(page.getByText('Removed linear')).toBeVisible()
   await expect(page.getByRole('button', { name: /Linear/i })).toBeVisible()
+  await review.pause()
+})
+
+test('installed source detail uses manifest fields and masked secrets', async ({
+  network,
+  page,
+  review,
+}) => {
+  network.use(...sourceLifecycleHandlers())
+
+  await page.goto('/#/sources')
+
+  await review.chapter(
+    'Open an installed source',
+    'CloudWatch Logs uses manifest defaults and configured secret inputs',
+  )
+  await page.getByRole('button', { name: /cloudwatch_logs/i }).click()
+
+  const dialog = page.getByRole('dialog', { name: /cloudwatch_logs/i })
+  await expect(dialog.getByRole('heading', { name: 'Configuration' })).toBeVisible()
+  await expect(dialog.getByText('Aws region', { exact: true })).toBeVisible()
+  const variableInputs = dialog.locator('input[type="text"]')
+  await expect(variableInputs.nth(0)).toHaveValue('us-east-1')
+  await expect(variableInputs.nth(1)).toHaveValue('amazonaws.com')
+
+  const secretInputs = dialog.locator('input[type="password"]')
+  await expect(secretInputs).toHaveCount(2)
+  await expect(secretInputs.first()).toHaveValue('••••••••')
+  await review.pause()
+
+  await review.chapter(
+    'Replace a configured secret',
+    'Focusing the masked secret clears the sentinel and allows a new value',
+  )
+  await secretInputs.first().focus()
+  await expect(secretInputs.first()).toHaveValue('')
+  await secretInputs.first().fill('AKIAUPDATED')
+  await expect(dialog.getByRole('button', { name: 'Save changes' })).toBeVisible()
   await review.pause()
 })
 

--- a/ui/tests/ui/sources.spec.ts
+++ b/ui/tests/ui/sources.spec.ts
@@ -1,7 +1,7 @@
 import { sourceLifecycleHandlers } from './support/source-handlers'
 import { expect, test } from './playwright.setup'
 
-test('lists core sources, searches, and shows the connected origin badge', async ({
+test('lists core sources by category, searches, and shows connected status', async ({
   network,
   page,
   review,
@@ -15,8 +15,12 @@ test('lists core sources, searches, and shows the connected origin badge', async
   await page.goto('/#/sources')
 
   await expect(page.getByRole('heading', { name: 'Sources', level: 1 })).toBeVisible()
-  await expect(page.getByRole('heading', { name: 'Connected' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Observability' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Developer Tools' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Communication' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Project Management' })).toBeVisible()
   await expect(page.getByRole('button', { name: /Github/i })).toBeVisible()
+  await expect(page.getByRole('button', { name: /Github/i }).getByText('Connected')).toBeVisible()
   await expect(page.getByRole('button', { name: /Linear/i })).toBeVisible()
   await expect(page.getByRole('button', { name: /Slack/i })).toBeVisible()
   await expect(page.getByRole('button', { name: /Sentry/i })).toBeVisible()

--- a/ui/tests/ui/support/source-fixtures.ts
+++ b/ui/tests/ui/support/source-fixtures.ts
@@ -87,6 +87,53 @@ const githubInfo = makeBundledSourceWithVariable(
   true,
 )
 
+const cloudwatchLogsInfo = create(SourceInfoSchema, {
+  name: 'cloudwatch_logs',
+  description: 'Query Amazon CloudWatch Logs groups, streams, and events.',
+  version: '0.1.0',
+  installed: true,
+  origin: SourceOrigin.BUNDLED,
+  credentialStorage: SourceCredentialStorage.FILE,
+  inputs: [
+    create(SourceInputSpecSchema, {
+      key: 'AWS_REGION',
+      required: false,
+      hint: 'AWS region for CloudWatch Logs API requests, for example `us-east-1`.',
+      input: {
+        case: 'variable',
+        value: create(SourceVariableInputSchema, { defaultValue: 'us-east-1' }),
+      },
+    }),
+    create(SourceInputSpecSchema, {
+      key: 'AWS_ENDPOINT_SUFFIX',
+      required: false,
+      hint: 'AWS endpoint DNS suffix. Keep `amazonaws.com` for standard AWS regions.',
+      input: {
+        case: 'variable',
+        value: create(SourceVariableInputSchema, { defaultValue: 'amazonaws.com' }),
+      },
+    }),
+    create(SourceInputSpecSchema, {
+      key: 'AWS_ACCESS_KEY_ID',
+      required: true,
+      hint: 'AWS access key ID with CloudWatch Logs read permissions.',
+      input: {
+        case: 'secret',
+        value: create(SourceSecretInputSchema, {}),
+      },
+    }),
+    create(SourceInputSpecSchema, {
+      key: 'AWS_SECRET_ACCESS_KEY',
+      required: true,
+      hint: 'AWS secret access key.',
+      input: {
+        case: 'secret',
+        value: create(SourceSecretInputSchema, {}),
+      },
+    }),
+  ],
+})
+
 const linearInfo = makeSourceInfo(
   'linear',
   'Query issues, projects, cycles, teams, and users from Linear.',
@@ -105,7 +152,13 @@ const sentryInfo = makeSourceInfo(
   false,
 )
 
-export const bundledCatalog: SourceInfo[] = [githubInfo, linearInfo, slackInfo, sentryInfo]
+export const bundledCatalog: SourceInfo[] = [
+  cloudwatchLogsInfo,
+  githubInfo,
+  linearInfo,
+  slackInfo,
+  sentryInfo,
+]
 
 const installedGithub: Source = create(SourceSchema, {
   name: 'github',
@@ -118,6 +171,21 @@ const installedGithub: Source = create(SourceSchema, {
   secrets: [create(SourceSecretSchema, { key: 'GITHUB_TOKEN', value: '' })],
 })
 
+const installedCloudwatchLogs: Source = create(SourceSchema, {
+  name: 'cloudwatch_logs',
+  version: '0.1.0',
+  origin: SourceOrigin.BUNDLED,
+  credentialStorage: SourceCredentialStorage.FILE,
+  variables: [
+    create(SourceVariableSchema, { key: 'AWS_REGION', value: 'us-east-1' }),
+    create(SourceVariableSchema, { key: 'AWS_ENDPOINT_SUFFIX', value: 'amazonaws.com' }),
+  ],
+  secrets: [
+    create(SourceSecretSchema, { key: 'AWS_ACCESS_KEY_ID', value: '' }),
+    create(SourceSecretSchema, { key: 'AWS_SECRET_ACCESS_KEY', value: '' }),
+  ],
+})
+
 const installedLinear: Source = create(SourceSchema, {
   name: 'linear',
   version: '1.0.0',
@@ -127,7 +195,7 @@ const installedLinear: Source = create(SourceSchema, {
   secrets: [create(SourceSecretSchema, { key: 'LINEAR_API_TOKEN', value: '' })],
 })
 
-export const initialInstalledSources: Source[] = [installedGithub]
+export const initialInstalledSources: Source[] = [installedCloudwatchLogs, installedGithub]
 
 export const discoverInitialResponse = create(DiscoverSourcesResponseSchema, {
   sources: bundledCatalog,
@@ -153,9 +221,15 @@ export const listAfterLinearRemovedResponse = listInitialResponse
 
 export const getInfoLinearResponse = create(GetSourceInfoResponseSchema, { sourceInfo: linearInfo })
 export const getInfoGithubResponse = create(GetSourceInfoResponseSchema, { sourceInfo: githubInfo })
+export const getInfoCloudwatchLogsResponse = create(GetSourceInfoResponseSchema, {
+  sourceInfo: cloudwatchLogsInfo,
+})
 
 export const getInstalledGithubResponse = create(GetSourceResponseSchema, {
   source: installedGithub,
+})
+export const getInstalledCloudwatchLogsResponse = create(GetSourceResponseSchema, {
+  source: installedCloudwatchLogs,
 })
 export const getInstalledLinearResponse = create(GetSourceResponseSchema, {
   source: installedLinear,

--- a/ui/tests/ui/support/source-handlers.ts
+++ b/ui/tests/ui/support/source-handlers.ts
@@ -15,8 +15,10 @@ import {
   discoverAfterLinearInstallResponse,
   discoverAfterLinearRemovedResponse,
   discoverInitialResponse,
+  getInfoCloudwatchLogsResponse,
   getInfoGithubResponse,
   getInfoLinearResponse,
+  getInstalledCloudwatchLogsResponse,
   getInstalledGithubResponse,
   getInstalledLinearResponse,
   listAfterLinearInstallResponse,
@@ -44,14 +46,20 @@ export function sourceLifecycleHandlers() {
     http.post(listUrl, () => grpcWebResponse(ListSourcesResponseSchema, listResponse)),
     http.post(getInfoUrl, async ({ request }) => {
       const body = new TextDecoder().decode(await request.arrayBuffer())
-      const response = body.includes('github') ? getInfoGithubResponse : getInfoLinearResponse
+      const response = body.includes('cloudwatch_logs')
+        ? getInfoCloudwatchLogsResponse
+        : body.includes('github')
+          ? getInfoGithubResponse
+          : getInfoLinearResponse
       return grpcWebResponse(GetSourceInfoResponseSchema, response)
     }),
     http.post(getUrl, async ({ request }) => {
       const body = new TextDecoder().decode(await request.arrayBuffer())
       const response = body.includes('linear')
         ? getInstalledLinearResponse
-        : getInstalledGithubResponse
+        : body.includes('cloudwatch_logs')
+          ? getInstalledCloudwatchLogsResponse
+          : getInstalledGithubResponse
       return grpcWebResponse(GetSourceResponseSchema, response)
     }),
     http.post(createBundledUrl, () => {


### PR DESCRIPTION
Superseded by #826.

The remaining changes from this follow-up branch were cherry-picked into `sources-management-v2` and pushed to PR #826:

- installed bundled source detail forms now render from manifest `SourceInfo.inputs`
- visible manifest defaults, including the CloudWatch AWS defaults, prefill in detail
- configured secrets render as masked placeholders and are only submitted when replaced
- the gray key/value binding fallback box was removed

Validation on #826 after collapsing these changes:

- `npm run check --prefix ui`
- `npm run type-check --prefix ui`
- `npm run test:ui --prefix ui -- ui/tests/ui/sources.spec.ts`