### PR TITLE
fix(sources/core/github): address manifest follow-up gaps

### DIFF
--- a/sources/core/github/README.md
+++ b/sources/core/github/README.md
@@ -1,9 +1,9 @@
 # GitHub Connector
 
-**Version:** 1.1.7
+**Version:** 1.1.8
 **Source:** OpenAPI-generated from GitHub's v3 REST API spec
 **Backend:** HTTP
-**Tables:** 362
+**Tables:** 364
 **Base URL:** `https://api.github.com` (override with `GITHUB_API_BASE` env var)
 
 ## Authentication
@@ -39,12 +39,12 @@ which avoids retrying ordinary permission failures.
 
 | Filter pattern | Tables | Example |
 |---|---|---|
-| No filter | 55 | `SELECT * FROM github.user_repos` |
+| No filter | 56 | `SELECT * FROM github.user_repos` |
 | `owner` + `repo` | 79 | `WHERE owner = 'org' AND repo = 'name'` |
 | `org` | 80 | `WHERE org = 'myorg'` |
 | `username` | 14 | `WHERE username = 'user'` |
 | `enterprise` | 8 | `WHERE enterprise = 'slug'` |
-| Compound (IDs) | 126 | `WHERE owner = '...' AND repo = '...' AND run_id = 123` |
+| Compound (IDs) | 127 | `WHERE owner = '...' AND repo = '...' AND run_id = 123` |
 
 Search is exposed through source-scoped table functions rather than tables.
 
@@ -60,10 +60,11 @@ Search is exposed through source-scoped table functions rather than tables.
 | Enterprise | ~12 | Enterprise Cloud account |
 | GitHub App JWT | ~19 | GitHub App installation, not a PAT |
 
-#### No filter required (26 tables)
+#### No filter required (27 tables)
 
 | Table | Description |
 |---|---|
+| `authenticated_user` | Authenticated user profile alias |
 | `user` | Authenticated user profile |
 | `user_repos` | Repositories for the authenticated user |
 | `user_starred` | Starred repositories |
@@ -212,7 +213,7 @@ Statistics:
 | `participation` | 1 | Owner vs non-owner commits |
 | `repo_stat_contributors` | 1 | Contributor statistics |
 
-#### Organization tables (4 tables confirmed)
+#### Organization tables (5 tables confirmed)
 
 | Table | Notes |
 |---|---|
@@ -220,6 +221,7 @@ Statistics:
 | `org_repos` | Organization repositories |
 | `members` | Org members (empty with limited PAT) |
 | `public_members` | Public org members |
+| `org_team_memberships` | Team membership by `org`, `team_slug`, and `username` |
 
 Remaining ~104 org tables require the PAT to be scoped to the organization with admin permissions.
 
@@ -275,6 +277,50 @@ LIMIT 50;
 
 Swap in qualifiers such as `review-requested:USER`, `review:none`, or
 `user-review-requested:@me` for reviewer workflows.
+
+For repo-scoped pull request lists, use the compact alias columns when you want
+the PR number, branch refs, head SHA, and author login without double-underscore
+field names:
+
+```sql
+SELECT pull_number, title, head_ref, head_sha, base_ref, user_login
+FROM github.pulls
+WHERE owner = 'myorg' AND repo = 'myrepo' AND state = 'open'
+ORDER BY updated_at DESC
+LIMIT 20;
+```
+
+`github.pulls.merged` is only populated by GitHub's per-PR lookup. For list
+workflows, identify merged pull requests with `merged_at IS NOT NULL` or start
+from `github.search_issues(q => 'repo:myorg/myrepo is:pull-request is:merged')`.
+
+```sql
+SELECT pull_number, title, merged_at
+FROM github.pulls
+WHERE owner = 'myorg' AND repo = 'myrepo' AND state = 'closed'
+  AND merged_at IS NOT NULL
+LIMIT 20;
+```
+
+`github.requested_reviewers` returns raw `users` and `teams` JSON plus compact
+`requested_reviewer_logins`, `requested_team_names`, `user_logins`,
+`team_names`, and `team_slugs` columns:
+
+```sql
+SELECT pull_number, requested_reviewer_logins, requested_team_names
+FROM github.requested_reviewers
+WHERE owner = 'myorg' AND repo = 'myrepo' AND pull_number = 123;
+```
+
+Use `github.authenticated_user` for the current token's user profile:
+
+```sql
+SELECT login, html_url
+FROM github.authenticated_user;
+```
+
+Use `github.org_team_memberships` when you know `org` and `team_slug`; the
+legacy `github.memberships` table is for numeric `team_id` lookups.
 
 For workflow runs, `repo_action_runs` accepts natural aliases for the GitHub
 `branch` and `status` parameters:

--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 1.1.7
+version: 1.1.8
 dsl_version: 3
 backend: http
 description: >-
@@ -57223,9 +57223,8 @@ tables:
   - name: memberships
     description: Get team membership for a user (Legacy)
     guide: >
-      Use this table to inspect one team membership. Requires team_id and username. If you only
-      know org and team_slug, resolve team_id from github.teams first; org and team_slug then select
-      the matching org team route instead of the legacy team_id path.
+      Use this legacy table when you already have the numeric team_id. Requires team_id and
+      username. If you only know org and team_slug, use github.org_team_memberships instead.
     filters:
       - name: team_id
         required: true
@@ -57313,6 +57312,81 @@ tables:
         expr:
           kind: from_filter
           key: team_slug
+  - name: org_team_memberships
+    description: Get organization team membership for a user
+    guide: >
+      Requires org, team_slug, and username. Use this table when you know the organization and team
+      slug. A missing membership returns an empty result instead of failing the query.
+    filters:
+      - name: org
+        required: true
+      - name: team_slug
+        required: true
+      - name: username
+        required: true
+    request:
+      method: GET
+      path: /orgs/{{filter.org}}/teams/{{filter.team_slug}}/memberships/{{filter.username}}
+    response:
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: link_header
+      page_start: 0
+      page_step: 1
+      offset_start: 0
+      link_header_require_results: false
+    columns:
+      - name: role
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: The role of the user in the team.
+        expr:
+          kind: path
+          path:
+            - role
+      - name: state
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: The state of the user's membership in the team.
+        expr:
+          kind: path
+          path:
+            - state
+      - name: url
+        type: Utf8
+        nullable: true
+        virtual: false
+        expr:
+          kind: path
+          path:
+            - url
+      - name: org
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: The organization name.
+        expr:
+          kind: from_filter
+          key: org
+      - name: team_slug
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: The slug of the team name.
+        expr:
+          kind: from_filter
+          key: team_slug
+      - name: username
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: The handle for the GitHub user account.
+        expr:
+          kind: from_filter
+          key: username
   - name: meta
     description: Get GitHub meta information
     guide: >
@@ -89706,7 +89780,8 @@ tables:
       Requires owner and repo. By default this table requests state=all from GitHub so aggregates include open and closed
       pull requests; add state when you need only open, closed, or all. Other useful optional filters are head and base. Add
       pull_number to jump from the default list call to a specific record lookup. GitHub only populates diff-stat columns
-      such as additions, deletions, and changed_files on that per-PR lookup, so include pull_number before using them.
+      such as additions, deletions, changed_files, and the merged boolean on that per-PR lookup, so include pull_number
+      before using them. For list queries, use merged_at IS NOT NULL to identify merged pull requests.
     filters:
       - name: owner
         required: true
@@ -90219,6 +90294,16 @@ tables:
         type: Utf8
         nullable: true
         virtual: false
+        expr:
+          kind: path
+          path:
+            - base
+            - ref
+      - name: base_ref
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Alias for base__ref.
         expr:
           kind: path
           path:
@@ -91325,6 +91410,16 @@ tables:
           path:
             - base
             - sha
+      - name: base_sha
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Alias for base__sha.
+        expr:
+          kind: path
+          path:
+            - base
+            - sha
       - name: base__user
         type: Utf8
         nullable: true
@@ -91674,6 +91769,16 @@ tables:
         type: Utf8
         nullable: true
         virtual: false
+        expr:
+          kind: path
+          path:
+            - head
+            - ref
+      - name: head_ref
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Alias for head__ref.
         expr:
           kind: path
           path:
@@ -92780,6 +92885,16 @@ tables:
           path:
             - head
             - sha
+      - name: head_sha
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Alias for head__sha.
+        expr:
+          kind: path
+          path:
+            - head
+            - sha
       - name: head__user
         type: Utf8
         nullable: true
@@ -93098,6 +93213,7 @@ tables:
         type: Boolean
         nullable: true
         virtual: false
+        description: Only populated by the per-PR lookup. Filter pull_number before using this boolean; for list workflows, use merged_at IS NOT NULL.
         expr:
           kind: path
           path:
@@ -93106,6 +93222,7 @@ tables:
         type: Utf8
         nullable: true
         virtual: false
+        description: Timestamp set when a pull request was merged. Use this to identify merged PRs in list responses.
         expr:
           kind: path
           path:
@@ -93726,11 +93843,12 @@ tables:
       - name: pull_number
         type: Int64
         nullable: true
-        virtual: true
-        description: The number that identifies the pull request.
+        virtual: false
+        description: Pull request number. Also usable as an optional pushed-down filter for per-PR lookup.
         expr:
-          kind: from_filter
-          key: pull_number
+          kind: path
+          path:
+            - number
       - name: rebaseable
         type: Utf8
         nullable: true
@@ -93953,6 +94071,16 @@ tables:
         type: Utf8
         nullable: true
         virtual: false
+        expr:
+          kind: path
+          path:
+            - user
+            - login
+      - name: user_login
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Alias for user__login.
         expr:
           kind: path
           path:
@@ -147864,18 +147992,75 @@ tables:
         type: Utf8
         nullable: true
         virtual: false
+        description: Raw requested team objects as JSON text. Use team_names or team_slugs for compact projections.
         expr:
           kind: path
           path:
             - teams
+      - name: team_names
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Comma-separated names for requested teams.
+        expr:
+          kind: join_array_path
+          path:
+            - teams
+          item_path:
+            - name
+      - name: requested_team_names
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Alias for team_names, matching the compact projection on github.pulls.
+        expr:
+          kind: join_array_path
+          path:
+            - teams
+          item_path:
+            - name
+      - name: team_slugs
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Comma-separated slugs for requested teams.
+        expr:
+          kind: join_array_path
+          path:
+            - teams
+          item_path:
+            - slug
       - name: users
         type: Utf8
         nullable: true
         virtual: false
+        description: Raw requested reviewer user objects as JSON text. Use user_logins for a compact projection.
         expr:
           kind: path
           path:
             - users
+      - name: user_logins
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Comma-separated logins for requested user reviewers.
+        expr:
+          kind: join_array_path
+          path:
+            - users
+          item_path:
+            - login
+      - name: requested_reviewer_logins
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Alias for user_logins, matching the compact projection on github.pulls.
+        expr:
+          kind: join_array_path
+          path:
+            - users
+          item_path:
+            - login
   - name: required_pull_request_reviews
     description: Get pull request review protection
     guide: >
@@ -165921,11 +166106,111 @@ tables:
         expr:
           kind: from_filter
           key: org
+  - name: authenticated_user
+    description: Get the authenticated user
+    guide: >
+      Works without WHERE filters. Alias for the current token's user profile; use github.user when
+      you need the broader generated user table or the account_id lookup route.
+    request:
+      method: GET
+      path: /user
+    response:
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: link_header
+      page_start: 0
+      page_step: 1
+      offset_start: 0
+      link_header_require_results: false
+    columns:
+      - name: login
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: The handle for the authenticated GitHub user.
+        expr:
+          kind: path
+          path:
+            - login
+      - name: id
+        type: Int64
+        nullable: true
+        virtual: false
+        expr:
+          kind: path
+          path:
+            - id
+      - name: node_id
+        type: Utf8
+        nullable: true
+        virtual: false
+        expr:
+          kind: path
+          path:
+            - node_id
+      - name: name
+        type: Utf8
+        nullable: true
+        virtual: false
+        expr:
+          kind: path
+          path:
+            - name
+      - name: email
+        type: Utf8
+        nullable: true
+        virtual: false
+        expr:
+          kind: path
+          path:
+            - email
+      - name: html_url
+        type: Utf8
+        nullable: true
+        virtual: false
+        expr:
+          kind: path
+          path:
+            - html_url
+      - name: type
+        type: Utf8
+        nullable: true
+        virtual: false
+        expr:
+          kind: path
+          path:
+            - type
+      - name: site_admin
+        type: Boolean
+        nullable: true
+        virtual: false
+        expr:
+          kind: path
+          path:
+            - site_admin
+      - name: created_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        expr:
+          kind: path
+          path:
+            - updated_at
   - name: user
     description: Get the authenticated user
     guide: >
-      Works without WHERE filters. Most useful optional filters: account_id. Add account_id to jump from the
-      default list call to a specific record lookup.
+      Works without WHERE filters. The default route returns the current authenticated user. Most useful optional
+      filters: account_id. Add account_id to jump from the default route to a specific record lookup. For the
+      current token's user profile, github.authenticated_user is the shorter alias.
     filters:
       - name: account_id
         required: false


### PR DESCRIPTION
## Intent

Close the manifest-only follow-ups from feedback reports without pulling in dependent predicate pushdown work.

This keeps the fixes scoped to source-spec shape, discoverability, and documented query ergonomics so the current source behaves predictably through existing Coral SQL planning.

## Changes

- Add `github.org_team_memberships` for the `org` + `team_slug` + `username` membership route and make missing org/team membership checks return empty rows.
- Keep legacy `github.memberships` for numeric `team_id` lookups while documenting the cleaner org/team path.
- Make `github.pulls.pull_number` project from GitHub's `number` field while preserving it as an optional per-PR lookup filter.
- Add compact PR aliases for head/base refs and SHAs plus author login.
- Clarify `github.pulls.merged` as per-PR lookup data and point list workflows at `merged_at`.
- Add compact `github.requested_reviewers` projections for user/team reviewer names.
- Add `github.authenticated_user` as a compact current-user alias and document it.

## Verification

- `cargo run --locked -p coral-cli -- source lint sources/core/github/manifest.yaml`
- `make lint-sources`
- `make docs-check`
- `git diff --check`
- Rebuilt `coral-cli`, installed bundled `github` in an isolated `CORAL_CONFIG_DIR`, and verified the new catalog metadata plus live GitHub queries for PR aliases, per-PR merged state, requested reviewer projections, authenticated user lookup, and empty org/team membership 404 behavior.

## Notes

Dependent predicate pushdown fixes are intentionally out of scope for this PR.
