### PR TITLE
feat(sources): per-method credential hints

### DIFF
--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -107,6 +107,8 @@ message SourceCredentialMethod {
   string label = 1;
   // Optional display description.
   string description = 2;
+  // Optional hint describing how to obtain the values this method needs.
+  string hint = 5;
   // Method-specific metadata.
   oneof method {
     // Secret value is supplied through the source configuration path.

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -616,6 +616,7 @@ fn credential_method_to_proto(
     SourceCredentialMethod {
         label: method.label.unwrap_or_default(),
         description: method.description.unwrap_or_default(),
+        hint: method.hint.unwrap_or_default(),
         method: Some(method_body),
     }
 }
@@ -727,6 +728,7 @@ mod tests {
                         kind: ManifestCredentialMethodKind::OAuth,
                         label: Some("Connect".to_string()),
                         description: None,
+                        hint: None,
                         oauth: Some(ManifestOAuthCredentialSpec {
                             flow: ManifestOAuthFlowSpec {
                                 kind: ManifestOAuthFlowKind::AuthorizationCode,
@@ -753,6 +755,7 @@ mod tests {
                         kind: ManifestCredentialMethodKind::SourceConfig,
                         label: Some("Paste token".to_string()),
                         description: None,
+                        hint: None,
                         oauth: None,
                     },
                 ],

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -728,7 +728,7 @@ mod tests {
                         kind: ManifestCredentialMethodKind::OAuth,
                         label: Some("Connect".to_string()),
                         description: None,
-                        hint: None,
+                        hint: Some("Authorize in your browser.".to_string()),
                         oauth: Some(ManifestOAuthCredentialSpec {
                             flow: ManifestOAuthFlowSpec {
                                 kind: ManifestOAuthFlowKind::AuthorizationCode,
@@ -770,6 +770,14 @@ mod tests {
         };
         let credential = secret.credential.expect("credential");
         assert_eq!(credential.methods.len(), 2);
+        assert_eq!(
+            credential.methods[0].hint, "Authorize in your browser.",
+            "authored method hint should map onto the proto"
+        );
+        assert_eq!(
+            credential.methods[1].hint, "",
+            "absent method hint should map to an empty proto string"
+        );
         match credential.methods[0].method.as_ref().expect("method") {
             ProtoCredentialMethod::Oauth(oauth) => {
                 assert_eq!(oauth.redirect_uri, "http://127.0.0.1:53682/oauth/callback");

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -999,6 +999,7 @@ fn prompt_secret_with_methods(
         .methods
         .get(selected)
         .ok_or_else(|| anyhow::anyhow!("credential method index {selected} is out of range"))?;
+    print_method_hint(method);
     match method.kind {
         ManifestCredentialMethodKind::SourceConfig => Ok(SecretInputOutcome::SourceConfig(
             prompt_source_config_secret(input)?,
@@ -1482,6 +1483,14 @@ fn print_input_hint(input: &ManifestInputSpec) {
     }
 }
 
+fn print_method_hint(method: &ManifestCredentialMethod) {
+    if let Some(hint) = method.hint.as_deref()
+        && !hint.is_empty()
+    {
+        println!("  {}", style(hint).dim());
+    }
+}
+
 pub(crate) fn finalize_input_value(
     input: &ManifestInputSpec,
     value: String,
@@ -1574,6 +1583,7 @@ mod tests {
                     kind: ManifestCredentialMethodKind::SourceConfig,
                     label: Some("Paste token".to_string()),
                     description: None,
+                    hint: None,
                     oauth: None,
                 }],
             }),

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -922,7 +922,7 @@ fn query_test_counts(response: &ValidateSourceResponse) -> QueryTestCounts {
 
 fn prompt_variable(input: &ManifestInputSpec) -> Result<Option<SourceVariable>, anyhow::Error> {
     let theme = ColorfulTheme::default();
-    print_input_hint(input);
+    print_prompt_hint(resolve_prompt_hint(input, None));
     let prompt = if input.default_value.is_empty() {
         input.key.clone()
     } else {
@@ -941,9 +941,12 @@ fn prompt_variable(input: &ManifestInputSpec) -> Result<Option<SourceVariable>, 
     }))
 }
 
-fn prompt_secret(input: &ManifestInputSpec) -> Result<Option<SourceSecret>, anyhow::Error> {
+fn prompt_secret(
+    input: &ManifestInputSpec,
+    method: Option<&ManifestCredentialMethod>,
+) -> Result<Option<SourceSecret>, anyhow::Error> {
     let theme = ColorfulTheme::default();
-    print_input_hint(input);
+    print_prompt_hint(resolve_prompt_hint(input, method));
     let prompt = if input.default_value.is_empty() {
         input.key.clone()
     } else {
@@ -964,6 +967,7 @@ fn prompt_secret(input: &ManifestInputSpec) -> Result<Option<SourceSecret>, anyh
 
 fn prompt_source_config_secret(
     input: &ManifestInputSpec,
+    method: Option<&ManifestCredentialMethod>,
 ) -> Result<Option<SourceSecret>, anyhow::Error> {
     let env_value = read_source_input_env(&input.key).unwrap_or_default();
     if !env_value.is_empty() {
@@ -972,7 +976,7 @@ fn prompt_source_config_secret(
             value: env_value,
         }));
     }
-    prompt_secret(input)
+    prompt_secret(input, method)
 }
 
 enum SecretInputOutcome {
@@ -989,7 +993,7 @@ fn prompt_secret_with_methods(
 ) -> Result<SecretInputOutcome, anyhow::Error> {
     let Some(credential) = input.credential.as_ref() else {
         return Ok(SecretInputOutcome::SourceConfig(
-            prompt_source_config_secret(input)?,
+            prompt_source_config_secret(input, None)?,
         ));
     };
     let Some(selected) = select_credential_method(input, credential, prefer_skip)? else {
@@ -999,15 +1003,20 @@ fn prompt_secret_with_methods(
         .methods
         .get(selected)
         .ok_or_else(|| anyhow::anyhow!("credential method index {selected} is out of range"))?;
-    print_method_hint(method);
+    // Inside a credential-method flow the selected method's hint is the
+    // guidance shown; the input-level hint is reserved for inspection
+    // surfaces and is not reprinted here.
     match method.kind {
         ManifestCredentialMethodKind::SourceConfig => Ok(SecretInputOutcome::SourceConfig(
-            prompt_source_config_secret(input)?,
+            prompt_source_config_secret(input, Some(method))?,
         )),
-        ManifestCredentialMethodKind::OAuth => Ok(SecretInputOutcome::OAuth {
-            credential: collect_oauth_credential_method(input, selected, method)?,
-            label: credential_method_label(method),
-        }),
+        ManifestCredentialMethodKind::OAuth => {
+            print_prompt_hint(resolve_prompt_hint(input, Some(method)));
+            Ok(SecretInputOutcome::OAuth {
+                credential: collect_oauth_credential_method(input, selected, method)?,
+                label: credential_method_label(method),
+            })
+        }
     }
 }
 
@@ -1475,18 +1484,28 @@ fn prompt_oauth_client_secret(input_key: &str) -> Result<String, anyhow::Error> 
     Ok(value)
 }
 
-fn print_input_hint(input: &ManifestInputSpec) {
-    if let Some(hint) = input.hint.as_deref()
-        && !hint.is_empty()
-    {
-        println!("  {}", style(hint).dim());
-    }
+/// Resolve the single hint to show while interactively collecting `input`.
+///
+/// Inside a credential-method flow (`method` is `Some`) the selected method's
+/// hint takes precedence, so the input-level hint — kept concise for
+/// inspection surfaces (`coral source info --verbose`, `coral.inputs`) and the
+/// generated docs — is not reprinted alongside it. When the selected method
+/// has no hint we fall back to the input-level hint rather than show nothing:
+/// a dormant safety net for multi-method secrets that have not authored
+/// per-method hints. For variables and plain secrets (`method` is `None`) the
+/// input-level hint is used directly. Returning a single value makes it
+/// impossible to print both the input-level and method-level hints together.
+fn resolve_prompt_hint<'a>(
+    input: &'a ManifestInputSpec,
+    method: Option<&'a ManifestCredentialMethod>,
+) -> Option<&'a str> {
+    let trimmed = |hint: Option<&'a str>| hint.map(str::trim).filter(|hint| !hint.is_empty());
+    trimmed(method.and_then(|method| method.hint.as_deref()))
+        .or_else(|| trimmed(input.hint.as_deref()))
 }
 
-fn print_method_hint(method: &ManifestCredentialMethod) {
-    if let Some(hint) = method.hint.as_deref()
-        && !hint.is_empty()
-    {
+fn print_prompt_hint(hint: Option<&str>) {
+    if let Some(hint) = hint {
         println!("  {}", style(hint).dim());
     }
 }
@@ -1531,8 +1550,9 @@ mod tests {
     use super::{
         CredentialPromptMode, RedirectPromptAction, ValidationFollowUp, ValidationSeverityMode,
         apply_redirect_prompt_key, collect_inputs_with_hint, expected_oauth_redirect,
-        finalize_input_value, render_redirect_prompt_key_echo, shell_quote_arg, source_name_arg,
-        submit_oauth_redirect_url, validate_oauth_redirect_url, validation_follow_up,
+        finalize_input_value, render_redirect_prompt_key_echo, resolve_prompt_hint,
+        shell_quote_arg, source_name_arg, submit_oauth_redirect_url, validate_oauth_redirect_url,
+        validation_follow_up,
     };
 
     #[test]
@@ -1591,6 +1611,79 @@ mod tests {
 
         assert!(CredentialPromptMode::EnvFirst.reads_env_before_prompt(&input));
         assert!(!CredentialPromptMode::CredentialMethodFirst.reads_env_before_prompt(&input));
+    }
+
+    fn secret_with_method(
+        input_hint: Option<&str>,
+        method_hint: Option<&str>,
+    ) -> (ManifestInputSpec, ManifestCredentialMethod) {
+        let method = ManifestCredentialMethod {
+            kind: ManifestCredentialMethodKind::SourceConfig,
+            label: Some("Paste token".to_string()),
+            description: None,
+            hint: method_hint.map(ToString::to_string),
+            oauth: None,
+        };
+        let input = ManifestInputSpec {
+            key: "GITHUB_TOKEN".to_string(),
+            kind: ManifestInputKind::Secret,
+            required: true,
+            default_value: String::new(),
+            hint: input_hint.map(ToString::to_string),
+            credential: Some(ManifestCredentialSpec {
+                methods: vec![method.clone()],
+            }),
+        };
+        (input, method)
+    }
+
+    #[test]
+    fn prompt_hint_uses_input_hint_outside_a_credential_method_flow() {
+        let (input, _) = secret_with_method(Some("Input-level summary."), Some("Method guidance."));
+        assert_eq!(
+            resolve_prompt_hint(&input, None),
+            Some("Input-level summary.")
+        );
+    }
+
+    #[test]
+    fn prompt_hint_uses_only_the_method_hint_inside_a_credential_method_flow() {
+        // Once a method is selected, the method hint is the guidance and the
+        // input-level hint is never reprinted (the source_config/"Paste token"
+        // path must not show both).
+        let (input, method) =
+            secret_with_method(Some("Input-level summary."), Some("Method guidance."));
+        assert_eq!(
+            resolve_prompt_hint(&input, Some(&method)),
+            Some("Method guidance.")
+        );
+    }
+
+    #[test]
+    fn prompt_hint_falls_back_to_input_hint_when_method_has_no_hint() {
+        // Dormant safety net: a multi-method secret whose selected method has
+        // no hint still shows the input-level hint rather than nothing.
+        let (input, method) = secret_with_method(Some("Input-level summary."), None);
+        assert_eq!(
+            resolve_prompt_hint(&input, Some(&method)),
+            Some("Input-level summary.")
+        );
+    }
+
+    #[test]
+    fn prompt_hint_shows_nothing_when_neither_method_nor_input_has_a_hint() {
+        let (input, method) = secret_with_method(None, None);
+        assert_eq!(resolve_prompt_hint(&input, Some(&method)), None);
+    }
+
+    #[test]
+    fn prompt_hint_trims_and_drops_blank_hints() {
+        let (input, method) = secret_with_method(Some("   "), Some("  Method guidance.  "));
+        assert_eq!(resolve_prompt_hint(&input, None), None);
+        assert_eq!(
+            resolve_prompt_hint(&input, Some(&method)),
+            Some("Method guidance.")
+        );
     }
 
     #[test]

--- a/crates/coral-client/src/sources.rs
+++ b/crates/coral-client/src/sources.rs
@@ -291,7 +291,7 @@ mod tests {
                         SourceCredentialMethod {
                             label: "Connect".to_string(),
                             description: String::new(),
-                            hint: String::new(),
+                            hint: "Authorize in your browser.".to_string(),
                             method: Some(ProtoCredentialMethod::Oauth(Box::new(
                                 OAuthCredentialMethod {
                                     flow: OauthCredentialFlowType::AuthorizationCode as i32,
@@ -340,6 +340,15 @@ mod tests {
             ManifestCredentialMethodKind::OAuth
         );
         assert_eq!(credential.methods[0].label.as_deref(), Some("Connect"));
+        assert_eq!(
+            credential.methods[0].hint.as_deref(),
+            Some("Authorize in your browser."),
+            "non-empty method hint should survive proto decoding"
+        );
+        assert_eq!(
+            credential.methods[1].hint, None,
+            "empty proto hint should decode to None"
+        );
         assert_eq!(
             credential.methods[0]
                 .oauth

--- a/crates/coral-client/src/sources.rs
+++ b/crates/coral-client/src/sources.rs
@@ -126,6 +126,7 @@ fn credential_method_from_proto(
         kind,
         label: (!method.label.is_empty()).then(|| method.label.clone()),
         description: (!method.description.is_empty()).then(|| method.description.clone()),
+        hint: (!method.hint.is_empty()).then(|| method.hint.clone()),
         oauth,
     })
 }
@@ -290,6 +291,7 @@ mod tests {
                         SourceCredentialMethod {
                             label: "Connect".to_string(),
                             description: String::new(),
+                            hint: String::new(),
                             method: Some(ProtoCredentialMethod::Oauth(Box::new(
                                 OAuthCredentialMethod {
                                     flow: OauthCredentialFlowType::AuthorizationCode as i32,
@@ -320,6 +322,7 @@ mod tests {
                         SourceCredentialMethod {
                             label: "Paste token".to_string(),
                             description: String::new(),
+                            hint: String::new(),
                             method: Some(ProtoCredentialMethod::SourceConfig(
                                 SourceConfigCredentialMethod {},
                             )),
@@ -384,6 +387,7 @@ mod tests {
                     methods: vec![SourceCredentialMethod {
                         label: "Connect".to_string(),
                         description: String::new(),
+                        hint: String::new(),
                         method: Some(ProtoCredentialMethod::Oauth(Box::new(
                             OAuthCredentialMethod {
                                 flow: flow as i32,
@@ -471,6 +475,7 @@ mod tests {
                     methods: vec![SourceCredentialMethod {
                         label: "Connect".to_string(),
                         description: String::new(),
+                        hint: String::new(),
                         method: None,
                     }],
                 }),

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -71,6 +71,8 @@ pub struct ManifestCredentialMethod {
     pub label: Option<String>,
     /// Optional display description.
     pub description: Option<String>,
+    /// Optional hint describing how to obtain the values this method needs.
+    pub hint: Option<String>,
     /// OAuth configuration when `kind` is [`ManifestCredentialMethodKind::OAuth`].
     pub oauth: Option<ManifestOAuthCredentialSpec>,
 }
@@ -622,6 +624,10 @@ fn parse_credential_method(
         .get("description")
         .and_then(Value::as_str)
         .map(ToString::to_string);
+    let hint = method
+        .get("hint")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
     match method.get("type").and_then(Value::as_str) {
         Some("source_config") => {
             if method.contains_key("oauth") {
@@ -633,6 +639,7 @@ fn parse_credential_method(
                 kind: ManifestCredentialMethodKind::SourceConfig,
                 label,
                 description,
+                hint,
                 oauth: None,
             })
         }
@@ -649,6 +656,7 @@ fn parse_credential_method(
                 kind: ManifestCredentialMethodKind::OAuth,
                 label,
                 description,
+                hint,
                 oauth: Some(oauth),
             })
         }

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -156,7 +156,8 @@
           "properties": {
             "type": { "const": "source_config" },
             "label": { "type": "string" },
-            "description": { "type": "string" }
+            "description": { "type": "string" },
+            "hint": { "type": "string" }
           }
         },
         {
@@ -167,6 +168,7 @@
             "type": { "const": "oauth" },
             "label": { "type": "string" },
             "description": { "type": "string" },
+            "hint": { "type": "string" },
             "oauth": { "$ref": "#/$defs/oauth_credential_method" }
           }
         }

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -218,16 +218,21 @@ tables:
 
 When a source should offer OAuth setup, keep the runtime auth shape the same and add `credential.methods` to the secret input. The OAuth method controls how Coral obtains the secret during setup; the `auth` block still decides how that stored secret is sent to the API.
 
+Give each method its own `hint` rather than one input-level hint: the field shown below the hint changes with the selected method, so scope each method's guidance to the inputs that method collects.
+
 ```yaml
 inputs:
   DEMO_API_TOKEN:
     kind: secret
-    hint: Access token for the Demo API. Use OAuth setup or paste a token with read access.
     credential:
       methods:
         - type: oauth
           label: Connect with Demo
           description: Open a browser and authorize Coral to read Demo API data.
+          hint: |
+            Signs you in through Demo in your browser and requests the
+            `read:data` scope. To use your own app, set DEMO_OAUTH_CLIENT_ID
+            to its Client ID.
           oauth:
             flow:
               type: authorization_code
@@ -247,6 +252,7 @@ inputs:
                   - read:data
         - type: source_config
           label: Paste token
+          hint: Paste a Demo API token with read access to the data you query.
 auth:
   type: HeaderAuth
   headers:

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -181,6 +181,10 @@ Cloud; for GitHub Enterprise Server, use
 
 `GITHUB_TOKEN` (required)
 
+Connect with GitHub OAuth or paste a personal access token. The
+OAuth methods request the `repo`, `read:org`, `read:user`, and
+`user:email` scopes.
+
 Credential methods:
 
 - **Connect with GitHub device code** — Signs you in through GitHub, with no app setup or client secret needed. Requests the `repo`, `read:org`, `read:user`, and `user:email` scopes. To use your own GitHub app instead, set GITHUB_OAUTH_CLIENT_ID to its Client ID and enable device flow on the app.
@@ -241,6 +245,10 @@ Base URL for the Google Calendar API. Keep the default unless you are
 testing against a mock Calendar-compatible API.
 
 `GOOGLE_CALENDAR_ACCESS_TOKEN` (required)
+
+Connect with Google OAuth or paste an access token. Either way the
+token needs the read-only
+`https://www.googleapis.com/auth/calendar.readonly` scope.
 
 Credential methods:
 

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -202,14 +202,13 @@ Base URL of your GitLab instance. Keep the default for
 
 `GITLAB_TOKEN` (required)
 
-Use GitLab OAuth or create a personal access token (PAT) with
-the `read_api` scope; some admin tables require elevated scopes.
-See [GitLab PAT docs](https://docs.gitlab.com/user/profile/personal_access_tokens/).
+Connect with GitLab OAuth or paste a personal access token. Both
+need the `read_api` scope; some admin tables require elevated scopes.
 
 Credential methods:
 
-- **Connect with GitLab.com OAuth** — Use GitLab.com OAuth authorization code with PKCE.
-- **Paste token**
+- **Connect with GitLab.com OAuth** — Sign in to GitLab.com in your browser. Requests the `read_api` scope. To use your own GitLab OAuth application, set GITLAB_OAUTH_CLIENT_ID to its Application ID.
+- **Paste token** — Create a personal access token with the `read_api` scope; some admin tables need elevated scopes. See [GitLab PAT docs](https://docs.gitlab.com/user/profile/personal_access_tokens/).
 
 ### `gmail`
 
@@ -221,20 +220,13 @@ account, or an email address when the token has delegated access.
 
 `GMAIL_TOKEN` (required)
 
-Use a read-only OAuth 2.0 access token for the Gmail API with the
-`https://www.googleapis.com/auth/gmail.readonly` scope.
-For the guided OAuth flow, enable the Gmail API in a Google Cloud
-project and create an OAuth 2.0 client of type "Desktop app". The
-guided OAuth credential method uses that client ID and client secret,
-then requests that read-only scope.
-See [Google OAuth client setup](https://support.google.com/cloud/answer/6158849).
-
-To paste a token manually, use a token issued with that same scope.
+Connect with Google OAuth or paste an access token. Either way the
+token needs the `https://www.googleapis.com/auth/gmail.readonly` scope.
 
 Credential methods:
 
-- **Connect with Google** — Use a Google OAuth client ID and client secret.
-- **Paste access token**
+- **Connect with Google** — Enable the Gmail API in a Google Cloud project and create an OAuth 2.0 client of type "Desktop app", then enter its Client ID and Client secret below. Requests read-only access with the `https://www.googleapis.com/auth/gmail.readonly` scope. See [Google OAuth client setup](https://support.google.com/cloud/answer/6158849).
+- **Paste access token** — Paste a read-only OAuth 2.0 access token issued with the `https://www.googleapis.com/auth/gmail.readonly` scope.
 
 ### `google_calendar`
 
@@ -393,19 +385,14 @@ Your Sentry organization slug (found in the Sentry URL after `/organizations/`)
 
 `SENTRY_TOKEN` (required)
 
-Use OAuth during interactive setup, or create an internal integration
-and generate a token with the following read scopes: org:read,
-event:read, member:read, project:read, project:releases, and
-team:read.
-
-OAuth setup requires a Sentry OAuth app; use that app's client ID
-when prompted.
-See [Sentry auth docs](https://docs.sentry.io/api/auth/).
+Connect with Sentry OAuth or paste an internal-integration token.
+Both need the `org:read`, `event:read`, `member:read`, `project:read`,
+`project:releases`, and `team:read` scopes.
 
 Credential methods:
 
-- **Connect with Sentry device flow** — Use a Sentry OAuth app instead of pasting an auth token.
-- **Paste auth token** — Paste a Sentry personal or internal integration token.
+- **Connect with Sentry device flow** — Sign in to Sentry with a device code. Enter your Sentry OAuth app's Client ID when prompted. Requests the `org:read`, `event:read`, `member:read`, `project:read`, `project:releases`, and `team:read` scopes. See [Sentry auth docs](https://docs.sentry.io/api/auth/).
+- **Paste auth token** — Create an internal integration and paste its token, granting the `org:read`, `event:read`, `member:read`, `project:read`, `project:releases`, and `team:read` read scopes. See [Sentry auth docs](https://docs.sentry.io/api/auth/).
 
 ### `slack`
 

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -181,30 +181,11 @@ Cloud; for GitHub Enterprise Server, use
 
 `GITHUB_TOKEN` (required)
 
-For GitHub Cloud, choose "Connect with GitHub device code" for the
-simplest setup. It signs in through GitHub and does not require you
-to create an OAuth app or enter a client secret.
+Credential methods:
 
-If you want to use your own GitHub OAuth app, set
-GITHUB_OAUTH_CLIENT_ID to the app's Client ID. To create an app,
-follow GitHub's guide:
-https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app.
-Enable device flow on the app before using the device-code option.
-For the browser "Connect with GitHub OAuth app" option, set the
-app's Authorization callback URL to
-`http://127.0.0.1:53682/oauth/callback` and set
-GITHUB_OAUTH_CLIENT_SECRET to the app's Client secret.
-
-The OAuth options request `repo`, `read:org`, `read:user`, and
-`user:email` scopes. Use the token method instead if you need a
-narrower or more elevated scope set, or if you are connecting
-to GitHub Enterprise Server.
-
-For token auth, if you're already authenticated in GitHub CLI, run
-`gh auth token`, or create a new personal access token (PAT).
-Grant read access to the repositories and organizations you plan
-to query; some admin tables require elevated scopes.
-See [GitHub PAT docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
+- **Connect with GitHub device code** — Signs you in through GitHub, with no app setup or client secret needed. Requests the `repo`, `read:org`, `read:user`, and `user:email` scopes. To use your own GitHub app instead, set GITHUB_OAUTH_CLIENT_ID to its Client ID and enable device flow on the app.
+- **Connect with GitHub OAuth app** — Uses your own GitHub OAuth app. Register one with its Authorization callback URL set to `http://127.0.0.1:53682/oauth/callback`, then enter the app's Client ID and Client secret below. Requests the `repo`, `read:org`, `read:user`, and `user:email` scopes. See [GitHub's guide](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app).
+- **Paste token** — If you use GitHub CLI, run `gh auth token`. Otherwise create a personal access token with read access to the repositories and organizations you query; some admin tables need elevated scopes. Works with GitHub Enterprise Server. See [GitHub PAT docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
 
 ### `gitlab`
 
@@ -220,6 +201,11 @@ Base URL of your GitLab instance. Keep the default for
 Use GitLab OAuth or create a personal access token (PAT) with
 the `read_api` scope; some admin tables require elevated scopes.
 See [GitLab PAT docs](https://docs.gitlab.com/user/profile/personal_access_tokens/).
+
+Credential methods:
+
+- **Connect with GitLab.com OAuth** — Use GitLab.com OAuth authorization code with PKCE.
+- **Paste token**
 
 ### `gmail`
 
@@ -241,6 +227,11 @@ See [Google OAuth client setup](https://support.google.com/cloud/answer/6158849)
 
 To paste a token manually, use a token issued with that same scope.
 
+Credential methods:
+
+- **Connect with Google** — Use a Google OAuth client ID and client secret.
+- **Paste access token**
+
 ### `google_calendar`
 
 `GOOGLE_CALENDAR_API_BASE` (optional)<br />
@@ -251,14 +242,10 @@ testing against a mock Calendar-compatible API.
 
 `GOOGLE_CALENDAR_ACCESS_TOKEN` (required)
 
-Use a read-only OAuth 2.0 access token for the Google Calendar API.
-For the guided OAuth flow, enable the Google Calendar API in a Google
-Cloud project and create an OAuth 2.0 client of type "Desktop app".
-The guided OAuth credential method uses that client ID and client secret,
-then requests the https://www.googleapis.com/auth/calendar.readonly scope.
-See [Google OAuth client setup](https://support.google.com/cloud/answer/6158849).
+Credential methods:
 
-To paste a token manually, use a token issued with that same scope.
+- **Connect Google Calendar** — Enable the Google Calendar API in a Google Cloud project and create an OAuth 2.0 client of type "Desktop app", then enter its Client ID and Client secret below. Requests read-only access with the `https://www.googleapis.com/auth/calendar.readonly` scope. See [Google OAuth client setup](https://support.google.com/cloud/answer/6158849).
+- **Paste access token** — Paste a read-only OAuth 2.0 access token issued with the `https://www.googleapis.com/auth/calendar.readonly` scope.
 
 ### `grafana`
 
@@ -407,29 +394,25 @@ OAuth setup requires a Sentry OAuth app; use that app's client ID
 when prompted.
 See [Sentry auth docs](https://docs.sentry.io/api/auth/).
 
+Credential methods:
+
+- **Connect with Sentry device flow** — Use a Sentry OAuth app instead of pasting an auth token.
+- **Paste auth token** — Paste a Sentry personal or internal integration token.
+
 ### `slack`
 
 `SLACK_TOKEN` (required)
 
-Slack doesn't provide a general-purpose API for reading messages.
-Instead, you need a Slack app with an OAuth token.
+Slack has no general-purpose API for reading messages, so you need
+a Slack app with an OAuth token. Both methods use these scopes:
+`channels:read`, `channels:history`, `groups:read`,
+`groups:history`, `users:read`, `users:read.email`. See the
+[Slack app setup guide](https://docs.slack.dev/app-management/quickstart-app-settings).
 
-If you already have a Slack app with the required scopes, you can
-find your OAuth token on its OAuth & Permissions page. The
-required scopes are: channels:read, channels:history, groups:read,
-groups:history, users:read, users:read.email.
+Credential methods:
 
-If you don't have a Slack app, create one with the required
-scopes pre-filled:
-
-- [User token app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%7D%2C%22oauth_config%22%3A%7B%22redirect_urls%22%3A%5B%22http%3A%2F%2Flocalhost%3A53682%2Foauth%2Fcallback%22%5D%2C%22scopes%22%3A%7B%22user%22%3A%5B%22channels%3Ahistory%22%2C%22groups%3Aread%22%2C%22channels%3Aread%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%2C%22pkce_enabled%22%3Atrue%7D%2C%22settings%22%3A%7B%22org_deploy_enabled%22%3Afalse%2C%22socket_mode_enabled%22%3Afalse%2C%22token_rotation_enabled%22%3Afalse%2C%22is_mcp_enabled%22%3Afalse%7D%7D)
-  — works with the "Connect with Slack" OAuth flow. Reads the
-  channels the authorizing user belongs to.
-- [Bot token app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%2C%22description%22%3A%22Coral+data+access%22%7D%2C%22oauth_config%22%3A%7B%22scopes%22%3A%7B%22bot%22%3A%5B%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%7D%2C%22features%22%3A%7B%22bot_user%22%3A%7B%22display_name%22%3A%22Coral%22%2C%22always_online%22%3Afalse%7D%7D%7D)
-  — install it, then paste the bot token. Reads the channels the
-  bot has been added to.
-
-For more details, see the [Slack app setup guide](https://docs.slack.dev/app-management/quickstart-app-settings).
+- **Connect with Slack** — Create a [user-token app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%7D%2C%22oauth_config%22%3A%7B%22redirect_urls%22%3A%5B%22http%3A%2F%2Flocalhost%3A53682%2Foauth%2Fcallback%22%5D%2C%22scopes%22%3A%7B%22user%22%3A%5B%22channels%3Ahistory%22%2C%22groups%3Aread%22%2C%22channels%3Aread%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%2C%22pkce_enabled%22%3Atrue%7D%2C%22settings%22%3A%7B%22org_deploy_enabled%22%3Afalse%2C%22socket_mode_enabled%22%3Afalse%2C%22token_rotation_enabled%22%3Afalse%2C%22is_mcp_enabled%22%3Afalse%7D%7D), which pre-fills the scopes and redirect URL, then enter its Client ID below and authorize in your browser. Reads the channels the authorizing user belongs to.
+- **Paste Slack OAuth Token** — Paste the OAuth token from your app's OAuth & Permissions page. If you don't have an app, create a [bot-token app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%2C%22description%22%3A%22Coral+data+access%22%7D%2C%22oauth_config%22%3A%7B%22scopes%22%3A%7B%22bot%22%3A%5B%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%7D%2C%22features%22%3A%7B%22bot_user%22%3A%7B%22display_name%22%3A%22Coral%22%2C%22always_online%22%3Afalse%7D%7D%7D), install it, then paste its bot token. Reads the channels the bot has been added to.
 
 ### `statusgator`
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -1082,6 +1082,18 @@ device-code or browser-based OAuth setup instead of asking the user to paste a
 token. If you want to support both flows, list the OAuth method first and add a
 `source_config` fallback for users who already have a token.
 
+Each method accepts three optional display fields used during interactive
+install (`coral source add --interactive`) and in the generated source docs:
+
+- `label` (string): the choice shown in the method picker.
+- `description` (string): a short one-line blurb for the method.
+- `hint` (string): markdown guidance shown next to the fields that method
+  collects — for example how to register the OAuth app, what the callback URL
+  is, or where to find an existing token. Keep each hint focused on the inputs
+  that method needs rather than restating the other methods. Prefer a per-method
+  `hint` over a single long input-level `hint` when the input offers several
+  methods, since the fields below the hint change with the selected method.
+
 ```yaml
 inputs:
   GITHUB_TOKEN:
@@ -1091,6 +1103,9 @@ inputs:
         - type: oauth
           label: Connect with GitHub
           description: Use OAuth instead of pasting a token.
+          hint: |
+            Signs you in through GitHub with no client secret. To use your
+            own app, set GITHUB_OAUTH_CLIENT_ID to its Client ID.
           oauth:
             flow:
               type: device_code

--- a/plugins/coral/skills/coral-create-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-create-source-spec/SKILL.md
@@ -214,12 +214,15 @@ For an OAuth-backed HTTP source, add the retrieval method to that same secret in
 inputs:
   FOOBAR_API_TOKEN:
     kind: secret
-    hint: Access token for the Foobar API. Use OAuth setup or paste a token with read access.
+    hint: Connect with Foobar OAuth or paste a token with read access.
     credential:
       methods:
         - type: oauth
           label: Connect with Foobar
           description: Open a browser and authorize Coral to read Foobar data.
+          hint: |
+            Signs you in through Foobar and requests the `read` scope. To
+            use your own app, set FOOBAR_OAUTH_CLIENT_ID to its Client ID.
           oauth:
             flow:
               type: authorization_code
@@ -239,6 +242,7 @@ inputs:
                   - read
         - type: source_config
           label: Paste token
+          hint: Paste a Foobar API token with read access to the data you query.
 auth:
   type: HeaderAuth
   headers:

--- a/plugins/coral/skills/coral-create-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-create-source-spec/SKILL.md
@@ -89,6 +89,7 @@ Only switch to Coral repo layout when the user is explicitly editing the Coral r
 - OAuth endpoint URLs may template declared `kind: variable` inputs with `{{input.KEY}}` for non-secret endpoint components such as tenant IDs or domains. Do not reference secret inputs, filters, function arguments, state, or inline defaults from OAuth endpoint URLs.
 - If a provider also supports manually pasted tokens, include a `type: source_config` fallback after the OAuth method. When the provider's token endpoint requires client authentication with a client secret, prompt for both OAuth client values: declare `client.id.input`, `client.secret.input`, and `client.secret.transport` (`basic_auth` or `request_body`).
 - Do not add top-level source inputs solely for OAuth client credentials; `client.id.input` and `client.secret.input` are collected during OAuth setup.
+- Each credential method accepts optional `label`, `description`, and `hint` fields, surfaced during interactive install and in the generated source docs. When an input offers more than one method, put the how-to-get-it guidance in each method's `hint` (rendered next to that method's fields) instead of in one long input-level `hint`, and scope each hint to the inputs that method collects.
 - For short-lived OAuth access tokens, make sure the OAuth method can obtain refresh tokens when the provider supports them, and document any scopes, consent prompts, or client settings required for refresh-token issuance. If the provider will not issue refresh tokens, call out that users must reconnect when access tokens expire unless the source has another supported long-lived credential path.
 - Keep table names stable and SQL-friendly.
 - Mark filters as required only when the API truly requires them.
@@ -138,10 +139,10 @@ Specific guidance:
   - include least-privilege scope guidance
 - For OAuth methods:
   - use a user-facing `label` such as `Connect with GitHub`
-  - describe the browser-based setup in `description`
-  - list required OAuth scopes in the secret hint or method description
-  - mention whether users need to register a fixed loopback redirect URI or provide their own OAuth client ID/secret
-  - for authorization-code flow, note that users can paste the final localhost redirect URL into the terminal if their browser cannot reach Coral's loopback listener directly
+  - keep `description` to a short one-line blurb; put the setup detail in the method's `hint`
+  - in the method's `hint`, list the required OAuth scopes and explain whether users must register a fixed loopback redirect URI or provide their own OAuth client ID/secret; when the method collects `client.id.input`/`client.secret.input`, say where to obtain those values
+  - for authorization-code flow, note in the method's `hint` that users can paste the final localhost redirect URL into the terminal if their browser cannot reach Coral's loopback listener directly
+  - when a secret offers multiple methods, scope each method's `hint` to the inputs that method collects instead of writing one broad input-level hint that mixes guidance for every method
 - For derived secrets (for example Basic auth blobs):
   - include a short shell example (for example a Base64 command)
 - Prefer stable documentation links.

--- a/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
+++ b/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
@@ -58,7 +58,8 @@ Additional hint guidance:
 
 - Base URL inputs should clarify default behavior and self-hosted alternatives.
 - Secret inputs should name token type and any format constraints (for example token prefixes).
-- OAuth-backed secret hints should name the required scopes, client ID/secret expectations, and redirect URI registration requirement.
+- OAuth setup guidance — required scopes, client ID/secret expectations, and redirect URI registration — belongs in the OAuth method's `hint` (`credential.methods[].hint`), not the input-level hint, since that text renders next to the fields the method collects.
+- When a secret declares multiple `credential.methods`, write a focused `hint` on each method (`credential.methods[].hint`) instead of one long input-level hint; the fields shown change with the selected method, so each method's hint should cover only the inputs it collects.
 - For encoded credentials, include a short shell example (for example `printf ... | base64`).
 - Prefer official docs links and stable settings pages over brittle click-path instructions.
 

--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -20,6 +20,10 @@ inputs:
       `https://<host>/api/v3`.
   GITHUB_TOKEN:
     kind: secret
+    hint: |
+      Connect with GitHub OAuth or paste a personal access token. The
+      OAuth methods request the `repo`, `read:org`, `read:user`, and
+      `user:email` scopes.
     credential:
       methods:
         - type: oauth

--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 1.1.7
+version: 1.1.8
 dsl_version: 3
 backend: http
 description: >-

--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -20,36 +20,17 @@ inputs:
       `https://<host>/api/v3`.
   GITHUB_TOKEN:
     kind: secret
-    hint: |
-      For GitHub Cloud, choose "Connect with GitHub device code" for the
-      simplest setup. It signs in through GitHub and does not require you
-      to create an OAuth app or enter a client secret.
-
-      If you want to use your own GitHub OAuth app, set
-      GITHUB_OAUTH_CLIENT_ID to the app's Client ID. To create an app,
-      follow GitHub's guide:
-      https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app.
-      Enable device flow on the app before using the device-code option.
-      For the browser "Connect with GitHub OAuth app" option, set the
-      app's Authorization callback URL to
-      `http://127.0.0.1:53682/oauth/callback` and set
-      GITHUB_OAUTH_CLIENT_SECRET to the app's Client secret.
-
-      The OAuth options request `repo`, `read:org`, `read:user`, and
-      `user:email` scopes. Use the token method instead if you need a
-      narrower or more elevated scope set, or if you are connecting
-      to GitHub Enterprise Server.
-
-      For token auth, if you're already authenticated in GitHub CLI, run
-      `gh auth token`, or create a new personal access token (PAT).
-      Grant read access to the repositories and organizations you plan
-      to query; some admin tables require elevated scopes.
-      See [GitHub PAT docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
     credential:
       methods:
         - type: oauth
           label: Connect with GitHub device code
           description: Sign in to GitHub with a device code.
+          hint: |
+            Signs you in through GitHub, with no app setup or client
+            secret needed. Requests the `repo`, `read:org`, `read:user`,
+            and `user:email` scopes. To use your own GitHub app instead,
+            set GITHUB_OAUTH_CLIENT_ID to its Client ID and enable device
+            flow on the app.
           oauth:
             flow:
               type: device_code
@@ -71,6 +52,13 @@ inputs:
         - type: oauth
           label: Connect with GitHub OAuth app
           description: Sign in through a GitHub OAuth app in your browser.
+          hint: |
+            Uses your own GitHub OAuth app. Register one with its
+            Authorization callback URL set to
+            `http://127.0.0.1:53682/oauth/callback`, then enter the app's
+            Client ID and Client secret below. Requests the `repo`,
+            `read:org`, `read:user`, and `user:email` scopes. See
+            [GitHub's guide](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app).
           oauth:
             flow:
               type: authorization_code
@@ -98,6 +86,12 @@ inputs:
         - type: source_config
           label: Paste token
           description: Paste a GitHub token or provide GITHUB_TOKEN.
+          hint: |
+            If you use GitHub CLI, run `gh auth token`. Otherwise create a
+            personal access token with read access to the repositories and
+            organizations you query; some admin tables need elevated
+            scopes. Works with GitHub Enterprise Server. See
+            [GitHub PAT docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
 auth:
   type: HeaderAuth
   headers:

--- a/sources/core/gitlab/manifest.yaml
+++ b/sources/core/gitlab/manifest.yaml
@@ -17,14 +17,17 @@ inputs:
   GITLAB_TOKEN:
     kind: secret
     hint: |
-      Use GitLab OAuth or create a personal access token (PAT) with
-      the `read_api` scope; some admin tables require elevated scopes.
-      See [GitLab PAT docs](https://docs.gitlab.com/user/profile/personal_access_tokens/).
+      Connect with GitLab OAuth or paste a personal access token. Both
+      need the `read_api` scope; some admin tables require elevated scopes.
     credential:
       methods:
         - type: oauth
           label: Connect with GitLab.com OAuth
           description: Use GitLab.com OAuth authorization code with PKCE.
+          hint: |
+            Sign in to GitLab.com in your browser. Requests the `read_api`
+            scope. To use your own GitLab OAuth application, set
+            GITLAB_OAUTH_CLIENT_ID to its Application ID.
           oauth:
             flow:
               type: authorization_code
@@ -45,6 +48,10 @@ inputs:
                   - read_api
         - type: source_config
           label: Paste token
+          hint: |
+            Create a personal access token with the `read_api` scope; some
+            admin tables need elevated scopes. See
+            [GitLab PAT docs](https://docs.gitlab.com/user/profile/personal_access_tokens/).
 base_url: '{{input.GITLAB_API_BASE}}'
 auth:
   type: HeaderAuth

--- a/sources/core/gmail/manifest.yaml
+++ b/sources/core/gmail/manifest.yaml
@@ -16,20 +16,19 @@ inputs:
   GMAIL_TOKEN:
     kind: secret
     hint: |
-      Use a read-only OAuth 2.0 access token for the Gmail API with the
-      `https://www.googleapis.com/auth/gmail.readonly` scope.
-      For the guided OAuth flow, enable the Gmail API in a Google Cloud
-      project and create an OAuth 2.0 client of type "Desktop app". The
-      guided OAuth credential method uses that client ID and client secret,
-      then requests that read-only scope.
-      See [Google OAuth client setup](https://support.google.com/cloud/answer/6158849).
-
-      To paste a token manually, use a token issued with that same scope.
+      Connect with Google OAuth or paste an access token. Either way the
+      token needs the `https://www.googleapis.com/auth/gmail.readonly` scope.
     credential:
       methods:
         - type: oauth
           label: Connect with Google
           description: Use a Google OAuth client ID and client secret.
+          hint: |
+            Enable the Gmail API in a Google Cloud project and create an
+            OAuth 2.0 client of type "Desktop app", then enter its Client ID
+            and Client secret below. Requests read-only access with the
+            `https://www.googleapis.com/auth/gmail.readonly` scope. See
+            [Google OAuth client setup](https://support.google.com/cloud/answer/6158849).
           oauth:
             flow:
               type: authorization_code
@@ -52,6 +51,9 @@ inputs:
                   - https://www.googleapis.com/auth/gmail.readonly
         - type: source_config
           label: Paste access token
+          hint: |
+            Paste a read-only OAuth 2.0 access token issued with the
+            `https://www.googleapis.com/auth/gmail.readonly` scope.
 auth:
   type: HeaderAuth
   headers:

--- a/sources/core/gmail/manifest.yaml
+++ b/sources/core/gmail/manifest.yaml
@@ -1,5 +1,5 @@
 name: gmail
-version: 0.1.0
+version: 0.1.1
 dsl_version: 3
 backend: http
 description: >-

--- a/sources/core/google_calendar/manifest.yaml
+++ b/sources/core/google_calendar/manifest.yaml
@@ -1,5 +1,5 @@
 name: google_calendar
-version: 0.1.0
+version: 0.1.1
 dsl_version: 3
 backend: http
 description: >-

--- a/sources/core/google_calendar/manifest.yaml
+++ b/sources/core/google_calendar/manifest.yaml
@@ -13,20 +13,18 @@ inputs:
       testing against a mock Calendar-compatible API.
   GOOGLE_CALENDAR_ACCESS_TOKEN:
     kind: secret
-    hint: |
-      Use a read-only OAuth 2.0 access token for the Google Calendar API.
-      For the guided OAuth flow, enable the Google Calendar API in a Google
-      Cloud project and create an OAuth 2.0 client of type "Desktop app".
-      The guided OAuth credential method uses that client ID and client secret,
-      then requests the https://www.googleapis.com/auth/calendar.readonly scope.
-      See [Google OAuth client setup](https://support.google.com/cloud/answer/6158849).
-
-      To paste a token manually, use a token issued with that same scope.
     credential:
       methods:
         - type: oauth
           label: Connect Google Calendar
           description: Use Google OAuth to retrieve a Calendar access token.
+          hint: |
+            Enable the Google Calendar API in a Google Cloud project and
+            create an OAuth 2.0 client of type "Desktop app", then enter
+            its Client ID and Client secret below. Requests read-only
+            access with the
+            `https://www.googleapis.com/auth/calendar.readonly` scope.
+            See [Google OAuth client setup](https://support.google.com/cloud/answer/6158849).
           oauth:
             flow:
               type: authorization_code
@@ -50,6 +48,9 @@ inputs:
         - type: source_config
           label: Paste access token
           description: Paste an existing Google Calendar OAuth access token.
+          hint: |
+            Paste a read-only OAuth 2.0 access token issued with the
+            `https://www.googleapis.com/auth/calendar.readonly` scope.
 base_url: "{{input.GOOGLE_CALENDAR_API_BASE}}"
 auth:
   type: HeaderAuth

--- a/sources/core/google_calendar/manifest.yaml
+++ b/sources/core/google_calendar/manifest.yaml
@@ -13,6 +13,10 @@ inputs:
       testing against a mock Calendar-compatible API.
   GOOGLE_CALENDAR_ACCESS_TOKEN:
     kind: secret
+    hint: |
+      Connect with Google OAuth or paste an access token. Either way the
+      token needs the read-only
+      `https://www.googleapis.com/auth/calendar.readonly` scope.
     credential:
       methods:
         - type: oauth

--- a/sources/core/sentry/manifest.yaml
+++ b/sources/core/sentry/manifest.yaml
@@ -12,19 +12,20 @@ inputs:
   SENTRY_TOKEN:
     kind: secret
     hint: |
-      Use OAuth during interactive setup, or create an internal integration
-      and generate a token with the following read scopes: org:read,
-      event:read, member:read, project:read, project:releases, and
-      team:read.
-
-      OAuth setup requires a Sentry OAuth app; use that app's client ID
-      when prompted.
-      See [Sentry auth docs](https://docs.sentry.io/api/auth/).
+      Connect with Sentry OAuth or paste an internal-integration token.
+      Both need the `org:read`, `event:read`, `member:read`, `project:read`,
+      `project:releases`, and `team:read` scopes.
     credential:
       methods:
         - type: oauth
           label: Connect with Sentry device flow
           description: Use a Sentry OAuth app instead of pasting an auth token.
+          hint: |
+            Sign in to Sentry with a device code. Enter your Sentry OAuth
+            app's Client ID when prompted. Requests the `org:read`,
+            `event:read`, `member:read`, `project:read`, `project:releases`,
+            and `team:read` scopes. See
+            [Sentry auth docs](https://docs.sentry.io/api/auth/).
           oauth:
             flow:
               type: device_code
@@ -47,6 +48,11 @@ inputs:
         - type: source_config
           label: Paste auth token
           description: Paste a Sentry personal or internal integration token.
+          hint: |
+            Create an internal integration and paste its token, granting the
+            `org:read`, `event:read`, `member:read`, `project:read`,
+            `project:releases`, and `team:read` read scopes. See
+            [Sentry auth docs](https://docs.sentry.io/api/auth/).
 base_url: https://sentry.io
 auth:
   type: HeaderAuth

--- a/sources/core/sentry/manifest.yaml
+++ b/sources/core/sentry/manifest.yaml
@@ -1,5 +1,5 @@
 name: sentry
-version: 2.1.0
+version: 2.1.1
 dsl_version: 3
 backend: http
 description: >-

--- a/sources/core/slack/manifest.yaml
+++ b/sources/core/slack/manifest.yaml
@@ -12,6 +12,11 @@ inputs:
         - type: oauth
           label: Connect with Slack
           description: Authorize Slack with OAuth and store a user token.
+          hint: |
+            Create a [user-token app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%7D%2C%22oauth_config%22%3A%7B%22redirect_urls%22%3A%5B%22http%3A%2F%2Flocalhost%3A53682%2Foauth%2Fcallback%22%5D%2C%22scopes%22%3A%7B%22user%22%3A%5B%22channels%3Ahistory%22%2C%22groups%3Aread%22%2C%22channels%3Aread%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%2C%22pkce_enabled%22%3Atrue%7D%2C%22settings%22%3A%7B%22org_deploy_enabled%22%3Afalse%2C%22socket_mode_enabled%22%3Afalse%2C%22token_rotation_enabled%22%3Afalse%2C%22is_mcp_enabled%22%3Afalse%7D%7D),
+            which pre-fills the scopes and redirect URL, then enter its
+            Client ID below and authorize in your browser. Reads the
+            channels the authorizing user belongs to.
           oauth:
             flow:
               type: authorization_code
@@ -37,26 +42,17 @@ inputs:
         - type: source_config
           label: Paste Slack OAuth Token
           description: Paste an existing Slack OAuth token with the required scopes.
+          hint: |
+            Paste the OAuth token from your app's OAuth & Permissions
+            page. If you don't have an app, create a [bot-token app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%2C%22description%22%3A%22Coral+data+access%22%7D%2C%22oauth_config%22%3A%7B%22scopes%22%3A%7B%22bot%22%3A%5B%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%7D%2C%22features%22%3A%7B%22bot_user%22%3A%7B%22display_name%22%3A%22Coral%22%2C%22always_online%22%3Afalse%7D%7D%7D),
+            install it, then paste its bot token. Reads the channels the
+            bot has been added to.
     hint: |
-      Slack doesn't provide a general-purpose API for reading messages.
-      Instead, you need a Slack app with an OAuth token.
-
-      If you already have a Slack app with the required scopes, you can
-      find your OAuth token on its OAuth & Permissions page. The
-      required scopes are: channels:read, channels:history, groups:read,
-      groups:history, users:read, users:read.email.
-
-      If you don't have a Slack app, create one with the required
-      scopes pre-filled:
-
-      - [User token app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%7D%2C%22oauth_config%22%3A%7B%22redirect_urls%22%3A%5B%22http%3A%2F%2Flocalhost%3A53682%2Foauth%2Fcallback%22%5D%2C%22scopes%22%3A%7B%22user%22%3A%5B%22channels%3Ahistory%22%2C%22groups%3Aread%22%2C%22channels%3Aread%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%2C%22pkce_enabled%22%3Atrue%7D%2C%22settings%22%3A%7B%22org_deploy_enabled%22%3Afalse%2C%22socket_mode_enabled%22%3Afalse%2C%22token_rotation_enabled%22%3Afalse%2C%22is_mcp_enabled%22%3Afalse%7D%7D)
-        — works with the "Connect with Slack" OAuth flow. Reads the
-        channels the authorizing user belongs to.
-      - [Bot token app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%2C%22description%22%3A%22Coral+data+access%22%7D%2C%22oauth_config%22%3A%7B%22scopes%22%3A%7B%22bot%22%3A%5B%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%7D%2C%22features%22%3A%7B%22bot_user%22%3A%7B%22display_name%22%3A%22Coral%22%2C%22always_online%22%3Afalse%7D%7D%7D)
-        — install it, then paste the bot token. Reads the channels the
-        bot has been added to.
-
-      For more details, see the [Slack app setup guide](https://docs.slack.dev/app-management/quickstart-app-settings).
+      Slack has no general-purpose API for reading messages, so you need
+      a Slack app with an OAuth token. Both methods use these scopes:
+      `channels:read`, `channels:history`, `groups:read`,
+      `groups:history`, `users:read`, `users:read.email`. See the
+      [Slack app setup guide](https://docs.slack.dev/app-management/quickstart-app-settings).
 base_url: https://slack.com
 auth:
   type: HeaderAuth

--- a/sources/core/slack/manifest.yaml
+++ b/sources/core/slack/manifest.yaml
@@ -1,5 +1,5 @@
 name: slack
-version: 2.1.0
+version: 2.1.1
 dsl_version: 3
 backend: http
 description: >-

--- a/xtask/src/docs/render.rs
+++ b/xtask/src/docs/render.rs
@@ -228,9 +228,15 @@ fn render_credential_methods(out: &mut String, methods: &[ManifestCredentialMeth
         let detail = method
             .hint
             .as_deref()
-            .or(method.description.as_deref())
             .map(str::trim)
-            .filter(|detail| !detail.is_empty());
+            .filter(|detail| !detail.is_empty())
+            .or_else(|| {
+                method
+                    .description
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|detail| !detail.is_empty())
+            });
         if let Some(detail) = detail {
             write!(out, " — {}", escape_mdx(&flatten_for_table_cell(detail)))
                 .expect("writing to String is infallible");
@@ -244,7 +250,7 @@ fn render_credential_methods(out: &mut String, methods: &[ManifestCredentialMeth
 fn default_method_label(kind: ManifestCredentialMethodKind) -> &'static str {
     match kind {
         ManifestCredentialMethodKind::SourceConfig => "Paste token",
-        ManifestCredentialMethodKind::OAuth => "OAuth",
+        ManifestCredentialMethodKind::OAuth => "Connect with OAuth",
     }
 }
 
@@ -471,8 +477,12 @@ const COMMUNITY_OUTRO: &str = concat!(
 
 #[cfg(test)]
 mod tests {
-    use super::{changelog_page, community_sources_page, escape_mdx, index_page};
-    use coral_spec::parse_source_manifest_yaml;
+    use super::{
+        changelog_page, community_sources_page, escape_mdx, index_page, render_credential_methods,
+    };
+    use coral_spec::{
+        ManifestCredentialMethod, ManifestCredentialMethodKind, parse_source_manifest_yaml,
+    };
 
     const SAMPLE_MANIFEST: &str = r#"
 name: demo
@@ -701,5 +711,60 @@ tables:
             "community_sources_page_renders_catalog",
             community_sources_page(&[demo, minimal])
         );
+    }
+
+    fn method(
+        kind: ManifestCredentialMethodKind,
+        label: Option<&str>,
+        description: Option<&str>,
+        hint: Option<&str>,
+    ) -> ManifestCredentialMethod {
+        ManifestCredentialMethod {
+            kind,
+            label: label.map(ToString::to_string),
+            description: description.map(ToString::to_string),
+            hint: hint.map(ToString::to_string),
+            oauth: None,
+        }
+    }
+
+    #[test]
+    fn credential_method_detail_prefers_hint_then_falls_back_to_description() {
+        let mut out = String::new();
+        render_credential_methods(
+            &mut out,
+            &[
+                // Real hint wins over description.
+                method(
+                    ManifestCredentialMethodKind::SourceConfig,
+                    Some("Paste token"),
+                    Some("short blurb"),
+                    Some("Create a read-only token."),
+                ),
+                // Blank hint must fall back to the description, not suppress it.
+                method(
+                    ManifestCredentialMethodKind::OAuth,
+                    Some("Connect"),
+                    Some("Authorize in your browser."),
+                    Some("   "),
+                ),
+            ],
+        );
+        assert!(out.contains("- **Paste token** — Create a read-only token."));
+        assert!(out.contains("- **Connect** — Authorize in your browser."));
+    }
+
+    #[test]
+    fn credential_method_label_falls_back_to_cli_defaults() {
+        let mut out = String::new();
+        render_credential_methods(
+            &mut out,
+            &[
+                method(ManifestCredentialMethodKind::OAuth, None, None, None),
+                method(ManifestCredentialMethodKind::SourceConfig, None, None, None),
+            ],
+        );
+        assert!(out.contains("- **Connect with OAuth**"));
+        assert!(out.contains("- **Paste token**"));
     }
 }

--- a/xtask/src/docs/render.rs
+++ b/xtask/src/docs/render.rs
@@ -5,7 +5,10 @@
 
 use std::fmt::Write as _;
 
-use coral_spec::{ManifestInputSpec, ValidatedSourceManifest};
+use coral_spec::{
+    ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestInputSpec,
+    ValidatedSourceManifest,
+};
 
 /// Render the `changelog.mdx` page from a raw `CHANGELOG.md`.
 ///
@@ -196,6 +199,52 @@ fn render_input_block(out: &mut String, input: &ManifestInputSpec) {
             out.push_str(&escape_mdx(hint));
             out.push('\n');
         }
+    }
+
+    if let Some(credential) = input.credential.as_ref() {
+        render_credential_methods(out, &credential.methods);
+    }
+}
+
+/// Render the credential retrieval methods declared on a secret input.
+///
+/// The interactive CLI and UI surface each method's hint contextually when
+/// the user picks it; the static docs can't, so we list every method with
+/// its label and authored hint (falling back to its short description) as a
+/// compact bullet list. Hints are freeform markdown, so each one is
+/// flattened to a single line and run through [`escape_mdx`].
+fn render_credential_methods(out: &mut String, methods: &[ManifestCredentialMethod]) {
+    if methods.is_empty() {
+        return;
+    }
+    out.push_str("\nCredential methods:\n\n");
+    for method in methods {
+        let label = method
+            .label
+            .as_deref()
+            .map_or_else(|| default_method_label(method.kind), str::trim);
+        write!(out, "- **{}**", escape_mdx(label)).expect("writing to String is infallible");
+
+        let detail = method
+            .hint
+            .as_deref()
+            .or(method.description.as_deref())
+            .map(str::trim)
+            .filter(|detail| !detail.is_empty());
+        if let Some(detail) = detail {
+            write!(out, " — {}", escape_mdx(&flatten_for_table_cell(detail)))
+                .expect("writing to String is infallible");
+        }
+        out.push('\n');
+    }
+}
+
+/// Fallback display label for a credential method with no authored label,
+/// mirroring the interactive CLI/UI defaults.
+fn default_method_label(kind: ManifestCredentialMethodKind) -> &'static str {
+    match kind {
+        ManifestCredentialMethodKind::SourceConfig => "Paste token",
+        ManifestCredentialMethodKind::OAuth => "OAuth",
     }
 }
 
@@ -441,6 +490,24 @@ inputs:
   DEMO_TOKEN:
     kind: secret
     hint: Create an API token in Settings → Tokens
+    credential:
+      methods:
+        - type: oauth
+          label: Connect with demo
+          description: Authorize with OAuth.
+          hint: Sign in through the demo provider in your browser.
+          oauth:
+            flow:
+              type: device_code
+            endpoints:
+              device_authorization_url: https://demo.example.com/device/code
+              token_url: https://demo.example.com/token
+            client:
+              id:
+                default: demo-client
+        - type: source_config
+          label: Paste token
+          hint: Create a read-only API token in Settings.
 base_url: "{{input.DEMO_API_BASE}}"
 auth:
   type: HeaderAuth

--- a/xtask/src/docs/snapshots/xtask__docs__render__tests__index_page_renders_rows.snap
+++ b/xtask/src/docs/snapshots/xtask__docs__render__tests__index_page_renders_rows.snap
@@ -1,6 +1,5 @@
 ---
 source: xtask/src/docs/render.rs
-assertion_line: 455
 expression: "index_page(&[demo, minimal])"
 ---
 ---
@@ -52,6 +51,11 @@ Use the `admin` account's `token` value.
 `DEMO_TOKEN` (required)
 
 Create an API token in Settings → Tokens
+
+Credential methods:
+
+- **Connect with demo** — Sign in through the demo provider in your browser.
+- **Paste token** — Create a read-only API token in Settings.
 
 ### `minimal`
 


### PR DESCRIPTION
- Add an optional per-method `hint` so each credential method's guidance renders next to the field it fills, both in the CLI and the generated source docs (and in the future, in the UI). 
- Split GitHub, Slack, and Google Calendar's long single hints into focused per-method hints.

## Test plan

<img width="641" height="552" alt="image" src="https://github.com/user-attachments/assets/7cec5535-dabc-473f-91cc-28b54dceb97d" />
<img width="638" height="518" alt="image" src="https://github.com/user-attachments/assets/ba4a579b-df45-44af-a24d-27bd7dc97e0b" />
<img width="651" height="637" alt="image" src="https://github.com/user-attachments/assets/603050e3-19e5-4076-97ee-74f6d62a03f6" />

Now you get per-method hints:

<img width="851" height="397" alt="image" src="https://github.com/user-attachments/assets/2fcfc388-d87b-4435-b716-3522f3f5fd11" />

<img width="763" height="250" alt="image" src="https://github.com/user-attachments/assets/cb324237-c3b7-4427-927a-b15bd31ef011" />

Input with no methods still show hints:
<img width="825" height="177" alt="image" src="https://github.com/user-attachments/assets/5d18495d-972f-4c4a-950e-fd5e25c4399d" />
