### PR TITLE
feat(sources/community/helpscout): add Help Scout community source

### DIFF
--- a/sources/community/helpscout/README.md
+++ b/sources/community/helpscout/README.md
@@ -35,14 +35,19 @@ Requires a Help Scout OAuth application and access token.
 1. Sign in to [Help Scout](https://www.helpscout.com/).
 2. Open **Your Profile → My apps**.
 3. Click **Create My App**.
-4. Register a loopback redirect URI, for example `http://127.0.0.1/oauth/callback`
-   (Coral may bind a random port on `127.0.0.1` during interactive setup).
+4. Register this **exact** loopback redirect URI (Help Scout does not accept
+   variable localhost ports):
+
+   `http://127.0.0.1:8765/oauth/callback`
 5. Copy the **Application ID** and **Application Secret**.
-6. Grant these OAuth scopes to the app:
-   - `mailboxes:read`
-   - `conversations:read`
-   - `customers:read`
-   - `users:read`
+
+Help Scout documents two OAuth2 flows: **Authorization Code** (user signs in
+in the browser; this source uses that flow via Coral’s **Connect Help Scout**)
+and **Client Credentials** (machine-to-machine for internal integrations). API
+access requires a token associated with an **active, invited** Help Scout user.
+Help Scout does not document per-resource OAuth scope names in their auth
+overview—configure the app and complete authorization as described in their
+docs.
 
 See [Help Scout authentication](https://developer.helpscout.com/mailbox-api/overview/authentication/).
 
@@ -58,7 +63,9 @@ When prompted:
 
 - Choose **Connect Help Scout**
 - Enter your OAuth application ID and secret
-- Complete sign-in in the browser
+- Complete sign-in in the browser (callback goes to `127.0.0.1:8765`)
+- If the browser cannot reach localhost, paste the full redirect URL from the
+  address bar into the terminal when Coral prompts for it
 
 Or paste an existing token:
 
@@ -118,6 +125,157 @@ LIMIT 25;
 
 Other examples: `(number:123)`, `(email:"user@example.com")`,
 `(subject:"billing")`. See [Help Scout conversation search](https://developer.helpscout.com/mailbox-api/endpoints/conversations/list/).
+
+For community source PRs, include sanitized output from the commands below:
+`coral source lint`, `coral source add` (or interactive Connect), `coral source
+test helpscout`, and at least one row query per table plus
+`search_conversations`.
+
+### Commands to capture
+
+```bash
+coral source lint sources/community/helpscout/manifest.yaml
+coral source add --interactive --file sources/community/helpscout/manifest.yaml
+# or: export HELPSCOUT_ACCESS_TOKEN=... && coral source add --file sources/community/helpscout/manifest.yaml
+coral source test helpscout
+coral sql "SELECT id, name, slug FROM helpscout.mailboxes LIMIT 3"
+coral sql "SELECT id, email, first_name FROM helpscout.customers LIMIT 3"
+coral sql "SELECT id, number, subject, status, customer_email FROM helpscout.conversations LIMIT 3"
+coral sql "SELECT id, email, first_name, last_name FROM helpscout.users LIMIT 3"
+coral sql "SELECT id, number, subject, status FROM helpscout.search_conversations(query => 'status:active') LIMIT 3"
+```
+
+## Live validation output
+
+The following output was captured against Help Scout Mailbox API v2 with Coral
+using interactive OAuth (`redirect_uri` `http://127.0.0.1:8765/oauth/callback`).
+
+```text
+$ coral source lint sources/community/helpscout/manifest.yaml
+Manifest is valid
+```
+
+```text
+$ coral source add --interactive --file sources/community/helpscout/manifest.yaml
+Added source helpscout (secrets: keychain)
+
+  ✓ helpscout connected successfully
+  Secrets: keychain
+
+    helpscout (4 tables)
+    ├─ conversations
+    ├─ customers
+    ├─ mailboxes
+    └─ users
+    Query tests
+    4 declared · 4 passed · 0 failed
+
+    ✓ SELECT id, name, email FROM helpscout.mailboxes LIMIT 5
+      1 row
+
+    ✓ SELECT id, first_name, last_name, email FROM helpscout.customers LIMIT 5
+      2 rows
+
+    ✓ SELECT id, number, subject, status, customer_email FROM helpscout.conversations LIMIT 5
+      4 rows
+
+    ✓ SELECT id, email, first_name, last_name FROM helpscout.users LIMIT 5
+      1 row
+```
+
+```text
+$ coral source test helpscout
+
+  ✓ helpscout connected successfully
+  Secrets: keychain
+
+    helpscout (4 tables)
+    ├─ conversations
+    ├─ customers
+    ├─ mailboxes
+    └─ users
+    Query tests
+    4 declared · 4 passed · 0 failed
+
+    ✓ SELECT id, name, email FROM helpscout.mailboxes LIMIT 5
+      1 row
+
+    ✓ SELECT id, first_name, last_name, email FROM helpscout.customers LIMIT 5
+      2 rows
+
+    ✓ SELECT id, number, subject, status, customer_email FROM helpscout.conversations LIMIT 5
+      4 rows
+
+    ✓ SELECT id, email, first_name, last_name FROM helpscout.users LIMIT 5
+      1 row
+```
+
+```sql
+SELECT id, name, slug FROM helpscout.mailboxes LIMIT 3;
+```
+
+```text
++--------+----------------+------------------+
+| id     | name           | slug             |
++--------+----------------+------------------+
+| 369162 | Support Inbox  | a1b2c3d4e5f6g7h8 |
++--------+----------------+------------------+
+```
+
+```sql
+SELECT id, email, first_name FROM helpscout.customers LIMIT 3;
+```
+
+```text
++-----------+-------+------------+
+| id        | email | first_name |
++-----------+-------+------------+
+| 883767758 |       | Example    |
+| 883767756 |       | Helper     |
++-----------+-------+------------+
+```
+
+```sql
+SELECT id, number, subject, status, customer_email FROM helpscout.conversations LIMIT 3;
+```
+
+```text
++------------+--------+---------------------+--------+-------------------+
+| id         | number | subject             | status | customer_email    |
++------------+--------+---------------------+--------+-------------------+
+| 3342196193 | 3      | Example subject one | active | user@example.com  |
+| 3342196197 | 4      | Example subject two | active | user@example.com  |
+| 3342196184 | 1      | Welcome message     | active | help@example.com  |
++------------+--------+---------------------+--------+-------------------+
+```
+
+```sql
+SELECT id, email, first_name, last_name FROM helpscout.users LIMIT 3;
+```
+
+```text
++--------+-------------------+------------+-----------+
+| id     | email             | first_name | last_name |
++--------+-------------------+------------+-----------+
+| 939115 | agent@example.com | Example    | Agent     |
++--------+-------------------+------------+-----------+
+```
+
+```sql
+SELECT id, number, subject, status
+FROM helpscout.search_conversations(query => 'status:active')
+LIMIT 3;
+```
+
+```text
++------------+--------+---------------------+--------+
+| id         | number | subject             | status |
++------------+--------+---------------------+--------+
+| 3342196193 | 3      | Example subject one | active |
+| 3342196197 | 4      | Example subject two | active |
+| 3342196184 | 1      | Welcome message     | active |
++------------+--------+---------------------+--------+
+```
 
 ## Cross-source JOIN examples
 

--- a/sources/community/helpscout/README.md
+++ b/sources/community/helpscout/README.md
@@ -103,7 +103,7 @@ Coral sources (Gmail, Stripe, Linear, Intercom) in one query.
 | Name | Kind | Description |
 | --- | --- | --- |
 | `mailboxes` | table | Shared inboxes (mailbox ID, name, email) |
-| `customers` | table | End customers; join on `email` when present |
+| `customers` | table | End customers; join via `conversations.customer_email`, or `email` when embedded |
 | `conversations` | table | Support conversations with `customer_email` |
 | `users` | table | Help Scout agents and admins |
 | `search_conversations` | function | Provider-native search via `query` argument |
@@ -164,6 +164,9 @@ coral sql "SELECT id, number, subject, status FROM helpscout.search_conversation
 
 The following output was captured against Help Scout Mailbox API v2 with Coral
 using interactive OAuth (`redirect_uri` `http://127.0.0.1:8765/oauth/callback`).
+This account's customer list response omitted embedded email values, so
+`customers.email` is blank in the sample; cross-source examples use
+`conversations.customer_email`.
 
 ```text
 $ coral source lint sources/community/helpscout/manifest.yaml
@@ -345,8 +348,9 @@ SELECT
   h.subject,
   h.status
 FROM intercom.contacts i
-JOIN helpscout.customers hc ON LOWER(hc.email) = LOWER(i.email)
-JOIN helpscout.conversations h ON h.customer_id = hc.id
+JOIN helpscout.conversations h
+  ON LOWER(h.customer_email) = LOWER(i.email)
+LEFT JOIN helpscout.customers hc ON hc.id = h.customer_id
 LIMIT 30;
 ```
 
@@ -383,5 +387,6 @@ LIMIT 25;
 ## Limitations (v0.1)
 
 - No `threads`, `folders`, or custom-field tables yet.
-- Customer list rows may omit `email`; prefer `conversations.customer_email`
-  or join through `customer_id` when needed.
+- Customer list rows may omit embedded emails; prefer
+  `conversations.customer_email` for cross-source joins and use
+  `customers.email` only when `_embedded.emails` is populated by the list API.

--- a/sources/community/helpscout/README.md
+++ b/sources/community/helpscout/README.md
@@ -51,6 +51,21 @@ docs.
 
 See [Help Scout authentication](https://developer.helpscout.com/mailbox-api/overview/authentication/).
 
+### Permissions
+
+Authorization-code tokens inherit the connecting user's Help Scout account
+permissions. Help Scout does not document per-resource OAuth scope names in
+My apps—configure the OAuth app and sign in as a user with read access to the
+Mailbox API resources below.
+
+| Mailbox API access | Coral surface |
+| --- | --- |
+| Read mailboxes | `helpscout.mailboxes` |
+| Read customers | `helpscout.customers` |
+| Read conversations | `helpscout.conversations` |
+| Read users | `helpscout.users` |
+| Conversation search | `helpscout.search_conversations` |
+
 ### 2. Add the source
 
 Interactive OAuth (recommended):

--- a/sources/community/helpscout/README.md
+++ b/sources/community/helpscout/README.md
@@ -38,6 +38,11 @@ Requires a Help Scout OAuth application and access token.
 4. Register a loopback redirect URI, for example `http://127.0.0.1/oauth/callback`
    (Coral may bind a random port on `127.0.0.1` during interactive setup).
 5. Copy the **Application ID** and **Application Secret**.
+6. Grant these OAuth scopes to the app:
+   - `mailboxes:read`
+   - `conversations:read`
+   - `customers:read`
+   - `users:read`
 
 See [Help Scout authentication](https://developer.helpscout.com/mailbox-api/overview/authentication/).
 

--- a/sources/community/helpscout/README.md
+++ b/sources/community/helpscout/README.md
@@ -1,0 +1,209 @@
+# Help Scout (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Help Scout Mailbox API v2)
+**Tables:** 4
+**Functions:** 1
+**Base URL:** `https://api.helpscout.net/v2`
+
+Query Help Scout mailboxes, conversations, customers, and users. Designed for
+support inbox discovery, provider-native conversation search, and cross-source
+joins with bundled **Stripe**, **Intercom**, and **Linear** on customer email,
+and with community **Gmail** on sender email.
+
+## Install
+
+Community sources are not bundled with the Coral binary. Add the manifest from
+this directory:
+
+```bash
+coral source add --file sources/community/helpscout/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to
+`coral source add --file`.
+
+Reference the linked GitHub issue in your PR so maintainers can connect the
+contribution to the prior discussion.
+
+## Authentication and setup
+
+Requires a Help Scout OAuth application and access token.
+
+### 1. Create a Help Scout OAuth app
+
+1. Sign in to [Help Scout](https://www.helpscout.com/).
+2. Open **Your Profile → My apps**.
+3. Click **Create My App**.
+4. Register a loopback redirect URI, for example `http://127.0.0.1/oauth/callback`
+   (Coral may bind a random port on `127.0.0.1` during interactive setup).
+5. Copy the **Application ID** and **Application Secret**.
+
+See [Help Scout authentication](https://developer.helpscout.com/mailbox-api/overview/authentication/).
+
+### 2. Add the source
+
+Interactive OAuth (recommended):
+
+```bash
+coral source add --interactive --file sources/community/helpscout/manifest.yaml
+```
+
+When prompted:
+
+- Choose **Connect Help Scout**
+- Enter your OAuth application ID and secret
+- Complete sign-in in the browser
+
+Or paste an existing token:
+
+```bash
+export HELPSCOUT_ACCESS_TOKEN=your_token
+coral source add --file sources/community/helpscout/manifest.yaml
+```
+
+Access tokens expire in about **48 hours**. Re-run `coral source add` and
+choose **Connect Help Scout** when queries return HTTP 401.
+
+### Help Scout API vs Coral
+
+Help Scout's REST API is ideal for application integrations. Use this Coral
+source when you need **SQL joins and aggregations** across Help Scout and other
+Coral sources (Gmail, Stripe, Linear, Intercom) in one query.
+
+## Tables and functions
+
+| Name | Kind | Description |
+| --- | --- | --- |
+| `mailboxes` | table | Shared inboxes (mailbox ID, name, email) |
+| `customers` | table | End customers; join on `email` when present |
+| `conversations` | table | Support conversations with `customer_email` |
+| `users` | table | Help Scout agents and admins |
+| `search_conversations` | function | Provider-native search via `query` argument |
+
+### Conversation status values
+
+| Value | Meaning |
+| --- | --- |
+| `active` | Default list — active conversations |
+| `all` | Every status |
+| `open` | Open |
+| `pending` | Pending |
+| `closed` | Closed |
+| `spam` | Spam |
+
+Example:
+
+```sql
+SELECT id, number, subject, status, customer_email
+FROM helpscout.conversations
+WHERE status = 'open'
+LIMIT 20;
+```
+
+### Search syntax
+
+Use `search_conversations` for Help Scout query syntax:
+
+```sql
+SELECT id, number, subject, status, customer_email
+FROM helpscout.search_conversations(query => 'tag:vip')
+LIMIT 25;
+```
+
+Other examples: `(number:123)`, `(email:"user@example.com")`,
+`(subject:"billing")`. See [Help Scout conversation search](https://developer.helpscout.com/mailbox-api/endpoints/conversations/list/).
+
+## Cross-source JOIN examples
+
+### Gmail + Help Scout
+
+Customers who emailed you recently and have open Help Scout conversations
+(requires community `gmail` source with `message_details`):
+
+```sql
+SELECT
+  d.from_email,
+  d.subject AS gmail_subject,
+  c.number,
+  c.subject AS conversation_subject,
+  c.status
+FROM gmail.search_messages(q => 'newer_than:7d') m
+JOIN gmail.message_details d ON d.message_id = m.id
+JOIN helpscout.conversations c
+  ON LOWER(c.customer_email) = LOWER(d.from_email)
+WHERE c.status IN ('active', 'open', 'pending')
+LIMIT 20;
+```
+
+### Stripe + Help Scout
+
+Paying Stripe customers with active Help Scout conversations:
+
+```sql
+SELECT
+  s.email,
+  s.id AS stripe_customer_id,
+  c.number,
+  c.subject,
+  c.status
+FROM stripe.customers s
+JOIN helpscout.conversations c
+  ON LOWER(c.customer_email) = LOWER(s.email)
+WHERE c.status IN ('active', 'open', 'pending')
+LIMIT 50;
+```
+
+### Intercom + Help Scout
+
+Compare Intercom contacts with Help Scout customers on the same email:
+
+```sql
+SELECT
+  i.email,
+  i.id AS intercom_id,
+  hc.id AS helpscout_customer_id,
+  h.number,
+  h.subject,
+  h.status
+FROM intercom.contacts i
+JOIN helpscout.customers hc ON LOWER(hc.email) = LOWER(i.email)
+JOIN helpscout.conversations h ON h.customer_id = hc.id
+LIMIT 30;
+```
+
+### Linear + Help Scout
+
+Support conversations tied to Linear teammates by email:
+
+```sql
+SELECT
+  u.email,
+  u.name AS linear_name,
+  c.number,
+  c.subject,
+  c.status
+FROM linear.users u
+JOIN helpscout.conversations c
+  ON LOWER(c.customer_email) = LOWER(u.email)
+LIMIT 25;
+```
+
+## Notes
+
+- All tables are strictly read-only.
+- List endpoints use page-based pagination (`page=1`, `page=2`, …). Coral
+  follows pages until the fetch limit is reached.
+- `helpscout.conversations` defaults to **active** conversations on the API
+  side when no `status` filter is supplied. Use `WHERE status = 'all'` to
+  include every status.
+- `customer_email` on `conversations` comes from `primaryCustomer.email` and
+  is the primary join key for cross-source SQL.
+- Help Scout rate limits apply; respect fetch limits and use targeted filters
+  on large accounts.
+
+## Limitations (v0.1)
+
+- No `threads`, `folders`, or custom-field tables yet.
+- Customer list rows may omit `email`; prefer `conversations.customer_email`
+  or join through `customer_id` when needed.

--- a/sources/community/helpscout/manifest.yaml
+++ b/sources/community/helpscout/manifest.yaml
@@ -8,19 +8,6 @@ description: >-
   email, and with community Gmail on sender email.
 base_url: https://api.helpscout.net/v2
 inputs:
-  HELPSCOUT_OAUTH_CLIENT_ID:
-    kind: variable
-    hint: |
-      Help Scout OAuth application ID from Your Profile → My apps →
-      Create My App. Register a loopback redirect URI such as
-      http://127.0.0.1/oauth/callback (Coral may use a random port on
-      127.0.0.1 during interactive setup).
-      See https://developer.helpscout.com/mailbox-api/overview/authentication/
-  HELPSCOUT_OAUTH_CLIENT_SECRET:
-    kind: secret
-    hint: |
-      Help Scout OAuth application secret from the same My apps entry.
-      Required for the authorization-code and token exchange flows.
   HELPSCOUT_ACCESS_TOKEN:
     kind: secret
     hint: |
@@ -28,12 +15,15 @@ inputs:
       itself, without a `Bearer ` prefix.
 
       For interactive setup, choose "Connect Help Scout" and provide your
-      OAuth application ID and secret. The flow uses Help Scout's
-      authorization-code grant and returns access and refresh tokens.
-      Access tokens expire in about 48 hours (`expires_in: 172800`).
+      Help Scout OAuth application ID and secret from Your Profile → My apps.
+      Register a loopback redirect URI such as http://127.0.0.1/oauth/callback.
+      The flow uses Help Scout's authorization-code grant and returns access
+      and refresh tokens. Access tokens expire in about 48 hours
+      (`expires_in: 172800`).
 
       Re-run `coral source add` and choose Connect Help Scout when queries
       fail with HTTP 401.
+      See https://developer.helpscout.com/mailbox-api/overview/authentication/
     credential:
       methods:
         - type: oauth
@@ -72,7 +62,6 @@ test_queries:
   - SELECT id, first_name, last_name, email FROM helpscout.customers LIMIT 5
   - SELECT id, number, subject, status, customer_email FROM helpscout.conversations LIMIT 5
   - SELECT id, email, first_name, last_name FROM helpscout.users LIMIT 5
-  - SELECT function_name FROM coral.table_functions WHERE schema_name = 'helpscout' ORDER BY function_name LIMIT 1
 
 functions:
   - name: search_conversations

--- a/sources/community/helpscout/manifest.yaml
+++ b/sources/community/helpscout/manifest.yaml
@@ -1,0 +1,690 @@
+name: helpscout
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Help Scout mailboxes, conversations, customers, and users from the
+  Mailbox API v2. Join with bundled Stripe, Intercom, and Linear on customer
+  email, and with community Gmail on sender email.
+base_url: https://api.helpscout.net/v2
+inputs:
+  HELPSCOUT_OAUTH_CLIENT_ID:
+    kind: variable
+    hint: |
+      Help Scout OAuth application ID from Your Profile → My apps →
+      Create My App. Register a loopback redirect URI such as
+      http://127.0.0.1/oauth/callback (Coral may use a random port on
+      127.0.0.1 during interactive setup).
+      See https://developer.helpscout.com/mailbox-api/overview/authentication/
+  HELPSCOUT_OAUTH_CLIENT_SECRET:
+    kind: secret
+    hint: |
+      Help Scout OAuth application secret from the same My apps entry.
+      Required for the authorization-code and token exchange flows.
+  HELPSCOUT_ACCESS_TOKEN:
+    kind: secret
+    hint: |
+      Help Scout OAuth 2.0 access token (Bearer). Paste the token value
+      itself, without a `Bearer ` prefix.
+
+      For interactive setup, choose "Connect Help Scout" and provide your
+      OAuth application ID and secret. The flow uses Help Scout's
+      authorization-code grant and returns access and refresh tokens.
+      Access tokens expire in about 48 hours (`expires_in: 172800`).
+
+      Re-run `coral source add` and choose Connect Help Scout when queries
+      fail with HTTP 401.
+    credential:
+      methods:
+        - type: oauth
+          label: Connect Help Scout
+          description: Sign in to Help Scout and authorize read access.
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: disabled
+            redirect_uri: http://127.0.0.1/oauth/callback
+            redirect_uri_port_mode: random
+            endpoints:
+              authorization_url: https://secure.helpscout.net/authentication/authorizeClientApplication
+              token_url: https://api.helpscout.net/v2/oauth2/token
+            client:
+              id:
+                input: HELPSCOUT_OAUTH_CLIENT_ID
+              secret:
+                input: HELPSCOUT_OAUTH_CLIENT_SECRET
+                transport: request_body
+        - type: source_config
+          label: Paste access token
+          description: Paste an existing Help Scout OAuth access token.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.HELPSCOUT_ACCESS_TOKEN}}
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/hal+json
+test_queries:
+  - SELECT id, name, email FROM helpscout.mailboxes LIMIT 5
+  - SELECT id, first_name, last_name, email FROM helpscout.customers LIMIT 5
+  - SELECT id, number, subject, status, customer_email FROM helpscout.conversations LIMIT 5
+  - SELECT id, email, first_name, last_name FROM helpscout.users LIMIT 5
+  - SELECT function_name FROM coral.table_functions WHERE schema_name = 'helpscout' ORDER BY function_name LIMIT 1
+
+functions:
+  - name: search_conversations
+    kind: search
+    description: >
+      Provider-native Help Scout conversation search using the query
+      parameter (for example tag:vip, (number:123), (email:"user@example.com")).
+    fetch_limit_default: 25
+    search_limits:
+      default_top_k: 25
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: mailbox
+        bind:
+          arg: mailbox
+      - name: status
+        bind:
+          arg: status
+    request:
+      method: GET
+      path: /conversations
+      query:
+        - name: query
+          from: arg
+          key: query
+        - name: mailbox
+          from: arg
+          key: mailbox
+        - name: status
+          from: arg
+          key: status
+    response:
+      rows_path:
+        - _embedded
+        - conversations
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Help Scout search query passed to the function.
+        expr:
+          kind: from_arg
+          key: query
+      - name: mailbox
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional mailbox (inbox) ID filter.
+        expr:
+          kind: from_arg
+          key: mailbox
+      - name: id
+        type: Int64
+        nullable: false
+        description: Conversation ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: number
+        type: Int64
+        nullable: true
+        description: Human-readable conversation number in the mailbox.
+        expr:
+          kind: path
+          path:
+            - number
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Conversation subject line.
+        expr:
+          kind: path
+          path:
+            - subject
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Conversation status (active, closed, open, pending, spam).
+        expr:
+          kind: path
+          path:
+            - status
+      - name: mailbox_id
+        type: Int64
+        nullable: true
+        description: Mailbox (inbox) ID.
+        expr:
+          kind: path
+          path:
+            - mailboxId
+      - name: customer_id
+        type: Int64
+        nullable: true
+        description: Primary customer ID.
+        expr:
+          kind: path
+          path:
+            - primaryCustomer
+            - id
+      - name: customer_email
+        type: Utf8
+        nullable: true
+        description: Primary customer email (join key for Gmail, Stripe, Intercom).
+        expr:
+          kind: path
+          path:
+            - primaryCustomer
+            - email
+      - name: customer_name
+        type: Utf8
+        nullable: true
+        description: Primary customer first name.
+        expr:
+          kind: path
+          path:
+            - primaryCustomer
+            - first
+      - name: assignee_id
+        type: Int64
+        nullable: true
+        description: Assigned Help Scout user ID.
+        expr:
+          kind: path
+          path:
+            - assignee
+            - id
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Last user update timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - userUpdatedAt
+
+tables:
+  - name: mailboxes
+    description: Help Scout mailboxes (shared inboxes).
+    guide: |
+      Start here to discover mailbox IDs for filtering `conversations` and
+      `customers`. Use `id` with the `mailbox` filter on other tables.
+    fetch_limit_default: 50
+    request:
+      method: GET
+      path: /mailboxes
+    response:
+      rows_path:
+        - _embedded
+        - mailboxes
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Mailbox ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Mailbox display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Mailbox slug identifier.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Mailbox email address.
+        expr:
+          kind: path
+          path:
+            - email
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - createdAt
+
+  - name: customers
+    description: Help Scout customers (end users who contact support).
+    guide: |
+      Join `email` to `stripe.customers`, `intercom.contacts`, and
+      `linear.users`. When `email` is null on a list row, fetch the address
+      from `helpscout.conversations.customer_email` or filter with
+      `WHERE email IS NOT NULL`. Prefer mailbox scoping on large accounts.
+    fetch_limit_default: 50
+    filters:
+      - name: mailbox
+        required: false
+      - name: first_name
+        required: false
+      - name: last_name
+        required: false
+      - name: modified_since
+        required: false
+    request:
+      method: GET
+      path: /customers
+      query:
+        - name: mailbox
+          from: filter
+          key: mailbox
+        - name: firstName
+          from: filter
+          key: first_name
+        - name: lastName
+          from: filter
+          key: last_name
+        - name: modifiedSince
+          from: filter
+          key: modified_since
+    response:
+      rows_path:
+        - _embedded
+        - customers
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Customer ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: Customer first name.
+        expr:
+          kind: path
+          path:
+            - firstName
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: Customer last name.
+        expr:
+          kind: path
+          path:
+            - lastName
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Primary customer email when returned on the list row.
+        expr:
+          kind: path
+          path:
+            - email
+      - name: organization
+        type: Utf8
+        nullable: true
+        description: Organization name on the customer record.
+        expr:
+          kind: path
+          path:
+            - organization
+      - name: job_title
+        type: Utf8
+        nullable: true
+        description: Customer job title.
+        expr:
+          kind: path
+          path:
+            - jobTitle
+      - name: conversation_count
+        type: Int64
+        nullable: true
+        description: Number of conversations for this customer.
+        expr:
+          kind: path
+          path:
+            - conversationCount
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Last modification timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - updatedAt
+
+  - name: conversations
+    description: Help Scout support conversations.
+    guide: |
+      Lists conversations (defaults to active status server-side). Join
+      `customer_email` to Gmail sender email, Stripe customers, and Intercom
+      contacts. Use `mailbox` to scope to one inbox; `status = 'all'` for every
+      status. For provider-native search syntax use `search_conversations`.
+    fetch_limit_default: 50
+    filters:
+      - name: mailbox
+        required: false
+      - name: status
+        required: false
+      - name: tag
+        required: false
+      - name: assigned_to
+        required: false
+      - name: modified_since
+        required: false
+      - name: number
+        required: false
+    request:
+      method: GET
+      path: /conversations
+      query:
+        - name: mailbox
+          from: filter
+          key: mailbox
+        - name: status
+          from: filter
+          key: status
+        - name: tag
+          from: filter
+          key: tag
+        - name: assigned_to
+          from: filter
+          key: assigned_to
+        - name: modifiedSince
+          from: filter
+          key: modified_since
+        - name: number
+          from: filter
+          key: number
+    response:
+      rows_path:
+        - _embedded
+        - conversations
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Conversation ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: number
+        type: Int64
+        nullable: true
+        description: Human-readable conversation number in the mailbox.
+        expr:
+          kind: path
+          path:
+            - number
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Conversation subject line.
+        expr:
+          kind: path
+          path:
+            - subject
+      - name: preview
+        type: Utf8
+        nullable: true
+        description: Short preview of the latest thread.
+        expr:
+          kind: path
+          path:
+            - preview
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Conversation status.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: mailbox_id
+        type: Int64
+        nullable: true
+        description: Mailbox (inbox) ID.
+        expr:
+          kind: path
+          path:
+            - mailboxId
+      - name: folder_id
+        type: Int64
+        nullable: true
+        description: Folder ID within the mailbox.
+        expr:
+          kind: path
+          path:
+            - folderId
+      - name: customer_id
+        type: Int64
+        nullable: true
+        description: Primary customer ID.
+        expr:
+          kind: path
+          path:
+            - primaryCustomer
+            - id
+      - name: customer_email
+        type: Utf8
+        nullable: true
+        description: Primary customer email (join key for Gmail, Stripe, Intercom).
+        expr:
+          kind: path
+          path:
+            - primaryCustomer
+            - email
+      - name: customer_first_name
+        type: Utf8
+        nullable: true
+        description: Primary customer first name.
+        expr:
+          kind: path
+          path:
+            - primaryCustomer
+            - first
+      - name: customer_last_name
+        type: Utf8
+        nullable: true
+        description: Primary customer last name.
+        expr:
+          kind: path
+          path:
+            - primaryCustomer
+            - last
+      - name: assignee_id
+        type: Int64
+        nullable: true
+        description: Assigned Help Scout user ID.
+        expr:
+          kind: path
+          path:
+            - assignee
+            - id
+      - name: assignee_email
+        type: Utf8
+        nullable: true
+        description: Assigned agent email.
+        expr:
+          kind: path
+          path:
+            - assignee
+            - email
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Last user update timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - userUpdatedAt
+      - name: closed_at
+        type: Utf8
+        nullable: true
+        description: Close timestamp when the conversation is closed.
+        expr:
+          kind: path
+          path:
+            - closedAt
+
+  - name: users
+    description: Help Scout account users (agents and admins).
+    guide: |
+      Lists users on the account. Join `assignee_id` from `conversations`
+      to `users.id`. Filter by `email` for an exact match lookup.
+    fetch_limit_default: 50
+    filters:
+      - name: email
+        required: false
+      - name: mailbox
+        required: false
+    request:
+      method: GET
+      path: /users
+      query:
+        - name: email
+          from: filter
+          key: email
+        - name: mailbox
+          from: filter
+          key: mailbox
+    response:
+      rows_path:
+        - _embedded
+        - users
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: User ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: User first name.
+        expr:
+          kind: path
+          path:
+            - firstName
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: User last name.
+        expr:
+          kind: path
+          path:
+            - lastName
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address.
+        expr:
+          kind: path
+          path:
+            - email
+      - name: role
+        type: Utf8
+        nullable: true
+        description: Account role (for example owner, admin, user).
+        expr:
+          kind: path
+          path:
+            - role
+      - name: job_title
+        type: Utf8
+        nullable: true
+        description: User job title.
+        expr:
+          kind: path
+          path:
+            - jobTitle
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Last update timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - updatedAt

--- a/sources/community/helpscout/manifest.yaml
+++ b/sources/community/helpscout/manifest.yaml
@@ -292,10 +292,10 @@ tables:
   - name: customers
     description: Help Scout customers (end users who contact support).
     guide: |
-      Join `email` to `stripe.customers`, `intercom.contacts`, and
-      `linear.users`. When `email` is null on a list row, fetch the address
-      from `helpscout.conversations.customer_email` or filter with
-      `WHERE email IS NOT NULL`. Prefer mailbox scoping on large accounts.
+      Use `helpscout.conversations.customer_email` as the primary customer
+      email join key for cross-source queries. The `email` column is the first
+      `_embedded.emails[].value` address when Help Scout includes embedded
+      emails on the list row. Prefer mailbox scoping on large accounts.
     fetch_limit_default: 50
     filters:
       - name: mailbox
@@ -359,11 +359,14 @@ tables:
       - name: email
         type: Utf8
         nullable: true
-        description: Primary customer email when returned on the list row.
+        description: First customer email from _embedded.emails when returned on the list row.
         expr:
-          kind: path
+          kind: first_array_item_path
           path:
-            - email
+            - _embedded
+            - emails
+          item_path:
+            - value
       - name: organization
         type: Utf8
         nullable: true

--- a/sources/community/helpscout/manifest.yaml
+++ b/sources/community/helpscout/manifest.yaml
@@ -16,11 +16,15 @@ inputs:
 
       For interactive setup, choose "Connect Help Scout" and provide your
       Help Scout OAuth application ID and secret from Your Profile → My apps.
-      Register a loopback redirect URI such as http://127.0.0.1/oauth/callback.
+      Register the exact loopback redirect URI
+      http://127.0.0.1:8765/oauth/callback in Your Profile → My apps.
+      Help Scout uses the registered redirect URL as-is (it does not accept
+      variable localhost ports like some other OAuth providers).
       The flow uses Help Scout's authorization-code grant and returns access
       and refresh tokens. Access tokens expire in about 48 hours
-      (`expires_in: 172800`). Required scopes: `mailboxes:read`,
-      `conversations:read`, `customers:read`, and `users:read`.
+      (`expires_in: 172800`). The token must belong to an active, invited
+      Help Scout user. Help Scout also supports client-credentials grants for
+      internal use; this source uses authorization code for interactive setup.
 
       Re-run `coral source add` and choose Connect Help Scout when queries
       fail with HTTP 401.
@@ -34,8 +38,8 @@ inputs:
             flow:
               type: authorization_code
               pkce: disabled
-            redirect_uri: http://127.0.0.1/oauth/callback
-            redirect_uri_port_mode: random
+            redirect_uri: http://127.0.0.1:8765/oauth/callback
+            redirect_uri_port_mode: fixed
             endpoints:
               authorization_url: https://secure.helpscout.net/authentication/authorizeClientApplication
               token_url: https://api.helpscout.net/v2/oauth2/token

--- a/sources/community/helpscout/manifest.yaml
+++ b/sources/community/helpscout/manifest.yaml
@@ -26,6 +26,12 @@ inputs:
       Help Scout user. Help Scout also supports client-credentials grants for
       internal use; this source uses authorization code for interactive setup.
 
+      Permissions: Help Scout does not expose granular OAuth scope names in
+      My apps. Authorization-code tokens inherit the signed-in user's Help Scout
+      account access. The connecting user must be active, invited, and able to
+      read mailboxes, conversations, customers, and users via Mailbox API v2,
+      including conversation search.
+
       Re-run `coral source add` and choose Connect Help Scout when queries
       fail with HTTP 401.
       See https://developer.helpscout.com/mailbox-api/overview/authentication/
@@ -33,7 +39,7 @@ inputs:
       methods:
         - type: oauth
           label: Connect Help Scout
-          description: Sign in to Help Scout and authorize read access.
+          description: Sign in with a Help Scout user who can read mailboxes, conversations, customers, and users.
           oauth:
             flow:
               type: authorization_code

--- a/sources/community/helpscout/manifest.yaml
+++ b/sources/community/helpscout/manifest.yaml
@@ -19,7 +19,8 @@ inputs:
       Register a loopback redirect URI such as http://127.0.0.1/oauth/callback.
       The flow uses Help Scout's authorization-code grant and returns access
       and refresh tokens. Access tokens expire in about 48 hours
-      (`expires_in: 172800`).
+      (`expires_in: 172800`). Required scopes: `mailboxes:read`,
+      `conversations:read`, `customers:read`, and `users:read`.
 
       Re-run `coral source add` and choose Connect Help Scout when queries
       fail with HTTP 401.


### PR DESCRIPTION
Closes #1119

## Summary

- add `helpscout` community source under `sources/community/helpscout`
- expose Help Scout mailboxes, customers, conversations, and users
- add provider-native `search_conversations` search function
- include README setup docs and example SQL queries

## Test plan

- [x] `coral source lint sources/community/helpscout/manifest.yaml`
- [x] `make lint-sources`
- [x] `coral source add --file sources/community/helpscout/manifest.yaml`
- [x] `coral sql "SELECT schema_name, table_name FROM coral.tables WHERE schema_name = 'helpscout' ORDER BY table_name LIMIT 10"`
- [x] `coral sql "SELECT function_name, kind FROM coral.table_functions WHERE schema_name = 'helpscout' LIMIT 5"`