### PR TITLE
perf(engine): stream HTTP/MCP scans into bounded RecordBatches

### DIFF
--- a/crates/coral-engine/src/backends/shared/json_exec.rs
+++ b/crates/coral-engine/src/backends/shared/json_exec.rs
@@ -251,7 +251,7 @@ mod tests {
         Arc::new(move |items: &[Value]| {
             let values: Int32Array = items
                 .iter()
-                .map(|value| value.as_i64().map(|n| n as i32))
+                .map(|value| value.as_i64().and_then(|n| i32::try_from(n).ok()))
                 .collect();
             RecordBatch::try_new(schema.clone(), vec![Arc::new(values) as Arc<dyn Array>]).map_err(
                 |error| datafusion::error::DataFusionError::ArrowError(Box::new(error), None),

--- a/crates/coral-engine/src/backends/shared/json_exec.rs
+++ b/crates/coral-engine/src/backends/shared/json_exec.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::error::Result;
+use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
@@ -16,7 +16,7 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
     SendableRecordBatchStream,
 };
-use futures::stream;
+use futures::{TryStreamExt, stream};
 use serde_json::Value;
 
 /// Fetches raw JSON rows for one logical table scan.
@@ -137,30 +137,70 @@ impl ExecutionPlan for JsonExec {
     fn execute(
         &self,
         _partition: usize,
-        _context: Arc<TaskContext>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let fetcher = self.fetcher.clone();
         let converter = self.converter.clone();
         let projected_schema = self.projected_schema.clone();
         let projection = self.projection.clone();
+        // Emit the fetched rows in `batch_size`-row chunks rather than a single
+        // batch spanning the whole result set. Each chunk's `Vec<Value>` is
+        // dropped as soon as it is converted, so the heavy serde_json
+        // representation is released incrementally instead of being held
+        // alongside one large `RecordBatch`.
+        let batch_size = context.session_config().batch_size().max(1);
 
         let stream = stream::once(async move {
             let items = fetcher.fetch().await?;
-            let batch = converter(&items)?;
-
-            match &projection {
-                Some(indices) => batch.project(indices).map_err(|error| {
-                    datafusion::error::DataFusionError::ArrowError(Box::new(error), None)
-                }),
-                None => Ok(batch),
-            }
-        });
+            let state = ChunkState {
+                rows: items.into_iter(),
+                converter,
+                projection,
+                batch_size,
+                emitted: false,
+            };
+            Ok::<_, DataFusionError>(stream::try_unfold(state, next_projected_batch))
+        })
+        .try_flatten();
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             projected_schema,
             stream,
         )))
     }
+}
+
+/// Streaming state for [`JsonExec`]: the remaining fetched rows plus the
+/// conversion/projection context needed to emit each bounded batch.
+struct ChunkState {
+    rows: std::vec::IntoIter<Value>,
+    converter: Converter,
+    projection: Option<Vec<usize>>,
+    batch_size: usize,
+    emitted: bool,
+}
+
+/// Pulls up to `batch_size` rows, converts them into one projected
+/// `RecordBatch`, and returns the advanced state. An empty result still yields
+/// a single empty batch so the schema is carried downstream, matching the
+/// previous single-batch behavior.
+async fn next_projected_batch(mut state: ChunkState) -> Result<Option<(RecordBatch, ChunkState)>> {
+    let chunk: Vec<Value> = state.rows.by_ref().take(state.batch_size).collect();
+    if chunk.is_empty() && state.emitted {
+        return Ok(None);
+    }
+    state.emitted = true;
+
+    let batch = (state.converter)(&chunk)?;
+    let batch = match &state.projection {
+        Some(indices) => batch
+            .project(indices)
+            .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?,
+        None => batch,
+    };
+    // `chunk` is dropped here, releasing this slice of `serde_json::Value`
+    // rows before the next batch is produced.
+    Ok(Some((batch, state)))
 }
 
 #[cfg(test)]
@@ -175,7 +215,7 @@ mod tests {
     use datafusion::physical_plan::ExecutionPlan;
     use serde_json::Value;
 
-    use super::{Converter, Fetcher, JsonExec, RowFetcher};
+    use super::{ChunkState, Converter, Fetcher, JsonExec, RowFetcher, next_projected_batch};
 
     #[derive(Debug)]
     struct NoopFetcher;
@@ -199,6 +239,87 @@ mod tests {
             )
             .map_err(|error| datafusion::error::DataFusionError::ArrowError(Box::new(error), None))
         })
+    }
+
+    fn int_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new("n", DataType::Int32, false)]))
+    }
+
+    // Builds one Int32 column "n" with one row per item, sized to the chunk so
+    // per-batch row counts and ordering are observable.
+    fn int_converter(schema: Arc<Schema>) -> Converter {
+        Arc::new(move |items: &[Value]| {
+            let values: Int32Array = items
+                .iter()
+                .map(|value| value.as_i64().map(|n| n as i32))
+                .collect();
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(values) as Arc<dyn Array>]).map_err(
+                |error| datafusion::error::DataFusionError::ArrowError(Box::new(error), None),
+            )
+        })
+    }
+
+    #[test]
+    fn streams_rows_in_bounded_batches_preserving_order() {
+        let rows: Vec<Value> = (0..5).map(Value::from).collect();
+        let mut state = ChunkState {
+            rows: rows.into_iter(),
+            converter: int_converter(int_schema()),
+            projection: None,
+            batch_size: 2,
+            emitted: false,
+        };
+
+        let mut batches = Vec::new();
+        while let Some((batch, next)) =
+            futures::executor::block_on(next_projected_batch(state)).expect("batch")
+        {
+            batches.push(batch);
+            state = next;
+        }
+
+        // 5 rows at batch_size 2 -> [2, 2, 1], not one batch of 5.
+        assert_eq!(
+            batches
+                .iter()
+                .map(RecordBatch::num_rows)
+                .collect::<Vec<_>>(),
+            vec![2, 2, 1]
+        );
+        let observed: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .expect("int column")
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert_eq!(observed, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn empty_result_yields_single_empty_batch() {
+        let state = ChunkState {
+            rows: Vec::new().into_iter(),
+            converter: int_converter(int_schema()),
+            projection: None,
+            batch_size: 8,
+            emitted: false,
+        };
+
+        let (batch, state) = futures::executor::block_on(next_projected_batch(state))
+            .expect("batch")
+            .expect("empty results still emit one schema-carrying batch");
+        assert_eq!(batch.num_rows(), 0);
+        assert!(
+            futures::executor::block_on(next_projected_batch(state))
+                .expect("done")
+                .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Intent — why

HTTP- and MCP-backed table scans go through `JsonExec`, which used `stream::once`: it fetched the **entire** result set as one `Vec<serde_json::Value>` and converted it into a **single giant `RecordBatch`**. At peak the whole dataset is held twice — the heavy serde_json buffer (each row re-stores its column-name keys as owned `String`s, ~3–5× the wire JSON) plus one contiguous Arrow batch — and the scan ignored DataFusion's `batch_size`. On large or unfiltered scans this drives multi-GB peak memory and was a contributor to the ~10 GB RSS we observed on real queries.

## What it enables — what

`JsonExec::execute` now emits the fetched rows as a **lazy stream of `batch_size`-row `RecordBatch`es** (default 8192) via `futures::stream::try_unfold`, dropping each chunk's `Vec<Value>` as soon as it is converted. Effects:

- **Caps the Arrow batch** at one `batch_size` chunk instead of one batch spanning the whole result.
- **Releases the heavy serde_json rows incrementally** as the consumer pulls, instead of holding the full `Vec<Value>` alongside the full Arrow batch.
- **Lets downstream operators pipeline / short-circuit** — e.g. a `LIMIT` stops pulling, so the remaining rows are never converted.
- **Respects `datafusion.execution.batch_size`**, making HTTP/MCP scans behave like the file-format scans the pipeline already supports.

Behavior-preserving details: per-chunk conversion uses the same fixed schema (`convert_items`), so every batch is schema-consistent and projection is applied identically; an **empty result still emits exactly one schema-carrying batch**.

**Scope is deliberately limited to the `JsonExec` conversion/emission boundary.** The upstream `fetch_rows` still fetches all pages up front — page-level fetch streaming and a bounded DataFusion `MemoryPool` are separate follow-ups (see #886 and the predicate-pushdown stack #399–#607). This is an independent branch and does **not** touch the catalog-memory PR (#1105).

## Usage examples

Transparent — no API or config change. Any HTTP/MCP source query now converts and emits in `batch_size` chunks rather than one mega-batch, e.g.:

```sql
-- previously: whole result -> one Vec<Value> + one giant RecordBatch
-- now:        emitted as 8192-row RecordBatches, freed incrementally
SELECT number, title FROM github.pulls WHERE owner = 'withcoral' AND repo = 'coral';
```

Batch size follows the session config (`datafusion.execution.batch_size`).

## Verification

- New unit tests in `json_exec.rs`: bounded chunking with order preserved (`[2,2,1]` for 5 rows at `batch_size=2`), and empty result → single empty batch.
- `cargo test -p coral-engine` — 227 lib + 124 integration pass (incl. HTTP `LIMIT`/`ORDER BY`/pagination); `coral-client` (28) and `coral-mcp` (21) pass; clippy clean.
- Consumer audit: every production consumer of the result already iterates the full `Vec<RecordBatch>` (no `batches[0]` assumption), and multiple batches were already possible (file scans, sorts, aggregates), so nothing downstream regresses.

## Benchmark — peak heap, old vs new

Measured with [`dhat`](https://docs.rs/dhat) (peak live heap, `max_bytes`), 200,000 synthetic rows, isolating the `JsonExec` scan stage. `new` is the real `JsonExec::execute`; `old` is a faithful inline reproduction of the prior `execute()` (whole `Vec<Value>` converted into one batch, both alive together). The harness was temporary and is **not** part of this PR.

| Row shape | fetched `Vec<Value>` floor | **old** peak | **new** peak | reduction |
|---|--:|--:|--:|--:|
| narrow — 16 fields × ~16 B | 473.8 MiB | 550.0 MiB | 476.9 MiB | **−13.3%** |
| medium — 8 fields × ~48 B | 277.7 MiB | 411.8 MiB | 282.5 MiB | **−31.4%** |
| wide — 3 fields × ~256 B | 302.5 MiB | 496.8 MiB | 309.2 MiB | **−37.8%** |

**Takeaways**

- The win = eliminating the second full copy of the result (the single giant Arrow `RecordBatch` that used to coexist with the whole fetched `Vec<serde_json::Value>`). New peak ≈ `Vec<Value>` + one `batch_size` chunk.
- Magnitude scales with row shape: wide rows make the Arrow batch a larger fraction of the total (~38% saved); narrow rows let serde_json key/enum overhead dominate the `Vec<Value>`, so the eliminated batch is a smaller fraction (~13% saved). Numeric-heavy columns (denser Arrow) would push the saving higher.
- The remaining floor **is** the un-streamed `Vec<serde_json::Value>` from `fetch_rows` (the "floor" column; new peak is within ~2% of it). Bringing that down is the separate fetch-streaming + bounded-memory-pool follow-up — out of scope here.
- `collect` and `drain` consumers measured identically because `fetch()` builds the full `Vec<Value>` before streaming begins, so the peak is hit up front regardless of consumer (a `LIMIT` short-circuit wouldn't move it either).

Run (harness not included): `cargo test -p coral-engine --lib mem_bench -- --ignored --nocapture --test-threads=1`.
