### PR TITLE
feat(codex): expose JSONL event provenance

### DIFF
--- a/crates/coral-engine/src/backends/file/file_groups.rs
+++ b/crates/coral-engine/src/backends/file/file_groups.rs
@@ -1,0 +1,86 @@
+//! File grouping helpers for file-backed table scans.
+
+use datafusion::datasource::listing::{ListingTableUrl, PartitionedFile};
+use datafusion::datasource::physical_plan::FileGroup;
+use datafusion::error::Result;
+use datafusion::logical_expr::Expr;
+use object_store::ObjectMeta;
+
+use super::metadata::FileMetadataColumns;
+use super::partitions::{
+    PartitionColumns, partition_filter_constraints, partition_values_for_path,
+};
+
+pub(super) struct FileGroupsForScan {
+    pub(super) groups: Vec<FileGroup>,
+    pub(super) grouped_by_partition: bool,
+}
+
+pub(super) fn file_groups_for_scan(
+    table_path: &ListingTableUrl,
+    partition_columns: &PartitionColumns,
+    files: Vec<ObjectMeta>,
+    file_metadata_columns: &FileMetadataColumns,
+    filters: &[Expr],
+    target_partitions: usize,
+    preserve_file_partitions: usize,
+) -> Result<FileGroupsForScan> {
+    let constraints = partition_filter_constraints(filters, partition_columns);
+    let mut partitioned_files = Vec::new();
+
+    for meta in files {
+        let partition_values =
+            partition_values_for_path(table_path, &meta.location, partition_columns)?;
+        if !constraints.matches(&partition_values) {
+            continue;
+        }
+
+        let mut partition_values = partition_values.into_scalars();
+        partition_values.extend(file_metadata_columns.file_values(table_path, &meta.location)?);
+        partitioned_files
+            .push(PartitionedFile::new_from_meta(meta).with_partition_values(partition_values));
+    }
+
+    if partitioned_files.is_empty() {
+        return Ok(FileGroupsForScan {
+            groups: vec![FileGroup::default()],
+            grouped_by_partition: false,
+        });
+    }
+
+    partitioned_files.sort_by(|left, right| {
+        left.object_meta
+            .location
+            .as_ref()
+            .cmp(right.object_meta.location.as_ref())
+    });
+
+    let file_group = FileGroup::new(partitioned_files);
+    let target_partitions = target_partitions.max(1);
+    if partition_columns.is_empty()
+        || file_metadata_columns.has_file_columns()
+        || preserve_file_partitions == 0
+    {
+        return Ok(FileGroupsForScan {
+            groups: file_group.split_files(target_partitions),
+            grouped_by_partition: false,
+        });
+    }
+
+    let grouped = file_group.group_by_partition_values(target_partitions);
+    if grouped.len() >= preserve_file_partitions {
+        Ok(FileGroupsForScan {
+            groups: grouped,
+            grouped_by_partition: true,
+        })
+    } else {
+        let files = grouped
+            .into_iter()
+            .flat_map(FileGroup::into_inner)
+            .collect::<Vec<_>>();
+        Ok(FileGroupsForScan {
+            groups: FileGroup::new(files).split_files(target_partitions),
+            grouped_by_partition: false,
+        })
+    }
+}

--- a/crates/coral-engine/src/backends/file/json.rs
+++ b/crates/coral-engine/src/backends/file/json.rs
@@ -21,7 +21,7 @@ use datafusion::datasource::TableProvider;
 use datafusion::datasource::file_format::json::JsonDecoder;
 use datafusion::datasource::listing::{ListingTableUrl, PartitionedFile};
 use datafusion::datasource::physical_plan::{
-    FileGroup, FileOpenFuture, FileOpener, FileScanConfig, FileScanConfigBuilder, FileSource,
+    FileOpenFuture, FileOpener, FileScanConfig, FileScanConfigBuilder, FileSource,
     JsonSource as DataFusionJsonSource,
 };
 use datafusion::datasource::source::DataSourceExec;
@@ -39,7 +39,7 @@ use datafusion_datasource_json::utils::{ChannelReader, JsonArrayToNdjsonReader};
 use futures::stream::{self, BoxStream};
 use futures::{Stream, StreamExt as _, TryStreamExt as _};
 use object_store::path::Path as ObjectPath;
-use object_store::{GetResultPayload, ObjectMeta, ObjectStore, ObjectStoreExt};
+use object_store::{GetResultPayload, ObjectStore, ObjectStoreExt};
 use serde_json::Value;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -48,10 +48,11 @@ use crate::backends::shared::mapping::json_value_to_text;
 use coral_spec::backends::file::{FileFormat, FileTableSpec};
 use coral_spec::{ColumnSpec, ManifestDataType};
 
+use super::file_groups::{FileGroupsForScan, file_groups_for_scan};
 use super::listing::{PreparedListingTable, prepare_listing_table};
+use super::metadata::FileMetadataColumns;
 use super::partitions::{
     PartitionColumns, filter_is_supported_partition_filter, filter_references_partition,
-    partition_filter_constraints, partition_values_for_path,
 };
 
 const JSON_ARRAY_CHANNEL_BUFFER_SIZE: usize = 128;
@@ -96,6 +97,7 @@ pub(super) struct JsonFileTableProvider {
     schema: SchemaRef,
     table_schema: TableSchema,
     json_fields: Arc<HashSet<String>>,
+    metadata_columns: FileMetadataColumns,
     partition_columns: PartitionColumns,
 }
 
@@ -127,8 +129,10 @@ impl JsonFileTableProvider {
         } = prepare_listing_table(ctx, source_schema, &table, home_dir, resolved_inputs).await?;
 
         let file_schema = schema_from_columns(table.columns(), source_schema, table.name())?;
-        let partition_fields = partition_columns.arrow_fields();
-        let table_schema = TableSchema::new(file_schema, partition_fields);
+        let table_schema = TableSchema::new(file_schema, partition_columns.arrow_fields());
+
+        let metadata_columns = FileMetadataColumns::try_new(&table.source.metadata)?;
+        let table_schema = metadata_columns.extend_table_schema_if_present(table_schema);
         let schema = Arc::clone(table_schema.table_schema());
         let json_fields = Arc::new(json_field_names(table.columns())?);
 
@@ -142,13 +146,17 @@ impl JsonFileTableProvider {
             schema,
             table_schema,
             json_fields,
+            metadata_columns,
             partition_columns,
         })
     }
 }
 
 pub(super) fn requires_custom_provider(table: &FileTableSpec) -> Result<bool> {
-    Ok(!table.source.partitions.is_empty() || !json_field_names(table.columns())?.is_empty())
+    let metadata_columns = FileMetadataColumns::try_new(&table.source.metadata)?;
+    Ok(!table.source.partitions.is_empty()
+        || metadata_columns.has_row_columns()
+        || !json_field_names(table.columns())?.is_empty())
 }
 
 #[async_trait]
@@ -203,13 +211,14 @@ impl TableProvider for JsonFileTableProvider {
                 DataFusionError::Execution(format!("failed to list {}: {error}", self.table_path))
             })?;
 
-        let JsonFileGroups {
+        let FileGroupsForScan {
             groups,
             grouped_by_partition,
-        } = json_file_groups(
+        } = file_groups_for_scan(
             &self.table_path,
             &self.partition_columns,
             files,
+            &self.metadata_columns,
             filters,
             state.config().target_partitions(),
             state.config_options().optimizer.preserve_file_partitions,
@@ -219,6 +228,7 @@ impl TableProvider for JsonFileTableProvider {
             self.table_schema.clone(),
             self.format,
             Arc::clone(&self.json_fields),
+            self.metadata_columns.clone(),
             projection,
         );
 
@@ -238,11 +248,22 @@ fn json_file_source(
     table_schema: TableSchema,
     format: FileFormat,
     json_fields: Arc<HashSet<String>>,
+    metadata_columns: FileMetadataColumns,
     projection: Option<&Vec<usize>>,
 ) -> Arc<dyn FileSource> {
     let read_mode = JsonReadMode::from_file_format(format);
-    if projection_requires_json_normalization(&table_schema, &json_fields, projection) {
-        Arc::new(CoralJsonSource::new(table_schema, read_mode, json_fields))
+    if projection_requires_json_normalization(
+        &table_schema,
+        &json_fields,
+        &metadata_columns,
+        projection,
+    ) {
+        Arc::new(CoralJsonSource::new(
+            table_schema,
+            read_mode,
+            json_fields,
+            metadata_columns,
+        ))
     } else {
         Arc::new(
             DataFusionJsonSource::new(table_schema)
@@ -254,9 +275,10 @@ fn json_file_source(
 fn projection_requires_json_normalization(
     table_schema: &TableSchema,
     json_fields: &HashSet<String>,
+    metadata_columns: &FileMetadataColumns,
     projection: Option<&Vec<usize>>,
 ) -> bool {
-    if json_fields.is_empty() {
+    if json_fields.is_empty() && !metadata_columns.has_row_columns() {
         return false;
     }
 
@@ -269,7 +291,9 @@ fn projection_requires_json_normalization(
             .table_schema()
             .fields()
             .get(*index)
-            .is_some_and(|field| json_fields.contains(field.name()))
+            .is_some_and(|field| {
+                json_fields.contains(field.name()) || metadata_columns.row_contains(field.name())
+            })
     })
 }
 
@@ -278,6 +302,7 @@ struct CoralJsonSource {
     table_schema: TableSchema,
     read_mode: JsonReadMode,
     json_fields: Arc<HashSet<String>>,
+    metadata_columns: FileMetadataColumns,
     projection: SplitProjection,
     batch_size: Option<usize>,
     metrics: ExecutionPlanMetricsSet,
@@ -288,12 +313,14 @@ impl CoralJsonSource {
         table_schema: TableSchema,
         read_mode: JsonReadMode,
         json_fields: Arc<HashSet<String>>,
+        metadata_columns: FileMetadataColumns,
     ) -> Self {
         let projection = SplitProjection::unprojected(&table_schema);
         Self {
             table_schema,
             read_mode,
             json_fields,
+            metadata_columns,
             projection,
             batch_size: None,
             metrics: ExecutionPlanMetricsSet::new(),
@@ -323,6 +350,7 @@ impl FileSource for CoralJsonSource {
             object_store,
             read_mode: self.read_mode,
             json_fields: Arc::clone(&self.json_fields),
+            metadata_columns: self.metadata_columns.clone(),
         }) as Arc<dyn FileOpener>;
 
         ProjectionOpener::try_new(
@@ -388,6 +416,7 @@ struct CoralJsonOpener {
     object_store: Arc<dyn ObjectStore>,
     read_mode: JsonReadMode,
     json_fields: Arc<HashSet<String>>,
+    metadata_columns: FileMetadataColumns,
 }
 
 impl FileOpener for CoralJsonOpener {
@@ -404,6 +433,7 @@ impl FileOpener for CoralJsonOpener {
         let compression = self.file_compression_type;
         let read_mode = self.read_mode;
         let json_fields = Arc::clone(&self.json_fields);
+        let metadata_columns = self.metadata_columns.clone();
         let location = partitioned_file.object_meta.location;
 
         Ok(Box::pin(async move {
@@ -411,7 +441,8 @@ impl FileOpener for CoralJsonOpener {
             match (read_mode, result.payload) {
                 (JsonReadMode::NewlineDelimited, GetResultPayload::File(file, _)) => {
                     let reader = compression.convert_read(file)?;
-                    let reader = CompatJsonlReader::new(reader, location, json_fields);
+                    let reader =
+                        CompatJsonlReader::new(reader, location, json_fields, metadata_columns);
                     let arrow_reader = ReaderBuilder::new(schema)
                         .with_batch_size(batch_size)
                         .build(reader)?;
@@ -425,7 +456,8 @@ impl FileOpener for CoralJsonOpener {
                         reader,
                         JSON_ARRAY_CONVERTER_BUFFER_SIZE,
                     );
-                    let reader = CompatJsonlReader::new(reader, location, json_fields);
+                    let reader =
+                        CompatJsonlReader::new(reader, location, json_fields, metadata_columns);
                     let arrow_reader = ReaderBuilder::new(schema)
                         .with_batch_size(batch_size)
                         .build(reader)?;
@@ -436,7 +468,8 @@ impl FileOpener for CoralJsonOpener {
                 (JsonReadMode::NewlineDelimited, GetResultPayload::Stream(stream)) => {
                     let input = stream.map_err(DataFusionError::from).boxed();
                     let input = compression.convert_stream(input)?;
-                    let input = normalize_jsonl_stream(input, location, json_fields);
+                    let input =
+                        normalize_jsonl_stream(input, location, json_fields, metadata_columns);
                     let decoder = ReaderBuilder::new(schema)
                         .with_batch_size(batch_size)
                         .build_decoder()?;
@@ -453,6 +486,7 @@ impl FileOpener for CoralJsonOpener {
                         input,
                         location,
                         json_fields,
+                        metadata_columns,
                         schema,
                         batch_size,
                     ))
@@ -480,6 +514,7 @@ struct CompatJsonlReader<R> {
     reader: BufReader<R>,
     location: ObjectPath,
     json_fields: Arc<HashSet<String>>,
+    metadata_columns: FileMetadataColumns,
     line: Vec<u8>,
     pending: Vec<u8>,
     pending_offset: usize,
@@ -487,11 +522,17 @@ struct CompatJsonlReader<R> {
 }
 
 impl<R: Read> CompatJsonlReader<R> {
-    fn new(reader: R, location: ObjectPath, json_fields: Arc<HashSet<String>>) -> Self {
+    fn new(
+        reader: R,
+        location: ObjectPath,
+        json_fields: Arc<HashSet<String>>,
+        metadata_columns: FileMetadataColumns,
+    ) -> Self {
         Self {
             reader: BufReader::new(reader),
             location,
             json_fields,
+            metadata_columns,
             line: Vec::new(),
             pending: Vec::new(),
             pending_offset: 0,
@@ -513,6 +554,7 @@ impl<R: Read> CompatJsonlReader<R> {
                 self.line_number,
                 &self.line,
                 &self.json_fields,
+                &self.metadata_columns,
             )
             .map_err(|error| datafusion_error_to_io(&error))?
             else {
@@ -589,6 +631,7 @@ struct JsonlStreamState {
     input: BoxStream<'static, Result<Bytes>>,
     location: ObjectPath,
     json_fields: Arc<HashSet<String>>,
+    metadata_columns: FileMetadataColumns,
     buffer: BytesMut,
     pending: VecDeque<Bytes>,
     line_number: usize,
@@ -599,9 +642,13 @@ impl JsonlStreamState {
     fn drain_complete_lines(&mut self) -> Result<()> {
         while let Some(line) = take_jsonl_line(&mut self.buffer) {
             self.line_number += 1;
-            if let Some(line) =
-                normalize_jsonl_line(&self.location, self.line_number, &line, &self.json_fields)?
-            {
+            if let Some(line) = normalize_jsonl_line(
+                &self.location,
+                self.line_number,
+                &line,
+                &self.json_fields,
+                &self.metadata_columns,
+            )? {
                 self.pending.push_back(line);
             }
         }
@@ -613,11 +660,13 @@ fn normalize_jsonl_stream(
     input: BoxStream<'static, Result<Bytes>>,
     location: ObjectPath,
     json_fields: Arc<HashSet<String>>,
+    metadata_columns: FileMetadataColumns,
 ) -> BoxStream<'static, Result<Bytes>> {
     let state = JsonlStreamState {
         input,
         location,
         json_fields,
+        metadata_columns,
         buffer: BytesMut::new(),
         pending: VecDeque::new(),
         line_number: 0,
@@ -645,6 +694,7 @@ fn normalize_jsonl_stream(
                         state.line_number,
                         &state.buffer,
                         &state.json_fields,
+                        &state.metadata_columns,
                     )? {
                         state.pending.push_back(line);
                     }
@@ -660,6 +710,7 @@ fn normalize_json_array_stream(
     mut input: BoxStream<'static, Result<Bytes>>,
     location: ObjectPath,
     json_fields: Arc<HashSet<String>>,
+    metadata_columns: FileMetadataColumns,
     schema: SchemaRef,
     batch_size: usize,
 ) -> BoxStream<'static, Result<RecordBatch>> {
@@ -695,7 +746,8 @@ fn normalize_json_array_stream(
             channel_reader,
             JSON_ARRAY_CONVERTER_BUFFER_SIZE,
         );
-        let mut reader = CompatJsonlReader::new(ndjson_reader, location, json_fields);
+        let mut reader =
+            CompatJsonlReader::new(ndjson_reader, location, json_fields, metadata_columns);
 
         match ReaderBuilder::new(schema)
             .with_batch_size(batch_size)
@@ -735,6 +787,7 @@ fn normalize_jsonl_line(
     line_number: usize,
     line: &[u8],
     json_fields: &HashSet<String>,
+    metadata_columns: &FileMetadataColumns,
 ) -> Result<Option<Bytes>> {
     let line = jsonl_line_text(location, line_number, line)?;
     if line.is_empty() {
@@ -746,7 +799,13 @@ fn normalize_jsonl_line(
             "failed to parse {location} line {line_number} as JSON: {error}"
         ))
     })?;
-    let value = normalize_json_record(location, Some(line_number), value, json_fields)?;
+    let value = normalize_json_record(
+        location,
+        Some(line_number),
+        value,
+        json_fields,
+        metadata_columns,
+    )?;
     Ok(Some(Bytes::from(json_value_to_line_bytes(&value)?)))
 }
 
@@ -755,6 +814,7 @@ fn normalize_json_record(
     line_number: Option<usize>,
     row: Value,
     json_fields: &HashSet<String>,
+    metadata_columns: &FileMetadataColumns,
 ) -> Result<Value> {
     let Value::Object(mut object) = row else {
         let row_description = line_number
@@ -764,6 +824,10 @@ fn normalize_json_record(
             "{location}{row_description} is not a JSON object"
         )));
     };
+
+    if let Some(line_number) = line_number {
+        metadata_columns.insert_row_values(location, line_number, &mut object)?;
+    }
 
     for field in json_fields {
         if let Some(value) = object.get_mut(field)
@@ -812,76 +876,6 @@ fn datafusion_error_to_io(error: &DataFusionError) -> io::Error {
 
 fn datafusion_error_to_arrow(error: DataFusionError) -> ArrowError {
     ArrowError::ExternalError(Box::new(error))
-}
-
-pub(super) struct JsonFileGroups {
-    pub(super) groups: Vec<FileGroup>,
-    pub(super) grouped_by_partition: bool,
-}
-
-pub(super) fn json_file_groups(
-    table_path: &ListingTableUrl,
-    partition_columns: &PartitionColumns,
-    files: Vec<ObjectMeta>,
-    filters: &[Expr],
-    target_partitions: usize,
-    preserve_file_partitions: usize,
-) -> Result<JsonFileGroups> {
-    let constraints = partition_filter_constraints(filters, partition_columns);
-    let mut partitioned_files = Vec::new();
-
-    for meta in files {
-        let partition_values =
-            partition_values_for_path(table_path, &meta.location, partition_columns)?;
-        if !constraints.matches(&partition_values) {
-            continue;
-        }
-
-        partitioned_files.push(
-            PartitionedFile::new_from_meta(meta)
-                .with_partition_values(partition_values.into_scalars()),
-        );
-    }
-
-    if partitioned_files.is_empty() {
-        return Ok(JsonFileGroups {
-            groups: vec![FileGroup::default()],
-            grouped_by_partition: false,
-        });
-    }
-
-    partitioned_files.sort_by(|left, right| {
-        left.object_meta
-            .location
-            .as_ref()
-            .cmp(right.object_meta.location.as_ref())
-    });
-
-    let file_group = FileGroup::new(partitioned_files);
-    let target_partitions = target_partitions.max(1);
-    if partition_columns.is_empty() || preserve_file_partitions == 0 {
-        return Ok(JsonFileGroups {
-            groups: file_group.split_files(target_partitions),
-            grouped_by_partition: false,
-        });
-    }
-
-    let grouped = file_group.group_by_partition_values(target_partitions);
-    if grouped.len() >= preserve_file_partitions {
-        Ok(JsonFileGroups {
-            groups: grouped,
-            grouped_by_partition: true,
-        })
-    } else {
-        let files = grouped
-            .into_iter()
-            .flat_map(FileGroup::into_inner)
-            .collect::<Vec<_>>();
-        Ok(JsonFileGroups {
-            groups: FileGroup::new(files).split_files(target_partitions),
-            grouped_by_partition: false,
-        })
-    }
 }
 
 fn json_field_names(columns: &[ColumnSpec]) -> Result<HashSet<String>> {

--- a/crates/coral-engine/src/backends/file/listing.rs
+++ b/crates/coral-engine/src/backends/file/listing.rs
@@ -433,6 +433,7 @@ mod tests {
                 .expect("location template should parse"),
             glob: None,
             partitions: vec![],
+            metadata: vec![],
             object_store: Some(FileObjectStoreSpec::S3 {
                 region: Some(
                     ParsedTemplate::parse("{{input.AWS_REGION}}")
@@ -457,6 +458,7 @@ mod tests {
                 .expect("location template should parse"),
             glob: None,
             partitions: vec![],
+            metadata: vec![],
             object_store: Some(FileObjectStoreSpec::S3 {
                 region: None,
                 auth: S3AuthSpec::AccessKey {

--- a/crates/coral-engine/src/backends/file/metadata.rs
+++ b/crates/coral-engine/src/backends/file/metadata.rs
@@ -1,0 +1,249 @@
+//! File metadata columns for file-backed tables.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::{DataType, Field, FieldRef, SchemaBuilder, SchemaRef};
+use datafusion::common::ScalarValue;
+use datafusion::datasource::listing::ListingTableUrl;
+use datafusion::error::{DataFusionError, Result};
+use datafusion_datasource::table_schema::TableSchema;
+use object_store::path::Path as ObjectPath;
+use serde_json::Value;
+
+use coral_spec::backends::file::{FileMetadataColumnSpec, FileMetadataKind};
+
+#[derive(Debug, Clone)]
+pub(super) struct FileMetadataColumns {
+    file_columns: Vec<FileMetadataColumn>,
+    row_columns: Vec<FileMetadataColumn>,
+}
+
+impl FileMetadataColumns {
+    pub(super) fn try_new(specs: &[FileMetadataColumnSpec]) -> Result<Self> {
+        let mut seen = HashSet::with_capacity(specs.len());
+        let mut file_columns = Vec::new();
+        let mut row_columns = Vec::new();
+
+        for spec in specs {
+            if !seen.insert(spec.name.as_str()) {
+                return Err(DataFusionError::Plan(format!(
+                    "duplicate metadata column '{}'",
+                    spec.name
+                )));
+            }
+
+            let column = FileMetadataColumn {
+                name: spec.name.clone(),
+                kind: spec.kind,
+            };
+            if is_file_scoped(column.kind) {
+                file_columns.push(column);
+            } else {
+                row_columns.push(column);
+            }
+        }
+
+        Ok(Self {
+            file_columns,
+            row_columns,
+        })
+    }
+
+    pub(super) fn has_file_columns(&self) -> bool {
+        !self.file_columns.is_empty()
+    }
+
+    pub(super) fn has_row_columns(&self) -> bool {
+        !self.row_columns.is_empty()
+    }
+
+    pub(super) fn reject_schema_collisions(
+        &self,
+        file_schema: &SchemaRef,
+        source_schema: &str,
+        table_name: &str,
+    ) -> Result<()> {
+        for field in file_schema.fields() {
+            if self.column_named(field.name()).is_some() {
+                return Err(DataFusionError::Plan(format!(
+                    "{source_schema}.{table_name} metadata column '{}' duplicates a file column",
+                    field.name()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn row_contains(&self, name: &str) -> bool {
+        self.row_columns
+            .iter()
+            .any(|metadata| metadata.name == name)
+    }
+
+    /// Extends a table schema with configured metadata columns, when present.
+    ///
+    /// Row-scoped metadata is read by the JSON decoder as part of the file
+    /// schema. File-scoped metadata is modeled as table partition fields so
+    /// `DataFusion` can attach one constant value per file.
+    pub(super) fn extend_table_schema_if_present(&self, table_schema: TableSchema) -> TableSchema {
+        if !self.has_row_columns() && !self.has_file_columns() {
+            return table_schema;
+        }
+
+        let file_schema = self.append_row_fields(Arc::clone(table_schema.file_schema()));
+        let partition_fields = table_schema
+            .table_partition_cols()
+            .iter()
+            .cloned()
+            .chain(self.file_fields())
+            .collect();
+        TableSchema::new(file_schema, partition_fields)
+    }
+
+    pub(super) fn file_values(
+        &self,
+        table_path: &ListingTableUrl,
+        location: &ObjectPath,
+    ) -> Result<Vec<ScalarValue>> {
+        if self.file_columns.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let relative_path = relative_file_path(table_path, location);
+        self.file_columns
+            .iter()
+            .map(|column| column.file_value(&relative_path))
+            .collect()
+    }
+
+    pub(super) fn insert_row_values(
+        &self,
+        location: &ObjectPath,
+        line_number: usize,
+        object: &mut serde_json::Map<String, Value>,
+    ) -> Result<()> {
+        for column in &self.row_columns {
+            object.insert(
+                column.name.clone(),
+                column.row_value(location, line_number)?,
+            );
+        }
+        Ok(())
+    }
+
+    fn file_fields(&self) -> Vec<FieldRef> {
+        self.file_columns
+            .iter()
+            .map(FileMetadataColumn::arrow_field)
+            .collect()
+    }
+
+    fn column_named(&self, name: &str) -> Option<&FileMetadataColumn> {
+        self.file_columns
+            .iter()
+            .chain(self.row_columns.iter())
+            .find(|column| column.name == name)
+    }
+
+    fn append_row_fields(&self, file_schema: SchemaRef) -> SchemaRef {
+        if self.row_columns.is_empty() {
+            return file_schema;
+        }
+
+        let mut builder = SchemaBuilder::from(file_schema.as_ref());
+        builder.extend(self.row_columns.iter().map(FileMetadataColumn::arrow_field));
+        Arc::new(builder.finish())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FileMetadataColumn {
+    name: String,
+    kind: FileMetadataKind,
+}
+
+impl FileMetadataColumn {
+    fn arrow_field(&self) -> FieldRef {
+        Arc::new(Field::new(
+            &self.name,
+            metadata_arrow_type(self.kind),
+            false,
+        ))
+    }
+
+    fn file_value(&self, relative_path: &str) -> Result<ScalarValue> {
+        match self.kind {
+            FileMetadataKind::RelativePath => {
+                Ok(ScalarValue::Utf8(Some(relative_path.to_string())))
+            }
+            FileMetadataKind::FileName => Ok(ScalarValue::Utf8(Some(file_name(relative_path)))),
+            FileMetadataKind::FileStem => Ok(ScalarValue::Utf8(Some(file_stem(relative_path)))),
+            FileMetadataKind::LineNumber => Err(DataFusionError::Execution(
+                "line_number metadata is row-scoped and cannot be computed per file".to_string(),
+            )),
+        }
+    }
+
+    fn row_value(&self, location: &ObjectPath, line_number: usize) -> Result<Value> {
+        match self.kind {
+            FileMetadataKind::LineNumber => Ok(Value::Number(serde_json::Number::from(
+                i64::try_from(line_number).map_err(|error| {
+                    DataFusionError::Execution(format!(
+                        "{location} line number {line_number} is not Int64: {error}"
+                    ))
+                })?,
+            ))),
+            FileMetadataKind::RelativePath
+            | FileMetadataKind::FileName
+            | FileMetadataKind::FileStem => Err(DataFusionError::Execution(format!(
+                "{} metadata is file-scoped and cannot be inserted per row",
+                self.kind.as_str()
+            ))),
+        }
+    }
+}
+
+fn is_file_scoped(kind: FileMetadataKind) -> bool {
+    matches!(
+        kind,
+        FileMetadataKind::RelativePath | FileMetadataKind::FileName | FileMetadataKind::FileStem
+    )
+}
+
+fn metadata_arrow_type(kind: FileMetadataKind) -> DataType {
+    match kind {
+        FileMetadataKind::RelativePath
+        | FileMetadataKind::FileName
+        | FileMetadataKind::FileStem => DataType::Utf8,
+        FileMetadataKind::LineNumber => DataType::Int64,
+    }
+}
+
+fn relative_file_path(table_path: &ListingTableUrl, location: &ObjectPath) -> String {
+    let Some(segments) = table_path.strip_prefix(location) else {
+        return location.to_string();
+    };
+
+    let relative_path = segments.collect::<Vec<_>>().join("/");
+    if relative_path.is_empty() {
+        return file_name(location.as_ref());
+    }
+    relative_path
+}
+
+fn file_stem(relative_path: &str) -> String {
+    let file_name = file_name(relative_path);
+    file_name
+        .rsplit_once('.')
+        .map_or(file_name.as_str(), |(stem, _extension)| stem)
+        .to_string()
+}
+
+fn file_name(relative_path: &str) -> String {
+    relative_path
+        .rsplit('/')
+        .next()
+        .unwrap_or(relative_path)
+        .to_string()
+}

--- a/crates/coral-engine/src/backends/file/mod.rs
+++ b/crates/coral-engine/src/backends/file/mod.rs
@@ -1,8 +1,10 @@
 //! Native file table provider backed by local files or object-store URLs.
 
 mod error;
+mod file_groups;
 mod json;
 mod listing;
+mod metadata;
 mod parquet_schema;
 mod partitions;
 mod provider;

--- a/crates/coral-engine/src/backends/file/provider.rs
+++ b/crates/coral-engine/src/backends/file/provider.rs
@@ -1,4 +1,4 @@
-//! Native `DataFusion` listing-table provider for file tables that need no Coral-specific row mapping.
+//! Native file table providers built on `DataFusion` file scan primitives.
 
 use std::any::Any;
 use std::collections::{BTreeMap, HashSet};
@@ -7,22 +7,51 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::common::Statistics;
 use datafusion::datasource::TableProvider;
+use datafusion::datasource::file_format::FileFormat as DataFusionFileFormat;
 use datafusion::datasource::listing::{ListingTable, ListingTableConfig};
-use datafusion::error::Result;
+use datafusion::datasource::physical_plan::FileScanConfigBuilder;
+use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
+use datafusion_datasource::table_schema::TableSchema;
+use futures::TryStreamExt as _;
+use object_store::ObjectStore;
 
 use crate::backends::schema_from_columns;
 use coral_spec::backends::file::{FileFormat, FileTableSpec};
 
+use super::file_groups::{FileGroupsForScan, file_groups_for_scan};
 use super::listing::{PreparedListingTable, prepare_listing_table};
+use super::metadata::FileMetadataColumns;
 use super::parquet_schema::infer_schema_expand_dicts;
+use super::partitions::{
+    PartitionColumns, filter_is_supported_partition_filter, filter_references_partition,
+};
 
 #[derive(Debug)]
 pub(crate) struct FileTableProvider {
-    inner: ListingTable,
+    inner: FileTableProviderInner,
+}
+
+#[derive(Debug)]
+enum FileTableProviderInner {
+    Listing(ListingTable),
+    Metadata(MetadataFileTableProvider),
+}
+
+#[derive(Debug)]
+struct MetadataFileTableProvider {
+    table_path: datafusion::datasource::listing::ListingTableUrl,
+    object_store: Arc<dyn ObjectStore>,
+    file_extension: String,
+    format: Arc<dyn DataFusionFileFormat>,
+    schema: SchemaRef,
+    table_schema: TableSchema,
+    metadata_columns: FileMetadataColumns,
+    partition_columns: PartitionColumns,
 }
 
 impl FileTableProvider {
@@ -56,7 +85,7 @@ impl FileTableProvider {
         home_dir: Option<&Path>,
         resolved_inputs: &BTreeMap<String, String>,
     ) -> Result<Self> {
-        let inner = Self::build_listing_table(
+        let inner = Self::build_provider(
             ctx.clone(),
             source_schema,
             &table,
@@ -74,7 +103,6 @@ impl FileTableProvider {
         home_dir: Option<&Path>,
         resolved_inputs: &BTreeMap<String, String>,
     ) -> Result<ListingTable> {
-        let format = table.format;
         let PreparedListingTable {
             table_path,
             listing_options,
@@ -82,31 +110,10 @@ impl FileTableProvider {
             ..
         } = prepare_listing_table(&ctx, source_schema, table, home_dir, resolved_inputs).await?;
 
-        let mut file_schema = if format == FileFormat::Parquet && !table.has_explicit_columns() {
-            infer_schema_expand_dicts(&ctx, &listing_options, &table_path).await?
-        } else {
-            schema_from_columns(table.columns(), source_schema, table.name())?
-        };
-
-        // Strip partition columns from the file schema. If an older writer
-        // stored partition columns (e.g. `_part_id`) inside the Parquet files,
-        // schema inference will include them here. DataFusion's ListingTable
-        // adds partition columns from the hive directory path; having them in
-        // both the file schema and the partition config produces a
-        // duplicate-field schema that causes queries to return zero rows.
-        let partition_names: HashSet<&str> = partition_columns.names().collect();
-        if !partition_names.is_empty() {
-            let fields: Vec<_> = file_schema
-                .fields()
-                .iter()
-                .filter(|f| !partition_names.contains(&f.name().as_str()))
-                .cloned()
-                .collect();
-            file_schema = Arc::new(Schema::new_with_metadata(
-                fields,
-                file_schema.metadata().clone(),
-            ));
-        }
+        let file_schema =
+            file_schema_for_table(&ctx, table, source_schema, &listing_options, &table_path)
+                .await?;
+        let file_schema = strip_partition_columns(file_schema, &partition_columns);
 
         let config = ListingTableConfig::new(table_path)
             .with_listing_options(listing_options)
@@ -115,27 +122,74 @@ impl FileTableProvider {
         Ok(ListingTable::try_new(config)?
             .with_cache(ctx.runtime_env().cache_manager.get_file_statistic_cache()))
     }
+
+    async fn build_provider(
+        ctx: SessionContext,
+        source_schema: &str,
+        table: &FileTableSpec,
+        home_dir: Option<&Path>,
+        resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<FileTableProviderInner> {
+        let metadata_columns = FileMetadataColumns::try_new(&table.source.metadata)?;
+        if metadata_columns.has_row_columns() {
+            return Err(DataFusionError::Plan(
+                "row-scoped file metadata is only supported by JSONL file tables".to_string(),
+            ));
+        }
+        if metadata_columns.has_file_columns() {
+            return MetadataFileTableProvider::try_new(
+                ctx,
+                source_schema,
+                table,
+                home_dir,
+                resolved_inputs,
+                metadata_columns,
+            )
+            .await
+            .map(FileTableProviderInner::Metadata);
+        }
+
+        Self::build_listing_table(ctx, source_schema, table, home_dir, resolved_inputs)
+            .await
+            .map(FileTableProviderInner::Listing)
+    }
 }
 
-#[async_trait]
-impl TableProvider for FileTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
+impl MetadataFileTableProvider {
+    async fn try_new(
+        ctx: SessionContext,
+        source_schema: &str,
+        table: &FileTableSpec,
+        home_dir: Option<&Path>,
+        resolved_inputs: &BTreeMap<String, String>,
+        metadata_columns: FileMetadataColumns,
+    ) -> Result<Self> {
+        let PreparedListingTable {
+            table_path,
+            object_store,
+            listing_options,
+            partition_columns,
+        } = prepare_listing_table(&ctx, source_schema, table, home_dir, resolved_inputs).await?;
 
-    fn schema(&self) -> SchemaRef {
-        self.inner.schema()
-    }
+        let file_schema =
+            file_schema_for_table(&ctx, table, source_schema, &listing_options, &table_path)
+                .await?;
+        let file_schema = strip_partition_columns(file_schema, &partition_columns);
+        metadata_columns.reject_schema_collisions(&file_schema, source_schema, table.name())?;
+        let table_schema = TableSchema::new(file_schema, partition_columns.arrow_fields());
+        let table_schema = metadata_columns.extend_table_schema_if_present(table_schema);
+        let schema = Arc::clone(table_schema.table_schema());
 
-    fn table_type(&self) -> TableType {
-        self.inner.table_type()
-    }
-
-    fn supports_filters_pushdown(
-        &self,
-        filters: &[&Expr],
-    ) -> Result<Vec<TableProviderFilterPushDown>> {
-        self.inner.supports_filters_pushdown(filters)
+        Ok(Self {
+            table_path,
+            object_store,
+            file_extension: listing_options.file_extension,
+            format: listing_options.format,
+            schema,
+            table_schema,
+            metadata_columns,
+            partition_columns,
+        })
     }
 
     async fn scan(
@@ -145,6 +199,131 @@ impl TableProvider for FileTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        self.inner.scan(state, projection, filters, limit).await
+        let files = self
+            .table_path
+            .list_all_files(state, self.object_store.as_ref(), &self.file_extension)
+            .await?
+            .try_collect()
+            .await?;
+
+        let FileGroupsForScan {
+            groups,
+            grouped_by_partition,
+        } = file_groups_for_scan(
+            &self.table_path,
+            &self.partition_columns,
+            files,
+            &self.metadata_columns,
+            filters,
+            state.config().target_partitions(),
+            state.config_options().optimizer.preserve_file_partitions,
+        )?;
+
+        let file_source = self.format.file_source(self.table_schema.clone());
+        let config = FileScanConfigBuilder::new(self.table_path.object_store(), file_source)
+            .with_file_groups(groups)
+            .with_statistics(Statistics::new_unknown(&self.schema))
+            .with_limit(limit)
+            .with_partitioned_by_file_group(grouped_by_partition)
+            .with_projection_indices(projection.cloned())?
+            .build();
+
+        self.format.create_physical_plan(state, config).await
+    }
+}
+
+async fn file_schema_for_table(
+    ctx: &SessionContext,
+    table: &FileTableSpec,
+    source_schema: &str,
+    listing_options: &datafusion::datasource::listing::ListingOptions,
+    table_path: &datafusion::datasource::listing::ListingTableUrl,
+) -> Result<SchemaRef> {
+    if table.format == FileFormat::Parquet && !table.has_explicit_columns() {
+        infer_schema_expand_dicts(ctx, listing_options, table_path).await
+    } else {
+        schema_from_columns(table.columns(), source_schema, table.name())
+    }
+}
+
+fn strip_partition_columns(
+    file_schema: SchemaRef,
+    partition_columns: &PartitionColumns,
+) -> SchemaRef {
+    // Strip partition columns from the file schema. If an older writer stored
+    // partition columns (e.g. `_part_id`) inside the Parquet files, schema
+    // inference will include them here. DataFusion's file scan adds partition
+    // columns from the path; having them in both places produces a
+    // duplicate-field schema that causes queries to return zero rows.
+    let partition_names: HashSet<&str> = partition_columns.names().collect();
+    if partition_names.is_empty() {
+        return file_schema;
+    }
+
+    let fields: Vec<_> = file_schema
+        .fields()
+        .iter()
+        .filter(|f| !partition_names.contains(&f.name().as_str()))
+        .cloned()
+        .collect();
+    Arc::new(Schema::new_with_metadata(
+        fields,
+        file_schema.metadata().clone(),
+    ))
+}
+
+#[async_trait]
+impl TableProvider for FileTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        match &self.inner {
+            FileTableProviderInner::Listing(inner) => inner.schema(),
+            FileTableProviderInner::Metadata(inner) => inner.schema.clone(),
+        }
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        match &self.inner {
+            FileTableProviderInner::Listing(inner) => inner.supports_filters_pushdown(filters),
+            FileTableProviderInner::Metadata(inner) => Ok(filters
+                .iter()
+                .map(|filter| {
+                    if filter_is_supported_partition_filter(filter, &inner.partition_columns) {
+                        TableProviderFilterPushDown::Exact
+                    } else if filter_references_partition(filter, &inner.partition_columns) {
+                        TableProviderFilterPushDown::Inexact
+                    } else {
+                        TableProviderFilterPushDown::Unsupported
+                    }
+                })
+                .collect()),
+        }
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn datafusion::catalog::Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match &self.inner {
+            FileTableProviderInner::Listing(inner) => {
+                inner.scan(state, projection, filters, limit).await
+            }
+            FileTableProviderInner::Metadata(inner) => {
+                inner.scan(state, projection, filters, limit).await
+            }
+        }
     }
 }

--- a/crates/coral-engine/src/backends/file/tests.rs
+++ b/crates/coral-engine/src/backends/file/tests.rs
@@ -1,4 +1,5 @@
-use super::json::json_file_groups;
+use super::file_groups::file_groups_for_scan;
+use super::metadata::FileMetadataColumns;
 use super::partitions::{
     PartitionColumns, partition_filter_constraints, partition_values_for_path,
 };
@@ -159,7 +160,7 @@ fn partition_pruning_canonicalizes_literals_by_partition_type() {
 }
 
 #[test]
-fn json_file_groups_split_partitioned_files_unless_preservation_is_enabled() {
+fn file_groups_split_partitioned_files_unless_preservation_is_enabled() {
     let table_path = ListingTableUrl::parse("s3://bucket/sessions/")
         .expect("table path")
         .with_glob("20??/**/*.jsonl")
@@ -186,17 +187,34 @@ fn json_file_groups_split_partitioned_files_unless_preservation_is_enabled() {
     let files = (0..4)
         .map(|index| object_meta(&format!("sessions/2026/05/14/session-{index}.jsonl")))
         .collect::<Vec<_>>();
+    let metadata_columns = FileMetadataColumns::try_new(&[]).expect("empty metadata should parse");
 
-    let split = json_file_groups(&table_path, &partition_columns, files.clone(), &[], 4, 0)
-        .expect("file groups should build");
+    let split = file_groups_for_scan(
+        &table_path,
+        &partition_columns,
+        files.clone(),
+        &metadata_columns,
+        &[],
+        4,
+        0,
+    )
+    .expect("file groups should build");
     assert_eq!(split.groups.len(), 4);
     assert!(
         !split.grouped_by_partition,
         "split groups must not claim DataFusion partition-preserving layout"
     );
 
-    let preserved = json_file_groups(&table_path, &partition_columns, files, &[], 4, 1)
-        .expect("file groups should build");
+    let preserved = file_groups_for_scan(
+        &table_path,
+        &partition_columns,
+        files,
+        &metadata_columns,
+        &[],
+        4,
+        1,
+    )
+    .expect("file groups should build");
     assert_eq!(preserved.groups.len(), 1);
     assert!(preserved.grouped_by_partition);
 }
@@ -282,6 +300,65 @@ async fn parquet_provider_exposes_inferred_schema_in_coral_columns() {
     assert!(rendered.contains("metric"));
     assert!(rendered.contains("value"));
     assert!(rendered.contains("Float64"));
+}
+
+#[tokio::test]
+async fn parquet_inferred_schema_rejects_metadata_name_collision() {
+    let fixture_dir = tempdir().expect("tempdir should be created");
+    let file = std::fs::File::create(fixture_dir.path().join("events.parquet"))
+        .expect("fixture file should be created");
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("file_path", DataType::Utf8, false),
+        Field::new("value", DataType::Float64, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec!["from-file"])),
+            Arc::new(Float64Array::from(vec![1.0])),
+        ],
+    )
+    .expect("record batch should be created");
+    let mut writer = ArrowWriter::try_new(file, schema, None).expect("writer should be created");
+    writer.write(&batch).expect("batch should be written");
+    writer.close().expect("writer should close");
+
+    let location = file_url_from_directory_path(fixture_dir.path());
+    let manifest = parse_source_manifest_value(json!({
+        "dsl_version": 3,
+        "name": "parquet_collision",
+        "version": "0.1.0",
+        "backend": "file",
+        "tables": [{
+            "name": "events",
+            "description": "events",
+            "format": "parquet",
+            "source": {
+                "location": location,
+                "glob": "**/*.parquet",
+                "metadata": [{ "name": "file_path", "kind": "relative_path" }]
+            },
+            "columns": [],
+        }]
+    }))
+    .expect("manifest should parse");
+
+    let ctx = SessionContext::new();
+    let registration = register_sources_blocking(&ctx, compile_sources(vec![manifest]))
+        .expect("source registration should collect provider failures");
+
+    assert!(registration.active_sources.is_empty());
+    let failure = registration
+        .failures
+        .first()
+        .expect("metadata collision should fail source registration");
+    assert!(
+        failure.detail.contains(
+            "parquet_collision.events metadata column 'file_path' duplicates a file column"
+        ),
+        "{}",
+        failure.detail
+    );
 }
 
 #[tokio::test]

--- a/crates/coral-engine/tests/engine/file_format_tests.rs
+++ b/crates/coral-engine/tests/engine/file_format_tests.rs
@@ -50,6 +50,15 @@ impl FixtureFormat {
         }
     }
 
+    fn file_name(self) -> &'static str {
+        match self {
+            Self::Parquet => "orders.parquet",
+            Self::Jsonl => "orders.jsonl",
+            Self::Json => "orders.json",
+            Self::Csv => "orders.csv",
+        }
+    }
+
     fn schema_name(self) -> &'static str {
         match self {
             Self::Parquet => "orders_parquet",
@@ -57,6 +66,55 @@ impl FixtureFormat {
             Self::Json => "orders_json",
             Self::Csv => "orders_csv",
         }
+    }
+}
+
+#[tokio::test]
+async fn file_scoped_metadata_queryable_across_file_formats() {
+    for format in [
+        FixtureFormat::Parquet,
+        FixtureFormat::Jsonl,
+        FixtureFormat::Json,
+        FixtureFormat::Csv,
+    ] {
+        let temp = TempDir::new().expect("temp dir");
+        write_orders_fixture(temp.path(), format, &orders());
+        let sources = vec![build_source(orders_manifest_with_file_metadata(
+            format,
+            temp.path(),
+        ))];
+        let schema = format.schema_name();
+
+        let rows = execution_to_rows(
+            &CoralQuery::execute_sql(
+                &sources,
+                test_runtime(),
+                &format!(
+                    "SELECT DISTINCT sale_date, file_path, file_name, file_stem \
+                     FROM {schema}.orders \
+                     ORDER BY sale_date"
+                ),
+            )
+            .await
+            .unwrap_or_else(|error| panic!("{format:?} metadata query failed: {error:?}")),
+        );
+
+        let file_name = format.file_name();
+        let expected = vec![
+            json!({
+                "sale_date": "2026-04-01",
+                "file_path": format!("sale_date=2026-04-01/{file_name}"),
+                "file_name": file_name,
+                "file_stem": "orders"
+            }),
+            json!({
+                "sale_date": "2026-04-02",
+                "file_path": format!("sale_date=2026-04-02/{file_name}"),
+                "file_name": file_name,
+                "file_stem": "orders"
+            }),
+        ];
+        assert_eq!(rows, expected, "{format:?} metadata rows differed");
     }
 }
 
@@ -256,6 +314,30 @@ fn orders_manifest(format: FixtureFormat, root: &Path) -> Value {
         "backend": "file",
         "tables": [table],
     })
+}
+
+fn orders_manifest_with_file_metadata(format: FixtureFormat, root: &Path) -> Value {
+    let mut manifest = orders_manifest(format, root);
+    let table = manifest
+        .as_object_mut()
+        .and_then(|manifest| manifest.get_mut("tables"))
+        .and_then(Value::as_array_mut)
+        .and_then(|tables| tables.first_mut())
+        .and_then(Value::as_object_mut)
+        .expect("orders manifest should have one table object");
+    let source = table
+        .get_mut("source")
+        .and_then(Value::as_object_mut)
+        .expect("orders table should have a source object");
+    source.insert(
+        "metadata".to_string(),
+        json!([
+            { "name": "file_path", "kind": "relative_path" },
+            { "name": "file_name", "kind": "file_name" },
+            { "name": "file_stem", "kind": "file_stem" }
+        ]),
+    );
+    manifest
 }
 
 fn nested_events_manifest(format: FixtureFormat, root: &Path) -> Value {

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -528,6 +528,11 @@ async fn codex_session_style_segment_partitions_and_json_payload_are_queryable()
                         "type": "Int64",
                         "path": { "kind": "segment", "index": 2 }
                     }
+                ],
+                "metadata": [
+                    { "name": "session_path", "kind": "relative_path" },
+                    { "name": "session_file", "kind": "file_stem" },
+                    { "name": "event_index", "kind": "line_number" }
                 ]
             },
             "columns": [
@@ -542,10 +547,11 @@ async fn codex_session_style_segment_partitions_and_json_payload_are_queryable()
         &CoralQuery::execute_sql(
             &[source],
             test_runtime(),
-            "SELECT year, month, day, type, json_get_str(payload, 'id') AS payload_id \
+            "SELECT year, month, day, session_path, session_file, event_index, \
+                    type, json_get_str(payload, 'id') AS payload_id \
              FROM codex_sessions_fixture.events \
              WHERE year = 2026 AND month = 5 AND day = 14 \
-             ORDER BY payload_id",
+             ORDER BY event_index",
         )
         .await
         .expect("codex-style sessions should query"),
@@ -558,6 +564,9 @@ async fn codex_session_style_segment_partitions_and_json_payload_are_queryable()
                 "year": 2026,
                 "month": 5,
                 "day": 14,
+                "session_path": "2026/05/14/rollout-2026-05-14T12-34-33.jsonl",
+                "session_file": "rollout-2026-05-14T12-34-33",
+                "event_index": 1,
                 "type": "event_msg",
                 "payload_id": "evt_1"
             }),
@@ -565,8 +574,222 @@ async fn codex_session_style_segment_partitions_and_json_payload_are_queryable()
                 "year": 2026,
                 "month": 5,
                 "day": 14,
+                "session_path": "2026/05/14/rollout-2026-05-14T12-34-33.jsonl",
+                "session_file": "rollout-2026-05-14T12-34-33",
+                "event_index": 2,
                 "type": "response_item",
                 "payload_id": "evt_2"
+            }),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn jsonl_metadata_columns_are_queryable_and_discoverable() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "2026/06/02/session.with.dots.jsonl",
+        &[
+            json!({
+                "id": 1,
+                "file_path": "payload/file.jsonl",
+                "file_name": "payload-file.jsonl",
+                "file_stem": "payload-file",
+                "event_index": -1
+            }),
+            json!({"id": 2}),
+        ],
+    );
+    let source = build_source(json!({
+        "name": "jsonl_metadata_fixture",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "file",
+        "tables": [{
+            "name": "events",
+            "description": "JSONL events with metadata",
+            "format": "jsonl",
+            "source": {
+                "location": dir_url(temp.path()),
+                "glob": "**/*.jsonl",
+                "metadata": [
+                    { "name": "file_path", "kind": "relative_path" },
+                    { "name": "file_name", "kind": "file_name" },
+                    { "name": "file_stem", "kind": "file_stem" },
+                    { "name": "event_index", "kind": "line_number" }
+                ]
+            },
+            "columns": [{ "name": "id", "type": "Int64" }]
+        }]
+    }));
+    let sources = [source];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT id, file_path, file_name, file_stem, event_index \
+             FROM jsonl_metadata_fixture.events \
+             ORDER BY event_index",
+        )
+        .await
+        .expect("metadata columns should query"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({
+                "id": 1,
+                "file_path": "2026/06/02/session.with.dots.jsonl",
+                "file_name": "session.with.dots.jsonl",
+                "file_stem": "session.with.dots",
+                "event_index": 1
+            }),
+            json!({
+                "id": 2,
+                "file_path": "2026/06/02/session.with.dots.jsonl",
+                "file_name": "session.with.dots.jsonl",
+                "file_stem": "session.with.dots",
+                "event_index": 2
+            }),
+        ]
+    );
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT column_name, data_type \
+             FROM coral.columns \
+             WHERE schema_name = 'jsonl_metadata_fixture' \
+               AND table_name = 'events' \
+               AND column_name IN ('file_path', 'file_name', 'file_stem', 'event_index') \
+             ORDER BY column_name",
+        )
+        .await
+        .expect("metadata columns should appear in catalog"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({"column_name": "event_index", "data_type": "Int64"}),
+            json!({"column_name": "file_name", "data_type": "Utf8"}),
+            json!({"column_name": "file_path", "data_type": "Utf8"}),
+            json!({"column_name": "file_stem", "data_type": "Utf8"}),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn jsonl_metadata_columns_work_for_single_file_locations() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(temp.path(), "events.jsonl", &[json!({"id": 1})]);
+    let file_url = url::Url::from_file_path(temp.path().join("events.jsonl"))
+        .expect("file path should convert to URL")
+        .to_string();
+    let source = build_source(json!({
+        "name": "jsonl_single_file_metadata",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "file",
+        "tables": [{
+            "name": "events",
+            "description": "Single JSONL file with metadata",
+            "format": "jsonl",
+            "source": {
+                "location": file_url,
+                "metadata": [
+                    { "name": "file_path", "kind": "relative_path" },
+                    { "name": "file_name", "kind": "file_name" },
+                    { "name": "file_stem", "kind": "file_stem" },
+                    { "name": "event_index", "kind": "line_number" }
+                ]
+            },
+            "columns": [{ "name": "id", "type": "Int64" }]
+        }]
+    }));
+    let sources = [source];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT id, file_path, file_name, file_stem, event_index \
+             FROM jsonl_single_file_metadata.events",
+        )
+        .await
+        .expect("single-file metadata columns should query"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "id": 1,
+            "file_path": "events.jsonl",
+            "file_name": "events.jsonl",
+            "file_stem": "events",
+            "event_index": 1
+        })]
+    );
+}
+
+#[tokio::test]
+async fn jsonl_metadata_preserves_object_store_path_text() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(temp.path(), "L%3ABC.jsonl", &[json!({"id": 1})]);
+    write_jsonl_file(temp.path(), "bad%ZZ.jsonl", &[json!({"id": 2})]);
+    let source = build_source(json!({
+        "name": "jsonl_percent_metadata",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "file",
+        "tables": [{
+            "name": "events",
+            "description": "JSONL files with literal percent path text",
+            "format": "jsonl",
+            "source": {
+                "location": dir_url(temp.path()),
+                "glob": "*.jsonl",
+                "metadata": [
+                    { "name": "file_path", "kind": "relative_path" },
+                    { "name": "file_name", "kind": "file_name" },
+                    { "name": "file_stem", "kind": "file_stem" }
+                ]
+            },
+            "columns": [{ "name": "id", "type": "Int64" }]
+        }]
+    }));
+    let sources = [source];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT id, file_path, file_name, file_stem \
+             FROM jsonl_percent_metadata.events \
+             ORDER BY id",
+        )
+        .await
+        .expect("metadata should preserve object-store path text"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({
+                "id": 1,
+                "file_path": "L%3ABC.jsonl",
+                "file_name": "L%3ABC.jsonl",
+                "file_stem": "L%3ABC"
+            }),
+            json!({
+                "id": 2,
+                "file_path": "bad%ZZ.jsonl",
+                "file_name": "bad%ZZ.jsonl",
+                "file_stem": "bad%ZZ"
             }),
         ]
     );

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -198,6 +198,8 @@ pub struct FileSourceSpec {
     #[serde(default)]
     pub partitions: Vec<PartitionColumnSpec>,
     #[serde(default)]
+    pub metadata: Vec<FileMetadataColumnSpec>,
+    #[serde(default)]
     pub object_store: Option<FileObjectStoreSpec>,
 }
 
@@ -226,6 +228,21 @@ impl FileSourceSpec {
                     "{schema}.{table} partition '{}' uses path.kind={}, which is currently supported only for backend=file formats jsonl and json; parquet and csv use DataFusion hive partitioning",
                     partition.name,
                     partition.path.kind()
+                )));
+            }
+        }
+        let mut seen_metadata = HashSet::new();
+        for metadata in &self.metadata {
+            if !seen_metadata.insert(metadata.name.clone()) {
+                return Err(ManifestError::validation(format!(
+                    "{schema}.{table} has duplicate metadata column '{}'",
+                    metadata.name
+                )));
+            }
+            if metadata.kind == FileMetadataKind::LineNumber && format != FileFormat::Jsonl {
+                return Err(ManifestError::validation(format!(
+                    "{schema}.{table} metadata column '{}' uses kind=line_number, which is only supported for backend=file format jsonl",
+                    metadata.name
                 )));
             }
         }
@@ -462,6 +479,40 @@ impl PartitionPathSpec {
     }
 }
 
+/// One declared metadata column derived from the scanned file.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileMetadataColumnSpec {
+    pub name: String,
+    pub kind: FileMetadataKind,
+}
+
+/// Metadata values the file backend can add to each scanned row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileMetadataKind {
+    /// Path to the scanned file, relative to `source.location`.
+    RelativePath,
+    /// File name of the scanned file, including its final extension.
+    FileName,
+    /// File stem of the scanned file, without its final extension.
+    FileStem,
+    /// One-based line number within the scanned JSONL file.
+    LineNumber,
+}
+
+impl FileMetadataKind {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RelativePath => "relative_path",
+            Self::FileName => "file_name",
+            Self::FileStem => "file_stem",
+            Self::LineNumber => "line_number",
+        }
+    }
+}
+
 /// Format-specific file reader options.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -531,7 +582,7 @@ impl RawFileTableSpec {
             &self.filters,
             &self.columns,
         )?;
-        validate_partition_column_overlap(schema, &self.name, &self.source, &self.columns)?;
+        validate_derived_column_overlap(schema, &self.name, &self.source, &self.columns)?;
         self.format_options
             .validate_for_format(format, schema, &self.name)?;
 
@@ -584,7 +635,7 @@ fn validate_native_file_table_features(
     Ok(())
 }
 
-fn validate_partition_column_overlap(
+fn validate_derived_column_overlap(
     schema: &str,
     table: &str,
     source: &FileSourceSpec,
@@ -601,6 +652,30 @@ fn validate_partition_column_overlap(
             return Err(ManifestError::validation(format!(
                 "{schema}.{table} column '{}' duplicates a partition column",
                 col.name
+            )));
+        }
+    }
+
+    let metadata_names = source
+        .metadata
+        .iter()
+        .map(|metadata| metadata.name.as_str())
+        .collect::<HashSet<_>>();
+
+    for col in columns {
+        if metadata_names.contains(col.name.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "{schema}.{table} column '{}' duplicates a metadata column",
+                col.name
+            )));
+        }
+    }
+
+    for metadata in &source.metadata {
+        if partition_names.contains(metadata.name.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "{schema}.{table} metadata column '{}' duplicates a partition column",
+                metadata.name
             )));
         }
     }
@@ -907,6 +982,184 @@ mod tests {
             }],
         }))
         .expect("jsonl segment partition manifest should parse");
+    }
+
+    #[test]
+    fn jsonl_file_manifest_accepts_metadata_columns() {
+        let manifest = FileSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "logs",
+            "version": "0.1.0",
+            "backend": "file",
+            "tables": [{
+                "name": "messages",
+                "description": "JSONL messages",
+                "format": "jsonl",
+                "source": {
+                    "location": "file:///tmp/logs/",
+                    "metadata": [
+                        { "name": "session_path", "kind": "relative_path" },
+                        { "name": "session_name", "kind": "file_name" },
+                        { "name": "session_file", "kind": "file_stem" },
+                        { "name": "event_index", "kind": "line_number" }
+                    ]
+                },
+                "columns": [{ "name": "kind", "type": "Utf8" }],
+            }],
+        }))
+        .expect("jsonl metadata manifest should parse");
+
+        let metadata = &manifest
+            .tables
+            .first()
+            .expect("manifest should include the JSONL table")
+            .source
+            .metadata;
+        let parsed_metadata = metadata
+            .iter()
+            .map(|metadata| (metadata.name.as_str(), metadata.kind.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            parsed_metadata,
+            vec![
+                ("session_path", "relative_path"),
+                ("session_name", "file_name"),
+                ("session_file", "file_stem"),
+                ("event_index", "line_number"),
+            ]
+        );
+    }
+
+    #[test]
+    fn file_manifest_rejects_duplicate_metadata_column_names() {
+        let error = FileSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "logs",
+            "version": "0.1.0",
+            "backend": "file",
+            "tables": [{
+                "name": "messages",
+                "description": "JSONL messages",
+                "format": "jsonl",
+                "source": {
+                    "location": "file:///tmp/logs/",
+                    "metadata": [
+                        { "name": "session_file", "kind": "file_name" },
+                        { "name": "session_file", "kind": "file_stem" }
+                    ]
+                },
+                "columns": [{ "name": "kind", "type": "Utf8" }],
+            }],
+        }))
+        .expect_err("duplicate metadata column names should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate metadata column 'session_file'"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn file_manifest_rejects_metadata_payload_column_overlap() {
+        let error = FileSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "logs",
+            "version": "0.1.0",
+            "backend": "file",
+            "tables": [{
+                "name": "messages",
+                "description": "JSONL messages",
+                "format": "jsonl",
+                "source": {
+                    "location": "file:///tmp/logs/",
+                    "metadata": [{ "name": "kind", "kind": "relative_path" }]
+                },
+                "columns": [{ "name": "kind", "type": "Utf8" }],
+            }],
+        }))
+        .expect_err("metadata and payload columns should not overlap");
+
+        assert!(error.to_string().contains("duplicates a metadata column"));
+    }
+
+    #[test]
+    fn file_manifest_rejects_metadata_partition_column_overlap() {
+        let error = FileSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "logs",
+            "version": "0.1.0",
+            "backend": "file",
+            "tables": [{
+                "name": "messages",
+                "description": "JSONL messages",
+                "format": "jsonl",
+                "source": {
+                    "location": "file:///tmp/logs/",
+                    "partitions": [{
+                        "name": "event_index",
+                        "type": "Int64",
+                        "path": { "kind": "segment", "index": 0 }
+                    }],
+                    "metadata": [{ "name": "event_index", "kind": "line_number" }]
+                },
+                "columns": [{ "name": "kind", "type": "Utf8" }],
+            }],
+        }))
+        .expect_err("metadata and partition columns should not overlap");
+
+        assert!(
+            error
+                .to_string()
+                .contains("metadata column 'event_index' duplicates a partition column"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn file_manifest_accepts_file_scoped_metadata_for_non_jsonl_tables() {
+        FileSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "warehouse",
+            "version": "0.1.0",
+            "backend": "file",
+            "tables": [{
+                "name": "events",
+                "description": "Warehouse events",
+                "format": "parquet",
+                "source": {
+                    "location": "file:///tmp/warehouse/",
+                    "metadata": [{ "name": "path", "kind": "relative_path" }]
+                },
+                "columns": [],
+            }],
+        }))
+        .expect("parquet file-scoped metadata columns should parse");
+    }
+
+    #[test]
+    fn file_manifest_rejects_line_number_metadata_for_non_jsonl_tables() {
+        let error = FileSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "warehouse",
+            "version": "0.1.0",
+            "backend": "file",
+            "tables": [{
+                "name": "events",
+                "description": "Warehouse events",
+                "format": "parquet",
+                "source": {
+                    "location": "file:///tmp/warehouse/",
+                    "metadata": [{ "name": "event_index", "kind": "line_number" }]
+                },
+                "columns": [],
+            }],
+        }))
+        .expect_err("parquet line_number metadata should fail");
+
+        assert!(error.to_string().contains("kind=line_number"));
+        assert!(error.to_string().contains("format jsonl"));
     }
 
     #[test]

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -245,6 +245,113 @@ tables:
     }
 
     #[test]
+    fn parse_source_manifest_yaml_accepts_jsonl_file_metadata() {
+        let manifest = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: file
+tables:
+  - name: events
+    description: Demo events
+    format: jsonl
+    source:
+      location: file:///tmp/events/
+      metadata:
+        - name: session_path
+          kind: relative_path
+        - name: session_file
+          kind: file_stem
+        - name: event_index
+          kind: line_number
+    columns:
+      - name: type
+        type: Utf8
+",
+        )
+        .expect("JSONL file metadata should pass full manifest parsing");
+        assert!(manifest.as_file().is_some());
+    }
+
+    #[test]
+    fn validate_manifest_schema_accepts_empty_file_metadata_for_non_jsonl_tables() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: file
+tables:
+  - name: events
+    description: Demo events
+    format: parquet
+    source:
+      location: file:///tmp/events/
+      metadata: []
+",
+        );
+        validate_manifest_schema(&manifest)
+            .expect("empty non-JSONL metadata should match Rust parsing");
+    }
+
+    #[test]
+    fn validate_manifest_schema_accepts_file_scoped_metadata_for_non_jsonl_tables() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: file
+tables:
+  - name: events
+    description: Demo events
+    format: parquet
+    source:
+      location: file:///tmp/events/
+      metadata:
+        - name: file_path
+          kind: relative_path
+",
+        );
+        validate_manifest_schema(&manifest)
+            .expect("file-scoped metadata should be valid for non-JSONL file tables");
+    }
+
+    #[test]
+    fn validate_manifest_schema_rejects_line_number_metadata_for_non_jsonl_tables() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: file
+tables:
+  - name: events
+    description: Demo events
+    format: parquet
+    source:
+      location: file:///tmp/events/
+      metadata:
+        - name: event_index
+          kind: line_number
+",
+        );
+        let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");
+        let message = error.to_string();
+        assert!(
+            message.starts_with("source manifest failed schema validation:"),
+            "{message}"
+        );
+        assert!(message.contains("/tables/0/source"), "{message}");
+        assert!(message.contains("metadata"), "{message}");
+        assert!(
+            message.contains("line_number"),
+            "schema error should reject non-JSONL line_number metadata: {message}"
+        );
+    }
+
+    #[test]
     fn validate_manifest_schema_rejects_http_table_source() {
         let manifest = manifest_json(
             r"

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -401,6 +401,35 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["name", "description", "format", "source"],
+      "allOf": [
+        {
+          "if": {
+            "required": ["format"],
+            "properties": {
+              "format": { "not": { "const": "jsonl" } }
+            }
+          },
+          "then": {
+            "properties": {
+              "source": {
+                "properties": {
+                  "metadata": {
+                    "not": {
+                      "contains": {
+                        "type": "object",
+                        "required": ["kind"],
+                        "properties": {
+                          "kind": { "const": "line_number" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
       "properties": {
         "name": { "type": "string", "minLength": 1 },
         "description": { "type": "string", "minLength": 1 },
@@ -432,6 +461,10 @@
         "partitions": {
           "type": "array",
           "items": { "$ref": "#/$defs/partition_column" }
+        },
+        "metadata": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/file_metadata_column" }
         },
         "object_store": { "$ref": "#/$defs/object_store" }
       }
@@ -519,6 +552,18 @@
           }
         }
       ]
+    },
+    "file_metadata_column": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "kind"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "kind": {
+          "type": "string",
+          "enum": ["relative_path", "file_name", "file_stem", "line_number"]
+        }
+      }
     },
     "manifest_data_type": {
       "type": "string",

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -396,6 +396,41 @@ Hive-style partitioning. Positional segment partitioning is currently limited to
 JSON and JSONL tables because those formats already use Coral's custom JSON row
 mapper.
 
+### File metadata
+
+File-backed tables can expose metadata columns derived from each scanned file.
+JSONL tables can also expose row-scoped line numbers. Metadata columns are
+declared under `source.metadata` and are appended to the table schema:
+
+```yaml
+source:
+  location: file:///Users/james/.codex/sessions/
+  glob: "20??/**/*.jsonl"
+  metadata:
+    - name: session_path
+      kind: relative_path
+    - name: session_file
+      kind: file_stem
+    - name: event_index
+      kind: line_number
+```
+
+Supported `kind` values are:
+
+- `relative_path`: the file path relative to `source.location`; for a
+  single-file `source.location`, this is the scanned file name (`Utf8`)
+- `file_name`: the final file name, including its extension (`Utf8`)
+- `file_stem`: the final file name without its last extension (`Utf8`)
+- `line_number`: the one-based line number within the JSONL file (`Int64`);
+  only supported for `format: jsonl`
+
+Metadata column names must not duplicate declared payload columns or partition
+columns. For inferred Parquet tables, metadata column names must also not
+duplicate physical file columns. If an undeclared raw JSON property has the
+same name as a metadata column, queries see the declared metadata value for
+that column name. File metadata preserves the object-store path text; literal
+percent sequences in object keys are not URL-decoded again.
+
 ## HTTP-backed tables
 
 For `http`, the source spec declares request and response behavior.

--- a/sources/core/codex/manifest.yaml
+++ b/sources/core/codex/manifest.yaml
@@ -14,8 +14,11 @@ tables:
       Reads current Codex session JSONL files under
       `~/.codex/sessions/<year>/<month>/<day>/`.
 
-      Filter on `year`, `month`, and `day` to prune files before scanning.
-      Use JSON functions such as `json_get_str(payload, 'cwd')` and
+      Filter on `year`, `month`, and `day` to prune files before scanning. Use
+      `session_path`, `session_file`, and one-based `event_index` values to
+      group events into a stable JSONL session and preserve ordering within
+      that session. Use JSON functions such as
+      `json_get_str(payload, 'cwd')` and
       `json_get_str(payload, 'model_provider')` for nested event payloads.
     source:
       location: file://~/.codex/sessions/
@@ -36,6 +39,13 @@ tables:
           path:
             kind: segment
             index: 2
+      metadata:
+        - name: session_path
+          kind: relative_path
+        - name: session_file
+          kind: file_stem
+        - name: event_index
+          kind: line_number
     columns:
       - name: timestamp
         type: Utf8


### PR DESCRIPTION
## Intent

Codex JSONL logs need stable file/session provenance before higher-level transcript surfaces can group events reliably. The raw `codex.events` table is append-only event data, but not every event payload carries a session id. The JSONL file is the real session boundary.

This PR adds opt-in file metadata for file-backed sources, keeps row-scoped `line_number` JSONL-only, and uses those columns in the bundled Codex source.

## What Changed

- Added `source.metadata` for `backend: file` tables.
- Supported file-scoped metadata kinds across file formats:
  - `relative_path`
  - `file_name`
  - `file_stem`
- Supported row-scoped metadata kind for JSONL only:
  - `line_number`
- Added a shared file-group scan path so Parquet, JSONL, JSON, and CSV can attach file-scoped metadata as per-file constants.
- Kept `line_number` injection in the custom JSONL row reader.
- Appended metadata fields to the table schema so they are queryable and discoverable through `coral.columns`.
- Updated `sources/core/codex/manifest.yaml` so `codex.events` exposes:
  - `session_path`
  - `session_file`
  - `event_index`

## Ownership / Boundaries

`coral-spec` owns the manifest contract and validation. Both the Rust parser and JSON schema allow file-scoped metadata across file formats and reject `line_number` outside JSONL file tables.

`coral-engine` owns runtime derivation because these values come from scan context: the matched object path and, for JSONL only, the line reader.

The Codex source only declares the metadata columns; it does not gain derived session/message/tool-call tables in this PR.

## Compatibility / User Impact

Existing file-backed tables are unchanged unless they opt into `source.metadata`.

For Codex, `codex.events` gains three columns that agents can use to group and order rows by JSONL session file:

- `session_path`
- `session_file`
- `event_index`

## Not In This PR

- No `codex.sessions`, `codex.messages`, or tool-call surfaces.
- No file-backed SQL views.
- No HTTP or MCP source metadata support.
- No row-scoped metadata beyond JSONL `line_number`.

Those are stack follow-ups.

## Validation

- `cargo test -p coral-engine --test engine file_format_tests`
- `cargo test -p coral-engine --test engine jsonl_tests`
- `cargo test -p coral-engine --test engine parquet_tests`
- `cargo test -p coral-engine --lib backends::file`
- `cargo test -p coral-spec metadata_for_non_jsonl`
- `cargo test -p coral-spec line_number_metadata`
- `cargo test -p coral-spec`
- `cargo clippy -p coral-engine --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p coral-spec --all-targets --all-features --locked -- -D warnings`
- `make rust-checks`
- `make docs-check`