### PR TITLE
perf(ui): speed up trace list loading

### DIFF
--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -1,6 +1,6 @@
 //! JSONL-backed span export for local trace capture.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{HashMap, HashSet, hash_map::Entry};
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -24,6 +24,7 @@ const JSONL_MAX_FILE_BYTES: u64 = 16 * 1024 * 1024;
 const JSONL_MAX_FILE_ROWS: usize = 50_000;
 const JSONL_MAX_FILE_AGE: Duration = Duration::from_hours(24);
 const JSONL_PRUNE_INTERVAL: Duration = Duration::from_hours(1);
+const JSONL_FILE_MTIME_SPAN_END_TOLERANCE: Duration = Duration::from_secs(2);
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum LocalTraceStoreError {
@@ -346,6 +347,13 @@ pub(crate) struct TraceStore {
     retention: Option<Duration>,
 }
 
+#[derive(Debug, Clone)]
+struct TraceStoreFile {
+    path: PathBuf,
+    modified_unix_nanos: i64,
+    span_end_upper_bound_unix_nanos: i64,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum TraceStoreError {
     #[error("trace '{0}' not found")]
@@ -362,6 +370,11 @@ pub(crate) enum TraceStoreError {
     },
     #[error("failed to read local trace store file {path}: {source}")]
     ReadFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to read local trace store file metadata {path}: {source}")]
+    FileMetadata {
         path: PathBuf,
         source: std::io::Error,
     },
@@ -452,18 +465,7 @@ struct TraceListSpanRecord {
     status: StoredTraceStatus,
     start_time_unix_nanos: i64,
     end_time_unix_nanos: i64,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct TraceSpanLocation {
-    file_index: usize,
-    line_number: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct LocatedTraceListSpanRecord {
-    span: TraceListSpanRecord,
-    location: TraceSpanLocation,
+    attributes_json: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -472,8 +474,8 @@ struct TracePrimaryCandidate {
     name: String,
     status: StoredTraceStatus,
     start_time_unix_nanos: i64,
+    attributes_json: String,
     priority: u8,
-    location: TraceSpanLocation,
 }
 
 #[derive(Debug, Clone)]
@@ -483,18 +485,8 @@ struct TraceListAggregate {
     end_time_unix_nanos: i64,
     span_count: u32,
     error_count: u32,
+    found_root_span: bool,
     primary: Option<TracePrimaryCandidate>,
-}
-
-#[derive(Debug, Clone)]
-struct TraceSummaryCandidate {
-    summary: TraceSummaryRecord,
-    primary: Option<TracePrimaryCandidate>,
-}
-
-#[derive(Debug, Deserialize)]
-struct TraceSpanAttributesRecord {
-    attributes_json: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -544,56 +536,77 @@ impl TraceStore {
         limit: usize,
         offset: usize,
     ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
         self.prune_expired()?;
-        let files = self.jsonl_files()?;
+        let files = self.jsonl_files_by_modified()?;
         let mut spans_by_id = HashMap::new();
-        for (file_index, path) in files.iter().enumerate() {
-            for span in read_list_spans_file(path, file_index)? {
-                spans_by_id.insert(
-                    (span.span.trace_id.clone(), span.span.span_id.clone()),
-                    span,
-                );
+        let mut traces: HashMap<String, TraceListAggregate> = HashMap::new();
+        let required_trace_count = offset.saturating_add(limit);
+        let mut oldest_scanned_file_index = None;
+
+        for (file_index, file) in files.iter().enumerate().rev() {
+            oldest_scanned_file_index = Some(file_index);
+            for span in read_list_spans_file(&file.path)? {
+                record_list_span(span, &mut spans_by_id, &mut traces);
+            }
+
+            let Some(newest_unscanned_file) =
+                file_index.checked_sub(1).and_then(|index| files.get(index))
+            else {
+                break;
+            };
+            if list_page_is_newer_than_unscanned_files(
+                &traces,
+                required_trace_count,
+                newest_unscanned_file.span_end_upper_bound_unix_nanos,
+            ) {
+                break;
             }
         }
 
-        let mut traces: HashMap<String, TraceListAggregate> = HashMap::new();
-        for span in spans_by_id.into_values() {
-            traces
-                .entry(span.span.trace_id.clone())
-                .and_modify(|aggregate| aggregate.record_span(&span))
-                .or_insert_with(|| TraceListAggregate::new(&span));
-        }
-
+        let page_trace_ids = trace_page_ids(&traces, offset, limit);
+        complete_list_aggregates_for_page(
+            &files,
+            oldest_scanned_file_index,
+            &page_trace_ids,
+            &mut spans_by_id,
+            &mut traces,
+        )?;
         let mut summaries = traces
             .into_values()
-            .map(TraceListAggregate::into_summary_candidate)
+            .filter(|aggregate| page_trace_ids.contains(&aggregate.trace_id))
+            .map(TraceListAggregate::into_summary)
             .collect::<Vec<_>>();
-        summaries.sort_by(|left, right| {
-            right
-                .summary
-                .end_time_unix_nanos
-                .cmp(&left.summary.end_time_unix_nanos)
-                .then_with(|| left.summary.trace_id.cmp(&right.summary.trace_id))
-        });
-        let mut summaries = summaries
-            .into_iter()
-            .skip(offset)
-            .take(limit)
-            .collect::<Vec<_>>();
-        enrich_summary_candidates(&mut summaries, &files)?;
+        sort_summaries(&mut summaries);
 
-        Ok(summaries
-            .into_iter()
-            .map(|candidate| candidate.summary)
-            .collect())
+        Ok(summaries.into_iter().take(limit).collect())
     }
 
     fn get_trace_sync(&self, trace_id: &str) -> Result<TraceDetailRecord, TraceStoreError> {
         let mut spans_by_id = HashMap::new();
         self.prune_expired()?;
-        for path in self.jsonl_files()? {
-            for span in read_trace_spans_file(&path, trace_id)? {
-                spans_by_id.insert((span.trace_id.clone(), span.span_id.clone()), span);
+        let files = self.jsonl_files_by_modified()?;
+        let mut earliest_span_start = i64::MAX;
+        let mut found_root_span = false;
+        for (file_index, file) in files.iter().enumerate().rev() {
+            for span in read_trace_spans_file(&file.path, trace_id)? {
+                earliest_span_start = earliest_span_start.min(span.start_time_unix_nanos);
+                found_root_span |= is_trace_root_span(&span);
+                spans_by_id
+                    .entry((span.trace_id.clone(), span.span_id.clone()))
+                    .or_insert(span);
+            }
+
+            let newest_unscanned_file =
+                file_index.checked_sub(1).and_then(|index| files.get(index));
+            if found_root_span
+                && newest_unscanned_file
+                    .is_some_and(|file| file.span_end_upper_bound_unix_nanos < earliest_span_start)
+            {
+                break;
             }
         }
         let mut spans = spans_by_id.into_values().collect::<Vec<_>>();
@@ -622,7 +635,7 @@ impl TraceStore {
         Ok(())
     }
 
-    fn jsonl_files(&self) -> Result<Vec<PathBuf>, TraceStoreError> {
+    fn jsonl_files_by_modified(&self) -> Result<Vec<TraceStoreFile>, TraceStoreError> {
         if !self.dir.exists() {
             return Ok(Vec::new());
         }
@@ -639,10 +652,28 @@ impl TraceStore {
             })?;
             let path = entry.path();
             if span_jsonl_file(&path) {
-                files.push(path);
+                let modified = path
+                    .metadata()
+                    .and_then(|metadata| metadata.modified())
+                    .map_err(|source| TraceStoreError::FileMetadata {
+                        path: path.clone(),
+                        source,
+                    })?;
+                let modified_unix_nanos = unix_nanos(modified);
+                files.push(TraceStoreFile {
+                    span_end_upper_bound_unix_nanos: modified
+                        .checked_add(JSONL_FILE_MTIME_SPAN_END_TOLERANCE)
+                        .map_or(i64::MAX, unix_nanos),
+                    modified_unix_nanos,
+                    path,
+                });
             }
         }
-        files.sort();
+        files.sort_by(|left, right| {
+            left.modified_unix_nanos
+                .cmp(&right.modified_unix_nanos)
+                .then_with(|| left.path.cmp(&right.path))
+        });
         Ok(files)
     }
 }
@@ -661,14 +692,14 @@ fn span_jsonl_file(path: &Path) -> bool {
 }
 
 impl TracePrimaryCandidate {
-    fn from_span(span: &TraceListSpanRecord, location: TraceSpanLocation) -> Self {
+    fn from_span(span: &TraceListSpanRecord) -> Self {
         Self {
             span_id: span.span_id.clone(),
             name: span.name.clone(),
             status: span.status,
             start_time_unix_nanos: span.start_time_unix_nanos,
+            attributes_json: span.attributes_json.clone(),
             priority: primary_priority(&span.name, span.parent_span_id.as_deref()),
-            location,
         }
     }
 
@@ -686,30 +717,30 @@ impl TracePrimaryCandidate {
 }
 
 impl TraceListAggregate {
-    fn new(span: &LocatedTraceListSpanRecord) -> Self {
+    fn new(span: &TraceListSpanRecord) -> Self {
         let mut aggregate = Self {
-            trace_id: span.span.trace_id.clone(),
-            start_time_unix_nanos: span.span.start_time_unix_nanos,
-            end_time_unix_nanos: span.span.end_time_unix_nanos,
+            trace_id: span.trace_id.clone(),
+            start_time_unix_nanos: span.start_time_unix_nanos,
+            end_time_unix_nanos: span.end_time_unix_nanos,
             span_count: 0,
             error_count: 0,
+            found_root_span: false,
             primary: None,
         };
         aggregate.record_span(span);
         aggregate
     }
 
-    fn record_span(&mut self, span: &LocatedTraceListSpanRecord) {
-        self.start_time_unix_nanos = self
-            .start_time_unix_nanos
-            .min(span.span.start_time_unix_nanos);
-        self.end_time_unix_nanos = self.end_time_unix_nanos.max(span.span.end_time_unix_nanos);
+    fn record_span(&mut self, span: &TraceListSpanRecord) {
+        self.start_time_unix_nanos = self.start_time_unix_nanos.min(span.start_time_unix_nanos);
+        self.end_time_unix_nanos = self.end_time_unix_nanos.max(span.end_time_unix_nanos);
         self.span_count = self.span_count.saturating_add(1);
-        if span.span.status == StoredTraceStatus::Error {
+        if span.status == StoredTraceStatus::Error {
             self.error_count = self.error_count.saturating_add(1);
         }
+        self.found_root_span |= is_root_span_parent(span.parent_span_id.as_deref());
 
-        let primary = TracePrimaryCandidate::from_span(&span.span, span.location);
+        let primary = TracePrimaryCandidate::from_span(span);
         if self
             .primary
             .as_ref()
@@ -719,7 +750,7 @@ impl TraceListAggregate {
         }
     }
 
-    fn into_summary_candidate(self) -> TraceSummaryCandidate {
+    fn into_summary(self) -> TraceSummaryRecord {
         let aggregate = TraceAggregate {
             trace_id: self.trace_id,
             start_time_unix_nanos: self.start_time_unix_nanos,
@@ -727,12 +758,122 @@ impl TraceListAggregate {
             span_count: self.span_count,
             error_count: self.error_count,
         };
-        let summary = summary_from_list_aggregate(&aggregate, self.primary.as_ref());
-        TraceSummaryCandidate {
-            summary,
-            primary: self.primary,
+        summary_from_list_aggregate(&aggregate, self.primary.as_ref())
+    }
+}
+
+fn record_list_span(
+    span: TraceListSpanRecord,
+    spans_by_id: &mut HashMap<(String, String), TraceListSpanRecord>,
+    traces: &mut HashMap<String, TraceListAggregate>,
+) {
+    let key = (span.trace_id.clone(), span.span_id.clone());
+    match spans_by_id.entry(key) {
+        Entry::Occupied(_) => {}
+        Entry::Vacant(entry) => {
+            traces
+                .entry(span.trace_id.clone())
+                .and_modify(|aggregate| aggregate.record_span(&span))
+                .or_insert_with(|| TraceListAggregate::new(&span));
+            entry.insert(span);
         }
     }
+}
+
+fn trace_page_ids(
+    traces: &HashMap<String, TraceListAggregate>,
+    offset: usize,
+    limit: usize,
+) -> HashSet<String> {
+    let mut aggregates = traces.values().collect::<Vec<_>>();
+    sort_trace_aggregates(&mut aggregates);
+    aggregates
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .map(|aggregate| aggregate.trace_id.clone())
+        .collect()
+}
+
+fn complete_list_aggregates_for_page(
+    files: &[TraceStoreFile],
+    oldest_scanned_file_index: Option<usize>,
+    page_trace_ids: &HashSet<String>,
+    spans_by_id: &mut HashMap<(String, String), TraceListSpanRecord>,
+    traces: &mut HashMap<String, TraceListAggregate>,
+) -> Result<(), TraceStoreError> {
+    if page_trace_ids.is_empty() {
+        return Ok(());
+    }
+
+    let Some(oldest_scanned_file_index) = oldest_scanned_file_index else {
+        return Ok(());
+    };
+    let completion_start_cutoff = page_completion_start_cutoff(traces, page_trace_ids);
+
+    for file in files.iter().take(oldest_scanned_file_index).rev() {
+        if completion_start_cutoff
+            .is_some_and(|cutoff| file.span_end_upper_bound_unix_nanos < cutoff)
+        {
+            break;
+        }
+        for span in read_list_spans_file_for_trace_ids(&file.path, page_trace_ids)? {
+            record_list_span(span, spans_by_id, traces);
+        }
+    }
+
+    Ok(())
+}
+
+fn page_completion_start_cutoff(
+    traces: &HashMap<String, TraceListAggregate>,
+    page_trace_ids: &HashSet<String>,
+) -> Option<i64> {
+    let mut cutoff = i64::MAX;
+    for trace_id in page_trace_ids {
+        let aggregate = traces.get(trace_id)?;
+        if !aggregate.found_root_span {
+            return None;
+        }
+        cutoff = cutoff.min(aggregate.start_time_unix_nanos);
+    }
+    Some(cutoff)
+}
+
+fn list_page_is_newer_than_unscanned_files(
+    traces: &HashMap<String, TraceListAggregate>,
+    required_trace_count: usize,
+    newest_unscanned_span_end_upper_bound_unix_nanos: i64,
+) -> bool {
+    if required_trace_count == 0 || traces.len() < required_trace_count {
+        return false;
+    }
+
+    let mut aggregates = traces.values().collect::<Vec<_>>();
+    sort_trace_aggregates(&mut aggregates);
+    aggregates
+        .get(required_trace_count - 1)
+        .is_some_and(|aggregate| {
+            aggregate.end_time_unix_nanos > newest_unscanned_span_end_upper_bound_unix_nanos
+        })
+}
+
+fn sort_trace_aggregates(aggregates: &mut [&TraceListAggregate]) {
+    aggregates.sort_by(|left, right| {
+        right
+            .end_time_unix_nanos
+            .cmp(&left.end_time_unix_nanos)
+            .then_with(|| left.trace_id.cmp(&right.trace_id))
+    });
+}
+
+fn sort_summaries(summaries: &mut [TraceSummaryRecord]) {
+    summaries.sort_by(|left, right| {
+        right
+            .end_time_unix_nanos
+            .cmp(&left.end_time_unix_nanos)
+            .then_with(|| left.trace_id.cmp(&right.trace_id))
+    });
 }
 
 fn primary_priority(name: &str, parent_span_id: Option<&str>) -> u8 {
@@ -745,16 +886,42 @@ fn primary_priority(name: &str, parent_span_id: Option<&str>) -> u8 {
     }
 }
 
-fn read_list_spans_file(
+fn is_trace_root_span(span: &TraceSpanRecord) -> bool {
+    is_root_span_parent(span.parent_span_id.as_deref())
+}
+
+fn is_root_span_parent(parent_span_id: Option<&str>) -> bool {
+    parent_span_id.is_none()
+}
+
+fn line_trace_id(line: &str) -> Option<&str> {
+    let value_start = line.find(r#""trace_id":""#)? + r#""trace_id":""#.len();
+    let value = line.get(value_start..)?;
+    let value_end = value.find('"')?;
+    value.get(..value_end)
+}
+
+fn read_list_spans_file(path: &Path) -> Result<Vec<TraceListSpanRecord>, TraceStoreError> {
+    read_list_spans_file_filtered(path, None)
+}
+
+fn read_list_spans_file_for_trace_ids(
     path: &Path,
-    file_index: usize,
-) -> Result<Vec<LocatedTraceListSpanRecord>, TraceStoreError> {
+    trace_ids: &HashSet<String>,
+) -> Result<Vec<TraceListSpanRecord>, TraceStoreError> {
+    read_list_spans_file_filtered(path, Some(trace_ids))
+}
+
+fn read_list_spans_file_filtered(
+    path: &Path,
+    trace_ids: Option<&HashSet<String>>,
+) -> Result<Vec<TraceListSpanRecord>, TraceStoreError> {
     let file = File::open(path).map_err(|source| TraceStoreError::OpenFile {
         path: path.to_path_buf(),
         source,
     })?;
     let mut reader = BufReader::new(file);
-    let mut spans = Vec::new();
+    let mut spans_by_id = HashMap::new();
     let mut line = String::new();
     let mut line_number = 0;
 
@@ -777,15 +944,17 @@ fn read_list_spans_file(
         if trimmed.trim().is_empty() {
             continue;
         }
+        if trace_ids.is_some_and(|ids| {
+            !line_trace_id(trimmed).is_some_and(|trace_id| ids.contains(trace_id))
+        }) {
+            continue;
+        }
 
         match serde_json::from_str::<TraceListSpanRecord>(trimmed) {
-            Ok(span) => spans.push(LocatedTraceListSpanRecord {
-                span,
-                location: TraceSpanLocation {
-                    file_index,
-                    line_number,
-                },
-            }),
+            Ok(span) if trace_ids.is_none_or(|ids| ids.contains(&span.trace_id)) => {
+                spans_by_id.insert((span.trace_id.clone(), span.span_id.clone()), span);
+            }
+            Ok(_span) => {}
             Err(_) if !complete_line => break,
             Err(source) => {
                 return Err(TraceStoreError::DecodeLine {
@@ -797,7 +966,7 @@ fn read_list_spans_file(
         }
     }
 
-    Ok(spans)
+    Ok(spans_by_id.into_values().collect())
 }
 
 fn read_trace_spans_file(
@@ -809,7 +978,7 @@ fn read_trace_spans_file(
         source,
     })?;
     let mut reader = BufReader::new(file);
-    let mut spans = Vec::new();
+    let mut spans_by_id = HashMap::new();
     let mut line = String::new();
     let mut line_number = 0;
 
@@ -832,11 +1001,16 @@ fn read_trace_spans_file(
         if trimmed.trim().is_empty() {
             continue;
         }
+        if !trimmed.contains(trace_id) {
+            continue;
+        }
 
         match serde_json::from_str::<TraceSpanIdentityRecord>(trimmed) {
             Ok(identity) if identity.trace_id == trace_id => {
                 match serde_json::from_str::<TraceSpanRecord>(trimmed) {
-                    Ok(span) => spans.push(span),
+                    Ok(span) => {
+                        spans_by_id.insert((span.trace_id.clone(), span.span_id.clone()), span);
+                    }
                     Err(_) if !complete_line => break,
                     Err(source) => {
                         return Err(TraceStoreError::DecodeLine {
@@ -859,7 +1033,7 @@ fn read_trace_spans_file(
         }
     }
 
-    Ok(spans)
+    Ok(spans_by_id.into_values().collect())
 }
 
 fn summary_from_spans(trace_id: &str, spans: &[TraceSpanRecord]) -> TraceSummaryRecord {
@@ -921,22 +1095,35 @@ fn summary_from_list_aggregate(
             row_count: 0,
             row_count_recorded: false,
         },
-        |primary| TraceSummaryRecord {
-            trace_id: aggregate.trace_id.clone(),
-            root_span_id: primary.span_id.clone(),
-            name: primary.name.clone(),
-            query: String::new(),
-            status: if primary.status == StoredTraceStatus::Unspecified {
-                fallback_status
-            } else {
-                primary.status
-            },
-            start_time_unix_nanos: aggregate.start_time_unix_nanos,
-            end_time_unix_nanos: aggregate.end_time_unix_nanos,
-            duration_nanos,
-            span_count: aggregate.span_count,
-            row_count: 0,
-            row_count_recorded: false,
+        |primary| {
+            let attributes = parse_attributes(&primary.attributes_json);
+            let status = status_from_attributes(attributes.as_ref()).unwrap_or_else(|| {
+                if primary.status == StoredTraceStatus::Unspecified {
+                    fallback_status
+                } else {
+                    primary.status
+                }
+            });
+            let row_count = attributes
+                .as_ref()
+                .and_then(|attrs| attr_u64(attrs, "row_count"));
+
+            TraceSummaryRecord {
+                trace_id: aggregate.trace_id.clone(),
+                root_span_id: primary.span_id.clone(),
+                name: primary.name.clone(),
+                query: attributes
+                    .as_ref()
+                    .and_then(|attrs| attr_string(attrs, "sql"))
+                    .unwrap_or_default(),
+                status,
+                start_time_unix_nanos: aggregate.start_time_unix_nanos,
+                end_time_unix_nanos: aggregate.end_time_unix_nanos,
+                duration_nanos,
+                span_count: aggregate.span_count,
+                row_count: row_count.unwrap_or_default(),
+                row_count_recorded: row_count.is_some(),
+            }
         },
     )
 }
@@ -999,128 +1186,6 @@ fn summary_from_aggregate(
             }
         },
     )
-}
-
-fn enrich_summary_candidates(
-    summaries: &mut [TraceSummaryCandidate],
-    files: &[PathBuf],
-) -> Result<(), TraceStoreError> {
-    let mut by_file: BTreeMap<usize, Vec<(usize, usize)>> = BTreeMap::new();
-    for (summary_index, summary) in summaries.iter().enumerate() {
-        if let Some(primary) = &summary.primary {
-            by_file
-                .entry(primary.location.file_index)
-                .or_default()
-                .push((primary.location.line_number, summary_index));
-        }
-    }
-
-    for (file_index, mut targets) in by_file {
-        targets.sort_by_key(|(line_number, _summary_index)| *line_number);
-        let Some(path) = files.get(file_index) else {
-            continue;
-        };
-        let attributes = read_span_attributes_file(path, &targets)?;
-        for (summary_index, attributes_json) in attributes {
-            if let Some(summary) = summaries.get_mut(summary_index)
-                && let Some(primary) = summary.primary.clone()
-            {
-                apply_primary_attributes(&mut summary.summary, &primary, &attributes_json);
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn read_span_attributes_file(
-    path: &Path,
-    targets: &[(usize, usize)],
-) -> Result<Vec<(usize, String)>, TraceStoreError> {
-    let file = File::open(path).map_err(|source| TraceStoreError::OpenFile {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    let mut reader = BufReader::new(file);
-    let mut attributes = Vec::new();
-    let mut line = String::new();
-    let mut line_number = 0;
-    let mut target_index = 0;
-
-    while target_index < targets.len() {
-        line.clear();
-        let bytes_read =
-            reader
-                .read_line(&mut line)
-                .map_err(|source| TraceStoreError::ReadFile {
-                    path: path.to_path_buf(),
-                    source,
-                })?;
-        if bytes_read == 0 {
-            break;
-        }
-
-        line_number += 1;
-        while targets
-            .get(target_index)
-            .is_some_and(|(target_line, _summary_index)| *target_line < line_number)
-        {
-            target_index += 1;
-        }
-        let Some((target_line, _summary_index)) = targets.get(target_index) else {
-            continue;
-        };
-        if *target_line != line_number {
-            continue;
-        }
-
-        let complete_line = line.ends_with('\n');
-        let trimmed = line.trim_end_matches(['\r', '\n']);
-        match serde_json::from_str::<TraceSpanAttributesRecord>(trimmed) {
-            Ok(record) => {
-                while let Some((target_line, summary_index)) = targets.get(target_index) {
-                    if *target_line != line_number {
-                        break;
-                    }
-                    attributes.push((*summary_index, record.attributes_json.clone()));
-                    target_index += 1;
-                }
-            }
-            Err(_) if !complete_line => break,
-            Err(source) => {
-                return Err(TraceStoreError::DecodeLine {
-                    path: path.to_path_buf(),
-                    line: line_number,
-                    source,
-                });
-            }
-        }
-    }
-
-    Ok(attributes)
-}
-
-fn apply_primary_attributes(
-    summary: &mut TraceSummaryRecord,
-    primary: &TracePrimaryCandidate,
-    attributes_json: &str,
-) {
-    let attributes = parse_attributes(attributes_json);
-    if let Some(status) = status_from_attributes(attributes.as_ref()) {
-        summary.status = status;
-    } else if primary.status != StoredTraceStatus::Unspecified {
-        summary.status = primary.status;
-    }
-
-    summary.query = attributes
-        .as_ref()
-        .and_then(|attrs| attr_string(attrs, "sql"))
-        .unwrap_or_default();
-    let row_count = attributes
-        .as_ref()
-        .and_then(|attrs| attr_u64(attrs, "row_count"));
-    summary.row_count = row_count.unwrap_or_default();
-    summary.row_count_recorded = row_count.is_some();
 }
 
 fn span_record(resource_json: &str, span: &SpanData) -> TraceSpanRecord {
@@ -1510,6 +1575,200 @@ mod tests {
     }
 
     #[test]
+    fn list_traces_stops_after_enough_recent_files() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+        let now = SystemTime::now();
+        let old_time = now - Duration::from_hours(2);
+        let recent_time = now - Duration::from_secs(1);
+        let mut recent_record = trace_record("recent-trace", "recent-span");
+        recent_record.start_time_unix_nanos = unix_nanos(recent_time);
+        recent_record.end_time_unix_nanos = unix_nanos(recent_time + Duration::from_millis(1));
+        let recent_path = dir.join(timestamped_jsonl_path(recent_time));
+        write_record_file(&recent_path, &recent_record);
+        set_modified_time(&recent_path, recent_time);
+        let old_path = dir.join(timestamped_jsonl_path(old_time));
+        fs::write(&old_path, "{not-json}\n").expect("write old corrupt record");
+        set_modified_time(&old_path, old_time);
+
+        let summaries = TraceStore::new(dir)
+            .list_traces_sync(1, 0)
+            .expect("list traces");
+
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(
+            summaries.first().expect("recent trace").trace_id,
+            "recent-trace"
+        );
+    }
+
+    #[test]
+    fn list_traces_scans_enough_recent_files_for_offset() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+        let now = SystemTime::now();
+        let old_time = now - Duration::from_hours(2);
+        let first_time = now - Duration::from_secs(1);
+        let second_time = now - Duration::from_secs(2);
+        for (trace_id, span_id, timestamp) in [
+            ("first-trace", "first-span", first_time),
+            ("second-trace", "second-span", second_time),
+        ] {
+            let mut record = trace_record(trace_id, span_id);
+            record.start_time_unix_nanos = unix_nanos(timestamp);
+            record.end_time_unix_nanos = unix_nanos(timestamp + Duration::from_millis(1));
+            let path = dir.join(timestamped_jsonl_path(timestamp));
+            write_record_file(&path, &record);
+            set_modified_time(&path, timestamp);
+        }
+        let old_path = dir.join(timestamped_jsonl_path(old_time));
+        fs::write(&old_path, "{not-json}\n").expect("write old corrupt record");
+        set_modified_time(&old_path, old_time);
+
+        let summaries = TraceStore::new(dir)
+            .list_traces_sync(1, 1)
+            .expect("list traces");
+
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(
+            summaries.first().expect("second trace").trace_id,
+            "second-trace"
+        );
+    }
+
+    #[test]
+    fn list_traces_completes_returned_summaries_from_older_files() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+        let now = SystemTime::now();
+        let unrelated_time = now - Duration::from_hours(3);
+        let child_time = now - Duration::from_hours(2);
+        let root_time = now - Duration::from_secs(1);
+        let unrelated_path = dir.join(timestamped_jsonl_path(unrelated_time));
+        fs::write(
+            &unrelated_path,
+            r#"{"trace_id":"split-trace","span_id":"ancient""#,
+        )
+        .expect("write ancient corrupt record");
+        set_modified_time(&unrelated_path, unrelated_time);
+
+        let mut child_record = trace_record("split-trace", "child-span");
+        child_record.parent_span_id = Some("root-span".to_string());
+        child_record.name = "GET github.pulls".to_string();
+        child_record.status = StoredTraceStatus::Error;
+        child_record.start_time_unix_nanos = unix_nanos(child_time);
+        child_record.end_time_unix_nanos = unix_nanos(child_time + Duration::from_millis(10));
+        child_record.duration_nanos = 10_000_000;
+        let child_path = dir.join(timestamped_jsonl_path(child_time));
+        write_record_file(&child_path, &child_record);
+        set_modified_time(&child_path, child_time);
+
+        let mut root_record = trace_record("split-trace", "root-span");
+        root_record.status = StoredTraceStatus::Unspecified;
+        root_record.attributes_json = r#"{"sql":"SELECT 1"}"#.to_string();
+        root_record.start_time_unix_nanos = unix_nanos(child_time - Duration::from_secs(1));
+        root_record.end_time_unix_nanos = unix_nanos(root_time + Duration::from_millis(1));
+        root_record.duration_nanos = root_record
+            .end_time_unix_nanos
+            .saturating_sub(root_record.start_time_unix_nanos);
+        let root_path = dir.join(timestamped_jsonl_path(root_time));
+        write_record_file(&root_path, &root_record);
+        set_modified_time(&root_path, root_time);
+
+        let summaries = TraceStore::new(dir)
+            .list_traces_sync(1, 0)
+            .expect("list traces");
+
+        assert_eq!(summaries.len(), 1);
+        let summary = summaries.first().expect("split trace");
+        assert_eq!(summary.trace_id, "split-trace");
+        assert_eq!(summary.root_span_id, "root-span");
+        assert_eq!(summary.query, "SELECT 1");
+        assert_eq!(summary.status, StoredTraceStatus::Error);
+        assert_eq!(summary.span_count, 2);
+    }
+
+    #[test]
+    fn list_traces_does_not_treat_query_primary_as_root_for_completion() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+        let now = SystemTime::now();
+        let parent_time = now - Duration::from_hours(2);
+        let query_time = now - Duration::from_secs(1);
+
+        let mut parent_record = trace_record("nested-query-trace", "parent-span");
+        parent_record.name = "grpc.request".to_string();
+        parent_record.start_time_unix_nanos = unix_nanos(parent_time);
+        parent_record.end_time_unix_nanos = unix_nanos(parent_time + Duration::from_millis(10));
+        parent_record.duration_nanos = 10_000_000;
+        let parent_path = dir.join(timestamped_jsonl_path(parent_time));
+        write_record_file(&parent_path, &parent_record);
+        set_modified_time(&parent_path, parent_time);
+
+        let mut query_record = trace_record("nested-query-trace", "query-span");
+        query_record.parent_span_id = Some("parent-span".to_string());
+        query_record.attributes_json = r#"{"sql":"SELECT nested"}"#.to_string();
+        query_record.start_time_unix_nanos = unix_nanos(query_time);
+        query_record.end_time_unix_nanos = unix_nanos(query_time + Duration::from_millis(1));
+        query_record.duration_nanos = 1_000_000;
+        let query_path = dir.join(timestamped_jsonl_path(query_time));
+        write_record_file(&query_path, &query_record);
+        set_modified_time(&query_path, query_time);
+
+        let summaries = TraceStore::new(dir)
+            .list_traces_sync(1, 0)
+            .expect("list traces");
+
+        assert_eq!(summaries.len(), 1);
+        let summary = summaries.first().expect("nested query trace");
+        assert_eq!(summary.root_span_id, "query-span");
+        assert_eq!(summary.query, "SELECT nested");
+        assert_eq!(summary.span_count, 2);
+        assert_eq!(
+            summary.start_time_unix_nanos,
+            parent_record.start_time_unix_nanos
+        );
+    }
+
+    #[test]
+    fn list_traces_keeps_scanning_when_file_mtime_is_coarse() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+        let base_time = SystemTime::now() - Duration::from_secs(10);
+        let hidden_modified = base_time;
+        let visible_modified = base_time + Duration::from_millis(10);
+
+        let mut hidden_record = trace_record("hidden-newer-trace", "hidden-span");
+        hidden_record.start_time_unix_nanos = unix_nanos(base_time);
+        hidden_record.end_time_unix_nanos = unix_nanos(base_time + Duration::from_millis(900));
+        let hidden_path = dir.join(timestamped_jsonl_path(hidden_modified));
+        write_record_file(&hidden_path, &hidden_record);
+        set_modified_time(&hidden_path, hidden_modified);
+
+        let mut visible_record = trace_record("visible-older-trace", "visible-span");
+        visible_record.start_time_unix_nanos = unix_nanos(base_time);
+        visible_record.end_time_unix_nanos = unix_nanos(base_time + Duration::from_millis(100));
+        let visible_path = dir.join(timestamped_jsonl_path(visible_modified));
+        write_record_file(&visible_path, &visible_record);
+        set_modified_time(&visible_path, visible_modified);
+
+        let summaries = TraceStore::new(dir)
+            .list_traces_sync(1, 0)
+            .expect("list traces");
+
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(
+            summaries.first().expect("newer trace").trace_id,
+            "hidden-newer-trace"
+        );
+    }
+
+    #[test]
     fn skips_incomplete_trailing_jsonl_record() {
         let temp = TempDir::new().expect("temp dir");
         let dir = temp.path().join("telemetry").join("traces");
@@ -1527,6 +1786,181 @@ mod tests {
                 .list_traces_sync(10, 0)
                 .expect("list traces")
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn get_trace_skips_unrelated_lines_before_decoding() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+        fs::write(
+            dir.join(timestamped_jsonl_path(SystemTime::now())),
+            "{not-json}\n",
+        )
+        .expect("write unrelated corrupt record");
+        let target_path = dir.join(timestamped_jsonl_path(
+            SystemTime::now() + Duration::from_secs(1),
+        ));
+        write_record_file(&target_path, &trace_record("target-trace", "target-span"));
+
+        let detail = TraceStore::new(dir)
+            .get_trace_sync("target-trace")
+            .expect("trace detail");
+
+        assert_eq!(detail.summary.trace_id, "target-trace");
+        assert_eq!(detail.spans.len(), 1);
+    }
+
+    #[test]
+    fn get_trace_stops_after_trace_is_newer_than_remaining_files() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+        let now = SystemTime::now();
+        let old_time = now - Duration::from_hours(2);
+        let recent_time = now - Duration::from_secs(1);
+        let mut target_record = trace_record("target-trace", "target-span");
+        target_record.start_time_unix_nanos = unix_nanos(recent_time);
+        target_record.end_time_unix_nanos = unix_nanos(recent_time + Duration::from_millis(1));
+        let target_path = dir.join(timestamped_jsonl_path(recent_time));
+        write_record_file(&target_path, &target_record);
+        set_modified_time(&target_path, recent_time);
+        let old_path = dir.join(timestamped_jsonl_path(old_time));
+        fs::write(&old_path, r#"{"trace_id":"target-trace""#).expect("write old corrupt record");
+        set_modified_time(&old_path, old_time);
+
+        let detail = TraceStore::new(dir)
+            .get_trace_sync("target-trace")
+            .expect("trace detail");
+
+        assert_eq!(detail.summary.trace_id, "target-trace");
+        assert_eq!(detail.spans.len(), 1);
+    }
+
+    #[test]
+    fn get_trace_does_not_treat_query_primary_as_root_span() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+        let now = SystemTime::now();
+        let parent_time = now - Duration::from_hours(2);
+        let query_time = now - Duration::from_secs(1);
+
+        let mut parent_record = trace_record("nested-detail-trace", "parent-span");
+        parent_record.name = "grpc.request".to_string();
+        parent_record.start_time_unix_nanos = unix_nanos(parent_time);
+        parent_record.end_time_unix_nanos = unix_nanos(parent_time + Duration::from_millis(10));
+        parent_record.duration_nanos = 10_000_000;
+        let parent_path = dir.join(timestamped_jsonl_path(parent_time));
+        write_record_file(&parent_path, &parent_record);
+        set_modified_time(&parent_path, parent_time);
+
+        let mut query_record = trace_record("nested-detail-trace", "query-span");
+        query_record.parent_span_id = Some("parent-span".to_string());
+        query_record.attributes_json = r#"{"sql":"SELECT nested"}"#.to_string();
+        query_record.start_time_unix_nanos = unix_nanos(query_time);
+        query_record.end_time_unix_nanos = unix_nanos(query_time + Duration::from_millis(1));
+        query_record.duration_nanos = 1_000_000;
+        let query_path = dir.join(timestamped_jsonl_path(query_time));
+        write_record_file(&query_path, &query_record);
+        set_modified_time(&query_path, query_time);
+
+        let detail = TraceStore::new(dir)
+            .get_trace_sync("nested-detail-trace")
+            .expect("trace detail");
+
+        assert_eq!(detail.summary.root_span_id, "query-span");
+        assert_eq!(detail.summary.query, "SELECT nested");
+        assert_eq!(detail.summary.span_count, 2);
+        assert_eq!(
+            detail.summary.start_time_unix_nanos,
+            parent_record.start_time_unix_nanos
+        );
+        assert_eq!(detail.spans.len(), 2);
+    }
+
+    #[test]
+    fn get_trace_keeps_newer_duplicate_span_record() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+        let base_time = SystemTime::now() - Duration::from_secs(10);
+        let older_modified = base_time;
+        let newer_modified = base_time + Duration::from_millis(10);
+
+        let mut older_record = trace_record("duplicate-trace", "duplicate-span");
+        older_record.attributes_json = r#"{"sql":"SELECT 'old'"}"#.to_string();
+        older_record.start_time_unix_nanos = unix_nanos(base_time + Duration::from_millis(500));
+        older_record.end_time_unix_nanos = unix_nanos(base_time + Duration::from_millis(600));
+        let older_path = dir.join(timestamped_jsonl_path(older_modified));
+        write_record_file(&older_path, &older_record);
+        set_modified_time(&older_path, older_modified);
+
+        let mut newer_record = trace_record("duplicate-trace", "duplicate-span");
+        newer_record.attributes_json = r#"{"sql":"SELECT 'new'"}"#.to_string();
+        newer_record.start_time_unix_nanos = unix_nanos(base_time + Duration::from_millis(500));
+        newer_record.end_time_unix_nanos = unix_nanos(base_time + Duration::from_millis(700));
+        let newer_path = dir.join(timestamped_jsonl_path(newer_modified));
+        write_record_file(&newer_path, &newer_record);
+        set_modified_time(&newer_path, newer_modified);
+
+        let detail = TraceStore::new(dir)
+            .get_trace_sync("duplicate-trace")
+            .expect("trace detail");
+
+        assert_eq!(detail.spans.len(), 1);
+        assert_eq!(detail.summary.query, "SELECT 'new'");
+        assert_eq!(
+            detail
+                .spans
+                .first()
+                .expect("duplicate span")
+                .attributes_json,
+            r#"{"sql":"SELECT 'new'"}"#
+        );
+    }
+
+    #[test]
+    fn trace_store_keeps_later_duplicate_span_record_in_same_file() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+        let base_time = SystemTime::now() - Duration::from_secs(10);
+
+        let mut older_record = trace_record("same-file-duplicate-trace", "duplicate-span");
+        older_record.attributes_json = r#"{"sql":"SELECT 'old'"}"#.to_string();
+        older_record.start_time_unix_nanos = unix_nanos(base_time + Duration::from_millis(500));
+        older_record.end_time_unix_nanos = unix_nanos(base_time + Duration::from_millis(600));
+
+        let mut newer_record = trace_record("same-file-duplicate-trace", "duplicate-span");
+        newer_record.attributes_json = r#"{"sql":"SELECT 'new'"}"#.to_string();
+        newer_record.start_time_unix_nanos = unix_nanos(base_time + Duration::from_millis(500));
+        newer_record.end_time_unix_nanos = unix_nanos(base_time + Duration::from_millis(700));
+        let path = dir.join(timestamped_jsonl_path(base_time));
+        write_record_file_lines(&path, &[older_record, newer_record]);
+        set_modified_time(&path, base_time);
+
+        let store = TraceStore::new(dir);
+        let summary = store
+            .list_traces_sync(1, 0)
+            .expect("list traces")
+            .into_iter()
+            .next()
+            .expect("trace summary");
+        let detail = store
+            .get_trace_sync("same-file-duplicate-trace")
+            .expect("trace detail");
+
+        assert_eq!(summary.query, "SELECT 'new'");
+        assert_eq!(detail.summary.query, "SELECT 'new'");
+        assert_eq!(
+            detail
+                .spans
+                .first()
+                .expect("duplicate span")
+                .attributes_json,
+            r#"{"sql":"SELECT 'new'"}"#
         );
     }
 
@@ -1640,6 +2074,15 @@ mod tests {
         let mut line = serde_json::to_string(record).expect("serialize record");
         line.push('\n');
         fs::write(path, line).expect("write trace record");
+    }
+
+    fn write_record_file_lines(path: &Path, records: &[TraceSpanRecord]) {
+        let mut lines = String::new();
+        for record in records {
+            lines.push_str(&serde_json::to_string(record).expect("serialize record"));
+            lines.push('\n');
+        }
+        fs::write(path, lines).expect("write trace records");
     }
 
     fn set_modified_time(path: &Path, modified: SystemTime) {

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -115,6 +115,7 @@ fn trace_store_status(error: TraceStoreError) -> Status {
         }
         TraceStoreError::ReadDir { .. }
         | TraceStoreError::OpenFile { .. }
+        | TraceStoreError::FileMetadata { .. }
         | TraceStoreError::ReadFile { .. }
         | TraceStoreError::DecodeLine { .. }
         | TraceStoreError::PruneExpired { .. }

--- a/ui/src/lib/coral-traces-client.ts
+++ b/ui/src/lib/coral-traces-client.ts
@@ -19,11 +19,28 @@ const transport = createGrpcWebTransport({
 })
 
 const traces = createClient(TraceService, transport)
+const listTraceRequests = new Map<string, Promise<ListTracesResponse>>()
+const getTraceRequests = new Map<string, Promise<GetTraceResponse>>()
 
 export async function listTraces(pageSize = 50, pageToken = ''): Promise<ListTracesResponse> {
-  return traces.listTraces(create(ListTracesRequestSchema, { pageSize, pageToken }))
+  const key = `${pageSize}:${pageToken}`
+  const inFlight = listTraceRequests.get(key)
+  if (inFlight) return inFlight
+
+  const request = traces
+    .listTraces(create(ListTracesRequestSchema, { pageSize, pageToken }))
+    .finally(() => listTraceRequests.delete(key))
+  listTraceRequests.set(key, request)
+  return request
 }
 
 export async function getTrace(traceId: string): Promise<GetTraceResponse> {
-  return traces.getTrace(create(GetTraceRequestSchema, { traceId }))
+  const inFlight = getTraceRequests.get(traceId)
+  if (inFlight) return inFlight
+
+  const request = traces
+    .getTrace(create(GetTraceRequestSchema, { traceId }))
+    .finally(() => getTraceRequests.delete(traceId))
+  getTraceRequests.set(traceId, request)
+  return request
 }


### PR DESCRIPTION
## Why

Trace list loading in the dev UI was slow because the local trace store had to read too much JSONL history for every list/detail request. On my local trace store this was visible even with release-mode backend code, and dev mode made the UI feel much worse.

## What changed

- List trace summaries by scanning newer trace files first and stopping once the requested page is proven newer than unscanned files.
- Complete only the returned page's summaries from older files, so split traces still report exact start/end/span counts/status without paying for a full-store summary pass.
- Keep trace detail reads newest-first and stop only after seeing a true root span with no older file able to contain earlier spans.
- Preserve newer duplicate span records across rolled files and later duplicate records within the same file.
- Coalesce duplicate in-flight trace list/detail requests in the UI client.

## Measurements

Measured from `coral.v1.TraceService/ListTraces` spans in local ClickHouse against the real local trace store.

| Window | n | avg | p50 | p95 | max |
| --- | ---: | ---: | ---: | ---: | ---: |
| Original baseline, 2026-06-02 09:20 UTC | 10 | 690.6ms | 589.5ms | 1160.5ms | 1571.3ms |
| Final patch, 2026-06-02 11:09-11:11 UTC | 13 | 104.8ms | 114.1ms | 125.4ms | 129.2ms |

That is about 6.6x faster on average, 5.2x faster at p50, and 9.3x faster at p95.

## Validation

- `cargo test -p coral-app telemetry::local_store --lib`
- `make rust-checks`
- `npm run check --prefix ui`
- `git diff --check`
- local dev UI load against a 289M / 2110-file trace store
- structured autoreview clean
