### PR TITLE
fix(spec): centralize relation namespace validation

### DIFF
--- a/crates/coral-spec/AGENTS.md
+++ b/crates/coral-spec/AGENTS.md
@@ -25,5 +25,9 @@ discovery, and normalized source-definition models.
   types.
 - Keep runtime execution concerns out of this crate. Engine behavior belongs in
   `coral-engine`.
+- Backends that declare SQL relations, including tables and source-scoped table
+  functions, must project those names into the shared declared-relation
+  namespace validator in `src/validate.rs`; do not hand-roll backend-local
+  table/function collision checks.
 - Prefer normalized source-spec values over raw YAML plumbing in public
   helpers.

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -21,9 +21,9 @@ use crate::inputs::{
     collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
 };
 use crate::{
-    ColumnSpec, FilterSpec, ManifestDataType, ManifestError, ManifestInputSpec, ParsedTemplate,
-    Result, SourceBackend, SourceManifestCommon, TableCommon, TemplateNamespace, TemplatePart,
-    validate_columns, validate_table_names, validate_test_queries,
+    ColumnSpec, DeclaredRelation, FilterSpec, ManifestDataType, ManifestError, ManifestInputSpec,
+    ParsedTemplate, Result, SourceBackend, SourceManifestCommon, TableCommon, TemplateNamespace,
+    TemplatePart, validate_columns, validate_declared_relation_namespace, validate_test_queries,
 };
 
 /// Validated top-level manifest for a native file-backed source.
@@ -624,7 +624,12 @@ impl FileSourceManifest {
             tables,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
-        validate_table_names(&name, tables.iter().map(|table| table.name.as_str()))?;
+        validate_declared_relation_namespace(
+            &name,
+            tables
+                .iter()
+                .map(|table| DeclaredRelation::table(table.name.as_str())),
+        )?;
         let common =
             SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
         let tables = tables

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -16,16 +16,16 @@ use serde::Deserialize;
 use serde_json::{Map, Value};
 
 use crate::{
-    ColumnSpec, DetailHintDeclaringSurface, DetailHintSpec, DetailHintTargetTable, FilterSpec,
-    HeaderSpec, ManifestError, ManifestInputSpec, PaginationSpec, ParsedTemplate, RequestRouteSpec,
-    RequestSpec, ResponseSpec, Result, SearchLimitsSpec, SourceBackend, SourceManifestCommon,
-    SourceTableFunctionSpec, TableCommon,
+    ColumnSpec, DeclaredRelation, DetailHintDeclaringSurface, DetailHintSpec,
+    DetailHintTargetTable, FilterSpec, HeaderSpec, ManifestError, ManifestInputSpec,
+    PaginationSpec, ParsedTemplate, RequestRouteSpec, RequestSpec, ResponseSpec, Result,
+    SearchLimitsSpec, SourceBackend, SourceManifestCommon, SourceTableFunctionSpec, TableCommon,
     inputs::{
         collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
     },
     validate::validate_template,
-    validate_detail_hint_references, validate_http_function, validate_http_function_names,
-    validate_http_table, validate_table_names, validate_test_queries,
+    validate_declared_relation_namespace, validate_detail_hint_references, validate_http_function,
+    validate_http_table, validate_test_queries,
 };
 
 /// Source-level authentication requirements for HTTP-backed source specs.
@@ -288,18 +288,23 @@ impl HttpSourceManifest {
             )));
         }
         validate_test_queries(&name, &test_queries)?;
-        validate_table_names(&name, tables.iter().map(|table| table.name.as_str()))?;
+        validate_declared_relation_namespace(
+            &name,
+            tables
+                .iter()
+                .map(|table| DeclaredRelation::table(table.name.as_str()))
+                .chain(
+                    functions
+                        .iter()
+                        .map(|function| DeclaredRelation::function(function.name.as_str())),
+                ),
+        )?;
         let common =
             SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated(&common.name))
             .collect::<Result<Vec<_>>>()?;
-        validate_http_function_names(
-            &common.name,
-            tables.iter().map(HttpTableSpec::name),
-            &functions,
-        )?;
         let functions = functions
             .into_iter()
             .map(|function| {

--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -11,15 +11,15 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
-    ColumnSpec, FilterMode, FilterSpec, FunctionArgBinding, ManifestError, ManifestInputKind,
-    ManifestInputSpec, PaginationSpec, RequestSpec, ResponseSpec, Result, SourceBackend,
-    SourceManifestCommon, SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon,
-    TableFunctionArgSpec, ValueSourceSpec,
+    ColumnSpec, DeclaredRelation, FilterMode, FilterSpec, FunctionArgBinding, ManifestError,
+    ManifestInputKind, ManifestInputSpec, PaginationSpec, RequestSpec, ResponseSpec, Result,
+    SourceBackend, SourceManifestCommon, SourceTableFunctionKind, SourceTableFunctionSpec,
+    TableCommon, TableFunctionArgSpec, ValueSourceSpec,
     inputs::{
         collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
     },
-    validate_columns, validate_filters_and_column_exprs, validate_identifier,
-    validate_test_queries, validate_unique_values,
+    validate_columns, validate_declared_relation_namespace, validate_filters_and_column_exprs,
+    validate_identifier, validate_test_queries, validate_unique_values,
 };
 
 /// Validated top-level manifest for a Model Context Protocol-backed source.
@@ -399,7 +399,17 @@ impl McpSourceManifest {
         }
         validate_test_queries(&name, &test_queries)?;
         validate_server(&name, &server, &declared_inputs)?;
-        validate_table_and_function_names(&name, &tables, &functions)?;
+        validate_declared_relation_namespace(
+            &name,
+            tables
+                .iter()
+                .map(|table| DeclaredRelation::table(table.name.as_str()))
+                .chain(
+                    functions
+                        .iter()
+                        .map(|function| DeclaredRelation::function(function.name.as_str())),
+                ),
+        )?;
         let common =
             SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
         let functions = functions
@@ -544,45 +554,6 @@ fn validate_server_env_value_source(source_name: &str, env: &McpEnvSpec) -> Resu
         &env.value,
         &format!("source '{source_name}' MCP server env '{}'", env.name),
     )
-}
-
-fn validate_table_and_function_names(
-    source_name: &str,
-    tables: &[RawMcpTableSpec],
-    functions: &[RawMcpTableFunctionSpec],
-) -> Result<()> {
-    let mut table_names = HashSet::new();
-    for table in tables {
-        validate_identifier(&table.name, &format!("source '{source_name}' table name"))?;
-        if !table_names.insert(table.name.to_ascii_lowercase()) {
-            return Err(ManifestError::validation(format!(
-                "source '{source_name}' table '{}' is declared more than once",
-                table.name
-            )));
-        }
-    }
-
-    let mut function_names = HashSet::new();
-    for function in functions {
-        validate_identifier(
-            &function.name,
-            &format!("source '{source_name}' function name"),
-        )?;
-        let normalized_name = function.name.to_ascii_lowercase();
-        if table_names.contains(&normalized_name) {
-            return Err(ManifestError::validation(format!(
-                "source '{source_name}' declares both a table and function named '{}'",
-                function.name
-            )));
-        }
-        if !function_names.insert(normalized_name) {
-            return Err(ManifestError::validation(format!(
-                "source '{source_name}' function '{}' is declared more than once",
-                function.name
-            )));
-        }
-    }
-    Ok(())
 }
 
 fn validate_mcp_function(source_name: &str, function: &RawMcpTableFunctionSpec) -> Result<()> {

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -115,8 +115,8 @@ pub use parser::{
 };
 pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken};
 pub(crate) use validate::{
-    DetailHintDeclaringSurface, DetailHintTargetTable, validate_columns,
-    validate_detail_hint_references, validate_filters_and_column_exprs, validate_http_function,
-    validate_http_function_names, validate_http_table, validate_identifier, validate_table_names,
-    validate_unique_values,
+    DeclaredRelation, DetailHintDeclaringSurface, DetailHintTargetTable, validate_columns,
+    validate_declared_relation_namespace, validate_detail_hint_references,
+    validate_filters_and_column_exprs, validate_http_function, validate_http_table,
+    validate_identifier, validate_unique_values,
 };

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -255,7 +255,7 @@ tables:
 
         assert_eq!(
             error.to_string(),
-            "source 'demo' has duplicate table 'messages'"
+            "source 'demo' table 'messages' is declared more than once"
         );
     }
 

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -67,6 +67,59 @@ tables:
     }
 
     #[test]
+    fn validate_manifest_schema_accepts_quoted_sql_table_names() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: player.stats
+    description: Demo messages
+    request:
+      method: GET
+      path: /messages
+  - name: message-events
+    description: Event messages
+    request:
+      method: GET
+      path: /events
+",
+        );
+        validate_manifest_schema(&manifest)
+            .expect("table names that require SQL quoting should pass schema validation");
+    }
+
+    #[test]
+    fn validate_manifest_schema_rejects_invalid_table_function_identifier() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+functions:
+  - name: search-messages
+    request:
+      method: GET
+      path: /messages/search
+",
+        );
+
+        let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");
+        let message = error.to_string();
+        assert!(
+            message.starts_with("source manifest failed schema validation:"),
+            "{message}"
+        );
+        assert!(message.contains("/functions/0/name"), "{message}");
+        assert!(message.contains("^[A-Za-z_][A-Za-z0-9_]*$"), "{message}");
+    }
+
+    #[test]
     fn validate_manifest_schema_accepts_one_of_bearer_auth_headers() {
         let manifest = manifest_json(
             r"

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -104,6 +104,11 @@
     }
   },
   "$defs": {
+    "table_function_identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+      "description": "Source-scoped table function identifier: starts with an ASCII letter or underscore, then uses only ASCII letters, numbers, or underscores"
+    },
     "inputs": {
       "type": "object",
       "additionalProperties": { "$ref": "#/$defs/input" },
@@ -577,7 +582,7 @@
       ],
       "required": ["name", "request"],
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
+        "name": { "$ref": "#/$defs/table_function_identifier" },
         "kind": { "type": "string", "enum": ["table", "search"] },
         "description": { "type": "string" },
         "fetch_limit_default": { "type": "integer", "minimum": 1 },
@@ -604,7 +609,7 @@
       "additionalProperties": false,
       "required": ["name", "tool"],
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
+        "name": { "$ref": "#/$defs/table_function_identifier" },
         "tool": { "type": "string", "minLength": 1 },
         "description": { "type": "string" },
         "fetch_limit_default": { "type": "integer", "minimum": 1 },

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -10,19 +10,82 @@ use crate::common::{
 };
 use crate::{ManifestError, ParsedTemplate, Result, TemplateNamespace};
 
-pub(crate) fn validate_table_names<'a>(
-    schema: &str,
-    table_names: impl IntoIterator<Item = &'a str>,
-) -> Result<()> {
-    let mut seen_tables = HashSet::new();
-    for table_name in table_names {
-        let key = table_name.to_ascii_lowercase();
-        if seen_tables.contains(&key) {
-            return Err(ManifestError::validation(format!(
-                "source '{schema}' has duplicate table '{key}'"
-            )));
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeclaredRelationKind {
+    Table,
+    Function,
+}
+
+impl DeclaredRelationKind {
+    fn validate_name(self, source_name: &str, name: &str) -> Result<()> {
+        match self {
+            Self::Table => {
+                if name.trim().is_empty() {
+                    return Err(ManifestError::validation(format!(
+                        "source '{source_name}' table name must not be empty"
+                    )));
+                }
+                Ok(())
+            }
+            Self::Function => {
+                validate_identifier(name, &format!("source '{source_name}' function name"))
+            }
         }
-        seen_tables.insert(key);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DeclaredRelation<'a> {
+    kind: DeclaredRelationKind,
+    name: &'a str,
+}
+
+impl<'a> DeclaredRelation<'a> {
+    pub(crate) fn table(name: &'a str) -> Self {
+        Self {
+            kind: DeclaredRelationKind::Table,
+            name,
+        }
+    }
+
+    pub(crate) fn function(name: &'a str) -> Self {
+        Self {
+            kind: DeclaredRelationKind::Function,
+            name,
+        }
+    }
+}
+
+pub(crate) fn validate_declared_relation_namespace<'a>(
+    source_name: &str,
+    relations: impl IntoIterator<Item = DeclaredRelation<'a>>,
+) -> Result<()> {
+    let mut namespace = HashMap::new();
+    for relation in relations {
+        relation.kind.validate_name(source_name, relation.name)?;
+
+        let key = relation.name.to_ascii_lowercase();
+        if let Some(previous_kind) = namespace.get(&key) {
+            return match (*previous_kind, relation.kind) {
+                (DeclaredRelationKind::Table, DeclaredRelationKind::Table) => {
+                    Err(ManifestError::validation(format!(
+                        "source '{source_name}' table '{}' is declared more than once",
+                        relation.name
+                    )))
+                }
+                (DeclaredRelationKind::Function, DeclaredRelationKind::Function) => {
+                    Err(ManifestError::validation(format!(
+                        "source '{source_name}' function '{}' is declared more than once",
+                        relation.name
+                    )))
+                }
+                _ => Err(ManifestError::validation(format!(
+                    "source '{source_name}' declares both a table and function named '{}'",
+                    relation.name
+                ))),
+            };
+        }
+        namespace.insert(key, relation.kind);
     }
 
     Ok(())
@@ -85,39 +148,6 @@ pub(crate) fn validate_http_table(
     }
 
     pagination.validate(schema, table_name)
-}
-
-pub(crate) fn validate_http_function_names(
-    source_name: &str,
-    table_names: impl IntoIterator<Item = impl AsRef<str>>,
-    functions: &[SourceTableFunctionSpec],
-) -> Result<()> {
-    let table_names = table_names
-        .into_iter()
-        .map(|name| name.as_ref().to_string())
-        .collect::<HashSet<_>>();
-    let mut function_names = HashSet::new();
-
-    for function in functions {
-        validate_identifier(
-            &function.name,
-            &format!("source '{source_name}' function name"),
-        )?;
-        if table_names.contains(&function.name) {
-            return Err(ManifestError::validation(format!(
-                "source '{source_name}' declares both a table and function named '{}'",
-                function.name
-            )));
-        }
-        if !function_names.insert(function.name.as_str()) {
-            return Err(ManifestError::validation(format!(
-                "source '{source_name}' function '{}' is declared more than once",
-                function.name
-            )));
-        }
-    }
-
-    Ok(())
 }
 
 pub(crate) fn validate_http_function(
@@ -892,8 +922,8 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        validate_columns, validate_filters_and_column_exprs, validate_http_function,
-        validate_http_function_names, validate_http_table, validate_table_names,
+        DeclaredRelation, validate_columns, validate_declared_relation_namespace,
+        validate_filters_and_column_exprs, validate_http_function, validate_http_table,
     };
     use crate::common::{
         ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding,
@@ -1065,18 +1095,215 @@ mod tests {
     }
 
     #[test]
-    fn validate_table_names_rejects_duplicate_table_names() {
-        let schema = "github";
-        let table_names = ["issues", "prs", "Issues"];
+    fn validate_declared_relation_namespace_rejects_duplicate_tables_that_differ_only_by_case() {
+        let relations = [
+            DeclaredRelation::table("issues"),
+            DeclaredRelation::table("prs"),
+            DeclaredRelation::table("Issues"),
+        ];
 
-        let error = validate_table_names(schema, table_names)
+        let error = validate_declared_relation_namespace("github", relations)
             .expect_err("expected duplicate table to be rejected");
 
         assert!(
             error
                 .to_string()
-                .contains("source 'github' has duplicate table 'issues'")
+                .contains("source 'github' table 'Issues' is declared more than once")
         );
+    }
+
+    #[test]
+    fn validate_declared_relation_namespace_rejects_duplicate_functions_that_differ_only_by_case() {
+        let relations = [
+            DeclaredRelation::function("search"),
+            DeclaredRelation::function("Search"),
+        ];
+
+        let error = validate_declared_relation_namespace("github", relations)
+            .expect_err("expected duplicate function to be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("source 'github' function 'Search' is declared more than once")
+        );
+    }
+
+    #[test]
+    fn validate_declared_relation_namespace_rejects_table_function_case_collisions() {
+        let relations = [
+            DeclaredRelation::table("Messages"),
+            DeclaredRelation::function("messages"),
+        ];
+
+        let error = validate_declared_relation_namespace("demo", relations)
+            .expect_err("expected table/function collision to be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("source 'demo' declares both a table and function named 'messages'")
+        );
+    }
+
+    #[test]
+    fn validate_declared_relation_namespace_reports_earlier_collisions_first() {
+        let relations = [
+            DeclaredRelation::table("issues"),
+            DeclaredRelation::function("issues"),
+            DeclaredRelation::function("bad-name"),
+        ];
+
+        let error = validate_declared_relation_namespace("demo", relations)
+            .expect_err("expected first namespace collision to be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "source 'demo' declares both a table and function named 'issues'"
+        );
+    }
+
+    #[test]
+    fn validate_declared_relation_namespace_allows_quoted_sql_table_names() {
+        let relations = [
+            DeclaredRelation::table("player.stats"),
+            DeclaredRelation::table("message-events"),
+            DeclaredRelation::function("search"),
+        ];
+
+        validate_declared_relation_namespace("demo", relations)
+            .expect("table names that require SQL quoting should remain valid");
+    }
+
+    #[test]
+    fn validate_declared_relation_namespace_rejects_empty_table_names() {
+        let relations = [DeclaredRelation::table("  ")];
+
+        let error = validate_declared_relation_namespace("demo", relations)
+            .expect_err("expected empty table name to be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "source 'demo' table name must not be empty"
+        );
+    }
+
+    #[test]
+    fn validate_declared_relation_namespace_rejects_invalid_function_names() {
+        let relations = [DeclaredRelation::function("1search")];
+
+        let error = validate_declared_relation_namespace("demo", relations)
+            .expect_err("expected invalid function name to be rejected");
+
+        assert!(error.to_string().contains(
+            "source 'demo' function name '1search' must start with a letter or underscore"
+        ));
+    }
+
+    #[test]
+    fn http_manifest_rejects_table_function_names_that_differ_only_by_case() {
+        let error = parse_source_manifest_value(json!({
+            "name": "demo",
+            "version": "0.1.0",
+            "dsl_version": 3,
+            "backend": "http",
+            "base_url": "https://example.com",
+            "tables": [{
+                "name": "Messages",
+                "description": "Messages",
+                "request": { "path": "/messages" }
+            }],
+            "functions": [{
+                "name": "messages",
+                "request": { "path": "/messages/search" }
+            }]
+        }))
+        .expect_err("HTTP table/function case collision should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "source 'demo' declares both a table and function named 'messages'"
+        );
+    }
+
+    #[test]
+    fn http_manifest_rejects_duplicate_function_names_that_differ_only_by_case() {
+        let error = parse_source_manifest_value(json!({
+            "name": "demo",
+            "version": "0.1.0",
+            "dsl_version": 3,
+            "backend": "http",
+            "base_url": "https://example.com",
+            "functions": [
+                {
+                    "name": "Search",
+                    "request": { "path": "/search" }
+                },
+                {
+                    "name": "search",
+                    "request": { "path": "/search" }
+                }
+            ]
+        }))
+        .expect_err("HTTP function case duplicate should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "source 'demo' function 'search' is declared more than once"
+        );
+    }
+
+    #[test]
+    fn http_backend_accepts_quoted_sql_table_names() {
+        crate::backends::http::HttpSourceManifest::parse_manifest_value(json!({
+            "name": "demo",
+            "version": "0.1.0",
+            "dsl_version": 3,
+            "backend": "http",
+            "base_url": "https://example.com",
+            "tables": [{
+                "name": "message-events",
+                "description": "Events",
+                "request": { "path": "/events" },
+                "columns": [{ "name": "id", "type": "Utf8" }]
+            }]
+        }))
+        .expect("HTTP table names that require SQL quoting should remain valid");
+    }
+
+    #[test]
+    fn file_backend_accepts_quoted_sql_table_names() {
+        crate::backends::file::FileSourceManifest::parse_manifest_value(json!({
+            "name": "demo",
+            "version": "0.1.0",
+            "dsl_version": 3,
+            "backend": "file",
+            "tables": [{
+                "name": "message-events",
+                "description": "Events",
+                "format": "jsonl",
+                "source": { "location": "file:///tmp/coral/events/" },
+                "columns": [{ "name": "id", "type": "Utf8" }]
+            }]
+        }))
+        .expect("file table names that require SQL quoting should remain valid");
+    }
+
+    #[test]
+    fn mcp_backend_accepts_quoted_sql_table_names() {
+        crate::backends::mcp::McpSourceManifest::parse_manifest_value(json!({
+            "name": "demo",
+            "version": "0.1.0",
+            "dsl_version": 3,
+            "backend": "mcp",
+            "server": { "transport": "stdio", "command": "demo-mcp-server" },
+            "tables": [{
+                "name": "message-events",
+                "tool": "list_events",
+                "columns": [{ "name": "id", "type": "Utf8" }]
+            }]
+        }))
+        .expect("MCP table names that require SQL quoting should remain valid");
     }
 
     #[test]
@@ -1484,32 +1711,6 @@ mod tests {
             error
                 .to_string()
                 .contains("references unknown request arg 'missing'")
-        );
-    }
-
-    #[test]
-    fn validate_http_function_names_rejects_table_name_collisions() {
-        let function = SourceTableFunctionSpec {
-            name: "messages".to_string(),
-            kind: SourceTableFunctionKind::Table,
-            description: String::new(),
-            fetch_limit_default: None,
-            search_limits: None,
-            detail_hints: Vec::new(),
-            args: vec![],
-            request: base_request(),
-            response: crate::ResponseSpec::default(),
-            pagination: PaginationSpec::default(),
-            columns: vec![],
-        };
-
-        let error = validate_http_function_names("demo", ["messages"], &[function])
-            .expect_err("function should not share a table name");
-
-        assert!(
-            error
-                .to_string()
-                .contains("declares both a table and function named 'messages'")
         );
     }
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -248,6 +248,18 @@ Column-expression templates do not support `secret`, `variable`, or `state` name
 | `template` | string | —       | Parsed Coral template string using `{{expr.*}}` and `{{filter.*}}` |
 | `values`   | object | —       | Named sub-expressions referenced from `{{expr.name}}` tokens       |
 
+## Relation names
+
+Tables and source-scoped table functions share one SQL relation namespace within
+a source. Name comparisons are case-insensitive, so `Issues`, `issues`, and a
+table function named `issues` conflict.
+
+Table names must be non-empty. Prefer plain `snake_case` table names, but names
+that require SQL quoting, such as `player.stats`, remain valid for compatibility
+and can be queried as quoted identifiers. Table-function names must be ASCII
+identifiers: start with a letter or underscore, then use only letters, numbers,
+or underscores.
+
 ## File-backed tables
 
 For `backend: file`, each table declares its own `format` and points at a

--- a/plugins/coral/skills/coral-create-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-create-source-spec/SKILL.md
@@ -90,7 +90,10 @@ Only switch to Coral repo layout when the user is explicitly editing the Coral r
 - If a provider also supports manually pasted tokens, include a `type: source_config` fallback after the OAuth method. When the provider's token endpoint requires client authentication with a client secret, prompt for both OAuth client values: declare `client.id.input`, `client.secret.input`, and `client.secret.transport` (`basic_auth` or `request_body`).
 - Do not add top-level source inputs solely for OAuth client credentials; `client.id.input` and `client.secret.input` are collected during OAuth setup.
 - For short-lived OAuth access tokens, make sure the OAuth method can obtain refresh tokens when the provider supports them, and document any scopes, consent prompts, or client settings required for refresh-token issuance. If the provider will not issue refresh tokens, call out that users must reconnect when access tokens expire unless the source has another supported long-lived credential path.
-- Keep table names stable and SQL-friendly.
+- Keep table and table-function names stable, SQL-friendly, and unique within
+  the source's case-insensitive relation namespace. Prefer plain `snake_case`
+  table names. Table-function names must start with an ASCII letter or
+  underscore and then use only ASCII letters, numbers, or underscores.
 - Mark filters as required only when the API truly requires them.
 - Use default table functions for parameterized non-retrieval operations, such as scoped child collections, time-range logs, metrics queries, or detail operations that do not map cleanly to a stable table.
 - Use `kind: search` table functions for provider endpoints that accept query text and return ranked candidates.

--- a/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
+++ b/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
@@ -66,7 +66,10 @@ Additional hint guidance:
 
 - Prefer one table per collection endpoint.
 - Add detail routes only when item fetches are actually needed.
-- Keep table names stable and SQL-friendly.
+- Keep table and table-function names stable, SQL-friendly, and unique within
+  the source's case-insensitive relation namespace. Prefer plain `snake_case`
+  table names. Table-function names must start with an ASCII letter or
+  underscore and then use only ASCII letters, numbers, or underscores.
 - Preserve provider semantics when filter behavior matters.
 - Add `test_queries` once you know which simple query or queries should confirm the source basically works.
 

--- a/plugins/coral/skills/coral-review-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-review-source-spec/SKILL.md
@@ -55,7 +55,13 @@ These checks should be based on the authoritative API docs for the API the sourc
 - Required filters are explicit and described in table `description` or `guide`.
 - Guides tell users how to start, which IDs to join through, and any provider-specific timestamp or query syntax traps.
 - Provider endpoints that accept query text and return ranked candidates use `kind: search` table functions with `search_limits`, stable result identifiers, and useful candidate metadata. Non-retrieval table functions keep the default kind for parameterized operations such as scoped child collections, time-range logs, metrics queries, or detail operations. Ordinary table filters are for exact lookup, scoping, or provider-side filtering; `mode: contains` is only substring matching. Flag provider-native search modeled as a filter and require a `kind: search` function.
-- Table and column names are snake_case, stable, and obvious. Avoid leaking odd provider operation names unless the source is intentionally generated.
+- Table, table-function, and column names are snake_case, stable, and obvious.
+  Table and table-function names must be unique within the source's
+  case-insensitive relation namespace. Table-function names must use SQL
+  identifier syntax: start with an ASCII letter or underscore, then use only
+  ASCII letters, numbers, or underscores. Prefer plain `snake_case` table names;
+  quoted SQL table names are valid for compatibility but should not leak odd
+  provider operation names unless the source is intentionally generated.
 
 ### HTTP and API Semantics
 


### PR DESCRIPTION
## Summary

Centralize source relation namespace validation in `coral-spec` so HTTP, MCP, and file-backed manifests apply the same source-level identity rules before runtime registration.

This fixes the drift where HTTP table functions could collide with tables by case while MCP rejected the same shape. The invariant now lives in one shared validator: tables and source-scoped table functions share a case-insensitive source relation namespace, while table-function names keep their existing identifier syntax and table names retain quoted-SQL compatibility.

## Changes

- Add a shared declared-relation namespace validator and route HTTP, MCP, and file manifest parsing through it.
- Remove backend-local duplicate/collision implementations that encoded the same rule differently.
- Keep public schema compatibility for table names while enforcing table-function identifier syntax.
- Update source-spec docs and maintained source author/review skills with the namespace contract.
- Adjust structured error coverage to preserve quoted dotted table-name behavior.

## Verification

- `cargo test -p coral-spec`
- `make docs-check`
- `make rust-checks`
- `git diff --check`
- `autoreview --mode local` clean after accepted compatibility fix
