### PR TITLE
refactor(app): share W3C trace context helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@
 - `crates/coral-mcp`: MCP stdio adapter over `coral-client`.
 - `crates/coral-spec`: declarative source-spec parsing, validation,
   input discovery, and normalized source-definition models.
+- `crates/coral-telemetry`: cross-crate telemetry helpers that are independent
+  of app bootstrap, query runtime, and adapter surfaces.
 - `plugins/coral`: Agent plugin packaging. `plugins/coral/skills` is the
   canonical in-repo home for maintained Coral agent skills.
 
@@ -48,6 +50,9 @@
   installed materialized package, never silently refreshes descriptors or
   projections, and should fail loudly on missing or incompatible artifacts with
   guidance to re-add the source.
+- Keep cross-crate W3C trace-context propagation helpers in
+  `coral-telemetry`; do not make `coral-app`, `coral-client`, `coral-engine`,
+  or `coral-mcp` depend on each other just to share telemetry carrier logic.
 - Keep shared Arrow IPC decoding and result rendering in `coral-client`.
 - Treat `coral-app` as an internal composition root even if sibling crates use
   its bootstrap seam today.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,7 @@ dependencies = [
  "coral-client",
  "coral-engine",
  "coral-spec",
+ "coral-telemetry",
  "etcetera",
  "fs2",
  "keyring-core",
@@ -1317,6 +1318,7 @@ dependencies = [
  "coral-api",
  "coral-app",
  "coral-spec",
+ "coral-telemetry",
  "http-body 1.0.1",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1339,6 +1341,7 @@ dependencies = [
  "bytes",
  "chrono",
  "coral-spec",
+ "coral-telemetry",
  "datafusion",
  "datafusion-datasource",
  "datafusion-datasource-json",
@@ -1374,6 +1377,7 @@ dependencies = [
  "coral-api",
  "coral-app",
  "coral-client",
+ "coral-telemetry",
  "jsonschema",
  "opentelemetry",
  "regex",
@@ -1401,6 +1405,17 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "coral-telemetry"
+version = "0.4.3"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ coral-client = { path = "crates/coral-client" }
 coral-engine = { path = "crates/coral-engine" }
 coral-mcp = { path = "crates/coral-mcp" }
 coral-spec = { path = "crates/coral-spec" }
+coral-telemetry = { path = "crates/coral-telemetry" }
 
 [profile.dev]
 debug = 2

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -46,6 +46,7 @@ coral-api.workspace = true
 coral-auth-aws = { path = "../auth/aws" }
 coral-engine.workspace = true
 coral-spec.workspace = true
+coral-telemetry.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-native-keyring-store.workspace = true

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 
 use opentelemetry::Value as OtelValue;
 use opentelemetry::metrics::MeterProvider as _;
-use opentelemetry::propagation::Extractor;
 use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
 use opentelemetry_otlp::{
     LogExporter, MetricExporter, SpanExporter as OtlpSpanExporter, WithExportConfig, WithHttpConfig,
@@ -300,22 +299,7 @@ pub fn build_root_span(traceparent: Option<&str>) -> tracing::Span {
         process.pid = i64::from(std::process::id()),
         status = tracing::field::Empty
     );
-    if let Some(tp) = traceparent {
-        struct StringMapExtractor<'a>(&'a HashMap<String, String>);
-        impl Extractor for StringMapExtractor<'_> {
-            fn get(&self, key: &str) -> Option<&str> {
-                self.0.get(key).map(String::as_str)
-            }
-            fn keys(&self) -> Vec<&str> {
-                self.0.keys().map(String::as_str).collect()
-            }
-        }
-        let carrier = HashMap::from([("traceparent".to_string(), tp.to_string())]);
-        let parent_cx = opentelemetry::global::get_text_map_propagator(|p| {
-            p.extract(&StringMapExtractor(&carrier))
-        });
-        drop(span.set_parent(parent_cx));
-    }
+    coral_telemetry::set_parent_from_trace_headers(&span, traceparent, None);
     span
 }
 

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -49,13 +49,6 @@ impl Extractor for MetadataExtractor<'_> {
     }
 }
 
-/// Extracts a W3C trace context from incoming gRPC request metadata.
-pub(crate) fn extract_trace_context(
-    metadata: &tonic::metadata::MetadataMap,
-) -> opentelemetry::Context {
-    opentelemetry::global::get_text_map_propagator(|p| p.extract(&MetadataExtractor(metadata)))
-}
-
 /// Wraps a generated tonic service and stores the inbound gRPC path on the request.
 ///
 /// Tonic preserves `http::Request` extensions when it decodes the protobuf
@@ -105,7 +98,6 @@ where
 
 /// Creates a span parented to the trace context extracted from a gRPC request.
 pub(crate) fn grpc_span<T>(request: &Request<T>) -> tracing::Span {
-    let parent_cx = extract_trace_context(request.metadata());
     let metadata = grpc_method(request);
     let span_name = format!("{}/{}", metadata.service, metadata.method);
     let span = tracing::info_span!(
@@ -124,7 +116,7 @@ pub(crate) fn grpc_span<T>(request: &Request<T>) -> tracing::Span {
         grpc.code = tracing::field::Empty,
         status = tracing::field::Empty,
     );
-    drop(span.set_parent(parent_cx));
+    coral_telemetry::set_parent_from_extractor(&span, &MetadataExtractor(request.metadata()));
     span
 }
 

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -62,7 +62,6 @@ impl AppClient {
     ///
     /// Returns [`ClientError`] if the gRPC clients cannot connect.
     pub async fn connect(endpoint_uri: &str) -> Result<Self, ClientError> {
-        crate::propagation::ensure_global_propagator();
         let endpoint = Endpoint::from_shared(endpoint_uri.to_string())?
             .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE);
         let grpc_endpoint = GrpcClientEndpoint::from_endpoint_uri(endpoint_uri);

--- a/crates/coral-client/src/propagation.rs
+++ b/crates/coral-client/src/propagation.rs
@@ -1,27 +1,6 @@
 //! W3C Trace Context propagation for tonic gRPC clients.
 
-use std::sync::OnceLock;
-
 use opentelemetry::propagation::Injector;
-use opentelemetry_sdk::propagation::TraceContextPropagator;
-use tracing_opentelemetry::OpenTelemetrySpanExt as _;
-
-static PROPAGATOR_INIT: OnceLock<()> = OnceLock::new();
-
-/// Installs `TraceContextPropagator` as the process-global text-map
-/// propagator the first time this is called.
-///
-/// `TraceContextInterceptor` injects via the global propagator on every
-/// outgoing request. Without this, a client-only process (talking to a
-/// remote endpoint or a separate test server, with no local
-/// `ServerBuilder::start` to install one) would fall back to the default
-/// no-op propagator and silently drop `traceparent` even when the caller
-/// has an active span.
-pub(crate) fn ensure_global_propagator() {
-    PROPAGATOR_INIT.get_or_init(|| {
-        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
-    });
-}
 
 struct MetadataInjector<'a>(&'a mut tonic::metadata::MetadataMap);
 
@@ -45,10 +24,7 @@ impl tonic::service::Interceptor for TraceContextInterceptor {
         &mut self,
         mut request: tonic::Request<()>,
     ) -> Result<tonic::Request<()>, tonic::Status> {
-        let cx = tracing::Span::current().context();
-        opentelemetry::global::get_text_map_propagator(|p| {
-            p.inject_context(&cx, &mut MetadataInjector(request.metadata_mut()));
-        });
+        coral_telemetry::inject_current_context(&mut MetadataInjector(request.metadata_mut()));
         Ok(request)
     }
 }

--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -39,6 +39,7 @@ url.workspace = true
 urlencoding.workspace = true
 
 coral-spec.workspace = true
+coral-telemetry.workspace = true
 
 [dev-dependencies]
 arrow.workspace = true

--- a/crates/coral-engine/src/backends/shared/trace.rs
+++ b/crates/coral-engine/src/backends/shared/trace.rs
@@ -10,7 +10,6 @@
 use opentelemetry::propagation::Injector;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use tracing::field;
-use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 /// Mark a span as errored with a generic processing failure.
 ///
@@ -135,10 +134,7 @@ impl Injector for HeaderMapInjector<'_> {
 /// Inject the current span's W3C trace context into the supplied header
 /// map. Used to propagate the trace into downstream HTTP services.
 pub(crate) fn inject_trace_context(span: &tracing::Span, headers: &mut HeaderMap) {
-    let cx = span.context();
-    opentelemetry::global::get_text_map_propagator(|propagator| {
-        propagator.inject_context(&cx, &mut HeaderMapInjector(headers));
-    });
+    coral_telemetry::inject_span_context(span, &mut HeaderMapInjector(headers));
 }
 
 #[cfg(test)]

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -23,6 +23,7 @@ opentelemetry.workspace = true
 
 coral-api.workspace = true
 coral-client.workspace = true
+coral-telemetry.workspace = true
 
 [dev-dependencies]
 coral-app.workspace = true

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -1,26 +1,13 @@
 //! OpenTelemetry helpers for MCP protocol spans.
 
-use std::collections::HashMap;
 use std::future::Future;
 
 use coral_api::grpc_response_status_code;
 use coral_client::{DecodedStatusError, decode_status_error};
-use opentelemetry::{propagation::Extractor, trace::Status as OtelStatus};
+use opentelemetry::trace::Status as OtelStatus;
 use rmcp::{ErrorData, model::ErrorCode};
 use tracing::{Instrument as _, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
-
-struct StringMapExtractor<'a>(&'a HashMap<String, String>);
-
-impl Extractor for StringMapExtractor<'_> {
-    fn get(&self, key: &str) -> Option<&str> {
-        self.0.get(key).map(String::as_str)
-    }
-
-    fn keys(&self) -> Vec<&str> {
-        self.0.keys().map(String::as_str).collect()
-    }
-}
 
 pub(crate) async fn instrument<T, F>(span: tracing::Span, future: F) -> T
 where
@@ -104,14 +91,7 @@ pub(crate) fn read_resource_span(uri: &str, trace_parent: Option<&str>) -> traci
 }
 
 fn apply_trace_parent(span: &tracing::Span, trace_parent: Option<&str>) {
-    let Some(trace_parent) = trace_parent else {
-        return;
-    };
-    let carrier = HashMap::from([("traceparent".to_string(), trace_parent.to_string())]);
-    let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
-        propagator.extract(&StringMapExtractor(&carrier))
-    });
-    drop(span.set_parent(parent_cx));
+    coral_telemetry::set_parent_from_trace_headers(span, trace_parent, None);
 }
 
 pub(crate) fn record_protocol_result<T>(span: &tracing::Span, result: &Result<T, ErrorData>) {

--- a/crates/coral-telemetry/Cargo.toml
+++ b/crates/coral-telemetry/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "coral-client"
+name = "coral-telemetry"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -10,20 +10,10 @@ publish = false
 workspace = true
 
 [dependencies]
-arrow = { workspace = true, features = ["prettyprint"] }
-http-body.workspace = true
 opentelemetry.workspace = true
-serde_json.workspace = true
-thiserror.workspace = true
-tonic.workspace = true
-tonic-types.workspace = true
+opentelemetry_sdk.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
-
-coral-api.workspace = true
-coral-app.workspace = true
-coral-spec.workspace = true
-coral-telemetry.workspace = true
 
 [dev-dependencies]
 opentelemetry_sdk = { workspace = true, features = ["testing"] }

--- a/crates/coral-telemetry/src/lib.rs
+++ b/crates/coral-telemetry/src/lib.rs
@@ -1,0 +1,227 @@
+//! Cross-crate telemetry helpers.
+//!
+//! This crate owns small telemetry utilities that need to be shared by the
+//! app, client, engine, and MCP adapter without adding dependency edges between
+//! those crates.
+
+use opentelemetry::Context;
+use opentelemetry::propagation::{Extractor, Injector, TextMapPropagator as _};
+use opentelemetry::trace::TraceContextExt as _;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+const TRACEPARENT_HEADER: &str = "traceparent";
+const TRACESTATE_HEADER: &str = "tracestate";
+
+struct TraceHeaders<'a> {
+    traceparent: &'a str,
+    tracestate: Option<&'a str>,
+}
+
+impl Extractor for TraceHeaders<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        match key {
+            TRACEPARENT_HEADER => Some(self.traceparent),
+            TRACESTATE_HEADER => self.tracestate,
+            _ => None,
+        }
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        if self.tracestate.is_some() {
+            vec![TRACEPARENT_HEADER, TRACESTATE_HEADER]
+        } else {
+            vec![TRACEPARENT_HEADER]
+        }
+    }
+}
+
+fn context_from_trace_headers(
+    traceparent: Option<&str>,
+    tracestate: Option<&str>,
+) -> Option<Context> {
+    let traceparent = traceparent?;
+    context_from_extractor(&TraceHeaders {
+        traceparent,
+        tracestate,
+    })
+}
+
+fn context_from_extractor(extractor: &dyn Extractor) -> Option<Context> {
+    let context = TraceContextPropagator::new().extract_with_context(&Context::new(), extractor);
+    context_has_valid_span(&context).then_some(context)
+}
+
+/// Sets `span`'s parent from W3C trace-context headers.
+pub fn set_parent_from_trace_headers(
+    span: &tracing::Span,
+    traceparent: Option<&str>,
+    tracestate: Option<&str>,
+) {
+    set_parent_from_context(span, context_from_trace_headers(traceparent, tracestate));
+}
+
+/// Sets `span`'s parent from a text-map carrier.
+pub fn set_parent_from_extractor(span: &tracing::Span, extractor: &dyn Extractor) {
+    set_parent_from_context(span, context_from_extractor(extractor));
+}
+
+fn set_parent_from_context(span: &tracing::Span, context: Option<Context>) {
+    let Some(context) = context else {
+        return;
+    };
+    if let Err(error) = span.set_parent(context) {
+        tracing::debug!(%error, "failed to set parent trace context");
+    }
+}
+
+fn inject_context(context: &Context, injector: &mut dyn Injector) {
+    TraceContextPropagator::new().inject_context(context, injector);
+}
+
+/// Injects `span`'s OpenTelemetry context into a W3C trace-context carrier.
+pub fn inject_span_context(span: &tracing::Span, injector: &mut dyn Injector) {
+    inject_context(&span.context(), injector);
+}
+
+/// Injects the current tracing span's OpenTelemetry context into a carrier.
+pub fn inject_current_context(injector: &mut dyn Injector) {
+    inject_context(&tracing::Span::current().context(), injector);
+}
+
+fn context_has_valid_span(context: &Context) -> bool {
+    context.span().span_context().is_valid()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use opentelemetry::trace::{SpanId, TraceContextExt as _, TraceId, TracerProvider as _};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+    use tracing_subscriber::prelude::*;
+
+    use super::{
+        TRACEPARENT_HEADER, TRACESTATE_HEADER, context_from_extractor, context_from_trace_headers,
+        inject_context, set_parent_from_trace_headers,
+    };
+
+    #[test]
+    fn extracts_valid_traceparent_and_tracestate() {
+        let trace_id = "00000000000000000000000000000077";
+        let span_id = "0000000000000088";
+        let context = context_from_trace_headers(
+            Some(&format!("00-{trace_id}-{span_id}-01")),
+            Some("vendor=value"),
+        )
+        .expect("valid trace context");
+
+        let span_context = context.span().span_context().clone();
+        assert_eq!(
+            span_context.trace_id(),
+            TraceId::from_hex(trace_id).expect("trace id")
+        );
+        assert_eq!(
+            span_context.span_id(),
+            SpanId::from_hex(span_id).expect("span id")
+        );
+        assert!(span_context.is_remote());
+        assert_eq!(span_context.trace_state().header(), "vendor=value");
+    }
+
+    #[test]
+    fn rejects_missing_or_invalid_traceparent() {
+        assert!(context_from_trace_headers(None, Some("vendor=value")).is_none());
+        assert!(context_from_trace_headers(Some("not-a-traceparent"), None).is_none());
+    }
+
+    #[test]
+    fn rejects_missing_or_invalid_traceparent_under_active_span() {
+        let memory = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(memory.clone())
+            .build();
+        let tracer = provider.tracer("trace-context-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let ambient = tracing::info_span!("ambient");
+            let _guard = ambient.enter();
+
+            assert!(context_from_trace_headers(None, Some("vendor=value")).is_none());
+            assert!(context_from_trace_headers(Some("not-a-traceparent"), None).is_none());
+            assert!(context_from_extractor(&HashMap::new()).is_none());
+        });
+        provider.shutdown().expect("provider shutdown");
+    }
+
+    #[test]
+    fn extracts_from_generic_carrier() {
+        let carrier = HashMap::from([(
+            TRACEPARENT_HEADER.to_string(),
+            "00-00000000000000000000000000000077-0000000000000088-01".to_string(),
+        )]);
+
+        assert!(context_from_extractor(&carrier).is_some());
+    }
+
+    #[test]
+    fn injects_trace_context_headers() {
+        let context = context_from_trace_headers(
+            Some("00-00000000000000000000000000000077-0000000000000088-01"),
+            Some("vendor=value"),
+        )
+        .expect("valid trace context");
+        let mut carrier = HashMap::new();
+
+        inject_context(&context, &mut carrier);
+
+        assert_eq!(
+            carrier.get(TRACEPARENT_HEADER).map(String::as_str),
+            Some("00-00000000000000000000000000000077-0000000000000088-01")
+        );
+        assert_eq!(
+            carrier.get(TRACESTATE_HEADER).map(String::as_str),
+            Some("vendor=value")
+        );
+    }
+
+    #[test]
+    fn sets_span_parent_from_trace_headers() {
+        let memory = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(memory.clone())
+            .build();
+        let tracer = provider.tracer("trace-context-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("child");
+            set_parent_from_trace_headers(
+                &span,
+                Some("00-00000000000000000000000000000077-0000000000000088-01"),
+                None,
+            );
+            let _guard = span.enter();
+        });
+        provider.force_flush().expect("flush spans");
+
+        let spans = memory.get_finished_spans().expect("finished spans");
+        let child = spans
+            .iter()
+            .find(|span| span.name == "child")
+            .expect("child span");
+        assert_eq!(
+            child.span_context.trace_id(),
+            TraceId::from_hex("00000000000000000000000000000077").expect("trace id")
+        );
+        assert_eq!(
+            child.parent_span_id,
+            SpanId::from_hex("0000000000000088").expect("span id")
+        );
+        assert!(child.parent_span_is_remote);
+        provider.shutdown().expect("provider shutdown");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `coral-telemetry` as the shared W3C trace-context helper crate.
- Refactors app, client, engine, and MCP callers onto one extraction/injection implementation.
- Rejects missing or invalid carrier context without accidentally inheriting ambient span context.

## Validation
- `cargo test -p coral-telemetry --all-features`
- `cargo clippy -p coral-telemetry -p coral-app -p coral-client -p coral-engine -p coral-mcp --all-features -- -D warnings`
- `cargo test -p coral-app telemetry:: --all-features`
- `cargo test -p coral-client --all-features`
- `cargo test -p coral-engine backends:: --all-features`
- `make rust-checks` on the completed stack

## Review
- Three adversarial reviews completed clean after fixes.
- `$autoreview --mode local --parallel-tests "cargo test -p coral-telemetry --all-features && cargo test -p coral-app telemetry:: --all-features && cargo test -p coral-client --all-features && cargo test -p coral-engine backends:: --all-features"` completed clean.