### PR TITLE
refactor(app): simplify telemetry provider setup

### DIFF
--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -12,10 +12,13 @@ use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
 use opentelemetry_otlp::{
     LogExporter, MetricExporter, SpanExporter as OtlpSpanExporter, WithExportConfig, WithHttpConfig,
 };
-use opentelemetry_sdk::logs::SdkLoggerProvider;
-use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::logs::{BatchLogProcessor, SdkLoggerProvider};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
-use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
+use opentelemetry_sdk::trace::{
+    BatchSpanProcessor, SdkTracerProvider, SpanData, SpanExporter, TracerProviderBuilder,
+};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use tracing_subscriber::Layer as _;
 use tracing_subscriber::filter::Targets;
@@ -244,6 +247,107 @@ fn parse_headers(raw: &str) -> HashMap<String, String> {
         .collect()
 }
 
+fn configured_otlp_endpoint(config: &TelemetryConfig) -> Option<&str> {
+    config
+        .otel
+        .endpoint
+        .as_deref()
+        .filter(|value| !value.is_empty())
+}
+
+fn configured_local_trace_store(
+    config: &TelemetryConfig,
+    dir: Option<PathBuf>,
+) -> Option<InstalledLocalTraceStore> {
+    dir.filter(|_| config.trace_history.enabled)
+        .map(|dir| InstalledLocalTraceStore::new(dir, config.trace_history.retention()))
+}
+
+fn telemetry_resource(service_name: &str) -> Resource {
+    Resource::builder()
+        .with_attribute(opentelemetry::KeyValue::new(
+            "service.name",
+            service_name.to_string(),
+        ))
+        .build()
+}
+
+fn build_otlp_trace_exporter(
+    endpoint: &str,
+    headers: HashMap<String, String>,
+    targets: Targets,
+) -> Result<TargetFilteringSpanExporter<OtlpSpanExporter>, AppError> {
+    let exporter = OtlpSpanExporter::builder()
+        .with_http()
+        .with_endpoint(normalize_otlp_endpoint(endpoint, "traces"))
+        .with_headers(headers)
+        .build()
+        .map_err(|e| AppError::InvalidInput(e.to_string()))?;
+    Ok(TargetFilteringSpanExporter::new(exporter, targets)
+        .denying_targets(OTLP_TRACE_DENIED_TARGETS))
+}
+
+fn add_otlp_trace_exporter(
+    builder: TracerProviderBuilder,
+    endpoint: &str,
+    headers: HashMap<String, String>,
+    targets: Targets,
+) -> Result<TracerProviderBuilder, AppError> {
+    let trace_exporter = build_otlp_trace_exporter(endpoint, headers, targets)?;
+    Ok(builder.with_span_processor(BatchSpanProcessor::builder(trace_exporter).build()))
+}
+
+fn add_local_trace_exporter(
+    builder: TracerProviderBuilder,
+    store: &InstalledLocalTraceStore,
+) -> Result<TracerProviderBuilder, AppError> {
+    let exporter = local_store::JsonlSpanExporter::new(store.dir.clone(), store.retention)
+        .map_err(|e| AppError::InvalidInput(e.to_string()))?;
+    let (internal_trace_targets, _) =
+        build_trace_targets(DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOCAL_TRACE_FILTER);
+    let exporter = TargetFilteringSpanExporter::new(exporter, internal_trace_targets)
+        .excluding_rpc_services(LOCAL_TRACE_EXCLUDED_RPC_SERVICES);
+    Ok(builder.with_span_processor(BatchSpanProcessor::builder(exporter).build()))
+}
+
+fn build_otlp_logger_provider(
+    resource: &Resource,
+    endpoint: &str,
+    headers: HashMap<String, String>,
+) -> Result<SdkLoggerProvider, AppError> {
+    let exporter = LogExporter::builder()
+        .with_http()
+        .with_endpoint(normalize_otlp_endpoint(endpoint, "logs"))
+        .with_headers(headers)
+        .build()
+        .map_err(|e| AppError::InvalidInput(e.to_string()))?;
+    Ok(SdkLoggerProvider::builder()
+        .with_resource(resource.clone())
+        .with_log_processor(BatchLogProcessor::builder(exporter).build())
+        .build())
+}
+
+fn build_otlp_meter_provider(
+    resource: &Resource,
+    endpoint: &str,
+    headers: HashMap<String, String>,
+) -> Result<SdkMeterProvider, AppError> {
+    let exporter = MetricExporter::builder()
+        .with_http()
+        .with_endpoint(normalize_otlp_endpoint(endpoint, "metrics"))
+        .with_headers(headers)
+        .build()
+        .map_err(|e| AppError::InvalidInput(e.to_string()))?;
+    Ok(SdkMeterProvider::builder()
+        .with_resource(resource.clone())
+        .with_reader(
+            PeriodicReader::builder(exporter)
+                .with_interval(METRICS_INTERVAL)
+                .build(),
+        )
+        .build())
+}
+
 /// Per-invocation context populated from the process environment by the CLI binary.
 #[derive(Debug, Default)]
 pub struct RunContext {
@@ -352,22 +456,13 @@ pub(crate) fn init_tracing(
     Ok(state.local_trace_store.clone())
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "Initialization wires OpenTelemetry traces, logs, metrics, and local export"
-)]
 fn try_init_tracing(
     config: &TelemetryConfig,
     enable_stderr_logs: bool,
     internal_trace_store_dir: Option<PathBuf>,
 ) -> Result<TracingInitState, AppError> {
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
-    let endpoint = config
-        .otel
-        .endpoint
-        .as_deref()
-        .filter(|value| !value.is_empty())
-        .map(str::to_string);
+    let endpoint = configured_otlp_endpoint(config);
     let (log_filter, log_filter_error) = build_log_filter(config.otel.log_filter.as_deref());
     let stderr_layer = enable_stderr_logs.then(|| {
         tracing_subscriber::fmt::layer()
@@ -377,70 +472,26 @@ fn try_init_tracing(
             .with_filter(log_filter.clone())
     });
 
-    let local_trace_store = internal_trace_store_dir
-        .filter(|_| config.trace_history.enabled)
-        .map(|dir| InstalledLocalTraceStore::new(dir, config.trace_history.retention()));
+    let local_trace_store = configured_local_trace_store(config, internal_trace_store_dir);
     let internal_trace_store_enabled = local_trace_store.is_some();
     let should_export_traces = endpoint.is_some() || internal_trace_store_enabled;
     let mut trace_filter_error = None;
     let otel_trace_layer = if should_export_traces {
-        let resource = opentelemetry_sdk::Resource::builder()
-            .with_attribute(opentelemetry::KeyValue::new(
-                "service.name",
-                config.otel.service_name.clone(),
-            ))
-            .build();
-
-        let headers = parse_headers(config.otel.headers.as_deref().unwrap_or_default());
+        let resource = telemetry_resource(&config.otel.service_name);
         let mut builder = SdkTracerProvider::builder().with_resource(resource.clone());
 
-        if let Some(ref endpoint) = endpoint {
+        if let Some(endpoint) = endpoint {
+            let headers = parse_headers(config.otel.headers.as_deref().unwrap_or_default());
             let (otlp_trace_targets, error) =
                 build_trace_targets(&config.otel.trace_filter, DEFAULT_TRACE_FILTER);
             trace_filter_error = error;
-            let trace_exporter = OtlpSpanExporter::builder()
-                .with_http()
-                .with_endpoint(normalize_otlp_endpoint(endpoint, "traces"))
-                .with_headers(headers.clone())
-                .build()
-                .map_err(|e| AppError::InvalidInput(e.to_string()))?;
-            let trace_exporter =
-                TargetFilteringSpanExporter::new(trace_exporter, otlp_trace_targets)
-                    .denying_targets(OTLP_TRACE_DENIED_TARGETS);
-            builder = builder.with_span_processor(
-                opentelemetry_sdk::trace::BatchSpanProcessor::builder(trace_exporter).build(),
-            );
-
-            let log_exporter = LogExporter::builder()
-                .with_http()
-                .with_endpoint(normalize_otlp_endpoint(endpoint, "logs"))
-                .with_headers(headers.clone())
-                .build()
-                .map_err(|e| AppError::InvalidInput(e.to_string()))?;
-            let logger_provider = SdkLoggerProvider::builder()
-                .with_resource(resource.clone())
-                .with_log_processor(
-                    opentelemetry_sdk::logs::BatchLogProcessor::builder(log_exporter).build(),
-                )
-                .build();
+            builder =
+                add_otlp_trace_exporter(builder, endpoint, headers.clone(), otlp_trace_targets)?;
+            let logger_provider = build_otlp_logger_provider(&resource, endpoint, headers.clone())?;
             if let Ok(mut guard) = LOGGER_PROVIDER.lock() {
                 *guard = Some(logger_provider);
             }
-
-            let metric_exporter = MetricExporter::builder()
-                .with_http()
-                .with_endpoint(normalize_otlp_endpoint(endpoint, "metrics"))
-                .with_headers(headers)
-                .build()
-                .map_err(|e| AppError::InvalidInput(e.to_string()))?;
-            let meter_provider = SdkMeterProvider::builder()
-                .with_resource(resource.clone())
-                .with_reader(
-                    opentelemetry_sdk::metrics::PeriodicReader::builder(metric_exporter)
-                        .with_interval(METRICS_INTERVAL)
-                        .build(),
-                )
-                .build();
+            let meter_provider = build_otlp_meter_provider(&resource, endpoint, headers)?;
             opentelemetry::global::set_meter_provider(meter_provider.clone());
             initialize_metrics(Some(&meter_provider));
             if let Ok(mut guard) = METER_PROVIDER.lock() {
@@ -449,23 +500,13 @@ fn try_init_tracing(
         }
 
         if let Some(store) = local_trace_store.as_ref() {
-            let exporter = local_store::JsonlSpanExporter::new(store.dir.clone(), store.retention)
-                .map_err(|e| AppError::InvalidInput(e.to_string()))?;
-            let (internal_trace_targets, _) =
-                build_trace_targets(DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOCAL_TRACE_FILTER);
-            let exporter = TargetFilteringSpanExporter::new(exporter, internal_trace_targets)
-                .excluding_rpc_services(LOCAL_TRACE_EXCLUDED_RPC_SERVICES);
-            builder = builder.with_span_processor(
-                opentelemetry_sdk::trace::BatchSpanProcessor::builder(exporter).build(),
-            );
+            builder = add_local_trace_exporter(builder, store)?;
         }
 
         let provider = builder.build();
         let tracer = provider.tracer("coral");
         let (trace_targets, layer_filter_error) = trace_layer_filter(
-            endpoint
-                .as_deref()
-                .map(|_| config.otel.trace_filter.as_str()),
+            endpoint.map(|_| config.otel.trace_filter.as_str()),
             internal_trace_store_enabled,
         );
         if trace_filter_error.is_none() {

--- a/crates/coral-app/tests/telemetry_otlp_loopback.rs
+++ b/crates/coral-app/tests/telemetry_otlp_loopback.rs
@@ -8,21 +8,26 @@
 use std::path::Path;
 
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value};
 use opentelemetry_proto::tonic::logs::v1::LogRecord;
+use opentelemetry_proto::tonic::metrics::v1::{Metric, metric, number_data_point};
 use opentelemetry_proto::tonic::trace::v1::Span;
 use prost::Message as _;
 use tempfile::TempDir;
+use tonic::Request;
 use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+use wiremock::{Mock, MockServer, Request as WiremockRequest, ResponseTemplate};
 
+use coral_api::v1::ExecuteSqlRequest;
 use coral_app::{ServerBuilder, shutdown_tracing};
+use coral_client::{AppClient, decode_execute_sql_response, default_workspace};
 
 #[tokio::test]
-async fn otlp_export_loopback_filters_body_spans_and_exports_logs() {
+async fn otlp_export_loopback_covers_traces_logs_and_metrics() {
     let collector = MockServer::start().await;
-    for signal_path in ["/v1/traces", "/v1/logs"] {
+    for signal_path in ["/v1/traces", "/v1/logs", "/v1/metrics"] {
         Mock::given(method("POST"))
             .and(path(signal_path))
             .respond_with(ResponseTemplate::new(200))
@@ -58,7 +63,7 @@ enabled = true
         .await
         .expect("start server with OTLP endpoint");
 
-    emit_test_telemetry();
+    emit_test_telemetry(server.endpoint_uri()).await;
 
     shutdown_tracing();
     server.shutdown().await.expect("shutdown server");
@@ -82,9 +87,32 @@ enabled = true
     );
     let logs = decode_exported_logs(&log_requests);
     assert_exported_log_contract(&logs);
+
+    let metric_requests = metric_requests(&collector).await;
+    assert!(
+        !metric_requests.is_empty(),
+        "collector should receive metric export"
+    );
+    let metrics = decode_exported_metrics(&metric_requests);
+    assert_exported_metric_contract(&metrics);
 }
 
-fn emit_test_telemetry() {
+async fn emit_test_telemetry(endpoint_uri: &str) {
+    let app = AppClient::connect(endpoint_uri)
+        .await
+        .expect("connect loopback client");
+    let response = app
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: "SELECT 1 AS loopback_value".to_string(),
+        }))
+        .await
+        .expect("execute loopback query")
+        .into_inner();
+    let result = decode_execute_sql_response(&response).expect("decode loopback query");
+    assert_eq!(result.row_count(), 1);
+
     let query = tracing::info_span!(
         target: "coral_app",
         "loopback_query",
@@ -114,15 +142,19 @@ fn emit_test_telemetry() {
     let _mcp_body = mcp_body.enter();
 }
 
-async fn trace_requests(collector: &MockServer) -> Vec<Request> {
+async fn trace_requests(collector: &MockServer) -> Vec<WiremockRequest> {
     requests_for_path(collector, "/v1/traces").await
 }
 
-async fn log_requests(collector: &MockServer) -> Vec<Request> {
+async fn log_requests(collector: &MockServer) -> Vec<WiremockRequest> {
     requests_for_path(collector, "/v1/logs").await
 }
 
-async fn requests_for_path(collector: &MockServer, signal_path: &str) -> Vec<Request> {
+async fn metric_requests(collector: &MockServer) -> Vec<WiremockRequest> {
+    requests_for_path(collector, "/v1/metrics").await
+}
+
+async fn requests_for_path(collector: &MockServer, signal_path: &str) -> Vec<WiremockRequest> {
     collector
         .received_requests()
         .await
@@ -132,7 +164,7 @@ async fn requests_for_path(collector: &MockServer, signal_path: &str) -> Vec<Req
         .collect()
 }
 
-fn decode_trace_exports(trace_requests: &[Request]) -> Vec<ExportTraceServiceRequest> {
+fn decode_trace_exports(trace_requests: &[WiremockRequest]) -> Vec<ExportTraceServiceRequest> {
     trace_requests
         .iter()
         .map(|request| {
@@ -151,7 +183,7 @@ fn exported_spans(trace_exports: &[ExportTraceServiceRequest]) -> Vec<Span> {
         .collect()
 }
 
-fn decode_exported_logs(log_requests: &[Request]) -> Vec<LogRecord> {
+fn decode_exported_logs(log_requests: &[WiremockRequest]) -> Vec<LogRecord> {
     log_requests
         .iter()
         .flat_map(|request| {
@@ -161,6 +193,19 @@ fn decode_exported_logs(log_requests: &[Request]) -> Vec<LogRecord> {
         })
         .flat_map(|resource_logs| resource_logs.scope_logs)
         .flat_map(|scope_logs| scope_logs.log_records)
+        .collect()
+}
+
+fn decode_exported_metrics(metric_requests: &[WiremockRequest]) -> Vec<Metric> {
+    metric_requests
+        .iter()
+        .flat_map(|request| {
+            ExportMetricsServiceRequest::decode(request.body.as_slice())
+                .expect("decode OTLP metric export")
+                .resource_metrics
+        })
+        .flat_map(|resource_metrics| resource_metrics.scope_metrics)
+        .flat_map(|scope_metrics| scope_metrics.metrics)
         .collect()
 }
 
@@ -199,6 +244,83 @@ fn assert_exported_log_contract(logs: &[LogRecord]) {
     );
 }
 
+fn assert_exported_metric_contract(metrics: &[Metric]) {
+    assert_sum_metric_has_point(
+        metrics,
+        "coral.query.count",
+        &[("operation", "execute_sql"), ("status", "ok")],
+        1,
+    );
+    assert_histogram_metric_has_point(
+        metrics,
+        "coral.query.duration",
+        &[("operation", "execute_sql"), ("status", "ok")],
+    );
+    assert_histogram_metric_has_point_with_sum(
+        metrics,
+        "coral.query.rows",
+        &[("operation", "execute_sql"), ("status", "ok")],
+        1,
+        1.0,
+    );
+}
+
+fn assert_sum_metric_has_point(
+    metrics: &[Metric],
+    name: &str,
+    attributes: &[(&str, &str)],
+    expected_value: i64,
+) {
+    let metric = metric_named(metrics, name);
+    let Some(metric::Data::Sum(sum)) = metric.data.as_ref() else {
+        panic!("expected {name} to export as sum: {metric:?}");
+    };
+    assert!(
+        sum.data_points
+            .iter()
+            .any(|point| attrs_include(&point.attributes, attributes)
+                && number_value_is(point.value.as_ref(), expected_value)),
+        "{name} should include attributes {attributes:?} and value {expected_value}: {metric:?}"
+    );
+}
+
+fn assert_histogram_metric_has_point(metrics: &[Metric], name: &str, attributes: &[(&str, &str)]) {
+    let metric = metric_named(metrics, name);
+    let Some(metric::Data::Histogram(histogram)) = metric.data.as_ref() else {
+        panic!("expected {name} to export as histogram: {metric:?}");
+    };
+    assert!(
+        histogram
+            .data_points
+            .iter()
+            .any(|point| point.count > 0 && attrs_include(&point.attributes, attributes)),
+        "{name} should include attributes {attributes:?}: {metric:?}"
+    );
+}
+
+fn assert_histogram_metric_has_point_with_sum(
+    metrics: &[Metric],
+    name: &str,
+    attributes: &[(&str, &str)],
+    expected_count: u64,
+    expected_sum: f64,
+) {
+    let metric = metric_named(metrics, name);
+    let Some(metric::Data::Histogram(histogram)) = metric.data.as_ref() else {
+        panic!("expected {name} to export as histogram: {metric:?}");
+    };
+    assert!(
+        histogram.data_points.iter().any(|point| {
+            point.count == expected_count
+                && point
+                    .sum
+                    .is_some_and(|sum| (sum - expected_sum).abs() < f64::EPSILON)
+                && attrs_include(&point.attributes, attributes)
+        }),
+        "{name} should include attributes {attributes:?}, count {expected_count}, and sum {expected_sum}: {metric:?}"
+    );
+}
+
 fn assert_local_trace_history_contract(local_trace_history: &str) {
     for expected in [
         "loopback_query",
@@ -228,6 +350,27 @@ fn has_span_named(spans: &[Span], name: &str) -> bool {
 
 fn span_names(spans: &[Span]) -> Vec<&str> {
     spans.iter().map(|span| span.name.as_str()).collect()
+}
+
+fn metric_named<'a>(metrics: &'a [Metric], name: &str) -> &'a Metric {
+    metrics
+        .iter()
+        .find(|metric| metric.name == name)
+        .unwrap_or_else(|| panic!("expected metric {name}; got {:?}", metric_names(metrics)))
+}
+
+fn metric_names(metrics: &[Metric]) -> Vec<&str> {
+    metrics.iter().map(|metric| metric.name.as_str()).collect()
+}
+
+fn attrs_include(attributes: &[KeyValue], expected: &[(&str, &str)]) -> bool {
+    expected
+        .iter()
+        .all(|(key, value)| string_attr(attributes, key) == Some(*value))
+}
+
+fn number_value_is(value: Option<&number_data_point::Value>, expected: i64) -> bool {
+    matches!(value, Some(number_data_point::Value::AsInt(value)) if *value == expected)
 }
 
 fn string_attr<'a>(attributes: &'a [KeyValue], key: &str) -> Option<&'a str> {


### PR DESCRIPTION
## Summary
- Extracts OTLP trace/log/metric provider construction and local trace exporter attachment from tracing init.
- Keeps global provider lifecycle side effects visible in `try_init_tracing`.
- Extends the OTLP loopback test to emit, decode, and assert metrics export.

## Validation
- `cargo fmt --all --check`
- `cargo test -p coral-app telemetry:: --all-features`
- `cargo test -p coral-app --test telemetry_otlp_loopback --all-features -- --nocapture`
- `cargo clippy -p coral-app --all-features --all-targets -- -D warnings`
- `make rust-checks` on the completed stack

## Review
- Three adversarial reviews completed clean after fixes.
- `$autoreview --mode local --parallel-tests "cargo test -p coral-app telemetry:: --all-features && cargo test -p coral-app --test telemetry_otlp_loopback --all-features && cargo clippy -p coral-app --all-features --all-targets -- -D warnings"` completed clean.