### PR TITLE
ci: isolate perf release build cache

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -494,7 +494,10 @@ jobs:
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: coral-validate-${{ runner.os }}
+          # Keep this separate from Rust checks. GitHub caches are immutable on
+          # exact-key hits, so sharing the debug/test cache prevents this job's
+          # release artifacts from warming future performance runs.
+          shared-key: coral-perf-release-${{ runner.os }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
## Summary

- give the performance regression job its own Rust cache key for release builds
- keep the normal Linux Rust checks cache key unchanged
- document why the perf cache must stay separate from the debug/test validation cache

## Why

The performance regression job restores the same `coral-validate-Linux` cache used by the Linux Rust checks job, then runs:

```sh
cargo build --locked -p coral-cli --release
```

In run `26819337573`, that cache restored successfully as a full exact-key hit, but Cargo still rebuilt the release dependency graph from `proc-macro2` onward. The adjacent successful `main` run showed the same pattern: after spending about 16 minutes compiling the release build, the cache post-step printed `Cache up-to-date`.

That means the job restored an immutable exact-hit cache that did not contain useful release artifacts, then could not save the release artifacts it had just built. Future perf jobs restore the same archive and rebuild again.

Using a perf-specific shared key lets `main` warm a cache whose `target/release` artifacts match the benchmark build profile.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/validate.yml"); puts "validate.yml parses"'`
- `git diff --check`
