### PR TITLE
fix(engine): explain table-function describe errors

### DIFF
--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use datafusion::common::utils::quote_identifier;
 
-use super::catalog::TableInfo;
+use super::catalog::{TableFunctionInfo, TableInfo};
 use super::error::StatusCode;
 
 /// Wire-stable `reason` code for unknown-column errors.
@@ -12,6 +12,9 @@ pub(crate) const UNKNOWN_COLUMN_REASON: &str = "UNKNOWN_COLUMN";
 
 /// Wire-stable `reason` code for table-not-found errors.
 pub(crate) const TABLE_NOT_FOUND_REASON: &str = "TABLE_NOT_FOUND";
+
+/// Wire-stable `reason` code for table functions used where a table is needed.
+pub(crate) const TABLE_FUNCTION_NOT_TABLE_REASON: &str = "TABLE_FUNCTION_NOT_TABLE";
 
 /// Minimum `strsim::normalized_levenshtein` score for a "did you mean?"
 /// suggestion to surface.
@@ -205,6 +208,32 @@ impl StructuredQueryError {
             hint,
             false,
             StatusCode::NotFound,
+            metadata,
+        )
+    }
+
+    /// Builds a structured error for a table function used where SQL expects a table.
+    pub(crate) fn table_function_not_table(function: &TableFunctionInfo) -> Self {
+        let display_ref = format_schema_function(function);
+        let mut metadata = HashMap::new();
+        metadata.insert("object_kind".to_string(), "table_function".to_string());
+        metadata.insert("schema".to_string(), function.schema_name.clone());
+        metadata.insert("function".to_string(), function.function_name.clone());
+
+        let schema_sql = sql_string_literal(&function.schema_name);
+        let function_sql = sql_string_literal(&function.function_name);
+
+        Self::new(
+            TABLE_FUNCTION_NOT_TABLE_REASON,
+            format!("`{display_ref}` is a table function, not a table"),
+            format!(
+                "`{display_ref}` is registered as a table function. Query it as `FROM {display_ref}(...)`; inspect arguments and result columns in `coral.table_functions`, or run `DESCRIBE SELECT * FROM {display_ref}(...)` after filling any required arguments."
+            ),
+            Some(format!(
+                "Inspect table functions with `SELECT schema_name, function_name, arguments_json, result_columns_json FROM coral.table_functions WHERE schema_name = {schema_sql} AND function_name = {function_sql}`."
+            )),
+            false,
+            StatusCode::InvalidArgument,
             metadata,
         )
     }
@@ -480,6 +509,18 @@ fn format_schema_table_fully_quoted(info: &TableInfo) -> String {
     )
 }
 
+fn format_schema_function(info: &TableFunctionInfo) -> String {
+    format!(
+        "{}.{}",
+        quote_dotted_identifier(&info.schema_name),
+        quote_identifier(&info.function_name)
+    )
+}
+
+fn sql_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
 // ---------------------------------------------------------------------------
 // Table-ref parsing
 // ---------------------------------------------------------------------------
@@ -625,6 +666,16 @@ mod tests {
         }
     }
 
+    fn table_function(schema: &str, name: &str) -> TableFunctionInfo {
+        TableFunctionInfo {
+            schema_name: schema.to_string(),
+            function_name: name.to_string(),
+            description: String::new(),
+            arguments: vec![],
+            result_columns: vec![],
+        }
+    }
+
     fn cp(relation: &[&str], name: &str) -> ColumnParts {
         ColumnParts {
             relation: relation.iter().map(ToString::to_string).collect(),
@@ -643,6 +694,7 @@ mod tests {
         // that pattern-matches on reason codes.
         assert_eq!(UNKNOWN_COLUMN_REASON, "UNKNOWN_COLUMN");
         assert_eq!(TABLE_NOT_FOUND_REASON, "TABLE_NOT_FOUND");
+        assert_eq!(TABLE_FUNCTION_NOT_TABLE_REASON, "TABLE_FUNCTION_NOT_TABLE");
     }
 
     #[test]
@@ -732,6 +784,39 @@ mod tests {
         assert!(
             !hint.contains("coral source"),
             "hint must stay transport-neutral (no CLI-specific commands), got: {hint}"
+        );
+    }
+
+    #[test]
+    fn table_function_not_table_points_at_table_functions_catalog() {
+        let err =
+            StructuredQueryError::table_function_not_table(&table_function("datadog", "metrics"));
+
+        assert_eq!(err.reason(), TABLE_FUNCTION_NOT_TABLE_REASON);
+        assert_eq!(err.status(), StatusCode::InvalidArgument);
+        assert_eq!(
+            err.summary(),
+            "`datadog.metrics` is a table function, not a table"
+        );
+        let hint = err.hint().expect("hint should be present");
+        assert!(hint.contains("coral.table_functions"), "got: {hint}");
+        assert!(hint.contains("schema_name = 'datadog'"), "got: {hint}");
+        assert!(hint.contains("function_name = 'metrics'"), "got: {hint}");
+        assert_eq!(
+            err.metadata().get("object_kind").map(String::as_str),
+            Some("table_function")
+        );
+        assert!(
+            err.detail()
+                .contains("Query it as `FROM datadog.metrics(...)`"),
+            "got: {}",
+            err.detail()
+        );
+        assert!(
+            err.detail()
+                .contains("DESCRIBE SELECT * FROM datadog.metrics(...)"),
+            "got: {}",
+            err.detail()
         );
     }
 

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -6,12 +6,15 @@ use datafusion::sql::sqlparser::ast::{ObjectName, ObjectNamePart};
 use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
 
+use crate::TableFunctionInfo;
 use crate::backends::http::ProviderQueryError;
 use crate::backends::mcp::McpProviderQueryError;
 use crate::contracts::{ColumnParts, StructuredQueryError, TableRefParts};
 use crate::{
     CoreError, QueryResultObserverError, SourceDecoratorError, SourceInputResolverError, TableInfo,
 };
+
+const DATAFUSION_DEFAULT_CATALOG: &str = "datafusion";
 
 pub(crate) fn datafusion_to_core(error: &DataFusionError, tables: &[TableInfo]) -> CoreError {
     datafusion_to_core_with_sql(error, tables, None)
@@ -22,6 +25,15 @@ pub(crate) fn datafusion_to_core_with_sql(
     tables: &[TableInfo],
     sql: Option<&str>,
 ) -> CoreError {
+    datafusion_to_core_with_sql_and_table_functions(error, tables, &[], sql)
+}
+
+pub(crate) fn datafusion_to_core_with_sql_and_table_functions(
+    error: &DataFusionError,
+    tables: &[TableInfo],
+    table_functions: &[TableFunctionInfo],
+    sql: Option<&str>,
+) -> CoreError {
     // Unwrap Context/Shared/Diagnostic wrappers so wrapped schema errors
     // get classified by their root variant instead of all landing in the
     // `Internal` bucket. Without `find_root()`, `SELECT bogus FROM wide`
@@ -30,7 +42,9 @@ pub(crate) fn datafusion_to_core_with_sql(
     // from the match arms below.
     match error.find_root() {
         DataFusionError::SQL(detail, _) => CoreError::InvalidInput(detail.to_string()),
-        DataFusionError::Plan(detail) => plan_error_to_core(detail, error, tables, sql),
+        DataFusionError::Plan(detail) => {
+            plan_error_to_core(detail, error, tables, table_functions, sql)
+        }
         DataFusionError::SchemaError(schema_error, _) => schema_error_to_core(schema_error),
         DataFusionError::NotImplemented(detail) => CoreError::Unimplemented(detail.clone()),
         DataFusionError::External(inner) => {
@@ -85,9 +99,15 @@ fn plan_error_to_core(
     detail: &str,
     error: &DataFusionError,
     tables: &[TableInfo],
+    table_functions: &[TableFunctionInfo],
     sql: Option<&str>,
 ) -> CoreError {
     if let Some(table_ref) = table_not_found_ref(error, detail, sql) {
+        if let Some(function) = table_function_for_ref(&table_ref, table_functions) {
+            return CoreError::QueryFailure(Box::new(
+                StructuredQueryError::table_function_not_table(function),
+            ));
+        }
         return CoreError::QueryFailure(Box::new(StructuredQueryError::table_not_found(
             &table_ref, tables,
         )));
@@ -237,6 +257,70 @@ fn table_ref_parts_from_object_name(object_name: ObjectName) -> Option<TableRefP
     Some(TableRefParts::new(parts))
 }
 
+fn table_function_for_ref<'a>(
+    reference: &TableRefParts,
+    table_functions: &'a [TableFunctionInfo],
+) -> Option<&'a TableFunctionInfo> {
+    let parts = reference.parts.as_slice();
+
+    resolve_table_function(parts, table_functions).or_else(|| {
+        let without_catalog = without_default_catalog(parts);
+        (without_catalog.len() != parts.len())
+            .then(|| resolve_table_function(without_catalog, table_functions))
+            .flatten()
+    })
+}
+
+fn resolve_table_function<'a>(
+    parts: &[String],
+    table_functions: &'a [TableFunctionInfo],
+) -> Option<&'a TableFunctionInfo> {
+    if parts.len() < 2 {
+        return None;
+    }
+
+    for candidate in SchemaQualifiedName::candidates(parts) {
+        if let Some(function) = table_functions
+            .iter()
+            .find(|function| candidate.matches(function))
+        {
+            return Some(function);
+        }
+    }
+    None
+}
+
+fn without_default_catalog(parts: &[String]) -> &[String] {
+    match parts {
+        [first, rest @ ..] if first.eq_ignore_ascii_case(DATAFUSION_DEFAULT_CATALOG) => rest,
+        _ => parts,
+    }
+}
+
+struct SchemaQualifiedName {
+    schema: String,
+    name: String,
+}
+
+impl SchemaQualifiedName {
+    fn candidates(parts: &[String]) -> impl Iterator<Item = Self> + '_ {
+        // Prefer the longest possible schema prefix so dotted source names
+        // like `"foo.bar".metrics` resolve as schema `foo.bar`.
+        (1..parts.len()).rev().map(|schema_len| {
+            let (schema_parts, name_parts) = parts.split_at(schema_len);
+            Self {
+                schema: schema_parts.join("."),
+                name: name_parts.join("."),
+            }
+        })
+    }
+
+    fn matches(&self, function: &TableFunctionInfo) -> bool {
+        function.schema_name.eq_ignore_ascii_case(&self.schema)
+            && function.function_name.eq_ignore_ascii_case(&self.name)
+    }
+}
+
 fn provider_error_to_core(error: &ProviderQueryError) -> CoreError {
     CoreError::QueryFailure(Box::new(error.to_structured()))
 }
@@ -249,6 +333,20 @@ fn mcp_provider_error_to_core(error: &McpProviderQueryError) -> CoreError {
 mod tests {
     use super::*;
     use crate::contracts::UNKNOWN_COLUMN_REASON;
+
+    fn table_function(schema: &str, name: &str) -> TableFunctionInfo {
+        TableFunctionInfo {
+            schema_name: schema.to_string(),
+            function_name: name.to_string(),
+            description: String::new(),
+            arguments: vec![],
+            result_columns: vec![],
+        }
+    }
+
+    fn table_ref(parts: &[&str]) -> TableRefParts {
+        TableRefParts::new(parts.iter().map(ToString::to_string).collect())
+    }
 
     #[test]
     fn datafusion_to_core_unwraps_context_wrapped_schema_error_to_structured() {
@@ -289,10 +387,49 @@ mod tests {
     #[test]
     fn plan_error_without_table_prefix_is_invalid_input() {
         let error = DataFusionError::Plan("syntax error at position 12".to_string());
-        let core = plan_error_to_core("syntax error at position 12", &error, &[], None);
+        let core = plan_error_to_core("syntax error at position 12", &error, &[], &[], None);
         match core {
             CoreError::InvalidInput(detail) => assert!(detail.contains("syntax error")),
             other => panic!("expected CoreError::InvalidInput, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn table_function_ref_matches_qualified_function() {
+        let functions = vec![table_function("datadog", "metrics")];
+        let function = table_function_for_ref(
+            &table_ref(&["datafusion", "datadog", "metrics"]),
+            &functions,
+        )
+        .expect("qualified table function should match");
+
+        assert_eq!(function.schema_name, "datadog");
+        assert_eq!(function.function_name, "metrics");
+    }
+
+    #[test]
+    fn table_function_ref_preserves_datafusion_schema_name() {
+        let functions = vec![table_function("datafusion", "metrics")];
+
+        for parts in [
+            ["datafusion", "metrics"].as_slice(),
+            ["datafusion", "datafusion", "metrics"].as_slice(),
+        ] {
+            let function = table_function_for_ref(&table_ref(parts), &functions)
+                .expect("datafusion schema name should match");
+
+            assert_eq!(function.schema_name, "datafusion");
+            assert_eq!(function.function_name, "metrics");
+        }
+    }
+
+    #[test]
+    fn table_function_ref_ignores_unqualified_function() {
+        let functions = vec![table_function("datadog", "metrics")];
+
+        assert!(
+            table_function_for_ref(&table_ref(&["datafusion", "public", "metrics"]), &functions,)
+                .is_none()
+        );
     }
 }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -13,7 +13,8 @@ use tracing::{Instrument as _, info_span};
 use crate::backends::compile_query_source;
 use crate::runtime::catalog;
 use crate::runtime::error::{
-    datafusion_to_core, datafusion_to_core_with_sql, query_result_observer_error_to_core,
+    datafusion_to_core, datafusion_to_core_with_sql_and_table_functions,
+    query_result_observer_error_to_core,
 };
 use crate::runtime::json::register_json_support;
 use crate::runtime::pattern_validator::register_pattern_validator;
@@ -264,7 +265,14 @@ impl QueryRuntimeAdapter {
         self.ctx
             .sql_with_options(sql, read_only_sql_options())
             .await
-            .map_err(|err| datafusion_to_core_with_sql(&err, &self.tables, Some(sql)))
+            .map_err(|err| {
+                datafusion_to_core_with_sql_and_table_functions(
+                    &err,
+                    &self.tables,
+                    &self.table_functions,
+                    Some(sql),
+                )
+            })
     }
 }
 

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 
-use coral_engine::{ColumnInfo, CoralQuery, QuerySource, TableInfo};
+use coral_engine::{ColumnInfo, CoralQuery, CoreError, QuerySource, TableInfo};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -483,6 +483,90 @@ async fn coral_table_functions_lists_source_functions() {
             "max_top_k": 100,
             "max_calls_per_query": 1
         })
+    );
+}
+
+#[tokio::test]
+async fn table_function_used_as_table_returns_guided_error() {
+    let sources = vec![build_source(http_manifest_with_function())];
+
+    for sql in [
+        "DESCRIBE searchy.search_issues",
+        "SELECT * FROM searchy.search_issues",
+    ] {
+        let error = CoralQuery::execute_sql(&sources, test_runtime(), sql)
+            .await
+            .expect_err("table function reference should explain the object kind");
+
+        let CoreError::QueryFailure(sqe) = error else {
+            panic!("expected structured query error");
+        };
+        assert_eq!(sqe.reason(), "TABLE_FUNCTION_NOT_TABLE");
+        assert!(
+            sqe.summary()
+                .contains("`searchy.search_issues` is a table function, not a table"),
+            "got: {}",
+            sqe.summary()
+        );
+        assert!(
+            sqe.detail()
+                .contains("Query it as `FROM searchy.search_issues(...)`"),
+            "got: {}",
+            sqe.detail()
+        );
+        assert!(
+            sqe.detail()
+                .contains("DESCRIBE SELECT * FROM searchy.search_issues(...)"),
+            "got: {}",
+            sqe.detail()
+        );
+        let hint = sqe.hint().expect("hint should point at catalog metadata");
+        assert!(hint.contains("coral.table_functions"), "got: {hint}");
+        assert!(hint.contains("schema_name = 'searchy'"), "got: {hint}");
+        assert!(
+            hint.contains("function_name = 'search_issues'"),
+            "got: {hint}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn describe_table_keeps_datafusion_shape() {
+    let (_temp, sources) = build_catalog_sources();
+
+    let execution = CoralQuery::execute_sql(&sources, test_runtime(), "DESCRIBE alpha.users")
+        .await
+        .expect("table describe should succeed");
+
+    assert_eq!(
+        execution
+            .schema()
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["column_name", "data_type", "is_nullable"]
+    );
+}
+
+#[tokio::test]
+async fn describe_select_from_table_function_keeps_datafusion_shape() {
+    let sources = vec![build_source(http_manifest_with_function())];
+
+    let execution = CoralQuery::execute_sql(
+        &sources,
+        test_runtime(),
+        "DESCRIBE SELECT * FROM searchy.search_issues(q => 'flaky')",
+    )
+    .await
+    .expect("query describe should succeed");
+
+    assert_eq!(
+        execution
+            .schema()
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["column_name", "data_type", "is_nullable"]
     );
 }
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -34,6 +34,17 @@ coral sql "<SQL>"
 
 JSON output is an array of row objects. Selected nullable columns are included with explicit `null` values when the row value is null.
 
+Use `DESCRIBE <schema>.<table>` to inspect a table's result columns:
+
+```shellscript
+coral sql "DESCRIBE datadog.hosts"
+```
+
+`DESCRIBE` expects a table. To inspect table functions, query
+`coral.table_functions`.
+
+`DESCRIBE SELECT ...` still describes the result schema of the query itself.
+
 ## `coral source`
 
 Manage configured sources, either the bundled ones, or your custom source specs.


### PR DESCRIPTION
## Intent

Coral has two queryable object kinds inside source schemas:

- tables, which can be referenced directly in `FROM` and described with `DESCRIBE <schema>.<table>`
- table functions, which must be called with parentheses and any required arguments before they produce rows

On `main`, using a table function where SQL expects a table falls through to DataFusion's generic missing-table error. For example, `DESCRIBE datadog.metrics` says `datadog.metrics` is not a table, but it does not tell the user that `metrics` is actually registered as a table function or where to find its arguments.

This PR makes that failure explicit without changing DataFusion's normal `DESCRIBE` output for real tables.

## What Changed

When DataFusion reports a missing relation during planning, Coral checks the registered table-function catalog before returning the normal `TABLE_NOT_FOUND` diagnostic.

If the schema-qualified relation matches a table function, Coral returns a structured query error with:

- reason: `TABLE_FUNCTION_NOT_TABLE`
- summary: `` `<schema>.<function>` is a table function, not a table ``
- detail: query it as `FROM <schema>.<function>(...)`; inspect arguments/result columns in `coral.table_functions`; or run `DESCRIBE SELECT * FROM <schema>.<function>(...)` once required arguments are known
- hint: a concrete `coral.table_functions` query for that schema/function

The same reason is used for `DESCRIBE datadog.metrics` and `SELECT * FROM datadog.metrics`, because both hit the same object-kind mistake. The remediation names the valid `DESCRIBE SELECT * FROM ...` form so the `DESCRIBE` case does not imply unsupported `DESCRIBE schema.function(args...)` syntax.

## User Impact

After this change:

```text
Error: `datadog.metrics` is a table function, not a table
Detail: `datadog.metrics` is registered as a table function. Query it as `FROM datadog.metrics(...)`; inspect arguments and result columns in `coral.table_functions`, or run `DESCRIBE SELECT * FROM datadog.metrics(...)` after filling any required arguments.
Hint: Inspect table functions with `SELECT schema_name, function_name, arguments_json, result_columns_json FROM coral.table_functions WHERE schema_name = 'datadog' AND function_name = 'metrics'`.
```

Users can inspect the callable shape before knowing the arguments:

```sql
SELECT schema_name, function_name, arguments_json, result_columns_json
FROM coral.table_functions
WHERE schema_name = 'datadog'
  AND function_name = 'metrics';
```

Existing successful paths are unchanged:

- `DESCRIBE datadog.hosts` still returns DataFusion's three-column describe output: `column_name`, `data_type`, `is_nullable`.
- `DESCRIBE SELECT * FROM datadog.metrics(...)` still describes the result schema of the called table function.
- real missing tables still use the existing `TABLE_NOT_FOUND` path and table suggestions.

## Boundaries

This stays in `coral-engine`'s DataFusion-to-Core error normalization layer. DataFusion still owns SQL planning and `DESCRIBE` behavior; Coral only enriches a failed relation lookup with catalog knowledge it already has.

This PR does not add a statement-planner hook, does not parse SQL a second time to distinguish `DESCRIBE` from `SELECT`, and does not add API/proto surface.

The special diagnostic only fires for schema-qualified references such as `datadog.metrics`. Bare names such as `metrics` remain ordinary missing-table errors because they are ambiguous without a schema.

## Edge Cases Covered

- a full DataFusion catalog-qualified ref such as `datafusion.datadog.metrics`
- a source schema literally named `datafusion`, such as `datafusion.metrics`
- quoted source schema pieces such as `"foo.bar".metrics`
- case-insensitive matching for unquoted references

## Not in This PR

- No custom `DESCRIBE` output shape for table functions.
- No `DESCRIBE FUNCTION` SQL extension.
- No new public API/proto field for table-function describe metadata.
- No change to the `coral.table_functions` catalog schema.

## Validation

Local validation:

- `cargo fmt --check`
- `cargo test -p coral-engine --lib table_function_ref --all-features --locked`
- `cargo test -p coral-engine --lib table_function_not_table_points_at_table_functions_catalog --all-features --locked`
- `cargo test -p coral-engine --test engine table_function_used_as_table_returns_guided_error --all-features --locked`
- earlier branch validation: `cargo check -p coral-engine --lib --locked`, `cargo clippy -p coral-engine --lib --all-features --locked -- -D warnings`, focused describe/table-function integration tests, and manual CLI smoke for `DESCRIBE datadog.metrics` and `SELECT * FROM datadog.metrics`

GitHub Validate was green before the review-feedback amendment; it should rerun on the new commit.
