### PR TITLE
feat(sources/community/discord): add thread channel coverage

### DIFF
--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -1,6 +1,6 @@
 # Discord
 
-Query Discord bot identity, guilds, channels, messages, members, and roles from the [Discord REST API v10](https://discord.com/developers/docs/intro).
+Query Discord bot identity, guilds, channels, threads, messages, members, and roles from the [Discord REST API v10](https://discord.com/developers/docs/intro).
 
 ## Prerequisites
 
@@ -17,6 +17,9 @@ Configure the following by table:
 | `current_user` | Token only | none | none |
 | `guilds` | Token only | none | none |
 | `channels` | `guild_id` filter | none | `VIEW_CHANNEL` (`0x400`) |
+| `active_threads` | `guild_id` filter | none | `VIEW_CHANNEL` (`0x400`), `READ_MESSAGE_HISTORY` (`0x10000`) |
+| `archived_threads` | `channel_id`, `visibility` filters | none | `VIEW_CHANNEL` (`0x400`), `READ_MESSAGE_HISTORY` (`0x10000`); private archives may require `MANAGE_THREADS` |
+| `joined_private_archived_threads` | `channel_id` filter | none | `VIEW_CHANNEL` (`0x400`), `READ_MESSAGE_HISTORY` (`0x10000`) |
 | `messages` | `channel_id` filter | `MESSAGE_CONTENT` | `VIEW_CHANNEL` (`0x400`), `READ_MESSAGE_HISTORY` (`0x10000`) |
 | `members` | `guild_id` filter | `GUILD_MEMBERS` | none |
 | `roles` | `guild_id` filter | none | `VIEW_CHANNEL` (`0x400`) |
@@ -43,11 +46,16 @@ After adding the source, discover IDs by querying:
 -- Find guilds the bot can see
 SELECT id, name FROM discord.guilds LIMIT 10;
 
--- Find channels in a guild
+-- Find top-level channels in a guild
 SELECT id, name, type FROM discord.channels WHERE guild_id = 'GUILD_ID';
+
+-- Find active thread channels and forum/media posts in a guild
+SELECT id, name, parent_id, type
+FROM discord.active_threads
+WHERE guild_id = 'GUILD_ID';
 ```
 
-Use the returned IDs as required filters for the `channels`, `messages`, `members`, and `roles` tables.
+Use guild IDs for `channels`, `active_threads`, `members`, and `roles`. Use top-level channel IDs for `archived_threads` and `joined_private_archived_threads`. Use thread IDs from `active_threads`, `archived_threads`, or `joined_private_archived_threads` as `channel_id` values for `messages`.
 
 ## Tables
 
@@ -56,6 +64,9 @@ Use the returned IDs as required filters for the `channels`, `messages`, `member
 | `current_user` | The Discord bot user associated with the configured token | none |
 | `guilds` | Discord guilds that the configured bot can see | none |
 | `channels` | Channels in a Discord guild | `guild_id` |
+| `active_threads` | Active thread channels in a Discord guild | `guild_id` |
+| `archived_threads` | Public or private archived thread channels in a parent channel | `channel_id`, `visibility` |
+| `joined_private_archived_threads` | Private archived thread channels the bot has joined | `channel_id` |
 | `messages` | Recent messages in a Discord channel | `channel_id` |
 | `members` | Members in a Discord guild | `guild_id` |
 | `roles` | Roles in a Discord guild | `guild_id` |
@@ -87,6 +98,32 @@ ORDER BY timestamp DESC
 LIMIT 20;
 ```
 
+For forum and media posts, first query the thread channel tables, then pass the returned thread ID to `messages`:
+
+```sql
+-- Active forum/media posts under a parent forum or media channel
+SELECT id, name, parent_id, last_message_id
+FROM discord.active_threads
+WHERE guild_id = 'GUILD_ID'
+  AND parent_id = 'FORUM_OR_MEDIA_CHANNEL_ID'
+ORDER BY id DESC
+LIMIT 20;
+
+-- Public archived forum/media posts under that same parent channel
+SELECT id, name, parent_id, last_message_id
+FROM discord.archived_threads
+WHERE channel_id = 'FORUM_OR_MEDIA_CHANNEL_ID'
+  AND visibility = 'public'
+LIMIT 20;
+
+-- Messages inside one forum/media post
+SELECT id, author__username, content, timestamp
+FROM discord.messages
+WHERE channel_id = 'THREAD_ID_FROM_ABOVE'
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
 ## Example queries
 
 ```sql
@@ -102,6 +139,13 @@ SELECT id, name, position, topic
 FROM discord.channels
 WHERE guild_id = '123456789012345678'
   AND type = 0;
+
+-- Active forum/media posts are thread channels
+SELECT id, name, parent_id, last_message_id
+FROM discord.active_threads
+WHERE guild_id = '123456789012345678'
+ORDER BY id DESC
+LIMIT 20;
 
 -- Recent messages in a channel
 SELECT id, author__username, content, timestamp
@@ -142,6 +186,8 @@ Discord uses Snowflake-based cursor pagination via `before`, `after`, and `aroun
 | Table | Pagination filters | Max per page |
 |---|---|---|
 | `guilds` | `before`, `after` (by guild ID), `with_counts` | 200 |
+| `archived_threads` | `before` (archive timestamp), `visibility` (`public` or `private`) | 100 |
+| `joined_private_archived_threads` | `before` (thread ID) | 100 |
 | `messages` | `before`, `after`, `around` (message ID, mutually exclusive) | 100 |
 | `members` | `after` (by user ID) | 1000 |
 

--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -18,7 +18,7 @@ Configure the following by table:
 | `guilds` | Token only | none | none |
 | `channels` | `guild_id` filter | none | `VIEW_CHANNEL` (`0x400`) |
 | `active_threads` | `guild_id` filter | none | `VIEW_CHANNEL` (`0x400`), `READ_MESSAGE_HISTORY` (`0x10000`) |
-| `archived_threads` | `channel_id`, `visibility` filters | none | `VIEW_CHANNEL` (`0x400`), `READ_MESSAGE_HISTORY` (`0x10000`); private archives may require `MANAGE_THREADS` |
+| `archived_threads` | `channel_id`, `visibility` filters | none | `VIEW_CHANNEL` (`0x400`), `READ_MESSAGE_HISTORY` (`0x10000`); `visibility = 'private'` also requires `MANAGE_THREADS` (`0x400000000`) |
 | `joined_private_archived_threads` | `channel_id` filter | none | `VIEW_CHANNEL` (`0x400`), `READ_MESSAGE_HISTORY` (`0x10000`) |
 | `messages` | `channel_id` filter | `MESSAGE_CONTENT` | `VIEW_CHANNEL` (`0x400`), `READ_MESSAGE_HISTORY` (`0x10000`) |
 | `members` | `guild_id` filter | `GUILD_MEMBERS` | none |
@@ -26,7 +26,7 @@ Configure the following by table:
 
 **Privileged intents** are enabled in the Developer Portal under **Bot → Privileged Gateway Intents**. Without `GUILD_MEMBERS`, `GET /guilds/{guild.id}/members` returns an empty result. Without `MESSAGE_CONTENT`, the `content`, `embeds`, and `attachments` columns return empty values.
 
-The minimal bot permission integer for read-only queries across all tables is `0x10400` (`VIEW_CHANNEL` + `READ_MESSAGE_HISTORY`). No bot permission is needed for reading guild members — only the `GUILD_MEMBERS` privileged intent controls access.
+The minimal bot permission integer for read-only queries across public channels, public archived threads, joined private archived threads, messages, and roles is `0x10400` (`VIEW_CHANNEL` + `READ_MESSAGE_HISTORY`). Querying `discord.archived_threads` with `visibility = 'private'` requires `MANAGE_THREADS` as well, for a combined permission integer of `0x400010400`. No bot permission is needed for reading guild members — only the `GUILD_MEMBERS` privileged intent controls access.
 
 The `bot` scope is always required. The `applications.commands` scope is optional and only needed if the bot uses slash commands alongside Coral.
 
@@ -241,7 +241,7 @@ permissions and intents each table needs.
 
 The following output was captured from a live Discord bot at setup time. The manifest
 test queries (`current_user`, `guilds`) passed validation. The `coral sql` examples
-below demonstrate manual queries against all six tables using a bot that was a
+below demonstrate manual queries against all nine tables using a bot that was a
 member of one guild. IDs, names, and message content are anonymized.
 
 ```shell
@@ -253,10 +253,13 @@ Added source discord
 
   ✓ discord connected successfully
 
-    discord (6 tables)
+    discord (9 tables)
+    ├─ active_threads
+    ├─ archived_threads
     ├─ channels
     ├─ current_user
     ├─ guilds
+    ├─ joined_private_archived_threads
     ├─ members
     ├─ messages
     └─ roles
@@ -273,10 +276,13 @@ $ coral source test discord
 
   ✓ discord connected successfully
 
-    discord (6 tables)
+    discord (9 tables)
+    ├─ active_threads
+    ├─ archived_threads
     ├─ channels
     ├─ current_user
     ├─ guilds
+    ├─ joined_private_archived_threads
     ├─ members
     ├─ messages
     └─ roles

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -3,8 +3,8 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query Discord bot identity, guilds, channels, messages, members, and roles
-  from the Discord REST API.
+  Query Discord bot identity, guilds, channels, threads, messages, members, and
+  roles from the Discord REST API.
 inputs:
   DISCORD_BOT_TOKEN:
     kind: secret
@@ -273,8 +273,11 @@ tables:
     description: Channels in a Discord guild
     guide: |
       Requires guild_id from discord.guilds. Use returned id values as
-      channel_id filters for discord.messages. Channel types: 0 text,
-      2 voice, 4 category, 5 announcement, 13 stage, 15 forum, 16 media.
+      channel_id filters for discord.messages. This endpoint returns guild
+      channels, but not thread channels. Use active_threads and archived thread
+      tables to discover thread channels and forum/media posts. Channel types:
+      0 text, 2 voice, 4 category, 5 announcement, 13 stage, 15 forum,
+      16 media.
       SELECT id, name, type, position FROM discord.channels
       WHERE guild_id = '<id>'.
     filters:
@@ -382,6 +385,14 @@ tables:
           kind: path
           path:
             - user_limit
+      - name: rtc_region
+        type: Utf8
+        nullable: true
+        description: Voice or stage channel RTC region
+        expr:
+          kind: path
+          path:
+            - rtc_region
       - name: flags
         type: Int64
         nullable: true
@@ -438,6 +449,22 @@ tables:
           kind: path
           path:
             - default_thread_rate_limit_per_user
+      - name: available_tags
+        type: Json
+        nullable: true
+        description: Forum or media channel tags as JSON
+        expr:
+          kind: path
+          path:
+            - available_tags
+      - name: default_reaction_emoji
+        type: Json
+        nullable: true
+        description: Default reaction emoji for new forum or media posts
+        expr:
+          kind: path
+          path:
+            - default_reaction_emoji
       - name: video_quality_mode
         type: Int64
         nullable: true
@@ -447,20 +474,312 @@ tables:
           path:
             - video_quality_mode
 
+  # ----------------------------------------------------------------------
+  # active_threads
+  # ----------------------------------------------------------------------
+  - name: active_threads
+    description: Active Discord thread channels in a guild
+    guide: |
+      Requires guild_id from discord.guilds. This returns active thread
+      channels, including forum and media posts that have not archived yet.
+      Thread channel types are 10 announcement thread, 11 public thread, and
+      12 private thread. Use returned id values as channel_id filters for
+      discord.messages.
+      SELECT id, name, parent_id, last_message_id
+      FROM discord.active_threads WHERE guild_id = '<id>'.
+    filters:
+      - name: guild_id
+        required: true
+    request:
+      method: GET
+      path: /guilds/{{filter.guild_id}}/threads/active
+    response:
+      rows_path:
+        - threads
+    columns: &thread_columns
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Discord thread channel ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: type
+        type: Int64
+        nullable: false
+        description: "Thread channel type integer: 10 announcement, 11 public, 12 private"
+        expr:
+          kind: path
+          path:
+            - type
+      - name: guild_id
+        type: Utf8
+        nullable: true
+        description: Guild ID from the thread channel object
+        expr:
+          kind: path
+          path:
+            - guild_id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Thread channel name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: parent_id
+        type: Utf8
+        nullable: true
+        description: Parent channel ID, such as the forum or media channel
+        expr:
+          kind: path
+          path:
+            - parent_id
+      - name: owner_id
+        type: Utf8
+        nullable: true
+        description: User ID that created the thread
+        expr:
+          kind: path
+          path:
+            - owner_id
+      - name: last_message_id
+        type: Utf8
+        nullable: true
+        description: Most recent message ID known to Discord
+        expr:
+          kind: path
+          path:
+            - last_message_id
+      - name: message_count
+        type: Int64
+        nullable: true
+        description: Approximate message count in the thread
+        expr:
+          kind: path
+          path:
+            - message_count
+      - name: member_count
+        type: Int64
+        nullable: true
+        description: Approximate member count in the thread
+        expr:
+          kind: path
+          path:
+            - member_count
+      - name: total_message_sent
+        type: Int64
+        nullable: true
+        description: Total number of messages ever sent in the thread
+        expr:
+          kind: path
+          path:
+            - total_message_sent
+      - name: rate_limit_per_user
+        type: Int64
+        nullable: true
+        description: Slowmode delay in seconds
+        expr:
+          kind: path
+          path:
+            - rate_limit_per_user
+      - name: flags
+        type: Int64
+        nullable: true
+        description: Thread channel flags as a bitfield
+        expr:
+          kind: path
+          path:
+            - flags
+      - name: thread_metadata
+        type: Json
+        nullable: true
+        description: Thread metadata as JSON
+        expr:
+          kind: path
+          path:
+            - thread_metadata
+      - name: thread_metadata__archived
+        type: Boolean
+        nullable: true
+        description: Whether the thread is archived
+        expr:
+          kind: path
+          path:
+            - thread_metadata
+            - archived
+      - name: thread_metadata__archive_timestamp
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the thread archive state last changed
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - thread_metadata
+              - archive_timestamp
+      - name: thread_metadata__auto_archive_duration
+        type: Int64
+        nullable: true
+        description: Auto-archive duration in minutes
+        expr:
+          kind: path
+          path:
+            - thread_metadata
+            - auto_archive_duration
+      - name: thread_metadata__locked
+        type: Boolean
+        nullable: true
+        description: Whether the thread is locked
+        expr:
+          kind: path
+          path:
+            - thread_metadata
+            - locked
+      - name: thread_metadata__invitable
+        type: Boolean
+        nullable: true
+        description: Whether non-moderators can add users to a private thread
+        expr:
+          kind: path
+          path:
+            - thread_metadata
+            - invitable
+      - name: applied_tags
+        type: Json
+        nullable: true
+        description: Forum or media tag IDs applied to the thread
+        expr:
+          kind: path
+          path:
+            - applied_tags
+      - name: member
+        type: Json
+        nullable: true
+        description: Current bot user's thread member object when returned
+        expr:
+          kind: path
+          path:
+            - member
+      - name: permalink
+        type: Utf8
+        nullable: true
+        description: Discord web URL for the thread channel
+        expr:
+          kind: template
+          template: "https://discord.com/channels/{{expr.guild_id|@me}}/{{expr.parent_id}}/{{expr.thread_id}}"
+          values:
+            guild_id:
+              kind: path
+              path:
+                - guild_id
+            parent_id:
+              kind: path
+              path:
+                - parent_id
+            thread_id:
+              kind: path
+              path:
+                - id
+
+  # ----------------------------------------------------------------------
+  # archived_threads
+  # ----------------------------------------------------------------------
+  - name: archived_threads
+    description: Public or private archived Discord thread channels in a parent channel
+    guide: |
+      Requires channel_id from discord.channels and visibility set to public or
+      private. Use this for archived forum/media posts and other archived
+      public or private threads under a specific parent channel. Private
+      archived threads may require MANAGE_THREADS unless the bot joined the
+      thread; use joined_private_archived_threads for the joined-only endpoint.
+      Use returned id values as channel_id filters for discord.messages.
+      SELECT id, name, parent_id, last_message_id
+      FROM discord.archived_threads
+      WHERE channel_id = '<parent-channel-id>' AND visibility = 'public'.
+    filters:
+      - name: channel_id
+        required: true
+        description: Parent channel ID, such as a text, announcement, forum, or media channel
+      - name: visibility
+        required: true
+        description: "Archived thread visibility: public or private"
+      - name: before
+        description: Archive timestamp cursor for threads before that ISO 8601 timestamp
+    request:
+      method: GET
+      path: /channels/{{filter.channel_id}}/threads/archived/{{filter.visibility}}
+      query:
+        - name: before
+          from: filter
+          key: before
+    response:
+      rows_path:
+        - threads
+    pagination:
+      mode: none
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    columns: *thread_columns
+
+  # ----------------------------------------------------------------------
+  # joined_private_archived_threads
+  # ----------------------------------------------------------------------
+  - name: joined_private_archived_threads
+    description: Private archived Discord thread channels the bot has joined
+    guide: |
+      Requires channel_id from discord.channels. This returns private archived
+      threads under a parent channel that the current bot user has joined.
+      Use returned id values as channel_id filters for discord.messages.
+      SELECT id, name, parent_id, last_message_id
+      FROM discord.joined_private_archived_threads
+      WHERE channel_id = '<parent-channel-id>'.
+    filters:
+      - name: channel_id
+        required: true
+        description: Parent channel ID, such as a text, announcement, forum, or media channel
+      - name: before
+        description: Thread ID cursor for joined private archived threads before that thread
+    request:
+      method: GET
+      path: /channels/{{filter.channel_id}}/users/@me/threads/archived/private
+      query:
+        - name: before
+          from: filter
+          key: before
+    response:
+      rows_path:
+        - threads
+    pagination:
+      mode: none
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    columns: *thread_columns
+
   # ──────────────────────────────────────────────────────────────────────
   # messages
   # ──────────────────────────────────────────────────────────────────────
   - name: messages
     description: Recent messages in a Discord channel
     guide: |
-      Requires channel_id from discord.channels. The bot must have
-      VIEW_CHANNEL and READ_MESSAGE_HISTORY permissions on the channel;
-      voice channels additionally require CONNECT. Messages are returned
-      newest-first. Use before, after, and around filters for cursor-based
-      pagination (pass message IDs as Snowflake strings). These filters are
-      mutually exclusive. Maximum 100 per request. Requires MESSAGE_CONTENT
-      privileged intent for content, embeds, and attachments (without it
-      those fields will be empty even with READ_MESSAGE_HISTORY).
+      Requires channel_id from discord.channels or a thread table. The bot must
+      have VIEW_CHANNEL and READ_MESSAGE_HISTORY permissions on the channel.
+      Forum and media posts are thread channels; query active_threads or an
+      archived thread table first, then pass the returned thread id as
+      channel_id. Messages are returned newest-first. Use before, after, and
+      around filters for cursor-based pagination (pass message IDs as Snowflake
+      strings). These filters are mutually exclusive. Maximum 100 per request.
+      Requires MESSAGE_CONTENT privileged intent for content, embeds, and
+      attachments (without it those fields will be empty even with
+      READ_MESSAGE_HISTORY).
       SELECT id, author__username, content, timestamp
       FROM discord.messages WHERE channel_id = '<id>' ORDER BY timestamp DESC
       LIMIT 20.

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -1,5 +1,5 @@
 name: discord
-version: 0.1.0
+version: 0.1.1
 dsl_version: 3
 backend: http
 description: >-
@@ -496,8 +496,9 @@ tables:
     response:
       rows_path:
         - threads
-    columns: &thread_columns
-      - name: id
+    columns:
+      - &thread_id_column
+        name: id
         type: Utf8
         nullable: false
         description: Discord thread channel ID
@@ -505,7 +506,8 @@ tables:
           kind: path
           path:
             - id
-      - name: type
+      - &thread_type_column
+        name: type
         type: Int64
         nullable: false
         description: "Thread channel type integer: 10 announcement, 11 public, 12 private"
@@ -513,7 +515,8 @@ tables:
           kind: path
           path:
             - type
-      - name: guild_id
+      - &thread_guild_id_column
+        name: guild_id
         type: Utf8
         nullable: true
         description: Guild ID from the thread channel object
@@ -521,7 +524,8 @@ tables:
           kind: path
           path:
             - guild_id
-      - name: name
+      - &thread_name_column
+        name: name
         type: Utf8
         nullable: true
         description: Thread channel name
@@ -529,7 +533,8 @@ tables:
           kind: path
           path:
             - name
-      - name: parent_id
+      - &thread_parent_id_column
+        name: parent_id
         type: Utf8
         nullable: true
         description: Parent channel ID, such as the forum or media channel
@@ -537,7 +542,8 @@ tables:
           kind: path
           path:
             - parent_id
-      - name: owner_id
+      - &thread_owner_id_column
+        name: owner_id
         type: Utf8
         nullable: true
         description: User ID that created the thread
@@ -545,7 +551,8 @@ tables:
           kind: path
           path:
             - owner_id
-      - name: last_message_id
+      - &thread_last_message_id_column
+        name: last_message_id
         type: Utf8
         nullable: true
         description: Most recent message ID known to Discord
@@ -553,7 +560,8 @@ tables:
           kind: path
           path:
             - last_message_id
-      - name: message_count
+      - &thread_message_count_column
+        name: message_count
         type: Int64
         nullable: true
         description: Approximate message count in the thread
@@ -561,7 +569,8 @@ tables:
           kind: path
           path:
             - message_count
-      - name: member_count
+      - &thread_member_count_column
+        name: member_count
         type: Int64
         nullable: true
         description: Approximate member count in the thread
@@ -569,7 +578,8 @@ tables:
           kind: path
           path:
             - member_count
-      - name: total_message_sent
+      - &thread_total_message_sent_column
+        name: total_message_sent
         type: Int64
         nullable: true
         description: Total number of messages ever sent in the thread
@@ -577,7 +587,8 @@ tables:
           kind: path
           path:
             - total_message_sent
-      - name: rate_limit_per_user
+      - &thread_rate_limit_per_user_column
+        name: rate_limit_per_user
         type: Int64
         nullable: true
         description: Slowmode delay in seconds
@@ -585,7 +596,8 @@ tables:
           kind: path
           path:
             - rate_limit_per_user
-      - name: flags
+      - &thread_flags_column
+        name: flags
         type: Int64
         nullable: true
         description: Thread channel flags as a bitfield
@@ -593,7 +605,8 @@ tables:
           kind: path
           path:
             - flags
-      - name: thread_metadata
+      - &thread_metadata_column
+        name: thread_metadata
         type: Json
         nullable: true
         description: Thread metadata as JSON
@@ -601,7 +614,8 @@ tables:
           kind: path
           path:
             - thread_metadata
-      - name: thread_metadata__archived
+      - &thread_metadata_archived_column
+        name: thread_metadata__archived
         type: Boolean
         nullable: true
         description: Whether the thread is archived
@@ -610,7 +624,8 @@ tables:
           path:
             - thread_metadata
             - archived
-      - name: thread_metadata__archive_timestamp
+      - &thread_metadata_archive_timestamp_column
+        name: thread_metadata__archive_timestamp
         type: Timestamp
         nullable: true
         description: Timestamp when the thread archive state last changed
@@ -622,7 +637,8 @@ tables:
             path:
               - thread_metadata
               - archive_timestamp
-      - name: thread_metadata__auto_archive_duration
+      - &thread_metadata_auto_archive_duration_column
+        name: thread_metadata__auto_archive_duration
         type: Int64
         nullable: true
         description: Auto-archive duration in minutes
@@ -631,7 +647,8 @@ tables:
           path:
             - thread_metadata
             - auto_archive_duration
-      - name: thread_metadata__locked
+      - &thread_metadata_locked_column
+        name: thread_metadata__locked
         type: Boolean
         nullable: true
         description: Whether the thread is locked
@@ -640,7 +657,8 @@ tables:
           path:
             - thread_metadata
             - locked
-      - name: thread_metadata__invitable
+      - &thread_metadata_invitable_column
+        name: thread_metadata__invitable
         type: Boolean
         nullable: true
         description: Whether non-moderators can add users to a private thread
@@ -649,7 +667,8 @@ tables:
           path:
             - thread_metadata
             - invitable
-      - name: applied_tags
+      - &thread_applied_tags_column
+        name: applied_tags
         type: Json
         nullable: true
         description: Forum or media tag IDs applied to the thread
@@ -657,7 +676,8 @@ tables:
           kind: path
           path:
             - applied_tags
-      - name: member
+      - &thread_member_column
+        name: member
         type: Json
         nullable: true
         description: Current bot user's thread member object when returned
@@ -665,7 +685,8 @@ tables:
           kind: path
           path:
             - member
-      - name: permalink
+      - &thread_permalink_column
+        name: permalink
         type: Utf8
         nullable: true
         description: Discord web URL for the thread channel
@@ -695,8 +716,9 @@ tables:
       Requires channel_id from discord.channels and visibility set to public or
       private. Use this for archived forum/media posts and other archived
       public or private threads under a specific parent channel. Private
-      archived threads may require MANAGE_THREADS unless the bot joined the
-      thread; use joined_private_archived_threads for the joined-only endpoint.
+      archived threads require MANAGE_THREADS; use
+      joined_private_archived_threads for private archived threads the bot has
+      joined.
       Use returned id values as channel_id filters for discord.messages.
       SELECT id, name, parent_id, last_message_id
       FROM discord.archived_threads
@@ -726,7 +748,52 @@ tables:
         default: 50
         max: 100
         query_param: limit
-    columns: *thread_columns
+    columns:
+      - name: channel_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Parent channel ID from required filter
+        expr:
+          kind: from_filter
+          key: channel_id
+      - name: visibility
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Archived thread visibility from required filter
+        expr:
+          kind: from_filter
+          key: visibility
+      - name: before
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Archive timestamp cursor for archived threads before that timestamp
+        expr:
+          kind: from_filter
+          key: before
+      - *thread_id_column
+      - *thread_type_column
+      - *thread_guild_id_column
+      - *thread_name_column
+      - *thread_parent_id_column
+      - *thread_owner_id_column
+      - *thread_last_message_id_column
+      - *thread_message_count_column
+      - *thread_member_count_column
+      - *thread_total_message_sent_column
+      - *thread_rate_limit_per_user_column
+      - *thread_flags_column
+      - *thread_metadata_column
+      - *thread_metadata_archived_column
+      - *thread_metadata_archive_timestamp_column
+      - *thread_metadata_auto_archive_duration_column
+      - *thread_metadata_locked_column
+      - *thread_metadata_invitable_column
+      - *thread_applied_tags_column
+      - *thread_member_column
+      - *thread_permalink_column
 
   # ----------------------------------------------------------------------
   # joined_private_archived_threads
@@ -762,7 +829,44 @@ tables:
         default: 50
         max: 100
         query_param: limit
-    columns: *thread_columns
+    columns:
+      - name: channel_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Parent channel ID from required filter
+        expr:
+          kind: from_filter
+          key: channel_id
+      - name: before
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Thread ID cursor for joined private archived threads before that thread
+        expr:
+          kind: from_filter
+          key: before
+      - *thread_id_column
+      - *thread_type_column
+      - *thread_guild_id_column
+      - *thread_name_column
+      - *thread_parent_id_column
+      - *thread_owner_id_column
+      - *thread_last_message_id_column
+      - *thread_message_count_column
+      - *thread_member_count_column
+      - *thread_total_message_sent_column
+      - *thread_rate_limit_per_user_column
+      - *thread_flags_column
+      - *thread_metadata_column
+      - *thread_metadata_archived_column
+      - *thread_metadata_archive_timestamp_column
+      - *thread_metadata_auto_archive_duration_column
+      - *thread_metadata_locked_column
+      - *thread_metadata_invitable_column
+      - *thread_applied_tags_column
+      - *thread_member_column
+      - *thread_permalink_column
 
   # ──────────────────────────────────────────────────────────────────────
   # messages


### PR DESCRIPTION
## Summary
- add Discord thread-channel coverage for active threads, archived public/private threads, and joined private archived threads
- document how forum/media posts map to thread IDs before querying discord.messages
- expose additional forum/media channel fields on discord.channels

## Validation
- coral source lint sources/community/discord/manifest.yaml
- git diff --check
- coral source test discord passed against the currently installed source, but that installed source still reports 6 tables, so it does not validate the new manifest tables

## Validation gap
- live validation of the updated local manifest was not run because coral source add --file sources/community/discord/manifest.yaml requires DISCORD_BOT_TOKEN, which is not set in this shell
- cargo tests were not run because cargo is not installed in this environment