### PR TITLE
ci: exclude community sources from release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,8 @@
   "packages": {
     ".": {
       "package-name": "coral",
-      "extra-files": ["Cargo.toml"]
+      "extra-files": ["Cargo.toml"],
+      "exclude-paths": ["sources/community"]
     }
   },
   "bootstrap-sha": "51de7ec4e927d627e02ada30d258921eb258d8e8"


### PR DESCRIPTION
## What changed

- Added `sources/community` to release-please `exclude-paths` for the root Coral package.
- Added repo guidance explaining that release notes should track shipped CLI behavior and keep community source-only changes out of binary release notes.

## Why

Community sources are not bundled into the Coral binary, so source-only changes under `sources/community` should not appear in Coral CLI release notes or drive release-please processing for the shipped artifact.

## Impact

Release-please will ignore commits that only change `sources/community` when building Coral release PRs and changelog entries. The generated docs changelog continues to mirror `CHANGELOG.md`, so it inherits the filtered release notes.

## Validation

- `jq . release-please-config.json`

Full Rust/UI checks were not run because this change only touches release automation JSON and repo agent guidance.