### PR TITLE
fix(spec): resolve DSL v4 response refs

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -221,6 +221,128 @@ components:
 }
 
 #[test]
+fn importer_resolves_referenced_response_objects() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: referenced_responses
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /repos/{owner}/{repo}/issues:
+    get:
+      operationId: issues/list-for-repo
+      parameters:
+        - {name: owner, in: path, required: true, schema: {type: string}}
+        - {name: repo, in: path, required: true, schema: {type: string}}
+      responses:
+        '200':
+          $ref: '#/components/responses/IssueList'
+components:
+  responses:
+    IssueList:
+      content:
+        application/json:
+          schema:
+            type: array
+            items: {$ref: '#/components/schemas/Issue'}
+  schemas:
+    Issue:
+      type: object
+      properties:
+        id: {type: integer}
+        title: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("response ref imports");
+    let operation = ir.operations.first().expect("operation");
+    assert_eq!(operation.output.cardinality, OutputCardinality::List);
+    assert!(
+        operation.diagnostics.is_empty(),
+        "{:?}",
+        operation.diagnostics
+    );
+
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let projection = catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == "issues_list_for_repo")
+        .expect("projection");
+    assert_eq!(projection.name, "issues");
+    assert_eq!(projection.visibility, ProjectionVisibility::Published);
+    assert!(matches!(projection.kind, ProjectionKind::Table));
+}
+
+#[test]
+fn importer_warns_for_unresolved_response_object_refs() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: broken_responses
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /missing:
+    get:
+      operationId: missing/list
+      responses:
+        '200':
+          $ref: '#/components/responses/Missing'
+  /external:
+    get:
+      operationId: external/list
+      responses:
+        '200':
+          $ref: 'https://example.com/openapi.yaml#/components/responses/Items'
+"
+        .as_bytes(),
+    )
+    .expect("broken response refs import with diagnostics");
+    let codes = ir
+        .operations
+        .iter()
+        .flat_map(|operation| operation.diagnostics.iter())
+        .map(|diagnostic| diagnostic.code.as_str())
+        .collect::<Vec<_>>();
+    assert!(codes.contains(&"OPENAPI_REF_NOT_FOUND"), "{codes:?}");
+    assert!(
+        codes.contains(&"OPENAPI_EXTERNAL_REF_UNSUPPORTED"),
+        "{codes:?}"
+    );
+    for operation in &ir.operations {
+        assert_eq!(operation.output.cardinality, OutputCardinality::None);
+    }
+}
+
+#[test]
 fn importer_preserves_non_string_parameter_defaults() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -20,9 +20,11 @@ impl OpenApiImporter<'_> {
         RestResponseAttachment,
         Option<IrEntityCandidate>,
     ) {
-        let Some((status_code, media_type, schema)) =
-            select_json_response(operation.get("responses").and_then(Value::as_object))
-        else {
+        let Some((status_code, media_type, schema)) = self.select_json_response(
+            operation.get("responses").and_then(Value::as_object),
+            operation_id,
+            diagnostics,
+        ) else {
             let response = ResponseSpec::default();
             return (
                 IrOperationOutput {
@@ -39,7 +41,7 @@ impl OpenApiImporter<'_> {
             );
         };
 
-        let Some(resolved) = self.resolve_ref(schema, operation_id, diagnostics) else {
+        let Some(resolved) = self.resolve_ref(&schema, operation_id, diagnostics) else {
             diagnostics.push(Diagnostic::warning(
                 "OPENAPI_RESPONSE_SCHEMA_UNRESOLVED",
                 format!("operation '{operation_id}' response schema could not be resolved"),
@@ -95,32 +97,39 @@ impl OpenApiImporter<'_> {
             entity,
         )
     }
-}
-
-fn select_json_response(responses: Option<&Map<String, Value>>) -> Option<(u16, String, &Value)> {
-    let responses = responses?;
-    let mut candidates = Vec::new();
-    for (status, response) in responses {
-        let Ok(status_code) = status.parse::<u16>() else {
-            continue;
-        };
-        if !(200..300).contains(&status_code) {
-            continue;
+    fn select_json_response(
+        &self,
+        responses: Option<&Map<String, Value>>,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<(u16, String, Value)> {
+        let responses = responses?;
+        let mut candidates = Vec::new();
+        for (status, response) in responses {
+            let Ok(status_code) = status.parse::<u16>() else {
+                continue;
+            };
+            if !(200..300).contains(&status_code) {
+                continue;
+            }
+            let Some(response) = self.resolve_ref(response, operation_id, diagnostics) else {
+                continue;
+            };
+            let Some(content) = response.get("content").and_then(Value::as_object) else {
+                continue;
+            };
+            let Some(json) = content.get("application/json") else {
+                continue;
+            };
+            let schema = json.get("schema").cloned().unwrap_or(Value::Null);
+            candidates.push((status_code, "application/json".to_string(), schema));
         }
-        let Some(content) = response.get("content").and_then(Value::as_object) else {
-            continue;
-        };
-        let Some(json) = content.get("application/json") else {
-            continue;
-        };
-        let schema = json.get("schema").unwrap_or(&Value::Null);
-        candidates.push((status_code, "application/json".to_string(), schema));
+        candidates
+            .iter()
+            .position(|(status, _, _)| *status == 200)
+            .and_then(|index| candidates.get(index).cloned())
+            .or_else(|| candidates.into_iter().min_by_key(|(status, _, _)| *status))
     }
-    candidates
-        .iter()
-        .position(|(status, _, _)| *status == 200)
-        .and_then(|index| candidates.get(index).cloned())
-        .or_else(|| candidates.into_iter().min_by_key(|(status, _, _)| *status))
 }
 
 fn classify_response_schema(


### PR DESCRIPTION
## Summary

- Resolve OpenAPI response-object `$ref`s before selecting JSON response content in the DSL v4 importer.
- Keep response schema `$ref` handling unchanged after response selection.
- Add regression coverage for referenced `components.responses` objects and missing/external response refs.

## Why

A valid OpenAPI response like `200: { $ref: '#/components/responses/Foo' }` was skipped before schema resolution, causing otherwise valid read operations to fall through to `OutputCardinality::None` and disappear from generated projections.

Fixes #1121.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p coral-spec --lib importer_`
