### PR TITLE
docs(identity): add identity PRD

### DIFF
--- a/plans/2026-05-27-identity-prd.md
+++ b/plans/2026-05-27-identity-prd.md
@@ -1,0 +1,786 @@
+# Coral Identity PRD
+
+## Summary
+
+Coral needs an identity model that is orthogonal to source specs. Sources define
+what can be queried. Identities define who or what Coral can act as. They meet
+inside a workspace, where each source surface that needs authority is bound to an
+identity.
+
+An identity has an owner:
+
+- **Workspace-owned** identities are shared by the whole workspace — every member
+  queries as the same identity. They fit org-tied authority: bots, service
+  accounts, trusted roles, OIDC.
+- **Member-owned** identities are user-scoped and private to one member. A
+  workspace declares a per-member slot, and each member binds their own identity
+  into it, so each member queries as themselves. They fit user-tied authority:
+  OAuth for Gmail or personal GitHub.
+
+A workspace is the shared curation and membership context: a tailored set of
+sources, projections, shared identity assignments, and open per-member slots.
+
+The model is:
+
+```text
+Source spec        -> installed/materialized source
+Identity spec      -> identity (workspace-owned or member-owned)
+Workspace source   -> a workspace's use of a materialized source
+Shared assignment  -> workspace source surface uses one workspace identity
+Per-member slot    -> workspace source surface needs each member's own identity
+Binding            -> a member fills a slot with one of their own identities
+Availability       -> who may query the workspace source
+```
+
+There is no global `Connection` object, no source-owned identity, no global-pool
+identity selection at query time, and no first-wave per-identity ACL. Query-time
+identity resolution still happens, but only as a deterministic lookup of the
+surface binding for the current member — never as a policy that chooses among
+candidate identities. When multiple compatible identities exist, the choice is
+made during setup and recorded as a binding; query execution only reads that
+binding. Those concepts either duplicate the surface binding or create a second
+permission model.
+
+Users should experience this as a simple authentication UX: source, connected
+as, available to, status, permissions needed, affected sources, and fix. Users
+should not manage credential material, injection methods, or source IR during
+ordinary setup and recovery. Recovery means guided repair when an identity or
+binding no longer works, such as refreshing credentials, reauthorizing, choosing
+a replacement identity, or filling a missing per-member slot.
+
+## Goals
+
+- Define identities as materialized objects owned by a workspace (shared) or a
+  member (user-scoped).
+- Define identity specs as the identity-side equivalent of source specs.
+- Define a surface-level identity extension for merged DSL v4, replacing
+  today's source-scoped credential/auth path only when the identity
+  implementation lands.
+- Bind identities through shared workspace assignments or per-member slots.
+- Let one workspace serve both org-tied (shared) and user-tied (per-member)
+  authority without changing access control.
+- Support private user workspaces, shared workspaces, and local CLI defaults.
+- Allow the same source surface to use different binding modes and identities in
+  different workspaces.
+- Allow one source to have multiple surfaces, each with its own identity
+  requirements.
+- Keep matching provider-native: issuer, capabilities, injection method, and
+  audience.
+- Keep authority changes explicit, especially sharing, reuse, broader
+  capabilities, principal changes, and audience changes.
+- Support multi-user workspace sharing through workspace-owned identities and
+  per-workspace-source availability, while treating workspace access control as
+  an external boundary. The layer that decides who may access or configure a
+  workspace, and identifies which member is querying, is a separate dependency,
+  not defined here.
+
+## Non-Goals
+
+- Redesign DSL v4 source IR, projections, OpenAPI import, or source
+  materialization internals.
+- Define DSL v4 surface granularity. This PRD binds identities to the surfaces
+  declared by source specs; whether a provider is modeled as one surface or many
+  is a source-spec decision.
+- Make source specs own identity materialization.
+- Select among multiple candidate identities at query time. Resolution is a
+  deterministic assignment lookup, not a policy.
+- Add cross-workspace reuse of workspace-owned (shared) identities. Member-owned
+  identities are the deliberate exception: they are user-scoped and reusable
+  across that member's own workspace slots.
+- Add a first-wave per-identity ACL model.
+- Normalize provider permissions into a universal Coral taxonomy.
+- Define every provider-specific identity spec in this PRD.
+- Define workspace access-control roles, permissions, or authorization policy.
+  This PRD assumes a workspace authorization layer exists and composes with it.
+- Define the user authentication / principal layer that identifies which member
+  is querying. This PRD assumes that layer and composes with it, but a later
+  effort builds it.
+- Apply to or migrate DSL v3 sources. This model is DSL v4-only; v3 sources keep
+  their existing source-scoped credentials.
+- Specify per-member query attribution, audit logging, or at-rest credential
+  encryption for shared identities. Storage will evolve to cover these
+  separately.
+
+## Core Model
+
+### Source Spec
+
+A source spec defines how Coral installs and materializes a queryable source.
+In merged DSL v4, a source declares a non-empty list of named surfaces. The
+current implementation supports OpenAPI surfaces with one descriptor (`url` or
+`file`), surface-local inputs, runtime `auth`, request headers, optional
+`base_url`, rate limiting, and test queries. Source specs do not choose concrete
+workspace or member identity bindings.
+
+### Materialized Source
+
+A materialized source is the installed result of running a source spec in a
+workspace. For DSL v4 today, Coral writes materialized artifacts under the
+workspace source state: fingerprint, projection catalog, diagnostics, and
+per-surface raw and normalized OpenAPI documents plus semantic IR. Query loading
+validates those artifacts and assembles engine runtime components from them; if
+the materialization is missing or incompatible, query loading fails closed.
+
+### Surface
+
+A surface is a provider interface declared by a source spec, such as GitHub
+REST, GitHub GraphQL, Slack Web API, or an AWS service API family. In merged DSL
+v4 today, a surface has an id, OpenAPI descriptor, surface inputs, and HTTP
+runtime config. It does not yet declare `identity_requirements`; current v4
+sources still use source-scoped inputs plus `auth` to inject credential material.
+
+This PRD proposes adding identity requirements as the next surface-level
+contract. A surface still does not choose a concrete identity, owner, or binding
+mode. For providers with several authority shapes, such as Slack bot tokens and
+Slack user tokens, a surface may accept more than one compatible identity shape;
+the workspace source setup decides which one to bind for that workspace.
+
+### Identity Spec
+
+An identity spec defines how Coral materializes provider-facing authority.
+Examples:
+
+- `github-oauth`
+- `slack-bot-oauth`
+- `aws-profile`
+- `aws-trusted-role`
+- `aws-oidc-trust`
+- `manual-bearer-token`
+
+An identity spec owns setup, principal discovery, audience discovery,
+capability request or validation, runtime injection method, refresh, recovery,
+and supported non-interactive setup.
+
+An identity spec is not source-aware. It describes how to create or refresh
+provider-facing authority, not which source surfaces will use that authority.
+When a provider-specific setup flow supports both ownership modes, the same
+identity spec can materialize workspace-owned identities or member-owned
+identities; ownership is chosen by the setup flow and later constrained by the
+workspace source binding.
+
+### Identity
+
+An identity is a materialized authority created by running an identity spec. It
+has an owner:
+
+- A **workspace-owned identity** is created in and owned by a workspace. It is
+  shared: any member querying through a surface assigned to it acts as that one
+  identity. It is strictly workspace-local and never reused by another workspace.
+- A **member-owned identity** is created and owned by a member and lives in that
+  member's user-scoped identity store. It is private to the member and reusable
+  across any of that member's workspace slots that it satisfies. No other member
+  can see, pick, or use it.
+
+Examples:
+
+- GitHub OAuth identity for `saul@work` (member-owned)
+- Slack bot identity for an Engineering Slack workspace (workspace-owned)
+- AWS STS identity for `arn:aws:sts::123456789012:assumed-role/ReadOnly/saul`
+- Google OAuth identity for a Google Workspace user (member-owned)
+
+An identity records non-secret metadata:
+
+- identity spec
+- owner: a workspace, or a member
+- issuer or authority service
+- connected principal
+- audience
+- capabilities
+- supported injection method
+- health and recovery state
+- credential material reference, when credential material exists
+
+Credential material is an implementation detail. Users should not manage it
+directly during normal use.
+
+In single-user local mode the member is the local user, so member-owned
+identities are simply that user's connected accounts, reusable across all their
+local workspaces. Multi-user mode adds more members on the same model; the
+member-identifying authentication layer is a separate dependency (see Non-Goals).
+
+### Identity Requirements
+
+Identity requirements are a future DSL v4 surface extension. They describe what
+shape of identity can be assigned to that surface:
+
+- **Issuer / authority service:** who minted or vouches for the identity, such
+  as GitHub, Google, Slack, AWS, or Coral OIDC.
+- **Capabilities:** provider-native permissions required by the surface, such
+  as OAuth scopes, app permissions, IAM actions, or product permissions.
+- **Injection method:** how Coral adds the identity to provider requests, such
+  as bearer token, API key header, basic auth, or AWS SigV4. Injection method is
+  an identity property, not a source property: one provider is often split across
+  several sources, so the identity — not the source — determines how its
+  credential is injected.
+- **Audience constraints:** where the identity must be valid, such as GitHub
+  host, Slack workspace, AWS account, AWS partition, region set, Datadog site,
+  Google Workspace domain, or provider base URL.
+
+### Workspace
+
+A workspace is the shared curation and membership context. It is a tailored set
+of sources and projections for a use case, plus the members who can use it. It
+owns its workspace sources, its workspace-owned (shared) identities, the shared
+assignments and per-member slots on their surfaces, and availability.
+
+A workspace does not own member identities. Those live in each member's
+user-scoped store; the workspace only holds the slot declaration and a per-member
+binding reference. Deleting a workspace never deletes a member's identities, and a
+member leaving only drops that member's bindings.
+
+This expands the current Coral notion of a workspace — today an isolated local
+source collection — into a multi-user sharing context with members. The layer
+that authenticates members and tells Coral which member is querying is a separate
+dependency this PRD assumes but does not define.
+
+### Workspace Source
+
+A workspace source is a workspace's use of a materialized source. It owns:
+
+- availability
+- per-surface binding for each enabled surface: exactly one shared assignment or
+  one per-member slot
+- readiness status, which for slots is evaluated per member
+
+### Surface Binding: Shared Assignment or Per-Member Slot
+
+Each surface of a workspace source is bound one of two ways. The binding mode is
+a property of the surface in that workspace, configured through the workspace
+source setup path, and is often inferred from the issuer or archetype
+(human-tied issuers default to a slot; app/bot/service-account/trusted-role/OIDC
+default to shared).
+
+One workspace source surface has one binding mode. It is not both a shared
+assignment and a per-member slot at the same time. The same materialized source
+surface can still be configured differently in different workspaces: one
+workspace can bind it to a shared bot identity, while another declares a
+per-member slot for user identities.
+
+A **shared assignment** binds the surface to one workspace-owned identity:
+
+```text
+workspace source + surface -> workspace identity
+```
+
+Every member queries as that identity.
+
+A **per-member slot** declares that the surface uses each member's own identity:
+
+```text
+workspace source + surface -> per-member slot (requirements only)
+```
+
+The slot carries the requirements but no concrete identity. Each member fills it
+with a **binding**:
+
+```text
+(workspace source + surface, member) -> that member's member-owned identity
+```
+
+A shared assignment is valid only when:
+
+- the identity is workspace-owned by the same workspace as the workspace source
+- the identity issuer matches an accepted issuer
+- the identity capabilities satisfy the surface requirements
+- the identity supports the required injection method
+- the identity audience satisfies the surface audience constraints
+
+A per-member binding is valid under the same issuer, capability, injection, and
+audience rules, except the identity must be member-owned by the binding member.
+
+Bindings and assignments, not identities, determine where an identity is used. A
+slot with no binding for a member is not an error; it is that member's "needs
+action" until they bind.
+
+If a member has several compatible member-owned identities for one slot, such as
+multiple Google accounts, the member chooses one during setup or when repairing
+that slot. The stored binding then makes query-time resolution deterministic.
+First-wave workspace sources expose one slot per surface; supporting multiple
+instances of the same source in one workspace would be the extension point for
+multiple slots against the same source surface.
+
+### Availability
+
+Availability describes who may query a workspace source. It belongs to the
+workspace source, not to the source spec or identity.
+
+Authorization and identity are separate questions. Availability decides who may
+query; the surface binding decides whose credential runs the query. A shared
+assignment runs every member's query as the workspace identity; a per-member slot
+runs each member's query as their own bound identity. Binding mode adds nobody to
+the availability set and creates no per-identity ACL.
+
+## Capability Matching
+
+Capabilities are provider-native facts, not Coral-invented generic
+permissions. A universal taxonomy would look tidy and be wrong, because
+providers do not expose equivalent semantics.
+
+Matching rules:
+
+- Required capabilities are matched as provider-native facts.
+- An identity satisfies a requirement only when Coral can prove the identity has
+  that capability or the provider's auth model makes it inherent.
+- Unknown, unvalidated, or ambiguous capabilities do not satisfy requirements.
+- Capabilities for manually supplied credentials come from one of two paths: the
+  user declares them explicitly at setup, or the identity spec extracts and
+  validates them from the credential when its format allows it, such as parsing
+  scopes or claims from a JWT. User-declared capabilities carry asserted-by-user
+  provenance, not provider-proven provenance.
+- A stronger capability satisfies a weaker requirement only when the identity
+  spec explicitly models that provider-specific implication.
+- Requesting additional capabilities is an authority-broadening action and
+  requires explicit confirmation.
+
+Specs may still include user-facing labels:
+
+```yaml
+capabilities:
+  - id: repo:read
+    kind: github_app_permission
+    label: Repository read access
+```
+
+Compatibility uses `id` and provider semantics. UX uses `label`.
+
+## Merged DSL v4 Facts and Identity Extension
+
+DSL v4 is now merged, so the implementation is the source of truth for this
+PRD's source-model assumptions.
+
+Current facts:
+
+- A v4 source manifest declares `dsl_version: 4` and a non-empty `surfaces`
+  list.
+- The only merged surface type is `openapi`.
+- A surface id must match `[a-z][a-z0-9_]*`.
+- Each surface declares exactly one descriptor: an `https://` `url`, or a
+  `file` descriptor used for local development/import.
+- Surface-local `inputs` are collected and merged into the source's declared
+  inputs. Today credential values are still source inputs, usually
+  `kind: secret`.
+- The surface HTTP runtime config is `base_url`, `auth`, `request_headers`, and
+  `rate_limit`. The merged `github_v4` preview source uses a surface-local
+  `GITHUB_TOKEN` secret and `HeaderAuth` to send
+  `Authorization: Bearer {{input.GITHUB_TOKEN}}`.
+- App materialization reads or fetches each OpenAPI descriptor and writes
+  fingerprint, projection catalog, diagnostics, and per-surface raw/normalized
+  descriptor plus semantic IR under the installed workspace source state.
+- Query loading validates the installed materialization against the stored
+  manifest and assembles runtime components from the materialized projections.
+  Missing, stale, or incompatible v4 artifacts fail closed.
+- Projections are generated SQL exposure choices. They carry surface and
+  operation references, but they do not choose identities.
+
+Identity must therefore extend the merged v4 surface model rather than replace
+it with a separate DSL v4 design. The current source-scoped `auth` and secret
+inputs remain the runtime credential path until identity binding is implemented.
+After identity support lands, a surface that requires authority declares identity
+requirements, and the workspace source binding supplies the concrete
+workspace-owned or member-owned identity.
+
+Proposed extension shape:
+
+```yaml
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/github-openapi.yaml
+    base_url: https://api.github.com
+    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          issuer: github
+          injection_method: bearer_authorization_header
+          audience:
+            host: api.github.com
+          capabilities:
+            - id: repo:read
+              kind: github_permission
+              label: Repository read access
+            - id: org:read
+              kind: github_permission
+              label: Organization read access
+```
+
+Identity extension contract:
+
+- `accepts` has OR semantics.
+- Capabilities inside one accepted shape have AND semantics.
+- Matching dimensions are issuer, audience, capabilities, and injection method.
+- A shared assignment binds a compatible workspace-owned identity; a per-member
+  slot is filled by each member's compatible member-owned identity. The surface's
+  `identity_requirements` are identical either way — only the binding's owner
+  differs.
+- For identity-managed surfaces, the bound identity owns credential material and
+  runtime injection. The implementation must either derive request auth from the
+  bound identity or define an explicit migration/coexistence rule with today's
+  `auth` field.
+- Because current v4 materialization fingerprints the authored manifest, the
+  identity implementation must decide whether identity-only manifest changes
+  require re-materialization or whether identity requirements live in metadata
+  that does not invalidate OpenAPI-derived artifacts.
+
+DSL v4 projections remain SQL exposure choices. They do not choose identities.
+
+## Examples
+
+### Personal Data Source in One Shared Workspace
+
+A per-member slot lets one shared workspace serve user-tied data without sharing
+anyone's credential. This example assumes a future DSL v4 Gmail source; today's
+checked-in Gmail sources are DSL v3 and are out of scope for this PRD.
+
+```text
+Materialized source: gmail_v4
+Surface: rest
+
+Workspace: mail (shared; members: Saul, Andrea)
+Workspace source: gmail_v4
+gmail_v4.rest -> per-member slot (issuer: google)
+Available to: Saul, Andrea
+
+Bindings (member-owned, user-scoped):
+  Saul   -> google-saul
+  Andrea -> google-andrea
+```
+
+The workspace, its curated source, and any projections are shared. The future
+DSL v4 Gmail surface is a per-member slot, so each member binds their own Google
+identity. Saul's query resolves to `google-saul` and Andrea's to
+`google-andrea` — each sees only their own mail — through a deterministic
+per-member lookup, not a global resolver. Neither member can see or use the
+other's identity. (Earlier drafts modeled this as two separate private
+workspaces; the per-member slot removes that need and keeps the curation
+shareable.)
+
+### Same Source, Different Workspace Identity
+
+```text
+Materialized source: github
+Surface: github-rest
+
+Workspace: saul-private
+github.github-rest -> per-member slot (issuer: github)
+                       Saul -> github-saul-work        (member-owned)
+
+Workspace: eng-shared
+github.github-rest -> github-coral-app-acme   (workspace-owned, shared)
+```
+
+The materialized source and surface are the same. The workspace source binding
+differs: one workspace declares a per-member slot and Saul fills it with his own
+identity, while another workspace assigns a shared workspace-owned identity.
+
+### One Source, Multiple Surfaces
+
+```text
+Workspace: eng-shared
+Workspace source: github
+
+github.github-rest    -> github-coral-app-acme       (shared assignment)
+github.github-graphql -> per-member slot (issuer: github)
+                           Saul  -> github-graphql-saul
+                           Priya -> github-graphql-priya
+```
+
+Each surface declares its own identity requirements, and the workspace binds each
+independently: a shared workspace-owned app for REST, and a per-member slot for
+GraphQL so each member queries as their own GitHub identity. Mixed binding within
+one workspace source is exactly what lets a shared workspace serve org-tied and
+user-tied authority at once.
+
+## Materialization and Setup
+
+Source and identity materialization are separate flows.
+
+Source materialization follows merged DSL v4. Running a source spec installs or
+refreshes the workspace source's authored manifest plus v4 materialized artifacts
+for its surfaces and generated projections. It does not create identities or
+decide which identity a workspace source surface will use.
+
+Identity materialization runs an identity spec to create or refresh one identity
+— workspace-owned (into the workspace) or member-owned (into the acting member's
+user-scoped store) — and returns enough non-secret metadata for UX: connected
+label, audience, capabilities, status, and recovery action.
+
+Adding a source to a workspace composes the two:
+
+1. Parse and validate the source spec, then build or refresh its v4
+   materialization artifacts.
+2. Create or select the workspace source, persisting the authored manifest and
+   current materialized artifacts.
+3. Read identity requirements for each enabled surface that requires authority.
+4. Decide each surface's binding mode: shared assignment or per-member slot
+   (default inferred from issuer/archetype, overridable during workspace source
+   setup).
+5. For shared surfaces, find or materialize a compatible workspace-owned identity
+   and assign it; suggest safe reuse only when allowed.
+6. For per-member surfaces, declare the slot. The acting member binds one of
+   their compatible member-owned identities, or materializes a new one.
+7. Validate and report ready, partially ready, or blocked. Slot readiness is per
+   member: a workspace can be ready for one member and need action for another
+   who has not bound yet.
+
+Each enabled surface gets one binding mode in that workspace source. For a
+provider such as Slack, a workspace source can choose a shared bot identity or a
+per-member user-token slot when the surface requirements permit both, but Coral
+does not keep both active and choose between them at query time.
+
+Setup should use the smallest safe user-visible decision. Compact setup is fine
+when there is one obvious private identity path. Reuse, shared access, broader
+capabilities, principal changes, audience changes, or availability changes must
+show impact before confirmation.
+
+### Non-Interactive Setup
+
+Non-interactive setup is required for tests, benchmarks, CI, MCP-driven flows,
+and sandboxed agent environments.
+
+Identity specs may support non-interactive materialization when the provider
+allows it safely, such as selecting an existing AWS profile, using configured
+cloud trust, or reading a supplied secret reference. Three-legged OAuth may
+still require human authorization.
+
+When non-interactive setup cannot proceed safely, Coral should return a
+structured, non-secret fix instead of launching a browser or prompting from a
+background context:
+
+```text
+GitHub identity required.
+
+Workspace source: github
+Surface: github-rest
+Required access: repo read, org read
+Fix: run interactive identity setup for GitHub, then retry.
+```
+
+## Query Execution and Recovery
+
+At query time, Coral does not choose identities from a global pool. It resolves
+the surface binding for the current member:
+
+1. Resolve the current workspace and the querying member.
+2. Resolve the workspace source for the queried source namespace.
+3. Resolve the surface needed by the table or function.
+4. Load the bound identity: for a shared assignment, the workspace identity; for
+   a per-member slot, the member's binding for that slot.
+5. Confirm the identity still satisfies the surface requirements.
+6. Resolve the effective request destination for the surface operation and
+   confirm it is covered by the bound identity's audience constraints.
+7. Inject the identity using the declared injection method.
+8. Execute the query.
+
+If no binding exists — no shared assignment, or no per-member binding for this
+member — the query is blocked with setup guidance for that member. If the bound
+identity is unhealthy, Coral follows the identity spec recovery rules. If it
+lacks a required capability, Coral reports an authorization failure and does not
+silently request broader access.
+
+Recovery messages stay non-secret, and their scope follows the identity's owner.
+A workspace-owned identity affects only its workspace, so its message is
+workspace-local. A member-owned identity can be bound in several of the member's
+workspaces, so its message is user-scoped and lists every affected workspace:
+
+```text
+GitHub access expired.
+
+Connected as: saul@work (your identity)
+Affected workspaces and sources:
+  mail-eng -> github
+  oncall   -> github
+Fix: refresh the GitHub identity once; all bindings recover.
+```
+
+Authorization failures should distinguish access from source health:
+
+```text
+Slack denied access to slack.messages.
+
+Workspace source: slack
+Surface: slack-web-api
+Connected as: Coral Slack App
+Reason: message history access has not been granted.
+Fix: grant message history access or assign an identity with that capability.
+```
+
+## UX Contract
+
+Normal users should see:
+
+- **Source:** what they query.
+- **Connected as:** the bound identity in the current workspace — the shared
+  workspace identity, or, for a per-member slot, your own bound identity.
+- **Available to:** who may query the workspace source.
+- **Status:** ready, partially ready, blocked, or needs action. For a per-member
+  slot this is evaluated for you specifically.
+- **Permissions needed:** missing access in provider language.
+- **Affected sources/surfaces:** what else uses the identity — within the
+  workspace for a shared identity, or across your workspaces for your own
+  member-owned identity.
+- **Fix:** exact next action.
+
+Coral may act silently only when it preserves the same authority:
+
+- refresh credential material using an existing refresh grant
+- renew temporary credentials for the same identity spec and audience
+- continue using the identity already assigned to the workspace source surface
+- revalidate after provider-side recovery
+
+Coral must ask before:
+
+- creating a new identity
+- changing principal
+- changing audience
+- requesting broader capabilities
+- changing injection method in a way that changes trust or credential handling
+- assigning an identity to another workspace source surface
+- changing a surface from a per-member slot to a shared assignment, so all
+  members query as one identity
+- sharing a workspace that contains identities or workspace sources
+- making a workspace source available to more users
+- switching from provider-managed auth to manual token entry
+
+## Sharing and Reuse Boundaries
+
+Safe defaults:
+
+- New workspaces default to private membership.
+- New workspace sources default to private availability.
+- A workspace-owned identity belongs to the workspace where it is created and is
+  never reused by another workspace.
+- A member-owned identity belongs to the member's user-scoped store and is
+  reusable across that member's own workspace slots that it satisfies.
+- Human-tied surfaces default to per-member slots, so each member uses their own
+  identity rather than sharing one.
+- Making a workspace source available to more users requires explicit
+  confirmation.
+- Sharing a workspace previews what new members get: the shared sources and
+  projections, the workspace-owned identities they will query as, and the
+  per-member slots they must fill with their own identity.
+- A workspace-owned identity backed by a human principal requires a warning;
+  prefer app, bot, service account, trusted-role, or OIDC identities for shared
+  assignments, and per-member slots for human-tied access.
+
+This PRD does not define workspace roles, permissions, or authorization policy.
+It assumes a workspace access-control layer decides who may query a workspace
+source, configure a workspace source, or share a workspace. Identity binding
+only consumes those decisions: once the workspace layer says a member may query,
+the binding determines whose credential runs that query. This must not become a
+separate per-identity ACL model.
+
+Reuse follows ownership. A workspace-owned identity may be suggested for another
+compatible surface in the same workspace only when it satisfies the requirements,
+the audience matches, no broader capability is needed, and availability does not
+change. A member-owned identity may be suggested to its owner for any compatible
+slot across that member's workspaces, but only to that member; it is never offered
+to or usable by anyone else.
+
+Even then, reuse is a choice:
+
+```text
+Use your existing GitHub identity?
+
+> github-saul-work
+  Connected as: saul@work
+  Already bound in: oncall
+  Access: repo read, org read
+
+  Connect another identity
+```
+
+If reuse changes blast radius, Coral must show the affected workspaces and
+workspace sources.
+
+## Representative Identity Archetypes
+
+The model should fit these archetypes:
+
+- **User OAuth identity:** Google user identity for Gmail, GitHub user OAuth
+  identity for GitHub REST.
+- **App or bot identity:** Slack bot identity, GitHub App installation identity.
+- **Local provider profile identity:** AWS profile resolved through the AWS SDK
+  credential chain.
+- **Cloud trust identity:** AWS trusted role or AWS OIDC trust.
+
+User OAuth identities are typically member-owned and bound through per-member
+slots; app/bot, profile, and cloud-trust identities are typically workspace-owned
+and bound through shared assignments. Binding mode is the workspace's choice, so
+either archetype can be bound either way when a use case requires it.
+
+Slack-style providers with both bot tokens and user tokens fit this model without
+a runtime resolver. The surface requirements can accept both identity shapes when
+both are valid for the source surface, and each workspace source chooses the
+binding mode that matches its use case.
+
+The first implementation does not need to ship all of them, but it must not
+choose concepts that break any of them.
+
+## Acceptance Criteria
+
+- The identity implementation extends DSL v4 surfaces with identity
+  requirements; projections do not choose identities.
+- A surface can be bound as a shared assignment or a per-member slot, with the
+  default inferred from the issuer/archetype and overridable during workspace
+  source setup.
+- Each workspace source surface has exactly one binding mode at a time; Coral
+  does not choose between shared and per-member identities at query time.
+- The same materialized source surface can use a shared assignment in one
+  workspace and a per-member slot in another workspace.
+- A future DSL v4 Gmail source, such as `gmail_v4`, can declare a per-member
+  slot on `gmail_v4.rest`, let the local user bind their own member-owned Google
+  identity, and keep availability private.
+- One shared workspace with a future DSL v4 Gmail per-member slot resolves
+  Saul's query to his identity and Andrea's to hers — each seeing only their own
+  data — through a deterministic per-member lookup with no global resolver.
+- A member-owned identity is reusable across that member's own workspace slots and
+  is never visible or usable to another member.
+- If a member has multiple compatible identities for one slot, setup records the
+  member's choice as the binding before queries run.
+- A shared Engineering workspace can use Slack or GitHub through a workspace-owned
+  app, bot, service account, trusted-role, or OIDC identity shared by all members.
+- One workspace-owned identity can back multiple compatible surfaces in the same
+  workspace only after compatibility checks pass and the user confirms any
+  increased blast radius.
+- Another workspace cannot silently reuse or inherit a workspace-owned identity.
+- New workspaces and workspace sources start private; sharing previews the shared
+  sources, projections, workspace-owned identities, and per-member slots new
+  members receive.
+- Provider-native capability facts drive matching; unknown or unvalidated
+  capabilities do not satisfy requirements.
+- Background, MCP, CI, and sandboxed flows do not launch interactive auth. They
+  use a supported non-interactive path or return a structured fix.
+- Recovery messages are non-secret and scoped to the identity's owner:
+  workspace-local for workspace-owned identities, user-scoped (listing affected
+  workspaces) for member-owned identities, each with surface, connected label,
+  reason, affected scope, and fix.
+
+## Open Questions
+
+- What exact field names should the identity extension use for
+  `identity_requirements`, accepted identity shapes, issuer, injection method,
+  audience, and capabilities?
+- How should identity-managed surfaces coexist with or migrate from the merged
+  DSL v4 `auth` field and surface-local secret inputs?
+- Should identity requirements be fingerprinted with the v4 manifest, or stored
+  as identity metadata so changing requirements does not invalidate
+  OpenAPI-derived materialized artifacts?
+- Which provider-specific `capabilities.kind` values should ship first?
+- Which representative identity archetypes should the first implementation ship
+  versus validate in fixtures?
+- What is the CLI vocabulary: `coral identity`, `coral access`, or another
+  surface?
+- Which first-wave identity specs support non-interactive materialization?
+- Should a surface's default binding mode (shared assignment vs per-member slot)
+  be declared by the identity spec archetype, inferred from the issuer, or
+  inferred some other way before workspace source setup can override it?
+- Where do member-owned identities and slot bindings live in app state, and how
+  does that storage key by member without a full principal layer in the first
+  local wave?
+- What is the minimal first implementation of the workspace-first model, given
+  that the user authentication / principal layer lands as a separate effort?
+- How does Coral detect or declare a non-interactive execution context, such as
+  CI, MCP, or a sandboxed agent, so it can choose a non-interactive path instead
+  of launching interactive auth?
+- How should server roles package query, manage workspace source, and manage
+  workspace permissions?


### PR DESCRIPTION
## Intent

Add the Identity PRD as the product contract for workspace-owned and member-owned identities, workspace source bindings, and recovery behavior.

## What it enables

This gives reviewers one identity-focused PRD over current `main`. DSL v4 is now treated as merged code, so the PRD records the current implementation facts it depends on instead of carrying a separate DSL v4 PRD.

## Usage examples

- Use `plans/2026-05-27-identity-prd.md` to review shared workspace identities, per-member slots, and deterministic query-time binding lookup.
- Use the merged DSL v4 implementation facts in the PRD to evaluate how identity requirements should extend existing v4 surfaces.
- Use the open questions to decide how identity-managed surfaces coexist with today's v4 `auth` field and materialization fingerprinting.
