### PR TITLE
fix(sources/community/cisa_kev): correct catalog columns

### DIFF
--- a/sources/community/cisa_kev/README.md
+++ b/sources/community/cisa_kev/README.md
@@ -30,15 +30,15 @@ Single-row feed metadata for the CISA KEV catalog. Use this table to check feed 
 
 | Column           | Type    | Description                              |
 | ---------------- | ------- | ---------------------------------------- |
-| `catalogVersion` | `Utf8`  | CISA catalog version string              |
-| `dateReleased`   | `Utf8`  | Date the catalog feed was released       |
+| `catalog_version` | `Utf8`  | CISA catalog version string              |
+| `date_released`   | `Utf8`  | Date the catalog feed was released       |
 | `count`          | `Int64` | Number of vulnerability rows in the feed |
 
 ## Quick Start
 
 ```bash
 # Confirm connectivity and freshness metadata
-coral sql "SELECT \"catalogVersion\", \"dateReleased\", count FROM cisa_kev.catalog LIMIT 1"
+coral sql "SELECT catalog_version, date_released, count FROM cisa_kev.catalog LIMIT 1"
 ```
 
 ### `vulnerabilities`


### PR DESCRIPTION
## Intent

The CISA KEV README should give users queries they can run directly. The source manifest exposes snake_case catalog columns, but the README documented the upstream JSON field names instead, so the quick-start query pointed at columns Coral does not expose.

## Changes

- Update the catalog column table to `catalog_version` and `date_released`.
- Update the quick-start query to use the exposed Coral column names.

## Verification

- `cargo run -q -p coral-cli -- source lint sources/community/cisa_kev/manifest.yaml`
- `git diff --check HEAD~1..HEAD`
