### PR TITLE
docs: fix OpenTelemetry trace filter link

### DIFF
--- a/docs/guides/observe-with-opentelemetry.mdx
+++ b/docs/guides/observe-with-opentelemetry.mdx
@@ -86,7 +86,7 @@ Coral emits five families of trace spans, all exported with the W3C Trace Contex
 
 #### Adjusting what gets exported
 
-`[otel].trace_filter` uses [`tracing-subscriber`'s `Targets`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.Targets.html) syntax. Enable noisy targets when you want them (`coral_engine::datafusion` covers physical-plan and optimizer-rule spans, off by default to keep export volume low), and disable any you do not (`coral_engine::http` silences the HTTP backend):
+`[otel].trace_filter` uses [`tracing-subscriber`'s `Targets`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/targets/struct.Targets.html) syntax. Enable noisy targets when you want them (`coral_engine::datafusion` covers physical-plan and optimizer-rule spans, off by default to keep export volume low), and disable any you do not (`coral_engine::http` silences the HTTP backend):
 
 ```toml
 [otel]


### PR DESCRIPTION
## Summary
- Update the OpenTelemetry guide to link to the current docs.rs page for `tracing_subscriber::filter::Targets`.

## Why
The old URL no longer points at the canonical `Targets` struct location, which makes the trace filter documentation harder to verify from the guide.

## Verification
- `make docs-check`
- `curl -I -L --max-time 20 https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/targets/struct.Targets.html`
- `/home/james/src/openclaw/agent-skills/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`
