### PR TITLE
feat(engine): add source-scoped SQL view runtime

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -53,6 +53,39 @@ pub(crate) struct RegisteredTableFunction {
     pub(crate) search_limits_json: Option<String>,
 }
 
+pub(crate) struct RegisteredSourceTable {
+    pub(crate) metadata: RegisteredTable,
+    pub(crate) implementation: RegisteredTableImplementation,
+}
+
+pub(crate) enum RegisteredTableImplementation {
+    Provider(Arc<dyn TableProvider>),
+    SqlView { sql: String },
+}
+
+impl RegisteredSourceTable {
+    pub(crate) fn provider(metadata: RegisteredTable, provider: Arc<dyn TableProvider>) -> Self {
+        Self {
+            metadata,
+            implementation: RegisteredTableImplementation::Provider(provider),
+        }
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "file-backed source views construct this in the next stacked PR"
+        )
+    )]
+    pub(crate) fn sql_view(metadata: RegisteredTable, sql: String) -> Self {
+        Self {
+            metadata,
+            implementation: RegisteredTableImplementation::SqlView { sql },
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct RegisteredFilter {
     pub(crate) name: String,
@@ -100,9 +133,44 @@ pub(crate) struct RegisteredSource {
 }
 
 pub(crate) struct BackendRegistration {
-    pub(crate) tables: HashMap<String, Arc<dyn TableProvider>>,
-    pub(crate) table_functions: SourceTableFunctions,
-    pub(crate) source: RegisteredSource,
+    tables: Vec<RegisteredSourceTable>,
+    table_functions: SourceTableFunctions,
+    source: RegisteredSource,
+}
+
+impl BackendRegistration {
+    pub(crate) fn new(
+        schema_name: String,
+        tables: Vec<RegisteredSourceTable>,
+        table_functions: SourceTableFunctions,
+        table_function_metadata: Vec<RegisteredTableFunction>,
+        inputs: Vec<RegisteredInput>,
+    ) -> Self {
+        let source_tables = tables
+            .iter()
+            .map(|table| table.metadata.clone())
+            .collect::<Vec<_>>();
+        Self {
+            tables,
+            table_functions,
+            source: RegisteredSource {
+                schema_name,
+                tables: source_tables,
+                table_functions: table_function_metadata,
+                inputs,
+            },
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        Vec<RegisteredSourceTable>,
+        SourceTableFunctions,
+        RegisteredSource,
+    ) {
+        (self.tables, self.table_functions, self.source)
+    }
 }
 
 /// Build a collision-free `DataFusion` UDTF name for a source-scoped function.
@@ -393,6 +461,9 @@ pub(crate) fn schema_from_columns(
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use datafusion::arrow::datatypes::{Field, Schema};
+    use datafusion::datasource::MemTable;
+
     use super::*;
 
     #[test]
@@ -430,5 +501,55 @@ mod tests {
         reqwest::Client::builder()
             .build()
             .map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn backend_registration_derives_source_metadata_from_source_tables() {
+        let provider =
+            Arc::new(MemTable::try_new(Schema::empty().into(), vec![vec![]]).expect("mem table"));
+        let events = registered_table("events");
+        let messages = registered_table("messages");
+
+        let registration = BackendRegistration::new(
+            "codex".to_string(),
+            vec![
+                RegisteredSourceTable::provider(events, provider),
+                RegisteredSourceTable::sql_view(messages, "SELECT * FROM codex.events".to_string()),
+            ],
+            HashMap::default(),
+            vec![],
+            vec![],
+        );
+
+        let (_tables, _functions, source) = registration.into_parts();
+        let table_names = source
+            .tables
+            .iter()
+            .map(|table| table.table_name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(table_names, ["events", "messages"]);
+    }
+
+    fn registered_table(name: &str) -> RegisteredTable {
+        RegisteredTable {
+            table_name: name.to_string(),
+            description: String::new(),
+            guide: String::new(),
+            columns: vec![RegisteredColumn {
+                name: "id".to_string(),
+                data_type: Field::new("id", DataType::Int64, false)
+                    .data_type()
+                    .to_string(),
+                nullable: false,
+                is_virtual: false,
+                is_required_filter: false,
+                filter_mode: None,
+                description: String::new(),
+            }],
+            filters: vec![],
+            required_filters: vec![],
+            search_limits_json: None,
+        }
     }
 }

--- a/crates/coral-engine/src/backends/composite.rs
+++ b/crates/coral-engine/src/backends/composite.rs
@@ -1,15 +1,13 @@
 //! Composite runtime source registration for app-assembled component packages.
 
-use std::collections::{BTreeSet, HashMap};
-use std::sync::Arc;
+use std::collections::BTreeSet;
 
 use async_trait::async_trait;
-use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
 use datafusion::prelude::SessionContext;
 
 use crate::backends::{
-    BackendRegistration, BackendRegistrationContext, CompiledBackendSource, RegisteredSource,
+    BackendRegistration, BackendRegistrationContext, CompiledBackendSource, RegisteredSourceTable,
     SourceTableFunctions,
 };
 
@@ -43,24 +41,22 @@ impl CompiledBackendSource for CompositeCompiledSource {
         ctx: &SessionContext,
         registration_context: &BackendRegistrationContext,
     ) -> datafusion::error::Result<BackendRegistration> {
-        let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
+        let mut tables = Vec::new();
+        let mut table_names = BTreeSet::new();
         let mut table_functions = SourceTableFunctions::new();
-        let mut registered_tables = Vec::new();
         let mut registered_functions = Vec::new();
         let mut inputs = Vec::new();
         let mut input_keys = BTreeSet::new();
 
         for component in &self.components {
             let registration = component.register(ctx, registration_context).await?;
-            for (name, table) in registration.tables {
-                if tables.insert(name.clone(), table).is_some() {
-                    return Err(DataFusionError::Execution(format!(
-                        "source '{}' registered duplicate table '{name}'",
-                        self.source_name
-                    )));
-                }
+            let (component_tables, component_table_functions, component_source) =
+                registration.into_parts();
+
+            for table in component_tables {
+                push_unique_table(&self.source_name, &mut table_names, &mut tables, table)?;
             }
-            for (name, function) in registration.table_functions {
+            for (name, function) in component_table_functions {
                 if table_functions.insert(name.clone(), function).is_some() {
                     return Err(DataFusionError::Execution(format!(
                         "source '{}' registered duplicate table function '{name}'",
@@ -68,24 +64,37 @@ impl CompiledBackendSource for CompositeCompiledSource {
                     )));
                 }
             }
-            registered_tables.extend(registration.source.tables);
-            registered_functions.extend(registration.source.table_functions);
-            for input in registration.source.inputs {
+            registered_functions.extend(component_source.table_functions);
+            for input in component_source.inputs {
                 if input_keys.insert(input.key.clone()) {
                     inputs.push(input);
                 }
             }
         }
 
-        Ok(BackendRegistration {
+        Ok(BackendRegistration::new(
+            self.source_name.clone(),
             tables,
             table_functions,
-            source: RegisteredSource {
-                schema_name: self.source_name.clone(),
-                tables: registered_tables,
-                table_functions: registered_functions,
-                inputs,
-            },
-        })
+            registered_functions,
+            inputs,
+        ))
     }
+}
+
+fn push_unique_table(
+    source_name: &str,
+    table_names: &mut BTreeSet<String>,
+    tables: &mut Vec<RegisteredSourceTable>,
+    table: RegisteredSourceTable,
+) -> datafusion::error::Result<()> {
+    let name = table.metadata.table_name.clone();
+    if table_names.insert(name.clone()) {
+        tables.push(table);
+        return Ok(());
+    }
+
+    Err(DataFusionError::Execution(format!(
+        "source '{source_name}' registered duplicate table '{name}'"
+    )))
 }

--- a/crates/coral-engine/src/backends/file/mod.rs
+++ b/crates/coral-engine/src/backends/file/mod.rs
@@ -24,7 +24,7 @@ use datafusion::prelude::SessionContext;
 
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
-    RegisteredSource, RegisteredTable, build_registered_inputs, build_registered_table,
+    RegisteredSourceTable, RegisteredTable, build_registered_inputs, build_registered_table,
     registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
 };
 use coral_spec::backends::file::{FileFormat, FileSourceManifest, FileTableSpec};
@@ -81,8 +81,7 @@ impl CompiledBackendSource for FileCompiledSource {
         ctx: &SessionContext,
         _registration: &BackendRegistrationContext,
     ) -> Result<BackendRegistration> {
-        let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
-        let mut table_infos = Vec::with_capacity(self.manifest.tables.len());
+        let mut tables = Vec::with_capacity(self.manifest.tables.len());
         let resolved_inputs = coral_spec::resolve_inputs(
             &self.manifest.declared_inputs,
             &self.source_secrets,
@@ -117,10 +116,8 @@ impl CompiledBackendSource for FileCompiledSource {
                 }
             };
             let schema = provider.schema();
-            let table_name = table.name().to_string();
             let metadata = registered_table(table, &schema);
-            tables.insert(table_name, provider);
-            table_infos.push(metadata);
+            tables.push(RegisteredSourceTable::provider(metadata, provider));
         }
 
         let secret_keys = self.source_secrets.keys().cloned().collect();
@@ -130,16 +127,13 @@ impl CompiledBackendSource for FileCompiledSource {
             &secret_keys,
         );
 
-        Ok(BackendRegistration {
+        Ok(BackendRegistration::new(
+            self.manifest.common.name.clone(),
             tables,
-            table_functions: HashMap::default(),
-            source: RegisteredSource {
-                schema_name: self.manifest.common.name.clone(),
-                tables: table_infos,
-                table_functions: vec![],
-                inputs,
-            },
-        })
+            HashMap::default(),
+            vec![],
+            inputs,
+        ))
     }
 }
 

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -11,7 +11,7 @@ use datafusion::prelude::SessionContext;
 
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
-    RegisteredSource, RegisteredTable, SourceTableFunctions, build_registered_inputs,
+    RegisteredSourceTable, RegisteredTable, SourceTableFunctions, build_registered_inputs,
     build_registered_table, build_registered_table_function, internal_table_function_name,
     registered_columns_from_specs, required_filter_names,
 };
@@ -106,8 +106,7 @@ impl CompiledBackendSource for HttpCompiledSource {
             &self.request_authenticators,
             runtime,
         )?;
-        let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
-        let mut table_infos = Vec::with_capacity(self.manifest.tables.len());
+        let mut tables = Vec::with_capacity(self.manifest.tables.len());
 
         for table in &self.manifest.tables {
             let provider: Arc<dyn TableProvider> = Arc::new(HttpSourceTableProvider::new(
@@ -115,8 +114,10 @@ impl CompiledBackendSource for HttpCompiledSource {
                 self.manifest.common.name.clone(),
                 table.clone(),
             )?);
-            tables.insert(table.name().to_string(), provider);
-            table_infos.push(registered_table(table));
+            tables.push(RegisteredSourceTable::provider(
+                registered_table(table),
+                provider,
+            ));
         }
         let mut table_functions =
             SourceTableFunctions::with_capacity(self.manifest.functions.len());
@@ -150,16 +151,13 @@ impl CompiledBackendSource for HttpCompiledSource {
             &secret_keys,
         );
 
-        Ok(BackendRegistration {
+        Ok(BackendRegistration::new(
+            self.manifest.common.name.clone(),
             tables,
             table_functions,
-            source: RegisteredSource {
-                schema_name: self.manifest.common.name.clone(),
-                tables: table_infos,
-                table_functions: table_function_infos,
-                inputs,
-            },
-        })
+            table_function_infos,
+            inputs,
+        ))
     }
 }
 

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -11,7 +11,7 @@ mod transport;
 
 pub(crate) use error::McpProviderQueryError;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -26,7 +26,7 @@ use self::provider::McpTableProvider;
 use self::transport::{StdioMcpToolCaller, StreamableHttpMcpToolCaller};
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
-    RegisteredSource, SourceTableFunctions, build_registered_inputs, build_registered_table,
+    RegisteredSourceTable, SourceTableFunctions, build_registered_inputs, build_registered_table,
     build_registered_table_function, internal_table_function_name, registered_columns_from_specs,
     required_filter_names,
 };
@@ -171,8 +171,7 @@ impl CompiledBackendSource for McpCompiledSource {
             ));
         }
 
-        let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
-        let mut table_infos = Vec::with_capacity(self.manifest.tables.len());
+        let mut tables = Vec::with_capacity(self.manifest.tables.len());
         for table in &self.manifest.tables {
             let provider: Arc<dyn TableProvider> = Arc::new(McpTableProvider::new(
                 self.caller.clone(),
@@ -180,14 +179,10 @@ impl CompiledBackendSource for McpCompiledSource {
                 Arc::clone(&self.source_inputs),
                 table.clone(),
             )?);
-            tables.insert(table.name().to_string(), provider);
             let required_filters = required_filter_names(table.filters());
             let columns = registered_columns_from_specs(table.columns(), table.filters());
-            table_infos.push(build_registered_table(
-                &table.common,
-                columns,
-                required_filters,
-            ));
+            let metadata = build_registered_table(&table.common, columns, required_filters);
+            tables.push(RegisteredSourceTable::provider(metadata, provider));
         }
 
         let secret_keys = self
@@ -202,16 +197,13 @@ impl CompiledBackendSource for McpCompiledSource {
             &secret_keys,
         );
 
-        Ok(BackendRegistration {
+        Ok(BackendRegistration::new(
+            self.manifest.common.name.clone(),
             tables,
             table_functions,
-            source: RegisteredSource {
-                schema_name: self.manifest.common.name.clone(),
-                tables: table_infos,
-                table_functions: table_function_infos,
-                inputs,
-            },
-        })
+            table_function_infos,
+            inputs,
+        ))
     }
 }
 

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -80,10 +80,11 @@ pub(crate) mod common;
 mod composite;
 pub(crate) use common::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
-    RegisteredSource, RegisteredTable, RegisteredTableFunction, SourceTableFunctions,
-    build_registered_inputs, build_registered_table, build_registered_table_function,
-    internal_table_function_name, registered_columns_from_schema, registered_columns_from_specs,
-    required_filter_names, schema_from_columns,
+    RegisteredSource, RegisteredSourceTable, RegisteredTable, RegisteredTableFunction,
+    RegisteredTableImplementation, SourceTableFunctions, build_registered_inputs,
+    build_registered_table, build_registered_table_function, internal_table_function_name,
+    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
+    schema_from_columns,
 };
 
 pub(crate) mod file;

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -9,3 +9,4 @@ pub(crate) mod query;
 pub(crate) mod registry;
 pub(crate) mod schema_provider;
 pub(crate) mod source_functions;
+pub(crate) mod source_views;

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -1,18 +1,21 @@
 //! Registers compiled backend sources into a shared `DataFusion` session.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
+use datafusion::catalog::{CatalogProvider, MemorySchemaProvider, SchemaProvider};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::prelude::SessionContext;
 use tracing::{Instrument as _, info_span};
 
 use crate::backends::{
     BackendRegistration, BackendRegistrationContext, CompiledBackendSource, RegisteredSource,
-    SourceTableFunctions,
+    RegisteredSourceTable, RegisteredTableImplementation, SourceTableFunctions,
 };
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
-use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
+use crate::runtime::source_views::{SourceSqlView, build_source_views};
+use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy, SourceTables};
 
 const RESERVED_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin"];
 
@@ -24,6 +27,11 @@ const RESERVED_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin"];
 pub(crate) struct CompiledQuerySource {
     pub(crate) source: QuerySource,
     pub(crate) compiled: Box<dyn CompiledBackendSource>,
+}
+
+struct SourceTableImplementations {
+    provider_tables: SourceTables,
+    sql_views: Vec<SourceSqlView>,
 }
 
 /// One selected source's readiness for runtime registration.
@@ -106,87 +114,32 @@ async fn register_sources_inner(
     prepare_source_decorators(source_decorators, &selected_sources)?;
 
     let mut result = SourceRegistrationResult::default();
-    let mut seen_schemas = std::collections::HashSet::new();
+    let mut seen_schemas = HashSet::new();
     let registration_context = BackendRegistrationContext::default();
 
     for source in sources {
         match source {
             SourceRegistrationCandidate::Compiled(selected_source) => {
-                let query_source = &selected_source.source;
-                let compiled_source = selected_source.compiled;
-                let schema_name = compiled_source.schema_name().to_string();
-                let source_name = compiled_source.source_name().to_string();
-
-                match register_source(
+                register_compiled_source(
                     ctx,
+                    &catalog,
                     &registration_context,
                     &mut seen_schemas,
-                    compiled_source.as_ref(),
+                    source_decorators,
+                    &mut result,
+                    selected_source,
                 )
-                .await
-                {
-                    Ok(registration) => {
-                        let BackendRegistration {
-                            tables,
-                            table_functions,
-                            source: registered_source,
-                        } = registration;
-                        let decorated_tables =
-                            decorate_source_tables(source_decorators, query_source, tables)?;
-                        match catalog.register_schema(
-                            compiled_source.schema_name(),
-                            Arc::new(StaticSchemaProvider::new(decorated_tables)),
-                        ) {
-                            Ok(_) => {
-                                register_table_functions(ctx, table_functions);
-                                result.active_sources.push(registered_source);
-                            }
-                            Err(error) => {
-                                let core_error = datafusion_to_core(&error, &[]);
-                                if handle_source_registration_failure(
-                                    source_decorators,
-                                    query_source,
-                                    &core_error,
-                                )? {
-                                    return Err(core_error);
-                                }
-                                push_source_failure(
-                                    &mut result,
-                                    &source_name,
-                                    &schema_name,
-                                    core_error.to_string(),
-                                );
-                            }
-                        }
-                    }
-                    Err(error) => {
-                        let core_error = datafusion_to_core(&error, &[]);
-                        if handle_source_registration_failure(
-                            source_decorators,
-                            query_source,
-                            &core_error,
-                        )? {
-                            return Err(core_error);
-                        }
-                        push_source_failure(
-                            &mut result,
-                            &source_name,
-                            &schema_name,
-                            core_error.to_string(),
-                        );
-                    }
-                }
+                .await?;
             }
             SourceRegistrationCandidate::CompileFailed { source, error } => {
-                if handle_source_registration_failure(source_decorators, &source, &error)? {
-                    return Err(error);
-                }
-                push_source_failure(
+                record_source_failure(
+                    source_decorators,
                     &mut result,
+                    &source,
                     source.source_name(),
                     source.source_name(),
-                    error.to_string(),
-                );
+                    error,
+                )?;
             }
         }
     }
@@ -194,6 +147,89 @@ async fn register_sources_inner(
     finish_source_decorators(source_decorators)?;
 
     Ok(result)
+}
+
+async fn register_compiled_source(
+    ctx: &SessionContext,
+    catalog: &Arc<dyn CatalogProvider>,
+    registration_context: &BackendRegistrationContext,
+    seen_schemas: &mut HashSet<String>,
+    source_decorators: &mut [Box<dyn SourceDecorator>],
+    result: &mut SourceRegistrationResult,
+    selected_source: CompiledQuerySource,
+) -> std::result::Result<(), CoreError> {
+    let query_source = selected_source.source;
+    let compiled_source = selected_source.compiled;
+    let schema_name = compiled_source.schema_name().to_string();
+    let source_name = compiled_source.source_name().to_string();
+
+    let registration = match register_source(
+        ctx,
+        registration_context,
+        seen_schemas,
+        compiled_source.as_ref(),
+    )
+    .await
+    {
+        Ok(registration) => registration,
+        Err(error) => {
+            return record_source_failure(
+                source_decorators,
+                result,
+                &query_source,
+                &source_name,
+                &schema_name,
+                datafusion_to_core(&error, &[]),
+            );
+        }
+    };
+
+    let (source_tables, table_functions, registered_source) = registration.into_parts();
+    let table_implementations = split_source_table_implementations(source_tables);
+    // Decorators wrap concrete backend providers first; SQL views are planned
+    // afterward so they resolve through the decorated source tables.
+    let decorated_tables = decorate_source_tables(
+        source_decorators,
+        &query_source,
+        table_implementations.provider_tables,
+    )?;
+    let source_tables = match build_source_schema_tables(
+        ctx,
+        catalog,
+        compiled_source.schema_name(),
+        decorated_tables,
+        table_implementations.sql_views,
+    )
+    .await
+    {
+        Ok(source_tables) => source_tables,
+        Err(error) => {
+            return record_source_failure(
+                source_decorators,
+                result,
+                &query_source,
+                &source_name,
+                &schema_name,
+                datafusion_to_core(&error, &[]),
+            );
+        }
+    };
+
+    if let Err(error) = publish_source_schema(catalog, compiled_source.schema_name(), source_tables)
+    {
+        return record_source_failure(
+            source_decorators,
+            result,
+            &query_source,
+            &source_name,
+            &schema_name,
+            datafusion_to_core(&error, &[]),
+        );
+    }
+
+    register_table_functions(ctx, table_functions);
+    result.active_sources.push(registered_source);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -230,6 +266,123 @@ async fn register_source(
     source.register(ctx, registration_context).await
 }
 
+fn split_source_table_implementations(
+    tables: Vec<RegisteredSourceTable>,
+) -> SourceTableImplementations {
+    let mut provider_tables = SourceTables::new();
+    let mut sql_views = Vec::new();
+
+    for table in tables {
+        match table.implementation {
+            RegisteredTableImplementation::Provider(provider) => {
+                provider_tables.insert(table.metadata.table_name, provider);
+            }
+            RegisteredTableImplementation::SqlView { sql } => {
+                sql_views.push(SourceSqlView::new(table.metadata, sql));
+            }
+        }
+    }
+
+    SourceTableImplementations {
+        provider_tables,
+        sql_views,
+    }
+}
+
+async fn build_source_schema_tables(
+    ctx: &SessionContext,
+    catalog: &Arc<dyn CatalogProvider>,
+    schema_name: &str,
+    mut provider_tables: SourceTables,
+    sql_views: Vec<SourceSqlView>,
+) -> DataFusionResult<SourceTables> {
+    if sql_views.is_empty() {
+        return Ok(provider_tables);
+    }
+
+    // Source registration uses a mutable DataFusion schema only while building
+    // SQL-backed views. The published source schema remains static, preserving
+    // the runtime invariant that source tables cannot be added after
+    // registration.
+    let planning_schema = SourcePlanningSchema::register(catalog, schema_name, &provider_tables)?;
+    let view_tables = build_source_views(ctx, schema_name, sql_views).await;
+    let restore_result = planning_schema.restore();
+    let view_tables = match (view_tables, restore_result) {
+        (Err(error), _) | (Ok(_), Err(error)) => return Err(error),
+        (Ok(view_tables), Ok(())) => view_tables,
+    };
+    merge_source_view_tables(schema_name, &mut provider_tables, view_tables)?;
+    Ok(provider_tables)
+}
+
+struct SourcePlanningSchema {
+    catalog: Arc<dyn CatalogProvider>,
+    schema_name: String,
+    previous_schema: Option<Arc<dyn SchemaProvider>>,
+}
+
+impl SourcePlanningSchema {
+    fn register(
+        catalog: &Arc<dyn CatalogProvider>,
+        schema_name: &str,
+        provider_tables: &SourceTables,
+    ) -> DataFusionResult<Self> {
+        let planning_schema = MemorySchemaProvider::new();
+        for (table_name, provider) in provider_tables {
+            planning_schema.register_table(table_name.clone(), Arc::clone(provider))?;
+        }
+        let previous_schema = catalog.register_schema(schema_name, Arc::new(planning_schema))?;
+        Ok(Self {
+            catalog: Arc::clone(catalog),
+            schema_name: schema_name.to_string(),
+            previous_schema,
+        })
+    }
+
+    fn restore(self) -> DataFusionResult<()> {
+        match self.previous_schema {
+            Some(previous_schema) => {
+                self.catalog
+                    .register_schema(&self.schema_name, previous_schema)?;
+            }
+            None => {
+                drop(self.catalog.deregister_schema(&self.schema_name, true)?);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn merge_source_view_tables(
+    schema_name: &str,
+    provider_tables: &mut SourceTables,
+    view_tables: SourceTables,
+) -> DataFusionResult<()> {
+    for (table_name, provider) in view_tables {
+        if provider_tables
+            .insert(table_name.clone(), provider)
+            .is_some()
+        {
+            return Err(DataFusionError::Plan(format!(
+                "source view {schema_name}.{table_name} conflicts with an existing source table"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn publish_source_schema(
+    catalog: &Arc<dyn CatalogProvider>,
+    schema_name: &str,
+    source_tables: SourceTables,
+) -> DataFusionResult<()> {
+    catalog.register_schema(
+        schema_name,
+        Arc::new(StaticSchemaProvider::new(source_tables)),
+    )?;
+    Ok(())
+}
+
 fn push_source_failure(
     result: &mut SourceRegistrationResult,
     source_name: &str,
@@ -247,6 +400,21 @@ fn push_source_failure(
         "skipping source"
     );
     result.failures.push(failure);
+}
+
+fn record_source_failure(
+    source_decorators: &mut [Box<dyn SourceDecorator>],
+    result: &mut SourceRegistrationResult,
+    source: &QuerySource,
+    source_name: &str,
+    schema_name: &str,
+    error: CoreError,
+) -> std::result::Result<(), CoreError> {
+    if handle_source_registration_failure(source_decorators, source, &error)? {
+        return Err(error);
+    }
+    push_source_failure(result, source_name, schema_name, error.to_string());
+    Ok(())
 }
 
 fn register_table_functions(ctx: &SessionContext, table_functions: SourceTableFunctions) {
@@ -324,7 +492,29 @@ fn source_decorator_error(name: &str, error: &crate::SourceDecoratorError) -> Co
 
 #[cfg(test)]
 mod tests {
-    use super::check_reserved_schema;
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use datafusion::arrow::array::{ArrayRef, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::catalog::MemorySchemaProvider;
+    use datafusion::common::TableReference;
+    use datafusion::datasource::MemTable;
+    use datafusion::error::Result as DataFusionResult;
+    use datafusion::prelude::SessionContext;
+    use serde_json::json;
+
+    use super::{
+        CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationResult,
+        check_reserved_schema, register_sources,
+    };
+    use crate::QuerySource;
+    use crate::backends::common::{
+        BackendRegistration, BackendRegistrationContext, CompiledBackendSource, RegisteredColumn,
+        RegisteredSourceTable, RegisteredTable,
+    };
 
     #[test]
     fn reserved_schema_coral_is_rejected() {
@@ -342,5 +532,340 @@ mod tests {
         check_reserved_schema("github").expect("github is not reserved");
         check_reserved_schema("pagerduty").expect("pagerduty is not reserved");
         check_reserved_schema("slack").expect("slack is not reserved");
+    }
+
+    #[tokio::test]
+    async fn source_registration_publishes_static_schema_with_views() {
+        let ctx = SessionContext::new();
+        let mut decorators = Vec::new();
+
+        let registration = register_sources(
+            &ctx,
+            vec![SourceRegistrationCandidate::Compiled(
+                compiled_query_source(TestCompiledSource::with_view(
+                    "SELECT text FROM test_source.events",
+                )),
+            )],
+            decorators.as_mut_slice(),
+        )
+        .await
+        .expect("source registration should succeed");
+
+        let active_source = registration
+            .active_sources
+            .first()
+            .expect("source registration should report one active source");
+        let table_names = active_source
+            .tables
+            .iter()
+            .map(|table| table.table_name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(table_names, ["events", "messages"]);
+
+        let rows = ctx
+            .sql("SELECT text FROM test_source.messages")
+            .await
+            .expect("view query should plan")
+            .collect()
+            .await
+            .expect("view query should execute");
+        assert_single_text_value(&rows, "hello");
+
+        let source_schema = ctx
+            .catalog("datafusion")
+            .expect("catalog should exist")
+            .schema("test_source")
+            .expect("source schema should exist");
+        let error = source_schema
+            .register_table("late_table".to_string(), empty_mem_table())
+            .expect_err("published source schema should be static");
+
+        assert!(
+            error
+                .to_string()
+                .contains("static schema provider does not support register_table"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_source_view_does_not_publish_source_schema() {
+        let ctx = SessionContext::new();
+        let mut decorators = Vec::new();
+
+        let registration = register_sources(
+            &ctx,
+            vec![SourceRegistrationCandidate::Compiled(
+                compiled_query_source(TestCompiledSource::with_view(
+                    "SELECT text FROM test_source.missing",
+                )),
+            )],
+            decorators.as_mut_slice(),
+        )
+        .await
+        .expect("invalid source should be skipped, not abort registration");
+
+        assert_source_skipped_without_schema(
+            &ctx,
+            &registration,
+            "failed to plan view test_source.messages",
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_source_view_restores_existing_schema() {
+        let ctx = SessionContext::new();
+        let catalog = ctx.catalog("datafusion").expect("catalog should exist");
+        catalog
+            .register_schema("test_source", Arc::new(MemorySchemaProvider::new()))
+            .expect("existing schema should register");
+        ctx.register_table(
+            TableReference::partial("test_source", "existing"),
+            event_mem_table(),
+        )
+        .expect("existing table should register");
+        let mut decorators = Vec::new();
+
+        let registration = register_sources(
+            &ctx,
+            vec![SourceRegistrationCandidate::Compiled(
+                compiled_query_source(TestCompiledSource::with_view(
+                    "SELECT text FROM test_source.missing",
+                )),
+            )],
+            decorators.as_mut_slice(),
+        )
+        .await
+        .expect("invalid source should be skipped, not abort registration");
+
+        assert_source_skipped(&registration, "failed to plan view test_source.messages");
+        let rows = ctx
+            .sql("SELECT text FROM test_source.existing")
+            .await
+            .expect("restored schema query should plan")
+            .collect()
+            .await
+            .expect("restored schema query should execute");
+        assert_single_text_value(&rows, "hello");
+    }
+
+    #[tokio::test]
+    async fn source_view_cannot_conflict_with_provider_table_name() {
+        let ctx = SessionContext::new();
+        let mut decorators = Vec::new();
+
+        let registration = register_sources(
+            &ctx,
+            vec![SourceRegistrationCandidate::Compiled(
+                compiled_query_source(TestCompiledSource::with_named_view(
+                    "events",
+                    "SELECT text FROM test_source.events",
+                )),
+            )],
+            decorators.as_mut_slice(),
+        )
+        .await
+        .expect("conflicting source view should be skipped, not abort registration");
+
+        assert_source_skipped_without_schema(
+            &ctx,
+            &registration,
+            "source view test_source.events conflicts with an existing source table",
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_source_view_names_do_not_publish_source_schema() {
+        let ctx = SessionContext::new();
+        let mut decorators = Vec::new();
+
+        let registration = register_sources(
+            &ctx,
+            vec![SourceRegistrationCandidate::Compiled(
+                compiled_query_source(TestCompiledSource::with_views(vec![
+                    TestSourceView::new("messages", "SELECT text FROM test_source.events"),
+                    TestSourceView::new("messages", "SELECT text FROM test_source.events"),
+                ])),
+            )],
+            decorators.as_mut_slice(),
+        )
+        .await
+        .expect("duplicate source views should be skipped, not abort registration");
+
+        assert_source_skipped_without_schema(
+            &ctx,
+            &registration,
+            "invalid view test_source.messages: duplicate source view name",
+        );
+    }
+
+    struct TestCompiledSource {
+        views: Vec<TestSourceView>,
+    }
+
+    struct TestSourceView {
+        name: &'static str,
+        sql: &'static str,
+    }
+
+    impl TestSourceView {
+        fn new(name: &'static str, sql: &'static str) -> Self {
+            Self { name, sql }
+        }
+    }
+
+    impl TestCompiledSource {
+        fn with_view(view_sql: &'static str) -> Self {
+            Self::with_named_view("messages", view_sql)
+        }
+
+        fn with_named_view(name: &'static str, sql: &'static str) -> Self {
+            Self::with_views(vec![TestSourceView::new(name, sql)])
+        }
+
+        fn with_views(views: Vec<TestSourceView>) -> Self {
+            Self { views }
+        }
+    }
+
+    #[async_trait]
+    impl CompiledBackendSource for TestCompiledSource {
+        fn schema_name(&self) -> &'static str {
+            "test_source"
+        }
+
+        fn source_name(&self) -> &'static str {
+            "test_source"
+        }
+
+        async fn register(
+            &self,
+            _ctx: &SessionContext,
+            _registration: &BackendRegistrationContext,
+        ) -> DataFusionResult<BackendRegistration> {
+            let mut tables = vec![RegisteredSourceTable::provider(
+                registered_text_table("events"),
+                event_mem_table(),
+            )];
+            tables.extend(self.views.iter().map(|view| {
+                RegisteredSourceTable::sql_view(
+                    registered_text_table(view.name),
+                    view.sql.to_string(),
+                )
+            }));
+
+            Ok(BackendRegistration::new(
+                "test_source".to_string(),
+                tables,
+                HashMap::default(),
+                vec![],
+                vec![],
+            ))
+        }
+    }
+
+    fn compiled_query_source(compiled: TestCompiledSource) -> CompiledQuerySource {
+        let manifest = coral_spec::parse_source_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "test_source",
+            "version": "0.1.0",
+            "backend": "file",
+            "tables": [{
+                "name": "events",
+                "description": "Events",
+                "format": "jsonl",
+                "source": { "location": "file:///tmp/coral-test/events.jsonl" },
+                "columns": [{ "name": "text", "type": "Utf8" }]
+            }]
+        }))
+        .expect("test manifest should parse");
+
+        CompiledQuerySource {
+            source: QuerySource::new(manifest, BTreeMap::new(), BTreeMap::new()),
+            compiled: Box::new(compiled),
+        }
+    }
+
+    fn registered_text_table(table_name: &str) -> RegisteredTable {
+        RegisteredTable {
+            table_name: table_name.to_string(),
+            description: String::new(),
+            guide: String::new(),
+            columns: vec![RegisteredColumn {
+                name: "text".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: true,
+                is_virtual: false,
+                is_required_filter: false,
+                filter_mode: None,
+                description: String::new(),
+            }],
+            filters: vec![],
+            required_filters: vec![],
+            search_limits_json: None,
+        }
+    }
+
+    fn event_mem_table() -> Arc<MemTable> {
+        let schema = Arc::new(Schema::new(vec![Field::new("text", DataType::Utf8, true)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(StringArray::from(vec!["hello"])) as ArrayRef],
+        )
+        .expect("record batch should build");
+        Arc::new(MemTable::try_new(schema, vec![vec![batch]]).expect("mem table should build"))
+    }
+
+    fn empty_mem_table() -> Arc<MemTable> {
+        Arc::new(
+            MemTable::try_new(Arc::new(Schema::empty()), vec![vec![]])
+                .expect("mem table should build"),
+        )
+    }
+
+    fn assert_source_skipped_without_schema(
+        ctx: &SessionContext,
+        registration: &SourceRegistrationResult,
+        expected_failure_detail: &str,
+    ) {
+        assert_source_skipped(registration, expected_failure_detail);
+
+        let source_schema = ctx
+            .catalog("datafusion")
+            .expect("catalog should exist")
+            .schema("test_source");
+        assert!(
+            source_schema.is_none(),
+            "failed view registration must remove the planning schema"
+        );
+    }
+
+    fn assert_source_skipped(
+        registration: &SourceRegistrationResult,
+        expected_failure_detail: &str,
+    ) {
+        assert!(registration.active_sources.is_empty());
+        let failure = registration
+            .failures
+            .first()
+            .expect("invalid source view should report one failure");
+        assert!(
+            failure.detail.contains(expected_failure_detail),
+            "unexpected failure: {:?}",
+            registration.failures
+        );
+    }
+
+    fn assert_single_text_value(batches: &[RecordBatch], expected: &str) {
+        let [batch] = batches else {
+            panic!("expected one batch, got {}", batches.len());
+        };
+        assert_eq!(batch.num_rows(), 1, "expected one row");
+        let text = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("first column should be a string array");
+        assert_eq!(text.value(0), expected);
     }
 }

--- a/crates/coral-engine/src/runtime/schema_provider.rs
+++ b/crates/coral-engine/src/runtime/schema_provider.rs
@@ -1,4 +1,4 @@
-//! Static schema provider used for the source metadata schema.
+//! Immutable schema provider for fully-built source and system schemas.
 
 use std::any::Any;
 use std::collections::HashMap;
@@ -9,15 +9,19 @@ use datafusion::catalog::SchemaProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 
-/// Immutable schema provider backed by a fixed set of in-memory tables.
+/// Fixed `DataFusion` schema provider backed by a complete table map.
+///
+/// Source registration may use mutable planning helpers while building derived
+/// relations, but published schemas stay immutable so runtime code cannot add
+/// tables after a source has been registered.
 #[derive(Debug)]
 pub(crate) struct StaticSchemaProvider {
     tables: HashMap<String, Arc<dyn TableProvider>>,
 }
 
 impl StaticSchemaProvider {
+    /// Builds a schema provider from a complete table map.
     #[must_use]
-    /// Builds a schema provider from the supplied table map.
     pub(crate) fn new(tables: HashMap<String, Arc<dyn TableProvider>>) -> Self {
         Self { tables }
     }

--- a/crates/coral-engine/src/runtime/source_views.rs
+++ b/crates/coral-engine/src/runtime/source_views.rs
@@ -1,0 +1,613 @@
+//! Builds SQL-backed source view providers.
+
+use datafusion::arrow::datatypes::{DataType, SchemaRef};
+use datafusion::common::{TableReference, tree_node::TreeNodeRecursion};
+use datafusion::dataframe::DataFrame;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::prelude::{SQLOptions, SessionContext};
+
+use crate::SourceTables;
+use crate::backends::RegisteredTable;
+
+pub(crate) struct SourceSqlView {
+    metadata: RegisteredTable,
+    sql: String,
+}
+
+impl SourceSqlView {
+    pub(crate) fn new(metadata: RegisteredTable, sql: String) -> Self {
+        Self { metadata, sql }
+    }
+
+    fn table_name(&self) -> &str {
+        &self.metadata.table_name
+    }
+}
+
+pub(crate) async fn build_source_views(
+    ctx: &SessionContext,
+    schema_name: &str,
+    views: Vec<SourceSqlView>,
+) -> Result<SourceTables> {
+    let mut view_tables = SourceTables::new();
+    for view in views {
+        let plan = source_view_plan(ctx, schema_name, &view).await?;
+        let provider = DataFrame::new(ctx.state(), plan).into_view();
+        validate_source_view_schema(schema_name, &view, &provider.schema())?;
+        if view_tables
+            .insert(view.table_name().to_string(), provider)
+            .is_some()
+        {
+            return Err(source_view_sql_error(
+                schema_name,
+                &view,
+                "duplicate source view name",
+            ));
+        }
+    }
+    Ok(view_tables)
+}
+
+fn source_view_sql_options() -> SQLOptions {
+    SQLOptions::new()
+        .with_allow_ddl(false)
+        .with_allow_dml(false)
+        .with_allow_statements(false)
+}
+
+async fn source_view_plan(
+    ctx: &SessionContext,
+    schema_name: &str,
+    view: &SourceSqlView,
+) -> Result<LogicalPlan> {
+    let plan = ctx
+        .state()
+        .create_logical_plan(&view.sql)
+        .await
+        .map_err(|error| {
+            DataFusionError::Plan(format!(
+                "failed to plan view {schema_name}.{}: {error}",
+                view.table_name()
+            ))
+        })?;
+    source_view_sql_options()
+        .verify_plan(&plan)
+        .map_err(|error| source_view_sql_error(schema_name, view, error))?;
+    validate_source_view_plan(schema_name, view, &plan)?;
+    Ok(plan)
+}
+
+fn validate_source_view_plan(
+    schema_name: &str,
+    view: &SourceSqlView,
+    plan: &LogicalPlan,
+) -> Result<()> {
+    let mut references_source_table = false;
+    plan.apply_with_subqueries(|node| match node {
+        LogicalPlan::TableScan(scan) => {
+            let recursion = validate_source_table_reference(schema_name, view, &scan.table_name)?;
+            references_source_table = true;
+            Ok(recursion)
+        }
+        LogicalPlan::Analyze(_)
+        | LogicalPlan::DescribeTable(_)
+        | LogicalPlan::Explain(_)
+        | LogicalPlan::Extension(_)
+        | LogicalPlan::Unnest(_) => Err(source_view_sql_error(
+            schema_name,
+            view,
+            format!(
+                "unsupported logical plan node {}",
+                logical_plan_node_name(node)
+            ),
+        )),
+        _ => Ok(TreeNodeRecursion::Continue),
+    })?;
+    if !references_source_table {
+        return Err(source_view_sql_error(
+            schema_name,
+            view,
+            "view SQL must reference at least one source-local table",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_source_table_reference(
+    schema_name: &str,
+    view: &SourceSqlView,
+    table_ref: &TableReference,
+) -> Result<TreeNodeRecursion> {
+    match table_ref {
+        TableReference::Partial { schema, .. } if schema.as_ref() == schema_name => {
+            Ok(TreeNodeRecursion::Continue)
+        }
+        TableReference::Partial { schema, table } => Err(source_view_sql_error(
+            schema_name,
+            view,
+            format!("view SQL must reference only source-local tables; found {schema}.{table}"),
+        )),
+        TableReference::Bare { table } => Err(source_view_sql_error(
+            schema_name,
+            view,
+            format!("view SQL must reference source tables as {schema_name}.table; found {table}"),
+        )),
+        TableReference::Full { .. } => Err(source_view_sql_error(
+            schema_name,
+            view,
+            format!(
+                "view SQL must reference source tables as {schema_name}.table; found {table_ref}"
+            ),
+        )),
+    }
+}
+
+fn logical_plan_node_name(plan: &LogicalPlan) -> &'static str {
+    match plan {
+        LogicalPlan::Analyze(_) => "Analyze",
+        LogicalPlan::DescribeTable(_) => "DescribeTable",
+        LogicalPlan::Explain(_) => "Explain",
+        LogicalPlan::Extension(_) => "Extension",
+        LogicalPlan::Unnest(_) => "Unnest",
+        _ => "Unknown",
+    }
+}
+
+fn validate_source_view_schema(
+    schema_name: &str,
+    view: &SourceSqlView,
+    actual_schema: &SchemaRef,
+) -> Result<()> {
+    let expected_columns = &view.metadata.columns;
+    let actual_fields = actual_schema.fields();
+    if expected_columns.len() != actual_fields.len() {
+        return Err(source_view_sql_error(
+            schema_name,
+            view,
+            format!(
+                "declared columns do not match SQL output: expected {} columns, got {}",
+                expected_columns.len(),
+                actual_fields.len()
+            ),
+        ));
+    }
+
+    for (ordinal, (expected, actual)) in expected_columns
+        .iter()
+        .zip(actual_fields.iter())
+        .enumerate()
+    {
+        if expected.name != *actual.name()
+            || !view_data_type_matches(&expected.data_type, actual.data_type())
+            || actual_allows_nulls_not_declared(expected.nullable, actual.is_nullable())
+        {
+            return Err(source_view_sql_error(
+                schema_name,
+                view,
+                format!(
+                    "declared columns do not match SQL output at position {}: expected {} {} nullable={}, got {} {} nullable={}",
+                    ordinal + 1,
+                    expected.name,
+                    expected.data_type,
+                    expected.nullable,
+                    actual.name(),
+                    actual.data_type(),
+                    actual.is_nullable()
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn actual_allows_nulls_not_declared(expected_nullable: bool, actual_nullable: bool) -> bool {
+    !expected_nullable && actual_nullable
+}
+
+fn view_data_type_matches(expected: &str, actual: &DataType) -> bool {
+    registered_data_type_matches(expected, actual) || expected == actual.to_string()
+}
+
+fn registered_data_type_matches(expected: &str, actual: &DataType) -> bool {
+    match expected {
+        "Utf8" | "Json" | "LargeUtf8" | "Utf8View" => is_string_type(actual),
+        "Int64" => matches!(actual, DataType::Int64),
+        "Boolean" => matches!(actual, DataType::Boolean),
+        "Float64" => matches!(actual, DataType::Float64),
+        "Timestamp" => matches!(actual, DataType::Timestamp(_, _)),
+        _ => false,
+    }
+}
+
+fn is_string_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+    )
+}
+
+fn source_view_sql_error(
+    schema_name: &str,
+    view: &SourceSqlView,
+    detail: impl std::fmt::Display,
+) -> DataFusionError {
+    DataFusionError::Plan(format!(
+        "invalid view {schema_name}.{}: {detail}",
+        view.table_name()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{ArrayRef, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::catalog::MemorySchemaProvider;
+    use datafusion::common::TableReference;
+    use datafusion::datasource::MemTable;
+    use datafusion::error::Result;
+    use datafusion::prelude::SessionContext;
+
+    use super::{SourceSqlView, build_source_views, source_view_plan, validate_source_view_schema};
+    use crate::CoreError;
+    use crate::backends::RegisteredTable;
+    use crate::backends::common::RegisteredColumn;
+    use crate::runtime::error::datafusion_to_core;
+
+    fn schema(fields: Vec<Field>) -> SchemaRef {
+        Arc::new(Schema::new(fields))
+    }
+
+    fn registered_table(table_name: &str, fields: Vec<Field>) -> RegisteredTable {
+        RegisteredTable {
+            table_name: table_name.to_string(),
+            description: String::new(),
+            guide: String::new(),
+            columns: fields
+                .into_iter()
+                .map(|field| RegisteredColumn {
+                    name: field.name().clone(),
+                    data_type: field.data_type().to_string(),
+                    nullable: field.is_nullable(),
+                    is_virtual: false,
+                    is_required_filter: false,
+                    filter_mode: None,
+                    description: String::new(),
+                })
+                .collect(),
+            filters: vec![],
+            required_filters: vec![],
+            search_limits_json: None,
+        }
+    }
+
+    fn source_view(sql: &str) -> SourceSqlView {
+        SourceSqlView::new(
+            registered_table("messages", vec![Field::new("text", DataType::Utf8, true)]),
+            sql.to_string(),
+        )
+    }
+
+    fn source_view_context() -> SessionContext {
+        let ctx = SessionContext::new();
+        let catalog = ctx.catalog("datafusion").expect("catalog should exist");
+        catalog
+            .register_schema("codex", Arc::new(MemorySchemaProvider::new()))
+            .expect("codex schema should register");
+        catalog
+            .register_schema("github", Arc::new(MemorySchemaProvider::new()))
+            .expect("github schema should register");
+        register_test_table(&ctx, TableReference::partial("codex", "events"));
+        register_test_table(&ctx, TableReference::partial("github", "issues"));
+        register_test_table(&ctx, TableReference::bare("events"));
+        ctx
+    }
+
+    fn register_test_table(ctx: &SessionContext, table_ref: TableReference) {
+        let table_schema = schema(vec![Field::new("text", DataType::Utf8, true)]);
+        let provider = Arc::new(
+            MemTable::try_new(table_schema, vec![vec![]]).expect("mem table should build"),
+        );
+        ctx.register_table(table_ref, provider)
+            .expect("test table should register");
+    }
+
+    async fn validate_source_view_sql(sql: &str) -> Result<()> {
+        let ctx = source_view_context();
+        let view = source_view(sql);
+        source_view_plan(&ctx, "codex", &view).await.map(|_plan| ())
+    }
+
+    #[tokio::test]
+    async fn source_view_accepts_source_qualified_relations_and_ctes() {
+        let view = source_view("WITH recent AS (SELECT * FROM codex.events) SELECT * FROM recent");
+        let ctx = source_view_context();
+
+        source_view_plan(&ctx, "codex", &view)
+            .await
+            .expect("source-local view should validate");
+    }
+
+    #[tokio::test]
+    async fn source_view_rejects_cross_source_relations() {
+        let error = validate_source_view_sql("SELECT * FROM github.issues")
+            .await
+            .expect_err("cross-source view should fail validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("must reference only source-local tables"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_source_view_sql_maps_to_invalid_input() {
+        let error = validate_source_view_sql("SELECT * FROM github.issues")
+            .await
+            .expect_err("cross-source view should fail validation");
+
+        match datafusion_to_core(&error, &[]) {
+            CoreError::InvalidInput(detail) => {
+                assert!(
+                    detail.contains("must reference only source-local tables"),
+                    "unexpected error detail: {detail}"
+                );
+            }
+            other => panic!("expected invalid input, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn source_view_rejects_cross_source_relations_in_subqueries() {
+        let error = validate_source_view_sql(
+            "SELECT (SELECT count(*) FROM github.issues) AS issue_count FROM codex.events",
+        )
+        .await
+        .expect_err("cross-source subquery should fail validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("must reference only source-local tables"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_view_rejects_unqualified_base_relations() {
+        let error = validate_source_view_sql("SELECT * FROM events")
+            .await
+            .expect_err("unqualified base table should fail validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("must reference source tables as codex.table"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_view_rejects_multiple_statements() {
+        let error = validate_source_view_sql(
+            "SELECT text FROM codex.events; SELECT text FROM codex.events",
+        )
+        .await
+        .expect_err("multiple statements should fail validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to plan view codex.messages"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_view_rejects_non_select_statements() {
+        let error = validate_source_view_sql("DROP TABLE codex.events")
+            .await
+            .expect_err("non-select statement should fail validation");
+
+        assert!(
+            error.to_string().contains("DDL not supported"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_view_rejects_constant_selects() {
+        let error = validate_source_view_sql("SELECT 'hello' AS text")
+            .await
+            .expect_err("constant view should fail validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("must reference at least one source-local table"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_view_rejects_unsupported_relation_forms() {
+        let error = validate_source_view_sql("SELECT * FROM UNNEST([1, 2])")
+            .await
+            .expect_err("table functions should fail validation");
+
+        assert!(
+            error.to_string().contains("unsupported logical plan node"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_view_rejects_quoted_cross_source_relations() {
+        let error = validate_source_view_sql(r#"SELECT * FROM "github".issues"#)
+            .await
+            .expect_err("quoted cross-source relation should fail validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("must reference only source-local tables"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_view_rejects_three_part_relations() {
+        let error = validate_source_view_sql("SELECT * FROM datafusion.codex.events")
+            .await
+            .expect_err("three-part relation should fail validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("must reference source tables as codex.table"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn source_view_schema_accepts_matching_declared_columns() {
+        let view = source_view("SELECT text FROM codex.events");
+        let actual_schema = schema(vec![Field::new("text", DataType::Utf8, true)]);
+
+        validate_source_view_schema("codex", &view, &actual_schema)
+            .expect("matching schema should validate");
+    }
+
+    #[test]
+    fn source_view_schema_accepts_stricter_actual_nullability() {
+        let view = source_view("SELECT coalesce(text, '') AS text FROM codex.events");
+        let actual_schema = schema(vec![Field::new("text", DataType::Utf8, false)]);
+
+        validate_source_view_schema("codex", &view, &actual_schema)
+            .expect("non-null SQL output should satisfy a nullable declaration");
+    }
+
+    #[test]
+    fn source_view_schema_accepts_datafusion_string_view_output() {
+        let view = source_view("SELECT CAST(NULL AS VARCHAR) AS text FROM codex.events");
+        let actual_schema = schema(vec![Field::new("text", DataType::Utf8View, true)]);
+
+        validate_source_view_schema("codex", &view, &actual_schema)
+            .expect("DataFusion string view output should satisfy a Utf8 declaration");
+    }
+
+    #[test]
+    fn source_view_schema_accepts_declared_json_string_output() {
+        let mut view = source_view("SELECT payload AS text FROM codex.events");
+        view.metadata
+            .columns
+            .first_mut()
+            .expect("source_view helper creates one column")
+            .data_type = "Json".to_string();
+        let actual_schema = schema(vec![Field::new("text", DataType::Utf8, true)]);
+
+        validate_source_view_schema("codex", &view, &actual_schema)
+            .expect("declared JSON should satisfy a string-backed SQL output");
+    }
+
+    #[test]
+    fn source_view_schema_rejects_looser_actual_nullability() {
+        let mut view = source_view("SELECT maybe_text AS text FROM codex.events");
+        view.metadata
+            .columns
+            .first_mut()
+            .expect("source_view helper creates one column")
+            .nullable = false;
+        let actual_schema = schema(vec![Field::new("text", DataType::Utf8, true)]);
+
+        let error = validate_source_view_schema("codex", &view, &actual_schema)
+            .expect_err("nullable SQL output should not satisfy a non-null declaration");
+
+        assert!(
+            error
+                .to_string()
+                .contains("declared columns do not match SQL output at position 1"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn source_view_schema_rejects_declared_column_drift() {
+        let view = source_view("SELECT body AS text FROM codex.events");
+        let actual_schema = schema(vec![Field::new("body", DataType::Utf8, true)]);
+
+        let error = validate_source_view_schema("codex", &view, &actual_schema)
+            .expect_err("mismatched schema should fail validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("declared columns do not match SQL output at position 1"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_view_builds_queryable_provider() {
+        let ctx = SessionContext::new();
+        ctx.catalog("datafusion")
+            .expect("catalog should exist")
+            .register_schema("codex", Arc::new(MemorySchemaProvider::new()))
+            .expect("source schema should register");
+
+        let event_schema = schema(vec![Field::new("text", DataType::Utf8, true)]);
+        let batch = RecordBatch::try_new(
+            Arc::clone(&event_schema),
+            vec![Arc::new(StringArray::from(vec!["hello"])) as ArrayRef],
+        )
+        .expect("batch should build");
+        let provider = Arc::new(
+            MemTable::try_new(Arc::clone(&event_schema), vec![vec![batch]])
+                .expect("mem table should build"),
+        );
+        ctx.register_table(TableReference::partial("codex", "events"), provider)
+            .expect("events table should register");
+        let views = vec![SourceSqlView::new(
+            registered_table("messages", vec![Field::new("text", DataType::Utf8, true)]),
+            "SELECT text FROM codex.events".to_string(),
+        )];
+
+        let mut view_tables = build_source_views(&ctx, "codex", views)
+            .await
+            .expect("source view should build");
+        let view_provider = view_tables
+            .remove("messages")
+            .expect("messages view provider should exist");
+        ctx.register_table(TableReference::partial("codex", "messages"), view_provider)
+            .expect("source view should register");
+
+        let batches = ctx
+            .sql("SELECT text FROM codex.messages")
+            .await
+            .expect("view query should plan")
+            .collect()
+            .await
+            .expect("view query should execute");
+
+        assert_single_text_value(&batches, "hello");
+    }
+
+    fn assert_single_text_value(batches: &[RecordBatch], expected: &str) {
+        let [batch] = batches else {
+            panic!("expected one batch, got {}", batches.len());
+        };
+        assert_eq!(batch.num_rows(), 1, "expected one row");
+        let text = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("first column should be a string array");
+        assert_eq!(text.value(0), expected);
+    }
+}


### PR DESCRIPTION
## Intent

Add private engine runtime support for source-scoped SQL views: table-shaped relations backed by SQL over the provider tables for the same source.

This gives the runtime a clean place to host derived source relations without asking agents to repeat raw JSON parsing or source-specific query shapes every time.

## Relation to prepared statements / #889

This is adjacent to source-declared prepared statements, but it is solving a narrower table-shaping problem.

Prepared statements are an invocation surface: "run this saved query", usually through `EXECUTE`. They are useful for reusable workflows, parameterized queries, and source-authored actions that happen to return rows.

Source SQL views are a relation surface: "this source has another table-shaped relation". They live in the normal table universe, so callers can use ordinary `SELECT`, filters, joins, limits, catalog discovery, and whatever agents already know how to do with tables.

The motivating case here is raw audit/event data:

- raw table: `codex.events(timestamp, type, payload, ...)`
- derived relations: `codex.sessions`, `codex.messages`, `codex.tool_calls`

For that shape, I do not want every agent or recipe redoing JSON archaeology over `payload`. I want the source to expose useful semantic tables.

This PR is intentionally not a general memory surface, not agent-authored saved views, and not public manifest syntax yet. It only adds the private engine runtime needed to register source-owned SQL-backed relations. The source-spec surface and Codex transcript tables are stacked separately so we can get mileage before widening the contract.

## What changed

- `BackendRegistration` now carries registered source table implementations, not only provider tables.
- A registered source relation can be provider-backed or SQL-backed.
- Source registration builds provider tables first, plans SQL views against those provider tables, then publishes one immutable source schema.
- SQL view planning uses DataFusion logical planning and `DataFrame::into_view()` rather than string-built `CREATE VIEW` statements.
- Temporary planning schemas restore any pre-existing DataFusion schema after planning, including failed planning.
- View validation rejects non-read-only SQL, multiple statements, constant selects with no source table scan, unqualified references, cross-source references, three-part references, duplicate view names, provider/view name conflicts, and declared schema drift.

## Boundaries

- No public source manifest, docs, CLI, MCP, or API surface is added in this PR.
- File manifest `views:` support is stacked in the next PR.
- Codex transcript tables are stacked after that.
- View-on-view support is intentionally not included: source views are planned against provider-backed source tables only.
- Views over table functions are intentionally not included: source views are planned before UDTFs are registered, and PR2 only supports SQL views over provider-backed source tables.
- Constant/static views are intentionally not included: a source view must reference at least one source-local provider table.
- Existing file, HTTP, and MCP backends continue to register provider tables in this PR.

## Validation

- `make rust-checks`: 993 tests passed.
- `make docs-check`.
- `git diff --check`.
- Focused engine coverage for source view planning, schema validation, table reference restrictions, constant-view rejection, duplicate/conflict handling, planning-schema restoration, and published static schemas.
- Real-config binary smoke on `codex-source-sql-views-runtime` (`coral 0.4.1+b336e004`) using Brad's installed Coral config, without adding sources: `coral.tables`/`coral.table_functions` registered `datadog`, `github`, `google_docs`, `google_meet`, `linear`, `sentry`, `slack`, and `wandb`; live queries succeeded for GitHub `search_issues`, Linear `teams` and `team_issues`, Slack `channels` and `messages`, Datadog `monitors`, and Sentry `projects`. Slack also surfaced a real provider error (`not_in_channel`) for an inaccessible channel before succeeding against `general`.