### PR TITLE
feat(spec): add DSL3 source SQL views

### DIFF
--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -132,21 +132,26 @@ fn http_manifest_for_surface(
         }
     }
     Ok(HttpSourceManifest {
-        common: SourceManifestCommon {
-            dsl_version: manifest.common.dsl_version,
-            name: manifest.common.name.clone(),
-            version: String::new(),
-            description: manifest.common.description.clone(),
-            test_queries: Vec::new(),
-        },
+        common: runtime_common_for_v4_source(manifest),
         base_url: surface_base_url(surface, materialized_surface)?,
         auth: surface.openapi_runtime.auth.clone(),
         request_headers: surface.openapi_runtime.request_headers.clone(),
         rate_limit: surface.openapi_runtime.rate_limit.clone(),
         tables,
         functions,
+        views: Vec::new(),
         declared_inputs: manifest.declared_inputs.clone(),
     })
+}
+
+fn runtime_common_for_v4_source(manifest: &V4SourceManifest) -> SourceManifestCommon {
+    SourceManifestCommon {
+        dsl_version: manifest.common.dsl_version,
+        name: manifest.common.name.clone(),
+        version: String::new(),
+        description: manifest.common.description.clone(),
+        test_queries: Vec::new(),
+    }
 }
 
 fn surface_base_url(

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -8,7 +8,7 @@ use crate::{QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceInputR
 use async_trait::async_trait;
 use coral_spec::{
     ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
-    SearchLimitsSpec, SourceTableFunctionSpec, TableCommon,
+    SearchLimitsSpec, SourceSqlViewSpec, SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use datafusion::catalog::TableFunctionImpl;
@@ -71,13 +71,6 @@ impl RegisteredSourceTable {
         }
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "file-backed source views construct this in the next stacked PR"
-        )
-    )]
     pub(crate) fn sql_view(metadata: RegisteredTable, sql: String) -> Self {
         Self {
             metadata,
@@ -374,6 +367,22 @@ pub(crate) fn build_registered_table(
         required_filters,
         search_limits_json: common.search_limits.as_ref().map(serialize_search_limits),
     }
+}
+
+pub(crate) fn build_registered_source_view(view: &SourceSqlViewSpec) -> RegisteredSourceTable {
+    let common = TableCommon {
+        name: view.name.clone(),
+        description: view.description.clone(),
+        guide: view.guide.clone(),
+        filters: Vec::new(),
+        fetch_limit_default: None,
+        search_limits: None,
+        detail_hints: Vec::new(),
+        columns: view.columns.clone(),
+    };
+    let columns = registered_columns_from_specs(&view.columns, &[]);
+    let metadata = build_registered_table(&common, columns, vec![]);
+    RegisteredSourceTable::sql_view(metadata, view.sql.clone())
 }
 
 pub(crate) fn build_registered_table_function(

--- a/crates/coral-engine/src/backends/file/mod.rs
+++ b/crates/coral-engine/src/backends/file/mod.rs
@@ -24,8 +24,9 @@ use datafusion::prelude::SessionContext;
 
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
-    RegisteredSourceTable, RegisteredTable, build_registered_inputs, build_registered_table,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
+    RegisteredSourceTable, RegisteredTable, build_registered_inputs, build_registered_source_view,
+    build_registered_table, registered_columns_from_schema, registered_columns_from_specs,
+    required_filter_names,
 };
 use coral_spec::backends::file::{FileFormat, FileSourceManifest, FileTableSpec};
 
@@ -81,7 +82,7 @@ impl CompiledBackendSource for FileCompiledSource {
         ctx: &SessionContext,
         _registration: &BackendRegistrationContext,
     ) -> Result<BackendRegistration> {
-        let mut tables = Vec::with_capacity(self.manifest.tables.len());
+        let mut tables = Vec::with_capacity(self.manifest.tables.len() + self.manifest.views.len());
         let resolved_inputs = coral_spec::resolve_inputs(
             &self.manifest.declared_inputs,
             &self.source_secrets,
@@ -118,6 +119,9 @@ impl CompiledBackendSource for FileCompiledSource {
             let schema = provider.schema();
             let metadata = registered_table(table, &schema);
             tables.push(RegisteredSourceTable::provider(metadata, provider));
+        }
+        for view in &self.manifest.views {
+            tables.push(build_registered_source_view(view));
         }
 
         let secret_keys = self.source_secrets.keys().cloned().collect();

--- a/crates/coral-engine/src/backends/file/tests.rs
+++ b/crates/coral-engine/src/backends/file/tests.rs
@@ -638,6 +638,59 @@ async fn file_provider_reads_csv_with_format_options() {
     assert!(rendered.contains("user"));
 }
 
+#[tokio::test]
+async fn file_view_registration_rejects_declared_schema_mismatch() {
+    let fixture_dir = tempdir().expect("tempdir should be created");
+    fs::write(
+        fixture_dir.path().join("events.jsonl"),
+        r#"{"type":"message"}"#,
+    )
+    .expect("fixture should write");
+    let location = file_url_from_directory_path(fixture_dir.path());
+    let manifest = parse_source_manifest_value(json!({
+        "dsl_version": 3,
+        "name": "view_mismatch",
+        "version": "0.1.0",
+        "backend": "file",
+        "tables": [{
+            "name": "events",
+            "description": "events",
+            "format": "jsonl",
+            "source": {
+                "location": location,
+                "glob": "**/*.jsonl",
+            },
+            "columns": [{ "name": "type", "type": "Utf8" }],
+        }],
+        "views": [{
+            "name": "messages",
+            "description": "messages",
+            "sql": "SELECT type AS actual FROM view_mismatch.events",
+            "columns": [{ "name": "declared", "type": "Utf8" }],
+        }],
+    }))
+    .expect("manifest should parse");
+
+    let ctx = SessionContext::new();
+    let registration = register_sources_blocking(&ctx, compile_sources(vec![manifest]))
+        .expect("registration should collect source failures");
+
+    assert!(registration.active_sources.is_empty());
+    let failure = registration
+        .failures
+        .first()
+        .expect("view mismatch should skip the source");
+    assert!(
+        failure
+            .detail
+            .contains("declared columns do not match SQL output at position 1"),
+        "{}",
+        failure.detail
+    );
+    assert!(failure.detail.contains("expected declared Utf8"));
+    assert!(failure.detail.contains("got actual Utf8"));
+}
+
 fn parquet_manifest(location: &str) -> ValidatedSourceManifest {
     parquet_manifest_with_glob_and_partitions(
         location,

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -12,8 +12,8 @@ use datafusion::prelude::SessionContext;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
     RegisteredSourceTable, RegisteredTable, SourceTableFunctions, build_registered_inputs,
-    build_registered_table, build_registered_table_function, internal_table_function_name,
-    registered_columns_from_specs, required_filter_names,
+    build_registered_source_view, build_registered_table, build_registered_table_function,
+    internal_table_function_name, registered_columns_from_specs, required_filter_names,
 };
 use crate::{RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver};
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
@@ -106,7 +106,7 @@ impl CompiledBackendSource for HttpCompiledSource {
             &self.request_authenticators,
             runtime,
         )?;
-        let mut tables = Vec::with_capacity(self.manifest.tables.len());
+        let mut tables = Vec::with_capacity(self.manifest.tables.len() + self.manifest.views.len());
 
         for table in &self.manifest.tables {
             let provider: Arc<dyn TableProvider> = Arc::new(HttpSourceTableProvider::new(
@@ -118,6 +118,9 @@ impl CompiledBackendSource for HttpCompiledSource {
                 registered_table(table),
                 provider,
             ));
+        }
+        for view in &self.manifest.views {
+            tables.push(build_registered_source_view(view));
         }
         let mut table_functions =
             SourceTableFunctions::with_capacity(self.manifest.functions.len());

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -26,9 +26,9 @@ use self::provider::McpTableProvider;
 use self::transport::{StdioMcpToolCaller, StreamableHttpMcpToolCaller};
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
-    RegisteredSourceTable, SourceTableFunctions, build_registered_inputs, build_registered_table,
-    build_registered_table_function, internal_table_function_name, registered_columns_from_specs,
-    required_filter_names,
+    RegisteredSourceTable, SourceTableFunctions, build_registered_inputs,
+    build_registered_source_view, build_registered_table, build_registered_table_function,
+    internal_table_function_name, registered_columns_from_specs, required_filter_names,
 };
 use crate::{SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError};
 
@@ -171,7 +171,7 @@ impl CompiledBackendSource for McpCompiledSource {
             ));
         }
 
-        let mut tables = Vec::with_capacity(self.manifest.tables.len());
+        let mut tables = Vec::with_capacity(self.manifest.tables.len() + self.manifest.views.len());
         for table in &self.manifest.tables {
             let provider: Arc<dyn TableProvider> = Arc::new(McpTableProvider::new(
                 self.caller.clone(),
@@ -183,6 +183,9 @@ impl CompiledBackendSource for McpCompiledSource {
             let columns = registered_columns_from_specs(table.columns(), table.filters());
             let metadata = build_registered_table(&table.common, columns, required_filters);
             tables.push(RegisteredSourceTable::provider(metadata, provider));
+        }
+        for view in &self.manifest.views {
+            tables.push(build_registered_source_view(view));
         }
 
         let secret_keys = self

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -387,6 +387,40 @@ fn mcp_table_manifest() -> coral_spec::ValidatedSourceManifest {
     .expect("mcp table manifest should parse")
 }
 
+fn mcp_table_view_manifest() -> coral_spec::ValidatedSourceManifest {
+    coral_spec::parse_source_manifest_value(json!({
+        "dsl_version": 3,
+        "name": "test_mcp",
+        "version": "0.1.0",
+        "backend": "mcp",
+        "server": { "transport": "stdio", "command": "unused" },
+        "tables": [{
+            "name": "issues",
+            "description": "Open issues",
+            "tool": "list_issues",
+            "tool_args": {
+                "owner": { "from": "literal", "value": "acme" }
+            },
+            "response": { "rows_path": ["issues"] },
+            "columns": [
+                { "name": "id", "type": "Utf8" },
+                { "name": "title", "type": "Utf8" },
+                { "name": "state", "type": "Utf8" }
+            ]
+        }],
+        "views": [{
+            "name": "open_issues",
+            "description": "Open issues",
+            "sql": "SELECT id, title FROM test_mcp.issues WHERE state = 'open'",
+            "columns": [
+                { "name": "id", "type": "Utf8" },
+                { "name": "title", "type": "Utf8" }
+            ]
+        }]
+    }))
+    .expect("mcp table view manifest should parse")
+}
+
 fn mcp_table_required_filter_manifest() -> coral_spec::ValidatedSourceManifest {
     coral_spec::parse_source_manifest_value(json!({
         "dsl_version": 3,
@@ -450,6 +484,50 @@ async fn scans_mcp_table_with_manifest_tool_args_and_no_filters() {
         "unbound optional filter should not be passed: {:?}",
         call.1
     );
+}
+
+#[tokio::test]
+async fn mcp_backend_registers_declared_sql_views() {
+    let ctx = SessionContext::new();
+    let caller = Arc::new(FakeMcpTableCaller {
+        calls: Mutex::new(Vec::new()),
+    });
+    register_test_sources_with_catalog(&ctx, compile_sources(mcp_table_view_manifest(), caller));
+
+    let batches = ctx
+        .sql("SELECT id, title FROM test_mcp.open_issues ORDER BY id")
+        .await
+        .expect("view query should plan")
+        .collect()
+        .await
+        .expect("view query should execute");
+    let rendered = pretty_format_batches(&batches)
+        .expect("batches should render")
+        .to_string();
+
+    assert!(rendered.contains("| 1  | Bug A"));
+    assert!(rendered.contains("| 2  | Bug B"));
+    assert!(!rendered.contains("| Bug C"));
+
+    let batches = ctx
+        .sql(
+            "SELECT column_name, data_type \
+             FROM coral.columns \
+             WHERE schema_name = 'test_mcp' \
+               AND table_name = 'open_issues' \
+             ORDER BY ordinal_position",
+        )
+        .await
+        .expect("catalog query should plan")
+        .collect()
+        .await
+        .expect("catalog query should execute");
+    let rendered = pretty_format_batches(&batches)
+        .expect("batches should render")
+        .to_string();
+
+    assert!(rendered.contains("| id"));
+    assert!(rendered.contains("| title"));
 }
 
 fn mcp_typed_filters_manifest() -> coral_spec::ValidatedSourceManifest {

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -82,9 +82,9 @@ pub(crate) use common::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
     RegisteredSource, RegisteredSourceTable, RegisteredTable, RegisteredTableFunction,
     RegisteredTableImplementation, SourceTableFunctions, build_registered_inputs,
-    build_registered_table, build_registered_table_function, internal_table_function_name,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    build_registered_source_view, build_registered_table, build_registered_table_function,
+    internal_table_function_name, registered_columns_from_schema, registered_columns_from_specs,
+    required_filter_names, schema_from_columns,
 };
 
 pub(crate) mod file;

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -301,6 +301,68 @@ async fn select_all_from_http_source() {
 }
 
 #[tokio::test]
+async fn http_backend_registers_declared_sql_views() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .mount(&server)
+        .await;
+    let mut manifest = base_http_manifest("http_user_views", &server.uri());
+    manifest
+        .as_object_mut()
+        .expect("manifest is an object")
+        .insert(
+            "views".to_string(),
+            json!([{
+                "name": "ada_users",
+                "description": "Ada users",
+                "sql": "SELECT id, name FROM http_user_views.users WHERE name = 'Ada'",
+                "columns": [
+                    { "name": "id", "type": "Int64" },
+                    { "name": "name", "type": "Utf8" }
+                ]
+            }]),
+        );
+    let source = build_source(manifest);
+    let sources = [source];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT id, name FROM http_user_views.ada_users",
+        )
+        .await
+        .expect("declared view should query"),
+    );
+
+    assert_eq!(rows, vec![json!({"id": 1, "name": "Ada"})]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT column_name, data_type \
+             FROM coral.columns \
+             WHERE schema_name = 'http_user_views' \
+               AND table_name = 'ada_users' \
+             ORDER BY ordinal_position",
+        )
+        .await
+        .expect("declared view columns should be discoverable"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({"column_name": "id", "data_type": "Int64"}),
+            json!({"column_name": "name", "data_type": "Utf8"}),
+        ]
+    );
+}
+
+#[tokio::test]
 async fn select_with_column_projection() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -124,6 +124,76 @@ async fn select_all_from_jsonl_source() {
 }
 
 #[tokio::test]
+async fn file_backend_registers_declared_sql_views() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "events.jsonl",
+        &[
+            json!({"type": "message", "payload": {"text": "hello"}}),
+            json!({"type": "debug", "payload": {"text": "skip"}}),
+        ],
+    );
+    let source = build_source(json!({
+        "name": "jsonl_view_fixture",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "file",
+        "tables": [{
+            "name": "events",
+            "description": "Raw events",
+            "format": "jsonl",
+            "source": {
+                "location": dir_url(temp.path()),
+                "glob": "**/*.jsonl"
+            },
+            "columns": [
+                { "name": "type", "type": "Utf8" },
+                { "name": "payload", "type": "Json" }
+            ]
+        }],
+        "views": [{
+            "name": "messages",
+            "description": "Message events",
+            "sql": "SELECT json_get_str(payload, 'text') AS text FROM jsonl_view_fixture.events WHERE type = 'message'",
+            "columns": [{ "name": "text", "type": "Utf8" }]
+        }]
+    }));
+    let sources = [source];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT text FROM jsonl_view_fixture.messages",
+        )
+        .await
+        .expect("declared view should query"),
+    );
+
+    assert_eq!(rows, vec![json!({"text": "hello"})]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT column_name, data_type \
+             FROM coral.columns \
+             WHERE schema_name = 'jsonl_view_fixture' \
+               AND table_name = 'messages' \
+             ORDER BY ordinal_position",
+        )
+        .await
+        .expect("declared view columns should be discoverable"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({"column_name": "text", "data_type": "Utf8"})]
+    );
+}
+
+#[tokio::test]
 async fn quoted_fully_qualified_table_reference_reports_sql_reference_hint() {
     let temp = TempDir::new().expect("temp dir");
     let source = github_pulls_source(temp.path());

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -22,8 +22,9 @@ use crate::inputs::{
 };
 use crate::{
     ColumnSpec, DeclaredRelation, FilterSpec, ManifestDataType, ManifestError, ManifestInputSpec,
-    ParsedTemplate, Result, SourceBackend, SourceManifestCommon, TableCommon, TemplateNamespace,
-    TemplatePart, validate_columns, validate_declared_relation_namespace, validate_test_queries,
+    ParsedTemplate, Result, SourceBackend, SourceManifestCommon, SourceSqlViewSpec, TableCommon,
+    TemplateNamespace, TemplatePart, validate_columns, validate_declared_relation_namespace,
+    validate_source_sql_view, validate_test_queries,
 };
 
 /// Validated top-level manifest for a native file-backed source.
@@ -31,6 +32,7 @@ use crate::{
 pub struct FileSourceManifest {
     pub common: SourceManifestCommon,
     pub tables: Vec<FileTableSpec>,
+    pub views: Vec<SourceSqlViewSpec>,
     pub declared_inputs: Vec<ManifestInputSpec>,
 }
 
@@ -129,6 +131,8 @@ struct RawFileSourceManifest {
     #[serde(default)]
     inputs: Option<Value>,
     tables: Vec<RawFileTableSpec>,
+    #[serde(default)]
+    views: Vec<SourceSqlViewSpec>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -575,13 +579,7 @@ impl RawFileTableSpec {
 
         self.source.validate_for_file(schema, &self.name, format)?;
         validate_columns(&self.columns, schema, &self.name)?;
-        validate_native_file_table_features(
-            schema,
-            &self.name,
-            format,
-            &self.filters,
-            &self.columns,
-        )?;
+        validate_native_file_table_features(schema, &self.name, &self.filters, &self.columns)?;
         validate_derived_column_overlap(schema, &self.name, &self.source, &self.columns)?;
         self.format_options
             .validate_for_format(format, schema, &self.name)?;
@@ -607,7 +605,6 @@ impl RawFileTableSpec {
 fn validate_native_file_table_features(
     schema: &str,
     table: &str,
-    _format: FileFormat,
     filters: &[FilterSpec],
     columns: &[ColumnSpec],
 ) -> Result<()> {
@@ -697,13 +694,19 @@ impl FileSourceManifest {
             backend: _backend,
             inputs: _inputs,
             tables,
+            views,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
         validate_declared_relation_namespace(
             &name,
             tables
                 .iter()
-                .map(|table| DeclaredRelation::table(table.name.as_str())),
+                .map(|table| DeclaredRelation::table(table.name.as_str()))
+                .chain(
+                    views
+                        .iter()
+                        .map(|view| DeclaredRelation::table(view.name.as_str())),
+                ),
         )?;
         let common =
             SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
@@ -711,9 +714,13 @@ impl FileSourceManifest {
             .into_iter()
             .map(|table| table.into_validated(&common.name))
             .collect::<Result<Vec<_>>>()?;
+        for view in &views {
+            validate_source_sql_view(&common.name, view)?;
+        }
         Ok(Self {
             common,
             tables,
+            views,
             declared_inputs,
         })
     }
@@ -1032,6 +1039,74 @@ mod tests {
                 ("session_file", "file_stem"),
                 ("event_index", "line_number"),
             ]
+        );
+    }
+
+    #[test]
+    fn file_manifest_accepts_source_scoped_views() {
+        let manifest = FileSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "logs",
+            "version": "0.1.0",
+            "backend": "file",
+            "tables": [{
+                "name": "events",
+                "description": "Raw events",
+                "format": "jsonl",
+                "source": { "location": "file:///tmp/logs/" },
+                "columns": [
+                    { "name": "type", "type": "Utf8" },
+                    { "name": "payload", "type": "Json" }
+                ],
+            }],
+            "views": [{
+                "name": "messages",
+                "description": "Projected messages",
+                "sql": "SELECT type, json_get_str(payload, 'text') AS text FROM logs.events",
+                "columns": [
+                    { "name": "type", "type": "Utf8" },
+                    { "name": "text", "type": "Utf8" }
+                ],
+            }],
+        }))
+        .expect("file views should parse");
+
+        let view = manifest
+            .views
+            .first()
+            .expect("manifest should include the declared view");
+        assert_eq!(view.name, "messages");
+        assert!(view.sql.contains("logs.events"));
+    }
+
+    #[test]
+    fn file_manifest_rejects_view_name_collisions() {
+        let error = FileSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "logs",
+            "version": "0.1.0",
+            "backend": "file",
+            "tables": [{
+                "name": "events",
+                "description": "Raw events",
+                "format": "jsonl",
+                "source": { "location": "file:///tmp/logs/" },
+                "columns": [{ "name": "type", "type": "Utf8" }],
+            }],
+            "views": [{
+                "name": "events",
+                "description": "Duplicate events",
+                "sql": "SELECT type FROM logs.events",
+                "columns": [{ "name": "type", "type": "Utf8" }],
+            }],
+        }))
+        .expect_err("table and view names should share one namespace");
+
+        assert!(
+            error
+                .to_string()
+                .contains("source 'logs' table 'events' is declared more than once"),
+            "{error}"
         );
     }
 

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -20,13 +20,14 @@ use crate::{
     ColumnSpec, DeclaredRelation, DetailHintDeclaringSurface, DetailHintSpec,
     DetailHintTargetTable, FilterSpec, HeaderSpec, ManifestError, ManifestInputSpec,
     PaginationSpec, ParsedTemplate, RequestRouteSpec, RequestSpec, ResponseSpec, Result,
-    SearchLimitsSpec, SourceBackend, SourceManifestCommon, SourceTableFunctionSpec, TableCommon,
+    SearchLimitsSpec, SourceBackend, SourceManifestCommon, SourceSqlViewSpec,
+    SourceTableFunctionSpec, TableCommon,
     inputs::{
         collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
     },
     validate::validate_template,
     validate_declared_relation_namespace, validate_detail_hint_references, validate_http_function,
-    validate_http_table, validate_test_queries,
+    validate_http_table, validate_source_sql_view, validate_test_queries,
 };
 
 /// Source-level authentication requirements for HTTP-backed source specs.
@@ -98,6 +99,7 @@ pub struct HttpSourceManifest {
     pub rate_limit: RateLimitSpec,
     pub tables: Vec<HttpTableSpec>,
     pub functions: Vec<SourceTableFunctionSpec>,
+    pub views: Vec<SourceSqlViewSpec>,
     pub declared_inputs: Vec<ManifestInputSpec>,
 }
 
@@ -126,6 +128,8 @@ struct RawHttpSourceManifest {
     tables: Vec<RawHttpTableSpec>,
     #[serde(default)]
     functions: Vec<SourceTableFunctionSpec>,
+    #[serde(default)]
+    views: Vec<SourceSqlViewSpec>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -282,6 +286,7 @@ impl HttpSourceManifest {
             inputs: _inputs,
             tables,
             functions,
+            views,
         } = raw;
         if tables.is_empty() && functions.is_empty() {
             return Err(ManifestError::validation(format!(
@@ -294,6 +299,11 @@ impl HttpSourceManifest {
             tables
                 .iter()
                 .map(|table| DeclaredRelation::table(table.name.as_str()))
+                .chain(
+                    views
+                        .iter()
+                        .map(|view| DeclaredRelation::table(view.name.as_str())),
+                )
                 .chain(
                     functions
                         .iter()
@@ -313,6 +323,9 @@ impl HttpSourceManifest {
                 Ok(function)
             })
             .collect::<Result<Vec<_>>>()?;
+        for view in &views {
+            validate_source_sql_view(&common.name, view)?;
+        }
         validate_http_detail_hints(&common.name, &tables, &functions)?;
         if base_url.raw().trim().is_empty() {
             return Err(ManifestError::validation(format!(
@@ -334,6 +347,7 @@ impl HttpSourceManifest {
             rate_limit,
             tables,
             functions,
+            views,
             declared_inputs,
         })
     }
@@ -392,5 +406,45 @@ pub(crate) fn test_http_table_spec(
         requests: vec![],
         response: ResponseSpec::default(),
         pagination: PaginationSpec::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parse_source_manifest_value;
+    use serde_json::json;
+
+    #[test]
+    fn http_manifest_accepts_source_scoped_views() {
+        let manifest = parse_source_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "github",
+            "version": "1.0.0",
+            "backend": "http",
+            "base_url": "https://api.github.com",
+            "tables": [{
+                "name": "issues",
+                "description": "Issues",
+                "request": { "path": "/issues" },
+                "columns": [
+                    { "name": "id", "type": "Int64" },
+                    { "name": "state", "type": "Utf8" }
+                ]
+            }],
+            "views": [{
+                "name": "open_issues",
+                "description": "Open issues",
+                "sql": "SELECT id FROM github.issues WHERE state = 'open'",
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }))
+        .expect("manifest should parse");
+        let http = manifest.as_http().expect("http manifest");
+        let view = http
+            .views
+            .first()
+            .expect("manifest should include the declared view");
+
+        assert_eq!(view.name, "open_issues");
     }
 }

--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -13,13 +13,13 @@ use serde_json::Value;
 use crate::{
     ColumnSpec, DeclaredRelation, FilterMode, FilterSpec, FunctionArgBinding, ManifestError,
     ManifestInputKind, ManifestInputSpec, PaginationSpec, RequestSpec, ResponseSpec, Result,
-    SourceBackend, SourceManifestCommon, SourceTableFunctionKind, SourceTableFunctionSpec,
-    TableCommon, TableFunctionArgSpec, ValueSourceSpec,
+    SourceBackend, SourceManifestCommon, SourceSqlViewSpec, SourceTableFunctionKind,
+    SourceTableFunctionSpec, TableCommon, TableFunctionArgSpec, ValueSourceSpec,
     inputs::{
         collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
     },
     validate_columns, validate_declared_relation_namespace, validate_filters_and_column_exprs,
-    validate_identifier, validate_test_queries, validate_unique_values,
+    validate_identifier, validate_source_sql_view, validate_test_queries, validate_unique_values,
 };
 
 /// Validated top-level manifest for a Model Context Protocol-backed source.
@@ -29,6 +29,7 @@ pub struct McpSourceManifest {
     pub server: McpServerSpec,
     pub functions: Vec<McpTableFunctionSpec>,
     pub tables: Vec<McpTableSpec>,
+    pub views: Vec<SourceSqlViewSpec>,
     pub declared_inputs: Vec<ManifestInputSpec>,
 }
 
@@ -50,6 +51,8 @@ struct RawMcpSourceManifest {
     functions: Vec<RawMcpTableFunctionSpec>,
     #[serde(default)]
     tables: Vec<RawMcpTableSpec>,
+    #[serde(default)]
+    views: Vec<SourceSqlViewSpec>,
 }
 
 /// MCP server connection settings.
@@ -390,6 +393,7 @@ impl McpSourceManifest {
             server,
             functions,
             tables,
+            views,
         } = raw;
 
         if functions.is_empty() && tables.is_empty() {
@@ -404,6 +408,11 @@ impl McpSourceManifest {
             tables
                 .iter()
                 .map(|table| DeclaredRelation::table(table.name.as_str()))
+                .chain(
+                    views
+                        .iter()
+                        .map(|view| DeclaredRelation::table(view.name.as_str())),
+                )
                 .chain(
                     functions
                         .iter()
@@ -420,12 +429,16 @@ impl McpSourceManifest {
             .into_iter()
             .map(|table| table.into_validated(&common.name))
             .collect::<Result<Vec<_>>>()?;
+        for view in &views {
+            validate_source_sql_view(&common.name, view)?;
+        }
 
         Ok(Self {
             common,
             server,
             functions,
             tables,
+            views,
             declared_inputs,
         })
     }
@@ -1794,5 +1807,37 @@ mod tests {
             error.to_string(),
             "source 'demo' must define at least one function or table"
         );
+    }
+
+    #[test]
+    fn accepts_source_scoped_views() {
+        let manifest = McpSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "mcp",
+            "server": { "transport": "stdio", "command": "demo-mcp-server" },
+            "tables": [{
+                "name": "issues",
+                "tool": "list_issues",
+                "columns": [
+                    { "name": "id", "type": "Utf8" },
+                    { "name": "state", "type": "Utf8" }
+                ]
+            }],
+            "views": [{
+                "name": "open_issues",
+                "description": "Open issues",
+                "sql": "SELECT id FROM demo.issues WHERE state = 'open'",
+                "columns": [{ "name": "id", "type": "Utf8" }]
+            }]
+        }))
+        .expect("manifest should parse");
+        let view = manifest
+            .views
+            .first()
+            .expect("manifest should include the declared view");
+
+        assert_eq!(view.name, "open_issues");
     }
 }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -134,6 +134,18 @@ impl TableCommon {
     }
 }
 
+/// Declarative source-scoped SQL view.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceSqlViewSpec {
+    pub name: String,
+    pub description: String,
+    #[serde(default)]
+    pub guide: String,
+    pub sql: String,
+    pub columns: Vec<ColumnSpec>,
+}
+
 /// How a filter value is matched against `SQL` predicates.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -98,8 +98,9 @@ pub use common::{
     FunctionArgBinding, HeaderSpec, HttpMethod, ManifestDataType, PageSizeSpec, PaginationMode,
     PaginationSpec, QueryParamSpec, RequestRouteSpec, RequestSpec, ResponseBodyFormat,
     ResponseSpec, RowStrategy, SearchLimitsSpec, SourceBackend, SourceManifestCommon,
-    SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon, TableFunctionArgSpec,
-    TimestampInput, ValidatedPagination, ValidatedPaginationMode, ValueSourceSpec,
+    SourceSqlViewSpec, SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon,
+    TableFunctionArgSpec, TimestampInput, ValidatedPagination, ValidatedPaginationMode,
+    ValueSourceSpec,
 };
 pub use error::{ManifestError, Result};
 pub use inputs::{
@@ -119,5 +120,5 @@ pub(crate) use validate::{
     DeclaredRelation, DetailHintDeclaringSurface, DetailHintTargetTable, validate_columns,
     validate_declared_relation_namespace, validate_detail_hint_references,
     validate_filters_and_column_exprs, validate_http_function, validate_http_table,
-    validate_identifier, validate_unique_values,
+    validate_identifier, validate_source_sql_view, validate_unique_values,
 };

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -94,6 +94,64 @@ tables:
     }
 
     #[test]
+    fn parse_source_manifest_yaml_accepts_http_source_sql_views() {
+        parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Demo messages
+    request:
+      path: /messages
+    columns:
+      - name: id
+        type: Int64
+views:
+  - name: message_ids
+    description: Message ids
+    sql: SELECT id FROM demo.messages
+    columns:
+      - name: id
+        type: Int64
+",
+        )
+        .expect("HTTP source SQL views should pass schema and parser validation");
+    }
+
+    #[test]
+    fn parse_source_manifest_yaml_accepts_mcp_source_sql_views() {
+        parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: mcp
+server:
+  transport: stdio
+  command: demo-mcp-server
+tables:
+  - name: messages
+    tool: list_messages
+    columns:
+      - name: id
+        type: Utf8
+views:
+  - name: message_ids
+    description: Message ids
+    sql: SELECT id FROM demo.messages
+    columns:
+      - name: id
+        type: Utf8
+",
+        )
+        .expect("MCP source SQL views should pass schema and parser validation");
+    }
+
+    #[test]
     fn validate_manifest_schema_accepts_quoted_sql_table_names() {
         let manifest = manifest_json(
             r"

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -20,6 +20,9 @@
           "tables": {
             "items": { "$ref": "#/$defs/http_table" }
           },
+          "views": {
+            "items": { "$ref": "#/$defs/source_sql_view" }
+          },
           "functions": {
             "items": { "$ref": "#/$defs/table_function" }
           }
@@ -36,6 +39,9 @@
         "properties": {
           "tables": {
             "items": { "$ref": "#/$defs/file_table" }
+          },
+          "views": {
+            "items": { "$ref": "#/$defs/source_sql_view" }
           }
         }
       }
@@ -54,6 +60,9 @@
         "properties": {
           "tables": {
             "items": { "$ref": "#/$defs/mcp_table" }
+          },
+          "views": {
+            "items": { "$ref": "#/$defs/source_sql_view" }
           },
           "functions": {
             "items": { "$ref": "#/$defs/mcp_table_function" }
@@ -87,6 +96,11 @@
       "items": { "type": "object" }
     },
     "functions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "object" }
+    },
+    "views": {
       "type": "array",
       "minItems": 1,
       "items": { "type": "object" }
@@ -454,6 +468,22 @@
         "format_options": { "$ref": "#/$defs/format_options" },
         "columns": {
           "type": "array",
+          "items": { "$ref": "#/$defs/column" }
+        }
+      }
+    },
+    "source_sql_view": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "description", "sql", "columns"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "guide": { "type": "string" },
+        "sql": { "type": "string", "minLength": 1 },
+        "columns": {
+          "type": "array",
+          "minItems": 1,
           "items": { "$ref": "#/$defs/column" }
         }
       }

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use crate::common::{
     BodySpec, ColumnSpec, DetailHintSpec, ExprSpec, FilterSpec, FunctionArgBinding,
     MAX_SEARCH_CALLS_PER_QUERY, MAX_SEARCH_CANDIDATES_PER_QUERY, MAX_SEARCH_TOP_K, PaginationSpec,
-    RequestRouteSpec, RequestSpec, SearchLimitsSpec, SourceTableFunctionKind,
+    RequestRouteSpec, RequestSpec, SearchLimitsSpec, SourceSqlViewSpec, SourceTableFunctionKind,
     SourceTableFunctionSpec, ValueSourceSpec,
 };
 use crate::{ManifestError, ParsedTemplate, Result, TemplateNamespace};
@@ -86,6 +86,39 @@ pub(crate) fn validate_declared_relation_namespace<'a>(
             };
         }
         namespace.insert(key, relation.kind);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_source_sql_view(schema: &str, view: &SourceSqlViewSpec) -> Result<()> {
+    if view.sql.trim().is_empty() {
+        return Err(ManifestError::validation(format!(
+            "{schema}.{} view sql must not be empty",
+            view.name
+        )));
+    }
+    if view.columns.is_empty() {
+        return Err(ManifestError::validation(format!(
+            "{schema}.{} view must define columns",
+            view.name
+        )));
+    }
+
+    validate_columns(&view.columns, schema, &view.name)?;
+    for column in &view.columns {
+        if column.r#virtual {
+            return Err(ManifestError::validation(format!(
+                "{schema}.{} view column '{}' is virtual, which is not supported for source SQL views",
+                view.name, column.name
+            )));
+        }
+        if column.expr.is_some() {
+            return Err(ManifestError::validation(format!(
+                "{schema}.{} view column '{}' uses expr, which is not supported for source SQL views; use SQL expressions instead",
+                view.name, column.name
+            )));
+        }
     }
 
     Ok(())

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -443,6 +443,38 @@ same name as a metadata column, queries see the declared metadata value for
 that column name. File metadata preserves the object-store path text; literal
 percent sequences in object keys are not URL-decoded again.
 
+### Source SQL views
+
+DSL3 `file`, `http`, and `mcp` sources can declare read-only SQL views in a
+top-level `views` array. Views are registered in the same source schema after
+the source's provider-backed tables, so they can expose ergonomic derived
+surfaces over raw provider tables without copying or rewriting source data.
+
+```yaml
+views:
+  - name: sessions
+    description: One row per session file
+    sql: |
+      SELECT session_file, COUNT(*) AS event_count
+      FROM codex.events
+      GROUP BY session_file
+    columns:
+      - name: session_file
+        type: Utf8
+      - name: event_count
+        type: Int64
+```
+
+View names share the same namespace as tables and table functions. A view must
+declare its output `columns`; those columns are surfaced through `coral.columns`
+and `coral.tables`. View columns do not support `virtual` or `expr` metadata;
+use SQL expressions in the view query instead. The SQL is executed by
+DataFusion and must reference at least one table in the same source using the
+source schema name, such as `codex.events`. Constant views such as `SELECT 1 AS
+id` are rejected. Views cannot reference other source schemas, table functions,
+or unqualified base table names, so view behavior does not depend on source
+registration order.
+
 ## HTTP-backed tables
 
 For `http`, the source spec declares request and response behavior.


### PR DESCRIPTION
## Intent

Expose PR #1164's private SQL-backed source relation runtime through the DSL3
source spec.

This is for source-authored derived tables: raw provider tables stay raw, and
the source can publish stable table-shaped surfaces over them. The motivating
case is still Codex transcript ingestion, where `codex.events` is the audit log
and surfaces such as `codex.messages` and `codex.sessions` should be ordinary
queryable catalog tables.

## What Changed

- DSL3 `file`, `http`, and `mcp` manifests accept a top-level `views` array.
- Views declare `name`, `description`, `sql`, and output `columns`.
- View names share the source relation namespace with tables and table functions.
- View columns are discoverable through `coral.tables` and `coral.columns`.
- The three backend compilers register views through the same SQL-backed source
  relation path added in PR #1164.
- The v4 OpenAPI materialization path is unchanged; generated HTTP components
  currently carry no views.

## Boundaries

- This is DSL3 source-authored derived tables, not a general saved-view or memory
  surface.
- Views must reference source-local base tables using the source schema name.
- Constant/static views are rejected by the runtime.
- Cross-source views are rejected by the runtime.
- View-on-view is not included.
- Views over table functions are not included.
- DSL4/v4 derived projection design is left for a separate discussion.

## Validation

- `make rust-checks`
- Focused parser/schema tests for HTTP and MCP `views`.
- Focused runtime tests for file, HTTP, and MCP declared SQL views.
- Real-config smoke with a throwaway DSL3 HTTP source over the live Canada
  Holidays API:
  - installed `public_http_view_smoke`
  - queried `public_http_view_smoke.federal_holidays`
  - verified `coral.tables` and `coral.columns`
  - removed the throwaway source afterwards
