### PR TITLE
feat(trajectory): episodes — associate each query with the intent it served (BENCH-496)

### DIFF
--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -20,6 +20,7 @@ fn main() {
                 "proto/coral/v1/sources.proto",
                 "proto/coral/v1/query.proto",
                 "proto/coral/v1/traces.proto",
+                "proto/coral/v1/episode.proto",
             ],
             &["proto"],
         )

--- a/crates/coral-api/proto/coral/v1/episode.proto
+++ b/crates/coral-api/proto/coral/v1/episode.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/resources.proto";
+
+// Episode lifecycle for trajectory memory (experimental; gated by the `episodes`
+// feature). An *episode* is one task-attempt — its queries grouped under one
+// intent. `OpenEpisode` registers the intent (and optional parent) against a
+// client-minted episode id; every subsequent Coral call then carries only the
+// opaque `coral-episode-id` metadata key, so intent never rides tool calls.
+service EpisodeService {
+  // Registers an episode: records `{ episode_id -> intent, parent }` once, into
+  // the per-workspace episode store. Idempotent for an identical
+  // `{ episode_id, intent, parent_episode_id }`; the same `episode_id` with a
+  // different intent/parent is an error.
+  rpc OpenEpisode(OpenEpisodeRequest) returns (OpenEpisodeResponse);
+}
+
+// Registers an episode: its intent (and optional parent) keyed by a
+// client-minted id. See `EpisodeService.OpenEpisode`.
+message OpenEpisodeRequest {
+  // Workspace that scopes the episode (per-tenant isolation).
+  Workspace workspace = 1;
+  // Client-minted, opaque episode id (e.g. a UUID). Carried on every subsequent
+  // call as the `coral-episode-id` metadata key.
+  string episode_id = 2;
+  // Natural-language task description — the retrieval handle. Possibly PII;
+  // persisted only in the episode store, never on spans, headers, or logs.
+  string intent = 3;
+  // Set for a child episode (a sub-task); links to the open parent episode.
+  optional string parent_episode_id = 4;
+}
+
+// Acknowledgement; intentionally empty for v1.
+message OpenEpisodeResponse {}

--- a/crates/coral-api/proto/coral/v1/episode.proto
+++ b/crates/coral-api/proto/coral/v1/episode.proto
@@ -22,14 +22,20 @@ service EpisodeService {
 message OpenEpisodeRequest {
   // Workspace that scopes the episode (per-tenant isolation).
   Workspace workspace = 1;
-  // Client-minted, opaque episode id (e.g. a UUID). Carried on every subsequent
-  // call as the `coral-episode-id` metadata key.
+  // Client-minted, opaque episode id (e.g. a UUID or ULID). Carried on every
+  // subsequent call as the `coral-episode-id` gRPC metadata value, so it must be
+  // a valid ASCII metadata value: graphic ASCII only (0x21–0x7E — no spaces,
+  // control bytes, or non-ASCII) and at most 128 bytes. The server validates and
+  // rejects ids outside this contract with `INVALID_ARGUMENT`.
   string episode_id = 2;
   // Natural-language task description — the retrieval handle. Possibly PII;
   // persisted only in the episode store, never on spans, headers, or logs.
+  // Required and non-empty, bounded in length; not carried as metadata.
   string intent = 3;
   // Set for a child episode (a sub-task); links to the open parent episode.
-  optional string parent_episode_id = 4;
+  // Empty when there is no parent (a root episode); otherwise the same format
+  // contract as `episode_id`.
+  string parent_episode_id = 4;
 }
 
 // Acknowledgement; intentionally empty for v1.

--- a/crates/coral-api/proto/coral/v1/episode.proto
+++ b/crates/coral-api/proto/coral/v1/episode.proto
@@ -30,7 +30,9 @@ message OpenEpisodeRequest {
   string episode_id = 2;
   // Natural-language task description — the retrieval handle. Possibly PII;
   // persisted only in the episode store, never on spans, headers, or logs.
-  // Required and non-empty, bounded in length; not carried as metadata.
+  // Required and non-empty (trimmed) and at most 4096 characters; the server
+  // rejects a blank or over-long intent with `INVALID_ARGUMENT`. Not carried as
+  // metadata.
   string intent = 3;
   // Set for a child episode (a sub-task); links to the open parent episode.
   // Empty when there is no parent (a root episode); otherwise the same format

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -15,8 +15,9 @@ use crate::state::{
 pub enum Feature {
     /// Expose the optional MCP `feedback` tool.
     Feedback,
-    /// Experimental trajectory-memory episode capture: associate each query with
-    /// the intent it served (`OpenEpisode` + the `coral-episode-id` metadata key).
+    /// Experimental trajectory-memory episodes (in progress): will associate each
+    /// query with the intent it served (`OpenEpisode` + the `coral-episode-id`
+    /// metadata key). No effect yet — the capture path is wired in a follow-up.
     Episodes,
 }
 
@@ -81,7 +82,7 @@ const FEATURE_SPECS: &[FeatureSpec] = &[
         feature: Feature::Episodes,
         key: "episodes",
         default_enabled: false,
-        description: "Experimental trajectory memory: associate each query with the intent it served. Records episode metadata (intent, parent) locally per workspace; off by default.",
+        description: "Experimental trajectory memory (in progress): will associate each query with the intent it served. Enabling this has no effect yet — the capture path lands in a follow-up. Off by default.",
         enable_flag: "enable-episodes",
         disable_flag: "disable-episodes",
     },

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -15,6 +15,9 @@ use crate::state::{
 pub enum Feature {
     /// Expose the optional MCP `feedback` tool.
     Feedback,
+    /// Experimental trajectory-memory episode capture: associate each query with
+    /// the intent it served (`OpenEpisode` + the `coral-episode-id` metadata key).
+    Episodes,
 }
 
 impl Feature {
@@ -65,14 +68,24 @@ struct FeatureSpec {
     disable_flag: &'static str,
 }
 
-const FEATURE_SPECS: &[FeatureSpec] = &[FeatureSpec {
-    feature: Feature::Feedback,
-    key: "feedback",
-    default_enabled: false,
-    description: "Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral.",
-    enable_flag: "enable-feedback",
-    disable_flag: "disable-feedback",
-}];
+const FEATURE_SPECS: &[FeatureSpec] = &[
+    FeatureSpec {
+        feature: Feature::Feedback,
+        key: "feedback",
+        default_enabled: false,
+        description: "Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral.",
+        enable_flag: "enable-feedback",
+        disable_flag: "disable-feedback",
+    },
+    FeatureSpec {
+        feature: Feature::Episodes,
+        key: "episodes",
+        default_enabled: false,
+        description: "Experimental trajectory memory: associate each query with the intent it served. Records episode metadata (intent, parent) locally per workspace; off by default.",
+        enable_flag: "enable-episodes",
+        disable_flag: "disable-episodes",
+    },
+];
 
 /// How a feature's value is configured in Coral's local config.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## BENCH-496 — Episodes: associate each query with the intent it served

**PR 1 of the trajectory-memory slice.** Full spec in [Linear BENCH-496](https://linear.app/withcoral/issue/BENCH-496/episodes-associate-each-query-with-the-intent-it-served).

Trajectory memory indexes/retrieves by **intent** — a task's queries grouped under one semantic description (_intent grain: one intent → one distilled trajectory_). This PR makes the **intent → queries** association native to Coral.

### Design (decided)

- **`OpenEpisode(episode_id, intent, parent_episode_id?)`** — one control-plane RPC, called **once** per episode. The **client mints** `episode_id` (a trace/span-id analog), so the call is fire-and-forget. Intent + parent go in the **body** → recorded in the per-tenant episode store. Idempotent for an identical `{id, intent, parent}`; the same `episode_id` with a different intent/parent is an error.
- **Per-call** **`coral-episode-id`** **metadata** on every Coral call → server stamps `episode.id` on the `coral.query` span (attribution only). **Header is the default** (plain gRPC metadata, any language, no OTel dep); **OTel baggage** **`episode.id`** **accepted** for distributed clients.
- **Episode store** (`coral.episodes`, per-workspace, JSONL → Parquet) holds the intent; capture (PR 2) joins query spans by `episode.id`. **Intent is never on spans, headers, baggage, or logs.**
- **Child episodes** via `parent_episode_id`.
- **Feature-gated** behind the off-by-default `episodes` feature → byte-identical when disabled.

### Increments

- [x] `episodes` feature flag (off by default) — `crates/coral-app/src/features.rs`
- [x] `EpisodeService.OpenEpisode` proto — `crates/coral-api/proto/coral/v1/episode.proto`
- [ ] `OpenEpisode` handler + per-tenant episode store (feature-gated registration)
- [ ] `coral-episode-id` metadata extraction → `episode.id` on the `coral.query` span
- [ ] `coral-client` interceptor + unit/integration tests

### Guardrails

- **Additive & byte-identical** with the feature off (no `OpenEpisode`, `coral-episode-id` ignored, no `episode.id` attribute, no capture).
- **Procedure, not data** — only the intent label + episode metadata are recorded; the `sql` result contract is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)