### PR TITLE
fix(spec): require omitted OpenAPI path params

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -616,6 +616,58 @@ paths:
 }
 
 #[test]
+fn importer_treats_path_parameters_as_required_when_required_is_omitted() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: omitted_path_required
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /tenants/{tenant}/items/{id}:
+    get:
+      operationId: items/get
+      parameters:
+        - {name: id, in: path, required: false, schema: {type: string}}
+        - {name: tenant, in: path, schema: {type: string, default: public}}
+        - {name: include_archived, in: query, schema: {type: boolean}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+    let operation = ir.operations.first().expect("operation");
+    let required = operation
+        .inputs
+        .iter()
+        .map(|input| (input.name.as_str(), input.required))
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(required.get("id"), Some(&true));
+    assert_eq!(required.get("tenant"), Some(&true));
+    assert_eq!(required.get("include_archived"), Some(&false));
+}
+
+#[test]
 fn importer_warns_for_invalid_parameters_and_unresolved_responses() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use super::naming::{pluralize, singularize};
 use super::test_support::github_openapi;
 use super::*;
-use crate::{PaginationMode, parse_source_manifest_yaml};
+use crate::{PaginationMode, SourceTableFunctionKind, parse_source_manifest_yaml};
 
 #[test]
 fn imports_and_generates_github_issue_slice() {
@@ -148,6 +148,67 @@ surfaces:
         .collect::<BTreeSet<_>>();
     assert!(!stale_arg_names.contains("page"));
     assert!(!stale_arg_names.contains("per_page"));
+}
+
+#[test]
+fn projection_generation_uses_omitted_path_required_for_table_function_args() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: path_required
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items/{id}:
+    get:
+      operationId: items/get
+      parameters:
+        - {name: id, in: path, required: false, schema: {type: string, default: public}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
+    let projection = catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == "items_get")
+        .expect("projection");
+    assert!(matches!(
+        projection.kind,
+        ProjectionKind::TableFunction {
+            function_kind: SourceTableFunctionKind::Table
+        }
+    ));
+    let id_input = projection
+        .inputs
+        .iter()
+        .find(|input| input.wire_name == "id")
+        .expect("id input");
+    assert_eq!(id_input.sql_exposure, SqlInputExposure::FunctionArg);
+    assert!(id_input.required);
+    assert_eq!(id_input.default_value.as_deref(), Some("public"));
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -106,7 +106,7 @@ fn generate_projection(
                 sql_exposure: exposure,
                 source_location: input.location,
                 wire_name: input.name.clone(),
-                required: input.required && input.default_value.is_none(),
+                required: projection_input_required(input),
                 data_type: manifest_type(input.data_type),
                 default_value: input.default_value.clone(),
                 description: input.description.clone(),
@@ -140,6 +140,11 @@ fn generate_projection(
     };
     diagnostics.extend(projection_diagnostics);
     projection
+}
+
+fn projection_input_required(input: &IrOperationInput) -> bool {
+    input.required
+        && (input.location == OpenApiParameterLocation::Path || input.default_value.is_none())
 }
 
 fn projection_input_sql_exposure(

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -155,10 +155,7 @@ impl OpenApiImporter<'_> {
                 Some(IrOperationInput {
                     name,
                     location,
-                    required: parameter_obj
-                        .get("required")
-                        .and_then(Value::as_bool)
-                        .unwrap_or(false),
+                    required: parameter_is_required(parameter_obj, location),
                     data_type: scalar,
                     default_value: schema.get("default").map(openapi_default_to_string),
                     description: parameter_obj
@@ -266,6 +263,19 @@ fn parse_parameter_location(location: &str) -> Option<OpenApiParameterLocation> 
         "cookie" => Some(OpenApiParameterLocation::Cookie),
         _ => None,
     }
+}
+
+fn parameter_is_required(
+    parameter_obj: &Map<String, Value>,
+    location: OpenApiParameterLocation,
+) -> bool {
+    if location == OpenApiParameterLocation::Path {
+        return true;
+    }
+    parameter_obj
+        .get("required")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn openapi_default_to_string(value: &Value) -> String {


### PR DESCRIPTION
## Summary

- Treat OpenAPI path parameters as required when their `required` flag is omitted during DSL v4 import.
- Preserve omitted non-path parameters as optional.
- Add focused importer and projection coverage so singleton path operations become table functions with required args.

Fixes #1155.

## Tests

- `cargo test -p coral-spec importer_treats_path_parameters_as_required_when_required_is_omitted`
- `cargo test -p coral-spec projection_generation_uses_omitted_path_required_for_table_function_args`
- `make rust-checks`

## Risks

Low. This changes DSL v4 OpenAPI import behavior only for path parameters with omitted `required`; OpenAPI treats path parameters as required, and explicit non-path behavior is preserved.

Project: https://github.com/orgs/withcoral/projects/1