### PR TITLE
fix(spec): handle OpenAPI 2XX responses

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -289,6 +289,82 @@ components:
 }
 
 #[test]
+fn importer_handles_2xx_response_range_success_codes() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: response_ranges
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /range-items:
+    get:
+      operationId: range/list
+      responses:
+        '2XX':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+  /numeric-items:
+    get:
+      operationId: numeric/list
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+        '2XX':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("response range imports");
+    let operations = ir
+        .operations
+        .iter()
+        .map(|operation| (operation.id.as_str(), operation))
+        .collect::<BTreeMap<_, _>>();
+
+    let range = operations.get("range_list").expect("range operation");
+    assert_eq!(range.output.cardinality, OutputCardinality::List);
+    let IrExecutionAttachment::Rest(range_rest) = &range.execution;
+    assert_eq!(range_rest.response.status_code, 200);
+
+    let numeric = operations.get("numeric_list").expect("numeric operation");
+    assert_eq!(numeric.output.cardinality, OutputCardinality::List);
+    let IrExecutionAttachment::Rest(numeric_rest) = &numeric.execution;
+    assert_eq!(numeric_rest.response.status_code, 201);
+}
+
+#[test]
 fn importer_warns_for_unresolved_response_object_refs() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -104,14 +104,12 @@ impl OpenApiImporter<'_> {
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Option<(u16, String, Value)> {
         let responses = responses?;
-        let mut candidates = Vec::new();
+        let mut numeric_candidates = Vec::new();
+        let mut range_candidates = Vec::new();
         for (status, response) in responses {
-            let Ok(status_code) = status.parse::<u16>() else {
+            let Some(status) = success_response_status(status) else {
                 continue;
             };
-            if !(200..300).contains(&status_code) {
-                continue;
-            }
             let Some(response) = self.resolve_ref(response, operation_id, diagnostics) else {
                 continue;
             };
@@ -122,14 +120,60 @@ impl OpenApiImporter<'_> {
                 continue;
             };
             let schema = json.get("schema").cloned().unwrap_or(Value::Null);
-            candidates.push((status_code, "application/json".to_string(), schema));
+            let candidate = (
+                status.representative_status_code(),
+                "application/json".to_string(),
+                schema,
+            );
+            if status.is_range() {
+                range_candidates.push(candidate);
+            } else {
+                numeric_candidates.push(candidate);
+            }
         }
-        candidates
-            .iter()
-            .position(|(status, _, _)| *status == 200)
-            .and_then(|index| candidates.get(index).cloned())
-            .or_else(|| candidates.into_iter().min_by_key(|(status, _, _)| *status))
+        preferred_numeric_response(numeric_candidates)
+            .or_else(|| range_candidates.into_iter().next())
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SuccessResponseStatus {
+    Numeric(u16),
+    Range2xx,
+}
+
+impl SuccessResponseStatus {
+    fn representative_status_code(self) -> u16 {
+        match self {
+            Self::Numeric(status_code) => status_code,
+            Self::Range2xx => 200,
+        }
+    }
+
+    fn is_range(self) -> bool {
+        matches!(self, Self::Range2xx)
+    }
+}
+
+fn success_response_status(status: &str) -> Option<SuccessResponseStatus> {
+    if let Ok(status_code) = status.parse::<u16>() {
+        return (200..300)
+            .contains(&status_code)
+            .then_some(SuccessResponseStatus::Numeric(status_code));
+    }
+    status
+        .eq_ignore_ascii_case("2XX")
+        .then_some(SuccessResponseStatus::Range2xx)
+}
+
+fn preferred_numeric_response(
+    candidates: Vec<(u16, String, Value)>,
+) -> Option<(u16, String, Value)> {
+    candidates
+        .iter()
+        .position(|(status, _, _)| *status == 200)
+        .and_then(|index| candidates.get(index).cloned())
+        .or_else(|| candidates.into_iter().min_by_key(|(status, _, _)| *status))
 }
 
 fn classify_response_schema(


### PR DESCRIPTION
## Summary
- recognize OpenAPI `2XX` response-range keys as successful JSON responses during v4 import
- preserve numeric 2xx precedence when concrete response codes are present
- add focused importer coverage for range-only and mixed numeric/range responses

## Tests
- `cargo test -p coral-spec importer_handles_2xx_response_range_success_codes`
- `make rust-checks`

## Risks
- Low. The change only broadens success-response selection for the OpenAPI range key and keeps existing numeric response ordering intact.

Fixes #1151
Project: https://github.com/orgs/withcoral/projects/1