### PR TITLE
feat(mcp): add Slack and GitHub MCP sources

### DIFF
--- a/crates/coral-engine/src/backends/mcp/function.rs
+++ b/crates/coral-engine/src/backends/mcp/function.rs
@@ -3,8 +3,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use coral_spec::ResponseSpec;
 use coral_spec::backends::mcp::{McpPaginationSpec, McpTableFunctionSpec};
+use coral_spec::{ResponseSpec, ValueSourceSpec};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::catalog::TableFunctionImpl;
 use datafusion::datasource::TableProvider;
@@ -14,6 +14,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::scalar::ScalarValue;
 use serde_json::Value;
 
+use super::McpSourceInputs;
 use super::client::McpSourceClient;
 use super::error::McpProviderQueryError;
 use super::fetch::McpFetchPlan;
@@ -34,6 +35,8 @@ struct McpFunctionState {
     tool_name: String,
     schema: SchemaRef,
     response: ResponseSpec,
+    source_inputs: Arc<McpSourceInputs>,
+    source_tool_args: Arc<BTreeMap<String, ValueSourceSpec>>,
     pagination: Option<McpPaginationSpec>,
     columns: Arc<[coral_spec::ColumnSpec]>,
     fetch_limit_default: Option<usize>,
@@ -63,12 +66,14 @@ impl McpSourceTableFunction {
     pub(super) fn new(
         backend: McpSourceClient,
         source_schema: String,
+        source_inputs: Arc<McpSourceInputs>,
         function: McpTableFunctionSpec,
     ) -> Result<Self> {
         let schema = schema_from_columns(function.columns(), &source_schema, function.name())?;
         let function_name = function.name().to_string();
         let tool_name = function.tool.clone();
         let response = function.common.response.clone();
+        let source_tool_args = Arc::new(function.tool_args.clone());
         let columns = function.common.columns.clone();
         let fetch_limit_default = function.fetch_limit_default();
         let pagination = function.pagination.clone();
@@ -81,6 +86,8 @@ impl McpSourceTableFunction {
                 tool_name,
                 schema,
                 response,
+                source_inputs,
+                source_tool_args,
                 pagination,
                 columns: Arc::from(columns),
                 fetch_limit_default,
@@ -156,8 +163,8 @@ impl TableProvider for McpFunctionCallTableProvider {
             relation: self.state.function_name.clone(),
             tool_name: self.state.tool_name.clone(),
             arguments,
-            source_inputs: None,
-            source_tool_args: Arc::new(BTreeMap::default()),
+            source_inputs: Some(Arc::clone(&self.state.source_inputs)),
+            source_tool_args: Arc::clone(&self.state.source_tool_args),
             response: self.state.response.clone(),
             pagination: self.state.pagination.clone(),
             limit: limit.or(self.state.fetch_limit_default),

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -161,6 +161,7 @@ impl CompiledBackendSource for McpCompiledSource {
             let function_impl: Arc<dyn TableFunctionImpl> = Arc::new(McpSourceTableFunction::new(
                 self.caller.clone(),
                 self.manifest.common.name.clone(),
+                Arc::clone(&self.source_inputs),
                 function.clone(),
             )?);
             table_functions.insert(internal_name.clone(), function_impl);

--- a/crates/coral-engine/src/backends/mcp/response.rs
+++ b/crates/coral-engine/src/backends/mcp/response.rs
@@ -44,14 +44,9 @@ pub(super) fn normalize_tool_result(
     let mut saw_non_text_content = false;
     for content in &result.content {
         if let Some(text) = extract_text_payload(content) {
-            return serde_json::from_str(text).map_err(|error| {
-                DataFusionError::External(Box::new(McpProviderQueryError::ResultDecode {
-                    source_schema: source_schema.to_string(),
-                    relation: relation.to_string(),
-                    tool: tool_name.to_string(),
-                    detail: error.to_string(),
-                }))
-            });
+            return Ok(
+                serde_json::from_str(text).unwrap_or_else(|_| Value::String(text.to_string()))
+            );
         }
         saw_non_text_content = true;
     }
@@ -82,4 +77,42 @@ fn extract_text_payload(content: &rmcp::model::Content) -> Option<&str> {
         return Some(text.as_str());
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use rmcp::model::{CallToolResult, Content};
+    use serde_json::json;
+
+    use super::normalize_tool_result;
+
+    fn text_result(text: &str) -> CallToolResult {
+        CallToolResult::success(vec![Content::text(text.to_string())])
+    }
+
+    #[test]
+    fn normalize_tool_result_decodes_json_text_content() {
+        let payload = normalize_tool_result(
+            "demo",
+            "messages",
+            "search_messages",
+            text_result(r#"{"items":[{"id":"1"}]}"#),
+        )
+        .expect("payload");
+
+        assert_eq!(payload, json!({ "items": [{ "id": "1" }] }));
+    }
+
+    #[test]
+    fn normalize_tool_result_preserves_plain_text_content() {
+        let payload = normalize_tool_result(
+            "demo",
+            "messages",
+            "search_messages",
+            text_result("## Results\n\nNo matching messages."),
+        )
+        .expect("payload");
+
+        assert_eq!(payload, json!("## Results\n\nNo matching messages."));
+    }
 }

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -274,6 +274,58 @@ async fn executes_mcp_table_function_with_bound_args() {
 }
 
 #[tokio::test]
+async fn executes_mcp_table_function_with_manifest_tool_args() {
+    let ctx = SessionContext::new();
+    let caller = Arc::new(FakeMcpCaller {
+        calls: Mutex::new(Vec::new()),
+    });
+    let manifest = coral_spec::parse_source_manifest_value(json!({
+        "dsl_version": 3,
+        "name": "test_mcp",
+        "version": "0.1.0",
+        "backend": "mcp",
+        "server": { "transport": "stdio", "command": "unused" },
+        "functions": [{
+            "name": "pull_request_diff",
+            "tool": "pull_request_read",
+            "tool_args": {
+                "method": { "from": "literal", "value": "get_diff" }
+            },
+            "args": [{
+                "name": "pull_number",
+                "required": true,
+                "bind": { "arg": "pullNumber" }
+            }],
+            "response": { "rows_path": ["items"] },
+            "columns": [
+                { "name": "title", "type": "Utf8" },
+                { "name": "url", "type": "Utf8" }
+            ]
+        }]
+    }))
+    .expect("mcp manifest should parse");
+    register_test_sources(&ctx, compile_sources(manifest, caller.clone()));
+
+    let _ = ctx
+        .sql("SELECT title FROM test_mcp.pull_request_diff(pull_number => 42)")
+        .await
+        .expect("query should plan")
+        .collect()
+        .await
+        .expect("query should execute");
+
+    let calls = caller.calls.lock().expect("calls lock");
+    assert_eq!(calls.len(), 1);
+    let call = calls.first().expect("one MCP call should be recorded");
+    assert_eq!(call.0, "pull_request_read");
+    assert_eq!(
+        call.1.get("method"),
+        Some(&Value::String("get_diff".to_string()))
+    );
+    assert_eq!(call.1.get("pullNumber"), Some(&Value::from(42)));
+}
+
+#[tokio::test]
 async fn mcp_table_function_preserves_json_scalar_arg_types() {
     let ctx = SessionContext::new();
     let caller = Arc::new(FakeMcpCaller {

--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -121,6 +121,8 @@ struct RawMcpTableFunctionSpec {
     #[serde(default)]
     fetch_limit_default: Option<usize>,
     #[serde(default)]
+    tool_args: BTreeMap<String, ValueSourceSpec>,
+    #[serde(default)]
     args: Vec<TableFunctionArgSpec>,
     #[serde(default)]
     pagination: Option<McpPaginationSpec>,
@@ -135,6 +137,7 @@ struct RawMcpTableFunctionSpec {
 pub struct McpTableFunctionSpec {
     pub common: SourceTableFunctionSpec,
     pub tool: String,
+    pub tool_args: BTreeMap<String, ValueSourceSpec>,
     pub pagination: Option<McpPaginationSpec>,
 }
 
@@ -305,6 +308,7 @@ impl RawMcpTableFunctionSpec {
         validate_mcp_function(source_name, &self)?;
         Ok(McpTableFunctionSpec {
             tool: self.tool,
+            tool_args: self.tool_args,
             pagination: self.pagination,
             common: SourceTableFunctionSpec {
                 name: self.name,
@@ -572,6 +576,27 @@ fn validate_mcp_function(source_name: &str, function: &RawMcpTableFunctionSpec) 
 
     let mut arg_names = HashSet::new();
     let mut request_arg_names = HashSet::new();
+    for (name, source) in &function.tool_args {
+        if name.trim().is_empty() {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' function '{}' tool_args has an empty key",
+                function.name
+            )));
+        }
+        if !request_arg_names.insert(name.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' function '{}' has multiple bindings for tool arg '{name}'",
+                function.name
+            )));
+        }
+        validate_source_scoped_value_source(
+            source,
+            &format!(
+                "source '{source_name}' function '{}' tool_args.{name}",
+                function.name
+            ),
+        )?;
+    }
     for arg in &function.args {
         validate_identifier(
             &arg.name,
@@ -918,6 +943,7 @@ fn validate_function_binding<'a>(
 mod tests {
     use std::collections::BTreeSet;
 
+    use crate::ValueSourceSpec;
     use serde_json::json;
 
     use super::{McpServerSpec, McpSourceManifest};
@@ -965,6 +991,78 @@ mod tests {
         assert_eq!(
             manifest.required_secret_names(),
             BTreeSet::from(["GITHUB_TOKEN".to_string()])
+        );
+    }
+
+    #[test]
+    fn parses_mcp_function_with_fixed_tool_args() {
+        let manifest = McpSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "demo_mcp",
+            "version": "0.1.0",
+            "backend": "mcp",
+            "server": {
+                "transport": "stdio",
+                "command": "demo-mcp-server"
+            },
+            "functions": [{
+                "name": "pull_request_diff",
+                "tool": "pull_request_read",
+                "tool_args": {
+                    "method": { "from": "literal", "value": "get_diff" }
+                },
+                "args": [{
+                    "name": "pull_number",
+                    "required": true,
+                    "bind": { "arg": "pullNumber" }
+                }],
+                "columns": [{ "name": "result", "type": "Utf8" }]
+            }]
+        }))
+        .expect("mcp function tool_args should parse");
+
+        let function = manifest.functions.first().expect("function should parse");
+        assert_eq!(function.name(), "pull_request_diff");
+        let method = function
+            .tool_args
+            .get("method")
+            .expect("method tool arg should parse");
+        let ValueSourceSpec::Literal { value } = method else {
+            panic!("method tool arg should be literal, got {method:?}");
+        };
+        assert_eq!(value, &json!("get_diff"));
+    }
+
+    #[test]
+    fn rejects_duplicate_tool_arg_bindings_across_function_args_and_tool_args() {
+        let error = McpSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "demo_mcp",
+            "version": "0.1.0",
+            "backend": "mcp",
+            "server": {
+                "transport": "stdio",
+                "command": "demo-mcp-server"
+            },
+            "functions": [{
+                "name": "pull_request_diff",
+                "tool": "pull_request_read",
+                "tool_args": {
+                    "method": { "from": "literal", "value": "get_diff" }
+                },
+                "args": [{
+                    "name": "method",
+                    "required": true,
+                    "bind": { "arg": "method" }
+                }],
+                "columns": [{ "name": "result", "type": "Utf8" }]
+            }]
+        }))
+        .expect_err("duplicate function tool arg binding should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "source 'demo_mcp' function 'pull_request_diff' has multiple bindings for tool arg 'method'"
         );
     }
 

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -660,6 +660,11 @@
         "tool": { "type": "string", "minLength": 1 },
         "description": { "type": "string" },
         "fetch_limit_default": { "type": "integer", "minimum": 1 },
+        "tool_args": {
+          "type": "object",
+          "propertyNames": { "minLength": 1 },
+          "additionalProperties": { "$ref": "#/$defs/mcp_tool_arg_value" }
+        },
         "args": {
           "type": "array",
           "items": { "$ref": "#/$defs/table_function_arg" }

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -708,6 +708,31 @@ functions:
 SELECT * FROM my_mcp.run_query(query => 'SELECT 1');
 ```
 
+MCP table functions can also declare source-scoped `tool_args` for fixed or
+input-backed MCP arguments that should not be exposed as SQL function
+arguments. These are merged with SQL-bound `args`, and a tool argument may only
+be bound once:
+
+```yaml
+functions:
+  - name: pull_request_diff
+    tool: pull_request_read
+    tool_args:
+      method:
+        from: literal
+        value: get_diff
+    args:
+      - name: pull_number
+        required: true
+        bind:
+          arg: pullNumber
+    columns:
+      - name: result
+        type: Utf8
+        expr:
+          kind: current_row
+```
+
 MCP tables and functions can also declare cursor pagination:
 
 ```yaml

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -660,7 +660,10 @@ server:
     key: MCP_ACCESS_TOKEN
 ```
 
-MCP tables call one tool and map the JSON result into rows:
+MCP tables call one tool and map the result into rows. When the tool returns
+`structuredContent`, Coral uses that JSON value. When the tool returns text
+content, Coral parses JSON text when possible and otherwise exposes the text as
+a single string row, which is useful for MCP servers that return Markdown:
 
 ```yaml
 tables:

--- a/sources/community/github_mcp/README.md
+++ b/sources/community/github_mcp/README.md
@@ -1,0 +1,130 @@
+# GitHub MCP Connector
+
+**Version:** 0.1.0
+**Source:** GitHub official remote MCP server
+**Backend:** MCP (Streamable HTTP, native)
+**Server URL:** `https://api.githubcopilot.com/mcp/x/all/readonly`
+**Surface:** 1 table + 21 functions wrapping read-oriented MCP tools
+
+This connector exposes GitHub's official remote MCP server as a Coral source.
+It is separate from the bundled `github` HTTP source and keeps MCP output
+intact: each table or function returns a `result` text column plus a `raw` JSON
+column.
+
+The bundled `github` source is the better fit when you need broad, stable REST
+API coverage with typed table schemas. This MCP source is focused on the
+agent-oriented GitHub MCP tool surface.
+
+## GitHub token setup
+
+GitHub's remote MCP server requires a valid GitHub access token in the
+`Authorization` header. The MCP server itself does not issue tokens, so Coral
+obtains or stores a GitHub token through the source credential setup.
+
+Register the source interactively:
+
+```bash
+coral source add --file sources/community/github_mcp/manifest.yaml --interactive
+```
+
+When prompted for `GITHUB_MCP_ACCESS_TOKEN`, choose one of:
+
+- **Connect with GitHub device code**: sign in with GitHub using device-code
+  OAuth. This does not require you to create an OAuth app.
+- **Connect with GitHub OAuth app**: use your own GitHub OAuth app. Register
+  the callback URL `http://127.0.0.1:53682/oauth/callback`, then provide
+  `GITHUB_MCP_OAUTH_CLIENT_ID` and `GITHUB_MCP_OAUTH_CLIENT_SECRET`.
+- **Paste GitHub token**: paste a personal access token or the output of
+  `gh auth token`.
+
+The OAuth methods request these scopes:
+
+```text
+repo read:org read:user user:email
+```
+
+The source uses GitHub's hosted all-toolsets read-only MCP URL:
+
+```text
+https://api.githubcopilot.com/mcp/x/all/readonly
+```
+
+GitHub documents that `/readonly` disables write tools even when enabled
+toolsets contain mutation tools. The manifest only exposes a focused subset of
+read-oriented tools.
+
+## Table
+
+| Table | MCP tool | Description |
+|---|---|---|
+| `me` | `get_me` | Authenticated GitHub user profile |
+
+## Functions
+
+All functions require named arguments.
+
+| Function | MCP tool | Required args | Description |
+|---|---|---|---|
+| `get_teams` | `get_teams` | none | Teams for a user, defaulting to the authenticated user |
+| `get_team_members` | `get_team_members` | `org`, `team_slug` | Members of a GitHub team |
+| `issue_read` | `issue_read` | `owner`, `repo`, `issue_number`, `method` | Read one issue, comments, sub-issues, labels, or events |
+| `list_issues` | `list_issues` | `owner`, `repo` | List repository issues |
+| `search_issues` | `search_issues` | `query` | Search issues |
+| `list_pull_requests` | `list_pull_requests` | `owner`, `repo` | List repository pull requests |
+| `pull_request_read` | `pull_request_read` | `owner`, `repo`, `pull_number`, `method` | Read one pull request, diff, files, comments, reviews, or checks |
+| `search_pull_requests` | `search_pull_requests` | `query` | Search pull requests |
+| `get_repository_tree` | `get_repository_tree` | `owner`, `repo` | Get a repository tree |
+| `get_commit` | `get_commit` | `owner`, `repo`, `sha` | Get commit details |
+| `get_file_contents` | `get_file_contents` | `owner`, `repo` | Get file or directory contents |
+| `list_branches` | `list_branches` | `owner`, `repo` | List repository branches |
+| `list_commits` | `list_commits` | `owner`, `repo` | List repository commits |
+| `list_releases` | `list_releases` | `owner`, `repo` | List repository releases |
+| `get_latest_release` | `get_latest_release` | `owner`, `repo` | Get the latest release |
+| `get_release_by_tag` | `get_release_by_tag` | `owner`, `repo`, `tag` | Get a release by tag |
+| `list_tags` | `list_tags` | `owner`, `repo` | List repository tags |
+| `search_code` | `search_code` | `query` | Search code |
+| `search_commits` | `search_commits` | `query` | Search commits |
+| `search_repositories` | `search_repositories` | `query` | Search repositories |
+| `search_users` | `search_users` | `query` | Search users |
+
+## Examples
+
+```sql
+SELECT result
+FROM github_mcp.me;
+
+SELECT result
+FROM github_mcp.search_issues(
+  query => 'repo:withcoral/coral is:open label:bug'
+);
+
+SELECT result
+FROM github_mcp.pull_request_read(
+  owner => 'withcoral',
+  repo => 'coral',
+  pull_number => 1183,
+  method => 'get_files'
+);
+
+SELECT result
+FROM github_mcp.get_file_contents(
+  owner => 'withcoral',
+  repo => 'coral',
+  path => 'README.md',
+  ref => 'refs/heads/main'
+);
+```
+
+## Notes
+
+GitHub's MCP server is optimized for agent workflows. Responses may be
+structured JSON or human-readable text. Use `result` for the rendered response
+and `raw` when the server returns structured data.
+
+This source intentionally uses GitHub's read-only MCP endpoint and exposes only
+read-oriented tools. The official MCP server also includes write-capable tools,
+but those are not modeled here because SQL queries should not unexpectedly
+mutate GitHub state.
+
+GitHub's official MCP documentation:
+https://github.com/github/github-mcp-server

--- a/sources/community/github_mcp/README.md
+++ b/sources/community/github_mcp/README.md
@@ -4,12 +4,15 @@
 **Source:** GitHub official remote MCP server
 **Backend:** MCP (Streamable HTTP, native)
 **Server URL:** `https://api.githubcopilot.com/mcp/x/all/readonly`
-**Surface:** 1 table + 60 functions wrapping GitHub's read-only MCP tools
+**Surface:** 64 tables + 16 functions wrapping GitHub's read-only MCP tools
 
 This connector exposes GitHub's official remote MCP server as a Coral source.
-It is separate from the bundled `github` HTTP source and keeps MCP output
-intact: each table or function returns a `result` text column plus a `raw` JSON
-column.
+It is separate from the bundled `github` HTTP source. GitHub MCP tools that
+return JSON expose typed SQL columns plus a `raw` JSON column for the full row.
+Stable GitHub resources are modeled as tables with `WHERE` filters. Search,
+scanning, report, and resource-content operations remain table functions.
+Tools that return Markdown, diff text, reports, or embedded resources expose a
+single `result` text column.
 
 The bundled `github` source is the better fit when you need broad, stable REST
 API coverage with typed table schemas. This MCP source follows GitHub's
@@ -56,118 +59,139 @@ returned by the all-toolsets endpoint at authoring time. Individual queries can
 still fail if the token, organization, repository, or account does not have
 access to the corresponding GitHub feature.
 
-## Table
+## Tables
 
-| Table | MCP tool | Description |
-|---|---|---|
-| `me` | `get_me` | Authenticated GitHub user profile |
+Use tables for stable GitHub resources. Required inputs are SQL `WHERE` filters; optional filters map to optional MCP tool arguments. Wrapper-style MCP tools are split into tables with fixed hidden method arguments where possible.
+
+| Table | MCP tool | Required filters | Description |
+|---|---|---|---|
+| `me` | `get_me` | none | Authenticated GitHub user profile returned by the get_me tool. |
+| `teams` | `get_teams` | none | Get teams for a GitHub user, defaulting to the authenticated user. |
+| `team_members` | `get_team_members` | `org`, `team_slug` | Get members of a team in a GitHub organization. |
+| `issue` | `issue_read` | `owner`, `repo`, `issue_number` | Read issue details, comments, sub-issues, or labels. |
+| `issues` | `list_issues` | `owner`, `repo` | List issues in a repository. |
+| `pull_requests` | `list_pull_requests` | `owner`, `repo` | List pull requests in a repository. |
+| `repository_tree` | `get_repository_tree` | `owner`, `repo` | Get a repository tree, optionally filtered by path prefix. |
+| `commit` | `get_commit` | `owner`, `repo`, `sha` | Get details for a repository commit. |
+| `branches` | `list_branches` | `owner`, `repo` | List branches in a repository. |
+| `commits` | `list_commits` | `owner`, `repo` | List repository commits. |
+| `releases` | `list_releases` | `owner`, `repo` | List repository releases. |
+| `latest_release` | `get_latest_release` | `owner`, `repo` | Get the latest release for a repository. |
+| `release_by_tag` | `get_release_by_tag` | `owner`, `repo`, `tag` | Get a repository release by tag. |
+| `tags` | `list_tags` | `owner`, `repo` | List repository tags. |
+| `code_scanning_alerts` | `list_code_scanning_alerts` | `owner`, `repo` | List code scanning alerts in a repository. |
+| `code_scanning_alert` | `get_code_scanning_alert` | `owner`, `repo`, `alert_number` | Get details for one code scanning alert. |
+| `dependabot_alerts` | `list_dependabot_alerts` | `owner`, `repo` | List Dependabot alerts in a repository. |
+| `dependabot_alert` | `get_dependabot_alert` | `owner`, `repo`, `alert_number` | Get details for one Dependabot alert. |
+| `secret_scanning_alerts` | `list_secret_scanning_alerts` | `owner`, `repo` | List secret scanning alerts in a repository. |
+| `secret_scanning_alert` | `get_secret_scanning_alert` | `owner`, `repo`, `alert_number` | Get details for one secret scanning alert. |
+| `global_security_advisories` | `list_global_security_advisories` | none | List global GitHub security advisories. |
+| `global_security_advisory` | `get_global_security_advisory` | `ghsa_id` | Get one global GitHub security advisory. |
+| `repository_security_advisories` | `list_repository_security_advisories` | `owner`, `repo` | List security advisories for a repository. |
+| `org_repository_security_advisories` | `list_org_repository_security_advisories` | `org` | List repository security advisories for an organization. |
+| `discussions` | `list_discussions` | `owner` | List GitHub Discussions for a repository or organization. |
+| `discussion` | `get_discussion` | `owner`, `repo`, `discussion_number` | Get one GitHub Discussion. |
+| `discussion_comments` | `get_discussion_comments` | `owner`, `repo`, `discussion_number` | Get comments for one GitHub Discussion. |
+| `discussion_categories` | `list_discussion_categories` | `owner` | List GitHub Discussion categories for a repository or organization. |
+| `notifications` | `list_notifications` | none | List GitHub notifications for the authenticated user. |
+| `notification_details` | `get_notification_details` | `notification_id` | Get details for one GitHub notification. |
+| `gists` | `list_gists` | none | List gists for a user or the authenticated user. |
+| `gist` | `get_gist` | `gist_id` | Get one GitHub gist by ID. |
+| `labels` | `list_label` | `owner`, `repo` | List labels in a repository. |
+| `label` | `get_label` | `owner`, `repo`, `name` | Get one label in a repository. |
+| `issue_types` | `list_issue_types` | `owner` | List issue types for an organization. |
+| `repository_collaborators` | `list_repository_collaborators` | `owner`, `repo` | List collaborators in a repository. |
+| `starred_repositories` | `list_starred_repositories` | none | List starred repositories for a user or the authenticated user. |
+| `tag` | `get_tag` | `owner`, `repo`, `tag` | Get details for one repository tag. |
+| `copilot_spaces` | `list_copilot_spaces` | none | List Copilot Spaces accessible to the authenticated user. |
+| `copilot_space` | `get_copilot_space` | `owner`, `name` | Get the contents of one Copilot Space. |
+| `copilot_job_status` | `get_copilot_job_status` | `owner`, `repo`, `id` | Get status for a GitHub Copilot coding agent job. |
+| `pull_request` | `pull_request_read` | `owner`, `repo`, `pull_number` | Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get. |
+| `pull_request_files` | `pull_request_read` | `owner`, `repo`, `pull_number` | Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get_files. |
+| `pull_request_review_comments` | `pull_request_read` | `owner`, `repo`, `pull_number` | Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get_review_comments. |
+| `pull_request_reviews` | `pull_request_read` | `owner`, `repo`, `pull_number` | Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get_reviews. |
+| `pull_request_comments` | `pull_request_read` | `owner`, `repo`, `pull_number` | Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get_comments. |
+| `pull_request_check_runs` | `pull_request_read` | `owner`, `repo`, `pull_number` | Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get_check_runs. |
+| `workflows` | `actions_list` | `owner`, `repo` | List GitHub Actions workflows, runs, jobs, or artifacts. Fixed to method=list_workflows. |
+| `workflow_runs` | `actions_list` | `owner`, `repo` | List GitHub Actions workflows, runs, jobs, or artifacts. Fixed to method=list_workflow_runs. |
+| `workflow_jobs` | `actions_list` | `owner`, `repo`, `resource_id` | List GitHub Actions workflows, runs, jobs, or artifacts. Fixed to method=list_workflow_jobs. |
+| `workflow_run_artifacts` | `actions_list` | `owner`, `repo`, `resource_id` | List GitHub Actions workflows, runs, jobs, or artifacts. Fixed to method=list_workflow_run_artifacts. |
+| `workflow` | `actions_get` | `owner`, `repo`, `resource_id` | Get one GitHub Actions workflow, run, job, artifact, or logs URL. Fixed to method=get_workflow. |
+| `workflow_run` | `actions_get` | `owner`, `repo`, `resource_id` | Get one GitHub Actions workflow, run, job, artifact, or logs URL. Fixed to method=get_workflow_run. |
+| `workflow_job` | `actions_get` | `owner`, `repo`, `resource_id` | Get one GitHub Actions workflow, run, job, artifact, or logs URL. Fixed to method=get_workflow_job. |
+| `workflow_run_usage` | `actions_get` | `owner`, `repo`, `resource_id` | Get one GitHub Actions workflow, run, job, artifact, or logs URL. Fixed to method=get_workflow_run_usage. |
+| `workflow_run_logs_url` | `actions_get` | `owner`, `repo`, `resource_id` | Get one GitHub Actions workflow, run, job, artifact, or logs URL. Fixed to method=get_workflow_run_logs_url. |
+| `projects` | `projects_list` | `owner` | List GitHub Projects, project fields, items, or status updates. Fixed to method=list_projects. |
+| `project_fields` | `projects_list` | `owner`, `project_number` | List GitHub Projects, project fields, items, or status updates. Fixed to method=list_project_fields. |
+| `project_items` | `projects_list` | `owner`, `project_number` | List GitHub Projects, project fields, items, or status updates. Fixed to method=list_project_items. |
+| `project_status_updates` | `projects_list` | `owner`, `project_number` | List GitHub Projects, project fields, items, or status updates. Fixed to method=list_project_status_updates. |
+| `project` | `projects_get` | `owner`, `project_number` | Get one GitHub Project, field, item, or status update. Fixed to method=get_project. |
+| `project_field` | `projects_get` | `field_id` | Get one GitHub Project, field, item, or status update. Fixed to method=get_project_field. |
+| `project_item` | `projects_get` | `item_id` | Get one GitHub Project, field, item, or status update. Fixed to method=get_project_item. |
+| `project_status_update` | `projects_get` | `status_update_id` | Get one GitHub Project, field, item, or status update. Fixed to method=get_project_status_update. |
 
 ## Functions
 
-All functions require named arguments.
+Use functions for search-style tools and operations whose input is naturally a
+call payload, plus Markdown, report, or resource-content tools. Text-oriented
+functions expose only `result`.
 
 | Function | MCP tool | Required args | Description |
 |---|---|---|---|
-| `get_teams` | `get_teams` | none | Get teams for a GitHub user, defaulting to the authenticated user. |
-| `get_team_members` | `get_team_members` | `org`, `team_slug` | Get members of a team in a GitHub organization. |
-| `issue_read` | `issue_read` | `owner`, `repo`, `issue_number`, `method` | Read issue details, comments, sub-issues, or labels. |
-| `list_issues` | `list_issues` | `owner`, `repo` | List issues in a repository. |
 | `search_issues` | `search_issues` | `query` | Search issues using GitHub issue search syntax. |
-| `list_pull_requests` | `list_pull_requests` | `owner`, `repo` | List pull requests in a repository. |
-| `pull_request_read` | `pull_request_read` | `owner`, `repo`, `pull_number`, `method` | Read pull request details, diff, files, comments, reviews, or checks. |
 | `search_pull_requests` | `search_pull_requests` | `query` | Search pull requests using GitHub pull request search syntax. |
-| `get_repository_tree` | `get_repository_tree` | `owner`, `repo` | Get a repository tree, optionally filtered by path prefix. |
-| `get_commit` | `get_commit` | `owner`, `repo`, `sha` | Get details for a repository commit. |
-| `get_file_contents` | `get_file_contents` | `owner`, `repo` | Get file or directory contents from a repository. |
-| `list_branches` | `list_branches` | `owner`, `repo` | List branches in a repository. |
-| `list_commits` | `list_commits` | `owner`, `repo` | List repository commits. |
-| `list_releases` | `list_releases` | `owner`, `repo` | List repository releases. |
-| `get_latest_release` | `get_latest_release` | `owner`, `repo` | Get the latest release for a repository. |
-| `get_release_by_tag` | `get_release_by_tag` | `owner`, `repo`, `tag` | Get a repository release by tag. |
-| `list_tags` | `list_tags` | `owner`, `repo` | List repository tags. |
 | `search_code` | `search_code` | `query` | Search code using GitHub code search syntax. |
 | `search_commits` | `search_commits` | `query` | Search commits using GitHub commit search syntax. |
 | `search_repositories` | `search_repositories` | `query` | Search repositories using GitHub repository search syntax. |
 | `search_users` | `search_users` | `query` | Search users using GitHub user search syntax. |
-| `actions_list` | `actions_list` | `method`, `owner`, `repo` | List GitHub Actions workflows, runs, jobs, or artifacts. |
-| `actions_get` | `actions_get` | `method`, `owner`, `repo`, `resource_id` | Get one GitHub Actions workflow, run, job, artifact, or logs URL. |
-| `get_job_logs` | `get_job_logs` | `owner`, `repo` | Get logs for one GitHub Actions job or failed jobs in a run. |
-| `list_code_scanning_alerts` | `list_code_scanning_alerts` | `owner`, `repo` | List code scanning alerts in a repository. |
-| `get_code_scanning_alert` | `get_code_scanning_alert` | `owner`, `repo`, `alert_number` | Get details for one code scanning alert. |
-| `list_dependabot_alerts` | `list_dependabot_alerts` | `owner`, `repo` | List Dependabot alerts in a repository. |
-| `get_dependabot_alert` | `get_dependabot_alert` | `owner`, `repo`, `alert_number` | Get details for one Dependabot alert. |
-| `list_secret_scanning_alerts` | `list_secret_scanning_alerts` | `owner`, `repo` | List secret scanning alerts in a repository. |
-| `get_secret_scanning_alert` | `get_secret_scanning_alert` | `owner`, `repo`, `alert_number` | Get details for one secret scanning alert. |
-| `check_dependency_vulnerabilities` | `check_dependency_vulnerabilities` | `owner`, `repo`, `dependencies` | Check dependencies against the GitHub Security Advisory Database. |
-| `list_global_security_advisories` | `list_global_security_advisories` | none | List global GitHub security advisories. |
-| `get_global_security_advisory` | `get_global_security_advisory` | `ghsa_id` | Get one global GitHub security advisory. |
-| `list_repository_security_advisories` | `list_repository_security_advisories` | `owner`, `repo` | List security advisories for a repository. |
-| `list_org_repository_security_advisories` | `list_org_repository_security_advisories` | `org` | List repository security advisories for an organization. |
-| `list_discussions` | `list_discussions` | `owner` | List GitHub Discussions for a repository or organization. |
-| `get_discussion` | `get_discussion` | `owner`, `repo`, `discussion_number` | Get one GitHub Discussion. |
-| `get_discussion_comments` | `get_discussion_comments` | `owner`, `repo`, `discussion_number` | Get comments for one GitHub Discussion. |
-| `list_discussion_categories` | `list_discussion_categories` | `owner` | List GitHub Discussion categories for a repository or organization. |
-| `list_notifications` | `list_notifications` | none | List GitHub notifications for the authenticated user. |
-| `get_notification_details` | `get_notification_details` | `notification_id` | Get details for one GitHub notification. |
-| `projects_list` | `projects_list` | `method`, `owner` | List GitHub Projects, project fields, items, or status updates. |
-| `projects_get` | `projects_get` | `method` | Get one GitHub Project, field, item, or status update. |
-| `list_gists` | `list_gists` | none | List gists for a user or the authenticated user. |
-| `get_gist` | `get_gist` | `gist_id` | Get one GitHub gist by ID. |
-| `list_label` | `list_label` | `owner`, `repo` | List labels in a repository. |
-| `get_label` | `get_label` | `owner`, `repo`, `name` | Get one label in a repository. |
-| `list_issue_types` | `list_issue_types` | `owner` | List issue types for an organization. |
-| `list_repository_collaborators` | `list_repository_collaborators` | `owner`, `repo` | List collaborators in a repository. |
-| `list_starred_repositories` | `list_starred_repositories` | none | List starred repositories for a user or the authenticated user. |
-| `get_tag` | `get_tag` | `owner`, `repo`, `tag` | Get details for one repository tag. |
 | `search_orgs` | `search_orgs` | `query` | Search organizations using GitHub organization search syntax. |
 | `semantic_issues_search` | `semantic_issues_search` | `query` | Search issues semantically with natural language. |
 | `semantic_issue_similarity_search` | `semantic_issue_similarity_search` | `owner`, `repo`, `issue_number` | Find issues semantically similar to one issue. |
-| `github_support_docs_search` | `github_support_docs_search` | `query` | Search GitHub support documentation through the GitHub MCP server. |
 | `web_search` | `web_search` | `query` | Run GitHub MCP's AI-powered web search. |
-| `list_copilot_spaces` | `list_copilot_spaces` | none | List Copilot Spaces accessible to the authenticated user. |
-| `get_copilot_space` | `get_copilot_space` | `owner`, `name` | Get the contents of one Copilot Space. |
-| `get_copilot_job_status` | `get_copilot_job_status` | `owner`, `repo`, `id` | Get status for a GitHub Copilot coding agent job. |
+| `pull_request_diff` | `pull_request_read` | `owner`, `repo`, `pull_number` | Read a pull request unified diff. |
+| `get_file_contents` | `get_file_contents` | `owner`, `repo` | Get file or directory contents from a repository. |
+| `check_dependency_vulnerabilities` | `check_dependency_vulnerabilities` | `owner`, `repo`, `dependencies` | Check dependencies against the GitHub Security Advisory Database. |
+| `github_support_docs_search` | `github_support_docs_search` | `query` | Search GitHub support documentation through the GitHub MCP server. |
 | `run_secret_scanning` | `run_secret_scanning` | `owner`, `repo`, `files` | Scan raw content strings or diff hunks for secrets with GitHub MCP. |
+| `get_job_logs` | `get_job_logs` | `owner`, `repo` | Get logs for one GitHub Actions job or failed jobs in a run. |
 
 ## Examples
 
 ```sql
-SELECT result
+SELECT login, name, public_repos
 FROM github_mcp.me;
 
-SELECT result
-FROM github_mcp.search_issues(
-  query => 'repo:withcoral/coral is:open label:bug'
-);
+SELECT number, title, state, html_url
+FROM github_mcp.issues
+WHERE owner = 'withcoral'
+  AND repo = 'coral'
+  AND state = 'OPEN'
+LIMIT 10;
 
 SELECT result
-FROM github_mcp.pull_request_read(
+FROM github_mcp.pull_request_diff(
   owner => 'withcoral',
   repo => 'coral',
-  pull_number => 1183,
-  method => 'get_files'
+  pull_number => 1183
 );
 
-SELECT result
-FROM github_mcp.actions_list(
-  method => 'list_workflows',
-  owner => 'withcoral',
-  repo => 'coral',
-  per_page => 5
-);
+SELECT name, path, state
+FROM github_mcp.workflows
+WHERE owner = 'withcoral'
+  AND repo = 'coral'
+LIMIT 5;
 
-SELECT result
-FROM github_mcp.list_global_security_advisories(
-  ecosystem => 'rust',
-  severity => 'critical'
-);
+SELECT ghsa_id, summary, severity, published_at
+FROM github_mcp.global_security_advisories
+WHERE ecosystem = 'rust'
+  AND severity = 'critical';
 
 SELECT result
 FROM github_mcp.github_support_docs_search(
   query => 'GitHub Actions reusable workflows'
 );
 
-SELECT result
+SELECT num_bytes_scanned, blobs_scanned, secrets
 FROM github_mcp.run_secret_scanning(
   owner => 'withcoral',
   repo => 'coral',
@@ -177,17 +201,18 @@ FROM github_mcp.run_secret_scanning(
 
 ## Notes
 
-GitHub's MCP server is optimized for agent workflows. Responses may be
-structured JSON or human-readable text. Use `result` for the rendered response
-and `raw` when the server returns structured data.
+GitHub's MCP server is optimized for agent workflows. Its read-oriented API
+tools generally return JSON serialized as MCP text content, so this source
+projects stable JSON fields into typed columns and keeps the full row in `raw`.
+Text-oriented relations keep only `result`.
 
 Coral currently sends MCP function string arguments as strings, numbers as JSON
-numbers, and booleans as JSON booleans. GitHub MCP arguments that require JSON
-arrays or objects are intentionally exposed in the catalog but limited until
-Coral grows explicit structured function-argument support. This affects
-required structured arguments such as `check_dependency_vulnerabilities`
-`dependencies`, and optional structured filters such as `actions_list`
-`workflow_runs_filter`.
+numbers, and booleans as JSON booleans. MCP table filters are declared with
+explicit SQL types where numeric or boolean values matter. GitHub MCP arguments
+that require JSON arrays or objects are intentionally exposed in the catalog
+but limited until Coral grows explicit structured function-argument support.
+This affects required structured arguments such as
+`check_dependency_vulnerabilities` `dependencies`.
 
 This source intentionally uses GitHub's read-only MCP endpoint. The official
 MCP server also includes write-capable tools, but those are not modeled here

--- a/sources/community/github_mcp/README.md
+++ b/sources/community/github_mcp/README.md
@@ -4,7 +4,7 @@
 **Source:** GitHub official remote MCP server
 **Backend:** MCP (Streamable HTTP, native)
 **Server URL:** `https://api.githubcopilot.com/mcp/x/all/readonly`
-**Surface:** 1 table + 21 functions wrapping read-oriented MCP tools
+**Surface:** 1 table + 60 functions wrapping GitHub's read-only MCP tools
 
 This connector exposes GitHub's official remote MCP server as a Coral source.
 It is separate from the bundled `github` HTTP source and keeps MCP output
@@ -12,8 +12,9 @@ intact: each table or function returns a `result` text column plus a `raw` JSON
 column.
 
 The bundled `github` source is the better fit when you need broad, stable REST
-API coverage with typed table schemas. This MCP source is focused on the
-agent-oriented GitHub MCP tool surface.
+API coverage with typed table schemas. This MCP source follows GitHub's
+agent-oriented MCP tool surface, including tools that do not have an equivalent
+in the bundled HTTP source.
 
 ## GitHub token setup
 
@@ -40,7 +41,7 @@ When prompted for `GITHUB_MCP_ACCESS_TOKEN`, choose one of:
 The OAuth methods request these scopes:
 
 ```text
-repo read:org read:user user:email
+repo read:org read:user user:email gist notifications read:project security_events
 ```
 
 The source uses GitHub's hosted all-toolsets read-only MCP URL:
@@ -50,8 +51,10 @@ https://api.githubcopilot.com/mcp/x/all/readonly
 ```
 
 GitHub documents that `/readonly` disables write tools even when enabled
-toolsets contain mutation tools. The manifest only exposes a focused subset of
-read-oriented tools.
+toolsets contain mutation tools. The manifest exposes the live read-only tools
+returned by the all-toolsets endpoint at authoring time. Individual queries can
+still fail if the token, organization, repository, or account does not have
+access to the corresponding GitHub feature.
 
 ## Table
 
@@ -65,27 +68,66 @@ All functions require named arguments.
 
 | Function | MCP tool | Required args | Description |
 |---|---|---|---|
-| `get_teams` | `get_teams` | none | Teams for a user, defaulting to the authenticated user |
-| `get_team_members` | `get_team_members` | `org`, `team_slug` | Members of a GitHub team |
-| `issue_read` | `issue_read` | `owner`, `repo`, `issue_number`, `method` | Read one issue, comments, sub-issues, labels, or events |
-| `list_issues` | `list_issues` | `owner`, `repo` | List repository issues |
-| `search_issues` | `search_issues` | `query` | Search issues |
-| `list_pull_requests` | `list_pull_requests` | `owner`, `repo` | List repository pull requests |
-| `pull_request_read` | `pull_request_read` | `owner`, `repo`, `pull_number`, `method` | Read one pull request, diff, files, comments, reviews, or checks |
-| `search_pull_requests` | `search_pull_requests` | `query` | Search pull requests |
-| `get_repository_tree` | `get_repository_tree` | `owner`, `repo` | Get a repository tree |
-| `get_commit` | `get_commit` | `owner`, `repo`, `sha` | Get commit details |
-| `get_file_contents` | `get_file_contents` | `owner`, `repo` | Get file or directory contents |
-| `list_branches` | `list_branches` | `owner`, `repo` | List repository branches |
-| `list_commits` | `list_commits` | `owner`, `repo` | List repository commits |
-| `list_releases` | `list_releases` | `owner`, `repo` | List repository releases |
-| `get_latest_release` | `get_latest_release` | `owner`, `repo` | Get the latest release |
-| `get_release_by_tag` | `get_release_by_tag` | `owner`, `repo`, `tag` | Get a release by tag |
-| `list_tags` | `list_tags` | `owner`, `repo` | List repository tags |
-| `search_code` | `search_code` | `query` | Search code |
-| `search_commits` | `search_commits` | `query` | Search commits |
-| `search_repositories` | `search_repositories` | `query` | Search repositories |
-| `search_users` | `search_users` | `query` | Search users |
+| `get_teams` | `get_teams` | none | Get teams for a GitHub user, defaulting to the authenticated user. |
+| `get_team_members` | `get_team_members` | `org`, `team_slug` | Get members of a team in a GitHub organization. |
+| `issue_read` | `issue_read` | `owner`, `repo`, `issue_number`, `method` | Read issue details, comments, sub-issues, or labels. |
+| `list_issues` | `list_issues` | `owner`, `repo` | List issues in a repository. |
+| `search_issues` | `search_issues` | `query` | Search issues using GitHub issue search syntax. |
+| `list_pull_requests` | `list_pull_requests` | `owner`, `repo` | List pull requests in a repository. |
+| `pull_request_read` | `pull_request_read` | `owner`, `repo`, `pull_number`, `method` | Read pull request details, diff, files, comments, reviews, or checks. |
+| `search_pull_requests` | `search_pull_requests` | `query` | Search pull requests using GitHub pull request search syntax. |
+| `get_repository_tree` | `get_repository_tree` | `owner`, `repo` | Get a repository tree, optionally filtered by path prefix. |
+| `get_commit` | `get_commit` | `owner`, `repo`, `sha` | Get details for a repository commit. |
+| `get_file_contents` | `get_file_contents` | `owner`, `repo` | Get file or directory contents from a repository. |
+| `list_branches` | `list_branches` | `owner`, `repo` | List branches in a repository. |
+| `list_commits` | `list_commits` | `owner`, `repo` | List repository commits. |
+| `list_releases` | `list_releases` | `owner`, `repo` | List repository releases. |
+| `get_latest_release` | `get_latest_release` | `owner`, `repo` | Get the latest release for a repository. |
+| `get_release_by_tag` | `get_release_by_tag` | `owner`, `repo`, `tag` | Get a repository release by tag. |
+| `list_tags` | `list_tags` | `owner`, `repo` | List repository tags. |
+| `search_code` | `search_code` | `query` | Search code using GitHub code search syntax. |
+| `search_commits` | `search_commits` | `query` | Search commits using GitHub commit search syntax. |
+| `search_repositories` | `search_repositories` | `query` | Search repositories using GitHub repository search syntax. |
+| `search_users` | `search_users` | `query` | Search users using GitHub user search syntax. |
+| `actions_list` | `actions_list` | `method`, `owner`, `repo` | List GitHub Actions workflows, runs, jobs, or artifacts. |
+| `actions_get` | `actions_get` | `method`, `owner`, `repo`, `resource_id` | Get one GitHub Actions workflow, run, job, artifact, or logs URL. |
+| `get_job_logs` | `get_job_logs` | `owner`, `repo` | Get logs for one GitHub Actions job or failed jobs in a run. |
+| `list_code_scanning_alerts` | `list_code_scanning_alerts` | `owner`, `repo` | List code scanning alerts in a repository. |
+| `get_code_scanning_alert` | `get_code_scanning_alert` | `owner`, `repo`, `alert_number` | Get details for one code scanning alert. |
+| `list_dependabot_alerts` | `list_dependabot_alerts` | `owner`, `repo` | List Dependabot alerts in a repository. |
+| `get_dependabot_alert` | `get_dependabot_alert` | `owner`, `repo`, `alert_number` | Get details for one Dependabot alert. |
+| `list_secret_scanning_alerts` | `list_secret_scanning_alerts` | `owner`, `repo` | List secret scanning alerts in a repository. |
+| `get_secret_scanning_alert` | `get_secret_scanning_alert` | `owner`, `repo`, `alert_number` | Get details for one secret scanning alert. |
+| `check_dependency_vulnerabilities` | `check_dependency_vulnerabilities` | `owner`, `repo`, `dependencies` | Check dependencies against the GitHub Security Advisory Database. |
+| `list_global_security_advisories` | `list_global_security_advisories` | none | List global GitHub security advisories. |
+| `get_global_security_advisory` | `get_global_security_advisory` | `ghsa_id` | Get one global GitHub security advisory. |
+| `list_repository_security_advisories` | `list_repository_security_advisories` | `owner`, `repo` | List security advisories for a repository. |
+| `list_org_repository_security_advisories` | `list_org_repository_security_advisories` | `org` | List repository security advisories for an organization. |
+| `list_discussions` | `list_discussions` | `owner` | List GitHub Discussions for a repository or organization. |
+| `get_discussion` | `get_discussion` | `owner`, `repo`, `discussion_number` | Get one GitHub Discussion. |
+| `get_discussion_comments` | `get_discussion_comments` | `owner`, `repo`, `discussion_number` | Get comments for one GitHub Discussion. |
+| `list_discussion_categories` | `list_discussion_categories` | `owner` | List GitHub Discussion categories for a repository or organization. |
+| `list_notifications` | `list_notifications` | none | List GitHub notifications for the authenticated user. |
+| `get_notification_details` | `get_notification_details` | `notification_id` | Get details for one GitHub notification. |
+| `projects_list` | `projects_list` | `method`, `owner` | List GitHub Projects, project fields, items, or status updates. |
+| `projects_get` | `projects_get` | `method` | Get one GitHub Project, field, item, or status update. |
+| `list_gists` | `list_gists` | none | List gists for a user or the authenticated user. |
+| `get_gist` | `get_gist` | `gist_id` | Get one GitHub gist by ID. |
+| `list_label` | `list_label` | `owner`, `repo` | List labels in a repository. |
+| `get_label` | `get_label` | `owner`, `repo`, `name` | Get one label in a repository. |
+| `list_issue_types` | `list_issue_types` | `owner` | List issue types for an organization. |
+| `list_repository_collaborators` | `list_repository_collaborators` | `owner`, `repo` | List collaborators in a repository. |
+| `list_starred_repositories` | `list_starred_repositories` | none | List starred repositories for a user or the authenticated user. |
+| `get_tag` | `get_tag` | `owner`, `repo`, `tag` | Get details for one repository tag. |
+| `search_orgs` | `search_orgs` | `query` | Search organizations using GitHub organization search syntax. |
+| `semantic_issues_search` | `semantic_issues_search` | `query` | Search issues semantically with natural language. |
+| `semantic_issue_similarity_search` | `semantic_issue_similarity_search` | `owner`, `repo`, `issue_number` | Find issues semantically similar to one issue. |
+| `github_support_docs_search` | `github_support_docs_search` | `query` | Search GitHub support documentation through the GitHub MCP server. |
+| `web_search` | `web_search` | `query` | Run GitHub MCP's AI-powered web search. |
+| `list_copilot_spaces` | `list_copilot_spaces` | none | List Copilot Spaces accessible to the authenticated user. |
+| `get_copilot_space` | `get_copilot_space` | `owner`, `name` | Get the contents of one Copilot Space. |
+| `get_copilot_job_status` | `get_copilot_job_status` | `owner`, `repo`, `id` | Get status for a GitHub Copilot coding agent job. |
+| `run_secret_scanning` | `run_secret_scanning` | `owner`, `repo`, `files` | Scan raw content strings or diff hunks for secrets with GitHub MCP. |
 
 ## Examples
 
@@ -107,11 +149,29 @@ FROM github_mcp.pull_request_read(
 );
 
 SELECT result
-FROM github_mcp.get_file_contents(
+FROM github_mcp.actions_list(
+  method => 'list_workflows',
   owner => 'withcoral',
   repo => 'coral',
-  path => 'README.md',
-  ref => 'refs/heads/main'
+  per_page => 5
+);
+
+SELECT result
+FROM github_mcp.list_global_security_advisories(
+  ecosystem => 'rust',
+  severity => 'critical'
+);
+
+SELECT result
+FROM github_mcp.github_support_docs_search(
+  query => 'GitHub Actions reusable workflows'
+);
+
+SELECT result
+FROM github_mcp.run_secret_scanning(
+  owner => 'withcoral',
+  repo => 'coral',
+  files => 'Cargo.toml content without secrets'
 );
 ```
 
@@ -121,10 +181,17 @@ GitHub's MCP server is optimized for agent workflows. Responses may be
 structured JSON or human-readable text. Use `result` for the rendered response
 and `raw` when the server returns structured data.
 
-This source intentionally uses GitHub's read-only MCP endpoint and exposes only
-read-oriented tools. The official MCP server also includes write-capable tools,
-but those are not modeled here because SQL queries should not unexpectedly
-mutate GitHub state.
+Coral currently sends MCP function string arguments as strings, numbers as JSON
+numbers, and booleans as JSON booleans. GitHub MCP arguments that require JSON
+arrays or objects are intentionally exposed in the catalog but limited until
+Coral grows explicit structured function-argument support. This affects
+required structured arguments such as `check_dependency_vulnerabilities`
+`dependencies`, and optional structured filters such as `actions_list`
+`workflow_runs_filter`.
+
+This source intentionally uses GitHub's read-only MCP endpoint. The official
+MCP server also includes write-capable tools, but those are not modeled here
+because SQL queries should not unexpectedly mutate GitHub state.
 
 GitHub's official MCP documentation:
 https://github.com/github/github-mcp-server

--- a/sources/community/github_mcp/manifest.yaml
+++ b/sources/community/github_mcp/manifest.yaml
@@ -2,8 +2,9 @@ dsl_version: 3
 name: github_mcp
 version: 0.1.0
 description: >-
-  Query GitHub repositories, issues, pull requests, users, and repository
-  content through GitHub's official remote MCP server.
+  Query GitHub repositories, issues, pull requests, Actions, security alerts,
+  projects, discussions, notifications, and other GitHub MCP tools through
+  GitHub's official remote MCP server.
 backend: mcp
 
 inputs:
@@ -11,8 +12,10 @@ inputs:
     kind: secret
     hint: |
       Connect with GitHub OAuth or paste a personal access token. The OAuth
-      methods request the `repo`, `read:org`, `read:user`, and `user:email`
-      scopes used by the read-oriented GitHub MCP tools exposed by this source.
+      methods request the GitHub scopes used by the read-oriented GitHub MCP
+      tools exposed by this source: `repo`, `read:org`, `read:user`,
+      `user:email`, `gist`, `notifications`, `read:project`, and
+      `security_events`.
 
       See GitHub's MCP server docs:
       https://github.com/github/github-mcp-server
@@ -23,10 +26,12 @@ inputs:
           description: Sign in to GitHub with a device code.
           hint: |
             Signs you in through GitHub, with no app setup or client secret
-            needed. Requests the `repo`, `read:org`, `read:user`, and
-            `user:email` scopes. To use your own GitHub app instead, set
-            GITHUB_MCP_OAUTH_CLIENT_ID to its Client ID and enable device flow
-            on the app.
+            needed. Requests the scopes needed for the read-oriented GitHub MCP
+            tools exposed by this source: `repo`, `read:org`, `read:user`,
+            `user:email`, `gist`, `notifications`, `read:project`, and
+            `security_events`. To use your own GitHub app instead, set
+            GITHUB_MCP_OAUTH_CLIENT_ID to its Client ID and enable device flow on
+            the app.
           oauth:
             flow:
               type: device_code
@@ -45,6 +50,10 @@ inputs:
                   - read:org
                   - read:user
                   - user:email
+                  - gist
+                  - notifications
+                  - read:project
+                  - security_events
         - type: oauth
           label: Connect with GitHub OAuth app
           description: Sign in through a GitHub OAuth app in your browser.
@@ -52,7 +61,7 @@ inputs:
             Uses your own GitHub OAuth app. Register one with its Authorization
             callback URL set to `http://127.0.0.1:53682/oauth/callback`, then
             enter the app's Client ID and Client secret below. Requests the
-            `repo`, `read:org`, `read:user`, and `user:email` scopes.
+            read-oriented GitHub MCP scopes exposed by this source.
           oauth:
             flow:
               type: authorization_code
@@ -77,14 +86,18 @@ inputs:
                   - read:org
                   - read:user
                   - user:email
+                  - gist
+                  - notifications
+                  - read:project
+                  - security_events
         - type: source_config
           label: Paste GitHub token
           description: Paste an existing GitHub token or provide GITHUB_MCP_ACCESS_TOKEN.
           hint: |
             If you use GitHub CLI, run `gh auth token`. Otherwise create a
-            personal access token with read access to the repositories and
-            organizations you query. Paste the raw token value, without a
-            `Bearer ` prefix.
+            personal access token with read access to the repositories,
+            organizations, notifications, projects, gists, and security data you
+            query. Paste the raw token value, without a `Bearer ` prefix.
 
 server:
   transport: streamable_http
@@ -159,7 +172,7 @@ functions:
 
   - name: issue_read
     tool: issue_read
-    description: Read issue details, comments, sub-issues, labels, or events.
+    description: Read issue details, comments, sub-issues, or labels.
     args:
       - name: owner
         required: true
@@ -180,7 +193,6 @@ functions:
           - get_comments
           - get_sub_issues
           - get_labels
-          - get_events
         bind:
           arg: method
       - name: page
@@ -189,9 +201,6 @@ functions:
       - name: per_page
         bind:
           arg: perPage
-      - name: after
-        bind:
-          arg: after
     columns:
       - name: result
         type: Utf8
@@ -218,8 +227,8 @@ functions:
           arg: repo
       - name: state
         values:
-          - open
-          - closed
+          - OPEN
+          - CLOSED
         bind:
           arg: state
       - name: since
@@ -485,13 +494,9 @@ functions:
         required: true
         bind:
           arg: sha
-      - name: detail
-        values:
-          - none
-          - stats
-          - full_patch
+      - name: include_diff
         bind:
-          arg: detail
+          arg: include_diff
       - name: page
         bind:
           arg: page
@@ -863,6 +868,1350 @@ functions:
       - name: per_page
         bind:
           arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: actions_list
+    tool: actions_list
+    description: List GitHub Actions workflows, runs, jobs, or artifacts.
+    args:
+      - name: method
+        required: true
+        values:
+          - list_workflows
+          - list_workflow_runs
+          - list_workflow_jobs
+          - list_workflow_run_artifacts
+        bind:
+          arg: method
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: resource_id
+        bind:
+          arg: resource_id
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: per_page
+      - name: workflow_jobs_filter
+        bind:
+          arg: workflow_jobs_filter
+      - name: workflow_runs_filter
+        bind:
+          arg: workflow_runs_filter
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: actions_get
+    tool: actions_get
+    description: Get one GitHub Actions workflow, run, job, artifact, or logs URL.
+    args:
+      - name: method
+        required: true
+        values:
+          - get_workflow
+          - get_workflow_run
+          - get_workflow_job
+          - download_workflow_run_artifact
+          - get_workflow_run_usage
+          - get_workflow_run_logs_url
+        bind:
+          arg: method
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: resource_id
+        required: true
+        bind:
+          arg: resource_id
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_job_logs
+    tool: get_job_logs
+    description: Get logs for one GitHub Actions job or failed jobs in a run.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: job_id
+        bind:
+          arg: job_id
+      - name: run_id
+        bind:
+          arg: run_id
+      - name: failed_only
+        bind:
+          arg: failed_only
+      - name: return_content
+        bind:
+          arg: return_content
+      - name: tail_lines
+        bind:
+          arg: tail_lines
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_code_scanning_alerts
+    tool: list_code_scanning_alerts
+    description: List code scanning alerts in a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: state
+        values:
+          - open
+          - closed
+          - dismissed
+          - fixed
+        bind:
+          arg: state
+      - name: severity
+        values:
+          - critical
+          - high
+          - medium
+          - low
+          - warning
+          - note
+          - error
+        bind:
+          arg: severity
+      - name: ref
+        bind:
+          arg: ref
+      - name: tool_name
+        bind:
+          arg: tool_name
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_code_scanning_alert
+    tool: get_code_scanning_alert
+    description: Get details for one code scanning alert.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: alert_number
+        required: true
+        bind:
+          arg: alertNumber
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_dependabot_alerts
+    tool: list_dependabot_alerts
+    description: List Dependabot alerts in a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: state
+        values:
+          - open
+          - fixed
+          - dismissed
+          - auto_dismissed
+        bind:
+          arg: state
+      - name: severity
+        values:
+          - low
+          - medium
+          - high
+          - critical
+        bind:
+          arg: severity
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_dependabot_alert
+    tool: get_dependabot_alert
+    description: Get details for one Dependabot alert.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: alert_number
+        required: true
+        bind:
+          arg: alertNumber
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_secret_scanning_alerts
+    tool: list_secret_scanning_alerts
+    description: List secret scanning alerts in a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: state
+        values:
+          - open
+          - resolved
+        bind:
+          arg: state
+      - name: resolution
+        values:
+          - false_positive
+          - wont_fix
+          - revoked
+          - pattern_edited
+          - pattern_deleted
+          - used_in_tests
+        bind:
+          arg: resolution
+      - name: secret_type
+        bind:
+          arg: secret_type
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_secret_scanning_alert
+    tool: get_secret_scanning_alert
+    description: Get details for one secret scanning alert.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: alert_number
+        required: true
+        bind:
+          arg: alertNumber
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: check_dependency_vulnerabilities
+    tool: check_dependency_vulnerabilities
+    description: Check dependencies against the GitHub Security Advisory Database.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: dependencies
+        required: true
+        bind:
+          arg: dependencies
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_global_security_advisories
+    tool: list_global_security_advisories
+    description: List global GitHub security advisories.
+    args:
+      - name: ghsa_id
+        bind:
+          arg: ghsaId
+      - name: cve_id
+        bind:
+          arg: cveId
+      - name: ecosystem
+        values:
+          - actions
+          - composer
+          - erlang
+          - go
+          - maven
+          - npm
+          - nuget
+          - other
+          - pip
+          - pub
+          - rubygems
+          - rust
+        bind:
+          arg: ecosystem
+      - name: severity
+        values:
+          - unknown
+          - low
+          - medium
+          - high
+          - critical
+        bind:
+          arg: severity
+      - name: advisory_type
+        values:
+          - reviewed
+          - malware
+          - unreviewed
+        bind:
+          arg: type
+      - name: affects
+        bind:
+          arg: affects
+      - name: cwes
+        bind:
+          arg: cwes
+      - name: is_withdrawn
+        bind:
+          arg: isWithdrawn
+      - name: published
+        bind:
+          arg: published
+      - name: updated
+        bind:
+          arg: updated
+      - name: modified
+        bind:
+          arg: modified
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_global_security_advisory
+    tool: get_global_security_advisory
+    description: Get one global GitHub security advisory.
+    args:
+      - name: ghsa_id
+        required: true
+        bind:
+          arg: ghsaId
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_repository_security_advisories
+    tool: list_repository_security_advisories
+    description: List security advisories for a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: state
+        values:
+          - triage
+          - draft
+          - published
+          - closed
+        bind:
+          arg: state
+      - name: sort
+        values:
+          - created
+          - updated
+          - published
+        bind:
+          arg: sort
+      - name: direction
+        values:
+          - asc
+          - desc
+        bind:
+          arg: direction
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_org_repository_security_advisories
+    tool: list_org_repository_security_advisories
+    description: List repository security advisories for an organization.
+    args:
+      - name: org
+        required: true
+        bind:
+          arg: org
+      - name: state
+        values:
+          - triage
+          - draft
+          - published
+          - closed
+        bind:
+          arg: state
+      - name: sort
+        values:
+          - created
+          - updated
+          - published
+        bind:
+          arg: sort
+      - name: direction
+        values:
+          - asc
+          - desc
+        bind:
+          arg: direction
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_discussions
+    tool: list_discussions
+    description: List GitHub Discussions for a repository or organization.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        bind:
+          arg: repo
+      - name: category
+        bind:
+          arg: category
+      - name: order_by
+        values:
+          - CREATED_AT
+          - UPDATED_AT
+        bind:
+          arg: orderBy
+      - name: direction
+        values:
+          - ASC
+          - DESC
+        bind:
+          arg: direction
+      - name: per_page
+        bind:
+          arg: perPage
+      - name: after
+        bind:
+          arg: after
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_discussion
+    tool: get_discussion
+    description: Get one GitHub Discussion.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: discussion_number
+        required: true
+        bind:
+          arg: discussionNumber
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_discussion_comments
+    tool: get_discussion_comments
+    description: Get comments for one GitHub Discussion.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: discussion_number
+        required: true
+        bind:
+          arg: discussionNumber
+      - name: include_replies
+        bind:
+          arg: includeReplies
+      - name: per_page
+        bind:
+          arg: perPage
+      - name: after
+        bind:
+          arg: after
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_discussion_categories
+    tool: list_discussion_categories
+    description: List GitHub Discussion categories for a repository or organization.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        bind:
+          arg: repo
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_notifications
+    tool: list_notifications
+    description: List GitHub notifications for the authenticated user.
+    args:
+      - name: owner
+        bind:
+          arg: owner
+      - name: repo
+        bind:
+          arg: repo
+      - name: notification_filter
+        values:
+          - default
+          - include_read_notifications
+          - only_participating
+        bind:
+          arg: filter
+      - name: since
+        bind:
+          arg: since
+      - name: before
+        bind:
+          arg: before
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_notification_details
+    tool: get_notification_details
+    description: Get details for one GitHub notification.
+    args:
+      - name: notification_id
+        required: true
+        bind:
+          arg: notificationID
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: projects_list
+    tool: projects_list
+    description: List GitHub Projects, project fields, items, or status updates.
+    args:
+      - name: method
+        required: true
+        values:
+          - list_projects
+          - list_project_fields
+          - list_project_items
+          - list_project_status_updates
+        bind:
+          arg: method
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: owner_type
+        values:
+          - user
+          - org
+        bind:
+          arg: owner_type
+      - name: project_number
+        bind:
+          arg: project_number
+      - name: query
+        bind:
+          arg: query
+      - name: fields
+        bind:
+          arg: fields
+      - name: per_page
+        bind:
+          arg: per_page
+      - name: after
+        bind:
+          arg: after
+      - name: before
+        bind:
+          arg: before
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: projects_get
+    tool: projects_get
+    description: Get one GitHub Project, field, item, or status update.
+    args:
+      - name: method
+        required: true
+        values:
+          - get_project
+          - get_project_field
+          - get_project_item
+          - get_project_status_update
+        bind:
+          arg: method
+      - name: owner
+        bind:
+          arg: owner
+      - name: owner_type
+        values:
+          - user
+          - org
+        bind:
+          arg: owner_type
+      - name: project_number
+        bind:
+          arg: project_number
+      - name: field_id
+        bind:
+          arg: field_id
+      - name: item_id
+        bind:
+          arg: item_id
+      - name: status_update_id
+        bind:
+          arg: status_update_id
+      - name: fields
+        bind:
+          arg: fields
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_gists
+    tool: list_gists
+    description: List gists for a user or the authenticated user.
+    args:
+      - name: username
+        bind:
+          arg: username
+      - name: since
+        bind:
+          arg: since
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_gist
+    tool: get_gist
+    description: Get one GitHub gist by ID.
+    args:
+      - name: gist_id
+        required: true
+        bind:
+          arg: gist_id
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_label
+    tool: list_label
+    description: List labels in a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_label
+    tool: get_label
+    description: Get one label in a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: name
+        required: true
+        bind:
+          arg: name
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_issue_types
+    tool: list_issue_types
+    description: List issue types for an organization.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_repository_collaborators
+    tool: list_repository_collaborators
+    description: List collaborators in a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: affiliation
+        values:
+          - outside
+          - direct
+          - all
+        bind:
+          arg: affiliation
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_starred_repositories
+    tool: list_starred_repositories
+    description: List starred repositories for a user or the authenticated user.
+    args:
+      - name: username
+        bind:
+          arg: username
+      - name: sort
+        values:
+          - created
+          - updated
+        bind:
+          arg: sort
+      - name: direction
+        values:
+          - asc
+          - desc
+        bind:
+          arg: direction
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_tag
+    tool: get_tag
+    description: Get details for one repository tag.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: tag
+        required: true
+        bind:
+          arg: tag
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: search_orgs
+    tool: search_orgs
+    description: Search organizations using GitHub organization search syntax.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: sort
+        values:
+          - followers
+          - repositories
+          - joined
+        bind:
+          arg: sort
+      - name: order
+        values:
+          - asc
+          - desc
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: semantic_issues_search
+    tool: semantic_issues_search
+    description: Search issues semantically with natural language.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: owner
+        bind:
+          arg: owner
+      - name: repo
+        bind:
+          arg: repo
+      - name: sort
+        values:
+          - comments
+          - reactions
+          - reactions-+1
+          - reactions--1
+          - reactions-smile
+          - reactions-thinking_face
+          - reactions-heart
+          - reactions-tada
+          - interactions
+          - created
+          - updated
+        bind:
+          arg: sort
+      - name: order
+        values:
+          - asc
+          - desc
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: semantic_issue_similarity_search
+    tool: semantic_issue_similarity_search
+    description: Find issues semantically similar to one issue.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: issue_number
+        required: true
+        bind:
+          arg: issue_number
+      - name: threshold
+        bind:
+          arg: threshold
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: per_page
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: github_support_docs_search
+    tool: github_support_docs_search
+    description: Search GitHub support documentation through the GitHub MCP server.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: web_search
+    tool: web_search
+    description: Run GitHub MCP's AI-powered web search.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_copilot_spaces
+    tool: list_copilot_spaces
+    description: List Copilot Spaces accessible to the authenticated user.
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_copilot_space
+    tool: get_copilot_space
+    description: Get the contents of one Copilot Space.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: name
+        required: true
+        bind:
+          arg: name
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_copilot_job_status
+    tool: get_copilot_job_status
+    description: Get status for a GitHub Copilot coding agent job.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: id
+        required: true
+        bind:
+          arg: id
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: run_secret_scanning
+    tool: run_secret_scanning
+    description: Scan raw content strings or diff hunks for secrets with GitHub MCP.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: files
+        required: true
+        bind:
+          arg: files
     columns:
       - name: result
         type: Utf8

--- a/sources/community/github_mcp/manifest.yaml
+++ b/sources/community/github_mcp/manifest.yaml
@@ -1,43 +1,24 @@
 dsl_version: 3
 name: github_mcp
-version: 0.1.0
-description: >-
-  Query GitHub repositories, issues, pull requests, Actions, security alerts,
-  projects, discussions, notifications, and other GitHub MCP tools through
-  GitHub's official remote MCP server.
+version: "0.1.0"
+description: "Query GitHub repositories, issues, pull requests, Actions, security alerts, projects, discussions, notifications, and other GitHub MCP tools through GitHub's official remote MCP server."
 backend: mcp
-
 inputs:
   GITHUB_MCP_ACCESS_TOKEN:
     kind: secret
-    hint: |
-      Connect with GitHub OAuth or paste a personal access token. The OAuth
-      methods request the GitHub scopes used by the read-oriented GitHub MCP
-      tools exposed by this source: `repo`, `read:org`, `read:user`,
-      `user:email`, `gist`, `notifications`, `read:project`, and
-      `security_events`.
-
-      See GitHub's MCP server docs:
-      https://github.com/github/github-mcp-server
+    hint: "Connect with GitHub OAuth or paste a personal access token. The OAuth\nmethods request the GitHub scopes used by the read-oriented GitHub MCP\ntools exposed by this source: `repo`, `read:org`, `read:user`,\n`user:email`, `gist`, `notifications`, `read:project`, and\n`security_events`.\n\nSee GitHub's MCP server docs:\nhttps://github.com/github/github-mcp-server\n"
     credential:
       methods:
         - type: oauth
           label: Connect with GitHub device code
           description: Sign in to GitHub with a device code.
-          hint: |
-            Signs you in through GitHub, with no app setup or client secret
-            needed. Requests the scopes needed for the read-oriented GitHub MCP
-            tools exposed by this source: `repo`, `read:org`, `read:user`,
-            `user:email`, `gist`, `notifications`, `read:project`, and
-            `security_events`. To use your own GitHub app instead, set
-            GITHUB_MCP_OAUTH_CLIENT_ID to its Client ID and enable device flow on
-            the app.
+          hint: "Signs you in through GitHub, with no app setup or client secret\nneeded. Requests the scopes needed for the read-oriented GitHub MCP\ntools exposed by this source: `repo`, `read:org`, `read:user`,\n`user:email`, `gist`, `notifications`, `read:project`, and\n`security_events`. To use your own GitHub app instead, set\nGITHUB_MCP_OAUTH_CLIENT_ID to its Client ID and enable device flow on\nthe app.\n"
           oauth:
             flow:
               type: device_code
             endpoints:
-              device_authorization_url: https://github.com/login/device/code
-              token_url: https://github.com/login/oauth/access_token
+              device_authorization_url: "https://github.com/login/device/code"
+              token_url: "https://github.com/login/oauth/access_token"
             client:
               id:
                 default: Iv23liJHis6Bs8NO1DAI
@@ -45,32 +26,20 @@ inputs:
             scopes:
               scope:
                 delimiter: space
-                values:
-                  - repo
-                  - read:org
-                  - read:user
-                  - user:email
-                  - gist
-                  - notifications
-                  - read:project
-                  - security_events
+                values: [repo, "read:org", "read:user", "user:email", gist, "notifications", "read:project", security_events]
         - type: oauth
           label: Connect with GitHub OAuth app
           description: Sign in through a GitHub OAuth app in your browser.
-          hint: |
-            Uses your own GitHub OAuth app. Register one with its Authorization
-            callback URL set to `http://127.0.0.1:53682/oauth/callback`, then
-            enter the app's Client ID and Client secret below. Requests the
-            read-oriented GitHub MCP scopes exposed by this source.
+          hint: "Uses your own GitHub OAuth app. Register one with its Authorization\ncallback URL set to `http://127.0.0.1:53682/oauth/callback`, then\nenter the app's Client ID and Client secret below. Requests the\nread-oriented GitHub MCP scopes exposed by this source.\n"
           oauth:
             flow:
               type: authorization_code
               pkce: required
-            redirect_uri: http://127.0.0.1:53682/oauth/callback
+            redirect_uri: "http://127.0.0.1:53682/oauth/callback"
             redirect_uri_port_mode: fixed
             endpoints:
-              authorization_url: https://github.com/login/oauth/authorize
-              token_url: https://github.com/login/oauth/access_token
+              authorization_url: "https://github.com/login/oauth/authorize"
+              token_url: "https://github.com/login/oauth/access_token"
             client:
               id:
                 default: Iv23liJHis6Bs8NO1DAI
@@ -81,186 +50,4113 @@ inputs:
             scopes:
               scope:
                 delimiter: space
-                values:
-                  - repo
-                  - read:org
-                  - read:user
-                  - user:email
-                  - gist
-                  - notifications
-                  - read:project
-                  - security_events
+                values: [repo, "read:org", "read:user", "user:email", gist, "notifications", "read:project", security_events]
         - type: source_config
           label: Paste GitHub token
           description: Paste an existing GitHub token or provide GITHUB_MCP_ACCESS_TOKEN.
-          hint: |
-            If you use GitHub CLI, run `gh auth token`. Otherwise create a
-            personal access token with read access to the repositories,
-            organizations, notifications, projects, gists, and security data you
-            query. Paste the raw token value, without a `Bearer ` prefix.
-
+          hint: "If you use GitHub CLI, run `gh auth token`. Otherwise create a\npersonal access token with read access to the repositories,\norganizations, notifications, projects, gists, and security data you\nquery. Paste the raw token value, without a `Bearer ` prefix.\n"
 server:
   transport: streamable_http
-  url: https://api.githubcopilot.com/mcp/x/all/readonly
+  url: "https://api.githubcopilot.com/mcp/x/all/readonly"
   auth:
     type: bearer
     from: input
     key: GITHUB_MCP_ACCESS_TOKEN
-
-test_queries:
-  - SELECT result FROM github_mcp.me LIMIT 1
-
+test_queries: [SELECT login FROM github_mcp.me LIMIT 1]
 tables:
   - name: me
     description: Authenticated GitHub user profile returned by the get_me tool.
     tool: get_me
     columns:
-      - name: result
+      - name: login
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
+      - name: id
+        type: Int64
+      - name: profile_url
+        type: Utf8
+      - name: avatar_url
+        type: Utf8
+      - name: name
+        type: Utf8
         expr:
-          kind: current_row
+          kind: path
+          path: [details, name]
+      - name: company
+        type: Utf8
+        expr:
+          kind: path
+          path: [details, company]
+      - name: blog
+        type: Utf8
+        expr:
+          kind: path
+          path: [details, blog]
+      - name: location
+        type: Utf8
+        expr:
+          kind: path
+          path: [details, location]
+      - name: public_repos
+        type: Int64
+        expr:
+          kind: path
+          path: [details, public_repos]
+      - name: public_gists
+        type: Int64
+        expr:
+          kind: path
+          path: [details, public_gists]
+      - name: followers
+        type: Int64
+        expr:
+          kind: path
+          path: [details, followers]
+      - name: following
+        type: Int64
+        expr:
+          kind: path
+          path: [details, following]
+      - name: created_at
+        type: Utf8
+        expr:
+          kind: path
+          path: [details, created_at]
+      - name: updated_at
+        type: Utf8
+        expr:
+          kind: path
+          path: [details, updated_at]
       - name: raw
         type: Json
-        description: Raw GitHub MCP response row.
+        description: Full JSON row returned by the GitHub MCP tool.
         expr:
           kind: current_row
-
-functions:
-  - name: get_teams
+  - name: teams
     tool: get_teams
-    description: Get teams for a GitHub user, defaulting to the authenticated user.
-    args:
+    description: "Get teams for a GitHub user, defaulting to the authenticated user."
+    filters:
       - name: user
-        bind:
-          arg: user
-    columns:
-      - name: result
+        tool_arg: user
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
+    columns:
+      - name: org
+        type: Utf8
+      - name: teams
+        type: Json
       - name: raw
         type: Json
-        description: Raw GitHub MCP response row.
+        description: Full JSON row returned by the GitHub MCP tool.
         expr:
           kind: current_row
-
-  - name: get_team_members
+      - name: user
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: user
+  - name: team_members
     tool: get_team_members
     description: Get members of a team in a GitHub organization.
-    args:
+    filters:
       - name: org
+        tool_arg: org
         required: true
-        bind:
-          arg: org
+        type: Utf8
       - name: team_slug
+        tool_arg: team_slug
         required: true
-        bind:
-          arg: team_slug
-    columns:
-      - name: result
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
+    columns:
+      - name: login
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: profile_url
+        type: Utf8
+      - name: avatar_url
+        type: Utf8
+      - name: type
+        type: Utf8
       - name: raw
         type: Json
-        description: Raw GitHub MCP response row.
+        description: Full JSON row returned by the GitHub MCP tool.
         expr:
           kind: current_row
-
-  - name: issue_read
+      - name: org
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: org
+      - name: team_slug
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: team_slug
+  - name: issue
     tool: issue_read
-    description: Read issue details, comments, sub-issues, or labels.
-    args:
+    description: "Read issue details, comments, sub-issues, or labels."
+    tool_args:
+      method:
+        from: literal
+        value: get
+    filters:
       - name: owner
+        tool_arg: owner
         required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: issue_number
-        required: true
-        bind:
-          arg: issue_number
-      - name: method
-        required: true
-        values:
-          - get
-          - get_comments
-          - get_sub_issues
-          - get_labels
-        bind:
-          arg: method
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: issue_number
+        tool_arg: issue_number
+        required: true
+        type: Int64
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: number
+        type: Int64
+      - name: title
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: author_association
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: closed_at
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: user
+        type: Json
+      - name: labels
+        type: Json
       - name: raw
         type: Json
-        description: Raw GitHub MCP response row.
+        description: Full JSON row returned by the GitHub MCP tool.
         expr:
           kind: current_row
-
-  - name: list_issues
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: issue_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: issue_number
+  - name: issues
     tool: list_issues
     description: List issues in a repository.
-    args:
+    filters:
       - name: owner
+        tool_arg: owner
         required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: state
-        values:
-          - OPEN
-          - CLOSED
-        bind:
-          arg: state
-      - name: since
-        bind:
-          arg: since
-      - name: order_by
-        bind:
-          arg: orderBy
-      - name: direction
-        values:
-          - ASC
-          - DESC
-        bind:
-          arg: direction
-      - name: per_page
-        bind:
-          arg: perPage
-      - name: after
-        bind:
-          arg: after
-    columns:
-      - name: result
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: state
+        tool_arg: state
+        type: Utf8
+      - name: since
+        tool_arg: since
+        type: Utf8
+      - name: order_by
+        tool_arg: orderBy
+        type: Utf8
+      - name: direction
+        tool_arg: direction
+        type: Utf8
+      - name: after
+        tool_arg: after
+        type: Utf8
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    response:
+      rows_path: [issues]
+    columns:
+      - name: number
+        type: Int64
+      - name: title
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: author_association
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: closed_at
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: user
+        type: Json
+      - name: labels
+        type: Json
       - name: raw
         type: Json
-        description: Raw GitHub MCP response row.
+        description: Full JSON row returned by the GitHub MCP tool.
         expr:
           kind: current_row
-
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: since
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: since
+      - name: direction
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: direction
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+  - name: pull_requests
+    tool: list_pull_requests
+    description: List pull requests in a repository.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: state
+        tool_arg: state
+        type: Utf8
+      - name: base
+        tool_arg: base
+        type: Utf8
+      - name: head
+        tool_arg: head
+        type: Utf8
+      - name: sort
+        tool_arg: sort
+        type: Utf8
+      - name: direction
+        tool_arg: direction
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: number
+        type: Int64
+      - name: title
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: author_association
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: merged_at
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: user
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: base
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: base
+      - name: head
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: head
+      - name: sort
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: sort
+      - name: direction
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: direction
+  - name: repository_tree
+    tool: get_repository_tree
+    description: "Get a repository tree, optionally filtered by path prefix."
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: tree_sha
+        tool_arg: tree_sha
+        type: Utf8
+      - name: path_filter
+        tool_arg: path_filter
+        type: Utf8
+      - name: recursive
+        tool_arg: recursive
+        type: Boolean
+    response:
+      rows_path: [tree]
+    columns:
+      - name: path
+        type: Utf8
+      - name: mode
+        type: Utf8
+      - name: type
+        type: Utf8
+      - name: sha
+        type: Utf8
+      - name: size
+        type: Int64
+      - name: url
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: tree_sha
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: tree_sha
+  - name: commit
+    tool: get_commit
+    description: Get details for a repository commit.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: sha
+        tool_arg: sha
+        required: true
+        type: Utf8
+      - name: include_diff
+        tool_arg: include_diff
+        type: Boolean
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: sha
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: commit
+        type: Json
+      - name: author
+        type: Json
+      - name: committer
+        type: Json
+      - name: parents
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+  - name: branches
+    tool: list_branches
+    description: List branches in a repository.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: name
+        type: Utf8
+      - name: sha
+        type: Utf8
+      - name: protected
+        type: Boolean
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+  - name: commits
+    tool: list_commits
+    description: List repository commits.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: sha
+        tool_arg: sha
+        type: Utf8
+      - name: path
+        tool_arg: path
+        type: Utf8
+      - name: author
+        tool_arg: author
+        type: Utf8
+      - name: since
+        tool_arg: since
+        type: Utf8
+      - name: until
+        tool_arg: until
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: sha
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: commit
+        type: Json
+      - name: author
+        type: Json
+      - name: committer
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: path
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: path
+      - name: since
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: since
+  - name: releases
+    tool: list_releases
+    description: List repository releases.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: id
+        type: Int64
+      - name: tag_name
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: draft
+        type: Boolean
+      - name: prerelease
+        type: Boolean
+      - name: created_at
+        type: Utf8
+      - name: published_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+  - name: latest_release
+    tool: get_latest_release
+    description: Get the latest release for a repository.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+    columns:
+      - name: id
+        type: Int64
+      - name: tag_name
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: draft
+        type: Boolean
+      - name: prerelease
+        type: Boolean
+      - name: created_at
+        type: Utf8
+      - name: published_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+  - name: release_by_tag
+    tool: get_release_by_tag
+    description: Get a repository release by tag.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: tag
+        tool_arg: tag
+        required: true
+        type: Utf8
+    columns:
+      - name: id
+        type: Int64
+      - name: tag_name
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: draft
+        type: Boolean
+      - name: prerelease
+        type: Boolean
+      - name: created_at
+        type: Utf8
+      - name: published_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: tag
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: tag
+  - name: tags
+    tool: list_tags
+    description: List repository tags.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: name
+        type: Utf8
+      - name: sha
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+  - name: code_scanning_alerts
+    tool: list_code_scanning_alerts
+    description: List code scanning alerts in a repository.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: state
+        tool_arg: state
+        type: Utf8
+      - name: severity
+        tool_arg: severity
+        type: Utf8
+      - name: ref
+        tool_arg: ref
+        type: Utf8
+      - name: tool_name
+        tool_arg: tool_name
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: number
+        type: Int64
+      - name: state
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: fixed_at
+        type: Utf8
+      - name: dismissed_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: rule
+        type: Json
+      - name: tool
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: severity
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: severity
+      - name: ref
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: ref
+  - name: code_scanning_alert
+    tool: get_code_scanning_alert
+    description: Get details for one code scanning alert.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: alert_number
+        tool_arg: alertNumber
+        required: true
+        type: Int64
+    columns:
+      - name: number
+        type: Int64
+      - name: state
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: fixed_at
+        type: Utf8
+      - name: dismissed_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: rule
+        type: Json
+      - name: tool
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: alert_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: alert_number
+  - name: dependabot_alerts
+    tool: list_dependabot_alerts
+    description: List Dependabot alerts in a repository.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: state
+        tool_arg: state
+        type: Utf8
+      - name: severity
+        tool_arg: severity
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: number
+        type: Int64
+      - name: state
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: fixed_at
+        type: Utf8
+      - name: dismissed_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: dependency
+        type: Json
+      - name: security_advisory
+        type: Json
+      - name: security_vulnerability
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: severity
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: severity
+  - name: dependabot_alert
+    tool: get_dependabot_alert
+    description: Get details for one Dependabot alert.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: alert_number
+        tool_arg: alertNumber
+        required: true
+        type: Int64
+    columns:
+      - name: number
+        type: Int64
+      - name: state
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: fixed_at
+        type: Utf8
+      - name: dismissed_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: dependency
+        type: Json
+      - name: security_advisory
+        type: Json
+      - name: security_vulnerability
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: alert_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: alert_number
+  - name: secret_scanning_alerts
+    tool: list_secret_scanning_alerts
+    description: List secret scanning alerts in a repository.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: state
+        tool_arg: state
+        type: Utf8
+      - name: resolution
+        tool_arg: resolution
+        type: Utf8
+      - name: secret_type
+        tool_arg: secret_type
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: number
+        type: Int64
+      - name: state
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: fixed_at
+        type: Utf8
+      - name: dismissed_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: secret_type
+        type: Utf8
+      - name: secret_type_display_name
+        type: Utf8
+      - name: resolution
+        type: Utf8
+      - name: locations_url
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+  - name: secret_scanning_alert
+    tool: get_secret_scanning_alert
+    description: Get details for one secret scanning alert.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: alert_number
+        tool_arg: alertNumber
+        required: true
+        type: Int64
+    columns:
+      - name: number
+        type: Int64
+      - name: state
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: fixed_at
+        type: Utf8
+      - name: dismissed_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: secret_type
+        type: Utf8
+      - name: secret_type_display_name
+        type: Utf8
+      - name: resolution
+        type: Utf8
+      - name: locations
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: alert_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: alert_number
+  - name: global_security_advisories
+    tool: list_global_security_advisories
+    description: List global GitHub security advisories.
+    filters:
+      - name: ghsa_id
+        tool_arg: ghsaId
+        type: Utf8
+      - name: cve_id
+        tool_arg: cveId
+        type: Utf8
+      - name: ecosystem
+        tool_arg: ecosystem
+        type: Utf8
+      - name: severity
+        tool_arg: severity
+        type: Utf8
+      - name: advisory_type
+        tool_arg: type
+        type: Utf8
+      - name: affects
+        tool_arg: affects
+        type: Utf8
+      - name: cwes
+        tool_arg: cwes
+        type: Utf8
+      - name: is_withdrawn
+        tool_arg: isWithdrawn
+        type: Boolean
+      - name: published
+        tool_arg: published
+        type: Utf8
+      - name: updated
+        tool_arg: updated
+        type: Utf8
+      - name: modified
+        tool_arg: modified
+        type: Utf8
+    columns:
+      - name: ghsa_id
+        type: Utf8
+      - name: cve_id
+        type: Utf8
+      - name: summary
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: severity
+        type: Utf8
+      - name: published_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: withdrawn_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: cvss
+        type: Json
+      - name: cwes
+        type: Json
+      - name: vulnerabilities
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: ecosystem
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: ecosystem
+      - name: advisory_type
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: advisory_type
+  - name: global_security_advisory
+    tool: get_global_security_advisory
+    description: Get one global GitHub security advisory.
+    filters:
+      - name: ghsa_id
+        tool_arg: ghsaId
+        required: true
+        type: Utf8
+    columns:
+      - name: ghsa_id
+        type: Utf8
+      - name: cve_id
+        type: Utf8
+      - name: summary
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: severity
+        type: Utf8
+      - name: published_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: withdrawn_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: cvss
+        type: Json
+      - name: cwes
+        type: Json
+      - name: vulnerabilities
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+  - name: repository_security_advisories
+    tool: list_repository_security_advisories
+    description: List security advisories for a repository.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: state
+        tool_arg: state
+        type: Utf8
+      - name: sort
+        tool_arg: sort
+        type: Utf8
+      - name: direction
+        tool_arg: direction
+        type: Utf8
+    columns:
+      - name: ghsa_id
+        type: Utf8
+      - name: cve_id
+        type: Utf8
+      - name: summary
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: severity
+        type: Utf8
+      - name: published_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: withdrawn_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: vulnerabilities
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: sort
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: sort
+      - name: direction
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: direction
+  - name: org_repository_security_advisories
+    tool: list_org_repository_security_advisories
+    description: List repository security advisories for an organization.
+    filters:
+      - name: org
+        tool_arg: org
+        required: true
+        type: Utf8
+      - name: state
+        tool_arg: state
+        type: Utf8
+      - name: sort
+        tool_arg: sort
+        type: Utf8
+      - name: direction
+        tool_arg: direction
+        type: Utf8
+    columns:
+      - name: ghsa_id
+        type: Utf8
+      - name: cve_id
+        type: Utf8
+      - name: summary
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: severity
+        type: Utf8
+      - name: published_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: withdrawn_at
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: repository
+        type: Json
+      - name: vulnerabilities
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: org
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: org
+      - name: sort
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: sort
+      - name: direction
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: direction
+  - name: discussions
+    tool: list_discussions
+    description: List GitHub Discussions for a repository or organization.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        type: Utf8
+      - name: category
+        tool_arg: category
+        type: Utf8
+      - name: order_by
+        tool_arg: orderBy
+        type: Utf8
+      - name: direction
+        tool_arg: direction
+        type: Utf8
+      - name: after
+        tool_arg: after
+        type: Utf8
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    response:
+      rows_path: [discussions]
+    columns:
+      - name: number
+        type: Int64
+      - name: title
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: author
+        type: Json
+      - name: category
+        type: Json
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: direction
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: direction
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+  - name: discussion
+    tool: get_discussion
+    description: Get one GitHub Discussion.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: discussion_number
+        tool_arg: discussionNumber
+        required: true
+        type: Int64
+    columns:
+      - name: number
+        type: Int64
+      - name: title
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: author
+        type: Json
+      - name: category
+        type: Json
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: discussion_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: discussion_number
+  - name: discussion_comments
+    tool: get_discussion_comments
+    description: Get comments for one GitHub Discussion.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: discussion_number
+        tool_arg: discussionNumber
+        required: true
+        type: Int64
+      - name: include_replies
+        tool_arg: includeReplies
+        type: Boolean
+      - name: after
+        tool_arg: after
+        type: Utf8
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    response:
+      rows_path: [comments]
+    columns:
+      - name: id
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: author
+        type: Json
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: replies
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: discussion_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: discussion_number
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+  - name: discussion_categories
+    tool: list_discussion_categories
+    description: List GitHub Discussion categories for a repository or organization.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        type: Utf8
+    response:
+      rows_path: [categories]
+    columns:
+      - name: id
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: emoji
+        type: Utf8
+      - name: is_answerable
+        type: Boolean
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+  - name: "notifications"
+    tool: list_notifications
+    description: List GitHub notifications for the authenticated user.
+    filters:
+      - name: owner
+        tool_arg: owner
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        type: Utf8
+      - name: "notification_filter"
+        tool_arg: filter
+        type: Utf8
+      - name: since
+        tool_arg: since
+        type: Utf8
+      - name: before
+        tool_arg: before
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: id
+        type: Utf8
+      - name: reason
+        type: Utf8
+      - name: unread
+        type: Boolean
+      - name: updated_at
+        type: Utf8
+      - name: last_read_at
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: subject
+        type: Json
+      - name: repository
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: since
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: since
+      - name: before
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: before
+  - name: "notification_details"
+    tool: get_notification_details
+    description: Get details for one GitHub notification.
+    filters:
+      - name: "notification_id"
+        tool_arg: "notificationID"
+        required: true
+        type: Int64
+    columns:
+      - name: id
+        type: Utf8
+      - name: reason
+        type: Utf8
+      - name: unread
+        type: Boolean
+      - name: updated_at
+        type: Utf8
+      - name: last_read_at
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: subject
+        type: Json
+      - name: repository
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: "notification_id"
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: "notification_id"
+  - name: gists
+    tool: list_gists
+    description: List gists for a user or the authenticated user.
+    filters:
+      - name: username
+        tool_arg: username
+        type: Utf8
+      - name: since
+        tool_arg: since
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: id
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: public
+        type: Boolean
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: owner
+        type: Json
+      - name: files
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: username
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: username
+      - name: since
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: since
+  - name: gist
+    tool: get_gist
+    description: Get one GitHub gist by ID.
+    filters:
+      - name: gist_id
+        tool_arg: gist_id
+        required: true
+        type: Utf8
+    columns:
+      - name: id
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: public
+        type: Boolean
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: owner
+        type: Json
+      - name: files
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: gist_id
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: gist_id
+  - name: labels
+    tool: list_label
+    description: List labels in a repository.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+    response:
+      rows_path: [labels]
+    columns:
+      - name: id
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: color
+        type: Utf8
+      - name: default
+        type: Boolean
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+  - name: label
+    tool: get_label
+    description: Get one label in a repository.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: name
+        tool_arg: name
+        required: true
+        type: Utf8
+    columns:
+      - name: id
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: color
+        type: Utf8
+      - name: default
+        type: Boolean
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+  - name: issue_types
+    tool: list_issue_types
+    description: List issue types for an organization.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+    columns:
+      - name: id
+        type: Int64
+      - name: "node_id"
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: color
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+  - name: repository_collaborators
+    tool: list_repository_collaborators
+    description: List collaborators in a repository.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: affiliation
+        tool_arg: affiliation
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    response:
+      rows_path: [items]
+    columns:
+      - name: login
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: role_name
+        type: Utf8
+      - name: permissions
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: affiliation
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: affiliation
+  - name: starred_repositories
+    tool: list_starred_repositories
+    description: List starred repositories for a user or the authenticated user.
+    filters:
+      - name: username
+        tool_arg: username
+        type: Utf8
+      - name: sort
+        tool_arg: sort
+        type: Utf8
+      - name: direction
+        tool_arg: direction
+        type: Utf8
+      - name: page
+        tool_arg: page
+        type: Int64
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: id
+        type: Int64
+      - name: name
+        type: Utf8
+      - name: full_name
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: private
+        type: Boolean
+      - name: fork
+        type: Boolean
+      - name: stargazers_count
+        type: Int64
+      - name: language
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: username
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: username
+      - name: sort
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: sort
+      - name: direction
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: direction
+  - name: tag
+    tool: get_tag
+    description: Get details for one repository tag.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: tag
+        tool_arg: tag
+        required: true
+        type: Utf8
+    columns:
+      - name: ref
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: object
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: tag
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: tag
+  - name: copilot_spaces
+    tool: list_copilot_spaces
+    description: List Copilot Spaces accessible to the authenticated user.
+    columns:
+      - name: id
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: owner
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+  - name: copilot_space
+    tool: get_copilot_space
+    description: Get the contents of one Copilot Space.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: name
+        tool_arg: name
+        required: true
+        type: Utf8
+    columns:
+      - name: id
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: owner
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: content
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+  - name: copilot_job_status
+    tool: get_copilot_job_status
+    description: Get status for a GitHub Copilot coding agent job.
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: id
+        tool_arg: id
+        required: true
+        type: Int64
+    columns:
+      - name: id
+        type: Utf8
+      - name: status
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: conclusion
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: pull_request
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+  - name: pull_request
+    tool: pull_request_read
+    description: "Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get."
+    tool_args:
+      method:
+        from: literal
+        value: get
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: pull_number
+        tool_arg: pullNumber
+        required: true
+        type: Int64
+      - name: page
+        tool_arg: page
+        type: Int64
+      - name: after
+        tool_arg: after
+        type: Utf8
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: number
+        type: Int64
+      - name: title
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: author_association
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: merged_at
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: user
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: pull_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: pull_number
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+  - name: pull_request_files
+    tool: pull_request_read
+    description: "Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get_files."
+    tool_args:
+      method:
+        from: literal
+        value: get_files
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: pull_number
+        tool_arg: pullNumber
+        required: true
+        type: Int64
+      - name: page
+        tool_arg: page
+        type: Int64
+      - name: after
+        tool_arg: after
+        type: Utf8
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: filename
+        type: Utf8
+      - name: status
+        type: Utf8
+      - name: additions
+        type: Int64
+      - name: deletions
+        type: Int64
+      - name: changes
+        type: Int64
+      - name: blob_url
+        type: Utf8
+      - name: raw_url
+        type: Utf8
+      - name: contents_url
+        type: Utf8
+      - name: sha
+        type: Utf8
+      - name: patch
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: pull_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: pull_number
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+  - name: pull_request_review_comments
+    tool: pull_request_read
+    description: "Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get_review_comments."
+    tool_args:
+      method:
+        from: literal
+        value: get_review_comments
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: pull_number
+        tool_arg: pullNumber
+        required: true
+        type: Int64
+      - name: page
+        tool_arg: page
+        type: Int64
+      - name: after
+        tool_arg: after
+        type: Utf8
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: id
+        type: Int64
+      - name: body
+        type: Utf8
+      - name: path
+        type: Utf8
+      - name: diff_hunk
+        type: Utf8
+      - name: position
+        type: Utf8
+      - name: original_position
+        type: Utf8
+      - name: commit_id
+        type: Utf8
+      - name: original_commit_id
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: pull_request_url
+        type: Utf8
+      - name: user
+        type: Json
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: pull_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: pull_number
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+  - name: pull_request_reviews
+    tool: pull_request_read
+    description: "Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get_reviews."
+    tool_args:
+      method:
+        from: literal
+        value: get_reviews
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: pull_number
+        tool_arg: pullNumber
+        required: true
+        type: Int64
+      - name: page
+        tool_arg: page
+        type: Int64
+      - name: after
+        tool_arg: after
+        type: Utf8
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: id
+        type: Int64
+      - name: body
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: pull_request_url
+        type: Utf8
+      - name: commit_id
+        type: Utf8
+      - name: user
+        type: Json
+      - name: submitted_at
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: pull_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: pull_number
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+  - name: pull_request_comments
+    tool: pull_request_read
+    description: "Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get_comments."
+    tool_args:
+      method:
+        from: literal
+        value: get_comments
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: pull_number
+        tool_arg: pullNumber
+        required: true
+        type: Int64
+      - name: page
+        tool_arg: page
+        type: Int64
+      - name: after
+        tool_arg: after
+        type: Utf8
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    columns:
+      - name: id
+        type: Int64
+      - name: body
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: issue_url
+        type: Utf8
+      - name: user
+        type: Json
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: pull_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: pull_number
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+  - name: pull_request_check_runs
+    tool: pull_request_read
+    description: "Read pull request details, diff, files, comments, reviews, or checks. Fixed to method=get_check_runs."
+    tool_args:
+      method:
+        from: literal
+        value: get_check_runs
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: pull_number
+        tool_arg: pullNumber
+        required: true
+        type: Int64
+      - name: page
+        tool_arg: page
+        type: Int64
+      - name: after
+        tool_arg: after
+        type: Utf8
+    limit_binding:
+      tool_arg: perPage
+      max: 100
+    response:
+      rows_path: [check_runs]
+    columns:
+      - name: id
+        type: Int64
+      - name: name
+        type: Utf8
+      - name: status
+        type: Utf8
+      - name: conclusion
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: started_at
+        type: Utf8
+      - name: completed_at
+        type: Utf8
+      - name: app
+        type: Json
+      - name: check_suite
+        type: Json
+      - name: pull_requests
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: pull_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: pull_number
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+  - name: workflows
+    tool: actions_list
+    description: "List GitHub Actions workflows, runs, jobs, or artifacts. Fixed to method=list_workflows."
+    tool_args:
+      method:
+        from: literal
+        value: list_workflows
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: resource_id
+        tool_arg: resource_id
+        type: Int64
+      - name: page
+        tool_arg: page
+        type: Int64
+      - name: workflow_jobs_filter
+        tool_arg: workflow_jobs_filter
+        type: Utf8
+      - name: workflow_runs_filter
+        tool_arg: workflow_runs_filter
+        type: Utf8
+    limit_binding:
+      tool_arg: per_page
+      max: 100
+    response:
+      rows_path: [workflows]
+    columns:
+      - name: id
+        type: Int64
+      - name: name
+        type: Utf8
+      - name: path
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: badge_url
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: resource_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: resource_id
+  - name: workflow_runs
+    tool: actions_list
+    description: "List GitHub Actions workflows, runs, jobs, or artifacts. Fixed to method=list_workflow_runs."
+    tool_args:
+      method:
+        from: literal
+        value: list_workflow_runs
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: resource_id
+        tool_arg: resource_id
+        type: Int64
+      - name: page
+        tool_arg: page
+        type: Int64
+      - name: workflow_jobs_filter
+        tool_arg: workflow_jobs_filter
+        type: Utf8
+      - name: workflow_runs_filter
+        tool_arg: workflow_runs_filter
+        type: Utf8
+    limit_binding:
+      tool_arg: per_page
+      max: 100
+    response:
+      rows_path: [workflow_runs]
+    columns:
+      - name: id
+        type: Int64
+      - name: name
+        type: Utf8
+      - name: display_title
+        type: Utf8
+      - name: status
+        type: Utf8
+      - name: conclusion
+        type: Utf8
+      - name: event
+        type: Utf8
+      - name: workflow_id
+        type: Int64
+      - name: head_branch
+        type: Utf8
+      - name: head_sha
+        type: Utf8
+      - name: run_number
+        type: Int64
+      - name: run_attempt
+        type: Int64
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: run_started_at
+        type: Utf8
+      - name: actor
+        type: Json
+      - name: triggering_actor
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: resource_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: resource_id
+  - name: workflow_jobs
+    tool: actions_list
+    description: "List GitHub Actions workflows, runs, jobs, or artifacts. Fixed to method=list_workflow_jobs."
+    tool_args:
+      method:
+        from: literal
+        value: list_workflow_jobs
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: resource_id
+        tool_arg: resource_id
+        required: true
+        type: Int64
+      - name: page
+        tool_arg: page
+        type: Int64
+      - name: workflow_jobs_filter
+        tool_arg: workflow_jobs_filter
+        type: Utf8
+      - name: workflow_runs_filter
+        tool_arg: workflow_runs_filter
+        type: Utf8
+    limit_binding:
+      tool_arg: per_page
+      max: 100
+    response:
+      rows_path: [jobs]
+    columns:
+      - name: id
+        type: Int64
+      - name: run_id
+        type: Int64
+      - name: workflow_name
+        type: Utf8
+      - name: head_branch
+        type: Utf8
+      - name: run_url
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: status
+        type: Utf8
+      - name: conclusion
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: started_at
+        type: Utf8
+      - name: completed_at
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: steps
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: resource_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: resource_id
+  - name: workflow_run_artifacts
+    tool: actions_list
+    description: "List GitHub Actions workflows, runs, jobs, or artifacts. Fixed to method=list_workflow_run_artifacts."
+    tool_args:
+      method:
+        from: literal
+        value: list_workflow_run_artifacts
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: resource_id
+        tool_arg: resource_id
+        required: true
+        type: Int64
+      - name: page
+        tool_arg: page
+        type: Int64
+      - name: workflow_jobs_filter
+        tool_arg: workflow_jobs_filter
+        type: Utf8
+      - name: workflow_runs_filter
+        tool_arg: workflow_runs_filter
+        type: Utf8
+    limit_binding:
+      tool_arg: per_page
+      max: 100
+    response:
+      rows_path: [artifacts]
+    columns:
+      - name: id
+        type: Int64
+      - name: "node_id"
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: size_in_bytes
+        type: Int64
+      - name: url
+        type: Utf8
+      - name: archive_download_url
+        type: Utf8
+      - name: expired
+        type: Boolean
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: expires_at
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: resource_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: resource_id
+  - name: workflow
+    tool: actions_get
+    description: "Get one GitHub Actions workflow, run, job, artifact, or logs URL. Fixed to method=get_workflow."
+    tool_args:
+      method:
+        from: literal
+        value: get_workflow
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: resource_id
+        tool_arg: resource_id
+        required: true
+        type: Int64
+    columns:
+      - name: id
+        type: Int64
+      - name: name
+        type: Utf8
+      - name: path
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: badge_url
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: resource_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: resource_id
+  - name: workflow_run
+    tool: actions_get
+    description: "Get one GitHub Actions workflow, run, job, artifact, or logs URL. Fixed to method=get_workflow_run."
+    tool_args:
+      method:
+        from: literal
+        value: get_workflow_run
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: resource_id
+        tool_arg: resource_id
+        required: true
+        type: Int64
+    columns:
+      - name: id
+        type: Int64
+      - name: name
+        type: Utf8
+      - name: display_title
+        type: Utf8
+      - name: status
+        type: Utf8
+      - name: conclusion
+        type: Utf8
+      - name: event
+        type: Utf8
+      - name: workflow_id
+        type: Int64
+      - name: head_branch
+        type: Utf8
+      - name: head_sha
+        type: Utf8
+      - name: run_number
+        type: Int64
+      - name: run_attempt
+        type: Int64
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: run_started_at
+        type: Utf8
+      - name: actor
+        type: Json
+      - name: triggering_actor
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: resource_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: resource_id
+  - name: workflow_job
+    tool: actions_get
+    description: "Get one GitHub Actions workflow, run, job, artifact, or logs URL. Fixed to method=get_workflow_job."
+    tool_args:
+      method:
+        from: literal
+        value: get_workflow_job
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: resource_id
+        tool_arg: resource_id
+        required: true
+        type: Int64
+    columns:
+      - name: id
+        type: Int64
+      - name: run_id
+        type: Int64
+      - name: workflow_name
+        type: Utf8
+      - name: head_branch
+        type: Utf8
+      - name: run_url
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: status
+        type: Utf8
+      - name: conclusion
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: started_at
+        type: Utf8
+      - name: completed_at
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: steps
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: resource_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: resource_id
+  - name: workflow_run_usage
+    tool: actions_get
+    description: "Get one GitHub Actions workflow, run, job, artifact, or logs URL. Fixed to method=get_workflow_run_usage."
+    tool_args:
+      method:
+        from: literal
+        value: get_workflow_run_usage
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: resource_id
+        tool_arg: resource_id
+        required: true
+        type: Int64
+    columns:
+      - name: billable
+        type: Json
+      - name: run_duration_ms
+        type: Int64
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: resource_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: resource_id
+  - name: workflow_run_logs_url
+    tool: actions_get
+    description: "Get one GitHub Actions workflow, run, job, artifact, or logs URL. Fixed to method=get_workflow_run_logs_url."
+    tool_args:
+      method:
+        from: literal
+        value: get_workflow_run_logs_url
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: repo
+        tool_arg: repo
+        required: true
+        type: Utf8
+      - name: resource_id
+        tool_arg: resource_id
+        required: true
+        type: Int64
+    columns:
+      - name: logs_url
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: repo
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: repo
+      - name: resource_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: resource_id
+  - name: projects
+    tool: projects_list
+    description: "List GitHub Projects, project fields, items, or status updates. Fixed to method=list_projects."
+    tool_args:
+      method:
+        from: literal
+        value: list_projects
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: owner_type
+        tool_arg: owner_type
+        type: Utf8
+      - name: project_number
+        tool_arg: project_number
+        type: Int64
+      - name: query
+        tool_arg: query
+        type: Utf8
+      - name: fields
+        tool_arg: fields
+        type: Utf8
+      - name: after
+        tool_arg: after
+        type: Utf8
+      - name: before
+        tool_arg: before
+        type: Utf8
+    limit_binding:
+      tool_arg: per_page
+      max: 100
+    response:
+      rows_path: [projects]
+    columns:
+      - name: id
+        type: Int64
+      - name: number
+        type: Int64
+      - name: title
+        type: Utf8
+      - name: short_description
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: public
+        type: Boolean
+      - name: closed
+        type: Boolean
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: owner_type
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner_type
+      - name: project_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: project_number
+      - name: query
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: query
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+      - name: before
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: before
+  - name: project_fields
+    tool: projects_list
+    description: "List GitHub Projects, project fields, items, or status updates. Fixed to method=list_project_fields."
+    tool_args:
+      method:
+        from: literal
+        value: list_project_fields
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: owner_type
+        tool_arg: owner_type
+        type: Utf8
+      - name: project_number
+        tool_arg: project_number
+        required: true
+        type: Int64
+      - name: query
+        tool_arg: query
+        type: Utf8
+      - name: fields
+        tool_arg: fields
+        type: Utf8
+      - name: after
+        tool_arg: after
+        type: Utf8
+      - name: before
+        tool_arg: before
+        type: Utf8
+    limit_binding:
+      tool_arg: per_page
+      max: 100
+    response:
+      rows_path: [fields]
+    columns:
+      - name: id
+        type: Int64
+      - name: name
+        type: Utf8
+      - name: data_type
+        type: Utf8
+      - name: options
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: owner_type
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner_type
+      - name: project_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: project_number
+      - name: query
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: query
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+      - name: before
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: before
+  - name: project_items
+    tool: projects_list
+    description: "List GitHub Projects, project fields, items, or status updates. Fixed to method=list_project_items."
+    tool_args:
+      method:
+        from: literal
+        value: list_project_items
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: owner_type
+        tool_arg: owner_type
+        type: Utf8
+      - name: project_number
+        tool_arg: project_number
+        required: true
+        type: Int64
+      - name: query
+        tool_arg: query
+        type: Utf8
+      - name: fields
+        tool_arg: fields
+        type: Utf8
+      - name: after
+        tool_arg: after
+        type: Utf8
+      - name: before
+        tool_arg: before
+        type: Utf8
+    limit_binding:
+      tool_arg: per_page
+      max: 100
+    response:
+      rows_path: [items]
+    columns:
+      - name: id
+        type: Int64
+      - name: content
+        type: Json
+      - name: field_values
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: owner_type
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner_type
+      - name: project_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: project_number
+      - name: query
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: query
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+      - name: before
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: before
+  - name: project_status_updates
+    tool: projects_list
+    description: "List GitHub Projects, project fields, items, or status updates. Fixed to method=list_project_status_updates."
+    tool_args:
+      method:
+        from: literal
+        value: list_project_status_updates
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: owner_type
+        tool_arg: owner_type
+        type: Utf8
+      - name: project_number
+        tool_arg: project_number
+        required: true
+        type: Int64
+      - name: query
+        tool_arg: query
+        type: Utf8
+      - name: fields
+        tool_arg: fields
+        type: Utf8
+      - name: after
+        tool_arg: after
+        type: Utf8
+      - name: before
+        tool_arg: before
+        type: Utf8
+    limit_binding:
+      tool_arg: per_page
+      max: 100
+    response:
+      rows_path: [status_updates]
+    columns:
+      - name: id
+        type: Int64
+      - name: body
+        type: Utf8
+      - name: start_date
+        type: Utf8
+      - name: target_date
+        type: Utf8
+      - name: status
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: creator
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: owner_type
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner_type
+      - name: project_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: project_number
+      - name: query
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: query
+      - name: after
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: after
+      - name: before
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: before
+  - name: project
+    tool: projects_get
+    description: "Get one GitHub Project, field, item, or status update. Fixed to method=get_project."
+    tool_args:
+      method:
+        from: literal
+        value: get_project
+    filters:
+      - name: owner
+        tool_arg: owner
+        required: true
+        type: Utf8
+      - name: owner_type
+        tool_arg: owner_type
+        type: Utf8
+      - name: project_number
+        tool_arg: project_number
+        required: true
+        type: Int64
+      - name: field_id
+        tool_arg: field_id
+        type: Utf8
+      - name: item_id
+        tool_arg: item_id
+        type: Utf8
+      - name: status_update_id
+        tool_arg: status_update_id
+        type: Utf8
+      - name: fields
+        tool_arg: fields
+        type: Utf8
+    columns:
+      - name: id
+        type: Int64
+      - name: "node_id"
+        type: Utf8
+      - name: title
+        type: Utf8
+      - name: short_description
+        type: Utf8
+      - name: url
+        type: Utf8
+      - name: public
+        type: Boolean
+      - name: closed
+        type: Boolean
+      - name: fields
+        type: Json
+      - name: field_values
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: owner_type
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner_type
+      - name: project_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: project_number
+      - name: field_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: field_id
+      - name: item_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: item_id
+      - name: status_update_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: status_update_id
+  - name: project_field
+    tool: projects_get
+    description: "Get one GitHub Project, field, item, or status update. Fixed to method=get_project_field."
+    tool_args:
+      method:
+        from: literal
+        value: get_project_field
+    filters:
+      - name: owner
+        tool_arg: owner
+        type: Utf8
+      - name: owner_type
+        tool_arg: owner_type
+        type: Utf8
+      - name: project_number
+        tool_arg: project_number
+        type: Int64
+      - name: field_id
+        tool_arg: field_id
+        required: true
+        type: Utf8
+      - name: item_id
+        tool_arg: item_id
+        type: Utf8
+      - name: status_update_id
+        tool_arg: status_update_id
+        type: Utf8
+      - name: fields
+        tool_arg: fields
+        type: Utf8
+    columns:
+      - name: id
+        type: Int64
+      - name: "node_id"
+        type: Utf8
+      - name: name
+        type: Utf8
+      - name: data_type
+        type: Utf8
+      - name: options
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: owner_type
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner_type
+      - name: project_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: project_number
+      - name: field_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: field_id
+      - name: item_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: item_id
+      - name: status_update_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: status_update_id
+  - name: project_item
+    tool: projects_get
+    description: "Get one GitHub Project, field, item, or status update. Fixed to method=get_project_item."
+    tool_args:
+      method:
+        from: literal
+        value: get_project_item
+    filters:
+      - name: owner
+        tool_arg: owner
+        type: Utf8
+      - name: owner_type
+        tool_arg: owner_type
+        type: Utf8
+      - name: project_number
+        tool_arg: project_number
+        type: Int64
+      - name: field_id
+        tool_arg: field_id
+        type: Utf8
+      - name: item_id
+        tool_arg: item_id
+        required: true
+        type: Utf8
+      - name: status_update_id
+        tool_arg: status_update_id
+        type: Utf8
+      - name: fields
+        tool_arg: fields
+        type: Utf8
+    columns:
+      - name: id
+        type: Int64
+      - name: "node_id"
+        type: Utf8
+      - name: content
+        type: Json
+      - name: field_values
+        type: Json
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: owner_type
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner_type
+      - name: project_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: project_number
+      - name: field_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: field_id
+      - name: item_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: item_id
+      - name: status_update_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: status_update_id
+  - name: project_status_update
+    tool: projects_get
+    description: "Get one GitHub Project, field, item, or status update. Fixed to method=get_project_status_update."
+    tool_args:
+      method:
+        from: literal
+        value: get_project_status_update
+    filters:
+      - name: owner
+        tool_arg: owner
+        type: Utf8
+      - name: owner_type
+        tool_arg: owner_type
+        type: Utf8
+      - name: project_number
+        tool_arg: project_number
+        type: Int64
+      - name: field_id
+        tool_arg: field_id
+        type: Utf8
+      - name: item_id
+        tool_arg: item_id
+        type: Utf8
+      - name: status_update_id
+        tool_arg: status_update_id
+        required: true
+        type: Utf8
+      - name: fields
+        tool_arg: fields
+        type: Utf8
+    columns:
+      - name: id
+        type: Int64
+      - name: "node_id"
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: start_date
+        type: Utf8
+      - name: target_date
+        type: Utf8
+      - name: status
+        type: Utf8
+      - name: creator
+        type: Utf8
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+      - name: owner
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner
+      - name: owner_type
+        type: Utf8
+        virtual: true
+        expr:
+          kind: from_filter
+          key: owner_type
+      - name: project_number
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: project_number
+      - name: field_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: field_id
+      - name: item_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: item_id
+      - name: status_update_id
+        type: Int64
+        virtual: true
+        expr:
+          kind: from_filter
+          key: status_update_id
+functions:
   - name: search_issues
     tool: search_issues
     description: Search issues using GitHub issue search syntax.
@@ -279,9 +4175,7 @@ functions:
         bind:
           arg: sort
       - name: order
-        values:
-          - asc
-          - desc
+        values: [asc, desc]
         bind:
           arg: order
       - name: page
@@ -290,120 +4184,40 @@ functions:
       - name: per_page
         bind:
           arg: perPage
+    response:
+      rows_path: [items]
     columns:
-      - name: result
+      - name: number
+        type: Int64
+      - name: title
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_pull_requests
-    tool: list_pull_requests
-    description: List pull requests in a repository.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
       - name: state
-        values:
-          - open
-          - closed
-          - all
-        bind:
-          arg: state
-      - name: base
-        bind:
-          arg: base
-      - name: head
-        bind:
-          arg: head
-      - name: sort
-        bind:
-          arg: sort
-      - name: direction
-        values:
-          - asc
-          - desc
-        bind:
-          arg: direction
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
+      - name: body
+        type: Utf8
+      - name: author_association
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: closed_at
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: user
+        type: Json
+      - name: labels
+        type: Json
+      - name: score
+        type: Float64
       - name: raw
         type: Json
-        description: Raw GitHub MCP response row.
+        description: Full JSON row returned by the GitHub MCP tool.
         expr:
           kind: current_row
-
-  - name: pull_request_read
-    tool: pull_request_read
-    description: Read pull request details, diff, files, comments, reviews, or checks.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: pull_number
-        required: true
-        bind:
-          arg: pullNumber
-      - name: method
-        required: true
-        values:
-          - get
-          - get_diff
-          - get_status
-          - get_files
-          - get_review_comments
-          - get_reviews
-          - get_comments
-          - get_check_runs
-        bind:
-          arg: method
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-      - name: after
-        bind:
-          arg: after
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
   - name: search_pull_requests
     tool: search_pull_requests
     description: Search pull requests using GitHub pull request search syntax.
@@ -422,9 +4236,7 @@ functions:
         bind:
           arg: sort
       - name: order
-        values:
-          - asc
-          - desc
+        values: [asc, desc]
         bind:
           arg: order
       - name: page
@@ -433,88 +4245,432 @@ functions:
       - name: per_page
         bind:
           arg: perPage
+    response:
+      rows_path: [items]
     columns:
-      - name: result
+      - name: number
+        type: Int64
+      - name: title
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
+      - name: state
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: author_association
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: merged_at
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: user
+        type: Json
+      - name: score
+        type: Float64
       - name: raw
         type: Json
-        description: Raw GitHub MCP response row.
+        description: Full JSON row returned by the GitHub MCP tool.
         expr:
           kind: current_row
-
-  - name: get_repository_tree
-    tool: get_repository_tree
-    description: Get a repository tree, optionally filtered by path prefix.
+  - name: search_code
+    tool: search_code
+    description: Search code using GitHub code search syntax.
     args:
-      - name: owner
+      - name: query
         required: true
         bind:
-          arg: owner
-      - name: repo
-        required: true
+          arg: query
+      - name: sort
+        values: [indexed]
         bind:
-          arg: repo
-      - name: tree_sha
+          arg: sort
+      - name: order
+        values: [asc, desc]
         bind:
-          arg: tree_sha
-      - name: path_filter
-        bind:
-          arg: path_filter
-      - name: recursive
-        bind:
-          arg: recursive
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_commit
-    tool: get_commit
-    description: Get details for a repository commit.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: sha
-        required: true
-        bind:
-          arg: sha
-      - name: include_diff
-        bind:
-          arg: include_diff
+          arg: order
       - name: page
         bind:
           arg: page
       - name: per_page
         bind:
           arg: perPage
+    response:
+      rows_path: [items]
+    columns:
+      - name: name
+        type: Utf8
+      - name: path
+        type: Utf8
+      - name: sha
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: repository
+        type: Json
+      - name: score
+        type: Float64
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+  - name: search_commits
+    tool: search_commits
+    description: Search commits using GitHub commit search syntax.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: sort
+        bind:
+          arg: sort
+      - name: order
+        values: [asc, desc]
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    response:
+      rows_path: [items]
+    columns:
+      - name: sha
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: commit
+        type: Json
+      - name: author
+        type: Json
+      - name: committer
+        type: Json
+      - name: repository
+        type: Json
+      - name: score
+        type: Float64
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+  - name: search_repositories
+    tool: search_repositories
+    description: Search repositories using GitHub repository search syntax.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: minimal_output
+        bind:
+          arg: minimal_output
+      - name: sort
+        bind:
+          arg: sort
+      - name: order
+        values: [asc, desc]
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    response:
+      rows_path: [items]
+    columns:
+      - name: id
+        type: Int64
+      - name: name
+        type: Utf8
+      - name: full_name
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: private
+        type: Boolean
+      - name: fork
+        type: Boolean
+      - name: stargazers_count
+        type: Int64
+      - name: language
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: score
+        type: Float64
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+  - name: search_users
+    tool: search_users
+    description: Search users using GitHub user search syntax.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: sort
+        bind:
+          arg: sort
+      - name: order
+        values: [asc, desc]
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    response:
+      rows_path: [items]
+    columns:
+      - name: login
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: profile_url
+        type: Utf8
+      - name: avatar_url
+        type: Utf8
+      - name: type
+        type: Utf8
+      - name: score
+        type: Float64
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+  - name: search_orgs
+    tool: search_orgs
+    description: Search organizations using GitHub organization search syntax.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: sort
+        values: [followers, repositories, joined]
+        bind:
+          arg: sort
+      - name: order
+        values: [asc, desc]
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    response:
+      rows_path: [items]
+    columns:
+      - name: login
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: profile_url
+        type: Utf8
+      - name: avatar_url
+        type: Utf8
+      - name: description
+        type: Utf8
+      - name: score
+        type: Float64
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+  - name: semantic_issues_search
+    tool: semantic_issues_search
+    description: Search issues semantically with natural language.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: owner
+        bind:
+          arg: owner
+      - name: repo
+        bind:
+          arg: repo
+      - name: sort
+        values: [comments, reactions, reactions-+1, reactions--1, reactions-smile, reactions-thinking_face, reactions-heart, reactions-tada, interactions, created, updated]
+        bind:
+          arg: sort
+      - name: order
+        values: [asc, desc]
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+    response:
+      rows_path: [items]
+    columns:
+      - name: number
+        type: Int64
+      - name: title
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: author_association
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: closed_at
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: score
+        type: Float64
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+  - name: semantic_issue_similarity_search
+    tool: semantic_issue_similarity_search
+    description: Find issues semantically similar to one issue.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: issue_number
+        required: true
+        bind:
+          arg: issue_number
+      - name: threshold
+        bind:
+          arg: threshold
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: per_page
+    response:
+      rows_path: [similar_issues]
+    columns:
+      - name: number
+        type: Int64
+      - name: title
+        type: Utf8
+      - name: state
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: author_association
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: created_at
+        type: Utf8
+      - name: updated_at
+        type: Utf8
+      - name: closed_at
+        type: Utf8
+      - name: id
+        type: Int64
+      - name: similarity
+        type: Float64
+      - name: score
+        type: Float64
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+  - name: web_search
+    tool: web_search
+    description: Run GitHub MCP's AI-powered web search.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    columns:
+      - name: type
+        type: Utf8
+      - name: text
+        type: Json
+      - name: text_value
+        type: Utf8
+        expr:
+          kind: path
+          path: [text, value]
+      - name: raw
+        type: Json
+        description: Full JSON row returned by the GitHub MCP tool.
+        expr:
+          kind: current_row
+  # pull_request_diff fixes pull_request_read.method=get_diff, which returns unified diff text rather than JSON.
+  - name: pull_request_diff
+    tool: pull_request_read
+    description: Read a pull request unified diff.
+    tool_args:
+      method:
+        from: literal
+        value: get_diff
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: pull_number
+        required: true
+        bind:
+          arg: pullNumber
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+      - name: after
+        bind:
+          arg: after
     columns:
       - name: result
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
+        description: Human-readable GitHub MCP unified diff text.
         expr:
           kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
+  # This GitHub MCP tool returns human-readable text/Markdown, a report, or embedded resource content rather than stable JSON rows.
   - name: get_file_contents
     tool: get_file_contents
     description: Get file or directory contents from a repository.
@@ -539,18 +4695,13 @@ functions:
     columns:
       - name: result
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
+        description: "Human-readable GitHub MCP output for text, Markdown, diff, report, or resource-style responses."
         expr:
           kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_branches
-    tool: list_branches
-    description: List branches in a repository.
+  # This GitHub MCP tool returns human-readable text/Markdown, a report, or embedded resource content rather than stable JSON rows.
+  - name: check_dependency_vulnerabilities
+    tool: check_dependency_vulnerabilities
+    description: Check dependencies against the GitHub Security Advisory Database.
     args:
       - name: owner
         required: true
@@ -560,339 +4711,35 @@ functions:
         required: true
         bind:
           arg: repo
-      - name: page
+      - name: dependencies
+        required: true
         bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
+          arg: dependencies
     columns:
       - name: result
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
+        description: "Human-readable GitHub MCP output for text, Markdown, diff, report, or resource-style responses."
         expr:
           kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_commits
-    tool: list_commits
-    description: List repository commits.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: sha
-        bind:
-          arg: sha
-      - name: path
-        bind:
-          arg: path
-      - name: author
-        bind:
-          arg: author
-      - name: since
-        bind:
-          arg: since
-      - name: until
-        bind:
-          arg: until
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_releases
-    tool: list_releases
-    description: List repository releases.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_latest_release
-    tool: get_latest_release
-    description: Get the latest release for a repository.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_release_by_tag
-    tool: get_release_by_tag
-    description: Get a repository release by tag.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: tag
-        required: true
-        bind:
-          arg: tag
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_tags
-    tool: list_tags
-    description: List repository tags.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: search_code
-    tool: search_code
-    description: Search code using GitHub code search syntax.
+  # This GitHub MCP tool returns human-readable text/Markdown, a report, or embedded resource content rather than stable JSON rows.
+  - name: github_support_docs_search
+    tool: github_support_docs_search
+    description: Search GitHub support documentation through the GitHub MCP server.
     args:
       - name: query
         required: true
         bind:
           arg: query
-      - name: sort
-        values:
-          - indexed
-        bind:
-          arg: sort
-      - name: order
-        values:
-          - asc
-          - desc
-        bind:
-          arg: order
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
     columns:
       - name: result
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
+        description: "Human-readable GitHub MCP output for text, Markdown, diff, report, or resource-style responses."
         expr:
           kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: search_commits
-    tool: search_commits
-    description: Search commits using GitHub commit search syntax.
+  - name: run_secret_scanning
+    tool: run_secret_scanning
+    description: Scan raw content strings or diff hunks for secrets with GitHub MCP.
     args:
-      - name: query
-        required: true
-        bind:
-          arg: query
-      - name: sort
-        bind:
-          arg: sort
-      - name: order
-        values:
-          - asc
-          - desc
-        bind:
-          arg: order
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: search_repositories
-    tool: search_repositories
-    description: Search repositories using GitHub repository search syntax.
-    args:
-      - name: query
-        required: true
-        bind:
-          arg: query
-      - name: minimal_output
-        bind:
-          arg: minimal_output
-      - name: sort
-        bind:
-          arg: sort
-      - name: order
-        values:
-          - asc
-          - desc
-        bind:
-          arg: order
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: search_users
-    tool: search_users
-    description: Search users using GitHub user search syntax.
-    args:
-      - name: query
-        required: true
-        bind:
-          arg: query
-      - name: sort
-        bind:
-          arg: sort
-      - name: order
-        values:
-          - asc
-          - desc
-        bind:
-          arg: order
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: actions_list
-    tool: actions_list
-    description: List GitHub Actions workflows, runs, jobs, or artifacts.
-    args:
-      - name: method
-        required: true
-        values:
-          - list_workflows
-          - list_workflow_runs
-          - list_workflow_jobs
-          - list_workflow_run_artifacts
-        bind:
-          arg: method
       - name: owner
         required: true
         bind:
@@ -901,72 +4748,28 @@ functions:
         required: true
         bind:
           arg: repo
-      - name: resource_id
+      - name: files
+        required: true
         bind:
-          arg: resource_id
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: per_page
-      - name: workflow_jobs_filter
-        bind:
-          arg: workflow_jobs_filter
-      - name: workflow_runs_filter
-        bind:
-          arg: workflow_runs_filter
+          arg: files
     columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
+      - name: num_bytes_scanned
+        type: Int64
         expr:
-          kind: current_row
+          kind: path
+          path: [numBytesScanned]
+      - name: blobs_scanned
+        type: Int64
+        expr:
+          kind: path
+          path: [blobsScanned]
+      - name: secrets
+        type: Json
       - name: raw
         type: Json
-        description: Raw GitHub MCP response row.
+        description: Full JSON row returned by the GitHub MCP tool.
         expr:
           kind: current_row
-
-  - name: actions_get
-    tool: actions_get
-    description: Get one GitHub Actions workflow, run, job, artifact, or logs URL.
-    args:
-      - name: method
-        required: true
-        values:
-          - get_workflow
-          - get_workflow_run
-          - get_workflow_job
-          - download_workflow_run_artifact
-          - get_workflow_run_usage
-          - get_workflow_run_logs_url
-        bind:
-          arg: method
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: resource_id
-        required: true
-        bind:
-          arg: resource_id
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
   - name: get_job_logs
     tool: get_job_logs
     description: Get logs for one GitHub Actions job or failed jobs in a run.
@@ -995,1231 +4798,20 @@ functions:
         bind:
           arg: tail_lines
     columns:
-      - name: result
+      - name: failed_jobs
+        type: Int64
+      - name: message
         type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
+      - name: run_id
+        type: Int64
+      - name: total_jobs
+        type: Int64
+      - name: jobs
+        type: Json
+      - name: logs
+        type: Json
       - name: raw
         type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_code_scanning_alerts
-    tool: list_code_scanning_alerts
-    description: List code scanning alerts in a repository.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: state
-        values:
-          - open
-          - closed
-          - dismissed
-          - fixed
-        bind:
-          arg: state
-      - name: severity
-        values:
-          - critical
-          - high
-          - medium
-          - low
-          - warning
-          - note
-          - error
-        bind:
-          arg: severity
-      - name: ref
-        bind:
-          arg: ref
-      - name: tool_name
-        bind:
-          arg: tool_name
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_code_scanning_alert
-    tool: get_code_scanning_alert
-    description: Get details for one code scanning alert.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: alert_number
-        required: true
-        bind:
-          arg: alertNumber
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_dependabot_alerts
-    tool: list_dependabot_alerts
-    description: List Dependabot alerts in a repository.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: state
-        values:
-          - open
-          - fixed
-          - dismissed
-          - auto_dismissed
-        bind:
-          arg: state
-      - name: severity
-        values:
-          - low
-          - medium
-          - high
-          - critical
-        bind:
-          arg: severity
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_dependabot_alert
-    tool: get_dependabot_alert
-    description: Get details for one Dependabot alert.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: alert_number
-        required: true
-        bind:
-          arg: alertNumber
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_secret_scanning_alerts
-    tool: list_secret_scanning_alerts
-    description: List secret scanning alerts in a repository.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: state
-        values:
-          - open
-          - resolved
-        bind:
-          arg: state
-      - name: resolution
-        values:
-          - false_positive
-          - wont_fix
-          - revoked
-          - pattern_edited
-          - pattern_deleted
-          - used_in_tests
-        bind:
-          arg: resolution
-      - name: secret_type
-        bind:
-          arg: secret_type
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_secret_scanning_alert
-    tool: get_secret_scanning_alert
-    description: Get details for one secret scanning alert.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: alert_number
-        required: true
-        bind:
-          arg: alertNumber
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: check_dependency_vulnerabilities
-    tool: check_dependency_vulnerabilities
-    description: Check dependencies against the GitHub Security Advisory Database.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: dependencies
-        required: true
-        bind:
-          arg: dependencies
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_global_security_advisories
-    tool: list_global_security_advisories
-    description: List global GitHub security advisories.
-    args:
-      - name: ghsa_id
-        bind:
-          arg: ghsaId
-      - name: cve_id
-        bind:
-          arg: cveId
-      - name: ecosystem
-        values:
-          - actions
-          - composer
-          - erlang
-          - go
-          - maven
-          - npm
-          - nuget
-          - other
-          - pip
-          - pub
-          - rubygems
-          - rust
-        bind:
-          arg: ecosystem
-      - name: severity
-        values:
-          - unknown
-          - low
-          - medium
-          - high
-          - critical
-        bind:
-          arg: severity
-      - name: advisory_type
-        values:
-          - reviewed
-          - malware
-          - unreviewed
-        bind:
-          arg: type
-      - name: affects
-        bind:
-          arg: affects
-      - name: cwes
-        bind:
-          arg: cwes
-      - name: is_withdrawn
-        bind:
-          arg: isWithdrawn
-      - name: published
-        bind:
-          arg: published
-      - name: updated
-        bind:
-          arg: updated
-      - name: modified
-        bind:
-          arg: modified
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_global_security_advisory
-    tool: get_global_security_advisory
-    description: Get one global GitHub security advisory.
-    args:
-      - name: ghsa_id
-        required: true
-        bind:
-          arg: ghsaId
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_repository_security_advisories
-    tool: list_repository_security_advisories
-    description: List security advisories for a repository.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: state
-        values:
-          - triage
-          - draft
-          - published
-          - closed
-        bind:
-          arg: state
-      - name: sort
-        values:
-          - created
-          - updated
-          - published
-        bind:
-          arg: sort
-      - name: direction
-        values:
-          - asc
-          - desc
-        bind:
-          arg: direction
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_org_repository_security_advisories
-    tool: list_org_repository_security_advisories
-    description: List repository security advisories for an organization.
-    args:
-      - name: org
-        required: true
-        bind:
-          arg: org
-      - name: state
-        values:
-          - triage
-          - draft
-          - published
-          - closed
-        bind:
-          arg: state
-      - name: sort
-        values:
-          - created
-          - updated
-          - published
-        bind:
-          arg: sort
-      - name: direction
-        values:
-          - asc
-          - desc
-        bind:
-          arg: direction
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_discussions
-    tool: list_discussions
-    description: List GitHub Discussions for a repository or organization.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        bind:
-          arg: repo
-      - name: category
-        bind:
-          arg: category
-      - name: order_by
-        values:
-          - CREATED_AT
-          - UPDATED_AT
-        bind:
-          arg: orderBy
-      - name: direction
-        values:
-          - ASC
-          - DESC
-        bind:
-          arg: direction
-      - name: per_page
-        bind:
-          arg: perPage
-      - name: after
-        bind:
-          arg: after
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_discussion
-    tool: get_discussion
-    description: Get one GitHub Discussion.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: discussion_number
-        required: true
-        bind:
-          arg: discussionNumber
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_discussion_comments
-    tool: get_discussion_comments
-    description: Get comments for one GitHub Discussion.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: discussion_number
-        required: true
-        bind:
-          arg: discussionNumber
-      - name: include_replies
-        bind:
-          arg: includeReplies
-      - name: per_page
-        bind:
-          arg: perPage
-      - name: after
-        bind:
-          arg: after
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_discussion_categories
-    tool: list_discussion_categories
-    description: List GitHub Discussion categories for a repository or organization.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        bind:
-          arg: repo
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_notifications
-    tool: list_notifications
-    description: List GitHub notifications for the authenticated user.
-    args:
-      - name: owner
-        bind:
-          arg: owner
-      - name: repo
-        bind:
-          arg: repo
-      - name: notification_filter
-        values:
-          - default
-          - include_read_notifications
-          - only_participating
-        bind:
-          arg: filter
-      - name: since
-        bind:
-          arg: since
-      - name: before
-        bind:
-          arg: before
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_notification_details
-    tool: get_notification_details
-    description: Get details for one GitHub notification.
-    args:
-      - name: notification_id
-        required: true
-        bind:
-          arg: notificationID
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: projects_list
-    tool: projects_list
-    description: List GitHub Projects, project fields, items, or status updates.
-    args:
-      - name: method
-        required: true
-        values:
-          - list_projects
-          - list_project_fields
-          - list_project_items
-          - list_project_status_updates
-        bind:
-          arg: method
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: owner_type
-        values:
-          - user
-          - org
-        bind:
-          arg: owner_type
-      - name: project_number
-        bind:
-          arg: project_number
-      - name: query
-        bind:
-          arg: query
-      - name: fields
-        bind:
-          arg: fields
-      - name: per_page
-        bind:
-          arg: per_page
-      - name: after
-        bind:
-          arg: after
-      - name: before
-        bind:
-          arg: before
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: projects_get
-    tool: projects_get
-    description: Get one GitHub Project, field, item, or status update.
-    args:
-      - name: method
-        required: true
-        values:
-          - get_project
-          - get_project_field
-          - get_project_item
-          - get_project_status_update
-        bind:
-          arg: method
-      - name: owner
-        bind:
-          arg: owner
-      - name: owner_type
-        values:
-          - user
-          - org
-        bind:
-          arg: owner_type
-      - name: project_number
-        bind:
-          arg: project_number
-      - name: field_id
-        bind:
-          arg: field_id
-      - name: item_id
-        bind:
-          arg: item_id
-      - name: status_update_id
-        bind:
-          arg: status_update_id
-      - name: fields
-        bind:
-          arg: fields
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_gists
-    tool: list_gists
-    description: List gists for a user or the authenticated user.
-    args:
-      - name: username
-        bind:
-          arg: username
-      - name: since
-        bind:
-          arg: since
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_gist
-    tool: get_gist
-    description: Get one GitHub gist by ID.
-    args:
-      - name: gist_id
-        required: true
-        bind:
-          arg: gist_id
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_label
-    tool: list_label
-    description: List labels in a repository.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_label
-    tool: get_label
-    description: Get one label in a repository.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: name
-        required: true
-        bind:
-          arg: name
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_issue_types
-    tool: list_issue_types
-    description: List issue types for an organization.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_repository_collaborators
-    tool: list_repository_collaborators
-    description: List collaborators in a repository.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: affiliation
-        values:
-          - outside
-          - direct
-          - all
-        bind:
-          arg: affiliation
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_starred_repositories
-    tool: list_starred_repositories
-    description: List starred repositories for a user or the authenticated user.
-    args:
-      - name: username
-        bind:
-          arg: username
-      - name: sort
-        values:
-          - created
-          - updated
-        bind:
-          arg: sort
-      - name: direction
-        values:
-          - asc
-          - desc
-        bind:
-          arg: direction
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_tag
-    tool: get_tag
-    description: Get details for one repository tag.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: tag
-        required: true
-        bind:
-          arg: tag
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: search_orgs
-    tool: search_orgs
-    description: Search organizations using GitHub organization search syntax.
-    args:
-      - name: query
-        required: true
-        bind:
-          arg: query
-      - name: sort
-        values:
-          - followers
-          - repositories
-          - joined
-        bind:
-          arg: sort
-      - name: order
-        values:
-          - asc
-          - desc
-        bind:
-          arg: order
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: perPage
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: semantic_issues_search
-    tool: semantic_issues_search
-    description: Search issues semantically with natural language.
-    args:
-      - name: query
-        required: true
-        bind:
-          arg: query
-      - name: owner
-        bind:
-          arg: owner
-      - name: repo
-        bind:
-          arg: repo
-      - name: sort
-        values:
-          - comments
-          - reactions
-          - reactions-+1
-          - reactions--1
-          - reactions-smile
-          - reactions-thinking_face
-          - reactions-heart
-          - reactions-tada
-          - interactions
-          - created
-          - updated
-        bind:
-          arg: sort
-      - name: order
-        values:
-          - asc
-          - desc
-        bind:
-          arg: order
-      - name: page
-        bind:
-          arg: page
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: semantic_issue_similarity_search
-    tool: semantic_issue_similarity_search
-    description: Find issues semantically similar to one issue.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: issue_number
-        required: true
-        bind:
-          arg: issue_number
-      - name: threshold
-        bind:
-          arg: threshold
-      - name: page
-        bind:
-          arg: page
-      - name: per_page
-        bind:
-          arg: per_page
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: github_support_docs_search
-    tool: github_support_docs_search
-    description: Search GitHub support documentation through the GitHub MCP server.
-    args:
-      - name: query
-        required: true
-        bind:
-          arg: query
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: web_search
-    tool: web_search
-    description: Run GitHub MCP's AI-powered web search.
-    args:
-      - name: query
-        required: true
-        bind:
-          arg: query
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: list_copilot_spaces
-    tool: list_copilot_spaces
-    description: List Copilot Spaces accessible to the authenticated user.
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_copilot_space
-    tool: get_copilot_space
-    description: Get the contents of one Copilot Space.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: name
-        required: true
-        bind:
-          arg: name
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: get_copilot_job_status
-    tool: get_copilot_job_status
-    description: Get status for a GitHub Copilot coding agent job.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: id
-        required: true
-        bind:
-          arg: id
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
-        expr:
-          kind: current_row
-
-  - name: run_secret_scanning
-    tool: run_secret_scanning
-    description: Scan raw content strings or diff hunks for secrets with GitHub MCP.
-    args:
-      - name: owner
-        required: true
-        bind:
-          arg: owner
-      - name: repo
-        required: true
-        bind:
-          arg: repo
-      - name: files
-        required: true
-        bind:
-          arg: files
-    columns:
-      - name: result
-        type: Utf8
-        description: GitHub MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw GitHub MCP response row.
+        description: Full JSON row returned by the GitHub MCP tool.
         expr:
           kind: current_row

--- a/sources/community/github_mcp/manifest.yaml
+++ b/sources/community/github_mcp/manifest.yaml
@@ -1,0 +1,876 @@
+dsl_version: 3
+name: github_mcp
+version: 0.1.0
+description: >-
+  Query GitHub repositories, issues, pull requests, users, and repository
+  content through GitHub's official remote MCP server.
+backend: mcp
+
+inputs:
+  GITHUB_MCP_ACCESS_TOKEN:
+    kind: secret
+    hint: |
+      Connect with GitHub OAuth or paste a personal access token. The OAuth
+      methods request the `repo`, `read:org`, `read:user`, and `user:email`
+      scopes used by the read-oriented GitHub MCP tools exposed by this source.
+
+      See GitHub's MCP server docs:
+      https://github.com/github/github-mcp-server
+    credential:
+      methods:
+        - type: oauth
+          label: Connect with GitHub device code
+          description: Sign in to GitHub with a device code.
+          hint: |
+            Signs you in through GitHub, with no app setup or client secret
+            needed. Requests the `repo`, `read:org`, `read:user`, and
+            `user:email` scopes. To use your own GitHub app instead, set
+            GITHUB_MCP_OAUTH_CLIENT_ID to its Client ID and enable device flow
+            on the app.
+          oauth:
+            flow:
+              type: device_code
+            endpoints:
+              device_authorization_url: https://github.com/login/device/code
+              token_url: https://github.com/login/oauth/access_token
+            client:
+              id:
+                default: Iv23liJHis6Bs8NO1DAI
+                input: GITHUB_MCP_OAUTH_CLIENT_ID
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - repo
+                  - read:org
+                  - read:user
+                  - user:email
+        - type: oauth
+          label: Connect with GitHub OAuth app
+          description: Sign in through a GitHub OAuth app in your browser.
+          hint: |
+            Uses your own GitHub OAuth app. Register one with its Authorization
+            callback URL set to `http://127.0.0.1:53682/oauth/callback`, then
+            enter the app's Client ID and Client secret below. Requests the
+            `repo`, `read:org`, `read:user`, and `user:email` scopes.
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: required
+            redirect_uri: http://127.0.0.1:53682/oauth/callback
+            redirect_uri_port_mode: fixed
+            endpoints:
+              authorization_url: https://github.com/login/oauth/authorize
+              token_url: https://github.com/login/oauth/access_token
+            client:
+              id:
+                default: Iv23liJHis6Bs8NO1DAI
+                input: GITHUB_MCP_OAUTH_CLIENT_ID
+              secret:
+                input: GITHUB_MCP_OAUTH_CLIENT_SECRET
+                transport: request_body
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - repo
+                  - read:org
+                  - read:user
+                  - user:email
+        - type: source_config
+          label: Paste GitHub token
+          description: Paste an existing GitHub token or provide GITHUB_MCP_ACCESS_TOKEN.
+          hint: |
+            If you use GitHub CLI, run `gh auth token`. Otherwise create a
+            personal access token with read access to the repositories and
+            organizations you query. Paste the raw token value, without a
+            `Bearer ` prefix.
+
+server:
+  transport: streamable_http
+  url: https://api.githubcopilot.com/mcp/x/all/readonly
+  auth:
+    type: bearer
+    from: input
+    key: GITHUB_MCP_ACCESS_TOKEN
+
+test_queries:
+  - SELECT result FROM github_mcp.me LIMIT 1
+
+tables:
+  - name: me
+    description: Authenticated GitHub user profile returned by the get_me tool.
+    tool: get_me
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+functions:
+  - name: get_teams
+    tool: get_teams
+    description: Get teams for a GitHub user, defaulting to the authenticated user.
+    args:
+      - name: user
+        bind:
+          arg: user
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_team_members
+    tool: get_team_members
+    description: Get members of a team in a GitHub organization.
+    args:
+      - name: org
+        required: true
+        bind:
+          arg: org
+      - name: team_slug
+        required: true
+        bind:
+          arg: team_slug
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: issue_read
+    tool: issue_read
+    description: Read issue details, comments, sub-issues, labels, or events.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: issue_number
+        required: true
+        bind:
+          arg: issue_number
+      - name: method
+        required: true
+        values:
+          - get
+          - get_comments
+          - get_sub_issues
+          - get_labels
+          - get_events
+        bind:
+          arg: method
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+      - name: after
+        bind:
+          arg: after
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_issues
+    tool: list_issues
+    description: List issues in a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: state
+        values:
+          - open
+          - closed
+        bind:
+          arg: state
+      - name: since
+        bind:
+          arg: since
+      - name: order_by
+        bind:
+          arg: orderBy
+      - name: direction
+        values:
+          - ASC
+          - DESC
+        bind:
+          arg: direction
+      - name: per_page
+        bind:
+          arg: perPage
+      - name: after
+        bind:
+          arg: after
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: search_issues
+    tool: search_issues
+    description: Search issues using GitHub issue search syntax.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: owner
+        bind:
+          arg: owner
+      - name: repo
+        bind:
+          arg: repo
+      - name: sort
+        bind:
+          arg: sort
+      - name: order
+        values:
+          - asc
+          - desc
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_pull_requests
+    tool: list_pull_requests
+    description: List pull requests in a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: state
+        values:
+          - open
+          - closed
+          - all
+        bind:
+          arg: state
+      - name: base
+        bind:
+          arg: base
+      - name: head
+        bind:
+          arg: head
+      - name: sort
+        bind:
+          arg: sort
+      - name: direction
+        values:
+          - asc
+          - desc
+        bind:
+          arg: direction
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: pull_request_read
+    tool: pull_request_read
+    description: Read pull request details, diff, files, comments, reviews, or checks.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: pull_number
+        required: true
+        bind:
+          arg: pullNumber
+      - name: method
+        required: true
+        values:
+          - get
+          - get_diff
+          - get_status
+          - get_files
+          - get_review_comments
+          - get_reviews
+          - get_comments
+          - get_check_runs
+        bind:
+          arg: method
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+      - name: after
+        bind:
+          arg: after
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: search_pull_requests
+    tool: search_pull_requests
+    description: Search pull requests using GitHub pull request search syntax.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: owner
+        bind:
+          arg: owner
+      - name: repo
+        bind:
+          arg: repo
+      - name: sort
+        bind:
+          arg: sort
+      - name: order
+        values:
+          - asc
+          - desc
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_repository_tree
+    tool: get_repository_tree
+    description: Get a repository tree, optionally filtered by path prefix.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: tree_sha
+        bind:
+          arg: tree_sha
+      - name: path_filter
+        bind:
+          arg: path_filter
+      - name: recursive
+        bind:
+          arg: recursive
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_commit
+    tool: get_commit
+    description: Get details for a repository commit.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: sha
+        required: true
+        bind:
+          arg: sha
+      - name: detail
+        values:
+          - none
+          - stats
+          - full_patch
+        bind:
+          arg: detail
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_file_contents
+    tool: get_file_contents
+    description: Get file or directory contents from a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: path
+        bind:
+          arg: path
+      - name: ref
+        bind:
+          arg: ref
+      - name: sha
+        bind:
+          arg: sha
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_branches
+    tool: list_branches
+    description: List branches in a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_commits
+    tool: list_commits
+    description: List repository commits.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: sha
+        bind:
+          arg: sha
+      - name: path
+        bind:
+          arg: path
+      - name: author
+        bind:
+          arg: author
+      - name: since
+        bind:
+          arg: since
+      - name: until
+        bind:
+          arg: until
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_releases
+    tool: list_releases
+    description: List repository releases.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_latest_release
+    tool: get_latest_release
+    description: Get the latest release for a repository.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: get_release_by_tag
+    tool: get_release_by_tag
+    description: Get a repository release by tag.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: tag
+        required: true
+        bind:
+          arg: tag
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_tags
+    tool: list_tags
+    description: List repository tags.
+    args:
+      - name: owner
+        required: true
+        bind:
+          arg: owner
+      - name: repo
+        required: true
+        bind:
+          arg: repo
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: search_code
+    tool: search_code
+    description: Search code using GitHub code search syntax.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: sort
+        values:
+          - indexed
+        bind:
+          arg: sort
+      - name: order
+        values:
+          - asc
+          - desc
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: search_commits
+    tool: search_commits
+    description: Search commits using GitHub commit search syntax.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: sort
+        bind:
+          arg: sort
+      - name: order
+        values:
+          - asc
+          - desc
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: search_repositories
+    tool: search_repositories
+    description: Search repositories using GitHub repository search syntax.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: minimal_output
+        bind:
+          arg: minimal_output
+      - name: sort
+        bind:
+          arg: sort
+      - name: order
+        values:
+          - asc
+          - desc
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row
+
+  - name: search_users
+    tool: search_users
+    description: Search users using GitHub user search syntax.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: sort
+        bind:
+          arg: sort
+      - name: order
+        values:
+          - asc
+          - desc
+        bind:
+          arg: order
+      - name: page
+        bind:
+          arg: page
+      - name: per_page
+        bind:
+          arg: perPage
+    columns:
+      - name: result
+        type: Utf8
+        description: GitHub MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw GitHub MCP response row.
+        expr:
+          kind: current_row

--- a/sources/community/github_mcp/manifest.yaml
+++ b/sources/community/github_mcp/manifest.yaml
@@ -1,18 +1,36 @@
 dsl_version: 3
 name: github_mcp
 version: "0.1.0"
-description: "Query GitHub repositories, issues, pull requests, Actions, security alerts, projects, discussions, notifications, and other GitHub MCP tools through GitHub's official remote MCP server."
+description: >-
+  Query GitHub repositories, issues, pull requests, Actions, security alerts,
+  projects, discussions, notifications, and other GitHub MCP tools through
+  GitHub's official remote MCP server.
 backend: mcp
 inputs:
   GITHUB_MCP_ACCESS_TOKEN:
     kind: secret
-    hint: "Connect with GitHub OAuth or paste a personal access token. The OAuth\nmethods request the GitHub scopes used by the read-oriented GitHub MCP\ntools exposed by this source: `repo`, `read:org`, `read:user`,\n`user:email`, `gist`, `notifications`, `read:project`, and\n`security_events`.\n\nSee GitHub's MCP server docs:\nhttps://github.com/github/github-mcp-server\n"
+    hint: |
+      Connect with GitHub OAuth or paste a personal access token. The OAuth
+      methods request the GitHub scopes used by the read-oriented GitHub MCP
+      tools exposed by this source: `repo`, `read:org`, `read:user`,
+      `user:email`, `gist`, `notifications`, `read:project`, and
+      `security_events`.
+
+      See GitHub's MCP server docs:
+      https://github.com/github/github-mcp-server
     credential:
       methods:
         - type: oauth
           label: Connect with GitHub device code
           description: Sign in to GitHub with a device code.
-          hint: "Signs you in through GitHub, with no app setup or client secret\nneeded. Requests the scopes needed for the read-oriented GitHub MCP\ntools exposed by this source: `repo`, `read:org`, `read:user`,\n`user:email`, `gist`, `notifications`, `read:project`, and\n`security_events`. To use your own GitHub app instead, set\nGITHUB_MCP_OAUTH_CLIENT_ID to its Client ID and enable device flow on\nthe app.\n"
+          hint: |
+            Signs you in through GitHub, with no app setup or client secret
+            needed. Requests the scopes needed for the read-oriented GitHub MCP
+            tools exposed by this source: `repo`, `read:org`, `read:user`,
+            `user:email`, `gist`, `notifications`, `read:project`, and
+            `security_events`. To use your own GitHub app instead, set
+            GITHUB_MCP_OAUTH_CLIENT_ID to its Client ID and enable device flow
+            on the app.
           oauth:
             flow:
               type: device_code
@@ -30,7 +48,11 @@ inputs:
         - type: oauth
           label: Connect with GitHub OAuth app
           description: Sign in through a GitHub OAuth app in your browser.
-          hint: "Uses your own GitHub OAuth app. Register one with its Authorization\ncallback URL set to `http://127.0.0.1:53682/oauth/callback`, then\nenter the app's Client ID and Client secret below. Requests the\nread-oriented GitHub MCP scopes exposed by this source.\n"
+          hint: |
+            Uses your own GitHub OAuth app. Register one with its Authorization
+            callback URL set to `http://127.0.0.1:53682/oauth/callback`, then
+            enter the app's Client ID and Client secret below. Requests the
+            read-oriented GitHub MCP scopes exposed by this source.
           oauth:
             flow:
               type: authorization_code
@@ -54,7 +76,11 @@ inputs:
         - type: source_config
           label: Paste GitHub token
           description: Paste an existing GitHub token or provide GITHUB_MCP_ACCESS_TOKEN.
-          hint: "If you use GitHub CLI, run `gh auth token`. Otherwise create a\npersonal access token with read access to the repositories,\norganizations, notifications, projects, gists, and security data you\nquery. Paste the raw token value, without a `Bearer ` prefix.\n"
+          hint: |
+            If you use GitHub CLI, run `gh auth token`. Otherwise create a
+            personal access token with read access to the repositories,
+            organizations, notifications, projects, gists, and security data
+            you query. Paste the raw token value, without a `Bearer ` prefix.
 server:
   transport: streamable_http
   url: "https://api.githubcopilot.com/mcp/x/all/readonly"

--- a/sources/community/github_mcp/manifest.yaml
+++ b/sources/community/github_mcp/manifest.yaml
@@ -2840,7 +2840,7 @@ tables:
         type: Utf8
       - name: resource_id
         tool_arg: resource_id
-        type: Int64
+        type: Utf8
       - name: page
         tool_arg: page
         type: Int64
@@ -2892,7 +2892,7 @@ tables:
           kind: from_filter
           key: repo
       - name: resource_id
-        type: Int64
+        type: Utf8
         virtual: true
         expr:
           kind: from_filter
@@ -2915,7 +2915,7 @@ tables:
         type: Utf8
       - name: resource_id
         tool_arg: resource_id
-        type: Int64
+        type: Utf8
       - name: page
         tool_arg: page
         type: Int64
@@ -2983,7 +2983,7 @@ tables:
           kind: from_filter
           key: repo
       - name: resource_id
-        type: Int64
+        type: Utf8
         virtual: true
         expr:
           kind: from_filter
@@ -3007,7 +3007,7 @@ tables:
       - name: resource_id
         tool_arg: resource_id
         required: true
-        type: Int64
+        type: Utf8
       - name: page
         tool_arg: page
         type: Int64
@@ -3067,7 +3067,7 @@ tables:
           kind: from_filter
           key: repo
       - name: resource_id
-        type: Int64
+        type: Utf8
         virtual: true
         expr:
           kind: from_filter
@@ -3091,7 +3091,7 @@ tables:
       - name: resource_id
         tool_arg: resource_id
         required: true
-        type: Int64
+        type: Utf8
       - name: page
         tool_arg: page
         type: Int64
@@ -3145,7 +3145,7 @@ tables:
           kind: from_filter
           key: repo
       - name: resource_id
-        type: Int64
+        type: Utf8
         virtual: true
         expr:
           kind: from_filter
@@ -3169,7 +3169,7 @@ tables:
       - name: resource_id
         tool_arg: resource_id
         required: true
-        type: Int64
+        type: Utf8
     columns:
       - name: id
         type: Int64
@@ -3207,7 +3207,7 @@ tables:
           kind: from_filter
           key: repo
       - name: resource_id
-        type: Int64
+        type: Utf8
         virtual: true
         expr:
           kind: from_filter
@@ -3231,7 +3231,7 @@ tables:
       - name: resource_id
         tool_arg: resource_id
         required: true
-        type: Int64
+        type: Utf8
     columns:
       - name: id
         type: Int64
@@ -3285,7 +3285,7 @@ tables:
           kind: from_filter
           key: repo
       - name: resource_id
-        type: Int64
+        type: Utf8
         virtual: true
         expr:
           kind: from_filter
@@ -3309,7 +3309,7 @@ tables:
       - name: resource_id
         tool_arg: resource_id
         required: true
-        type: Int64
+        type: Utf8
     columns:
       - name: id
         type: Int64
@@ -3355,7 +3355,7 @@ tables:
           kind: from_filter
           key: repo
       - name: resource_id
-        type: Int64
+        type: Utf8
         virtual: true
         expr:
           kind: from_filter
@@ -3379,7 +3379,7 @@ tables:
       - name: resource_id
         tool_arg: resource_id
         required: true
-        type: Int64
+        type: Utf8
     columns:
       - name: billable
         type: Json
@@ -3403,7 +3403,7 @@ tables:
           kind: from_filter
           key: repo
       - name: resource_id
-        type: Int64
+        type: Utf8
         virtual: true
         expr:
           kind: from_filter
@@ -3427,7 +3427,7 @@ tables:
       - name: resource_id
         tool_arg: resource_id
         required: true
-        type: Int64
+        type: Utf8
     columns:
       - name: logs_url
         type: Utf8
@@ -3453,7 +3453,7 @@ tables:
           kind: from_filter
           key: repo
       - name: resource_id
-        type: Int64
+        type: Utf8
         virtual: true
         expr:
           kind: from_filter

--- a/sources/community/slack_mcp/README.md
+++ b/sources/community/slack_mcp/README.md
@@ -4,7 +4,7 @@
 **Source:** Slack official remote MCP server
 **Backend:** MCP (Streamable HTTP, native)
 **Server URL:** `https://mcp.slack.com/mcp`
-**Surface:** 2 tables + 9 functions wrapping read-oriented MCP tools
+**Surface:** 1 table + 11 functions wrapping read-oriented MCP tools
 
 This connector exposes Slack's official MCP server as a Coral source. It is
 separate from the bundled `slack` HTTP source and keeps the MCP output intact:
@@ -95,12 +95,11 @@ Provide:
 Coral opens the Slack OAuth page, exchanges the authorization code for a user
 access token, and stores that token as the source secret.
 
-## Tables
+## Table
 
 | Table | MCP tool | Description |
 |---|---|---|
-| `channels` | `list_channels` | Channels visible to the authenticated user |
-| `emoji` | `list_emoji` | Custom emoji available in the workspace |
+| `user_profile` | `slack_read_user_profile` | Authenticated Slack user profile |
 
 ## Functions
 
@@ -108,15 +107,17 @@ All functions require named arguments.
 
 | Function | MCP tool | Required args | Description |
 |---|---|---|---|
-| `search_messages` | `search_messages` | `query` | Search messages visible to the authenticated user |
-| `search_channels` | `search_channels` | `query` | Search channels by name or description |
-| `search_users` | `search_users` | `query` | Search users by name, email, or user ID |
-| `search_files` | `search_files` | `query` | Search Slack files |
-| `read_channel` | `read_channel` | `channel_id` | Read recent messages from a channel or conversation |
-| `read_thread` | `read_thread` | `channel_id`, `message_ts` | Read replies in a thread |
-| `read_user_profile` | `read_user_profile` | `user_id` | Read a user profile |
-| `list_channel_members` | `list_channel_members` | `channel_id` | List channel members |
-| `canvas_read` | `canvas_read` | `canvas_id` | Read a canvas |
+| `search_public` | `slack_search_public` | `query` | Search messages and files in public channels |
+| `search_messages` | `slack_search_public_and_private` | `query` | Search messages and files visible to the authenticated user |
+| `search_channels` | `slack_search_channels` | `query` | Search channels by name or description |
+| `search_users` | `slack_search_users` | `query` | Search users by name, email, or profile attributes |
+| `search_emojis` | `slack_search_emojis` | `query` | Search custom emoji by name |
+| `read_channel` | `slack_read_channel` | `channel_id` | Read recent messages from a channel or conversation |
+| `read_thread` | `slack_read_thread` | `channel_id`, `message_ts` | Read replies in a thread |
+| `read_user_profile` | `slack_read_user_profile` | none | Read a user profile, defaulting to the authenticated user |
+| `list_channel_members` | `slack_list_channel_members` | `channel_id` | List channel members |
+| `read_canvas` | `slack_read_canvas` | `canvas_id` | Read a canvas |
+| `read_file` | `slack_read_file` | `file_id` | Read file content and metadata |
 
 ## Examples
 

--- a/sources/community/slack_mcp/README.md
+++ b/sources/community/slack_mcp/README.md
@@ -1,0 +1,153 @@
+# Slack MCP Connector
+
+**Version:** 0.1.0
+**Source:** Slack official remote MCP server
+**Backend:** MCP (Streamable HTTP, native)
+**Server URL:** `https://mcp.slack.com/mcp`
+**Surface:** 2 tables + 9 functions wrapping read-oriented MCP tools
+
+This connector exposes Slack's official MCP server as a Coral source. It is
+separate from the bundled `slack` HTTP source and keeps the MCP output intact:
+most functions return a `result` text column plus a `raw` JSON column.
+
+## Slack app setup
+
+Slack requires MCP clients to use a Slack app that is either internal or
+published in the Slack Marketplace.
+
+1. Open https://api.slack.com/apps.
+2. Select **Create New App**.
+3. Select **From an app manifest**.
+4. Select the workspace where you want to test the connector.
+5. Paste this manifest in the **JSON** tab:
+
+```json
+{
+  "display_information": {
+    "name": "Coral Slack MCP"
+  },
+  "oauth_config": {
+    "pkce_enabled": true,
+    "redirect_urls": [
+      "http://localhost:53684/oauth/callback"
+    ],
+    "scopes": {
+      "user": [
+        "search:read.public",
+        "search:read.private",
+        "search:read.mpim",
+        "search:read.im",
+        "search:read.files",
+        "search:read.users",
+        "channels:history",
+        "groups:history",
+        "mpim:history",
+        "im:history",
+        "channels:read",
+        "groups:read",
+        "mpim:read",
+        "users:read",
+        "users:read.email",
+        "files:read",
+        "emoji:read",
+        "canvases:read"
+      ]
+    }
+  },
+  "settings": {
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": false,
+    "is_hosted": false,
+    "is_mcp_enabled": true,
+    "token_rotation_enabled": false
+  }
+}
+```
+
+6. Create the app and review Slack's generated permission summary.
+7. Open **Basic Information** and copy **Client ID** and **Client Secret**
+   from **App Credentials**.
+
+The manifest registers the fixed local OAuth redirect URL used by this source:
+
+```text
+http://localhost:53684/oauth/callback
+```
+
+It also enables Slack's MCP app setting. If Slack's app creation flow ignores
+or rejects the MCP setting for your workspace, enable **Model Context
+Protocol** manually under **Agents & AI Apps** after creating the app.
+
+## Coral setup
+
+Register the source interactively:
+
+```bash
+coral source add --file sources/community/slack_mcp/manifest.yaml --interactive
+```
+
+When prompted for `SLACK_MCP_ACCESS_TOKEN`, choose **Connect with Slack MCP**.
+Provide:
+
+- `SLACK_MCP_OAUTH_CLIENT_ID`: your Slack app client ID
+- `SLACK_MCP_OAUTH_CLIENT_SECRET`: your Slack app client secret
+
+Coral opens the Slack OAuth page, exchanges the authorization code for a user
+access token, and stores that token as the source secret.
+
+## Tables
+
+| Table | MCP tool | Description |
+|---|---|---|
+| `channels` | `list_channels` | Channels visible to the authenticated user |
+| `emoji` | `list_emoji` | Custom emoji available in the workspace |
+
+## Functions
+
+All functions require named arguments.
+
+| Function | MCP tool | Required args | Description |
+|---|---|---|---|
+| `search_messages` | `search_messages` | `query` | Search messages visible to the authenticated user |
+| `search_channels` | `search_channels` | `query` | Search channels by name or description |
+| `search_users` | `search_users` | `query` | Search users by name, email, or user ID |
+| `search_files` | `search_files` | `query` | Search Slack files |
+| `read_channel` | `read_channel` | `channel_id` | Read recent messages from a channel or conversation |
+| `read_thread` | `read_thread` | `channel_id`, `message_ts` | Read replies in a thread |
+| `read_user_profile` | `read_user_profile` | `user_id` | Read a user profile |
+| `list_channel_members` | `list_channel_members` | `channel_id` | List channel members |
+| `canvas_read` | `canvas_read` | `canvas_id` | Read a canvas |
+
+## Examples
+
+```sql
+SELECT result
+FROM slack_mcp.search_channels(query => 'general');
+
+SELECT result
+FROM slack_mcp.read_channel(
+  channel_id => 'C0123456789',
+  limit => 25
+);
+
+SELECT result
+FROM slack_mcp.read_thread(
+  channel_id => 'C0123456789',
+  message_ts => '1712345678.123456',
+  limit => 100
+);
+```
+
+## Notes
+
+Slack's MCP server is optimized for agents, so responses may be human-readable
+Markdown instead of stable row objects. Use `result` for the rendered response
+and `raw` when the server returns structured data.
+
+This source intentionally exposes read-oriented tools only. Slack's MCP server
+also includes write-capable tools such as message posting and canvas updates,
+but those are not modeled here because SQL queries should not unexpectedly
+mutate Slack state.
+
+Slack's official MCP documentation:
+https://docs.slack.dev/ai/slack-mcp-server/

--- a/sources/community/slack_mcp/manifest.yaml
+++ b/sources/community/slack_mcp/manifest.yaml
@@ -91,28 +91,11 @@ test_queries:
   - SELECT result FROM slack_mcp.search_channels(query => 'general') LIMIT 1
 
 tables:
-  - name: channels
+  - name: user_profile
     description: >-
-      Slack channels visible to the authenticated user, returned by the
-      Slack MCP list_channels tool.
-    tool: list_channels
-    columns:
-      - name: result
-        type: Utf8
-        description: Slack MCP response text or one stringified structured row.
-        expr:
-          kind: current_row
-      - name: raw
-        type: Json
-        description: Raw Slack MCP response row.
-        expr:
-          kind: current_row
-
-  - name: emoji
-    description: >-
-      Custom emoji available in the workspace, returned by the Slack MCP
-      list_emoji tool.
-    tool: list_emoji
+      Current authenticated Slack user's profile, returned by the Slack MCP
+      slack_read_user_profile tool.
+    tool: slack_read_user_profile
     columns:
       - name: result
         type: Utf8
@@ -126,29 +109,127 @@ tables:
           kind: current_row
 
 functions:
-  - name: search_messages
-    tool: search_messages
-    description: Search messages across Slack content visible to the authenticated user.
+  - name: search_public
+    tool: slack_search_public
+    description: Search messages and files in public Slack channels.
     args:
       - name: query
         required: true
         bind:
           arg: query
+      - name: content_types
+        bind:
+          arg: content_types
+      - name: context_channel_id
+        bind:
+          arg: context_channel_id
+      - name: cursor
+        bind:
+          arg: cursor
+      - name: limit
+        bind:
+          arg: limit
+      - name: after
+        bind:
+          arg: after
+      - name: before
+        bind:
+          arg: before
+      - name: include_bots
+        bind:
+          arg: include_bots
       - name: sort
         values:
-          - timestamp
           - score
+          - timestamp
         bind:
           arg: sort
       - name: sort_dir
         values:
-          - desc
           - asc
+          - desc
         bind:
           arg: sort_dir
-      - name: count
+      - name: response_format
+        values:
+          - detailed
+          - concise
         bind:
-          arg: count
+          arg: response_format
+      - name: include_context
+        bind:
+          arg: include_context
+      - name: max_context_length
+        bind:
+          arg: max_context_length
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+  - name: search_messages
+    tool: slack_search_public_and_private
+    description: Search messages and files visible to the authenticated user.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: channel_types
+        bind:
+          arg: channel_types
+      - name: content_types
+        bind:
+          arg: content_types
+      - name: context_channel_id
+        bind:
+          arg: context_channel_id
+      - name: cursor
+        bind:
+          arg: cursor
+      - name: limit
+        bind:
+          arg: limit
+      - name: after
+        bind:
+          arg: after
+      - name: before
+        bind:
+          arg: before
+      - name: include_bots
+        bind:
+          arg: include_bots
+      - name: sort
+        values:
+          - score
+          - timestamp
+        bind:
+          arg: sort
+      - name: sort_dir
+        values:
+          - asc
+          - desc
+        bind:
+          arg: sort_dir
+      - name: response_format
+        values:
+          - detailed
+          - concise
+        bind:
+          arg: response_format
+      - name: include_context
+        bind:
+          arg: include_context
+      - name: max_context_length
+        bind:
+          arg: max_context_length
     columns:
       - name: result
         type: Utf8
@@ -162,13 +243,31 @@ functions:
           kind: current_row
 
   - name: search_channels
-    tool: search_channels
+    tool: slack_search_channels
     description: Search Slack channels by name or description.
     args:
       - name: query
         required: true
         bind:
           arg: query
+      - name: channel_types
+        bind:
+          arg: channel_types
+      - name: cursor
+        bind:
+          arg: cursor
+      - name: limit
+        bind:
+          arg: limit
+      - name: response_format
+        values:
+          - detailed
+          - concise
+        bind:
+          arg: response_format
+      - name: include_archived
+        bind:
+          arg: include_archived
     columns:
       - name: result
         type: Utf8
@@ -182,13 +281,25 @@ functions:
           kind: current_row
 
   - name: search_users
-    tool: search_users
-    description: Search Slack users by name, email, or user ID.
+    tool: slack_search_users
+    description: Search Slack users by name, email, or profile attributes.
     args:
       - name: query
         required: true
         bind:
           arg: query
+      - name: cursor
+        bind:
+          arg: cursor
+      - name: limit
+        bind:
+          arg: limit
+      - name: response_format
+        values:
+          - detailed
+          - concise
+        bind:
+          arg: response_format
     columns:
       - name: result
         type: Utf8
@@ -201,9 +312,9 @@ functions:
         expr:
           kind: current_row
 
-  - name: search_files
-    tool: search_files
-    description: Search files shared in Slack.
+  - name: search_emojis
+    tool: slack_search_emojis
+    description: Search custom Slack emoji by name.
     args:
       - name: query
         required: true
@@ -222,22 +333,31 @@ functions:
           kind: current_row
 
   - name: read_channel
-    tool: read_channel
+    tool: slack_read_channel
     description: Read recent messages from a Slack channel or conversation.
     args:
       - name: channel_id
         required: true
         bind:
           arg: channel_id
+      - name: limit
+        bind:
+          arg: limit
+      - name: cursor
+        bind:
+          arg: cursor
       - name: oldest
         bind:
           arg: oldest
       - name: latest
         bind:
           arg: latest
-      - name: limit
+      - name: response_format
+        values:
+          - detailed
+          - concise
         bind:
-          arg: limit
+          arg: response_format
     columns:
       - name: result
         type: Utf8
@@ -251,7 +371,7 @@ functions:
           kind: current_row
 
   - name: read_thread
-    tool: read_thread
+    tool: slack_read_thread
     description: Read replies in a Slack thread.
     args:
       - name: channel_id
@@ -265,6 +385,21 @@ functions:
       - name: limit
         bind:
           arg: limit
+      - name: cursor
+        bind:
+          arg: cursor
+      - name: oldest
+        bind:
+          arg: oldest
+      - name: latest
+        bind:
+          arg: latest
+      - name: response_format
+        values:
+          - detailed
+          - concise
+        bind:
+          arg: response_format
     columns:
       - name: result
         type: Utf8
@@ -278,13 +413,21 @@ functions:
           kind: current_row
 
   - name: read_user_profile
-    tool: read_user_profile
-    description: Read a Slack user's profile.
+    tool: slack_read_user_profile
+    description: Read a Slack user's profile, defaulting to the authenticated user.
     args:
       - name: user_id
-        required: true
         bind:
           arg: user_id
+      - name: include_locale
+        bind:
+          arg: include_locale
+      - name: response_format
+        values:
+          - detailed
+          - concise
+        bind:
+          arg: response_format
     columns:
       - name: result
         type: Utf8
@@ -298,7 +441,7 @@ functions:
           kind: current_row
 
   - name: list_channel_members
-    tool: list_channel_members
+    tool: slack_list_channel_members
     description: List members in a Slack channel or conversation.
     args:
       - name: channel_id
@@ -308,6 +451,22 @@ functions:
       - name: limit
         bind:
           arg: limit
+      - name: cursor
+        bind:
+          arg: cursor
+      - name: response_format
+        values:
+          - detailed
+          - concise
+          - ids_only
+        bind:
+          arg: response_format
+      - name: include_deleted
+        bind:
+          arg: include_deleted
+      - name: include_bots
+        bind:
+          arg: include_bots
     columns:
       - name: result
         type: Utf8
@@ -320,14 +479,34 @@ functions:
         expr:
           kind: current_row
 
-  - name: canvas_read
-    tool: canvas_read
+  - name: read_canvas
+    tool: slack_read_canvas
     description: Read a Slack canvas.
     args:
       - name: canvas_id
         required: true
         bind:
           arg: canvas_id
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+  - name: read_file
+    tool: slack_read_file
+    description: Read a Slack file by file ID.
+    args:
+      - name: file_id
+        required: true
+        bind:
+          arg: file_id
     columns:
       - name: result
         type: Utf8

--- a/sources/community/slack_mcp/manifest.yaml
+++ b/sources/community/slack_mcp/manifest.yaml
@@ -1,0 +1,341 @@
+dsl_version: 3
+name: slack_mcp
+version: 0.1.0
+description: >-
+  Query Slack messages, channels, files, canvases, users, and workspace
+  metadata through Slack's official remote MCP server.
+backend: mcp
+
+inputs:
+  SLACK_MCP_ACCESS_TOKEN:
+    kind: secret
+    hint: |
+      Slack MCP OAuth access token. Paste the token value itself, without a
+      `Bearer ` prefix, or choose "Connect with Slack MCP" during interactive
+      setup with a Slack app client ID and client secret.
+
+      See Slack's MCP server docs:
+      https://docs.slack.dev/ai/slack-mcp-server/
+    credential:
+      methods:
+        - type: oauth
+          label: Connect with Slack MCP
+          description: >-
+            Open a browser, authorize a Slack app with MCP enabled, and store
+            the resulting user access token.
+          hint: |
+            Provide the client ID and client secret from a Slack app that is
+            either internal or published in the Slack Marketplace, has Model
+            Context Protocol enabled under Agents & AI Apps, and has this
+            redirect URL registered:
+            http://localhost:53684/oauth/callback
+
+            The OAuth flow prompts for Slack user scopes covering the
+            read-oriented MCP tools exposed by this source: search:read.public,
+            search:read.private, search:read.mpim, search:read.im,
+            search:read.files, search:read.users, channels:history,
+            groups:history, mpim:history, im:history, channels:read,
+            groups:read, mpim:read, users:read, users:read.email, files:read,
+            emoji:read, and canvases:read.
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: required
+            redirect_uri: http://localhost:53684/oauth/callback
+            redirect_uri_port_mode: fixed
+            endpoints:
+              authorization_url: https://slack.com/oauth/v2_user/authorize
+              token_url: https://slack.com/api/oauth.v2.user.access
+            client:
+              id:
+                input: SLACK_MCP_OAUTH_CLIENT_ID
+              secret:
+                input: SLACK_MCP_OAUTH_CLIENT_SECRET
+                transport: request_body
+            scopes:
+              scope:
+                delimiter: comma
+                values:
+                  - search:read.public
+                  - search:read.private
+                  - search:read.mpim
+                  - search:read.im
+                  - search:read.files
+                  - search:read.users
+                  - channels:history
+                  - groups:history
+                  - mpim:history
+                  - im:history
+                  - channels:read
+                  - groups:read
+                  - mpim:read
+                  - users:read
+                  - users:read.email
+                  - files:read
+                  - emoji:read
+                  - canvases:read
+        - type: source_config
+          label: Paste Slack MCP access token
+          description: Paste an existing Slack user OAuth access token.
+          hint: Paste the raw Slack user OAuth access token, without a `Bearer ` prefix.
+
+server:
+  transport: streamable_http
+  url: https://mcp.slack.com/mcp
+  auth:
+    type: bearer
+    from: input
+    key: SLACK_MCP_ACCESS_TOKEN
+
+test_queries:
+  - SELECT result FROM slack_mcp.search_channels(query => 'general') LIMIT 1
+
+tables:
+  - name: channels
+    description: >-
+      Slack channels visible to the authenticated user, returned by the
+      Slack MCP list_channels tool.
+    tool: list_channels
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+  - name: emoji
+    description: >-
+      Custom emoji available in the workspace, returned by the Slack MCP
+      list_emoji tool.
+    tool: list_emoji
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+functions:
+  - name: search_messages
+    tool: search_messages
+    description: Search messages across Slack content visible to the authenticated user.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: sort
+        values:
+          - timestamp
+          - score
+        bind:
+          arg: sort
+      - name: sort_dir
+        values:
+          - desc
+          - asc
+        bind:
+          arg: sort_dir
+      - name: count
+        bind:
+          arg: count
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+  - name: search_channels
+    tool: search_channels
+    description: Search Slack channels by name or description.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+  - name: search_users
+    tool: search_users
+    description: Search Slack users by name, email, or user ID.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+  - name: search_files
+    tool: search_files
+    description: Search files shared in Slack.
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+  - name: read_channel
+    tool: read_channel
+    description: Read recent messages from a Slack channel or conversation.
+    args:
+      - name: channel_id
+        required: true
+        bind:
+          arg: channel_id
+      - name: oldest
+        bind:
+          arg: oldest
+      - name: latest
+        bind:
+          arg: latest
+      - name: limit
+        bind:
+          arg: limit
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+  - name: read_thread
+    tool: read_thread
+    description: Read replies in a Slack thread.
+    args:
+      - name: channel_id
+        required: true
+        bind:
+          arg: channel_id
+      - name: message_ts
+        required: true
+        bind:
+          arg: message_ts
+      - name: limit
+        bind:
+          arg: limit
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+  - name: read_user_profile
+    tool: read_user_profile
+    description: Read a Slack user's profile.
+    args:
+      - name: user_id
+        required: true
+        bind:
+          arg: user_id
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+  - name: list_channel_members
+    tool: list_channel_members
+    description: List members in a Slack channel or conversation.
+    args:
+      - name: channel_id
+        required: true
+        bind:
+          arg: channel_id
+      - name: limit
+        bind:
+          arg: limit
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row
+
+  - name: canvas_read
+    tool: canvas_read
+    description: Read a Slack canvas.
+    args:
+      - name: canvas_id
+        required: true
+        bind:
+          arg: canvas_id
+    columns:
+      - name: result
+        type: Utf8
+        description: Slack MCP response text or one stringified structured row.
+        expr:
+          kind: current_row
+      - name: raw
+        type: Json
+        description: Raw Slack MCP response row.
+        expr:
+          kind: current_row


### PR DESCRIPTION
## Summary

Adds two community MCP sources backed by official remote MCP servers:

- `slack_mcp`: Slack's official remote MCP server over Streamable HTTP, with interactive OAuth setup through a Slack app, 1 table, and 11 read-oriented functions for user profile, public/private search, channel search, user search, emoji search, channel history, threads, channel members, files, and canvases.
- `github_mcp`: GitHub's official remote MCP server over Streamable HTTP, using the hosted all-toolsets read-only endpoint, with device-code OAuth, OAuth app, and pasted-token credential flows, 1 table, and 21 read-oriented functions for user context, issues, pull requests, repository trees, files, commits, releases, code search, repository search, and user search.

This also updates MCP result normalization so text content that is not valid JSON is preserved as a string instead of failing result decode. Some MCP servers return human-readable Markdown or rendered text, so this keeps those responses queryable through the `result` column.

## User Impact

Users can add Slack and GitHub MCP servers as Coral sources and query their read-oriented tool surfaces through SQL. These sources are complementary to the existing REST-backed sources: they expose provider MCP tools directly and keep the tool output available as `result` plus `raw`.

The GitHub MCP source intentionally uses GitHub's read-only MCP endpoint, and both new sources avoid modeling write-capable tools so SQL queries do not unexpectedly mutate provider state.

## Validation

- `cargo fmt --all`
- `cargo test -p coral-engine backends::mcp::response --all-features --locked`
- `cargo clippy -p coral-engine --all-targets --all-features --locked -- -D warnings`
- `make rust-checks`
- `make docs-check`
- `cargo run -p coral-cli -- source lint sources/community/slack_mcp/manifest.yaml`
- `cargo run -p coral-cli -- source lint sources/community/github_mcp/manifest.yaml`
- Isolated live GitHub MCP validation with temporary `CORAL_CONFIG_DIR` and `gh auth token`:
  - `source test github_mcp`
  - `github_mcp.search_repositories(...)`
  - `github_mcp.pull_request_read(...)`
  - `github_mcp.get_repository_tree(...)`
- Live Slack MCP validation with OAuth token stored by `coral source add --interactive`:
  - `source test slack_mcp`
  - `slack_mcp.search_channels(query => 'general', limit => 1)`
- `git diff --check`