### PR TITLE
fix(app): reject SQL-controlled v4 base URLs

### DIFF
--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -1511,6 +1511,38 @@ components:
 "
     }
 
+    fn v4_openapi_fixture_with_defaulted_input_server_url() -> &'static str {
+        r#"
+openapi: 3.0.3
+servers:
+  - url: "{apiBase}"
+    variables:
+      apiBase:
+        default: "{{input.API_BASE|https://fallback.example.com}}"
+paths:
+  /repos/{owner}/{repo}/issues:
+    get:
+      operationId: issues/list-for-repo
+      parameters:
+        - {name: owner, in: path, required: true, schema: {type: string}}
+        - {name: repo, in: path, required: true, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: '#/components/schemas/issue'}
+components:
+  schemas:
+    issue:
+      type: object
+      properties:
+        id: {type: integer}
+        title: {type: string}
+"#
+    }
+
     fn manifest_v4_with_file_descriptor(openapi_file: &std::path::Path) -> String {
         format!(
             r#"
@@ -1526,6 +1558,24 @@ surfaces:
         default: http://127.0.0.1:1
     base_url: "{{{{input.API_BASE}}}}"
 "#,
+            openapi_file.display()
+        )
+    }
+
+    fn manifest_v4_with_input_and_derived_base_url(openapi_file: &std::path::Path) -> String {
+        format!(
+            r"
+name: github_v4_test
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    inputs:
+      API_BASE:
+        kind: variable
+        default: https://api.example.com
+",
             openapi_file.display()
         )
     }
@@ -1710,6 +1760,51 @@ tables:
             .get_source_info(&default_workspace(), &source_name)
             .expect("installed v4 source should be usable");
         assert_eq!(info.name.as_str(), "github_v4_test");
+    }
+
+    #[test]
+    fn import_v4_source_rejects_derived_base_url_input_token_defaults() {
+        let temp = TempDir::new().expect("temp dir");
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
+        std::fs::write(
+            &openapi_file,
+            v4_openapi_fixture_with_defaulted_input_server_url(),
+        )
+        .expect("write fixture");
+        let manager = SourceManager::new(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout.clone(),
+        );
+
+        let error = manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_v4_with_input_and_derived_base_url(&openapi_file),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect_err("source add should reject derived base_url input token defaults");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("derived OpenAPI server base_url input token"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            !layout
+                .v4_materialized_dir(
+                    &default_workspace(),
+                    &SourceName::parse("github_v4_test").expect("source")
+                )
+                .exists(),
+            "failed materialization should not install artifacts"
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -9,12 +9,13 @@ use coral_spec::v4::{
     Diagnostic, Fingerprint, FingerprintSurface, MaterializedSurface, OPENAPI_IMPORTER_VERSION,
     PROJECTION_GENERATOR_VERSION, ProjectionCatalog, SemanticIr, V4_ARTIFACT_SCHEMA_VERSION,
     V4MaterializedSource, V4SourceManifest, generate_projection_catalog, import_openapi_surface,
-    normalize_source_document, validate_materialized_source,
+    normalize_source_document, openapi_document_metadata, validate_materialized_source,
+    validate_openapi_base_url_template,
 };
 use coral_spec::{
     ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestInputKind, ManifestInputSpec,
     ManifestOAuthClientSecretTransport, ManifestOAuthFlowKind, ManifestOAuthPkceMode,
-    ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter,
+    ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter, ParsedTemplate,
 };
 use serde_json::{Value, json};
 use sha2::{Digest as _, Sha256};
@@ -498,6 +499,7 @@ fn write_materialization(
     let mut fingerprint_surfaces = Vec::new();
     for surface in &manifest.surfaces {
         let bytes = read_descriptor(surface)?;
+        validate_materialized_surface_base_url(manifest, surface, &bytes)?;
         let observed = sha256_hex(&bytes);
         let semantic_ir = import_openapi_surface(manifest, surface, &bytes).map_err(|error| {
             AppError::FailedPrecondition(format!(
@@ -562,6 +564,39 @@ fn write_materialization(
     write_yaml(&temp_dir.join("projections.yaml"), &projections)?;
     write_yaml(&temp_dir.join("diagnostics.yaml"), &diagnostics)?;
     Ok(())
+}
+
+fn validate_materialized_surface_base_url(
+    manifest: &V4SourceManifest,
+    surface: &coral_spec::v4::V4Surface,
+    bytes: &[u8],
+) -> Result<(), AppError> {
+    if !surface.openapi_runtime.base_url.raw().trim().is_empty() {
+        return Ok(());
+    }
+    let metadata = openapi_document_metadata(bytes).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "failed to derive base_url for DSL v4 surface '{}': {error}",
+            surface.id
+        ))
+    })?;
+    let Some(server_url) = metadata.server_url.as_deref() else {
+        return Ok(());
+    };
+    let base_url = ParsedTemplate::parse(server_url).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "failed to parse derived base_url for DSL v4 surface '{}': {error}",
+            surface.id
+        ))
+    })?;
+    validate_openapi_base_url_template(
+        &manifest.common.name,
+        &surface.id,
+        &surface.inputs,
+        &base_url,
+        "derived OpenAPI server",
+    )
+    .map_err(|error| AppError::FailedPrecondition(error.to_string()))
 }
 
 fn read_descriptor(surface: &coral_spec::v4::V4Surface) -> Result<Vec<u8>, AppError> {

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -7,7 +7,7 @@ use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::v4::{
     ProjectionKind, ProjectionVisibility, V4MaterializedSource, V4SourceManifest,
     openapi_document_metadata, projection_arg_specs, projection_column_specs,
-    projection_filter_specs, request_spec_for_projection,
+    projection_filter_specs, request_spec_for_projection, validate_openapi_base_url_template,
 };
 use coral_spec::{ParsedTemplate, SourceManifestCommon, SourceTableFunctionSpec, TableCommon};
 
@@ -139,7 +139,7 @@ fn http_manifest_for_surface(
             description: manifest.common.description.clone(),
             test_queries: Vec::new(),
         },
-        base_url: surface_base_url(surface, materialized_surface)?,
+        base_url: surface_base_url(manifest, surface, materialized_surface)?,
         auth: surface.openapi_runtime.auth.clone(),
         request_headers: surface.openapi_runtime.request_headers.clone(),
         rate_limit: surface.openapi_runtime.rate_limit.clone(),
@@ -150,11 +150,14 @@ fn http_manifest_for_surface(
 }
 
 fn surface_base_url(
+    manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
     materialized_surface: &coral_spec::v4::MaterializedSurface,
 ) -> Result<ParsedTemplate, AppError> {
     if !surface.openapi_runtime.base_url.raw().trim().is_empty() {
-        return Ok(surface.openapi_runtime.base_url.clone());
+        let base_url = surface.openapi_runtime.base_url.clone();
+        validate_surface_base_url_template(manifest, surface, &base_url, "authored")?;
+        return Ok(base_url);
     }
     let bytes = std::fs::read(&materialized_surface.raw_source_document_path).map_err(|error| {
         AppError::FailedPrecondition(format!(
@@ -174,10 +177,122 @@ fn surface_base_url(
             surface.id
         ))
     })?;
-    ParsedTemplate::parse(server_url).map_err(|error| {
+    let base_url = ParsedTemplate::parse(server_url).map_err(|error| {
         AppError::FailedPrecondition(format!(
             "failed to parse derived base_url for DSL v4 surface '{}': {error}",
             surface.id
         ))
-    })
+    })?;
+    validate_surface_base_url_template(manifest, surface, &base_url, "derived OpenAPI server")?;
+    Ok(base_url)
+}
+
+fn validate_surface_base_url_template(
+    manifest: &V4SourceManifest,
+    surface: &coral_spec::v4::V4Surface,
+    base_url: &ParsedTemplate,
+    provenance: &str,
+) -> Result<(), AppError> {
+    validate_openapi_base_url_template(
+        &manifest.common.name,
+        &surface.id,
+        &surface.inputs,
+        base_url,
+        provenance,
+    )
+    .map_err(|error| AppError::FailedPrecondition(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use coral_spec::backends::http::{AuthSpec, RateLimitSpec};
+    use coral_spec::v4::{
+        MaterializedSurface, OPENAPI_IMPORTER_VERSION, OpenApiRuntimeConfig, SemanticIr,
+        SurfaceDescriptor, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4SourceCommon,
+        V4SourceManifest, V4Surface,
+    };
+
+    use super::surface_base_url;
+
+    fn surface_without_authored_base_url() -> V4Surface {
+        V4Surface {
+            id: "rest".to_string(),
+            surface_type: SurfaceType::OpenApi,
+            descriptor: SurfaceDescriptor::File {
+                file: PathBuf::from("/tmp/openapi.yaml"),
+            },
+            inputs: Vec::new(),
+            openapi_runtime: OpenApiRuntimeConfig {
+                base_url: coral_spec::ParsedTemplate::parse("").expect("empty template"),
+                auth: AuthSpec::default(),
+                request_headers: Vec::new(),
+                rate_limit: RateLimitSpec::default(),
+            },
+        }
+    }
+
+    fn manifest_with_surface(surface: V4Surface) -> V4SourceManifest {
+        V4SourceManifest {
+            common: V4SourceCommon {
+                dsl_version: 4,
+                name: "demo".to_string(),
+                description: String::new(),
+                test_queries: Vec::new(),
+            },
+            declared_inputs: surface.inputs.clone(),
+            surfaces: vec![surface],
+        }
+    }
+
+    fn materialized_surface(raw_source_document_path: PathBuf) -> MaterializedSurface {
+        MaterializedSurface {
+            surface_id: "rest".to_string(),
+            semantic_ir: SemanticIr {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "demo".to_string(),
+                surface_id: "rest".to_string(),
+                surface_type: SurfaceType::OpenApi,
+                importer_version: OPENAPI_IMPORTER_VERSION.to_string(),
+                operations: Vec::new(),
+                types: Vec::new(),
+                diagnostics: Vec::new(),
+            },
+            source_document_sha256: String::new(),
+            normalized_source_document_path: raw_source_document_path.clone(),
+            raw_source_document_path,
+        }
+    }
+
+    #[test]
+    fn derived_openapi_server_url_rejects_runtime_controlled_tokens() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let openapi = temp.path().join("openapi.yaml");
+        std::fs::write(
+            &openapi,
+            r#"
+openapi: 3.0.3
+servers:
+  - url: https://{host}
+    variables:
+      host:
+        default: "{{filter.host}}"
+paths: {}
+"#,
+        )
+        .expect("write openapi");
+
+        let surface = surface_without_authored_base_url();
+        let manifest = manifest_with_surface(surface.clone());
+        let error = surface_base_url(&manifest, &surface, &materialized_surface(openapi))
+            .expect_err("runtime token should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("base_url may only reference source inputs"),
+            "unexpected error: {error}"
+        );
+    }
 }

--- a/crates/coral-spec/src/v4/manifest.rs
+++ b/crates/coral-spec/src/v4/manifest.rs
@@ -10,7 +10,8 @@ use crate::inputs::{
     validate_oauth_endpoint_templates_with_scope,
 };
 use crate::{
-    HeaderSpec, ManifestError, ManifestInputSpec, ParsedTemplate, Result, validate_test_queries,
+    HeaderSpec, ManifestError, ManifestInputSpec, ParsedTemplate, Result, TemplateNamespace,
+    validate_test_queries,
 };
 
 #[derive(Debug, Clone)]
@@ -165,6 +166,15 @@ impl V4SourceManifest {
             let inputs = collect_declared_inputs(surface_value)?;
             validate_input_references(surface_value, &inputs)?;
             validate_oauth_endpoint_templates_with_scope(&inputs, "surface inputs")?;
+            if let Some(base_url) = raw_surface.base_url.as_ref() {
+                validate_openapi_base_url_template(
+                    &name,
+                    &raw_surface.id,
+                    &inputs,
+                    base_url,
+                    "authored",
+                )?;
+            }
             merge_surface_inputs(
                 &name,
                 &raw_surface.id,
@@ -233,6 +243,45 @@ fn parse_descriptor(source_name: &str, surface: &RawV4Surface) -> Result<Surface
             surface.id
         ))),
     }
+}
+
+pub fn validate_openapi_base_url_template(
+    source_name: &str,
+    surface_id: &str,
+    inputs: &[ManifestInputSpec],
+    base_url: &ParsedTemplate,
+    provenance: &str,
+) -> Result<()> {
+    let provenance = if provenance.is_empty() {
+        String::new()
+    } else {
+        format!("{provenance} ")
+    };
+    for token in base_url.tokens() {
+        match token.namespace() {
+            TemplateNamespace::Input => {
+                if token.default_value().is_some() {
+                    return Err(ManifestError::validation(format!(
+                        "source '{source_name}' surface '{surface_id}' {provenance}base_url input token '{{{{{}}}}}' must declare defaults under source inputs",
+                        token.raw()
+                    )));
+                }
+                if !inputs.iter().any(|input| input.key == token.key()) {
+                    return Err(ManifestError::validation(format!(
+                        "source '{source_name}' surface '{surface_id}' {provenance}base_url references undeclared input '{}'",
+                        token.key()
+                    )));
+                }
+            }
+            _ => {
+                return Err(ManifestError::validation(format!(
+                    "source '{source_name}' surface '{surface_id}' {provenance}base_url may only reference source inputs; unsupported template token '{{{{{}}}}}'",
+                    token.raw()
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn merge_surface_inputs(

--- a/crates/coral-spec/src/v4/manifest_tests.rs
+++ b/crates/coral-spec/src/v4/manifest_tests.rs
@@ -101,6 +101,62 @@ surfaces:
 }
 
 #[test]
+fn rejects_v4_openapi_base_url_runtime_controlled_tokens() {
+    for token in [
+        "filter.host",
+        "arg.host",
+        "state.next",
+        "expr.host",
+        "custom.host",
+    ] {
+        let raw = format!(
+            r#"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: "https://{{{{{token}}}}}"
+"#
+        );
+        let error = parse_source_manifest_yaml(&raw).expect_err("runtime token should be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("base_url may only reference source inputs"),
+            "unexpected error for {token}: {message}"
+        );
+    }
+}
+
+#[test]
+fn rejects_v4_openapi_base_url_input_token_defaults() {
+    let error = parse_source_manifest_yaml(
+        r#"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    inputs:
+      API_BASE:
+        kind: variable
+        default: https://api.example.com
+    base_url: "{{input.API_BASE|https://fallback.example.com}}"
+"#,
+    )
+    .expect_err("base_url token default should be rejected");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("must declare defaults under top-level inputs")
+            || message.contains("must declare defaults under source inputs"),
+        "unexpected error: {message}"
+    );
+}
+
+#[test]
 fn rejects_v4_oauth_endpoint_templates_referencing_undeclared_surface_inputs() {
     let error = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -38,7 +38,7 @@ pub use ir::{
 };
 pub use manifest::{
     OpenApiRuntimeConfig, SurfaceDescriptor, SurfaceType, V4SourceCommon, V4SourceManifest,
-    V4Surface,
+    V4Surface, validate_openapi_base_url_template,
 };
 pub use naming::normalize_identifier;
 pub use projections::{

--- a/docs/project/security.mdx
+++ b/docs/project/security.mdx
@@ -104,6 +104,9 @@ you configure; it does not make an otherwise untrusted local agent safe.
   source uses `keychain` or `file (plaintext)` secret storage.
 - Review custom source specs before installing them, especially `base_url`,
   `auth`, and file `location` fields.
+- For DSL v4 OpenAPI surfaces, `base_url` may be literal or reference declared
+  `{{input.KEY}}` values only; query-time tokens such as `{{filter.host}}`,
+  `{{arg.host}}`, and `{{state.next}}` are rejected.
 - Configure `coral mcp-stdio` only in MCP clients you are comfortable allowing
   to query your installed sources.
 

--- a/docs/project/security.mdx
+++ b/docs/project/security.mdx
@@ -104,9 +104,6 @@ you configure; it does not make an otherwise untrusted local agent safe.
   source uses `keychain` or `file (plaintext)` secret storage.
 - Review custom source specs before installing them, especially `base_url`,
   `auth`, and file `location` fields.
-- For DSL v4 OpenAPI surfaces, `base_url` may be literal or reference declared
-  `{{input.KEY}}` values only; query-time tokens such as `{{filter.host}}`,
-  `{{arg.host}}`, and `{{state.next}}` are rejected.
 - Configure `coral mcp-stdio` only in MCP clients you are comfortable allowing
   to query your installed sources.
 


### PR DESCRIPTION
## Summary
- reject DSL v4 OpenAPI `base_url` templates that use SQL-controlled runtime namespaces such as `filter`, `arg`, `state`, `expr`, or unknown namespaces
- apply the same guard defensively when deriving `base_url` from OpenAPI `servers[0].url` and server variable defaults
- document the v4 `base_url` source-input-only constraint in the security guidance

## Tests
- `cargo test -p coral-spec rejects_v4_openapi_base_url_runtime_controlled_tokens`
- `cargo test -p coral-app derived_openapi_server_url_rejects_runtime_controlled_tokens`
- `make rust-checks`
- `make docs-check`

## Risks
- Low-to-moderate. This intentionally rejects v4 OpenAPI sources that put query-time tokens in `base_url`; declared `input` tokens and literal base URLs continue to work.

Fixes #1150
Project: https://github.com/orgs/withcoral/projects/1