### PR TITLE
fix(spec): preserve non-string enum values

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -365,6 +365,57 @@ paths:
 }
 
 #[test]
+fn importer_preserves_non_string_schema_enum_values() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: enum_values
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /status:
+    get:
+      operationId: enum/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                enum:
+                  - active
+                  - 0
+                  - true
+                  - null
+"
+        .as_bytes(),
+    )
+    .expect("enum import");
+    let operation = ir.operations.first().expect("operation");
+    let ty = ir
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("enum type");
+    let IrTypeShape::Enum { values } = &ty.shape else {
+        panic!("enum imported as {:?}", ty.shape);
+    };
+    assert_eq!(values, &["active", "0", "true", "null"]);
+}
+
+#[test]
 fn importer_warns_for_unresolved_response_object_refs() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -78,11 +78,7 @@ impl OpenApiImporter<'_> {
             }
         } else if let Some(values) = resolved.get("enum").and_then(Value::as_array) {
             IrTypeShape::Enum {
-                values: values
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .map(ToString::to_string)
-                    .collect(),
+                values: values.iter().map(enum_value).collect(),
             }
         } else {
             match resolved
@@ -195,6 +191,12 @@ fn required_fields(schema: &Value) -> BTreeSet<String> {
         .filter_map(Value::as_str)
         .map(ToString::to_string)
         .collect()
+}
+
+fn enum_value(value: &Value) -> String {
+    value
+        .as_str()
+        .map_or_else(|| value.to_string(), ToString::to_string)
 }
 
 fn type_id_from_ref(reference: &str) -> String {


### PR DESCRIPTION
Summary:
- preserve non-string OpenAPI schema enum members instead of dropping them during v4 import
- represent non-string enum members as compact JSON literals while keeping string enum values unchanged
- add focused import coverage for string, numeric, boolean, and null enum members

Tests:
- cargo test -p coral-spec importer_preserves_non_string_schema_enum_values
- make rust-checks

Risks:
- Low; existing string enum serialization is unchanged, and previously dropped enum members are now visible in IR as strings.

Fixes #1159
Project: https://github.com/orgs/withcoral/projects/1