### PR TITLE
fix(spec): validate v4 OAuth endpoint templates

### DIFF
--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -477,7 +477,14 @@ fn credential_like_input_key(key: &str) -> bool {
     })
 }
 
-fn validate_oauth_endpoint_templates(inputs: &[ManifestInputSpec]) -> Result<()> {
+pub(crate) fn validate_oauth_endpoint_templates(inputs: &[ManifestInputSpec]) -> Result<()> {
+    validate_oauth_endpoint_templates_with_scope(inputs, "top-level inputs")
+}
+
+pub(crate) fn validate_oauth_endpoint_templates_with_scope(
+    inputs: &[ManifestInputSpec],
+    input_scope: &str,
+) -> Result<()> {
     let declared = inputs
         .iter()
         .map(|input| (input.key.as_str(), input))
@@ -490,7 +497,12 @@ fn validate_oauth_endpoint_templates(inputs: &[ManifestInputSpec]) -> Result<()>
             let Some(oauth) = method.oauth.as_ref() else {
                 continue;
             };
-            validate_oauth_endpoint_templates_for_method(&input.key, oauth, &declared)?;
+            validate_oauth_endpoint_templates_for_method(
+                &input.key,
+                oauth,
+                &declared,
+                input_scope,
+            )?;
         }
     }
     Ok(())
@@ -500,9 +512,16 @@ fn validate_oauth_endpoint_templates_for_method(
     input_key: &str,
     oauth: &ManifestOAuthCredentialSpec,
     declared: &BTreeMap<&str, &ManifestInputSpec>,
+    input_scope: &str,
 ) -> Result<()> {
     if let Some(template) = oauth.authorization_url.as_deref() {
-        validate_oauth_endpoint_template(input_key, "authorization_url", template, declared)?;
+        validate_oauth_endpoint_template(
+            input_key,
+            "authorization_url",
+            template,
+            declared,
+            input_scope,
+        )?;
     }
     if let Some(template) = oauth.device_authorization_url.as_deref() {
         validate_oauth_endpoint_template(
@@ -510,9 +529,16 @@ fn validate_oauth_endpoint_templates_for_method(
             "device_authorization_url",
             template,
             declared,
+            input_scope,
         )?;
     }
-    validate_oauth_endpoint_template(input_key, "token_url", &oauth.token_url, declared)
+    validate_oauth_endpoint_template(
+        input_key,
+        "token_url",
+        &oauth.token_url,
+        declared,
+        input_scope,
+    )
 }
 
 fn validate_oauth_endpoint_template(
@@ -520,6 +546,7 @@ fn validate_oauth_endpoint_template(
     field: &str,
     raw_template: &str,
     declared: &BTreeMap<&str, &ManifestInputSpec>,
+    input_scope: &str,
 ) -> Result<()> {
     let template = ParsedTemplate::parse(raw_template)?;
     let mut rendered = String::with_capacity(template.raw().len());
@@ -537,13 +564,13 @@ fn validate_oauth_endpoint_template(
                 }
                 if token.default_value().is_some() {
                     return Err(ManifestError::validation(format!(
-                        "manifest input '{}' must declare defaults under top-level inputs",
+                        "manifest input '{}' must declare defaults under {input_scope}",
                         token.key()
                     )));
                 }
                 let Some(input) = declared.get(token.key()) else {
                     return Err(ManifestError::validation(format!(
-                        "manifest input '{}' is referenced but not declared under top-level inputs",
+                        "manifest input '{}' is referenced but not declared under {input_scope}",
                         token.key()
                     )));
                 };

--- a/crates/coral-spec/src/v4/manifest.rs
+++ b/crates/coral-spec/src/v4/manifest.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::backends::http::{AuthSpec, RateLimitSpec};
-use crate::inputs::{collect_declared_inputs, validate_input_references};
+use crate::inputs::{
+    collect_declared_inputs, validate_input_references,
+    validate_oauth_endpoint_templates_with_scope,
+};
 use crate::{
     HeaderSpec, ManifestError, ManifestInputSpec, ParsedTemplate, Result, validate_test_queries,
 };
@@ -161,6 +164,7 @@ impl V4SourceManifest {
             }
             let inputs = collect_declared_inputs(surface_value)?;
             validate_input_references(surface_value, &inputs)?;
+            validate_oauth_endpoint_templates_with_scope(&inputs, "surface inputs")?;
             merge_surface_inputs(
                 &name,
                 &raw_surface.id,

--- a/crates/coral-spec/src/v4/manifest_tests.rs
+++ b/crates/coral-spec/src/v4/manifest_tests.rs
@@ -61,3 +61,114 @@ surfaces:
         ""
     );
 }
+
+#[test]
+fn rejects_v4_oauth_endpoint_templates_referencing_runtime_tokens() {
+    let error = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    inputs:
+      ACCESS_TOKEN:
+        kind: secret
+        credential:
+          methods:
+            - type: oauth
+              oauth:
+                flow:
+                  type: authorization_code
+                  pkce: required
+                redirect_uri: http://127.0.0.1:53682/oauth/callback
+                endpoints:
+                  authorization_url: https://provider.example.com/oauth/authorize
+                  token_url: https://provider.example.com/{{filter.tenant}}/oauth/token
+                client:
+                  id:
+                    default: demo-client
+",
+    )
+    .expect_err("runtime token in oauth endpoint should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("oauth.endpoints.token_url uses unsupported template token 'filter.tenant'")
+    );
+}
+
+#[test]
+fn rejects_v4_oauth_endpoint_templates_referencing_undeclared_surface_inputs() {
+    let error = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    inputs:
+      ACCESS_TOKEN:
+        kind: secret
+        credential:
+          methods:
+            - type: oauth
+              oauth:
+                flow:
+                  type: authorization_code
+                  pkce: required
+                redirect_uri: http://127.0.0.1:53682/oauth/callback
+                endpoints:
+                  authorization_url: https://provider.example.com/oauth/authorize
+                  token_url: https://provider.example.com/{{input.TENANT_ID}}/oauth/token
+                client:
+                  id:
+                    default: demo-client
+",
+    )
+    .expect_err("undeclared endpoint input should fail");
+
+    assert!(error.to_string().contains(
+        "manifest input 'TENANT_ID' is referenced but not declared under surface inputs"
+    ));
+}
+
+#[test]
+fn parses_v4_oauth_endpoint_templates_referencing_surface_variables() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    inputs:
+      TENANT_ID:
+        kind: variable
+        default: organizations
+      ACCESS_TOKEN:
+        kind: secret
+        credential:
+          methods:
+            - type: oauth
+              oauth:
+                flow:
+                  type: authorization_code
+                  pkce: required
+                redirect_uri: http://127.0.0.1:53682/oauth/callback
+                endpoints:
+                  authorization_url: https://login.example.com/{{input.TENANT_ID}}/oauth/authorize
+                  token_url: https://login.example.com/{{input.TENANT_ID}}/oauth/token
+                client:
+                  id:
+                    default: demo-client
+",
+    )
+    .expect("v4 manifest");
+
+    assert_eq!(manifest.declared_inputs().len(), 2);
+}


### PR DESCRIPTION
## Summary
- Reuse the existing OAuth endpoint-template validator for DSL v4 surface inputs.
- Reject runtime tokens such as filter.* in v4 OAuth endpoint URLs at manifest parse time.
- Add v4 manifest tests for rejection and accepted source-variable endpoint templates.

## Tests
- cargo test -p coral-spec v4_oauth_endpoint
- make rust-checks
- git diff --check

## Risks
- Low. This tightens v4 manifest validation to match the existing source input contract; invalid manifests that previously parsed will now fail early.

Closes #1160
Project: https://github.com/orgs/withcoral/projects/1