### PR TITLE
fix(spec): retain projection rename diagnostics

### DIFF
--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -294,6 +294,23 @@ components:
         .get("pulls_list_commits")
         .expect("pulls_list_commits projection");
     assert_eq!(pull_commits.0, "repos_pulls_commits");
+
+    let catalog_collision_diagnostics = catalog
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "PROJECTION_NAME_COLLISION_RESOLVED")
+        .collect::<Vec<_>>();
+    assert_eq!(catalog_collision_diagnostics.len(), 3);
+    let projection_collision_diagnostics = catalog
+        .projections
+        .iter()
+        .flat_map(|projection| &projection.diagnostics)
+        .filter(|diagnostic| diagnostic.code == "PROJECTION_NAME_COLLISION_RESOLVED")
+        .count();
+    assert_eq!(
+        projection_collision_diagnostics,
+        catalog_collision_diagnostics.len()
+    );
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -32,7 +32,11 @@ pub fn generate_projection_catalog(
         }
         diagnostics.extend(ir.diagnostics.clone());
     }
-    resolve_projection_name_collisions(manifest, surfaces, &mut projections);
+    diagnostics.extend(resolve_projection_name_collisions(
+        manifest,
+        surfaces,
+        &mut projections,
+    ));
     Ok(ProjectionCatalog {
         artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
         source_name: manifest.common.name.clone(),

--- a/crates/coral-spec/src/v4/projections/names.rs
+++ b/crates/coral-spec/src/v4/projections/names.rs
@@ -14,7 +14,7 @@ pub(super) fn resolve_projection_name_collisions(
     manifest: &V4SourceManifest,
     surfaces: &[SemanticIr],
     projections: &mut [Projection],
-) {
+) -> Vec<Diagnostic> {
     let operations = surfaces
         .iter()
         .flat_map(|ir| {
@@ -59,6 +59,7 @@ pub(super) fn resolve_projection_name_collisions(
         }
     }
 
+    let mut diagnostics = Vec::new();
     for indexes in groups.values().filter(|indexes| indexes.len() > 1) {
         for index in indexes {
             if keep_base_name.contains(index) {
@@ -88,16 +89,19 @@ pub(super) fn resolve_projection_name_collisions(
                 .get_mut(*index)
                 .expect("projection index came from projections");
             projection.name.clone_from(&name);
-            projection.diagnostics.push(Diagnostic {
+            let diagnostic = Diagnostic {
                 code: "PROJECTION_NAME_COLLISION_RESOLVED".to_string(),
                 severity: DiagnosticSeverity::Warning,
                 message: format!("projection name collision resolved as '{name}'"),
                 surface_id: Some(projection.surface_id.clone()),
                 operation_id: Some(projection.operation_id.clone()),
                 projection_name: Some(name),
-            });
+            };
+            projection.diagnostics.push(diagnostic.clone());
+            diagnostics.push(diagnostic);
         }
     }
+    diagnostics
 }
 
 fn projection_name_priority(


### PR DESCRIPTION
## Summary
- Return projection-name collision diagnostics from the collision resolver.
- Append rename diagnostics to the projection catalog-level diagnostics while keeping them on the renamed projections.
- Extend the collision regression test to assert catalog diagnostics retain the rename warnings.

## Tests
- cargo test -p coral-spec projection_names_use_path_context_for_collisions
- make rust-checks
- git diff --check

## Risks
- Low. This preserves existing renaming behavior and only keeps the generated diagnostics in the aggregate catalog output.

Closes #1152
Project: https://github.com/orgs/withcoral/projects/1