### PR TITLE
feat(codemode): add Monty Python codemode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,7 +299,7 @@ dependencies = [
  "arrow-select",
  "flatbuffers",
  "lz4_flex",
- "zstd",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -563,10 +572,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attribute-derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05832cdddc8f2650cc2cc187cc2e952b8c133a48eb055f35211f61ee81502d77"
+dependencies = [
+ "attribute-derive-macro",
+ "derive-where",
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7cdbbd4bd005c5d3e2e9c885e6fa575db4f4a3572335b974d8db853b6beb61"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "manyhow",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn",
+]
 
 [[package]]
 name = "autocfg"
@@ -727,7 +775,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -774,6 +822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,7 +846,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -800,6 +863,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -838,7 +907,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.4.2",
  "cpufeatures 0.3.0",
 ]
 
@@ -881,6 +950,12 @@ dependencies = [
  "futures-lite",
  "piper",
 ]
+
+[[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "brotli"
@@ -950,11 +1025,49 @@ dependencies = [
 
 [[package]]
 name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1014,8 +1127,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1026,7 +1141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -1104,10 +1219,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "collection_literals"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "combine"
@@ -1131,18 +1270,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
- "bzip2",
+ "bzip2 0.6.1",
  "compression-core",
  "flate2",
  "liblzma",
  "memchr",
- "zstd",
- "zstd-safe",
+ "zstd 0.13.3",
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -1197,6 +1350,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -1289,6 +1448,7 @@ dependencies = [
  "coral-api",
  "coral-app",
  "coral-client",
+ "coral-codemode",
  "coral-mcp",
  "coral-spec",
  "crossterm",
@@ -1326,6 +1486,22 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "coral-codemode"
+version = "0.4.2"
+dependencies = [
+ "coral-api",
+ "coral-client",
+ "monty",
+ "monty_type_checking",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
 ]
 
 [[package]]
@@ -1373,6 +1549,7 @@ dependencies = [
  "coral-api",
  "coral-app",
  "coral-client",
+ "coral-codemode",
  "jsonschema",
  "opentelemetry",
  "regex",
@@ -1453,6 +1630,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1600,7 +1811,7 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "bytes",
- "bzip2",
+ "bzip2 0.6.1",
  "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
@@ -1642,7 +1853,7 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
- "zstd",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -1739,7 +1950,7 @@ dependencies = [
  "async-compression",
  "async-trait",
  "bytes",
- "bzip2",
+ "bzip2 0.6.1",
  "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -1761,7 +1972,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
- "zstd",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -2004,7 +2215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13ff70cb2c1960f03ba647aa2813fb1efba4c33bc221d973dd4a462a6376359a"
 dependencies = [
  "datafusion",
- "jiter",
+ "jiter 0.13.0",
  "log",
  "paste",
 ]
@@ -2278,7 +2489,7 @@ dependencies = [
  "delegate",
  "futures",
  "pin-project",
- "similar",
+ "similar 2.7.0",
  "tracing",
  "tracing-futures",
  "unicode-width",
@@ -2320,6 +2531,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2384,6 +2606,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "drop_bomb"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2628,18 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -2496,7 +2736,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -2506,6 +2757,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -2711,6 +2972,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "get-size-derive2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9f8ab1b98a1284961d722ce994d9a0f3018ab1917618d4113824a72b9f71bc9"
+dependencies = [
+ "attribute-derive",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "get-size2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0cd0777a1057362cab35a779e0d79dacecb8d73e2c733eaafeb7ea917b08f03"
+dependencies = [
+ "compact_str",
+ "get-size-derive2",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "ordermap",
+ "smallvec",
+ "thin-vec",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,6 +3085,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,6 +3124,34 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -3192,7 +3525,7 @@ checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
- "similar",
+ "similar 2.7.0",
  "tempfile",
 ]
 
@@ -3203,10 +3536,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "interpolator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3243,6 +3612,21 @@ name = "jiter"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020ba671987d7444d251d3ee5340be1bf4606cd6c0b53e6f4066b5a1ee376b22"
+dependencies = [
+ "ahash",
+ "bitvec",
+ "lexical-parse-float",
+ "num-bigint",
+ "num-traits",
+ "pyo3",
+ "smallvec",
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7866f284df68dbc242796251ed9768bde2b58ebc4d7d32cc07cc7fd993e3ed6c"
 dependencies = [
  "ahash",
  "bitvec",
@@ -3307,7 +3691,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bytecount",
- "fancy-regex",
+ "fancy-regex 0.13.0",
  "fraction",
  "getrandom 0.2.17",
  "iso8601",
@@ -3490,6 +3874,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,6 +3910,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matchit"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
 
 [[package]]
 name = "md-5"
@@ -3568,6 +3981,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "monty"
+version = "0.0.18"
+source = "git+https://github.com/pydantic/monty.git?rev=e868c802c83d4fa36e44845ee08549061455cf74#e868c802c83d4fa36e44845ee08549061455cf74"
+dependencies = [
+ "ahash",
+ "chrono",
+ "fancy-regex 0.17.0",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "itertools",
+ "jiter 0.15.0",
+ "libm",
+ "monty-macros",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "postcard",
+ "ruff_python_ast",
+ "ruff_python_parser",
+ "ruff_python_stdlib",
+ "ruff_text_size",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "speedate",
+ "strum 0.27.2",
+]
+
+[[package]]
+name = "monty-macros"
+version = "0.0.18"
+source = "git+https://github.com/pydantic/monty.git?rev=e868c802c83d4fa36e44845ee08549061455cf74#e868c802c83d4fa36e44845ee08549061455cf74"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "monty_type_checking"
+version = "0.0.18"
+source = "git+https://github.com/pydantic/monty.git?rev=e868c802c83d4fa36e44845ee08549061455cf74#e868c802c83d4fa36e44845ee08549061455cf74"
+dependencies = [
+ "monty_typeshed",
+ "ruff_db",
+ "ruff_python_ast",
+ "ruff_text_size",
+ "salsa",
+ "ty_module_resolver",
+ "ty_python_core",
+ "ty_python_semantic",
+]
+
+[[package]]
+name = "monty_typeshed"
+version = "0.0.18"
+source = "git+https://github.com/pydantic/monty.git?rev=e868c802c83d4fa36e44845ee08549061455cf74#e868c802c83d4fa36e44845ee08549061455cf74"
+dependencies = [
+ "path-slash",
+ "ruff_db",
+ "walkdir",
+ "zip",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3625,6 +4103,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -3870,6 +4349,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordermap"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3937,7 +4425,18 @@ dependencies = [
  "thrift",
  "tokio",
  "twox-hash",
- "zstd",
+ "zstd 0.13.3",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3951,6 +4450,30 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+ "password-hash",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3972,11 +4495,49 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4058,6 +4619,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4125,6 +4699,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -4433,6 +5018,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "quote-use"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
+dependencies = [
+ "quote",
+ "quote-use-macros",
+]
+
+[[package]]
+name = "quote-use-macros"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,11 +5059,22 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -4473,12 +5091,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4495,6 +5132,26 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "recursive"
@@ -4717,6 +5374,206 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruff_annotate_snippets"
+version = "0.1.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "ruff_db"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "anstyle",
+ "arc-swap",
+ "camino",
+ "dashmap",
+ "dunce",
+ "filetime",
+ "get-size2",
+ "matchit 0.9.2",
+ "path-slash",
+ "pathdiff",
+ "ruff_annotate_snippets",
+ "ruff_diagnostics",
+ "ruff_memory_usage",
+ "ruff_notebook",
+ "ruff_python_ast",
+ "ruff_python_parser",
+ "ruff_python_trivia",
+ "ruff_source_file",
+ "ruff_text_size",
+ "rustc-hash",
+ "salsa",
+ "serde",
+ "serde_json",
+ "similar 3.1.1",
+ "supports-hyperlinks",
+ "thiserror 2.0.18",
+ "tracing",
+ "ty_static",
+ "web-time",
+ "zip",
+]
+
+[[package]]
+name = "ruff_diagnostics"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "get-size2",
+ "is-macro",
+ "ruff_text_size",
+ "serde",
+]
+
+[[package]]
+name = "ruff_index"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "get-size2",
+ "ruff_macros",
+ "salsa",
+]
+
+[[package]]
+name = "ruff_macros"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "heck",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "ruff_python_trivia",
+ "syn",
+]
+
+[[package]]
+name = "ruff_memory_usage"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "get-size2",
+]
+
+[[package]]
+name = "ruff_notebook"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "rand 0.10.1",
+ "ruff_diagnostics",
+ "ruff_source_file",
+ "ruff_text_size",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "ruff_python_ast"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "aho-corasick",
+ "bitflags",
+ "compact_str",
+ "get-size2",
+ "is-macro",
+ "memchr",
+ "ruff_python_trivia",
+ "ruff_source_file",
+ "ruff_text_size",
+ "rustc-hash",
+ "salsa",
+ "thin-vec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ruff_python_literal"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "bitflags",
+ "icu_properties",
+ "itertools",
+ "ruff_python_ast",
+]
+
+[[package]]
+name = "ruff_python_parser"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "compact_str",
+ "get-size2",
+ "memchr",
+ "ruff_python_ast",
+ "ruff_python_trivia",
+ "ruff_text_size",
+ "rustc-hash",
+ "static_assertions",
+ "thin-vec",
+ "unicode-ident",
+ "unicode-normalization",
+ "unicode_names2",
+]
+
+[[package]]
+name = "ruff_python_stdlib"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "bitflags",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ruff_python_trivia"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "itertools",
+ "ruff_source_file",
+ "ruff_text_size",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ruff_source_file"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "get-size2",
+ "memchr",
+ "ruff_text_size",
+ "serde",
+]
+
+[[package]]
+name = "ruff_text_size"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "get-size2",
+ "serde",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4866,6 +5723,51 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "salsa"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4612ff789805e65c87e9b38cb749a293212a615af065bed8a2001086801498c3"
+dependencies = [
+ "boxcar",
+ "compact_str",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "hashbrown 0.17.1",
+ "hashlink",
+ "indexmap",
+ "intrusive-collections",
+ "inventory",
+ "ordermap",
+ "parking_lot",
+ "portable-atomic",
+ "rustc-hash",
+ "salsa-macro-rules",
+ "salsa-macros",
+ "smallvec",
+ "thin-vec",
+ "tracing",
+ "typeid",
+]
+
+[[package]]
+name = "salsa-macro-rules"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e354cbac6939b9b09cd9c11fb419a53e64b4a0f755d929f56a09f4cc752e41"
+
+[[package]]
+name = "salsa-macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3067861075c2b80608f84ad49fb88f2c7610b94cdf8b4201e79ddee87f8980c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "same-file"
@@ -5059,6 +5961,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+dependencies = [
+ "serde_core",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5069,6 +5993,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5164,6 +6099,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "similar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5180,6 +6124,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snap"
@@ -5195,6 +6142,26 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "speedate"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba069c070b5e213f2a094deb7e5ed50ecb092be36102a4f4042e8d2056d060e"
+dependencies = [
+ "lexical-parse-float",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -5252,16 +6219,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
 
 [[package]]
 name = "syn"
@@ -5345,6 +6366,12 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"
@@ -5843,6 +6870,155 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "ty_combine"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "ordermap",
+ "ruff_db",
+ "ruff_python_ast",
+]
+
+[[package]]
+name = "ty_module_resolver"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "anyhow",
+ "camino",
+ "compact_str",
+ "get-size2",
+ "regex",
+ "regex-syntax",
+ "ruff_db",
+ "ruff_memory_usage",
+ "ruff_python_ast",
+ "ruff_python_stdlib",
+ "rustc-hash",
+ "salsa",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "ty_python_core"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "bitflags",
+ "bitvec",
+ "get-size2",
+ "hashbrown 0.17.1",
+ "itertools",
+ "ruff_db",
+ "ruff_index",
+ "ruff_macros",
+ "ruff_memory_usage",
+ "ruff_python_ast",
+ "ruff_python_parser",
+ "ruff_python_trivia",
+ "ruff_text_size",
+ "rustc-hash",
+ "salsa",
+ "serde",
+ "smallvec",
+ "static_assertions",
+ "tracing",
+ "ty_combine",
+ "ty_module_resolver",
+ "ty_site_packages",
+ "ty_vendored",
+]
+
+[[package]]
+name = "ty_python_semantic"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "bitflags",
+ "compact_str",
+ "drop_bomb",
+ "get-size2",
+ "indexmap",
+ "itertools",
+ "memchr",
+ "ordermap",
+ "rayon",
+ "ruff_db",
+ "ruff_diagnostics",
+ "ruff_index",
+ "ruff_macros",
+ "ruff_memory_usage",
+ "ruff_python_ast",
+ "ruff_python_literal",
+ "ruff_python_parser",
+ "ruff_python_stdlib",
+ "ruff_python_trivia",
+ "ruff_source_file",
+ "ruff_text_size",
+ "rustc-hash",
+ "salsa",
+ "smallvec",
+ "static_assertions",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "ty_module_resolver",
+ "ty_python_core",
+ "ty_site_packages",
+]
+
+[[package]]
+name = "ty_site_packages"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "camino",
+ "colored",
+ "get-size2",
+ "indexmap",
+ "ruff_annotate_snippets",
+ "ruff_db",
+ "ruff_python_ast",
+ "ruff_python_trivia",
+ "ruff_source_file",
+ "ruff_text_size",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "tracing",
+ "ty_static",
+]
+
+[[package]]
+name = "ty_static"
+version = "0.0.1"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "ruff_macros",
+]
+
+[[package]]
+name = "ty_vendored"
+version = "0.0.0"
+source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+dependencies = [
+ "path-slash",
+ "ruff_db",
+ "static_assertions",
+ "walkdir",
+ "zip",
+]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5872,6 +7048,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5888,6 +7073,28 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_names2"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
+dependencies = [
+ "phf 0.11.3",
+ "unicode_names2_generator",
+]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91e5b84611016120197efd7dc93ef76774f4e084cd73c9fb3ea4a86c570c56e"
+dependencies = [
+ "getopts",
+ "log",
+ "phf_codegen",
+ "rand 0.8.6",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -5939,6 +7146,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -6882,6 +8090,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2 0.4.4",
+ "constant_time_eq 0.1.5",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac 0.12.1",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd 0.11.2+zstd.1.5.2",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6895,11 +8123,30 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 7.2.4",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,8 @@ keyring-core = { version = "1.0.0", default-features = false }
 apple-native-keyring-store = { version = "1.0.0", default-features = false, features = ["keychain"] }
 windows-native-keyring-store = { version = "1.0.0", default-features = false }
 zbus-secret-service-keyring-store = { version = "1.0.0", default-features = false, features = ["rt-tokio-crypto-rust"] }
+monty = { git = "https://github.com/pydantic/monty.git", rev = "e868c802c83d4fa36e44845ee08549061455cf74", package = "monty" }
+monty_type_checking = { git = "https://github.com/pydantic/monty.git", rev = "e868c802c83d4fa36e44845ee08549061455cf74", package = "monty_type_checking" }
 object_store = { version = "0.13.2", features = ["aws"] }
 opentelemetry = "0.31.0"
 opentelemetry-appender-tracing = "0.31.0"
@@ -116,6 +118,7 @@ coral-api = { path = "crates/coral-api" }
 coral-app = { path = "crates/coral-app" }
 coral-cli = { path = "crates/coral-cli" }
 coral-client = { path = "crates/coral-client" }
+coral-codemode = { path = "crates/coral-codemode" }
 coral-engine = { path = "crates/coral-engine" }
 coral-mcp = { path = "crates/coral-mcp" }
 coral-spec = { path = "crates/coral-spec" }

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -13,6 +13,8 @@ use crate::state::{
 /// Runtime feature keys recognized by Coral.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Feature {
+    /// Expose the optional MCP `codemode` tool.
+    Codemode,
     /// Expose the optional MCP `feedback` tool.
     Feedback,
 }
@@ -65,14 +67,24 @@ struct FeatureSpec {
     disable_flag: &'static str,
 }
 
-const FEATURE_SPECS: &[FeatureSpec] = &[FeatureSpec {
-    feature: Feature::Feedback,
-    key: "feedback",
-    default_enabled: false,
-    description: "Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral.",
-    enable_flag: "enable-feedback",
-    disable_flag: "disable-feedback",
-}];
+const FEATURE_SPECS: &[FeatureSpec] = &[
+    FeatureSpec {
+        feature: Feature::Codemode,
+        key: "codemode",
+        default_enabled: false,
+        description: "Exposes the MCP codemode tool when enabled. Codemode runs Monty Python with read-only Coral SQL available as an explicit host function.",
+        enable_flag: "enable-codemode",
+        disable_flag: "disable-codemode",
+    },
+    FeatureSpec {
+        feature: Feature::Feedback,
+        key: "feedback",
+        default_enabled: false,
+        description: "Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral.",
+        enable_flag: "enable-feedback",
+        disable_flag: "disable-feedback",
+    },
+];
 
 /// How a feature's value is configured in Coral's local config.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -326,9 +338,10 @@ mod tests {
     }
 
     #[test]
-    fn defaults_disable_feedback() {
+    fn defaults_disable_experimental_features() {
         let features = Features::default();
 
+        assert!(!features.enabled(Feature::Codemode));
         assert!(!features.enabled(Feature::Feedback));
     }
 
@@ -376,6 +389,7 @@ mod tests {
         let raw = raw([("future_flag", RawFeatureValue::Bool(true))]);
         let features = Features::from_raw_overrides(&raw);
 
+        assert!(!features.enabled(Feature::Codemode));
         assert!(!features.enabled(Feature::Feedback));
     }
 
@@ -396,7 +410,10 @@ mod tests {
             .iter()
             .map(|spec| status_from_raw(spec, &raw, &features))
             .collect::<Vec<_>>();
-        let status = statuses.first().expect("feedback status");
+        let status = statuses
+            .iter()
+            .find(|status| status.key == "feedback")
+            .expect("feedback status");
 
         assert_eq!(status.key, "feedback");
         assert_eq!(status.configured, FeatureConfiguredState::InvalidValue);
@@ -408,6 +425,7 @@ mod tests {
         let error = unknown_feature_error("nope");
 
         assert!(error.to_string().contains("unknown feature 'nope'"));
+        assert!(error.to_string().contains("codemode"));
         assert!(error.to_string().contains("feedback"));
     }
 }

--- a/crates/coral-cli/Cargo.toml
+++ b/crates/coral-cli/Cargo.toml
@@ -35,6 +35,7 @@ url.workspace = true
 coral-api.workspace = true
 coral-app.workspace = true
 coral-client.workspace = true
+coral-codemode.workspace = true
 coral-mcp.workspace = true
 coral-spec.workspace = true
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -34,6 +34,7 @@ use coral_client::{
     AppClient, decode_execute_sql_response, default_workspace, format_batches_json,
     format_batches_table, manifest_input_from_proto,
 };
+use coral_codemode::{CodemodeClients, PythonCodemodeRequest};
 use dialoguer::console::measure_text_width;
 use tonic::Request;
 
@@ -63,6 +64,8 @@ struct Cli {
 enum Command {
     /// Execute a SQL query
     Sql(SqlArgs),
+    /// Execute codemode against Coral
+    Codemode(CodemodeArgs),
     /// Manage data sources
     Source(SourceArgs),
     /// Interactive wizard to set up Coral and explore use cases
@@ -112,6 +115,52 @@ struct SqlArgs {
     format: OutputFormat,
     /// SQL query to execute
     sql: String,
+}
+
+#[derive(Debug, Args)]
+/// Execute codemode against Coral
+struct CodemodeArgs {
+    #[command(subcommand)]
+    command: CodemodeCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum CodemodeCommand {
+    /// Execute Monty Python with Coral host functions
+    Python(PythonCodemodeArgs),
+}
+
+#[derive(Debug, Args)]
+#[command(group(
+    ArgGroup::new("code_input")
+        .args(["code", "file"])
+        .required(true)
+        .multiple(false)
+))]
+struct PythonCodemodeArgs {
+    /// Python code to execute
+    #[arg(long)]
+    code: Option<String>,
+
+    /// Path to a Python file to execute
+    #[arg(long)]
+    file: Option<PathBuf>,
+
+    /// Output format for codemode results
+    #[arg(long, value_enum, default_value = "text")]
+    format: CodemodeOutputFormat,
+
+    /// Maximum Monty execution time in milliseconds
+    #[arg(long = "timeout-ms", default_value_t = coral_codemode::DEFAULT_TIMEOUT_MS)]
+    timeout_ms: u64,
+
+    /// Maximum number of `sql()` host-function calls
+    #[arg(long = "max-sql-calls", default_value_t = coral_codemode::DEFAULT_MAX_SQL_CALLS)]
+    max_sql_calls: usize,
+
+    /// Skip Monty's static type checker
+    #[arg(long = "no-type-check")]
+    no_type_check: bool,
 }
 
 #[derive(Debug, Default)]
@@ -297,6 +346,12 @@ enum OutputFormat {
     Json,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CodemodeOutputFormat {
+    Text,
+    Json,
+}
+
 /// Typed CLI error whose stderr rendering and exit code are owned by the binary.
 #[derive(Debug, thiserror::Error)]
 pub enum CliError {
@@ -308,6 +363,16 @@ pub enum CliError {
         /// Low-cardinality query failure class for telemetry.
         error_type: String,
         /// Human-readable query failure summary for telemetry.
+        error_message: String,
+    },
+    /// Codemode failed with a structured, user-facing diagnostic.
+    #[error("codemode failed")]
+    Codemode {
+        /// Complete stderr diagnostic rendered for the codemode failure.
+        rendered_stderr: String,
+        /// Low-cardinality codemode failure class for telemetry.
+        error_type: String,
+        /// Human-readable codemode failure summary for telemetry.
         error_message: String,
     },
     /// A source was available as a bundled source but has not been installed.
@@ -340,6 +405,9 @@ impl CliError {
         match self {
             Self::Query {
                 rendered_stderr, ..
+            }
+            | Self::Codemode {
+                rendered_stderr, ..
             } => Some(rendered_stderr.clone()),
             Self::SourceNotInstalled { source_name } => Some(format!(
                 "source '{source_name}' is not installed. Run `coral source add {source_name}` to install it, then retry `coral source test {source_name}`.\n"
@@ -358,9 +426,11 @@ impl CliError {
 impl Command {
     fn required_runtime(&self) -> RequiredRuntime {
         match self {
-            Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
-                RequiredRuntime::AppClient
-            }
+            Command::Sql(_)
+            | Command::Codemode(_)
+            | Command::Source(_)
+            | Command::Onboard
+            | Command::McpStdio(_) => RequiredRuntime::AppClient,
             Command::Features(_) | Command::Completion(_) => RequiredRuntime::None,
             #[cfg(feature = "embedded-ui")]
             Command::Ui(_) => RequiredRuntime::None,
@@ -375,7 +445,9 @@ impl Command {
 impl coral_app::RunErrorTelemetry for CliError {
     fn telemetry_error_type(&self) -> Cow<'_, str> {
         match self {
-            Self::Query { error_type, .. } => Cow::Borrowed(error_type.as_str()),
+            Self::Query { error_type, .. } | Self::Codemode { error_type, .. } => {
+                Cow::Borrowed(error_type.as_str())
+            }
             Self::SourceNotInstalled { .. } => Cow::Borrowed("SOURCE_NOT_INSTALLED"),
             Self::SourceNotFound { .. } | Self::SourceRemoveNotFound { .. } => {
                 Cow::Borrowed("SOURCE_NOT_FOUND")
@@ -386,7 +458,9 @@ impl coral_app::RunErrorTelemetry for CliError {
 
     fn telemetry_error_message(&self) -> Cow<'_, str> {
         match self {
-            Self::Query { error_message, .. } => Cow::Borrowed(error_message.as_str()),
+            Self::Query { error_message, .. } | Self::Codemode { error_message, .. } => {
+                Cow::Borrowed(error_message.as_str())
+            }
             Self::SourceNotInstalled { source_name } => {
                 Cow::Owned(format!("source '{source_name}' is not installed"))
             }
@@ -520,7 +594,11 @@ async fn run_no_runtime_command(
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args).await.map_err(Into::into),
-        Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
+        Command::Sql(_)
+        | Command::Codemode(_)
+        | Command::Source(_)
+        | Command::Onboard
+        | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
         }
     }
@@ -554,6 +632,7 @@ async fn run_app_command(
             let result = decode_execute_sql_response(&response).map_err(anyhow::Error::from)?;
             print_batches(result.batches(), args.format)?;
         }
+        Command::Codemode(args) => run_codemode(&app, args).await?,
         Command::Source(args) => run_source(&app, args).await?,
         Command::Onboard => {
             onboard::run(&app).await?;
@@ -565,6 +644,7 @@ async fn run_app_command(
             Box::pin(coral_mcp::run_stdio_with_client(
                 app,
                 coral_mcp::McpOptions {
+                    codemode_enabled: features.enabled(coral_app::features::Feature::Codemode),
                     feedback_enabled: features.enabled(coral_app::features::Feature::Feedback),
                     trace_parent: ctx.and_then(|ctx| ctx.trace_parent.clone()),
                 },
@@ -617,6 +697,83 @@ fn run_features(
         }
     }
     Ok(())
+}
+
+async fn run_codemode(app: &AppClient, args: CodemodeArgs) -> Result<(), CliError> {
+    match args.command {
+        CodemodeCommand::Python(args) => run_python_codemode(app, args).await,
+    }
+}
+
+async fn run_python_codemode(app: &AppClient, args: PythonCodemodeArgs) -> Result<(), CliError> {
+    let code = codemode_code(&args).map_err(CliError::Internal)?;
+    let request = PythonCodemodeRequest {
+        code,
+        type_check: !args.no_type_check,
+        timeout_ms: args.timeout_ms,
+        max_sql_calls: args.max_sql_calls,
+    };
+    let clients = CodemodeClients::new(app.query_client(), app.catalog_client());
+    let result = coral_codemode::run_python(clients, request)
+        .await
+        .map_err(codemode_cli_error)?;
+    print_codemode_result(result, args.format).map_err(CliError::Internal)
+}
+
+fn codemode_code(args: &PythonCodemodeArgs) -> Result<String, anyhow::Error> {
+    match (&args.code, &args.file) {
+        (Some(code), None) => Ok(code.clone()),
+        (None, Some(file)) => std::fs::read_to_string(file)
+            .map_err(|error| anyhow::anyhow!("failed to read {}: {error}", file.display())),
+        _ => unreachable!("clap enforces exactly one codemode code input"),
+    }
+}
+
+fn print_codemode_result(
+    result: coral_codemode::CodemodeResult,
+    format: CodemodeOutputFormat,
+) -> Result<(), anyhow::Error> {
+    match format {
+        CodemodeOutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        }
+        CodemodeOutputFormat::Text => {
+            if !result.stdout.is_empty() {
+                print!("{}", result.stdout);
+            }
+            match result.output {
+                serde_json::Value::String(value) => println!("{value}"),
+                value => println!("{}", serde_json::to_string_pretty(&value)?),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn codemode_cli_error(error: coral_codemode::CodemodeError) -> CliError {
+    match error {
+        coral_codemode::CodemodeError::Query(status) => CliError::Query {
+            error_message: query_error::telemetry_error_message(&status),
+            error_type: query_error::telemetry_error_type(&status),
+            rendered_stderr: query_error::render_query_error(&status),
+        },
+        coral_codemode::CodemodeError::Catalog(status) => {
+            let error_message = status.message().to_string();
+            CliError::Codemode {
+                rendered_stderr: format!("codemode catalog lookup failed: {error_message}\n"),
+                error_type: format!("CODEMODE_CATALOG_{:?}", status.code()),
+                error_message,
+            }
+        }
+        coral_codemode::CodemodeError::Invalid(message) => CliError::Codemode {
+            rendered_stderr: format!("codemode failed: {message}\n"),
+            error_type: "CODEMODE_INVALID".to_string(),
+            error_message: message,
+        },
+        coral_codemode::CodemodeError::Internal(message) => {
+            CliError::Internal(anyhow::anyhow!("codemode internal error: {message}"))
+        }
+    }
 }
 
 async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
@@ -886,6 +1043,45 @@ mod tests {
         let cli = Cli::try_parse_from(["coral", "source", "list"]).expect("source list parses");
 
         assert_eq!(cli.command.required_runtime(), RequiredRuntime::AppClient);
+    }
+
+    #[test]
+    fn codemode_python_uses_normal_app_bootstrap() {
+        let cli = Cli::try_parse_from([
+            "coral",
+            "codemode",
+            "python",
+            "--code",
+            "rows = sql('SELECT 1')\nrows",
+            "--format",
+            "json",
+        ])
+        .expect("codemode args should parse");
+
+        assert_eq!(cli.command.required_runtime(), RequiredRuntime::AppClient);
+        let super::Command::Codemode(args) = cli.command else {
+            panic!("expected codemode command");
+        };
+        let super::CodemodeCommand::Python(args) = args.command;
+        assert_eq!(args.code.as_deref(), Some("rows = sql('SELECT 1')\nrows"));
+        assert_eq!(args.format, super::CodemodeOutputFormat::Json);
+        assert!(!args.no_type_check);
+    }
+
+    #[test]
+    fn codemode_python_rejects_file_and_code_together() {
+        let error = Cli::try_parse_from([
+            "coral",
+            "codemode",
+            "python",
+            "--code",
+            "1 + 1",
+            "--file",
+            "script.py",
+        ])
+        .expect_err("file and code together should fail");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/coral-cli/tests/features.rs
+++ b/crates/coral-cli/tests/features.rs
@@ -64,7 +64,7 @@ fn features_without_subcommand_requires_explicit_action() {
 }
 
 #[test]
-fn features_list_shows_feedback_status_without_state_creation() {
+fn features_list_shows_known_feature_status_without_state_creation() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("missing-config");
 
@@ -81,6 +81,10 @@ fn features_list_shows_feedback_status_without_state_creation() {
     );
     assert!(stdout.contains("Enabled"), "missing table header: {stdout}");
     assert!(
+        stdout.contains("codemode"),
+        "missing codemode row: {stdout}"
+    );
+    assert!(
         stdout.contains("feedback"),
         "missing feedback row: {stdout}"
     );
@@ -91,6 +95,10 @@ fn features_list_shows_feedback_status_without_state_creation() {
     assert!(
         stdout.contains("false"),
         "missing disabled effective state: {stdout}"
+    );
+    assert!(
+        stdout.contains("Exposes the MCP codemode tool when enabled. Codemode runs Monty Python with read-only Coral SQL available as an explicit host function."),
+        "feature list should match documented codemode text: {stdout}"
     );
     assert!(
         stdout.contains("Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral."),
@@ -108,14 +116,14 @@ fn features_list_applies_global_process_override_without_state_creation() {
     let config_dir = temp.path().join("missing-config");
 
     let assert = coral_cmd(&config_dir)
-        .args(["--enable-feedback", "features", "list"])
+        .args(["--enable-codemode", "features", "list"])
         .assert()
         .success();
 
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
     assert!(
-        stdout.contains("feedback"),
-        "missing feedback row: {stdout}"
+        stdout.contains("codemode"),
+        "missing codemode row: {stdout}"
     );
     assert!(
         stdout.contains("default"),
@@ -224,6 +232,10 @@ fn features_unknown_key_fails_without_writing_config() {
     assert!(
         stderr.contains("unknown feature 'unknown'"),
         "missing unknown feature error: {stderr}"
+    );
+    assert!(
+        stderr.contains("codemode"),
+        "error should mention valid feature keys: {stderr}"
     );
     assert!(
         stderr.contains("feedback"),

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -29,6 +29,8 @@ use tokio::{
     time::timeout,
 };
 
+const RAW_JSONRPC_TIMEOUT: Duration = Duration::from_secs(15);
+
 fn json_object(value: &Value) -> Map<String, Value> {
     value.as_object().cloned().expect("json object")
 }
@@ -114,7 +116,7 @@ async fn read_jsonrpc_response(
     let mut line = String::new();
     loop {
         line.clear();
-        let bytes_read = timeout(Duration::from_secs(5), stdout.read_line(&mut line)).await??;
+        let bytes_read = timeout(RAW_JSONRPC_TIMEOUT, stdout.read_line(&mut line)).await??;
         if bytes_read == 0 {
             return Err(format!("mcp stdio closed before response id {id}").into());
         }
@@ -359,6 +361,76 @@ async fn mcp_stdio_enable_feedback_flag_lists_feedback_tool()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_enable_codemode_flag_lists_codemode_tool()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client_with_args(&server, &["--enable-codemode"]).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert_eq!(
+        tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>(),
+        vec![
+            "sql",
+            "list_catalog",
+            "search_catalog",
+            "describe_table",
+            "list_columns",
+            "codemode"
+        ]
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_codemode_python_cli_runs_sql_and_catalog_helpers()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let code = r#"
+catalog = list_catalog(schema="local_messages", kind="table")
+rows = sql("SELECT text FROM local_messages.messages ORDER BY text")
+{"first_table": catalog["items"][0]["name"], "first_text": rows[0]["text"]}
+"#;
+
+    let output = StdCommand::new(env!("CARGO_BIN_EXE_coral"))
+        .args([
+            "codemode",
+            "python",
+            "--code",
+            code,
+            "--format",
+            "json",
+            "--no-type-check",
+        ])
+        .env("CORAL_ENDPOINT", server.endpoint_uri())
+        .env("CORAL_CONFIG_DIR", server.config_dir())
+        .output()?;
+    assert!(
+        output.status.success(),
+        "codemode command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let structured: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(structured["output"]["first_table"], "local_messages.events");
+    assert_eq!(structured["output"]["first_text"], "hello");
+    assert_eq!(structured["query_count"], 1);
+    assert_eq!(server.execute_sql_requests().len(), 1);
+    assert!(
+        !server.list_catalog_requests().is_empty(),
+        "codemode list_catalog() should call catalog service"
+    );
+
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn mcp_stdio_feature_config_enables_feedback_tool() -> Result<(), Box<dyn std::error::Error>>
 {
     let server = MockServer::start().await;
@@ -393,6 +465,24 @@ async fn mcp_stdio_features_enable_command_enables_feedback_tool()
     assert!(
         tools.iter().any(|tool| tool.name.as_ref() == "feedback"),
         "feedback tool should be listed after `coral features enable feedback`"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_features_enable_command_enables_codemode_tool()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    run_features_command(&server, &["enable", "codemode"])?;
+    let client = start_mcp_client(&server).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert!(
+        tools.iter().any(|tool| tool.name.as_ref() == "codemode"),
+        "codemode tool should be listed after `coral features enable codemode`"
     );
 
     client.cancel().await?;
@@ -569,6 +659,12 @@ future_flag = true
             .iter()
             .all(|tool| tool.get("name").and_then(Value::as_str) != Some("feedback")),
         "invalid feature config must not enable feedback: {tools_list}"
+    );
+    assert!(
+        tools
+            .iter()
+            .all(|tool| tool.get("name").and_then(Value::as_str) != Some("codemode")),
+        "invalid feature config must not enable codemode: {tools_list}"
     );
 
     drop(stdin);

--- a/crates/coral-codemode/Cargo.toml
+++ b/crates/coral-codemode/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "coral-mcp"
+name = "coral-codemode"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -10,23 +10,14 @@ publish = false
 workspace = true
 
 [dependencies]
+monty.workspace = true
+monty_type_checking.workspace = true
 regex.workspace = true
-rmcp.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tonic.workspace = true
-tracing.workspace = true
-tracing-opentelemetry.workspace = true
-opentelemetry.workspace = true
 
 coral-api.workspace = true
-coral-codemode.workspace = true
 coral-client.workspace = true
-
-[dev-dependencies]
-coral-app.workspace = true
-jsonschema.workspace = true
-tempfile.workspace = true
-tonic-types.workspace = true

--- a/crates/coral-codemode/src/catalog.rs
+++ b/crates/coral-codemode/src/catalog.rs
@@ -1,0 +1,380 @@
+use coral_api::v1::{
+    ColumnSearchResult, DescribeTableResponse, ListCatalogResponse, ListColumnsResponse,
+    SearchCatalogResponse, Table as ProtoTable, TableFunction as ProtoTableFunction,
+    TableFunctionArgument as ProtoTableFunctionArgument,
+    TableFunctionResultColumn as ProtoTableFunctionResultColumn, TableSummary as ProtoTableSummary,
+    catalog_item,
+};
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::values::{
+    format_schema_table_equivalent, format_sql_identifier, insert_pagination_fields,
+    missing_table_summary_value, paged_collection_value,
+};
+
+pub(crate) fn describe_table_value(
+    schema: &str,
+    table: &str,
+    response: &DescribeTableResponse,
+) -> Value {
+    if let Some(table) = &response.table {
+        return describe_found_table_value(table);
+    }
+    describe_missing_table_value(
+        schema,
+        table,
+        &response.available_schemas,
+        &response.same_schema_tables,
+        &response.suggestions,
+    )
+}
+
+fn describe_found_table_value(table: &ProtoTable) -> Value {
+    serde_json::to_value(FoundTableValue::from(table)).expect("found table value serializes")
+}
+
+fn describe_missing_table_value(
+    schema: &str,
+    table: &str,
+    available_schemas: &[String],
+    same_schema_tables: &[ProtoTableSummary],
+    suggestions: &[ProtoTableSummary],
+) -> Value {
+    let same_schema_tables = same_schema_tables
+        .iter()
+        .map(missing_table_summary_value)
+        .collect::<Vec<_>>();
+    let suggestions = suggestions
+        .iter()
+        .map(missing_table_summary_value)
+        .collect::<Vec<_>>();
+    let escaped_table = regex::escape(table);
+    let search_arguments = if same_schema_tables.is_empty() {
+        SuggestedCallArguments {
+            pattern: Some(escaped_table),
+            schema: None,
+            kind: Some("table"),
+            limit: None,
+        }
+    } else {
+        SuggestedCallArguments {
+            pattern: Some(escaped_table),
+            schema: Some(schema),
+            kind: Some("table"),
+            limit: None,
+        }
+    };
+    let mut suggested_calls = vec![SuggestedCall {
+        tool: "search_catalog",
+        arguments: search_arguments,
+    }];
+    if !same_schema_tables.is_empty() {
+        suggested_calls.push(SuggestedCall {
+            tool: "list_catalog",
+            arguments: SuggestedCallArguments {
+                pattern: None,
+                schema: Some(schema),
+                kind: Some("table"),
+                limit: Some(10),
+            },
+        });
+    }
+    serde_json::to_value(MissingTableValue {
+        found: false,
+        requested: RequestedTable { schema, table },
+        available_schemas,
+        same_schema_tables,
+        suggestions,
+        suggested_calls,
+    })
+    .expect("missing table value serializes")
+}
+
+pub(crate) fn search_catalog_value(response: &SearchCatalogResponse) -> Value {
+    let pagination = response.pagination.unwrap_or_default();
+    let items = response
+        .items
+        .iter()
+        .filter_map(catalog_search_result_value)
+        .collect::<Vec<_>>();
+    paged_collection_value("items", items, &pagination)
+}
+
+pub(crate) fn list_catalog_value(response: &ListCatalogResponse) -> Value {
+    let pagination = response.pagination.unwrap_or_default();
+    let items = response
+        .items
+        .iter()
+        .filter_map(catalog_item_value)
+        .collect::<Vec<_>>();
+    paged_collection_value("items", items, &pagination)
+}
+
+fn catalog_item_value(item: &coral_api::v1::CatalogItem) -> Option<Value> {
+    match item.item.as_ref()? {
+        catalog_item::Item::Table(table) => {
+            serde_json::to_value(CatalogTableItemValue::from(table)).ok()
+        }
+        catalog_item::Item::TableFunction(function) => {
+            serde_json::to_value(CatalogTableFunctionItemValue::from(function)).ok()
+        }
+    }
+}
+
+fn minimal_table_function_call_example(function: &ProtoTableFunction) -> String {
+    let reference = format_schema_table_equivalent(&function.schema_name, &function.name);
+    let required_arguments = function
+        .arguments
+        .iter()
+        .filter(|argument| argument.required)
+        .map(|argument| format!("{} => '<value>'", format_sql_identifier(&argument.name)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{reference}({required_arguments})")
+}
+
+fn catalog_search_result_value(result: &coral_api::v1::CatalogSearchResult) -> Option<Value> {
+    let mut value = catalog_item_value(result.item.as_ref()?)?;
+    value.as_object_mut()?.insert(
+        "matched_fields".to_string(),
+        serde_json::to_value(&result.matched_fields).ok()?,
+    );
+    Some(value)
+}
+
+pub(crate) fn list_columns_value(
+    schema: &str,
+    table: &str,
+    response: &ListColumnsResponse,
+) -> Value {
+    let pagination = response.pagination.unwrap_or_default();
+    let columns = response
+        .columns
+        .iter()
+        .filter_map(column_search_result_value)
+        .collect::<Vec<_>>();
+    let mut value = Map::from_iter([
+        ("schema_name".to_string(), Value::from(schema)),
+        ("table_name".to_string(), Value::from(table)),
+        ("columns".to_string(), Value::Array(columns)),
+    ]);
+    insert_pagination_fields(&mut value, &pagination);
+    Value::Object(value)
+}
+
+fn column_search_result_value(result: &ColumnSearchResult) -> Option<Value> {
+    let column = result.column.as_ref()?;
+    let Value::Object(mut value) = serde_json::to_value(ColumnValue::from(column)).ok()? else {
+        return None;
+    };
+    if !result.matched_fields.is_empty() {
+        value.insert(
+            "matched_fields".to_string(),
+            serde_json::to_value(&result.matched_fields).ok()?,
+        );
+    }
+    Some(Value::Object(value))
+}
+
+#[derive(Serialize)]
+struct FoundTableValue<'a> {
+    found: bool,
+    schema_name: &'a str,
+    table_name: &'a str,
+    name: String,
+    description: &'a str,
+    guide: &'a str,
+    required_filters: &'a [String],
+    column_count: usize,
+    columns_hint: &'static str,
+}
+
+impl<'a> From<&'a ProtoTable> for FoundTableValue<'a> {
+    fn from(table: &'a ProtoTable) -> Self {
+        Self {
+            found: true,
+            schema_name: &table.schema_name,
+            table_name: &table.name,
+            name: format!("{}.{}", table.schema_name, table.name),
+            description: &table.description,
+            guide: &table.guide,
+            required_filters: &table.required_filters,
+            column_count: table.columns.len(),
+            columns_hint: "Use list_columns with this schema/table to inspect columns.",
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct MissingTableValue<'a> {
+    found: bool,
+    requested: RequestedTable<'a>,
+    available_schemas: &'a [String],
+    same_schema_tables: Vec<Value>,
+    suggestions: Vec<Value>,
+    suggested_calls: Vec<SuggestedCall<'a>>,
+}
+
+#[derive(Serialize)]
+struct RequestedTable<'a> {
+    schema: &'a str,
+    table: &'a str,
+}
+
+#[derive(Serialize)]
+struct SuggestedCall<'a> {
+    tool: &'static str,
+    arguments: SuggestedCallArguments<'a>,
+}
+
+#[derive(Serialize)]
+struct SuggestedCallArguments<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pattern: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kind: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    limit: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct CatalogTableItemValue<'a> {
+    kind: &'static str,
+    schema_name: &'a str,
+    name: String,
+    sql_reference: String,
+    description: &'a str,
+    table: CatalogTableValue<'a>,
+}
+
+impl<'a> From<&'a ProtoTableSummary> for CatalogTableItemValue<'a> {
+    fn from(table: &'a ProtoTableSummary) -> Self {
+        Self {
+            kind: "table",
+            schema_name: &table.schema_name,
+            name: format!("{}.{}", table.schema_name, table.name),
+            sql_reference: format_schema_table_equivalent(&table.schema_name, &table.name),
+            description: &table.description,
+            table: CatalogTableValue {
+                table_name: &table.name,
+                guide: &table.guide,
+                required_filters: &table.required_filters,
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct CatalogTableValue<'a> {
+    table_name: &'a str,
+    guide: &'a str,
+    required_filters: &'a [String],
+}
+
+#[derive(Serialize)]
+struct CatalogTableFunctionItemValue<'a> {
+    kind: &'static str,
+    schema_name: &'a str,
+    name: String,
+    sql_reference: String,
+    sql_call_example: String,
+    description: &'a str,
+    table_function: CatalogTableFunctionValue<'a>,
+}
+
+impl<'a> From<&'a ProtoTableFunction> for CatalogTableFunctionItemValue<'a> {
+    fn from(function: &'a ProtoTableFunction) -> Self {
+        Self {
+            kind: "table_function",
+            schema_name: &function.schema_name,
+            name: format!("{}.{}", function.schema_name, function.name),
+            sql_reference: format_schema_table_equivalent(&function.schema_name, &function.name),
+            sql_call_example: minimal_table_function_call_example(function),
+            description: &function.description,
+            table_function: CatalogTableFunctionValue {
+                function_name: &function.name,
+                arguments: function
+                    .arguments
+                    .iter()
+                    .map(TableFunctionArgumentValue::from)
+                    .collect(),
+                result_columns: function
+                    .result_columns
+                    .iter()
+                    .map(TableFunctionResultColumnValue::from)
+                    .collect(),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct CatalogTableFunctionValue<'a> {
+    function_name: &'a str,
+    arguments: Vec<TableFunctionArgumentValue<'a>>,
+    result_columns: Vec<TableFunctionResultColumnValue<'a>>,
+}
+
+#[derive(Serialize)]
+struct TableFunctionArgumentValue<'a> {
+    name: &'a str,
+    required: bool,
+    values: &'a [String],
+}
+
+impl<'a> From<&'a ProtoTableFunctionArgument> for TableFunctionArgumentValue<'a> {
+    fn from(argument: &'a ProtoTableFunctionArgument) -> Self {
+        Self {
+            name: &argument.name,
+            required: argument.required,
+            values: &argument.values,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct TableFunctionResultColumnValue<'a> {
+    column_name: &'a str,
+    data_type: &'a str,
+    is_nullable: bool,
+    description: &'a str,
+}
+
+impl<'a> From<&'a ProtoTableFunctionResultColumn> for TableFunctionResultColumnValue<'a> {
+    fn from(column: &'a ProtoTableFunctionResultColumn) -> Self {
+        Self {
+            column_name: &column.name,
+            data_type: &column.data_type,
+            is_nullable: column.nullable,
+            description: &column.description,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ColumnValue<'a> {
+    column_name: &'a str,
+    data_type: &'a str,
+    is_nullable: bool,
+    is_virtual: bool,
+    is_required_filter: bool,
+    description: &'a str,
+    ordinal_position: u32,
+}
+
+impl<'a> From<&'a coral_api::v1::Column> for ColumnValue<'a> {
+    fn from(column: &'a coral_api::v1::Column) -> Self {
+        Self {
+            column_name: &column.name,
+            data_type: &column.data_type,
+            is_nullable: column.nullable,
+            is_virtual: column.is_virtual,
+            is_required_filter: column.is_required_filter,
+            description: &column.description,
+            ordinal_position: column.ordinal_position,
+        }
+    }
+}

--- a/crates/coral-codemode/src/lib.rs
+++ b/crates/coral-codemode/src/lib.rs
@@ -1,0 +1,812 @@
+//! Transport-neutral codemode execution for Coral.
+//!
+//! The first codemode is Monty-backed Python with explicit read-only host
+//! functions for SQL and catalog discovery. MCP and CLI adapters should call
+//! this crate rather than owning execution behavior themselves.
+
+mod catalog;
+mod values;
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use catalog::{describe_table_value, list_catalog_value, list_columns_value, search_catalog_value};
+use coral_api::v1::{
+    CatalogItemKind as ProtoCatalogItemKind, DescribeTableRequest, ExecuteSqlRequest,
+    ListCatalogRequest, ListColumnsRequest, PaginationRequest, SearchCatalogRequest,
+};
+use coral_client::{
+    CatalogClient, QueryClient, batches_to_json_rows_json_safe_numbers,
+    decode_execute_sql_response, default_workspace,
+};
+use monty::{
+    DictPairs, ExtFunctionResult, FunctionCall, JsonMontyObject, LimitedTracker, MontyObject,
+    MontyRun, NameLookupResult, PrintWriter, ResourceLimits, RunProgress,
+};
+use monty_type_checking::{SourceFile, type_check};
+use serde::Serialize;
+use serde_json::Value;
+use tokio::time::{Instant, timeout};
+use tonic::Request;
+
+/// Default Monty execution timeout used by CLI and MCP adapters.
+pub const DEFAULT_TIMEOUT_MS: u64 = 60_000;
+/// Minimum accepted Monty execution timeout.
+pub const MIN_TIMEOUT_MS: u64 = 100;
+/// Maximum accepted Monty execution timeout.
+pub const MAX_TIMEOUT_MS: u64 = 60_000;
+/// Default number of allowed `sql()` host-function calls.
+pub const DEFAULT_MAX_SQL_CALLS: usize = 20;
+/// Maximum number of allowed `sql()` host-function calls.
+pub const MAX_SQL_CALLS: usize = 100;
+
+const SCRIPT_NAME: &str = "coral_codemode.py";
+const TYPE_STUBS_NAME: &str = "coral_codemode_stubs.pyi";
+const DEFAULT_MAX_MEMORY_BYTES: usize = 32 * 1024 * 1024;
+const DEFAULT_MAX_ALLOCATIONS: usize = 200_000;
+
+const SQL_FUNCTION_NAME: &str = "sql";
+const LIST_CATALOG_FUNCTION_NAME: &str = "list_catalog";
+const SEARCH_CATALOG_FUNCTION_NAME: &str = "search_catalog";
+const DESCRIBE_TABLE_FUNCTION_NAME: &str = "describe_table";
+const LIST_COLUMNS_FUNCTION_NAME: &str = "list_columns";
+
+const SQL_FUNCTION_DOC: &str =
+    "Execute one read-only SQL query against Coral sources and return result rows.";
+const LIST_CATALOG_FUNCTION_DOC: &str = "List Coral catalog items.";
+const SEARCH_CATALOG_FUNCTION_DOC: &str = "Search Coral catalog metadata with a Rust regex.";
+const DESCRIBE_TABLE_FUNCTION_DOC: &str = "Describe one Coral table.";
+const LIST_COLUMNS_FUNCTION_DOC: &str = "List columns for one Coral table.";
+
+const TYPE_STUBS: &str = r#"
+from typing import Any
+
+def sql(query: str) -> list[dict[str, Any]]:
+    """Execute one read-only SQL query against Coral sources and return result rows."""
+    ...
+
+def list_catalog(schema: Any = None, kind: Any = None, limit: int = 50, offset: int = 0) -> dict[str, Any]:
+    """List Coral catalog items."""
+    ...
+
+def search_catalog(pattern: str, schema: Any = None, kind: Any = None, ignore_case: bool = True, limit: int = 20, offset: int = 0) -> dict[str, Any]:
+    """Search Coral catalog metadata with a Rust regex."""
+    ...
+
+def describe_table(schema: str, table: str) -> dict[str, Any]:
+    """Describe one Coral table."""
+    ...
+
+def list_columns(schema: str, table: str, pattern: Any = None, ignore_case: bool = True, required_only: bool = False, limit: int = 50, offset: int = 0) -> dict[str, Any]:
+    """List columns for one Coral table."""
+    ...
+"#;
+
+#[derive(Clone)]
+/// Coral clients available to codemode host functions.
+pub struct CodemodeClients {
+    /// SQL query client used by `sql()`.
+    pub query: QueryClient,
+    /// Catalog client used by catalog helper functions.
+    pub catalog: CatalogClient,
+}
+
+impl CodemodeClients {
+    #[must_use]
+    /// Builds codemode clients from existing Coral gRPC clients.
+    pub fn new(query: QueryClient, catalog: CatalogClient) -> Self {
+        Self { query, catalog }
+    }
+}
+
+/// Request for one Monty-backed Python codemode execution.
+#[derive(Clone, Debug)]
+pub struct PythonCodemodeRequest {
+    /// Python code to execute.
+    pub code: String,
+    /// Whether to run Monty's static type checker before execution.
+    pub type_check: bool,
+    /// Maximum execution time in milliseconds.
+    pub timeout_ms: u64,
+    /// Maximum number of `sql()` host-function calls.
+    pub max_sql_calls: usize,
+}
+
+impl PythonCodemodeRequest {
+    #[must_use]
+    /// Builds a request with conservative default execution limits.
+    pub fn new(code: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            type_check: true,
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+            max_sql_calls: DEFAULT_MAX_SQL_CALLS,
+        }
+    }
+}
+
+/// Result produced by one codemode run.
+#[derive(Debug, Serialize)]
+pub struct CodemodeResult {
+    /// Natural JSON representation of the final Monty Python value.
+    pub output: Value,
+    /// Text captured from Python `print()` calls.
+    pub stdout: String,
+    /// Number of Coral SQL queries executed through `sql()`.
+    pub query_count: usize,
+}
+
+/// Error returned by codemode execution.
+#[derive(Debug, thiserror::Error)]
+pub enum CodemodeError {
+    /// Invalid user code or host-function arguments.
+    #[error("{0}")]
+    Invalid(String),
+    /// Internal execution or serialization failure.
+    #[error("codemode internal error: {0}")]
+    Internal(String),
+    /// SQL query failure.
+    #[error("query failed: {0}")]
+    Query(tonic::Status),
+    /// Catalog lookup failure.
+    #[error("catalog lookup failed: {0}")]
+    Catalog(tonic::Status),
+}
+
+impl CodemodeError {
+    #[must_use]
+    /// Converts the codemode error into a gRPC status for MCP rendering.
+    pub fn into_status(self) -> tonic::Status {
+        match self {
+            Self::Invalid(message) => tonic::Status::invalid_argument(message),
+            Self::Internal(message) => tonic::Status::internal(message),
+            Self::Query(status) | Self::Catalog(status) => status,
+        }
+    }
+
+    #[must_use]
+    /// Returns a structured status when this error originated from Coral RPCs.
+    pub fn status(&self) -> Option<&tonic::Status> {
+        match self {
+            Self::Query(status) | Self::Catalog(status) => Some(status),
+            Self::Invalid(_) | Self::Internal(_) => None,
+        }
+    }
+}
+
+struct CodemodeState {
+    clients: CodemodeClients,
+    query_count: usize,
+    max_sql_calls: usize,
+    deadline: Instant,
+}
+
+impl CodemodeState {
+    fn new(clients: CodemodeClients, max_sql_calls: usize, timeout_ms: u64) -> Self {
+        Self {
+            clients,
+            query_count: 0,
+            max_sql_calls,
+            deadline: Instant::now() + Duration::from_millis(timeout_ms),
+        }
+    }
+
+    fn remaining_time(&self) -> Result<Duration, CodemodeError> {
+        self.deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| CodemodeError::Invalid("codemode timeout exceeded".to_string()))
+    }
+
+    async fn query_rows(&mut self, sql: &str) -> Result<Vec<Value>, CodemodeError> {
+        if self.query_count >= self.max_sql_calls {
+            return Err(CodemodeError::Invalid(format!(
+                "codemode exceeded max_sql_calls ({})",
+                self.max_sql_calls
+            )));
+        }
+        self.query_count = self.query_count.saturating_add(1);
+
+        let mut query_client = self.clients.query.clone();
+        let response = timeout(
+            self.remaining_time()?,
+            query_client.execute_sql(Request::new(ExecuteSqlRequest {
+                workspace: Some(default_workspace()),
+                sql: sql.to_string(),
+            })),
+        )
+        .await
+        .map_err(|_elapsed| CodemodeError::Invalid("codemode timeout exceeded".to_string()))?
+        .map_err(CodemodeError::Query)?
+        .into_inner();
+
+        let result = decode_execute_sql_response(&response)
+            .map_err(|error| CodemodeError::Internal(error.to_string()))?;
+        batches_to_json_rows_json_safe_numbers(result.batches())
+            .map_err(|error| CodemodeError::Internal(error.to_string()))
+    }
+
+    async fn list_catalog(&self, arguments: &CallArguments<'_>) -> Result<Value, CodemodeError> {
+        let schema = arguments.optional_string("schema")?;
+        let kind = arguments.optional_catalog_kind("kind")?;
+        let limit = arguments.optional_u32("limit", 50, 1, 200)?;
+        let offset = arguments.optional_u32("offset", 0, 0, u32::MAX)?;
+        let mut catalog_client = self.clients.catalog.clone();
+        let response = timeout(
+            self.remaining_time()?,
+            catalog_client.list_catalog(Request::new(ListCatalogRequest {
+                workspace: Some(default_workspace()),
+                schema_name: schema.unwrap_or_default(),
+                kind: catalog_item_kind(kind) as i32,
+                pagination: Some(PaginationRequest { limit, offset }),
+            })),
+        )
+        .await
+        .map_err(|_elapsed| CodemodeError::Invalid("codemode timeout exceeded".to_string()))?
+        .map_err(CodemodeError::Catalog)?
+        .into_inner();
+        Ok(list_catalog_value(&response))
+    }
+
+    async fn search_catalog(&self, arguments: &CallArguments<'_>) -> Result<Value, CodemodeError> {
+        let pattern = arguments.required_string("pattern")?;
+        let schema = arguments.optional_string("schema")?;
+        let kind = arguments.optional_catalog_kind("kind")?;
+        let ignore_case = arguments.optional_bool("ignore_case", true)?;
+        let limit = arguments.optional_u32("limit", 20, 1, 100)?;
+        let offset = arguments.optional_u32("offset", 0, 0, u32::MAX)?;
+        let mut catalog_client = self.clients.catalog.clone();
+        let response = timeout(
+            self.remaining_time()?,
+            catalog_client.search_catalog(Request::new(SearchCatalogRequest {
+                workspace: Some(default_workspace()),
+                pattern,
+                ignore_case,
+                schema_name: schema.unwrap_or_default(),
+                kind: catalog_item_kind(kind) as i32,
+                pagination: Some(PaginationRequest { limit, offset }),
+            })),
+        )
+        .await
+        .map_err(|_elapsed| CodemodeError::Invalid("codemode timeout exceeded".to_string()))?
+        .map_err(CodemodeError::Catalog)?
+        .into_inner();
+        Ok(search_catalog_value(&response))
+    }
+
+    async fn describe_table(&self, arguments: &CallArguments<'_>) -> Result<Value, CodemodeError> {
+        let schema = arguments.required_string("schema")?;
+        let table = arguments.required_string("table")?;
+        self.describe_table_value(&schema, &table).await
+    }
+
+    async fn describe_table_value(
+        &self,
+        schema: &str,
+        table: &str,
+    ) -> Result<Value, CodemodeError> {
+        let mut catalog_client = self.clients.catalog.clone();
+        let response = timeout(
+            self.remaining_time()?,
+            catalog_client.describe_table(Request::new(DescribeTableRequest {
+                workspace: Some(default_workspace()),
+                schema_name: schema.to_string(),
+                table_name: table.to_string(),
+            })),
+        )
+        .await
+        .map_err(|_elapsed| CodemodeError::Invalid("codemode timeout exceeded".to_string()))?
+        .map_err(CodemodeError::Catalog)?
+        .into_inner();
+        Ok(describe_table_value(schema, table, &response))
+    }
+
+    async fn list_columns(&self, arguments: &CallArguments<'_>) -> Result<Value, CodemodeError> {
+        let schema = arguments.required_string("schema")?;
+        let table = arguments.required_string("table")?;
+        let pattern = arguments.optional_non_empty_string("pattern")?;
+        let ignore_case = arguments.optional_bool("ignore_case", true)?;
+        let required_only = arguments.optional_bool("required_only", false)?;
+        let limit = arguments.optional_u32("limit", 50, 1, 200)?;
+        let offset = arguments.optional_u32("offset", 0, 0, u32::MAX)?;
+        let mut catalog_client = self.clients.catalog.clone();
+        match timeout(
+            self.remaining_time()?,
+            catalog_client.list_columns(Request::new(ListColumnsRequest {
+                workspace: Some(default_workspace()),
+                schema_name: schema.clone(),
+                table_name: table.clone(),
+                pattern,
+                ignore_case,
+                required_only,
+                pagination: Some(PaginationRequest { limit, offset }),
+            })),
+        )
+        .await
+        .map_err(|_elapsed| CodemodeError::Invalid("codemode timeout exceeded".to_string()))?
+        {
+            Ok(response) => Ok(list_columns_value(&schema, &table, &response.into_inner())),
+            Err(status) if status.code() == tonic::Code::NotFound => {
+                self.describe_table_value(&schema, &table).await
+            }
+            Err(status) => Err(CodemodeError::Catalog(status)),
+        }
+    }
+}
+
+/// Executes one Monty-backed Python codemode request.
+///
+/// # Errors
+///
+/// Returns [`CodemodeError`] when code is invalid, resource limits are exceeded,
+/// or a Coral SQL/catalog host call fails.
+pub async fn run_python(
+    clients: CodemodeClients,
+    request: PythonCodemodeRequest,
+) -> Result<CodemodeResult, CodemodeError> {
+    validate_request(&request)?;
+    if request.type_check {
+        type_check_code(&request.code)?;
+    }
+
+    let runner = MontyRun::new(request.code, SCRIPT_NAME, Vec::new())
+        .map_err(|error| monty_codemode_error(&error))?;
+    let limits = ResourceLimits::new()
+        .max_duration(Duration::from_millis(request.timeout_ms))
+        .max_memory(DEFAULT_MAX_MEMORY_BYTES)
+        .max_allocations(DEFAULT_MAX_ALLOCATIONS);
+    let mut stdout = String::new();
+    let mut state = CodemodeState::new(clients, request.max_sql_calls, request.timeout_ms);
+    let mut progress = runner
+        .start(
+            Vec::new(),
+            LimitedTracker::new(limits),
+            PrintWriter::CollectString(&mut stdout),
+        )
+        .map_err(|error| monty_codemode_error(&error))?;
+
+    loop {
+        progress = match progress {
+            RunProgress::Complete(value) => {
+                return Ok(CodemodeResult {
+                    output: monty_to_json(&value)?,
+                    stdout,
+                    query_count: state.query_count,
+                });
+            }
+            RunProgress::NameLookup(lookup) => {
+                let result = host_function_doc(&lookup.name).map_or(
+                    NameLookupResult::Undefined,
+                    |docstring| {
+                        NameLookupResult::Value(MontyObject::Function {
+                            name: lookup.name.clone(),
+                            docstring: Some(docstring.to_string()),
+                        })
+                    },
+                );
+                lookup
+                    .resume(result, PrintWriter::CollectString(&mut stdout))
+                    .map_err(|error| monty_codemode_error(&error))?
+            }
+            RunProgress::FunctionCall(call) => {
+                resume_function_call(&mut state, call, &mut stdout).await?
+            }
+            RunProgress::OsCall(call) => {
+                let error = call.function_call.on_no_handler();
+                call.resume(error, PrintWriter::CollectString(&mut stdout))
+                    .map_err(|error| monty_codemode_error(&error))?
+            }
+            RunProgress::ResolveFutures(pending) => {
+                return Err(CodemodeError::Invalid(format!(
+                    "codemode async external futures are not supported; pending call ids: {:?}",
+                    pending.pending_call_ids()
+                )));
+            }
+        };
+    }
+}
+
+async fn resume_function_call(
+    state: &mut CodemodeState,
+    call: FunctionCall<LimitedTracker>,
+    stdout: &mut String,
+) -> Result<RunProgress<LimitedTracker>, CodemodeError> {
+    match call.function_name.as_str() {
+        SQL_FUNCTION_NAME => {
+            let arguments = CallArguments::new(
+                SQL_FUNCTION_NAME,
+                &[SQL_ARGUMENT_QUERY],
+                &call.args,
+                &call.kwargs,
+            )?;
+            let sql = arguments.required_string(SQL_ARGUMENT_QUERY)?;
+            let rows = state.query_rows(&sql).await?;
+            let result = json_to_monty(Value::Array(rows))?;
+            resume_call(call, result, stdout)
+        }
+        LIST_CATALOG_FUNCTION_NAME => {
+            let arguments = CallArguments::new(
+                LIST_CATALOG_FUNCTION_NAME,
+                &LIST_CATALOG_ARGUMENTS,
+                &call.args,
+                &call.kwargs,
+            )?;
+            let result = json_to_monty(state.list_catalog(&arguments).await?)?;
+            resume_call(call, result, stdout)
+        }
+        SEARCH_CATALOG_FUNCTION_NAME => {
+            let arguments = CallArguments::new(
+                SEARCH_CATALOG_FUNCTION_NAME,
+                &SEARCH_CATALOG_ARGUMENTS,
+                &call.args,
+                &call.kwargs,
+            )?;
+            let result = json_to_monty(state.search_catalog(&arguments).await?)?;
+            resume_call(call, result, stdout)
+        }
+        DESCRIBE_TABLE_FUNCTION_NAME => {
+            let arguments = CallArguments::new(
+                DESCRIBE_TABLE_FUNCTION_NAME,
+                &DESCRIBE_TABLE_ARGUMENTS,
+                &call.args,
+                &call.kwargs,
+            )?;
+            let result = json_to_monty(state.describe_table(&arguments).await?)?;
+            resume_call(call, result, stdout)
+        }
+        LIST_COLUMNS_FUNCTION_NAME => {
+            let arguments = CallArguments::new(
+                LIST_COLUMNS_FUNCTION_NAME,
+                &LIST_COLUMNS_ARGUMENTS,
+                &call.args,
+                &call.kwargs,
+            )?;
+            let result = json_to_monty(state.list_columns(&arguments).await?)?;
+            resume_call(call, result, stdout)
+        }
+        _ => {
+            let function_name = call.function_name.clone();
+            call.resume(
+                ExtFunctionResult::NotFound(function_name),
+                PrintWriter::CollectString(stdout),
+            )
+            .map_err(|error| monty_codemode_error(&error))
+        }
+    }
+}
+
+fn resume_call(
+    call: FunctionCall<LimitedTracker>,
+    result: MontyObject,
+    stdout: &mut String,
+) -> Result<RunProgress<LimitedTracker>, CodemodeError> {
+    call.resume(result, PrintWriter::CollectString(stdout))
+        .map_err(|error| monty_codemode_error(&error))
+}
+
+fn validate_request(request: &PythonCodemodeRequest) -> Result<(), CodemodeError> {
+    if request.code.trim().is_empty() {
+        return Err(CodemodeError::Invalid(
+            "codemode code must not be empty".to_string(),
+        ));
+    }
+    if !(MIN_TIMEOUT_MS..=MAX_TIMEOUT_MS).contains(&request.timeout_ms) {
+        return Err(CodemodeError::Invalid(format!(
+            "timeout_ms must be between {MIN_TIMEOUT_MS} and {MAX_TIMEOUT_MS}"
+        )));
+    }
+    if request.max_sql_calls > MAX_SQL_CALLS {
+        return Err(CodemodeError::Invalid(format!(
+            "max_sql_calls must be between 0 and {MAX_SQL_CALLS}"
+        )));
+    }
+    Ok(())
+}
+
+fn type_check_code(code: &str) -> Result<(), CodemodeError> {
+    let stubs = SourceFile::new(TYPE_STUBS, TYPE_STUBS_NAME);
+    match type_check(&SourceFile::new(code, SCRIPT_NAME), Some(&stubs)) {
+        Ok(None) => Ok(()),
+        Ok(Some(diagnostics)) => Err(CodemodeError::Invalid(format!(
+            "Monty type check failed:\n{diagnostics}"
+        ))),
+        Err(error) => Err(CodemodeError::Internal(format!(
+            "Monty type checker failed: {error}"
+        ))),
+    }
+}
+
+fn host_function_doc(name: &str) -> Option<&'static str> {
+    match name {
+        SQL_FUNCTION_NAME => Some(SQL_FUNCTION_DOC),
+        LIST_CATALOG_FUNCTION_NAME => Some(LIST_CATALOG_FUNCTION_DOC),
+        SEARCH_CATALOG_FUNCTION_NAME => Some(SEARCH_CATALOG_FUNCTION_DOC),
+        DESCRIBE_TABLE_FUNCTION_NAME => Some(DESCRIBE_TABLE_FUNCTION_DOC),
+        LIST_COLUMNS_FUNCTION_NAME => Some(LIST_COLUMNS_FUNCTION_DOC),
+        _ => None,
+    }
+}
+
+const SQL_ARGUMENT_QUERY: &str = "query";
+const LIST_CATALOG_ARGUMENTS: [&str; 4] = ["schema", "kind", "limit", "offset"];
+const SEARCH_CATALOG_ARGUMENTS: [&str; 6] = [
+    "pattern",
+    "schema",
+    "kind",
+    "ignore_case",
+    "limit",
+    "offset",
+];
+const DESCRIBE_TABLE_ARGUMENTS: [&str; 2] = ["schema", "table"];
+const LIST_COLUMNS_ARGUMENTS: [&str; 7] = [
+    "schema",
+    "table",
+    "pattern",
+    "ignore_case",
+    "required_only",
+    "limit",
+    "offset",
+];
+
+struct CallArguments<'a> {
+    function_name: &'static str,
+    positional_names: &'static [&'static str],
+    positional: &'a [MontyObject],
+    keyword: Vec<(&'static str, &'a MontyObject)>,
+}
+
+impl<'a> CallArguments<'a> {
+    fn new(
+        function_name: &'static str,
+        positional_names: &'static [&'static str],
+        positional: &'a [MontyObject],
+        keyword: &'a [(MontyObject, MontyObject)],
+    ) -> Result<Self, CodemodeError> {
+        if positional.len() > positional_names.len() {
+            return Err(CodemodeError::Invalid(format!(
+                "{function_name}() expected at most {} positional arguments, got {}",
+                positional_names.len(),
+                positional.len()
+            )));
+        }
+
+        let mut seen = BTreeSet::new();
+        for name in positional_names.iter().take(positional.len()) {
+            let inserted = seen.insert(*name);
+            debug_assert!(inserted, "argument names are unique");
+        }
+
+        let mut parsed_keyword = Vec::with_capacity(keyword.len());
+        for (key, value) in keyword {
+            let MontyObject::String(key) = key else {
+                return Err(CodemodeError::Invalid(format!(
+                    "{function_name}() keyword argument names must be strings"
+                )));
+            };
+            let Some(name) = positional_names
+                .iter()
+                .copied()
+                .find(|name| key.as_str() == *name)
+            else {
+                return Err(CodemodeError::Invalid(format!(
+                    "{function_name}() got unexpected keyword argument '{key}'"
+                )));
+            };
+            if !seen.insert(name) {
+                return Err(CodemodeError::Invalid(format!(
+                    "{function_name}() got multiple values for argument '{key}'"
+                )));
+            }
+            parsed_keyword.push((name, value));
+        }
+
+        Ok(Self {
+            function_name,
+            positional_names,
+            positional,
+            keyword: parsed_keyword,
+        })
+    }
+
+    fn required_string(&self, name: &'static str) -> Result<String, CodemodeError> {
+        let value = self.value(name).ok_or_else(|| {
+            CodemodeError::Invalid(format!("{}() missing {name} argument", self.function_name))
+        })?;
+        required_string(value, &format!("{}() {name}", self.function_name))
+    }
+
+    fn optional_string(&self, name: &'static str) -> Result<Option<String>, CodemodeError> {
+        let Some(value) = self.value(name) else {
+            return Ok(None);
+        };
+        optional_string(value, &format!("{}() {name}", self.function_name))
+    }
+
+    fn optional_non_empty_string(
+        &self,
+        name: &'static str,
+    ) -> Result<Option<String>, CodemodeError> {
+        let Some(value) = self.value(name) else {
+            return Ok(None);
+        };
+        optional_non_empty_string(value, &format!("{}() {name}", self.function_name))
+    }
+
+    fn optional_bool(&self, name: &'static str, default: bool) -> Result<bool, CodemodeError> {
+        let Some(value) = self.value(name) else {
+            return Ok(default);
+        };
+        let MontyObject::Bool(value) = value else {
+            return Err(CodemodeError::Invalid(format!(
+                "{}() {name} must be a boolean",
+                self.function_name
+            )));
+        };
+        Ok(*value)
+    }
+
+    fn optional_u32(
+        &self,
+        name: &'static str,
+        default: u32,
+        min: u32,
+        max: u32,
+    ) -> Result<u32, CodemodeError> {
+        let Some(value) = self.value(name) else {
+            return Ok(default);
+        };
+        let MontyObject::Int(value) = value else {
+            return Err(CodemodeError::Invalid(format!(
+                "{}() {name} must be an integer",
+                self.function_name
+            )));
+        };
+        if *value < i64::from(min) || *value > i64::from(max) {
+            return Err(CodemodeError::Invalid(format!(
+                "{}() {name} must be between {min} and {max}",
+                self.function_name
+            )));
+        }
+        u32::try_from(*value).map_err(|_error| {
+            CodemodeError::Invalid(format!(
+                "{}() {name} must be between {min} and {max}",
+                self.function_name
+            ))
+        })
+    }
+
+    fn optional_catalog_kind(
+        &self,
+        name: &'static str,
+    ) -> Result<Option<CatalogKind>, CodemodeError> {
+        let Some(kind) = self.optional_string(name)? else {
+            return Ok(None);
+        };
+        match kind.as_str() {
+            "table" => Ok(Some(CatalogKind::Table)),
+            "table_function" => Ok(Some(CatalogKind::TableFunction)),
+            _ => Err(CodemodeError::Invalid(format!(
+                "{}() {name} must be 'table' or 'table_function'",
+                self.function_name
+            ))),
+        }
+    }
+
+    fn value(&self, name: &'static str) -> Option<&'a MontyObject> {
+        self.positional_names
+            .iter()
+            .position(|candidate| *candidate == name)
+            .and_then(|idx| self.positional.get(idx))
+            .or_else(|| {
+                self.keyword
+                    .iter()
+                    .find_map(|(key, value)| (*key == name).then_some(*value))
+            })
+    }
+}
+
+#[derive(Clone, Copy)]
+enum CatalogKind {
+    Table,
+    TableFunction,
+}
+
+fn catalog_item_kind(kind: Option<CatalogKind>) -> ProtoCatalogItemKind {
+    match kind {
+        None => ProtoCatalogItemKind::Unspecified,
+        Some(CatalogKind::Table) => ProtoCatalogItemKind::Table,
+        Some(CatalogKind::TableFunction) => ProtoCatalogItemKind::TableFunction,
+    }
+}
+
+fn required_string(value: &MontyObject, context: &str) -> Result<String, CodemodeError> {
+    let MontyObject::String(value) = value else {
+        return Err(CodemodeError::Invalid(format!(
+            "{context} must be a string"
+        )));
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(CodemodeError::Invalid(format!(
+            "{context} must not be empty"
+        )));
+    }
+    Ok(value.to_string())
+}
+
+fn optional_string(value: &MontyObject, context: &str) -> Result<Option<String>, CodemodeError> {
+    if matches!(value, MontyObject::None) {
+        return Ok(None);
+    }
+    let MontyObject::String(value) = value else {
+        return Err(CodemodeError::Invalid(format!(
+            "{context} must be a string"
+        )));
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(value.to_string()))
+    }
+}
+
+fn optional_non_empty_string(
+    value: &MontyObject,
+    context: &str,
+) -> Result<Option<String>, CodemodeError> {
+    if matches!(value, MontyObject::None) {
+        return Ok(None);
+    }
+    let MontyObject::String(value) = value else {
+        return Err(CodemodeError::Invalid(format!(
+            "{context} must be a string"
+        )));
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        Err(CodemodeError::Invalid(format!(
+            "{context} must not be empty"
+        )))
+    } else {
+        Ok(Some(value.to_string()))
+    }
+}
+
+fn monty_to_json(value: &MontyObject) -> Result<Value, CodemodeError> {
+    serde_json::to_value(JsonMontyObject(value))
+        .map_err(|error| CodemodeError::Internal(error.to_string()))
+}
+
+fn json_to_monty(value: Value) -> Result<MontyObject, CodemodeError> {
+    match value {
+        Value::Null => Ok(MontyObject::None),
+        Value::Bool(value) => Ok(MontyObject::Bool(value)),
+        Value::Number(value) => Ok(number_to_monty(&value)),
+        Value::String(value) => Ok(MontyObject::String(value)),
+        Value::Array(values) => values
+            .into_iter()
+            .map(json_to_monty)
+            .collect::<Result<Vec<_>, _>>()
+            .map(MontyObject::List),
+        Value::Object(map) => map
+            .into_iter()
+            .map(|(key, value)| Ok((MontyObject::String(key), json_to_monty(value)?)))
+            .collect::<Result<Vec<_>, CodemodeError>>()
+            .map(DictPairs::from)
+            .map(MontyObject::Dict),
+    }
+}
+
+fn number_to_monty(value: &serde_json::Number) -> MontyObject {
+    if let Some(value) = value.as_i64() {
+        MontyObject::Int(value)
+    } else if let Some(value) = value.as_f64() {
+        MontyObject::Float(value)
+    } else {
+        MontyObject::String(value.to_string())
+    }
+}
+
+fn monty_codemode_error(error: &monty::MontyException) -> CodemodeError {
+    CodemodeError::Invalid(error.to_string())
+}

--- a/crates/coral-codemode/src/values.rs
+++ b/crates/coral-codemode/src/values.rs
@@ -1,0 +1,82 @@
+use coral_api::v1::{PaginationResponse, TableSummary};
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+pub(crate) fn missing_table_summary_value(table: &TableSummary) -> Value {
+    serde_json::to_value(MissingTableSummaryValue::from(table))
+        .expect("missing table summary value serializes")
+}
+
+pub(crate) fn paged_collection_value(
+    collection_key: &str,
+    items: Vec<Value>,
+    pagination: &PaginationResponse,
+) -> Value {
+    let mut value = Map::from_iter([(collection_key.to_string(), Value::Array(items))]);
+    insert_pagination_fields(&mut value, pagination);
+    Value::Object(value)
+}
+
+pub(crate) fn insert_pagination_fields(
+    value: &mut Map<String, Value>,
+    pagination: &PaginationResponse,
+) {
+    value.insert("total".to_string(), Value::from(pagination.total_count));
+    value.insert("limit".to_string(), Value::from(pagination.limit));
+    value.insert("offset".to_string(), Value::from(pagination.offset));
+    value.insert("has_more".to_string(), Value::from(pagination.has_more));
+    if pagination.has_more {
+        value.insert(
+            "next_offset".to_string(),
+            Value::from(pagination.next_offset),
+        );
+    }
+}
+
+#[derive(Serialize)]
+struct MissingTableSummaryValue<'a> {
+    schema_name: &'a str,
+    table_name: &'a str,
+    name: String,
+    description: &'a str,
+    required_filters: &'a [String],
+}
+
+impl<'a> From<&'a TableSummary> for MissingTableSummaryValue<'a> {
+    fn from(table: &'a TableSummary) -> Self {
+        Self {
+            schema_name: &table.schema_name,
+            table_name: &table.name,
+            name: format!("{}.{}", table.schema_name, table.name),
+            description: &table.description,
+            required_filters: &table.required_filters,
+        }
+    }
+}
+
+pub(crate) fn format_schema_table_equivalent(schema_name: &str, table_name: &str) -> String {
+    format!(
+        "{}.{}",
+        format_sql_identifier(schema_name),
+        format_sql_identifier(table_name)
+    )
+}
+
+pub(crate) fn format_sql_identifier(identifier: &str) -> String {
+    if identifier_needs_quotes(identifier) {
+        format!("\"{}\"", identifier.replace('"', "\"\""))
+    } else {
+        identifier.to_string()
+    }
+}
+
+fn identifier_needs_quotes(identifier: &str) -> bool {
+    let mut chars = identifier.chars();
+    let Some(first) = chars.next() else {
+        return true;
+    };
+    if !(first.is_ascii_lowercase() || first == '_') {
+        return true;
+    }
+    !chars.all(|char| char.is_ascii_lowercase() || char.is_ascii_digit() || char == '_')
+}

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The exposed MCP surface is intentionally small:
 //!
-//! - tools: `sql`, paginated `list_catalog`, `search_catalog`, `describe_table`, `list_columns`, and optionally `feedback`
+//! - tools: `sql`, paginated `list_catalog`, `search_catalog`, `describe_table`, `list_columns`, and optionally `codemode` and `feedback`
 //! - resources: `coral://guide`, `coral://tables`
 //!
 //! Protocol lifecycle, initialization, and stdio transport behavior should stay
@@ -39,6 +39,8 @@ pub(crate) use server::CoralMcpServer;
 /// Optional MCP surface features.
 #[derive(Debug, Clone, Default)]
 pub struct McpOptions {
+    /// Expose the codemode execution tool.
+    pub codemode_enabled: bool,
     /// Expose the feedback submission tool.
     pub feedback_enabled: bool,
     /// Optional W3C traceparent used to parent each MCP request span.

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -10,6 +10,7 @@ use coral_client::{
     AppClient, CatalogClient, FeedbackClient, QueryClient, SourceClient,
     batches_to_json_rows_json_safe_numbers, decode_execute_sql_response, default_workspace,
 };
+use coral_codemode::{CodemodeClients, PythonCodemodeRequest};
 use rmcp::{
     ErrorData, ServerHandler,
     model::{
@@ -26,13 +27,13 @@ use tonic::Request;
 use crate::{
     McpOptions,
     surface::{
-        CatalogToolKind, build_tool_result, describe_table_arguments, describe_table_tool,
-        describe_table_value, feedback_tool, guide_resource, guide_resource_content,
-        initial_instructions, list_catalog_arguments, list_catalog_tool, list_catalog_value,
-        list_columns_arguments, list_columns_tool, list_columns_value, required_string_argument,
-        search_catalog_arguments, search_catalog_tool, search_catalog_value, sql_tool,
-        status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
-        tool_error_result,
+        CatalogToolKind, build_tool_result, codemode_arguments, codemode_tool,
+        describe_table_arguments, describe_table_tool, describe_table_value, feedback_tool,
+        guide_resource, guide_resource_content, initial_instructions, list_catalog_arguments,
+        list_catalog_tool, list_catalog_value, list_columns_arguments, list_columns_tool,
+        list_columns_value, required_string_argument, search_catalog_arguments,
+        search_catalog_tool, search_catalog_value, sql_tool, status_to_error_data, tables_resource,
+        tables_resource_content, tool_error_from_status, tool_error_result,
     },
     telemetry,
 };
@@ -236,6 +237,17 @@ impl CoralMcpServer {
         })
     }
 
+    async fn execute_codemode_value(
+        &self,
+        request: PythonCodemodeRequest,
+    ) -> Result<Value, tonic::Status> {
+        let clients = CodemodeClients::new(self.query.clone(), self.catalog.clone());
+        let result = coral_codemode::run_python(clients, request)
+            .await
+            .map_err(coral_codemode::CodemodeError::into_status)?;
+        serialize_tool_value(result)
+    }
+
     async fn submit_feedback_value(
         &self,
         trying_to_do: &str,
@@ -367,6 +379,19 @@ impl CoralMcpServer {
                 self.list_columns_tool_result(request.arguments.as_ref())
                     .await
             }
+            "codemode" if self.options.codemode_enabled => {
+                let arguments = codemode_arguments(request.arguments.as_ref())?;
+                let request = PythonCodemodeRequest {
+                    code: arguments.code,
+                    type_check: arguments.type_check,
+                    timeout_ms: arguments.timeout_ms,
+                    max_sql_calls: arguments.max_sql_calls,
+                };
+                Ok(ToolCallOutcome::from_value_result(
+                    "Codemode",
+                    self.execute_codemode_value(request).await,
+                ))
+            }
             "feedback" if self.options.feedback_enabled => {
                 let trying_to_do =
                     required_string_argument(request.arguments.as_ref(), "trying_to_do")?;
@@ -468,6 +493,9 @@ impl ServerHandler for CoralMcpServer {
                 describe_table_tool(),
                 list_columns_tool(),
             ];
+            if self.options.codemode_enabled {
+                tools.push(codemode_tool(visible_table_count));
+            }
             if self.options.feedback_enabled {
                 tools.push(feedback_tool());
             }

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -17,8 +17,8 @@ pub(crate) use resources::{
     tables_resource_content,
 };
 pub(crate) use tools::{
-    CatalogToolKind, build_tool_result, describe_table_arguments, describe_table_tool,
-    feedback_tool, list_catalog_arguments, list_catalog_tool, list_columns_arguments,
-    list_columns_tool, required_string_argument, search_catalog_arguments, search_catalog_tool,
-    sql_tool,
+    CatalogToolKind, build_tool_result, codemode_arguments, codemode_tool,
+    describe_table_arguments, describe_table_tool, feedback_tool, list_catalog_arguments,
+    list_catalog_tool, list_columns_arguments, list_columns_tool, required_string_argument,
+    search_catalog_arguments, search_catalog_tool, sql_tool,
 };

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -42,6 +42,13 @@ pub(crate) struct ListColumnsArguments {
     pub(crate) pagination: Pagination,
 }
 
+pub(crate) struct CodemodeArguments {
+    pub(crate) code: String,
+    pub(crate) type_check: bool,
+    pub(crate) timeout_ms: u64,
+    pub(crate) max_sql_calls: usize,
+}
+
 pub(crate) fn sql_tool(visible_table_count: usize) -> Tool {
     Tool::new(
         "sql",
@@ -59,6 +66,50 @@ pub(crate) fn sql_tool(visible_table_count: usize) -> Tool {
     )
     .with_annotations(
         ToolAnnotations::with_title("Run SQL")
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(true),
+    )
+}
+
+pub(crate) fn codemode_tool(visible_table_count: usize) -> Tool {
+    Tool::new(
+        "codemode",
+        codemode_tool_description(visible_table_count),
+        json_object_schema(&json!({
+            "type": "object",
+            "required": ["code"],
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "Python code to execute inside Monty. The final expression is returned as `output`. Host functions include sql(), list_catalog(), search_catalog(), describe_table(), and list_columns()."
+                },
+                "type_check": {
+                    "type": "boolean",
+                    "description": "Whether to run Monty's static type checker before execution. Defaults to true.",
+                    "default": true
+                },
+                "timeout_ms": {
+                    "type": "integer",
+                    "description": "Maximum Monty execution time in milliseconds, from 100 to 60000. Defaults to 60000.",
+                    "minimum": 100,
+                    "maximum": 60000,
+                    "default": 60000
+                },
+                "max_sql_calls": {
+                    "type": "integer",
+                    "description": "Maximum number of sql() host-function calls allowed, from 0 to 100. Defaults to 20.",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "default": 20
+                }
+            }
+        })),
+    )
+    .with_raw_output_schema(codemode_output_schema())
+    .with_annotations(
+        ToolAnnotations::with_title("Run Codemode")
             .read_only(true)
             .destructive(false)
             .idempotent(true)
@@ -370,6 +421,30 @@ pub(crate) fn list_columns_arguments(
     })
 }
 
+pub(crate) fn codemode_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<CodemodeArguments, ErrorData> {
+    Ok(CodemodeArguments {
+        code: required_string_argument(arguments, "code")?,
+        type_check: optional_bool_argument(arguments, "type_check", true)?,
+        timeout_ms: optional_u64_argument(
+            arguments,
+            "timeout_ms",
+            coral_codemode::DEFAULT_TIMEOUT_MS,
+            coral_codemode::MIN_TIMEOUT_MS,
+            coral_codemode::MAX_TIMEOUT_MS,
+        )?,
+        max_sql_calls: usize::try_from(optional_u64_argument(
+            arguments,
+            "max_sql_calls",
+            20,
+            0,
+            100,
+        )?)
+        .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?,
+    })
+}
+
 pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
     let pretty = serde_json::to_string_pretty(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
@@ -389,10 +464,42 @@ fn sql_tool_description(visible_table_count: usize) -> String {
     }
 }
 
+fn codemode_tool_description(visible_table_count: usize) -> String {
+    if visible_table_count == 0 {
+        "Execute Monty Python in a sandbox. Coral SQL and catalog helpers are available inside the code, but no user tables are currently visible.".to_string()
+    } else {
+        format!(
+            "Execute Monty Python in a sandbox. Host functions include `sql(query)`, `list_catalog()`, `search_catalog(pattern)`, `describe_table(schema, table)`, and `list_columns(schema, table)`. {visible_table_count} table(s) are currently visible."
+        )
+    }
+}
+
 fn search_catalog_description(visible_table_count: usize, visible_function_count: usize) -> String {
     format!(
         "Search database catalog metadata with a Rust regex. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible."
     )
+}
+
+fn codemode_output_schema() -> Arc<Map<String, Value>> {
+    json_object_schema(&json!({
+        "type": "object",
+        "required": ["output", "stdout", "query_count"],
+        "additionalProperties": false,
+        "properties": {
+            "output": {
+                "description": "Natural JSON representation of the final Monty Python value."
+            },
+            "stdout": {
+                "type": "string",
+                "description": "Text captured from Python print() calls."
+            },
+            "query_count": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of Coral SQL queries executed through sql()."
+            }
+        }
+    }))
 }
 
 fn list_catalog_output_schema() -> Arc<Map<String, Value>> {
@@ -786,6 +893,31 @@ fn optional_bool_argument(
     value.as_bool().ok_or_else(|| {
         ErrorData::invalid_params(format!("argument '{key}' must be a boolean"), None)
     })
+}
+
+fn optional_u64_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+    default: u64,
+    min: u64,
+    max: u64,
+) -> Result<u64, ErrorData> {
+    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
+        return Ok(default);
+    };
+    let Some(value) = value.as_u64() else {
+        return Err(ErrorData::invalid_params(
+            format!("argument '{key}' must be an unsigned integer"),
+            None,
+        ));
+    };
+    if value < min || value > max {
+        return Err(ErrorData::invalid_params(
+            format!("argument '{key}' must be between {min} and {max}"),
+            None,
+        ));
+    }
+    Ok(value)
 }
 
 fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -883,6 +883,117 @@ async fn list_catalog_surfaces_table_functions() {
 }
 
 #[tokio::test]
+async fn mcp_codemode_tool_runs_monty_with_coral_sql_host_function() {
+    let temp = TempDir::new().expect("temp dir");
+    let manifest_path = write_fixture_manifest(temp.path());
+    let manifest_yaml = fs::read_to_string(&manifest_path).expect("read manifest");
+    let mut session = start_session_with_options(
+        &temp,
+        McpOptions {
+            codemode_enabled: true,
+            ..McpOptions::default()
+        },
+    )
+    .await;
+    let client = &session.client;
+
+    add_demo_source(&mut session.source_client, manifest_yaml).await;
+
+    let tools = client.list_all_tools().await.expect("tools");
+    assert_eq!(
+        tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>(),
+        vec![
+            "sql",
+            "list_catalog",
+            "search_catalog",
+            "describe_table",
+            "list_columns",
+            "codemode"
+        ]
+    );
+    let codemode_tool = tool_by_name(&tools, "codemode");
+    let annotations = codemode_tool
+        .annotations
+        .as_ref()
+        .expect("codemode annotations");
+    assert_eq!(annotations.read_only_hint, Some(true));
+    assert_eq!(annotations.destructive_hint, Some(false));
+    assert_eq!(annotations.idempotent_hint, Some(true));
+    assert_eq!(annotations.open_world_hint, Some(true));
+
+    let code = r#"
+catalog = list_catalog(schema="local_messages", kind="table")
+columns = list_columns("local_messages", "messages")
+rows = sql("SELECT text FROM local_messages.messages ORDER BY text")
+print("rows", len(rows))
+{"texts": [row["text"] for row in rows], "count": len(rows), "first_table": catalog["items"][0]["name"], "column_total": columns["total"]}
+"#;
+    let codemode = client
+        .call_tool(
+            CallToolRequestParams::new("codemode").with_arguments(json_object(&json!({
+                "code": code
+            }))),
+        )
+        .await
+        .expect("codemode");
+    assert_eq!(codemode.is_error, Some(false));
+    let structured = codemode.structured_content.expect("structured content");
+    assert_eq!(structured["output"]["texts"][0], "hello");
+    assert_eq!(structured["output"]["texts"][1], "world");
+    assert_eq!(structured["output"]["count"], 2);
+    assert_eq!(structured["output"]["first_table"], "local_messages.events");
+    assert_eq!(structured["output"]["column_total"], 3);
+    assert_eq!(structured["stdout"], "rows 2\n");
+    assert_eq!(structured["query_count"], 1);
+    assert_matches_output_schema(codemode_tool, &structured);
+
+    let rejected = client
+        .call_tool(
+            CallToolRequestParams::new("codemode").with_arguments(json_object(&json!({
+                "code": "sql('SELECT 1')",
+                "max_sql_calls": 0
+            }))),
+        )
+        .await
+        .expect("codemode query cap should return a tool error");
+    assert_eq!(rejected.is_error, Some(true));
+    assert!(
+        rejected.content[0]
+            .as_text()
+            .expect("text content")
+            .text
+            .contains("max_sql_calls")
+    );
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_codemode_tool_is_disabled_by_default() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_session(&temp).await;
+    let client = &session.client;
+
+    let tools = client.list_all_tools().await.expect("tools");
+    assert!(tools.iter().all(|tool| tool.name != "codemode"));
+
+    let codemode = client
+        .call_tool(
+            CallToolRequestParams::new("codemode").with_arguments(json_object(&json!({
+                "code": "1 + 1"
+            }))),
+        )
+        .await
+        .expect_err("codemode should not be exposed by default");
+    assert!(codemode.to_string().contains("tool 'codemode' not found"));
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
 async fn mcp_feedback_tool_persists_blocked_agent_report() {
     let temp = TempDir::new().expect("temp dir");
     let session = start_session_with_options(

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -19,6 +19,7 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
 | Tool     | `describe_table` | Show compact metadata for one database table            |
 | Tool     | `list_columns`   | List columns for one database table with pagination     |
+| Tool     | `codemode`       | Optional experimental Monty Python execution with SQL and catalog host functions |
 | Resource | `coral://guide`  | Database workflow guide for agents                     |
 | Resource | `coral://tables` | JSON summaries of database tables and required filters  |
 
@@ -53,6 +54,22 @@ Agents should treat the discovery tools as catalog helpers, not as replacement p
 ### Richer metadata via SQL
 
 For deeper introspection, query `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` through the `sql` tool instead of relying only on `list_catalog` or `coral://tables`. Use `coral.filters` as the normalized filter surface, with `coral.columns.filter_mode` available when inspecting filter-only virtual columns.
+
+### Codemode tool
+
+`codemode` is experimental and disabled by default. Enable it persistently with:
+
+```shellscript
+coral features enable codemode
+```
+
+Or expose it for one MCP process:
+
+```shellscript
+coral --enable-codemode mcp-stdio
+```
+
+The tool runs one Monty Python body and returns `output`, captured `stdout`, and `query_count`. Code can call `sql(query)`, `list_catalog()`, `search_catalog(pattern)`, `describe_table(schema, table)`, and `list_columns(schema, table)`. SQL calls are capped by `max_sql_calls`; filesystem, environment, and network host functions are not exposed.
 
 ### Searching a provider's data
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -12,6 +12,7 @@ top-level flags:
 coral --enable-<FEATURE> <COMMAND>
 coral --disable-<FEATURE> <COMMAND>
 coral --enable-feedback mcp-stdio
+coral --enable-codemode mcp-stdio
 coral --disable-feedback mcp-stdio
 ```
 
@@ -33,6 +34,40 @@ coral sql "<SQL>"
 | `--format` | `table` \| `json` | `table` | Output format |
 
 JSON output is an array of row objects. Selected nullable columns are included with explicit `null` values when the row value is null.
+
+## `coral codemode python`
+
+Execute one Monty Python body against Coral and exit.
+
+```shellscript
+coral codemode python --file ./analysis.py
+coral codemode python --code 'rows = sql("SELECT 1 AS value"); rows'
+```
+
+Python codemode exposes explicit read-only host functions: `sql(query)`, `list_catalog()`, `search_catalog(pattern)`, `describe_table(schema, table)`, and `list_columns(schema, table)`.
+
+The CLI command is explicit and does not require the `codemode` runtime feature flag. That feature only controls whether MCP exposes the `codemode` tool.
+
+### Options
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `--code` | string | none | Python code to execute. Mutually exclusive with `--file`. |
+| `--file` | path | none | Python file to execute. Mutually exclusive with `--code`. |
+| `--format` | `text` \| `json` | `text` | Output format |
+| `--timeout-ms` | integer | `60000` | Maximum Monty execution time in milliseconds |
+| `--max-sql-calls` | integer | `20` | Maximum number of `sql()` host-function calls |
+| `--no-type-check` | boolean flag | unset | Skip Monty's static type checker |
+
+JSON output mirrors the MCP structured result:
+
+```json
+{
+  "output": [{ "value": 1 }],
+  "stdout": "",
+  "query_count": 1
+}
+```
 
 ## `coral source`
 
@@ -227,6 +262,7 @@ This server exposes:
 | Tool     | `search_catalog` | Search database catalog metadata by regex |
 | Tool     | `describe_table` | Show compact database table metadata |
 | Tool     | `list_columns`   | List columns for one database table |
+| Tool     | `codemode`       | Experimental. Execute Monty Python with SQL and catalog host functions when the `codemode` feature is enabled |
 | Resource | `coral://guide`  | Database workflow guide for agents |
 | Resource | `coral://tables` | Database table summaries         |
 

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -22,6 +22,7 @@ Experimental runtime features are configured under `[features]`.
 ```toml
 [features]
 feedback = true
+codemode = false
 ```
 
 You can inspect available features and their effective state with:
@@ -35,12 +36,14 @@ Enable or disable a feature with:
 ```shellscript
 coral features enable feedback
 coral features disable feedback
+coral features enable codemode
 ```
 
 Feature values must be booleans. Unknown feature keys are preserved in `config.toml` but ignored by Coral.
 
 | Feature | Default | Description |
 | ------- | ------- | ----------- |
+| `codemode` | `false` | Experimental. Exposes the MCP `codemode` tool when enabled. The CLI `coral codemode python` command is explicit and does not require this feature flag. |
 | `feedback` | `false` | Experimental. Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral. |
 
 ## OpenTelemetry


### PR DESCRIPTION
## Summary

Adds an experimental Coral codemode capability backed by [Monty](https://github.com/pydantic/monty) Python.

This introduces a transport-neutral `coral-codemode` crate, exposes codemode through MCP behind a new `codemode` feature flag, and adds a CLI entrypoint via `coral codemode python`.

## What Changed

- Added `coral-codemode` crate with Monty execution, resource limits, type checking, JSON conversion, and host-function dispatch.
- Added read-only Python host functions:
  - `sql(query)`
  - `list_catalog(...)`
  - `search_catalog(...)`
  - `describe_table(schema, table)`
  - `list_columns(schema, table, ...)`
- Added MCP `codemode` tool gated by:
  - `coral features enable codemode`
  - `coral --enable-codemode mcp-stdio`
- Added CLI support:
  - `coral codemode python --file ./analysis.py`
  - `coral codemode python --code 'rows = sql("SELECT 1"); rows'`
- Added docs for CLI, MCP, and configuration.
- Added tests for feature gating, MCP tool behavior, and CLI codemode execution.

## Examples

Run codemode directly from the CLI:

```shell
coral codemode python --code 'rows = sql("SELECT 1 AS value"); rows'
```

Run a file and emit structured JSON:

```shell
coral codemode python --file ./analysis.py --format json
```

Use catalog helpers before querying:

```shell
coral codemode python --format json --code '
catalog = list_catalog(limit=5)
rows = sql("SELECT schema_name, table_name FROM coral.tables LIMIT 5")
{"catalog_total": catalog["total"], "rows": rows}
'
```

Expose codemode over MCP for one process:

```shell
coral --enable-codemode mcp-stdio
```

Call the MCP tool:

```json
{
  "code": "rows = sql(\"SELECT schema_name, table_name FROM coral.tables LIMIT 5\")\nrows",
  "type_check": true,
  "timeout_ms": 60000,
  "max_sql_calls": 20
}
```

## Notes

- CLI codemode is explicit and does not require the `codemode` feature flag.
- The `codemode` feature flag only controls MCP tool exposure.
- Codemode is single-shot for this first version.
- Filesystem, environment, and network host functions are not exposed.
- SQL calls are capped by `max_sql_calls`.
- Default timeout is 60 seconds.

## Validation

- `cargo fmt`
- `cargo check -p coral-codemode`
- `cargo check -p coral-mcp`
- `cargo test -p coral-codemode`
- `cargo test -p coral-mcp`
- `cargo test -p coral-cli features`
- `cargo test -p coral-cli --features cli-test-server mcp`
- `cargo clippy -p coral-codemode -p coral-mcp -p coral-cli --all-features --tests -- -D warnings`
- `make rust-checks`
