### PR TITLE
fix(spec): preserve path parameter defaults

### DIFF
--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -14,6 +14,8 @@ use coral_engine::{
 };
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use serde_json::{Value, json};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 use wiremock::matchers::{
     body_json, body_string, header, method, path, query_param, query_param_is_missing,
 };
@@ -103,6 +105,61 @@ fn function_only_search_manifest(name: &str, base_url: &str) -> Value {
         .expect("manifest is an object")
         .remove("tables");
     manifest
+}
+
+async fn spawn_raw_http_path_recorder(
+    response_body: &str,
+) -> (String, tokio::task::JoinHandle<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("raw HTTP listener should bind");
+    let base_url = format!(
+        "http://{}",
+        listener
+            .local_addr()
+            .expect("raw HTTP listener should have a local address")
+    );
+    let response_body = response_body.to_string();
+    let handle = tokio::spawn(async move {
+        let (mut stream, _) = listener
+            .accept()
+            .await
+            .expect("raw HTTP listener should accept one request");
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 1024];
+        loop {
+            let read = stream
+                .read(&mut buffer)
+                .await
+                .expect("raw HTTP listener should read request");
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buffer[..read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+        let request_text = String::from_utf8_lossy(&request);
+        let request_target = request_text
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .expect("request line should include a target")
+            .to_string();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("raw HTTP listener should write response");
+        request_target
+    });
+
+    (base_url, handle)
 }
 
 fn split_function_manifest(name: &str, base_url: &str) -> Value {
@@ -1753,6 +1810,97 @@ async fn table_function_treats_typed_null_as_omitted_optional_argument() {
             "title": "Flaky workspace cleanup",
             "score": 9.5
         })]
+    );
+}
+
+#[tokio::test]
+async fn path_template_default_filter_sends_encoded_dot_segment() {
+    let (base_url, request_target) = spawn_raw_http_path_recorder(r#"{"data":[{"id":1}]}"#).await;
+
+    let manifest = json!({
+        "name": "http_path_default_filter",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": base_url,
+        "tables": [{
+            "name": "items",
+            "description": "Items",
+            "filters": [{ "name": "tenant" }],
+            "request": {
+                "method": "GET",
+                "path": "/api/tenants/{{filter.tenant|%252E%252E}}/items"
+            },
+            "response": { "rows_path": ["data"] },
+            "columns": [{ "name": "id", "type": "Int64" }]
+        }]
+    });
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT id FROM http_path_default_filter.items",
+        )
+        .await
+        .expect("omitted optional filter should use template default"),
+    );
+
+    assert_eq!(rows, vec![json!({ "id": 1 })]);
+    assert_eq!(
+        request_target
+            .await
+            .expect("raw HTTP listener should finish"),
+        "/api/tenants/%252E%252E/items"
+    );
+}
+
+#[tokio::test]
+async fn path_template_default_arg_sends_encoded_dot_segment() {
+    let (base_url, request_target) =
+        spawn_raw_http_path_recorder(r#"{"items":[{"title":"default namespace"}]}"#).await;
+
+    let manifest = json!({
+        "name": "http_path_default_arg",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": base_url,
+        "functions": [{
+            "name": "search_items",
+            "description": "Search items",
+            "args": [{
+                "name": "tenant",
+                "required": false,
+                "bind": { "arg": "tenant" }
+            }],
+            "request": {
+                "method": "GET",
+                "path": "/api/search/{{arg.tenant|%252E}}/items"
+            },
+            "response": { "rows_path": ["items"] },
+            "columns": [{ "name": "title", "type": "Utf8" }]
+        }]
+    });
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT title FROM http_path_default_arg.search_items()",
+        )
+        .await
+        .expect("omitted optional argument should use template default"),
+    );
+
+    assert_eq!(rows, vec![json!({ "title": "default namespace" })]);
+    assert_eq!(
+        request_target
+            .await
+            .expect("raw HTTP listener should finish"),
+        "/api/search/%252E/items"
     );
 }
 

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -211,8 +211,164 @@ paths:
         .find(|input| input.wire_name == "id")
         .expect("id input");
     assert_eq!(id_input.sql_exposure, SqlInputExposure::FunctionArg);
-    assert!(id_input.required);
+    assert!(!id_input.required);
     assert_eq!(id_input.default_value.as_deref(), Some("public"));
+
+    let id_arg = projection_arg_specs(projection)
+        .into_iter()
+        .find(|arg| arg.name == "id")
+        .expect("id arg");
+    assert!(!id_arg.required);
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "The fixture keeps related path default escaping cases together."
+)]
+fn request_paths_preserve_path_parameter_defaults() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: github
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.github.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /tenants/{tenant}/items:
+    get:
+      operationId: list-items
+      parameters:
+        - name: tenant
+          in: path
+          required: true
+          schema:
+            type: string
+            default: '|public}}'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: '#/components/schemas/Item'}
+  /search/{tenant}/items:
+    get:
+      operationId: search-items
+      parameters:
+        - name: tenant
+          in: path
+          required: true
+          schema:
+            type: string
+            default: '..'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: '#/components/schemas/Item'}
+  /namespaces/{namespace}/items:
+    get:
+      operationId: list-namespace-items
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+            default: '.'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: '#/components/schemas/Item'}
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        id: {type: integer}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
+    let table_projection = catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == "list_items")
+        .expect("table projection");
+    let table_operation = ir
+        .operations
+        .iter()
+        .find(|operation| operation.id == table_projection.operation_id)
+        .expect("table operation");
+    let table_request =
+        request_spec_for_projection(table_projection, table_operation).expect("table request");
+    assert_eq!(
+        table_request.path.raw(),
+        "/tenants/{{filter.tenant|%7Cpublic%7D%7D}}/items"
+    );
+    let table_filter = projection_filter_specs(table_projection)
+        .into_iter()
+        .find(|filter| filter.name == "tenant")
+        .expect("tenant filter");
+    assert!(!table_filter.required);
+
+    let search_projection = catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == "search_items")
+        .expect("search projection");
+    let search_operation = ir
+        .operations
+        .iter()
+        .find(|operation| operation.id == search_projection.operation_id)
+        .expect("search operation");
+    let search_request =
+        request_spec_for_projection(search_projection, search_operation).expect("search request");
+    assert_eq!(
+        search_request.path.raw(),
+        "/search/{{arg.tenant|%252E%252E}}/items"
+    );
+    let search_arg = projection_arg_specs(search_projection)
+        .into_iter()
+        .find(|arg| arg.name == "tenant")
+        .expect("tenant arg");
+    assert!(!search_arg.required);
+
+    let namespace_projection = catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == "list_namespace_items")
+        .expect("namespace projection");
+    let namespace_operation = ir
+        .operations
+        .iter()
+        .find(|operation| operation.id == namespace_projection.operation_id)
+        .expect("namespace operation");
+    let namespace_request = request_spec_for_projection(namespace_projection, namespace_operation)
+        .expect("namespace request");
+    assert_eq!(
+        namespace_request.path.raw(),
+        "/namespaces/{{filter.namespace|%252E}}/items"
+    );
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -215,11 +215,7 @@ fn generated_projection_name(operation: &IrOperation, is_search: bool) -> String
 }
 
 fn projection_input_required(input: &IrOperationInput) -> bool {
-    input.required
-        && (matches!(
-            input.location,
-            IrInputLocation::Path | IrInputLocation::ToolArg
-        ) || input.default_value.is_none())
+    input.required && (input.default_value.is_none() || input.location == IrInputLocation::ToolArg)
 }
 
 fn projection_input_sql_exposure(

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -130,8 +130,12 @@ pub fn request_spec_for_projection(
     for input in &projection.inputs {
         if input.source_location == IrInputLocation::Path {
             let replacement = match input.sql_exposure {
-                SqlInputExposure::Filter => format!("{{{{filter.{}}}}}", input.name),
-                SqlInputExposure::FunctionArg => format!("{{{{arg.{}}}}}", input.name),
+                SqlInputExposure::Filter => {
+                    path_template_token("filter", &input.name, input.default_value.as_deref())
+                }
+                SqlInputExposure::FunctionArg => {
+                    path_template_token("arg", &input.name, input.default_value.as_deref())
+                }
                 SqlInputExposure::Internal => continue,
             };
             path = path.replace(&format!("{{{}}}", input.wire_name), &replacement);
@@ -173,4 +177,43 @@ pub fn request_spec_for_projection(
         body: crate::BodySpec::default(),
         headers: Vec::new(),
     })
+}
+
+fn path_template_token(namespace: &str, key: &str, default: Option<&str>) -> String {
+    default.map_or_else(
+        || format!("{{{{{namespace}.{key}}}}}"),
+        |default| {
+            let encoded_default = encode_path_segment_default(default);
+            format!("{{{{{namespace}.{key}|{encoded_default}}}}}")
+        },
+    )
+}
+
+fn encode_path_segment_default(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    let is_dot_segment = matches!(value, "." | "..");
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            b'.' if is_dot_segment => encoded.push_str("%252E"),
+            _ => push_percent_encoded(&mut encoded, byte),
+        }
+    }
+    encoded
+}
+
+fn push_percent_encoded(output: &mut String, byte: u8) {
+    output.push('%');
+    output.push(hex_digit(byte >> 4));
+    output.push(hex_digit(byte & 0x0f));
+}
+
+fn hex_digit(nibble: u8) -> char {
+    match nibble {
+        0..=9 => char::from(b'0' + nibble),
+        10..=15 => char::from(b'A' + (nibble - 10)),
+        _ => unreachable!("hex nibble must be in 0..=15"),
+    }
 }


### PR DESCRIPTION
Summary:
- Preserve authored path parameter defaults when rendering generated v4 request path templates.
- Cover both table filter tokens and table-function arg tokens.

Tests:
- cargo test -p coral-spec request_paths_preserve_path_parameter_defaults
- make rust-checks
- git diff --check

Risks:
- Low. Path parameters without defaults render unchanged; defaulted path parameters now use the existing template fallback form.

Project: https://github.com/orgs/withcoral/projects/1
Closes #1153