### PR TITLE
fix(spec): remove OpenAPI-branded v4 IR location

### DIFF
--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -33,7 +33,7 @@ pub struct IrOperation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IrOperationInput {
     pub name: String,
-    pub location: OpenApiParameterLocation,
+    pub location: IrInputLocation,
     pub required: bool,
     pub data_type: IrScalarType,
     pub default_value: Option<String>,
@@ -106,7 +106,7 @@ pub enum IrScalarType {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
-pub enum OpenApiParameterLocation {
+pub enum IrInputLocation {
     Path,
     Query,
     Header,
@@ -136,8 +136,8 @@ pub enum IrExecutionAttachment {
 #[cfg(test)]
 mod tests {
     use super::{
-        HttpMethod, IrExecutionAttachment, IrOperation, IrOperationOutput, IrScalarType, IrType,
-        IrTypeShape, OutputCardinality, SemanticIr,
+        HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
+        IrOperationOutput, IrScalarType, IrType, IrTypeShape, OutputCardinality, SemanticIr,
     };
     use crate::PaginationSpec;
     use crate::v4::diagnostics::Diagnostic;
@@ -240,5 +240,30 @@ diagnostics: []
             error.to_string().contains("shape") || error.to_string().contains("type"),
             "unexpected legacy local tag error: {error}"
         );
+    }
+
+    #[test]
+    fn input_location_serialization_preserves_artifact_shape() {
+        let input = IrOperationInput {
+            name: "owner".to_string(),
+            location: IrInputLocation::Path,
+            required: true,
+            data_type: IrScalarType::String,
+            default_value: None,
+            description: String::new(),
+        };
+
+        let yaml = serde_yaml::to_string(&input).expect("serialize input");
+        assert!(
+            yaml.contains("location: path"),
+            "unexpected serialized input: {yaml}"
+        );
+        assert!(
+            !yaml.contains("OpenApi"),
+            "Rust type names must not leak into artifacts: {yaml}"
+        );
+
+        let decoded: IrOperationInput = serde_yaml::from_str(&yaml).expect("deserialize input");
+        assert_eq!(decoded.location, IrInputLocation::Path);
     }
 }

--- a/crates/coral-spec/src/v4/ir/rest.rs
+++ b/crates/coral-spec/src/v4/ir/rest.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::v4::ir::{HttpMethod, IrScalarType, OpenApiParameterLocation};
+use crate::v4::ir::{HttpMethod, IrInputLocation, IrScalarType};
 use crate::{PaginationSpec, ResponseSpec};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,7 +23,7 @@ pub struct RestRequestBody {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RestParameterBinding {
     pub input_name: String,
-    pub location: OpenApiParameterLocation,
+    pub location: IrInputLocation,
     pub wire_name: String,
     pub required: bool,
     pub data_type: IrScalarType,

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -31,10 +31,10 @@ pub use artifacts::{
 };
 pub use diagnostics::{Diagnostic, DiagnosticSeverity};
 pub use ir::{
-    HttpMethod, IrEntityCandidate, IrExecutionAttachment, IrField, IrOperation, IrOperationInput,
-    IrOperationOutput, IrScalarType, IrType, IrTypeShape, OpenApiParameterLocation,
-    OutputCardinality, RestExecutionAttachment, RestParameterBinding, RestRequestBody,
-    RestResponseAttachment, SemanticIr,
+    HttpMethod, IrEntityCandidate, IrExecutionAttachment, IrField, IrInputLocation, IrOperation,
+    IrOperationInput, IrOperationOutput, IrScalarType, IrType, IrTypeShape, OutputCardinality,
+    RestExecutionAttachment, RestParameterBinding, RestRequestBody, RestResponseAttachment,
+    SemanticIr,
 };
 pub use manifest::{
     OpenApiRuntimeConfig, SurfaceDescriptor, SurfaceType, V4SourceCommon, V4SourceManifest,

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{
-    HttpMethod, IrExecutionAttachment, IrOperation, IrOperationInput, IrScalarType, IrTypeShape,
-    OpenApiParameterLocation, OutputCardinality, SemanticIr,
+    HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
+    IrScalarType, IrTypeShape, OutputCardinality, SemanticIr,
 };
 use crate::v4::manifest::V4SourceManifest;
 use crate::v4::naming::{normalize_identifier, stable_suffix};
@@ -147,8 +147,7 @@ fn generate_projection(
 }
 
 fn projection_input_required(input: &IrOperationInput) -> bool {
-    input.required
-        && (input.location == OpenApiParameterLocation::Path || input.default_value.is_none())
+    input.required && (input.location == IrInputLocation::Path || input.default_value.is_none())
 }
 
 fn projection_input_sql_exposure(
@@ -156,16 +155,14 @@ fn projection_input_sql_exposure(
     default_exposure: SqlInputExposure,
     pagination_query_params: &HashSet<&str>,
 ) -> (SqlInputExposure, bool) {
-    let pagination_owned_query_input = input.location == OpenApiParameterLocation::Query
+    let pagination_owned_query_input = input.location == IrInputLocation::Query
         && pagination_query_params.contains(input.name.as_str());
     let exposure = match input.location {
-        OpenApiParameterLocation::Query if pagination_owned_query_input => {
+        IrInputLocation::Query if pagination_owned_query_input => SqlInputExposure::Internal,
+        IrInputLocation::Path | IrInputLocation::Query => default_exposure,
+        IrInputLocation::Header | IrInputLocation::Cookie | IrInputLocation::Body => {
             SqlInputExposure::Internal
         }
-        OpenApiParameterLocation::Path | OpenApiParameterLocation::Query => default_exposure,
-        OpenApiParameterLocation::Header
-        | OpenApiParameterLocation::Cookie
-        | OpenApiParameterLocation::Body => SqlInputExposure::Internal,
     };
     (exposure, pagination_owned_query_input)
 }

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::v4::diagnostics::Diagnostic;
-use crate::v4::ir::OpenApiParameterLocation;
+use crate::v4::ir::IrInputLocation;
 use crate::{
     DetailHintSpec, ManifestDataType, PaginationSpec, SearchLimitsSpec, SourceTableFunctionKind,
 };
@@ -52,7 +52,7 @@ pub enum ProjectionVisibility {
 pub struct ProjectionInput {
     pub name: String,
     pub sql_exposure: SqlInputExposure,
-    pub source_location: OpenApiParameterLocation,
+    pub source_location: IrInputLocation,
     pub wire_name: String,
     pub required: bool,
     pub data_type: ManifestDataType,

--- a/crates/coral-spec/src/v4/projections/pagination.rs
+++ b/crates/coral-spec/src/v4/projections/pagination.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::PaginationSpec;
-use crate::v4::ir::OpenApiParameterLocation;
+use crate::v4::ir::IrInputLocation;
 
 use super::model::ProjectionInput;
 
@@ -28,6 +28,6 @@ pub(super) fn pagination_owns_input(
     input: &ProjectionInput,
     pagination_query_params: &HashSet<&str>,
 ) -> bool {
-    input.source_location == OpenApiParameterLocation::Query
+    input.source_location == IrInputLocation::Query
         && pagination_query_params.contains(input.wire_name.as_str())
 }

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use serde_json::Value;
 
-use crate::v4::ir::{IrExecutionAttachment, IrOperation, OpenApiParameterLocation};
+use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrOperation};
 use crate::{
     ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, ManifestDataType,
     ParsedTemplate, RequestSpec, Result, TableFunctionArgSpec,
@@ -106,7 +106,7 @@ pub fn request_spec_for_projection(
     let pagination_query_params = pagination_query_param_names(&projection.pagination);
     let mut path = rest.path_template.clone();
     for input in &projection.inputs {
-        if input.source_location == OpenApiParameterLocation::Path {
+        if input.source_location == IrInputLocation::Path {
             let replacement = match input.sql_exposure {
                 SqlInputExposure::Filter => format!("{{{{filter.{}}}}}", input.name),
                 SqlInputExposure::FunctionArg => format!("{{{{arg.{}}}}}", input.name),
@@ -118,7 +118,7 @@ pub fn request_spec_for_projection(
     let query = projection
         .inputs
         .iter()
-        .filter(|input| input.source_location == OpenApiParameterLocation::Query)
+        .filter(|input| input.source_location == IrInputLocation::Query)
         .filter(|input| !pagination_owns_input(input, &pagination_query_params))
         .filter_map(|input| {
             let value = match input.sql_exposure {

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -4,8 +4,8 @@ use serde_json::{Map, Value};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{
-    HttpMethod, IrExecutionAttachment, IrOperation, IrOperationInput, IrScalarType,
-    OpenApiParameterLocation, RestExecutionAttachment, RestParameterBinding, RestRequestBody,
+    HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
+    IrScalarType, RestExecutionAttachment, RestParameterBinding, RestRequestBody,
 };
 use crate::v4::naming::normalize_identifier;
 use crate::{ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result};
@@ -89,7 +89,7 @@ impl OpenApiImporter<'_> {
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Vec<IrOperationInput> {
-        let mut merged: BTreeMap<(OpenApiParameterLocation, String), Value> = BTreeMap::new();
+        let mut merged: BTreeMap<(IrInputLocation, String), Value> = BTreeMap::new();
         for parameter in path_item
             .get("parameters")
             .and_then(Value::as_array)
@@ -255,21 +255,18 @@ fn parse_http_method(method: &str) -> HttpMethod {
     }
 }
 
-fn parse_parameter_location(location: &str) -> Option<OpenApiParameterLocation> {
+fn parse_parameter_location(location: &str) -> Option<IrInputLocation> {
     match location {
-        "path" => Some(OpenApiParameterLocation::Path),
-        "query" => Some(OpenApiParameterLocation::Query),
-        "header" => Some(OpenApiParameterLocation::Header),
-        "cookie" => Some(OpenApiParameterLocation::Cookie),
+        "path" => Some(IrInputLocation::Path),
+        "query" => Some(IrInputLocation::Query),
+        "header" => Some(IrInputLocation::Header),
+        "cookie" => Some(IrInputLocation::Cookie),
         _ => None,
     }
 }
 
-fn parameter_is_required(
-    parameter_obj: &Map<String, Value>,
-    location: OpenApiParameterLocation,
-) -> bool {
-    if location == OpenApiParameterLocation::Path {
+fn parameter_is_required(parameter_obj: &Map<String, Value>, location: IrInputLocation) -> bool {
+    if location == IrInputLocation::Path {
         return true;
     }
     parameter_obj
@@ -290,10 +287,10 @@ fn openapi_default_to_string(value: &Value) -> String {
 fn detect_pagination(inputs: &[IrOperationInput]) -> PaginationSpec {
     let has_page = inputs
         .iter()
-        .any(|input| input.location == OpenApiParameterLocation::Query && input.name == "page");
+        .any(|input| input.location == IrInputLocation::Query && input.name == "page");
     let has_per_page = inputs
         .iter()
-        .any(|input| input.location == OpenApiParameterLocation::Query && input.name == "per_page");
+        .any(|input| input.location == IrInputLocation::Query && input.name == "per_page");
     if has_page && has_per_page {
         PaginationSpec {
             mode: PaginationMode::Page,


### PR DESCRIPTION
Fixes #1156.

Summary:
- Rename the shared v4 IR parameter location type to IrInputLocation.
- Keep serialized artifact fields and snake_case values unchanged.
- Add a serialization compatibility regression so no artifact schema bump is needed.

Tests:
- cargo test -p coral-spec input_location_serialization_preserves_artifact_shape
- cargo test -p coral-spec imports_and_generates_github_issue_slice
- make rust-checks

Risks:
- Low; this is a Rust API/type-name cleanup and the materialized YAML shape stays unchanged.