### PR TITLE
fix(spec): use editor-friendly v4 artifact YAML

### DIFF
--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -73,7 +73,7 @@ pub struct IrType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
 pub enum IrTypeShape {
     Scalar(IrScalarType),
     Object { fields: Vec<IrField> },
@@ -128,7 +128,117 @@ pub enum HttpMethod {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
 pub enum IrExecutionAttachment {
     Rest(RestExecutionAttachment),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        HttpMethod, IrExecutionAttachment, IrOperation, IrOperationOutput, IrScalarType, IrType,
+        IrTypeShape, OutputCardinality, SemanticIr,
+    };
+    use crate::PaginationSpec;
+    use crate::v4::diagnostics::Diagnostic;
+    use crate::v4::ir::rest::{RestExecutionAttachment, RestResponseAttachment};
+    use crate::v4::manifest::SurfaceType;
+    use crate::v4::{OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
+
+    #[test]
+    fn semantic_ir_yaml_uses_editor_friendly_enum_shapes() {
+        let ir = SemanticIr {
+            artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+            source_name: "demo".to_string(),
+            surface_id: "rest".to_string(),
+            surface_type: SurfaceType::OpenApi,
+            importer_version: OPENAPI_IMPORTER_VERSION.to_string(),
+            operations: vec![IrOperation {
+                id: "list_issues".to_string(),
+                method_name: "GET".to_string(),
+                description: String::new(),
+                deprecated: false,
+                read_only: true,
+                inputs: Vec::new(),
+                output: IrOperationOutput {
+                    cardinality: OutputCardinality::List,
+                    type_ref: "issue".to_string(),
+                    row_path: Vec::new(),
+                },
+                entity: None,
+                execution: IrExecutionAttachment::Rest(RestExecutionAttachment {
+                    method: HttpMethod::Get,
+                    path_template: "/issues".to_string(),
+                    parameters: Vec::new(),
+                    request_body: None,
+                    response: RestResponseAttachment {
+                        status_code: 200,
+                        media_type: "application/json".to_string(),
+                        response: crate::ResponseSpec::default(),
+                    },
+                    pagination: PaginationSpec::default(),
+                }),
+                diagnostics: Vec::new(),
+            }],
+            types: vec![
+                IrType {
+                    id: "issue".to_string(),
+                    shape: IrTypeShape::Object { fields: Vec::new() },
+                    nullable: false,
+                    description: String::new(),
+                },
+                IrType {
+                    id: "issue_id".to_string(),
+                    shape: IrTypeShape::Scalar(IrScalarType::String),
+                    nullable: false,
+                    description: String::new(),
+                },
+            ],
+            diagnostics: vec![Diagnostic::warning(
+                "TEST",
+                "diagnostic",
+                "rest".to_string(),
+                None,
+            )],
+        };
+
+        let yaml = serde_yaml::to_string(&ir).expect("serialize semantic IR");
+        assert!(
+            !yaml.contains('!'),
+            "semantic IR should not use YAML local tags: {yaml}"
+        );
+        assert!(yaml.contains("type: rest"), "missing rest tag: {yaml}");
+        assert!(yaml.contains("type: object"), "missing object tag: {yaml}");
+        assert!(yaml.contains("type: scalar"), "missing scalar tag: {yaml}");
+
+        serde_yaml::from_str::<SemanticIr>(&yaml).expect("semantic IR should round-trip");
+    }
+
+    #[test]
+    fn semantic_ir_yaml_rejects_legacy_local_tags() {
+        let legacy_yaml = format!(
+            r#"
+artifact_schema_version: {V4_ARTIFACT_SCHEMA_VERSION}
+source_name: demo
+surface_id: rest
+surface_type: openapi
+importer_version: {OPENAPI_IMPORTER_VERSION}
+operations: []
+types:
+  - id: issue
+    shape: !Object
+      fields: []
+    nullable: false
+    description: ""
+diagnostics: []
+"#
+        );
+
+        let error = serde_yaml::from_str::<SemanticIr>(&legacy_yaml)
+            .expect_err("semantic IR should reject legacy local tags");
+        assert!(
+            error.to_string().contains("shape") || error.to_string().contains("type"),
+            "unexpected legacy local tag error: {error}"
+        );
+    }
 }

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -4,8 +4,8 @@
 )]
 
 pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 1;
-pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v2";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v3";
+pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v3";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v4";
 
 mod artifacts;
 mod diagnostics;

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -33,7 +33,7 @@ pub struct Projection {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
 pub enum ProjectionKind {
     Table,
     TableFunction {
@@ -75,4 +75,72 @@ pub struct ProjectionColumn {
     pub source_path: Vec<String>,
     pub nullable: bool,
     pub description: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Projection, ProjectionCatalog, ProjectionKind, ProjectionVisibility, SqlInputExposure,
+    };
+    use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
+    use crate::{ManifestDataType, PaginationSpec, SearchLimitsSpec, SourceTableFunctionKind};
+
+    #[test]
+    fn projection_catalog_yaml_uses_editor_friendly_enum_shapes() {
+        let catalog = ProjectionCatalog {
+            artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+            source_name: "demo".to_string(),
+            generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+            projections: vec![Projection {
+                name: "search_issues".to_string(),
+                kind: ProjectionKind::TableFunction {
+                    function_kind: SourceTableFunctionKind::Search,
+                },
+                description: String::new(),
+                guide: String::new(),
+                surface_id: "rest".to_string(),
+                operation_id: "issues/search".to_string(),
+                visibility: ProjectionVisibility::Published,
+                inputs: Vec::new(),
+                columns: Vec::new(),
+                pagination: PaginationSpec::default(),
+                search_limits: Some(SearchLimitsSpec {
+                    default_top_k: 30,
+                    max_top_k: 100,
+                    max_calls_per_query: 100,
+                }),
+                detail_hints: Vec::new(),
+                diagnostics: Vec::new(),
+            }],
+            diagnostics: Vec::new(),
+        };
+
+        let yaml = serde_yaml::to_string(&catalog).expect("serialize projection catalog");
+        assert!(
+            !yaml.contains('!'),
+            "projection catalog should not use YAML local tags: {yaml}"
+        );
+        assert!(
+            yaml.contains("type: table_function"),
+            "missing projection kind tag: {yaml}"
+        );
+        assert!(
+            yaml.contains("function_kind: search"),
+            "missing function kind: {yaml}"
+        );
+
+        serde_yaml::from_str::<ProjectionCatalog>(&yaml)
+            .expect("projection catalog should round-trip");
+    }
+
+    #[test]
+    fn projection_input_unit_enums_remain_plain_scalars() {
+        let exposure =
+            serde_yaml::to_string(&SqlInputExposure::Filter).expect("serialize exposure");
+        let data_type =
+            serde_yaml::to_string(&ManifestDataType::Utf8).expect("serialize data type");
+
+        assert_eq!(exposure.trim(), "filter");
+        assert_eq!(data_type.trim(), "Utf8");
+    }
 }


### PR DESCRIPTION
Fixes #954.

Summary:
- Change v4 artifact-facing enum serialization from YAML local tags to type/value mappings.
- Cover semantic IR and projection catalog artifact enums with round-trip tests that reject YAML local tags.
- Bump OPENAPI_IMPORTER_VERSION and PROJECTION_GENERATOR_VERSION so existing materialized artifacts are treated as stale and users are guided to re-add sources.

Tests:
- cargo test -p coral-spec semantic_ir_yaml_uses_editor_friendly_enum_shapes
- cargo test -p coral-spec projection_catalog_yaml_uses_editor_friendly_enum_shapes
- cargo test -p coral-spec projection_input_unit_enums_remain_plain_scalars
- make rust-checks

Risks:
- Materialized v4 artifact YAML shape changes intentionally. Existing installed v4 materializations should be regenerated by re-adding the source.