### PR TITLE
fix(app): make source re-add atomic

### DIFF
--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -151,33 +151,39 @@ impl CredentialManager {
             .read_material(workspace_name, credential_set_id, storage)
     }
 
-    /// Read persisted credential material for the declared inputs, refreshing
-    /// provider-managed credentials before returning when needed.
-    pub(crate) async fn read_material_for_inputs(
+    /// Refresh provider-managed credentials already captured for a runtime.
+    ///
+    /// This updates the supplied material in memory only. Runtime input
+    /// resolution uses source snapshots, so it must not re-read or write live
+    /// source credential material after query-source loading has finished.
+    pub(crate) async fn refresh_material_for_inputs(
+        &self,
+        inputs: &[ManifestInputSpec],
+        material: &mut BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
+        for input in inputs {
+            self.refresh_oauth_input_material(input, material).await?;
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn refresh_and_persist_material_for_inputs_with_refresh_lock_held(
         &self,
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
         inputs: &[ManifestInputSpec],
-    ) -> Result<BTreeMap<String, String>, AppError> {
-        if !has_oauth_credential_inputs(inputs) {
-            return self.read_material(workspace_name, credential_set_id, storage);
-        }
-
-        let _refresh_file_lock = self
-            .credential_refresh_lock(workspace_name, credential_set_id)
-            .await?;
-        let mut material = self.read_material(workspace_name, credential_set_id, storage)?;
+        material: &mut BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
         self.refresh_and_persist_oauth_material(
             workspace_name,
             credential_set_id,
             storage,
             inputs,
-            &mut material,
+            material,
         )
         .await
-        .map_err(credential_refresh_error)?;
-        Ok(material)
+        .map_err(credential_refresh_error)
     }
 
     pub(crate) fn default_write_storage(&self) -> Result<CredentialStorageKind, AppError> {
@@ -199,6 +205,32 @@ impl CredentialManager {
         })
     }
 
+    async fn refresh_oauth_input_material(
+        &self,
+        input: &ManifestInputSpec,
+        material: &mut BTreeMap<String, String>,
+    ) -> Result<bool, AppError> {
+        if input.kind != ManifestInputKind::Secret {
+            return Ok(false);
+        }
+        let Some(credential) = input.credential.as_ref() else {
+            return Ok(false);
+        };
+        let Some(oauth) = credential
+            .methods
+            .iter()
+            .find_map(|method| method.oauth.as_ref())
+        else {
+            return Ok(false);
+        };
+        self.oauth_credential_service
+            .refresh_if_needed(
+                RefreshOAuthCredentialRequest::for_source_input(&input.key, oauth),
+                material,
+            )
+            .await
+    }
+
     async fn refresh_and_persist_oauth_material(
         &self,
         workspace_name: &WorkspaceName,
@@ -208,27 +240,7 @@ impl CredentialManager {
         material: &mut BTreeMap<String, String>,
     ) -> Result<(), AppError> {
         for input in inputs {
-            if input.kind != ManifestInputKind::Secret {
-                continue;
-            }
-            let Some(credential) = input.credential.as_ref() else {
-                continue;
-            };
-            let Some(oauth) = credential
-                .methods
-                .iter()
-                .find_map(|method| method.oauth.as_ref())
-            else {
-                continue;
-            };
-            if self
-                .oauth_credential_service
-                .refresh_if_needed(
-                    RefreshOAuthCredentialRequest::for_source_input(&input.key, oauth),
-                    material,
-                )
-                .await?
-            {
+            if self.refresh_oauth_input_material(input, material).await? {
                 *material = self.persist_refreshed_oauth_material(
                     workspace_name,
                     credential_set_id,
@@ -265,7 +277,7 @@ impl CredentialManager {
         )
     }
 
-    async fn credential_refresh_lock(
+    pub(crate) async fn credential_refresh_lock(
         &self,
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
@@ -309,7 +321,7 @@ impl CredentialMaterialGuard<'_> {
         })
     }
 
-    pub(crate) fn update_material_or_empty_on_parse_with_state_lock_held<F>(
+    pub(crate) fn update_material_with_state_lock<F>(
         &self,
         storage: CredentialStorageKind,
         update: F,
@@ -354,15 +366,6 @@ impl CredentialMaterialGuard<'_> {
         })
     }
 
-    pub(crate) fn snapshot_material(
-        &self,
-        storage: CredentialStorageKind,
-    ) -> Result<CredentialMaterialSnapshot, AppError> {
-        self.manager
-            .store
-            .snapshot_material(self.workspace_name, self.credential_set_id, storage)
-    }
-
     pub(crate) fn snapshot_material_with_state_lock_held(
         &self,
         storage: CredentialStorageKind,
@@ -372,15 +375,6 @@ impl CredentialMaterialGuard<'_> {
             self.credential_set_id,
             storage,
         )
-    }
-
-    pub(crate) fn restore_material(
-        &self,
-        snapshot: &CredentialMaterialSnapshot,
-    ) -> Result<(), AppError> {
-        self.manager
-            .store
-            .restore_material(self.workspace_name, self.credential_set_id, snapshot)
     }
 
     pub(crate) fn restore_material_with_state_lock_held(
@@ -394,6 +388,7 @@ impl CredentialMaterialGuard<'_> {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn remove_material(&self, storage: CredentialStorageKind) -> Result<(), AppError> {
         self.manager
             .store
@@ -412,16 +407,12 @@ impl CredentialMaterialGuard<'_> {
     }
 }
 
-fn has_oauth_credential_inputs(inputs: &[ManifestInputSpec]) -> bool {
-    inputs.iter().any(|input| {
-        input.kind == ManifestInputKind::Secret
-            && input.credential.as_ref().is_some_and(|credential| {
-                credential
-                    .methods
-                    .iter()
-                    .any(|method| method.oauth.is_some())
-            })
-    })
+fn visible_material_keys(material: &BTreeMap<String, String>) -> Vec<String> {
+    material
+        .keys()
+        .filter(|key| !is_internal_material_key(key))
+        .cloned()
+        .collect()
 }
 
 fn replace_provider_input_material(
@@ -440,14 +431,6 @@ fn replace_provider_input_material(
 
 fn provider_input_material_key(key: &str, input_key: &str) -> bool {
     key == input_key || self::oauth::material_key_belongs_to_input(key, input_key)
-}
-
-fn visible_material_keys(material: &BTreeMap<String, String>) -> Vec<String> {
-    material
-        .keys()
-        .filter(|key| !is_internal_material_key(key))
-        .cloned()
-        .collect()
 }
 
 fn credential_refresh_error(error: AppError) -> AppError {

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -309,7 +309,7 @@ impl CredentialMaterialGuard<'_> {
         })
     }
 
-    pub(crate) fn update_material_or_empty_on_parse<F>(
+    pub(crate) fn update_material_or_empty_on_parse_with_state_lock_held<F>(
         &self,
         storage: CredentialStorageKind,
         update: F,
@@ -317,43 +317,41 @@ impl CredentialMaterialGuard<'_> {
     where
         F: Fn(BTreeMap<String, String>) -> Result<BTreeMap<String, String>, AppError>,
     {
-        self.manager
-            .store
-            .update_material(
-                self.workspace_name,
-                self.credential_set_id,
-                storage,
-                |material| {
-                    let updated = update(material)?;
-                    let visible_keys = visible_material_keys(&updated);
-                    Ok((
-                        updated,
-                        CredentialWriteOutcome {
-                            visible_keys,
-                            storage,
-                        },
-                    ))
-                },
-            )
-            .or_else(|error| match error {
-                AppError::Credentials(CredentialsError::Parse(_))
-                    if storage == CredentialStorageKind::File =>
-                {
-                    let updated = update(BTreeMap::new())?;
-                    let visible_keys = visible_material_keys(&updated);
-                    self.manager.store.replace_material(
-                        self.workspace_name,
-                        self.credential_set_id,
-                        storage,
-                        &updated,
-                    )?;
-                    Ok(CredentialWriteOutcome {
+        let result = self.manager.store.update_material_with_state_lock_held(
+            self.workspace_name,
+            self.credential_set_id,
+            storage,
+            |material| {
+                let updated = update(material)?;
+                let visible_keys = visible_material_keys(&updated);
+                Ok((
+                    updated,
+                    CredentialWriteOutcome {
                         visible_keys,
                         storage,
-                    })
-                }
-                other => Err(other),
-            })
+                    },
+                ))
+            },
+        );
+        result.or_else(|error| match error {
+            AppError::Credentials(CredentialsError::Parse(_))
+                if storage == CredentialStorageKind::File =>
+            {
+                let updated = update(BTreeMap::new())?;
+                let visible_keys = visible_material_keys(&updated);
+                self.manager.store.replace_material_with_state_lock_held(
+                    self.workspace_name,
+                    self.credential_set_id,
+                    storage,
+                    &updated,
+                )?;
+                Ok(CredentialWriteOutcome {
+                    visible_keys,
+                    storage,
+                })
+            }
+            other => Err(other),
+        })
     }
 
     pub(crate) fn snapshot_material(
@@ -365,6 +363,17 @@ impl CredentialMaterialGuard<'_> {
             .snapshot_material(self.workspace_name, self.credential_set_id, storage)
     }
 
+    pub(crate) fn snapshot_material_with_state_lock_held(
+        &self,
+        storage: CredentialStorageKind,
+    ) -> Result<CredentialMaterialSnapshot, AppError> {
+        self.manager.store.snapshot_material_with_state_lock_held(
+            self.workspace_name,
+            self.credential_set_id,
+            storage,
+        )
+    }
+
     pub(crate) fn restore_material(
         &self,
         snapshot: &CredentialMaterialSnapshot,
@@ -374,10 +383,32 @@ impl CredentialMaterialGuard<'_> {
             .restore_material(self.workspace_name, self.credential_set_id, snapshot)
     }
 
+    pub(crate) fn restore_material_with_state_lock_held(
+        &self,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), AppError> {
+        self.manager.store.restore_material_with_state_lock_held(
+            self.workspace_name,
+            self.credential_set_id,
+            snapshot,
+        )
+    }
+
     pub(crate) fn remove_material(&self, storage: CredentialStorageKind) -> Result<(), AppError> {
         self.manager
             .store
             .remove_material(self.workspace_name, self.credential_set_id, storage)
+    }
+
+    pub(crate) fn remove_material_with_state_lock_held(
+        &self,
+        storage: CredentialStorageKind,
+    ) -> Result<(), AppError> {
+        self.manager.store.remove_material_with_state_lock_held(
+            self.workspace_name,
+            self.credential_set_id,
+            storage,
+        )
     }
 }
 

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -339,6 +339,7 @@ impl CredentialStore {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn snapshot_material(
         &self,
         workspace_name: &WorkspaceName,
@@ -379,6 +380,7 @@ impl CredentialStore {
         .map_err(Into::into)
     }
 
+    #[cfg(test)]
     pub(crate) fn restore_material(
         &self,
         workspace_name: &WorkspaceName,
@@ -422,6 +424,7 @@ impl CredentialStore {
         Ok(())
     }
 
+    #[cfg(test)]
     pub(crate) fn remove_material(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -110,16 +110,39 @@ trait CredentialMaterialBackend: Send + Sync {
         material: Option<&EncodedCredentialMaterial>,
     ) -> Result<(), CredentialsError>;
 
+    fn write_with_state_lock_held(
+        &self,
+        set: &CredentialSetRef<'_>,
+        material: Option<&EncodedCredentialMaterial>,
+    ) -> Result<(), CredentialsError> {
+        self.write(set, material)
+    }
+
     fn snapshot(
         &self,
         set: &CredentialSetRef<'_>,
     ) -> Result<CredentialMaterialSnapshot, CredentialsError>;
+
+    fn snapshot_with_state_lock_held(
+        &self,
+        set: &CredentialSetRef<'_>,
+    ) -> Result<CredentialMaterialSnapshot, CredentialsError> {
+        self.snapshot(set)
+    }
 
     fn restore(
         &self,
         set: &CredentialSetRef<'_>,
         snapshot: &CredentialMaterialSnapshot,
     ) -> Result<(), CredentialsError>;
+
+    fn restore_with_state_lock_held(
+        &self,
+        set: &CredentialSetRef<'_>,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), CredentialsError> {
+        self.restore(set, snapshot)
+    }
 }
 
 #[derive(Clone)]
@@ -214,6 +237,33 @@ impl CredentialStore {
         Ok(())
     }
 
+    pub(crate) fn replace_material_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
+        values: &BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        let backend = self.backend(storage);
+        tracing::trace!(%credential_set_id, %storage, "replacing credential material with state lock held");
+        let encoded = if values.is_empty() {
+            None
+        } else {
+            Some(encode_values(storage, values)?)
+        };
+        contextualize_storage_error(
+            backend.write_with_state_lock_held(&set, encoded.as_ref()),
+            "writing",
+            credential_set_id,
+            storage,
+        )?;
+        Ok(())
+    }
+
     pub(crate) fn update_material<F, R>(
         &self,
         workspace_name: &WorkspaceName,
@@ -228,6 +278,28 @@ impl CredentialStore {
         let current = self.read_material(workspace_name, credential_set_id, storage)?;
         let (next, result) = update(current)?;
         self.replace_material(workspace_name, credential_set_id, storage, &next)?;
+        Ok(result)
+    }
+
+    pub(crate) fn update_material_with_state_lock_held<F, R>(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
+        update: F,
+    ) -> Result<R, AppError>
+    where
+        F: FnOnce(BTreeMap<String, String>) -> Result<(BTreeMap<String, String>, R), AppError>,
+    {
+        tracing::trace!(%credential_set_id, %storage, "updating credential material with state lock held");
+        let current = self.read_material(workspace_name, credential_set_id, storage)?;
+        let (next, result) = update(current)?;
+        self.replace_material_with_state_lock_held(
+            workspace_name,
+            credential_set_id,
+            storage,
+            &next,
+        )?;
         Ok(result)
     }
 
@@ -287,6 +359,26 @@ impl CredentialStore {
         .map_err(Into::into)
     }
 
+    pub(crate) fn snapshot_material_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
+    ) -> Result<CredentialMaterialSnapshot, AppError> {
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        tracing::trace!(%credential_set_id, %storage, "snapshotting credential material with state lock held");
+        contextualize_storage_error(
+            self.backend(storage).snapshot_with_state_lock_held(&set),
+            "snapshotting",
+            credential_set_id,
+            storage,
+        )
+        .map_err(Into::into)
+    }
+
     pub(crate) fn restore_material(
         &self,
         workspace_name: &WorkspaceName,
@@ -308,6 +400,28 @@ impl CredentialStore {
         Ok(())
     }
 
+    pub(crate) fn restore_material_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), AppError> {
+        let storage = snapshot.storage();
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        tracing::trace!(%credential_set_id, %storage, "restoring credential material with state lock held");
+        contextualize_storage_error(
+            self.backend(storage)
+                .restore_with_state_lock_held(&set, snapshot),
+            "restoring",
+            credential_set_id,
+            storage,
+        )?;
+        Ok(())
+    }
+
     pub(crate) fn remove_material(
         &self,
         workspace_name: &WorkspaceName,
@@ -321,6 +435,26 @@ impl CredentialStore {
         tracing::trace!(%credential_set_id, %storage, "removing credential material");
         contextualize_storage_error(
             self.backend(storage).write(&set, None),
+            "removing",
+            credential_set_id,
+            storage,
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn remove_material_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
+    ) -> Result<(), AppError> {
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        tracing::trace!(%credential_set_id, %storage, "removing credential material with state lock held");
+        contextualize_storage_error(
+            self.backend(storage).write_with_state_lock_held(&set, None),
             "removing",
             credential_set_id,
             storage,
@@ -494,6 +628,38 @@ impl FileCredentialBackend {
             .map_err(|error| CredentialsError::Parse(error.to_string()))?;
         Ok(self.layout.secret_file(set.workspace_name, &source_name))
     }
+
+    fn write_unlocked(path: &Path, material: Option<&[u8]>) -> Result<(), CredentialsError> {
+        match material {
+            Some(material) => write_file_unlocked(path, material),
+            None => remove_file_if_exists_unlocked(path).map_err(Into::into),
+        }
+    }
+
+    fn snapshot_unlocked(path: &Path) -> Result<CredentialMaterialSnapshot, CredentialsError> {
+        match std::fs::read(path) {
+            Ok(bytes) => Ok(CredentialMaterialSnapshot::new(
+                CredentialStorageKind::File,
+                Some(bytes),
+            )),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(
+                CredentialMaterialSnapshot::new(CredentialStorageKind::File, None),
+            ),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn validate_file_snapshot(
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), CredentialsError> {
+        if snapshot.storage() != CredentialStorageKind::File {
+            return Err(CredentialsError::SnapshotStorageMismatch {
+                snapshot: snapshot.storage().as_config_value(),
+                requested: CredentialStorageKind::File.as_config_value(),
+            });
+        }
+        Ok(())
+    }
 }
 
 impl CredentialMaterialBackend for FileCredentialBackend {
@@ -516,10 +682,16 @@ impl CredentialMaterialBackend for FileCredentialBackend {
     ) -> Result<(), CredentialsError> {
         let path = self.material_file(set)?;
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        match material {
-            Some(material) => write_file_unlocked(&path, material.bytes()),
-            None => remove_file_if_exists_unlocked(&path).map_err(Into::into),
-        }
+        Self::write_unlocked(&path, material.map(EncodedCredentialMaterial::bytes))
+    }
+
+    fn write_with_state_lock_held(
+        &self,
+        set: &CredentialSetRef<'_>,
+        material: Option<&EncodedCredentialMaterial>,
+    ) -> Result<(), CredentialsError> {
+        let path = self.material_file(set)?;
+        Self::write_unlocked(&path, material.map(EncodedCredentialMaterial::bytes))
     }
 
     fn snapshot(
@@ -528,16 +700,15 @@ impl CredentialMaterialBackend for FileCredentialBackend {
     ) -> Result<CredentialMaterialSnapshot, CredentialsError> {
         let path = self.material_file(set)?;
         let _lock = FileLock::shared(self.layout.state_lock())?;
-        match std::fs::read(path) {
-            Ok(bytes) => Ok(CredentialMaterialSnapshot::new(
-                CredentialStorageKind::File,
-                Some(bytes),
-            )),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(
-                CredentialMaterialSnapshot::new(CredentialStorageKind::File, None),
-            ),
-            Err(error) => Err(error.into()),
-        }
+        Self::snapshot_unlocked(&path)
+    }
+
+    fn snapshot_with_state_lock_held(
+        &self,
+        set: &CredentialSetRef<'_>,
+    ) -> Result<CredentialMaterialSnapshot, CredentialsError> {
+        let path = self.material_file(set)?;
+        Self::snapshot_unlocked(&path)
     }
 
     fn restore(
@@ -545,18 +716,20 @@ impl CredentialMaterialBackend for FileCredentialBackend {
         set: &CredentialSetRef<'_>,
         snapshot: &CredentialMaterialSnapshot,
     ) -> Result<(), CredentialsError> {
-        if snapshot.storage() != CredentialStorageKind::File {
-            return Err(CredentialsError::SnapshotStorageMismatch {
-                snapshot: snapshot.storage().as_config_value(),
-                requested: CredentialStorageKind::File.as_config_value(),
-            });
-        }
+        Self::validate_file_snapshot(snapshot)?;
         let path = self.material_file(set)?;
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        match snapshot.material() {
-            Some(bytes) => write_file_unlocked(&path, bytes),
-            None => remove_file_if_exists_unlocked(&path).map_err(Into::into),
-        }
+        Self::write_unlocked(&path, snapshot.material())
+    }
+
+    fn restore_with_state_lock_held(
+        &self,
+        set: &CredentialSetRef<'_>,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), CredentialsError> {
+        Self::validate_file_snapshot(snapshot)?;
+        let path = self.material_file(set)?;
+        Self::write_unlocked(&path, snapshot.material())
     }
 }
 

--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -9,11 +9,12 @@ use coral_engine::{
     EngineExtensions, QuerySource, RequestAuthenticator, SourceInputResolutionContext,
     SourceInputResolver, SourceInputResolverError,
 };
-use coral_spec::ManifestInputKind;
+use coral_spec::{ManifestInputKind, ManifestInputSpec};
+use tokio::sync::Mutex;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
-use crate::sources::SourceName;
+use crate::sources::model::InstalledSource;
 use crate::state::ConfigStore;
 use crate::workspaces::WorkspaceName;
 
@@ -52,11 +53,28 @@ impl EngineExtensionsProvider for AwsEngineExtensionsProvider {
     }
 }
 
+type SourceCredentialMaterial = BTreeMap<String, String>;
+type SharedSourceCredentialMaterial = Arc<Mutex<SourceCredentialMaterial>>;
+type SourceCredentialSnapshotByName = BTreeMap<String, SharedSourceCredentialSnapshot>;
+
+#[derive(Clone)]
+pub(crate) struct SourceCredentialSnapshot {
+    pub(crate) source: InstalledSource,
+    pub(crate) material: SourceCredentialMaterial,
+}
+
+#[derive(Clone)]
+struct SharedSourceCredentialSnapshot {
+    source: InstalledSource,
+    material: SharedSourceCredentialMaterial,
+}
+
 #[derive(Clone)]
 pub(crate) struct CredentialRefreshingInputResolver {
     workspace_name: WorkspaceName,
     config_store: ConfigStore,
     credential_manager: CredentialManager,
+    source_credentials: Arc<SourceCredentialSnapshotByName>,
     delegate: Option<Arc<dyn SourceInputResolver>>,
 }
 
@@ -65,12 +83,26 @@ impl CredentialRefreshingInputResolver {
         workspace_name: WorkspaceName,
         config_store: ConfigStore,
         credential_manager: CredentialManager,
+        source_credentials: BTreeMap<String, SourceCredentialSnapshot>,
         delegate: Option<Arc<dyn SourceInputResolver>>,
     ) -> Self {
+        let source_credentials = source_credentials
+            .into_iter()
+            .map(|(source_name, snapshot)| {
+                (
+                    source_name,
+                    SharedSourceCredentialSnapshot {
+                        source: snapshot.source,
+                        material: Arc::new(Mutex::new(snapshot.material)),
+                    },
+                )
+            })
+            .collect();
         Self {
             workspace_name,
             config_store,
             credential_manager,
+            source_credentials: Arc::new(source_credentials),
             delegate,
         }
     }
@@ -79,7 +111,7 @@ impl CredentialRefreshingInputResolver {
 impl fmt::Debug for CredentialRefreshingInputResolver {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CredentialRefreshingInputResolver")
-            .field("workspace_name", &self.workspace_name)
+            .field("source_count", &self.source_credentials.len())
             .field("has_delegate", &self.delegate.is_some())
             .finish_non_exhaustive()
     }
@@ -91,24 +123,12 @@ impl SourceInputResolver for CredentialRefreshingInputResolver {
         &self,
         source: &SourceInputResolutionContext,
     ) -> Result<BTreeMap<String, String>, SourceInputResolverError> {
-        let source_name = SourceName::parse(source.source_name())
-            .map_err(|error| SourceInputResolverError::invalid_input(error.to_string()))?;
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        let installed_source = self
-            .config_store
-            .get_source(&self.workspace_name, &source_name)
-            .map_err(source_input_error)?;
         let material =
-            if let Some(credential_storage) = installed_source.credential_storage_for_material() {
-                self.credential_manager
-                    .read_material_for_inputs(
-                        &self.workspace_name,
-                        &credential_set_id,
-                        credential_storage,
-                        source.declared_inputs(),
-                    )
-                    .await
-                    .map_err(source_input_error)?
+            if let Some(source_credentials) = self.source_credentials.get(source.source_name()) {
+                let mut material = source_credentials.material.lock().await;
+                self.refresh_source_material(source, source_credentials, &mut material)
+                    .await?;
+                material.clone()
             } else {
                 BTreeMap::new()
             };
@@ -139,11 +159,88 @@ impl SourceInputResolver for CredentialRefreshingInputResolver {
     }
 }
 
+impl CredentialRefreshingInputResolver {
+    async fn refresh_source_material(
+        &self,
+        source: &SourceInputResolutionContext,
+        snapshot: &SharedSourceCredentialSnapshot,
+        material: &mut BTreeMap<String, String>,
+    ) -> Result<(), SourceInputResolverError> {
+        if !has_oauth_credential_inputs(source.declared_inputs()) {
+            return Ok(());
+        }
+        let Some(storage) = snapshot.source.credential_storage_for_material() else {
+            return self
+                .credential_manager
+                .refresh_material_for_inputs(source.declared_inputs(), material)
+                .await
+                .map_err(source_input_error);
+        };
+
+        let credential_set_id = CredentialSetId::for_source(&snapshot.source.name);
+        let _refresh_lock = self
+            .credential_manager
+            .credential_refresh_lock(&self.workspace_name, &credential_set_id)
+            .await
+            .map_err(source_input_error)?;
+        if !self.source_config_still_matches_snapshot(&snapshot.source)? {
+            return self
+                .credential_manager
+                .refresh_material_for_inputs(source.declared_inputs(), material)
+                .await
+                .map_err(source_input_error);
+        }
+
+        let mut current_material = self
+            .credential_manager
+            .read_material(&self.workspace_name, &credential_set_id, storage)
+            .map_err(source_input_error)?;
+        self.credential_manager
+            .refresh_and_persist_material_for_inputs_with_refresh_lock_held(
+                &self.workspace_name,
+                &credential_set_id,
+                storage,
+                source.declared_inputs(),
+                &mut current_material,
+            )
+            .await
+            .map_err(source_input_error)?;
+        *material = current_material;
+        Ok(())
+    }
+
+    fn source_config_still_matches_snapshot(
+        &self,
+        snapshot: &InstalledSource,
+    ) -> Result<bool, SourceInputResolverError> {
+        match self
+            .config_store
+            .get_source(&self.workspace_name, &snapshot.name)
+        {
+            Ok(current) => Ok(current == *snapshot),
+            Err(AppError::SourceNotFound(_)) => Ok(false),
+            Err(error) => Err(source_input_error(error)),
+        }
+    }
+}
+
 fn resolve_from_material(
     source: &SourceInputResolutionContext,
     material: &BTreeMap<String, String>,
 ) -> BTreeMap<String, String> {
     coral_spec::resolve_inputs(source.declared_inputs(), material, source.variables())
+}
+
+fn has_oauth_credential_inputs(inputs: &[ManifestInputSpec]) -> bool {
+    inputs.iter().any(|input| {
+        input.kind == ManifestInputKind::Secret
+            && input.credential.as_ref().is_some_and(|credential| {
+                credential
+                    .methods
+                    .iter()
+                    .any(|method| method.oauth.is_some())
+            })
+    })
 }
 
 fn source_with_refreshed_secrets(

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -21,7 +21,8 @@ use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::episode::EpisodeId;
 use crate::query::QueryAttribution;
 use crate::query::extensions::{
-    CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
+    CredentialRefreshingInputResolver, EngineExtensionsProvider, SourceCredentialSnapshot,
+    engine_extensions_for_providers,
 };
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
@@ -42,6 +43,13 @@ pub(crate) enum QueryManagerError {
 pub(crate) struct ValidatedSource {
     pub(crate) source: InstalledSource,
     pub(crate) report: SourceValidationReport,
+}
+
+#[derive(Debug, Clone)]
+struct LoadedQuerySource {
+    source: InstalledSource,
+    query_source: QuerySource,
+    credential_material: BTreeMap<String, String>,
 }
 
 #[derive(Clone)]
@@ -84,12 +92,13 @@ impl QueryManager {
             &trace_sql,
             attribution.episode_id.as_ref(),
             async {
-                let (sources, config) = self
-                    .load_query_sources_with_config(workspace_name)
+                let (loaded_sources, config) = self
+                    .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
+                    .runtime_config(workspace_name, &loaded_sources, &config)
                     .map_err(QueryManagerError::App)?;
+                let sources = query_sources_from_loaded(&loaded_sources);
                 CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -113,12 +122,13 @@ impl QueryManager {
             &trace_sql,
             attribution.episode_id.as_ref(),
             async {
-                let (sources, config) = self
-                    .load_query_sources_with_config(workspace_name)
+                let (loaded_sources, config) = self
+                    .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
+                    .runtime_config(workspace_name, &loaded_sources, &config)
                     .map_err(QueryManagerError::App)?;
+                let sources = query_sources_from_loaded(&loaded_sources);
                 CoralQuery::list_catalog(&sources, runtime, schema_filter)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -153,12 +163,13 @@ impl QueryManager {
             &trace_sql,
             attribution.episode_id.as_ref(),
             async {
-                let (sources, config) = self
-                    .load_query_sources_with_config(workspace_name)
+                let (loaded_sources, config) = self
+                    .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
+                    .runtime_config(workspace_name, &loaded_sources, &config)
                     .map_err(QueryManagerError::App)?;
+                let sources = query_sources_from_loaded(&loaded_sources);
                 CoralQuery::describe_table(&sources, runtime, schema_name, table_name)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -181,12 +192,13 @@ impl QueryManager {
             sql,
             attribution.episode_id.as_ref(),
             async {
-                let (sources, config) = self
-                    .load_query_sources_with_config(workspace_name)
+                let (loaded_sources, config) = self
+                    .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
+                    .runtime_config(workspace_name, &loaded_sources, &config)
                     .map_err(QueryManagerError::App)?;
+                let sources = query_sources_from_loaded(&loaded_sources);
                 CoralQuery::execute_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -209,12 +221,13 @@ impl QueryManager {
             sql,
             attribution.episode_id.as_ref(),
             async {
-                let (sources, config) = self
-                    .load_query_sources_with_config(workspace_name)
+                let (loaded_sources, config) = self
+                    .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
+                    .runtime_config(workspace_name, &loaded_sources, &config)
                     .map_err(QueryManagerError::App)?;
+                let sources = query_sources_from_loaded(&loaded_sources);
                 CoralQuery::explain_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -230,7 +243,7 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<ValidatedSource, QueryManagerError> {
-        let (source, query_source, version, config) = {
+        let (source, loaded_source, version, config) = {
             let _state_lock = self
                 .config_store
                 .state_lock_shared()
@@ -243,49 +256,56 @@ impl QueryManager {
                 .get_source(workspace_name, source_name)
                 .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
                 .map_err(QueryManagerError::App)?;
-            let (query_source, version) = self
+            let (loaded_source, version) = self
                 .load_query_source(workspace_name, &source)
                 .map_err(QueryManagerError::App)?;
-            (source, query_source, version, config)
+            (source, loaded_source, version, config)
         };
         let runtime = self
-            .runtime_config(workspace_name, std::slice::from_ref(&query_source), &config)
+            .runtime_config(
+                workspace_name,
+                std::slice::from_ref(&loaded_source),
+                &config,
+            )
             .map_err(QueryManagerError::App)?;
-        let report =
-            CoralQuery::validate_source(&query_source, runtime, query_source.test_queries())
-                .await
-                .map_err(QueryManagerError::Core)?;
+        let report = CoralQuery::validate_source(
+            &loaded_source.query_source,
+            runtime,
+            loaded_source.query_source.test_queries(),
+        )
+        .await
+        .map_err(QueryManagerError::Core)?;
         let mut source = source;
         source.version = version;
 
         Ok(ValidatedSource { source, report })
     }
 
-    fn load_query_sources_with_config(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<(Vec<QuerySource>, AppConfig), AppError> {
-        let _state_lock = self.config_store.state_lock_shared()?;
-        let config = self.config_store.load_config_unlocked()?;
-        let sources = self.load_query_sources(workspace_name, &config)?;
-        Ok((sources, config))
-    }
-
     fn load_query_sources(
         &self,
         workspace_name: &WorkspaceName,
+    ) -> Result<(Vec<LoadedQuerySource>, AppConfig), AppError> {
+        let _state_lock = self.config_store.state_lock_shared()?;
+        let config = self.config_store.load_config_unlocked()?;
+        let sources = self.load_query_sources_from_config(workspace_name, &config)?;
+        Ok((sources, config))
+    }
+
+    fn load_query_sources_from_config(
+        &self,
+        workspace_name: &WorkspaceName,
         config: &AppConfig,
-    ) -> Result<Vec<QuerySource>, AppError> {
+    ) -> Result<Vec<LoadedQuerySource>, AppError> {
         let span = tracing::info_span!(
             "coral.app.query_sources.load",
             workspace = %workspace_name,
             source.count = tracing::field::Empty,
         );
         let _guard = span.enter();
-        let mut query_sources = Vec::new();
+        let mut loaded_sources = Vec::new();
         for source in config.workspace_sources(workspace_name) {
             match self.load_query_source(workspace_name, &source) {
-                Ok((query_source, _version)) => query_sources.push(query_source),
+                Ok((loaded_source, _version)) => loaded_sources.push(loaded_source),
                 Err(
                     error @ (AppError::Credentials(CredentialsError::Unavailable(_))
                     | AppError::MissingOrIncompatibleV4Materialization { .. }),
@@ -301,15 +321,15 @@ impl QueryManager {
                 }
             }
         }
-        span.record("source.count", query_sources.len());
-        Ok(query_sources)
+        span.record("source.count", loaded_sources.len());
+        Ok(loaded_sources)
     }
 
     fn load_query_source(
         &self,
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
-    ) -> Result<(QuerySource, Option<String>), AppError> {
+    ) -> Result<(LoadedQuerySource, Option<String>), AppError> {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = installed.source_spec;
         let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
@@ -382,22 +402,42 @@ impl QueryManager {
         } else {
             QuerySource::from_manifest(&source_spec, source.variables.clone(), resolved_secrets)
         };
-        Ok((query_source, installed.candidate.version))
+        Ok((
+            LoadedQuerySource {
+                source: source.clone(),
+                query_source,
+                credential_material: stored_secrets,
+            },
+            installed.candidate.version,
+        ))
     }
 
     fn runtime_config(
         &self,
         workspace_name: &WorkspaceName,
-        selected_sources: &[QuerySource],
+        selected_sources: &[LoadedQuerySource],
         config: &AppConfig,
     ) -> Result<QueryRuntimeConfig, AppError> {
+        let query_sources = query_sources_from_loaded(selected_sources);
         let mut extensions =
-            engine_extensions_for_providers(&self.engine_extensions_providers, selected_sources);
+            engine_extensions_for_providers(&self.engine_extensions_providers, &query_sources);
         let provider_input_resolver = extensions.source_input_resolver.take();
         extensions.source_input_resolver = Some(Arc::new(CredentialRefreshingInputResolver::new(
             workspace_name.clone(),
             self.config_store.clone(),
             self.credential_manager.clone(),
+            selected_sources
+                .iter()
+                .map(|source| {
+                    (
+                        source.query_source.source_name().to_string(),
+                        SourceCredentialSnapshot {
+                            source: source.source.clone(),
+                            material: source.credential_material.clone(),
+                        },
+                    )
+                })
+                .collect(),
             provider_input_resolver,
         )));
         let mut runtime_context = self.runtime_context.clone();
@@ -405,12 +445,19 @@ impl QueryManager {
         let mut runtime = QueryRuntimeConfig::new(runtime_context, extensions);
         let selected_source_names = selected_sources
             .iter()
-            .map(|source| source.source_name().to_string())
+            .map(|source| source.query_source.source_name().to_string())
             .collect::<Vec<_>>();
         runtime.memory = config.memory_config()?;
         runtime.dependent_join = config.dependent_join_config(&selected_source_names)?;
         Ok(runtime)
     }
+}
+
+fn query_sources_from_loaded(loaded_sources: &[LoadedQuerySource]) -> Vec<QuerySource> {
+    loaded_sources
+        .iter()
+        .map(|source| source.query_source.clone())
+        .collect()
 }
 
 #[derive(Clone, Copy)]
@@ -1081,13 +1128,13 @@ tables:
             )
             .expect("persist secret material");
 
-        let (query_source, _) = fixture
+        let (loaded_source, _) = fixture
             .manager
             .load_query_source(&workspace_name, &source)
             .expect("optional secret should load when present");
 
         assert_eq!(
-            query_source.secrets(),
+            loaded_source.query_source.secrets(),
             &BTreeMap::from([("OAUTH_TOKEN".to_string(), "oauth-token".to_string())])
         );
     }
@@ -1219,14 +1266,9 @@ surfaces:
             )
             .expect("persist source");
 
-        let config = fixture
-            .manager
-            .config_store
-            .load_config()
-            .expect("load config");
         let error = fixture
             .manager
-            .load_query_sources(&workspace_name, &config)
+            .load_query_sources(&workspace_name)
             .expect_err("missing materialization should fail closed");
 
         assert!(
@@ -1271,10 +1313,8 @@ surfaces:
             layout,
             Vec::new(),
         );
-        let config = manager.config_store.load_config().expect("load config");
-
         let error = manager
-            .load_query_sources(&workspace_name, &config)
+            .load_query_sources(&workspace_name)
             .expect_err("unavailable keychain should fail closed");
 
         assert!(
@@ -1332,6 +1372,103 @@ surfaces:
     }
 
     #[tokio::test]
+    async fn runtime_input_resolver_uses_loaded_credential_snapshot() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("secured_messages").expect("source name");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let installed_source = InstalledSource {
+            name: source_name.clone(),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: vec!["API_TOKEN".to_string()],
+            credential_storage: Some(CredentialStorageKind::File),
+            origin: SourceOrigin::Bundled,
+        };
+        fixture
+            .manager
+            .config_store
+            .upsert_source(&workspace_name, installed_source.clone())
+            .expect("persist live source");
+        fixture
+            .manager
+            .credential_manager
+            .replace_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &BTreeMap::from([("API_TOKEN".to_string(), "live-token".to_string())]),
+            )
+            .expect("write live credential material");
+        let source_spec = parse_source_manifest_yaml(
+            r"
+name: secured_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+inputs:
+  API_TOKEN:
+    kind: secret
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Secured messages
+    request:
+      method: GET
+      path: /messages
+    response: {}
+    columns:
+      - name: id
+        type: Utf8
+",
+        )
+        .expect("parse source manifest");
+        let loaded_source = LoadedQuerySource {
+            source: installed_source,
+            query_source: QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new()),
+            credential_material: BTreeMap::from([(
+                "API_TOKEN".to_string(),
+                "snapshot-token".to_string(),
+            )]),
+        };
+        let runtime = fixture
+            .manager
+            .runtime_config(
+                &workspace_name,
+                std::slice::from_ref(&loaded_source),
+                &AppConfig::default(),
+            )
+            .expect("runtime config");
+        let input_resolver = runtime
+            .extensions
+            .source_input_resolver
+            .expect("runtime installs input resolver");
+        fixture
+            .manager
+            .credential_manager
+            .replace_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &BTreeMap::from([("API_TOKEN".to_string(), "changed-live-token".to_string())]),
+            )
+            .expect("replace live credential material");
+
+        let resolved_inputs = input_resolver
+            .resolve_inputs(&SourceInputResolutionContext::from_query_source(
+                &loaded_source.query_source,
+            ))
+            .await
+            .expect("resolve source inputs");
+
+        assert_eq!(
+            resolved_inputs.get("API_TOKEN").map(String::as_str),
+            Some("snapshot-token")
+        );
+    }
+
+    #[tokio::test]
     async fn runtime_config_composes_provider_input_resolver_with_refreshed_inputs() {
         let calls = Arc::new(AtomicUsize::new(0));
         let observed_token = Arc::new(Mutex::new(None));
@@ -1342,34 +1479,6 @@ surfaces:
                 observed_token: Arc::clone(&observed_token),
             })],
         );
-        let source_name = SourceName::parse("secured_messages").expect("source name");
-        let workspace_name = WorkspaceName::default();
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        fixture
-            .manager
-            .config_store
-            .upsert_source(
-                &workspace_name,
-                InstalledSource {
-                    name: source_name.clone(),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: vec!["API_TOKEN".to_string()],
-                    credential_storage: Some(CredentialStorageKind::File),
-                    origin: SourceOrigin::Bundled,
-                },
-            )
-            .expect("persist source");
-        fixture
-            .manager
-            .credential_manager
-            .replace_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-                &BTreeMap::from([("API_TOKEN".to_string(), "stored-token".to_string())]),
-            )
-            .expect("write credential material");
         let source_spec = parse_source_manifest_yaml(
             r#"
 name: secured_messages
@@ -1396,12 +1505,26 @@ tables:
 "#,
         )
         .expect("parse source manifest");
-        let source = QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new());
+        let loaded_source = LoadedQuerySource {
+            source: InstalledSource {
+                name: SourceName::parse("secured_messages").expect("source name"),
+                version: None,
+                variables: BTreeMap::new(),
+                secrets: vec!["API_TOKEN".to_string()],
+                credential_storage: None,
+                origin: SourceOrigin::Bundled,
+            },
+            query_source: QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new()),
+            credential_material: BTreeMap::from([(
+                "API_TOKEN".to_string(),
+                "stored-token".to_string(),
+            )]),
+        };
         let runtime = fixture
             .manager
             .runtime_config(
-                &workspace_name,
-                std::slice::from_ref(&source),
+                &WorkspaceName::default(),
+                std::slice::from_ref(&loaded_source),
                 &AppConfig::default(),
             )
             .expect("runtime config");
@@ -1411,7 +1534,9 @@ tables:
             .expect("runtime installs input resolver");
 
         let resolved_inputs = input_resolver
-            .resolve_inputs(&SourceInputResolutionContext::from_query_source(&source))
+            .resolve_inputs(&SourceInputResolutionContext::from_query_source(
+                &loaded_source.query_source,
+            ))
             .await
             .expect("resolve source inputs");
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -84,12 +84,8 @@ impl QueryManager {
             &trace_sql,
             attribution.episode_id.as_ref(),
             async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name, &config)
+                let (sources, config) = self
+                    .load_query_sources_with_config(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &sources, &config)
@@ -117,12 +113,8 @@ impl QueryManager {
             &trace_sql,
             attribution.episode_id.as_ref(),
             async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name, &config)
+                let (sources, config) = self
+                    .load_query_sources_with_config(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &sources, &config)
@@ -161,12 +153,8 @@ impl QueryManager {
             &trace_sql,
             attribution.episode_id.as_ref(),
             async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name, &config)
+                let (sources, config) = self
+                    .load_query_sources_with_config(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &sources, &config)
@@ -193,12 +181,8 @@ impl QueryManager {
             sql,
             attribution.episode_id.as_ref(),
             async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name, &config)
+                let (sources, config) = self
+                    .load_query_sources_with_config(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &sources, &config)
@@ -225,12 +209,8 @@ impl QueryManager {
             sql,
             attribution.episode_id.as_ref(),
             async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name, &config)
+                let (sources, config) = self
+                    .load_query_sources_with_config(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &sources, &config)
@@ -250,17 +230,24 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<ValidatedSource, QueryManagerError> {
-        let config = self
-            .config_store
-            .load_config()
-            .map_err(QueryManagerError::App)?;
-        let source = config
-            .get_source(workspace_name, source_name)
-            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
-            .map_err(QueryManagerError::App)?;
-        let (query_source, version) = self
-            .load_query_source(workspace_name, &source)
-            .map_err(QueryManagerError::App)?;
+        let (source, query_source, version, config) = {
+            let _state_lock = self
+                .config_store
+                .state_lock_shared()
+                .map_err(QueryManagerError::App)?;
+            let config = self
+                .config_store
+                .load_config_unlocked()
+                .map_err(QueryManagerError::App)?;
+            let source = config
+                .get_source(workspace_name, source_name)
+                .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
+                .map_err(QueryManagerError::App)?;
+            let (query_source, version) = self
+                .load_query_source(workspace_name, &source)
+                .map_err(QueryManagerError::App)?;
+            (source, query_source, version, config)
+        };
         let runtime = self
             .runtime_config(workspace_name, std::slice::from_ref(&query_source), &config)
             .map_err(QueryManagerError::App)?;
@@ -272,6 +259,16 @@ impl QueryManager {
         source.version = version;
 
         Ok(ValidatedSource { source, report })
+    }
+
+    fn load_query_sources_with_config(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<(Vec<QuerySource>, AppConfig), AppError> {
+        let _state_lock = self.config_store.state_lock_shared()?;
+        let config = self.config_store.load_config_unlocked()?;
+        let sources = self.load_query_sources(workspace_name, &config)?;
+        Ok((sources, config))
     }
 
     fn load_query_sources(

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -146,7 +146,6 @@ struct PersistSourceRequest<'a> {
     manifest_yaml: Option<&'a str>,
     bindings: ValidatedBindings,
     origin: SourceOrigin,
-    credential_storage: Option<CredentialStorageKind>,
     materialization_tmp: Option<PathBuf>,
 }
 
@@ -365,12 +364,6 @@ impl SourceManager {
         let bindings = validate_bindings(candidate, bindings, &stored_material)?;
         let materialization_inputs =
             materialization_inputs_from_bindings(&bindings, &stored_material);
-        let credential_storage = self.source_persist_storage(
-            workspace_name,
-            &candidate.name,
-            &bindings,
-            !stored_material.is_empty(),
-        )?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
@@ -378,7 +371,6 @@ impl SourceManager {
                 manifest_yaml,
                 bindings,
                 origin,
-                credential_storage,
                 materialization_tmp: self
                     .prepare_v4_materialization(
                         workspace_name,
@@ -427,7 +419,6 @@ impl SourceManager {
             bindings,
             &oauth_input_keys,
         )?;
-        let has_stored_material = !stored_material.is_empty();
         let stored_material_for_materialization = stored_material.clone();
         let bindings = self
             .bindings_with_oauth_material(
@@ -440,12 +431,6 @@ impl SourceManager {
             .await?;
         let materialization_inputs =
             materialization_inputs_from_bindings(&bindings, &stored_material_for_materialization);
-        let credential_storage = self.source_persist_storage(
-            workspace_name,
-            &candidate.name,
-            &bindings,
-            has_stored_material,
-        )?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
@@ -453,7 +438,6 @@ impl SourceManager {
                 manifest_yaml,
                 bindings,
                 origin,
-                credential_storage,
                 materialization_tmp: self
                     .prepare_v4_materialization(
                         workspace_name,
@@ -473,16 +457,19 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
-        let stored = self.config_store.get_source(workspace_name, source_name)?;
-        let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
         let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
         let credential_guard = self
             .credential_manager
             .material_guard(workspace_name, &credential_set_id)?;
+        let _state_lock = self.config_store.state_lock_exclusive()?;
+        let stored = self
+            .config_store
+            .get_source_unlocked(workspace_name, source_name)?;
+        let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
         let credential_storage = stored.credential_storage_for_material();
         let credential_material = credential_storage
-            .map(|storage| credential_guard.snapshot_material(storage))
+            .map(|storage| credential_guard.snapshot_material_with_state_lock_held(storage))
             .transpose()?;
         let previous = SourceRollbackState {
             source: stored,
@@ -494,18 +481,6 @@ impl SourceManager {
             },
             credential_material,
         };
-        if let Some(credential_storage) = credential_storage
-            && let Err(error) = credential_guard.remove_material(credential_storage)
-        {
-            self.restore_source_rollback_state(
-                workspace_name,
-                source_name,
-                Some(previous),
-                None,
-                &credential_guard,
-            );
-            return Err(error);
-        }
         let source_dir_backup =
             source_dir.with_file_name(format!("{source_name}.delete.rollback.{}", Uuid::new_v4()));
         let had_source_dir = source_dir.exists();
@@ -514,7 +489,7 @@ impl SourceManager {
                 std::fs::remove_dir_all(&source_dir_backup)?;
             }
             if let Err(error) = std::fs::rename(&source_dir, &source_dir_backup) {
-                self.restore_source_rollback_state(
+                self.restore_source_rollback_state_with_state_lock_held(
                     workspace_name,
                     source_name,
                     Some(previous),
@@ -524,7 +499,10 @@ impl SourceManager {
                 return Err(error.into());
             }
         }
-        if let Err(error) = self.config_store.remove_source(workspace_name, source_name) {
+        if let Err(error) = self
+            .config_store
+            .remove_source_unlocked(workspace_name, source_name)
+        {
             if had_source_dir
                 && source_dir_backup.exists()
                 && let Err(restore_error) = std::fs::rename(&source_dir_backup, &source_dir)
@@ -534,7 +512,29 @@ impl SourceManager {
                     source_dir_backup.display()
                 )));
             }
-            self.restore_source_rollback_state(
+            self.restore_source_rollback_state_with_state_lock_held(
+                workspace_name,
+                source_name,
+                Some(previous),
+                None,
+                &credential_guard,
+            );
+            return Err(error);
+        }
+        if let Some(credential_storage) = credential_storage
+            && let Err(error) =
+                credential_guard.remove_material_with_state_lock_held(credential_storage)
+        {
+            if had_source_dir
+                && source_dir_backup.exists()
+                && let Err(restore_error) = std::fs::rename(&source_dir_backup, &source_dir)
+            {
+                return Err(AppError::FailedPrecondition(format!(
+                    "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
+                    source_dir_backup.display()
+                )));
+            }
+            self.restore_source_rollback_state_with_state_lock_held(
                 workspace_name,
                 source_name,
                 Some(previous),
@@ -579,6 +579,17 @@ impl SourceManager {
             .credential_manager
             .material_guard(workspace_name, &credential_set_id)?;
         let _state_lock = self.config_store.state_lock_exclusive()?;
+        let credential_storage = match self.source_persist_storage_with_state_lock_held(
+            workspace_name,
+            request.candidate,
+            &request.bindings,
+        ) {
+            Ok(storage) => storage,
+            Err(error) => {
+                cleanup_materialization_tmp(request.materialization_tmp.as_deref());
+                return Err(error);
+            }
+        };
         let previous =
             self.load_source_rollback_state(workspace_name, &source_name, &credential_guard)?;
         if let Err(error) =
@@ -600,18 +611,16 @@ impl SourceManager {
             secrets,
             replaced_oauth_inputs,
         } = request.bindings;
-        let (visible_secret_keys, credential_storage) = if let Some(requested_storage) =
-            request.credential_storage
-        {
-            let expected_secret_keys = request
-                .candidate
-                .inputs
-                .iter()
-                .filter(|input| input.kind == ManifestInputKind::Secret)
-                .map(|input| input.key.clone())
-                .collect::<BTreeSet<_>>();
-            let credential_write = match credential_guard
-                .update_material_or_empty_on_parse_with_state_lock_held(
+        let (visible_secret_keys, credential_storage) =
+            if let Some(requested_storage) = credential_storage {
+                let expected_secret_keys = request
+                    .candidate
+                    .inputs
+                    .iter()
+                    .filter(|input| input.kind == ManifestInputKind::Secret)
+                    .map(|input| input.key.clone())
+                    .collect::<BTreeSet<_>>();
+                let credential_write = match credential_guard.update_material_with_state_lock(
                     requested_storage,
                     |mut credential_material| {
                         credential_material.retain(|key, _| {
@@ -625,28 +634,28 @@ impl SourceManager {
                         Ok(credential_material)
                     },
                 ) {
-                Ok(outcome) => outcome,
-                Err(error) => {
-                    cleanup_materialization_tmp(request.materialization_tmp.as_deref());
-                    self.restore_source_rollback_state_with_state_lock_held(
-                        workspace_name,
-                        &source_name,
-                        previous,
-                        Some(requested_storage),
-                        &credential_guard,
-                    );
-                    return Err(error);
-                }
-            };
-            let credential_storage = if credential_write.visible_keys.is_empty() {
-                None
+                    Ok(outcome) => outcome,
+                    Err(error) => {
+                        cleanup_materialization_tmp(request.materialization_tmp.as_deref());
+                        self.restore_source_rollback_state_with_state_lock_held(
+                            workspace_name,
+                            &source_name,
+                            previous,
+                            Some(requested_storage),
+                            &credential_guard,
+                        );
+                        return Err(error);
+                    }
+                };
+                let credential_storage = if credential_write.visible_keys.is_empty() {
+                    None
+                } else {
+                    Some(credential_write.storage)
+                };
+                (credential_write.visible_keys, credential_storage)
             } else {
-                Some(credential_write.storage)
+                (Vec::new(), None)
             };
-            (credential_write.visible_keys, credential_storage)
-        } else {
-            (Vec::new(), None)
-        };
 
         let materialization_backup =
             if let Some(materialization_tmp) = request.materialization_tmp.as_ref() {
@@ -860,26 +869,46 @@ impl SourceManager {
         }
     }
 
-    fn source_persist_storage(
+    fn source_persist_storage_with_state_lock_held(
         &self,
         workspace_name: &WorkspaceName,
-        source_name: &SourceName,
+        candidate: &CandidateSource,
         bindings: &ValidatedBindings,
-        has_stored_material: bool,
     ) -> Result<Option<CredentialStorageKind>, AppError> {
-        match self.config_store.get_source(workspace_name, source_name) {
-            Ok(source) if !source.secrets.is_empty() => {
-                Ok(Some(source.effective_credential_storage()))
+        let needs_stored_material = candidate.inputs.iter().any(|input| {
+            input.kind == ManifestInputKind::Secret
+                && input.required
+                && !bindings.secrets.contains_key(&input.key)
+        });
+        let existing_storage = match self
+            .config_store
+            .get_source_unlocked(workspace_name, &candidate.name)
+        {
+            Ok(source) => source.credential_storage_for_material(),
+            Err(AppError::SourceNotFound(_)) if needs_stored_material => {
+                let legacy_secret_file = self.layout.secret_file(workspace_name, &candidate.name);
+                if legacy_secret_file.is_file() {
+                    Some(CredentialStorageKind::File)
+                } else {
+                    None
+                }
             }
-            Ok(_) | Err(AppError::SourceNotFound(_))
-                if bindings.secrets.is_empty() && !has_stored_material =>
-            {
-                Ok(None)
-            }
-            Ok(_) | Err(AppError::SourceNotFound(_)) => {
-                self.credential_manager.default_write_storage().map(Some)
-            }
-            Err(error) => Err(error),
+            Err(AppError::SourceNotFound(_)) => None,
+            Err(error) => return Err(error),
+        };
+        let stored_material = match existing_storage {
+            Some(storage) => self.read_source_material(workspace_name, &candidate.name, storage)?,
+            None => BTreeMap::new(),
+        };
+        validate_required_secret_material(candidate, bindings, &stored_material)?;
+
+        if existing_storage.is_some() {
+            return Ok(existing_storage);
+        }
+        if bindings.secrets.is_empty() && stored_material.is_empty() {
+            Ok(None)
+        } else {
+            self.credential_manager.default_write_storage().map(Some)
         }
     }
 
@@ -1063,43 +1092,6 @@ impl SourceManager {
         new_material_storage: Option<CredentialStorageKind>,
         credential_material: &CredentialMaterialGuard<'_>,
     ) {
-        self.restore_source_rollback_state_inner(
-            workspace_name,
-            source_name,
-            previous,
-            new_material_storage,
-            credential_material,
-            true,
-        );
-    }
-
-    fn restore_source_rollback_state(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-        previous: Option<SourceRollbackState>,
-        new_material_storage: Option<CredentialStorageKind>,
-        credential_material: &CredentialMaterialGuard<'_>,
-    ) {
-        self.restore_source_rollback_state_inner(
-            workspace_name,
-            source_name,
-            previous,
-            new_material_storage,
-            credential_material,
-            false,
-        );
-    }
-
-    fn restore_source_rollback_state_inner(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-        previous: Option<SourceRollbackState>,
-        new_material_storage: Option<CredentialStorageKind>,
-        credential_material: &CredentialMaterialGuard<'_>,
-        state_lock_held: bool,
-    ) {
         if let Some(previous) = previous {
             let manifest_path = self.layout.manifest_file(workspace_name, source_name);
             match previous.manifest_yaml {
@@ -1122,36 +1114,25 @@ impl SourceManager {
             }
             match previous.credential_material {
                 Some(snapshot) => {
-                    let restore_result = if state_lock_held {
+                    if let Err(e) =
                         credential_material.restore_material_with_state_lock_held(&snapshot)
-                    } else {
-                        credential_material.restore_material(&snapshot)
-                    };
-                    if let Err(e) = restore_result {
+                    {
                         warn!("rollback: failed to restore source credential material: {e}");
                     }
                 }
                 None => {
-                    if let Some(storage) = new_material_storage {
-                        let remove_result = if state_lock_held {
+                    if let Some(storage) = new_material_storage
+                        && let Err(e) =
                             credential_material.remove_material_with_state_lock_held(storage)
-                        } else {
-                            credential_material.remove_material(storage)
-                        };
-                        if let Err(e) = remove_result {
-                            warn!("rollback: failed to remove new source credential material: {e}");
-                        }
+                    {
+                        warn!("rollback: failed to remove new source credential material: {e}");
                     }
                 }
             }
-            let upsert_result = if state_lock_held {
-                self.config_store
-                    .upsert_source_unlocked(workspace_name, previous.source)
-            } else {
-                self.config_store
-                    .upsert_source(workspace_name, previous.source)
-            };
-            if let Err(e) = upsert_result {
+            if let Err(e) = self
+                .config_store
+                .upsert_source_unlocked(workspace_name, previous.source)
+            {
                 warn!("rollback: failed to restore source config: {e}");
             }
         } else {
@@ -1161,15 +1142,10 @@ impl SourceManager {
             {
                 warn!("rollback: failed to remove source directory: {e}");
             }
-            if let Some(storage) = new_material_storage {
-                let remove_result = if state_lock_held {
-                    credential_material.remove_material_with_state_lock_held(storage)
-                } else {
-                    credential_material.remove_material(storage)
-                };
-                if let Err(e) = remove_result {
-                    warn!("rollback: failed to remove source credential material: {e}");
-                }
+            if let Some(storage) = new_material_storage
+                && let Err(e) = credential_material.remove_material_with_state_lock_held(storage)
+            {
+                warn!("rollback: failed to remove source credential material: {e}");
             }
         }
     }
@@ -1306,6 +1282,26 @@ fn source_needs_stored_material_for_validation(
             && !filled_secret_keys.contains(&input.key)
             && persisted_secret_keys.is_none_or(|keys| keys.contains(&input.key))
     }))
+}
+
+fn validate_required_secret_material(
+    candidate: &CandidateSource,
+    bindings: &ValidatedBindings,
+    stored_material: &BTreeMap<String, String>,
+) -> Result<(), AppError> {
+    for input in &candidate.inputs {
+        if input.kind == ManifestInputKind::Secret
+            && input.required
+            && !bindings.secrets.contains_key(&input.key)
+            && !stored_material.contains_key(&input.key)
+        {
+            return Err(AppError::InvalidInput(format!(
+                "missing required source secret '{}'",
+                input.key
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn material_key_belongs_to_source_secret(
@@ -1549,11 +1545,10 @@ mod tests {
 
     use super::{
         ImportSourceCommand, ImportSourceEventSender, ImportSourceWithCredentialsCommand,
-        ImportSourceWithCredentialsEvent, PendingImportSourceWithCredentialsEvent, SourceBinding,
-        SourceBindings, SourceManager, SourceOAuthCredentialRetrieval, ValidatedBindings,
-        PersistSourceRequest,
-        materialization_inputs_from_bindings, normalize_binding_key,
-        source_needs_stored_material_for_validation,
+        ImportSourceWithCredentialsEvent, PendingImportSourceWithCredentialsEvent,
+        PersistSourceRequest, SourceBinding, SourceBindings, SourceManager,
+        SourceOAuthCredentialRetrieval, ValidatedBindings, materialization_inputs_from_bindings,
+        normalize_binding_key, source_needs_stored_material_for_validation,
     };
     use crate::credentials::{
         CredentialManager, CredentialSetId, CredentialStorageKind, CredentialStoragePreference,
@@ -1840,7 +1835,6 @@ tables:
                         manifest_yaml: Some(&updated_manifest),
                         bindings,
                         origin: SourceOrigin::Imported,
-                        credential_storage: None,
                         materialization_tmp: None,
                     },
                 )
@@ -1874,6 +1868,155 @@ tables:
 
         let stored_after = std::fs::read_to_string(&manifest_path).expect("stored manifest");
         assert!(stored_after.contains("https://replacement.example.com"));
+    }
+
+    #[test]
+    fn readd_source_revalidates_required_secret_material_under_state_lock() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let manager = SourceManager::new(config_store, credential_manager.clone(), layout);
+
+        let workspace_name = default_workspace();
+        manager
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings {
+                        variables: Vec::new(),
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "secret-token".to_string(),
+                        }],
+                    },
+                },
+            )
+            .expect("initial import");
+
+        let source_name = SourceName::parse("secured_messages").expect("source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        credential_manager
+            .material_guard(&workspace_name, &credential_set_id)
+            .expect("credential guard")
+            .remove_material(CredentialStorageKind::File)
+            .expect("remove stored material");
+        let manifest = manifest_with_secret();
+        let candidate =
+            describe_manifest(&manifest, SourceOrigin::Imported, false).expect("describe manifest");
+        let bindings = ValidatedBindings {
+            variables: BTreeMap::new(),
+            secrets: BTreeMap::new(),
+            replaced_oauth_inputs: BTreeSet::new(),
+        };
+
+        let error = manager
+            .persist_source(
+                &workspace_name,
+                PersistSourceRequest {
+                    candidate: &candidate,
+                    manifest_yaml: Some(&manifest),
+                    bindings,
+                    origin: SourceOrigin::Imported,
+                    materialization_tmp: None,
+                },
+            )
+            .expect_err("re-add without current required material should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing required source secret 'API_TOKEN'"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn delete_source_waits_for_state_lock_before_removing_credentials() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let manager = SourceManager::new(config_store.clone(), credential_manager.clone(), layout);
+
+        let workspace_name = default_workspace();
+        manager
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings {
+                        variables: Vec::new(),
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "secret-token".to_string(),
+                        }],
+                    },
+                },
+            )
+            .expect("initial import");
+
+        let source_name = SourceName::parse("secured_messages").expect("source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let state_lock = config_store.state_lock_shared().expect("shared state lock");
+        let delete_manager = manager.clone();
+        let delete_workspace_name = workspace_name.clone();
+        let delete_source_name = source_name.clone();
+        let (started_tx, started_rx) = std_mpsc::channel();
+        let (done_tx, done_rx) = std_mpsc::channel();
+        let handle = thread::spawn(move || {
+            started_tx.send(()).expect("send started");
+            let result = delete_manager
+                .delete_source(&delete_workspace_name, &delete_source_name)
+                .map(|source| source.name.as_str().to_string())
+                .map_err(|error| error.to_string());
+            done_tx.send(result).expect("send delete result");
+        });
+
+        started_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("delete thread should start");
+        match done_rx.recv_timeout(Duration::from_millis(300)) {
+            Err(std_mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std_mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("source delete thread exited before sending a result")
+            }
+            Ok(result) => {
+                panic!("source delete completed while shared state lock was held: {result:?}")
+            }
+        }
+        let material = credential_manager
+            .read_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
+            .expect("read material during shared lock");
+        assert_eq!(
+            material.get("API_TOKEN").map(String::as_str),
+            Some("secret-token")
+        );
+
+        drop(state_lock);
+        let result = done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("source delete should finish after releasing the state lock")
+            .expect("source delete should succeed");
+        assert_eq!(result, "secured_messages");
+        handle.join().expect("join source delete thread");
+        let material = credential_manager
+            .read_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
+            .expect("read material after delete");
+        assert!(material.is_empty());
     }
 
     fn manifest_with_oauth_secret(token_url: &str, redirect_port: u16) -> String {

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -578,13 +578,14 @@ impl SourceManager {
         let credential_guard = self
             .credential_manager
             .material_guard(workspace_name, &credential_set_id)?;
+        let _state_lock = self.config_store.state_lock_exclusive()?;
         let previous =
             self.load_source_rollback_state(workspace_name, &source_name, &credential_guard)?;
         if let Err(error) =
             self.persist_manifest_artifact(workspace_name, &source_name, request.manifest_yaml)
         {
             cleanup_materialization_tmp(request.materialization_tmp.as_deref());
-            self.restore_source_rollback_state(
+            self.restore_source_rollback_state_with_state_lock_held(
                 workspace_name,
                 &source_name,
                 previous,
@@ -599,16 +600,18 @@ impl SourceManager {
             secrets,
             replaced_oauth_inputs,
         } = request.bindings;
-        let (visible_secret_keys, credential_storage) =
-            if let Some(requested_storage) = request.credential_storage {
-                let expected_secret_keys = request
-                    .candidate
-                    .inputs
-                    .iter()
-                    .filter(|input| input.kind == ManifestInputKind::Secret)
-                    .map(|input| input.key.clone())
-                    .collect::<BTreeSet<_>>();
-                let credential_write = match credential_guard.update_material_or_empty_on_parse(
+        let (visible_secret_keys, credential_storage) = if let Some(requested_storage) =
+            request.credential_storage
+        {
+            let expected_secret_keys = request
+                .candidate
+                .inputs
+                .iter()
+                .filter(|input| input.kind == ManifestInputKind::Secret)
+                .map(|input| input.key.clone())
+                .collect::<BTreeSet<_>>();
+            let credential_write = match credential_guard
+                .update_material_or_empty_on_parse_with_state_lock_held(
                     requested_storage,
                     |mut credential_material| {
                         credential_material.retain(|key, _| {
@@ -622,28 +625,28 @@ impl SourceManager {
                         Ok(credential_material)
                     },
                 ) {
-                    Ok(outcome) => outcome,
-                    Err(error) => {
-                        cleanup_materialization_tmp(request.materialization_tmp.as_deref());
-                        self.restore_source_rollback_state(
-                            workspace_name,
-                            &source_name,
-                            previous,
-                            Some(requested_storage),
-                            &credential_guard,
-                        );
-                        return Err(error);
-                    }
-                };
-                let credential_storage = if credential_write.visible_keys.is_empty() {
-                    None
-                } else {
-                    Some(credential_write.storage)
-                };
-                (credential_write.visible_keys, credential_storage)
-            } else {
-                (Vec::new(), None)
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    cleanup_materialization_tmp(request.materialization_tmp.as_deref());
+                    self.restore_source_rollback_state_with_state_lock_held(
+                        workspace_name,
+                        &source_name,
+                        previous,
+                        Some(requested_storage),
+                        &credential_guard,
+                    );
+                    return Err(error);
+                }
             };
+            let credential_storage = if credential_write.visible_keys.is_empty() {
+                None
+            } else {
+                Some(credential_write.storage)
+            };
+            (credential_write.visible_keys, credential_storage)
+        } else {
+            (Vec::new(), None)
+        };
 
         let materialization_backup =
             if let Some(materialization_tmp) = request.materialization_tmp.as_ref() {
@@ -656,7 +659,7 @@ impl SourceManager {
                     Ok(backup) => backup,
                     Err(error) => {
                         cleanup_materialization_tmp(request.materialization_tmp.as_deref());
-                        self.restore_source_rollback_state(
+                        self.restore_source_rollback_state_with_state_lock_held(
                             workspace_name,
                             &source_name,
                             previous,
@@ -684,7 +687,7 @@ impl SourceManager {
         };
         if let Err(error) = self
             .config_store
-            .upsert_source(workspace_name, stored.clone())
+            .upsert_source_unlocked(workspace_name, stored.clone())
         {
             let restore_result = restore_materialization_backup(
                 &self.layout,
@@ -692,7 +695,7 @@ impl SourceManager {
                 &source_name,
                 materialization_backup,
             );
-            self.restore_source_rollback_state(
+            self.restore_source_rollback_state_with_state_lock_held(
                 workspace_name,
                 &source_name,
                 previous,
@@ -1026,14 +1029,19 @@ impl SourceManager {
         source_name: &SourceName,
         credential_material: &CredentialMaterialGuard<'_>,
     ) -> Result<Option<SourceRollbackState>, AppError> {
-        let source = match self.config_store.get_source(workspace_name, source_name) {
+        let source = match self
+            .config_store
+            .get_source_unlocked(workspace_name, source_name)
+        {
             Ok(source) => source,
             Err(AppError::SourceNotFound(_)) => return Ok(None),
             Err(error) => return Err(error),
         };
         let credential_material = source
             .credential_storage_for_material()
-            .map(|credential_storage| credential_material.snapshot_material(credential_storage))
+            .map(|credential_storage| {
+                credential_material.snapshot_material_with_state_lock_held(credential_storage)
+            })
             .transpose()?;
         Ok(Some(SourceRollbackState {
             manifest_yaml: match source.origin {
@@ -1047,6 +1055,24 @@ impl SourceManager {
         }))
     }
 
+    fn restore_source_rollback_state_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        previous: Option<SourceRollbackState>,
+        new_material_storage: Option<CredentialStorageKind>,
+        credential_material: &CredentialMaterialGuard<'_>,
+    ) {
+        self.restore_source_rollback_state_inner(
+            workspace_name,
+            source_name,
+            previous,
+            new_material_storage,
+            credential_material,
+            true,
+        );
+    }
+
     fn restore_source_rollback_state(
         &self,
         workspace_name: &WorkspaceName,
@@ -1054,6 +1080,25 @@ impl SourceManager {
         previous: Option<SourceRollbackState>,
         new_material_storage: Option<CredentialStorageKind>,
         credential_material: &CredentialMaterialGuard<'_>,
+    ) {
+        self.restore_source_rollback_state_inner(
+            workspace_name,
+            source_name,
+            previous,
+            new_material_storage,
+            credential_material,
+            false,
+        );
+    }
+
+    fn restore_source_rollback_state_inner(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        previous: Option<SourceRollbackState>,
+        new_material_storage: Option<CredentialStorageKind>,
+        credential_material: &CredentialMaterialGuard<'_>,
+        state_lock_held: bool,
     ) {
         if let Some(previous) = previous {
             let manifest_path = self.layout.manifest_file(workspace_name, source_name);
@@ -1077,22 +1122,36 @@ impl SourceManager {
             }
             match previous.credential_material {
                 Some(snapshot) => {
-                    if let Err(e) = credential_material.restore_material(&snapshot) {
+                    let restore_result = if state_lock_held {
+                        credential_material.restore_material_with_state_lock_held(&snapshot)
+                    } else {
+                        credential_material.restore_material(&snapshot)
+                    };
+                    if let Err(e) = restore_result {
                         warn!("rollback: failed to restore source credential material: {e}");
                     }
                 }
                 None => {
-                    if let Some(storage) = new_material_storage
-                        && let Err(e) = credential_material.remove_material(storage)
-                    {
-                        warn!("rollback: failed to remove new source credential material: {e}");
+                    if let Some(storage) = new_material_storage {
+                        let remove_result = if state_lock_held {
+                            credential_material.remove_material_with_state_lock_held(storage)
+                        } else {
+                            credential_material.remove_material(storage)
+                        };
+                        if let Err(e) = remove_result {
+                            warn!("rollback: failed to remove new source credential material: {e}");
+                        }
                     }
                 }
             }
-            if let Err(e) = self
-                .config_store
-                .upsert_source(workspace_name, previous.source)
-            {
+            let upsert_result = if state_lock_held {
+                self.config_store
+                    .upsert_source_unlocked(workspace_name, previous.source)
+            } else {
+                self.config_store
+                    .upsert_source(workspace_name, previous.source)
+            };
+            if let Err(e) = upsert_result {
                 warn!("rollback: failed to restore source config: {e}");
             }
         } else {
@@ -1102,10 +1161,15 @@ impl SourceManager {
             {
                 warn!("rollback: failed to remove source directory: {e}");
             }
-            if let Some(storage) = new_material_storage
-                && let Err(e) = credential_material.remove_material(storage)
-            {
-                warn!("rollback: failed to remove source credential material: {e}");
+            if let Some(storage) = new_material_storage {
+                let remove_result = if state_lock_held {
+                    credential_material.remove_material_with_state_lock_held(storage)
+                } else {
+                    credential_material.remove_material(storage)
+                };
+                if let Err(e) = remove_result {
+                    warn!("rollback: failed to remove source credential material: {e}");
+                }
             }
         }
     }
@@ -1487,6 +1551,7 @@ mod tests {
         ImportSourceCommand, ImportSourceEventSender, ImportSourceWithCredentialsCommand,
         ImportSourceWithCredentialsEvent, PendingImportSourceWithCredentialsEvent, SourceBinding,
         SourceBindings, SourceManager, SourceOAuthCredentialRetrieval, ValidatedBindings,
+        PersistSourceRequest,
         materialization_inputs_from_bindings, normalize_binding_key,
         source_needs_stored_material_for_validation,
     };
@@ -1495,6 +1560,7 @@ mod tests {
         CredentialStore,
     };
     use crate::sources::SourceName;
+    use crate::sources::catalog::describe_manifest;
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::WorkspaceName;
@@ -1722,6 +1788,92 @@ tables:
         type: Utf8
 "#
         .to_string()
+    }
+
+    #[test]
+    fn readd_source_waits_for_state_lock_before_replacing_manifest() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let manager = SourceManager::new(config_store.clone(), credential_manager, layout.clone());
+
+        let workspace_name = default_workspace();
+        let original_manifest = manifest_without_secrets();
+        manager
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: original_manifest.clone(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("initial import");
+
+        let source_name = SourceName::parse("public_messages").expect("source");
+        let manifest_path = layout.manifest_file(&workspace_name, &source_name);
+        let stored_before = std::fs::read_to_string(&manifest_path).expect("stored manifest");
+        let state_lock = config_store.state_lock_shared().expect("shared state lock");
+
+        let updated_manifest =
+            original_manifest.replace("https://example.com", "https://replacement.example.com");
+        let persist_manager = manager.clone();
+        let persist_workspace_name = workspace_name.clone();
+        let (started_tx, started_rx) = std_mpsc::channel();
+        let (done_tx, done_rx) = std_mpsc::channel();
+        let handle = thread::spawn(move || {
+            let candidate = describe_manifest(&updated_manifest, SourceOrigin::Imported, false)
+                .expect("describe manifest");
+            let bindings = ValidatedBindings {
+                variables: BTreeMap::new(),
+                secrets: BTreeMap::new(),
+                replaced_oauth_inputs: BTreeSet::new(),
+            };
+            started_tx.send(()).expect("send started");
+            let result = persist_manager
+                .persist_source(
+                    &persist_workspace_name,
+                    PersistSourceRequest {
+                        candidate: &candidate,
+                        manifest_yaml: Some(&updated_manifest),
+                        bindings,
+                        origin: SourceOrigin::Imported,
+                        credential_storage: None,
+                        materialization_tmp: None,
+                    },
+                )
+                .map(|source| source.name.as_str().to_string())
+                .map_err(|error| error.to_string());
+            done_tx.send(result).expect("send import result");
+        });
+
+        started_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("import thread should start");
+        match done_rx.recv_timeout(Duration::from_millis(300)) {
+            Err(std_mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std_mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("source re-add thread exited before sending a result")
+            }
+            Ok(result) => {
+                panic!("source re-add completed while shared state lock was held: {result:?}")
+            }
+        }
+        let stored_during_lock = std::fs::read_to_string(&manifest_path).expect("stored manifest");
+        assert_eq!(stored_during_lock, stored_before);
+
+        drop(state_lock);
+        let result = done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("source re-add should finish after releasing the state lock")
+            .expect("source re-add should succeed");
+        assert_eq!(result, "public_messages");
+        handle.join().expect("join source re-add thread");
+
+        let stored_after = std::fs::read_to_string(&manifest_path).expect("stored manifest");
+        assert!(stored_after.contains("https://replacement.example.com"));
     }
 
     fn manifest_with_oauth_secret(token_url: &str, redirect_port: u16) -> String {

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -21,7 +21,7 @@ pub(crate) struct CandidateSource {
 }
 
 /// App-owned model for one source installed in a workspace.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct InstalledSource {
     /// Bare installed source name.
     pub(crate) name: SourceName,

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -425,11 +425,6 @@ impl ConfigStore {
         self.load_unlocked()
     }
 
-    pub(crate) fn load_config(&self) -> Result<AppConfig, AppError> {
-        let _lock = self.state_lock_shared()?;
-        self.load_config_unlocked()
-    }
-
     /// Loads the source catalog without taking the app state lock.
     ///
     /// Callers must already hold the state lock in shared or exclusive mode
@@ -456,6 +451,7 @@ impl ConfigStore {
         Ok(result)
     }
 
+    #[cfg(test)]
     fn update_catalog<T>(
         &self,
         update: impl FnOnce(&mut SourceCatalog) -> T,
@@ -514,6 +510,7 @@ impl ConfigStore {
         self.update_catalog_unlocked(|catalog| catalog.upsert_source(workspace_name, source))
     }
 
+    #[cfg(test)]
     pub(crate) fn upsert_source(
         &self,
         workspace_name: &WorkspaceName,
@@ -522,12 +519,15 @@ impl ConfigStore {
         self.update_catalog(|catalog| catalog.upsert_source(workspace_name, source))
     }
 
-    pub(crate) fn remove_source(
+    /// Removes one installed source without taking the app state lock.
+    ///
+    /// Callers must already hold the state lock in exclusive mode.
+    pub(crate) fn remove_source_unlocked(
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<(), AppError> {
-        self.update_catalog(|catalog| {
+        self.update_catalog_unlocked(|catalog| {
             catalog.remove_source(workspace_name, source_name);
         })
     }

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -408,34 +408,60 @@ impl ConfigStore {
         Ok(())
     }
 
-    fn lock_shared(&self) -> Result<FileLock, AppError> {
+    pub(crate) fn state_lock_shared(&self) -> Result<FileLock, AppError> {
         FileLock::shared(self.layout.state_lock()).map_err(Into::into)
     }
 
-    fn lock_exclusive(&self) -> Result<FileLock, AppError> {
+    pub(crate) fn state_lock_exclusive(&self) -> Result<FileLock, AppError> {
         FileLock::exclusive(self.layout.state_lock()).map_err(Into::into)
     }
 
-    pub(crate) fn load_config(&self) -> Result<AppConfig, AppError> {
-        let _lock = self.lock_shared()?;
+    /// Loads the app config without taking the app state lock.
+    ///
+    /// Callers must already hold the state lock in shared or exclusive mode
+    /// while using any filesystem-backed source artifacts derived from the
+    /// returned config.
+    pub(crate) fn load_config_unlocked(&self) -> Result<AppConfig, AppError> {
         self.load_unlocked()
+    }
+
+    pub(crate) fn load_config(&self) -> Result<AppConfig, AppError> {
+        let _lock = self.state_lock_shared()?;
+        self.load_config_unlocked()
+    }
+
+    /// Loads the source catalog without taking the app state lock.
+    ///
+    /// Callers must already hold the state lock in shared or exclusive mode
+    /// while using any filesystem-backed source artifacts derived from the
+    /// returned catalog.
+    pub(crate) fn load_catalog_unlocked(&self) -> Result<SourceCatalog, AppError> {
+        self.load_config_unlocked().map(|config| config.catalog)
     }
 
     pub(crate) fn load_catalog(&self) -> Result<SourceCatalog, AppError> {
         let span = info_span!("coral.app.config.load_catalog");
         let _guard = span.enter();
-        self.load_config().map(|config| config.catalog)
+        let _lock = self.state_lock_shared()?;
+        self.load_catalog_unlocked()
+    }
+
+    fn update_catalog_unlocked<T>(
+        &self,
+        update: impl FnOnce(&mut SourceCatalog) -> T,
+    ) -> Result<T, AppError> {
+        let mut config = self.load_unlocked()?;
+        let result = update(&mut config.catalog);
+        self.save_unlocked(&config)?;
+        Ok(result)
     }
 
     fn update_catalog<T>(
         &self,
         update: impl FnOnce(&mut SourceCatalog) -> T,
     ) -> Result<T, AppError> {
-        let _lock = self.lock_exclusive()?;
-        let mut config = self.load_unlocked()?;
-        let result = update(&mut config.catalog);
-        self.save_unlocked(&config)?;
-        Ok(result)
+        let _lock = self.state_lock_exclusive()?;
+        self.update_catalog_unlocked(update)
     }
 
     pub(crate) fn list_workspace_sources(
@@ -454,14 +480,38 @@ impl ConfigStore {
             .map(|catalog| catalog.workspace_source_names(workspace_name))
     }
 
+    /// Loads one installed source without taking the app state lock.
+    ///
+    /// Callers must already hold the state lock while using source artifacts
+    /// associated with the returned config entry.
+    pub(crate) fn get_source_unlocked(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<InstalledSource, AppError> {
+        self.load_catalog_unlocked()?
+            .get_source(workspace_name, source_name)
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
+    }
+
     pub(crate) fn get_source(
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
-        self.load_catalog()?
-            .get_source(workspace_name, source_name)
-            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
+        let _lock = self.state_lock_shared()?;
+        self.get_source_unlocked(workspace_name, source_name)
+    }
+
+    /// Upserts one installed source without taking the app state lock.
+    ///
+    /// Callers must already hold the state lock in exclusive mode.
+    pub(crate) fn upsert_source_unlocked(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: InstalledSource,
+    ) -> Result<(), AppError> {
+        self.update_catalog_unlocked(|catalog| catalog.upsert_source(workspace_name, source))
     }
 
     pub(crate) fn upsert_source(


### PR DESCRIPTION
Fixes #1123.

Summary:
- Hold the app state lock across query-source config, manifest, v4 artifact, and credential-material reads.
- Hold the exclusive app state lock across source persistence: rollback snapshot, manifest write, credential update, v4 materialization swap, and config upsert.
- Add state-lock-held credential helpers for file-backed material writes to avoid recursive lock acquisition.
- Add a regression covering a source re-add racing a shared app-state reader.

Tests:
- cargo test -p coral-app readd_source_waits_for_state_lock_before_replacing_manifest
- cargo test -p coral-app import_v4_source_writes_materialized_artifacts
- cargo test -p coral-app load_query_source_passes_present_optional_secrets_to_runtime
- cargo test -p coral-app load_query_sources_fails_closed
- make rust-checks

Risks:
- Source re-add now serializes more filesystem reads and writes under the app state lock; this is intentional but may increase wait time during large v4 materialization swaps.

Project: https://github.com/orgs/withcoral/projects/1