### PR TITLE
perf(mcp): compact success tool text

### DIFF
--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -371,10 +371,10 @@ pub(crate) fn list_columns_arguments(
 }
 
 pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
-    let pretty = serde_json::to_string_pretty(&value)
+    let compact = serde_json::to_string(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
     let mut result = CallToolResult::structured(value);
-    result.content = vec![Content::text(pretty)];
+    result.content = vec![Content::text(compact)];
     Ok(result)
 }
 
@@ -799,9 +799,41 @@ fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{Map, Value};
+    use serde_json::{Map, Value, json};
 
-    use super::{list_catalog_arguments, search_catalog_arguments};
+    use super::{build_tool_result, list_catalog_arguments, search_catalog_arguments};
+
+    #[test]
+    fn success_tool_result_text_uses_compact_json() {
+        let value = json!({
+            "rows": [
+                {
+                    "id": 1,
+                    "text": "hello"
+                },
+                {
+                    "id": 2,
+                    "text": "world"
+                }
+            ]
+        });
+
+        let result = build_tool_result(value.clone()).expect("tool result");
+
+        let text = result
+            .content
+            .first()
+            .and_then(|content| content.as_text())
+            .expect("text content");
+        assert_eq!(
+            text.text,
+            r#"{"rows":[{"id":1,"text":"hello"},{"id":2,"text":"world"}]}"#
+        );
+        assert_eq!(
+            result.structured_content.expect("structured content"),
+            value
+        );
+    }
 
     #[test]
     fn catalog_kind_argument_accepts_null_as_all_kinds() {


### PR DESCRIPTION
## Intent

Make successful MCP tool-result text cheaper without changing the structured MCP contract. This changes only the fallback `content[0].text` rendering from pretty JSON to compact JSON. `structuredContent` remains the same value.

## Why this slice

Headroom's useful lesson here is the boring one: first remove non-information-bearing formatting, then measure on real tool calls. This is lossless text formatting compaction; it does not drop keys, rows, or values.

## Real live token measurement

Command used from the benchmark branch after this stack was restacked:

```shell
cargo run --locked -p xtask -- mcp-token-bench --coral-bin /tmp/coral-token-bins/coral-main --json
cargo run --locked -p xtask -- mcp-token-bench --coral-bin /tmp/coral-token-bins/coral-pr1 --json
```

- Config: default live Coral config
- Transport: real `coral mcp-stdio`
- Tokenizer: `gpt-5` / `o200k_base`
- Cases: 16 live MCP `tools/call` requests covering discovery, SQL, empty result, and error result

Totals:

| Metric | Before | After | Saved | Savings |
|---|---:|---:|---:|---:|
| Text tokens | 57524 | 38898 | 18626 | 32.4% |
| Protocol result tokens | 107432 | 80312 | 27120 | 25.2% |

Per-case text tokens:

| case | tool | baseline text | pr1 text | savings | protocol savings |
|---|---|---:|---:|---:|---:|
| `discovery.search.github_pull` | `search_catalog` | 3612 | 2372 | 1240 | 1768 |
| `discovery.search.slack_messages` | `search_catalog` | 8343 | 6172 | 2171 | 3228 |
| `discovery.search.table_functions` | `search_catalog` | 15356 | 10222 | 5134 | 7682 |
| `discovery.list.github_tables` | `list_catalog` | 2335 | 1614 | 721 | 1014 |
| `discovery.list.table_functions` | `list_catalog` | 12436 | 8195 | 4241 | 6271 |
| `discovery.columns.github_pulls` | `list_columns` | 3137 | 2030 | 1107 | 1534 |
| `discovery.columns.github_pulls_required` | `list_columns` | 188 | 123 | 65 | 90 |
| `discovery.columns.github_pulls_search` | `list_columns` | 1620 | 1030 | 590 | 843 |
| `discovery.describe.github_pulls` | `describe_table` | 207 | 176 | 31 | 44 |
| `sql.wide_coral_tables` | `sql` | 1837 | 1413 | 424 | 568 |
| `sql.narrow_many_tables` | `sql` | 1099 | 595 | 504 | 658 |
| `sql.long_catalog_text` | `sql` | 1332 | 1008 | 324 | 428 |
| `sql.github_pulls_columns` | `sql` | 5211 | 3432 | 1779 | 2558 |
| `sql.empty_result` | `sql` | 7 | 4 | 3 | 6 |
| `sql.headroom_contents` | `sql` | 756 | 464 | 292 | 428 |
| `sql.invalid_statement` | `sql` | 48 | 48 | 0 | 0 |

## Actual output examples

Abbreviated actual MCP `content[0].text` outputs from the same live runs.

#### `discovery.search.github_pull`

Before:
```text
{\n  "items": [\n    {\n      "kind": "table_function",\n      "schema_name": "datadog",\n      "name": "datadog.apm_dependencies",\n      "sql_reference": "datadog.apm_dependencies",\n      "sql_call_example": "datadog.apm_dependencies(service => '<value>')",\n      "description": "Datadog APM service dependencies for a target service.",\n      "table_funct ...
```
After:
```text
{"items":[{"kind":"table_function","schema_name":"datadog","name":"datadog.apm_dependencies","sql_reference":"datadog.apm_dependencies","sql_call_example":"datadog.apm_dependencies(service => '<value>')","description":"Datadog APM service dependencies for a target service.","table_function":{"function_name":"apm_dependencies","arguments":[{"name":"service"," ...
```

#### `discovery.columns.github_pulls`

Before:
```text
{\n  "schema_name": "github",\n  "table_name": "pulls",\n  "columns": [\n    {\n      "column_name": "_links",\n      "data_type": "Utf8",\n      "is_nullable": true,\n      "is_virtual": false,\n      "is_required_filter": false,\n      "description": "",\n      "ordinal_position": 0\n    },\n    {\n      "column_name": "_links__comments",\n      "data_type ...
```
After:
```text
{"schema_name":"github","table_name":"pulls","columns":[{"column_name":"_links","data_type":"Utf8","is_nullable":true,"is_virtual":false,"is_required_filter":false,"description":"","ordinal_position":0},{"column_name":"_links__comments","data_type":"Utf8","is_nullable":true,"is_virtual":false,"is_required_filter":false,"description":"Hypermedia Link","ordina ...
```

#### `sql.github_pulls_columns`

Before:
```text
{\n  "rows": [\n    {\n      "schema_name": "github",\n      "table_name": "pulls",\n      "column_name": "_links",\n      "data_type": "Utf8",\n      "description": ""\n    },\n    {\n      "schema_name": "github",\n      "table_name": "pulls",\n      "column_name": "_links__comments",\n      "data_type": "Utf8",\n      "description": "Hypermedia Link"\n    ...
```
After:
```text
{"rows":[{"schema_name":"github","table_name":"pulls","column_name":"_links","data_type":"Utf8","description":""},{"schema_name":"github","table_name":"pulls","column_name":"_links__comments","data_type":"Utf8","description":"Hypermedia Link"},{"schema_name":"github","table_name":"pulls","column_name":"_links__comments__href","data_type":"Utf8","description" ...
```

#### `sql.invalid_statement`

Error text is intentionally unchanged:

```text
Error: Query request is invalid\nDetail: invalid input: DML not supported: Delete\nHint: Check the SQL and retry. Use `coral://guide`, `coral.tables`, and `coral.columns` for discovery.
```

## Validation

- `cargo test --locked -p coral-mcp`
- `make docs-check`
- `make rust-checks`
- Live benchmark reports: `/tmp/coral-token-main.json`, `/tmp/coral-token-pr1.json`
