### PR TITLE
perf(mcp): compact sql text rows

### DIFF
--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -26,13 +26,13 @@ use tonic::Request;
 use crate::{
     McpOptions,
     surface::{
-        CatalogToolKind, build_tool_result, describe_table_arguments, describe_table_tool,
-        describe_table_value, feedback_tool, guide_resource, guide_resource_content,
-        initial_instructions, list_catalog_arguments, list_catalog_tool, list_catalog_value,
-        list_columns_arguments, list_columns_tool, list_columns_value, required_string_argument,
-        search_catalog_arguments, search_catalog_tool, search_catalog_value, sql_tool,
-        status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
-        tool_error_result,
+        CatalogToolKind, build_tool_result, build_tool_result_with_text, describe_table_arguments,
+        describe_table_tool, describe_table_value, feedback_tool, guide_resource,
+        guide_resource_content, initial_instructions, list_catalog_arguments, list_catalog_tool,
+        list_catalog_value, list_columns_arguments, list_columns_tool, list_columns_value,
+        required_string_argument, search_catalog_arguments, search_catalog_tool,
+        search_catalog_value, sql_tool, status_to_error_data, tables_resource,
+        tables_resource_content, tool_error_from_status, tool_error_result,
     },
     telemetry,
 };
@@ -44,7 +44,10 @@ const CATALOG_KIND_TABLE: ProtoCatalogItemKind = ProtoCatalogItemKind::Table;
 const CATALOG_KIND_TABLE_FUNCTION: ProtoCatalogItemKind = ProtoCatalogItemKind::TableFunction;
 
 enum ToolCallOutcome {
-    Success(Value),
+    Success {
+        value: Value,
+        text: Option<String>,
+    },
     ToolError {
         operation: &'static str,
         status: tonic::Status,
@@ -54,6 +57,13 @@ enum ToolCallOutcome {
 #[derive(Serialize)]
 struct SqlRowsValue {
     rows: Vec<Value>,
+}
+
+#[derive(Serialize)]
+struct CompactSqlRowsText {
+    columns: Vec<String>,
+    rows: Vec<Vec<Value>>,
+    row_count: usize,
 }
 
 #[derive(Serialize)]
@@ -67,10 +77,61 @@ fn serialize_tool_value(value: impl Serialize) -> Result<Value, tonic::Status> {
     serde_json::to_value(value).map_err(|error| tonic::Status::internal(error.to_string()))
 }
 
+fn serialize_tool_text(value: impl Serialize) -> Result<String, tonic::Status> {
+    serde_json::to_string(&value).map_err(|error| tonic::Status::internal(error.to_string()))
+}
+
+fn compact_sql_rows_text(rows: &[Value]) -> Result<String, tonic::Status> {
+    let Some(columns) = sql_row_columns(rows) else {
+        return serialize_tool_text(SqlRowsValue {
+            rows: rows.to_vec(),
+        });
+    };
+    let mut compact_rows = Vec::with_capacity(rows.len());
+    for row in rows {
+        let object = row.as_object().expect("columns require object rows");
+        compact_rows.push(
+            columns
+                .iter()
+                .map(|column| object.get(column).cloned().unwrap_or(Value::Null))
+                .collect(),
+        );
+    }
+    serialize_tool_text(CompactSqlRowsText {
+        columns,
+        rows: compact_rows,
+        row_count: rows.len(),
+    })
+}
+
+fn sql_row_columns(rows: &[Value]) -> Option<Vec<String>> {
+    let mut columns = Vec::new();
+    for row in rows {
+        let object = row.as_object()?;
+        for column in object.keys() {
+            if !columns.iter().any(|existing| existing == column) {
+                columns.push(column.clone());
+            }
+        }
+    }
+    Some(columns)
+}
+
 impl ToolCallOutcome {
+    fn success(value: Value) -> Self {
+        Self::Success { value, text: None }
+    }
+
+    fn success_with_text(value: Value, text: String) -> Self {
+        Self::Success {
+            value,
+            text: Some(text),
+        }
+    }
+
     fn from_value_result(operation: &'static str, result: Result<Value, tonic::Status>) -> Self {
         match result {
-            Ok(value) => Self::Success(value),
+            Ok(value) => Self::success(value),
             Err(status) => Self::ToolError { operation, status },
         }
     }
@@ -230,10 +291,11 @@ impl CoralMcpServer {
             .map_err(|error| tonic::Status::internal(error.to_string()))
     }
 
-    async fn execute_sql_value(&self, sql: &str) -> Result<Value, tonic::Status> {
-        serialize_tool_value(SqlRowsValue {
-            rows: self.query_rows(sql).await?,
-        })
+    async fn execute_sql_tool_outcome(&self, sql: &str) -> Result<ToolCallOutcome, tonic::Status> {
+        let rows = self.query_rows(sql).await?;
+        let text = compact_sql_rows_text(&rows)?;
+        let value = serialize_tool_value(SqlRowsValue { rows })?;
+        Ok(ToolCallOutcome::success_with_text(value, text))
     }
 
     async fn submit_feedback_value(
@@ -283,7 +345,7 @@ impl CoralMcpServer {
             .await
             .map(|response| search_catalog_value(&response.into_inner()))
         {
-            Ok(value) => Ok(ToolCallOutcome::Success(value)),
+            Ok(value) => Ok(ToolCallOutcome::success(value)),
             Err(status) if status.code() == tonic::Code::InvalidArgument => {
                 Err(status_to_error_data(&status))
             }
@@ -327,7 +389,7 @@ impl CoralMcpServer {
             .load_table_description(&arguments.schema, &arguments.table)
             .await
         {
-            Ok(response) => Ok(ToolCallOutcome::Success(describe_table_value(
+            Ok(response) => Ok(ToolCallOutcome::success(describe_table_value(
                 &arguments.schema,
                 &arguments.table,
                 &response,
@@ -346,10 +408,13 @@ impl CoralMcpServer {
         match request.name.as_ref() {
             "sql" => {
                 let sql = required_string_argument(request.arguments.as_ref(), "sql")?;
-                Ok(ToolCallOutcome::from_value_result(
-                    "Query",
-                    self.execute_sql_value(&sql).await,
-                ))
+                match self.execute_sql_tool_outcome(&sql).await {
+                    Ok(outcome) => Ok(outcome),
+                    Err(status) => Ok(ToolCallOutcome::ToolError {
+                        operation: "Query",
+                        status,
+                    }),
+                }
             }
             "list_catalog" => {
                 self.list_catalog_tool_result(request.arguments.as_ref())
@@ -406,7 +471,7 @@ impl CoralMcpServer {
             }))
             .await
         {
-            Ok(response) => Ok(ToolCallOutcome::Success(list_columns_value(
+            Ok(response) => Ok(ToolCallOutcome::success(list_columns_value(
                 &arguments.schema,
                 &arguments.table,
                 &response.into_inner(),
@@ -419,7 +484,7 @@ impl CoralMcpServer {
                     .load_table_description(&arguments.schema, &arguments.table)
                     .await
                 {
-                    Ok(response) => Ok(ToolCallOutcome::Success(describe_table_value(
+                    Ok(response) => Ok(ToolCallOutcome::success(describe_table_value(
                         &arguments.schema,
                         &arguments.table,
                         &response,
@@ -557,8 +622,11 @@ fn finish_tool_call(
     outcome: Result<ToolCallOutcome, ErrorData>,
 ) -> Result<CallToolResult, ErrorData> {
     match outcome {
-        Ok(ToolCallOutcome::Success(value)) => {
-            let result = build_tool_result(value);
+        Ok(ToolCallOutcome::Success { value, text }) => {
+            let result = match text {
+                Some(text) => Ok(build_tool_result_with_text(value, text)),
+                None => build_tool_result(value),
+            };
             telemetry::record_protocol_result(span, &result);
             result
         }

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -17,8 +17,8 @@ pub(crate) use resources::{
     tables_resource_content,
 };
 pub(crate) use tools::{
-    CatalogToolKind, build_tool_result, describe_table_arguments, describe_table_tool,
-    feedback_tool, list_catalog_arguments, list_catalog_tool, list_columns_arguments,
-    list_columns_tool, required_string_argument, search_catalog_arguments, search_catalog_tool,
-    sql_tool,
+    CatalogToolKind, build_tool_result, build_tool_result_with_text, describe_table_arguments,
+    describe_table_tool, feedback_tool, list_catalog_arguments, list_catalog_tool,
+    list_columns_arguments, list_columns_tool, required_string_argument, search_catalog_arguments,
+    search_catalog_tool, sql_tool,
 };

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -373,9 +373,13 @@ pub(crate) fn list_columns_arguments(
 pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
     let compact = serde_json::to_string(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+    Ok(build_tool_result_with_text(value, compact))
+}
+
+pub(crate) fn build_tool_result_with_text(value: Value, text: String) -> CallToolResult {
     let mut result = CallToolResult::structured(value);
-    result.content = vec![Content::text(compact)];
-    Ok(result)
+    result.content = vec![Content::text(text)];
+    result
 }
 
 fn sql_tool_description(visible_table_count: usize) -> String {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -1027,14 +1027,30 @@ async fn mcp_tool_error_does_not_end_session() {
     let sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "SELECT text FROM local_messages.messages ORDER BY text"
+                "sql": "SELECT type, text FROM local_messages.messages ORDER BY text"
             }))),
         )
         .await
         .expect("sql");
     assert_eq!(
-        sql.structured_content.expect("structured content")["rows"][0]["text"],
-        "hello"
+        sql.content[0].as_text().expect("text content").text,
+        r#"{"columns":["type","text"],"rows":[["user","hello"],["assistant","world"]],"row_count":2}"#
+    );
+    let rows = &sql.structured_content.expect("structured content")["rows"];
+    assert_eq!(rows[0]["type"], "user");
+    assert_eq!(rows[0]["text"], "hello");
+    assert_eq!(
+        rows,
+        &json!([
+            {
+                "type": "user",
+                "text": "hello"
+            },
+            {
+                "type": "assistant",
+                "text": "world"
+            }
+        ])
     );
     assert_eq!(sql.is_error, Some(false));
 

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -60,7 +60,27 @@ Some sources expose native search endpoints (for example, GitHub issue search) a
 
 ## Query result format
 
-The `sql` tool returns rows as a JSON array of objects. To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
+The `sql` tool returns full row objects in MCP `structuredContent`:
+
+```json
+{
+  "rows": [{ "name": "github", "table_count": 42 }]
+}
+```
+
+The duplicate text content uses a compact column-array view to save tokens:
+
+```json
+{
+  "columns": ["name", "table_count"],
+  "rows": [["github", 42]],
+  "row_count": 1
+}
+```
+
+The two views contain the same values. Use `structuredContent.rows` when your client needs the object-shaped contract; use the text content when your client is feeding the result directly to a model.
+
+To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
 
 - `Int64` (`BIGINT`) and `UInt64`
 - `Decimal32`, `Decimal64`, `Decimal128`, and `Decimal256`


### PR DESCRIPTION
## What changed

This makes successful `sql` MCP text output use a compact rowset view:

```json
{"columns":["name","type"],"rows":[[".actrc","file"]],"row_count":1}
```

`structuredContent.rows` remains the full array of row objects. Catalog and discovery tools keep the compact JSON text from the previous PR.

## Why

Headroom's SmartCrusher pattern is useful here: tabular data repeats the same field names on every row. For model-facing text, a `columns` array plus row arrays preserves the values while dropping repeated keys. The structured MCP contract stays object-shaped for clients that need it.

## Output examples

This PR changes successful `sql` MCP `content[0].text` only. Discovery tool text is unchanged from the previous PR. `structuredContent.rows` remains the full array of row objects.

Real `sql.headroom_contents` sample, trimmed to two rows from `chopratejas/headroom`:

```diff
-{"rows":[{"name":".actrc","type":"file","path":".actrc","size":"382"},{"name":".actrc.local.example","type":"file","path":".actrc.local.example","size":"538"}]}
+{"columns":["name","type","path","size"],"rows":[[".actrc","file",".actrc","382"],[".actrc.local.example","file",".actrc.local.example","538"]],"row_count":20}
```

Real `sql.schema_descriptions` sample, trimmed to two rows:

```diff
-{"rows":[{"schema_name":"github","table_name":"accepted_assignments","description":"List accepted assignments for an assignment"},{"schema_name":"github","table_name":"access","description":"Get the level of access for workflows outside of the repository"}]}
+{"columns":["schema_name","table_name","description"],"rows":[["github","accepted_assignments","List accepted assignments for an assignment"],["github","access","Get the level of access for workflows outside of the repository"]],"row_count":20}
```

Real `sql.coral_tables` sample, with long guides abbreviated here:

```diff
-{"rows":[{"schema_name":"datadog","table_name":"dashboards","description":"Datadog dashboards","guide":"Use this table for dashboard inventory ...\n","required_filters":"","search_limits_json":null},{"schema_name":"datadog","table_name":"downtimes","description":"Datadog scheduled downtimes","guide":"Use this table for maintenance-window ...\n","required_filters":"","search_limits_json":null}]}
+{"columns":["schema_name","table_name","description","guide","required_filters","search_limits_json"],"rows":[["datadog","dashboards","Datadog dashboards","Use this table for dashboard inventory ...\n","",null],["datadog","downtimes","Datadog scheduled downtimes","Use this table for maintenance-window ...\n","",null]],"row_count":20}
```

## Token evidence

Token counts are actual `gpt-5` / `o200k_base` tokenizer counts from real `coral mcp-stdio` calls against the live Coral config. The sampled calls include `search_catalog`, `list_catalog`, `list_columns`, and three `sql` queries, including `github.contents` against `chopratejas/headroom`. `Text` is MCP `content[0].text`; `Protocol` is the compact serialized MCP `result` object.

| Case | Tool | Text before | Text after | Protocol before | Protocol after |
|---|---|---:|---:|---:|---:|
| `discovery.search.github_pull` | `search_catalog` | 2,372 | 2,372 | 4,933 | 4,933 |
| `discovery.search.slack_messages` | `search_catalog` | 6,172 | 6,172 | 12,701 | 12,701 |
| `discovery.list.github_tables` | `list_catalog` | 1,614 | 1,614 | 3,318 | 3,318 |
| `discovery.columns.github_pulls` | `list_columns` | 2,030 | 2,030 | 4,168 | 4,168 |
| `sql.coral_tables` | `sql` | 1,413 | 1,128 | 2,901 | 2,590 |
| `sql.schema_descriptions` | `sql` | 416 | 291 | 892 | 752 |
| `sql.headroom_contents` | `sql` | 464 | 323 | 988 | 848 |
| **Total** |  | **14,481** | **13,930** | **29,901** | **29,310** |

Aggregate savings for this PR over PR1: text `14,481 -> 13,930` tokens, protocol result `29,901 -> 29,310` tokens. On the three SQL calls alone, text drops `2,293 -> 1,742` tokens.

## Validation

- `cargo test --locked -p coral-mcp mcp_`
- `make docs-check`
- `make rust-checks`
- `cargo run --locked -p xtask -- mcp-token-bench --coral-bin target/debug/coral` on the top of the stack
