### PR TITLE
chore(xtask): benchmark MCP model surface tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,11 @@
   latency. CI installs the bundled `github` source with fake credentials and
   fails when release `coral sql "select * from coral.tables"` has a hyperfine
   mean above 750 ms.
+- Run `cargo run --locked -p xtask -- mcp-token-bench --coral-bin target/debug/coral`
+  when validating MCP model-surface token efficiency changes, including
+  initialization, tool/resource listings, resource reads, and tool-call
+  results. The command uses the real live Coral config by default; pass
+  `--config-dir` only for explicit fixture work.
 - `make rust-checks` is the Rust-only local gate and should keep using
   `--all-features`; the embedded UI feature is a normal CLI build surface.
 - The built UI artifact is produced by repo/CI orchestration (`make ui-build`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -800,6 +809,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -2496,7 +2511,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -3307,7 +3333,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bytecount",
- "fancy-regex",
+ "fancy-regex 0.13.0",
  "fraction",
  "getrandom 0.2.17",
  "iso8601",
@@ -5407,6 +5433,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiktoken-rs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex 0.17.0",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6702,6 +6743,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tiktoken-rs",
  "walkdir",
 ]
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -20,6 +20,7 @@ pulldown-cmark = { version = "0.13", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+tiktoken-rs = "0.12"
 walkdir.workspace = true
 
 coral-spec.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,7 @@
 //!   - `export-skills` exports installable agent skills from the canonical
 //!     plugin tree into a distribution checkout.
 //!   - `perf-check` runs command-level performance regression checks.
+//!   - `mcp-token-bench` measures MCP model-surface token counts.
 //!   - `generate-schemas` refreshes checked-in generated JSON schemas.
 
 #![allow(
@@ -50,6 +51,8 @@ enum Command {
     ExportSkills(ExportSkillsArgs),
     /// Run command-level performance regression checks.
     PerfCheck(perf::Args),
+    /// Measure MCP tool result token counts against a live Coral config.
+    McpTokenBench(perf::McpTokenBenchArgs),
     /// Regenerate checked-in generated JSON schemas.
     GenerateSchemas(schemas::Args),
 }
@@ -99,6 +102,7 @@ fn run(command: &Command) -> Result<bool> {
         }
         Command::ExportSkills(args) => skills::export(&args.dest),
         Command::PerfCheck(args) => perf::run(args),
+        Command::McpTokenBench(args) => perf::run_mcp_token_bench(args),
         Command::GenerateSchemas(args) => schemas::run(args),
     }
 }

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -1,13 +1,15 @@
 //! Performance regression checks for user-visible Coral commands.
 
 use std::fs;
-use std::io::ErrorKind;
+use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
-use serde_json::Value;
+use serde::Serialize;
+use serde_json::{Value, json};
+use tiktoken_rs::CoreBPE;
 
 const DEFAULT_SQL: &str = "select * from coral.tables";
 
@@ -32,6 +34,25 @@ pub(crate) struct Args {
     /// Fake token used to install the GitHub source without real credentials.
     #[arg(long, default_value = "coral-ci-fake-token")]
     github_token: String,
+}
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct McpTokenBenchArgs {
+    /// Path to the Coral binary to run as an MCP stdio server.
+    #[arg(long, default_value = "target/debug/coral")]
+    coral_bin: PathBuf,
+
+    /// Optional config directory. Omit this to use the real live Coral config.
+    #[arg(long)]
+    config_dir: Option<PathBuf>,
+
+    /// Model name used to select the tokenizer.
+    #[arg(long, default_value = "gpt-5")]
+    model: String,
+
+    /// Emit JSON instead of a Markdown table.
+    #[arg(long)]
+    json: bool,
 }
 
 pub(crate) fn run(args: &Args) -> Result<bool> {
@@ -73,6 +94,39 @@ pub(crate) fn run(args: &Args) -> Result<bool> {
     Ok(true)
 }
 
+pub(crate) fn run_mcp_token_bench(args: &McpTokenBenchArgs) -> Result<bool> {
+    let coral_bin = absolute_path(&args.coral_bin)?;
+    ensure_executable(&coral_bin)?;
+    let tokenizer = tiktoken_rs::bpe_for_model(&args.model)
+        .with_context(|| format!("loading tokenizer for model {}", args.model))?;
+    let mut client = McpStdioClient::start(&coral_bin, args.config_dir.as_deref())?;
+    client.initialize()?;
+
+    let rows: Vec<McpTokenBenchRow> = default_mcp_token_cases()
+        .iter()
+        .map(|case| measure_mcp_token_case(&mut client, tokenizer, case))
+        .collect::<Result<_>>()?;
+
+    let report = McpTokenBenchReport {
+        model: args.model.clone(),
+        coral_bin: coral_bin.display().to_string(),
+        config_dir: args.config_dir.as_ref().map_or_else(
+            || "default live Coral config".to_string(),
+            |path| path.display().to_string(),
+        ),
+        rows,
+    };
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).context("serializing token bench report")?
+        );
+    } else {
+        print_mcp_token_report(&report);
+    }
+    Ok(true)
+}
+
 fn validate_args(args: &Args) -> Result<()> {
     if args.max_mean_seconds <= 0.0 {
         bail!("--max-mean-seconds must be positive");
@@ -81,6 +135,321 @@ fn validate_args(args: &Args) -> Result<()> {
         bail!("--runs must be positive");
     }
     Ok(())
+}
+
+fn measure_mcp_token_case(
+    client: &mut McpStdioClient,
+    tokenizer: &CoreBPE,
+    case: &McpTokenCase,
+) -> Result<McpTokenBenchRow> {
+    let response = match &case.request {
+        McpTokenRequest::Tool { name, arguments } => client.call_tool(name, arguments)?,
+        McpTokenRequest::Request { method, params, .. } => client.request(method, params)?,
+    };
+    if let Some(error) = response.get("error") {
+        return Ok(McpTokenBenchRow {
+            case: case.name.to_string(),
+            surface: case.request.surface().to_string(),
+            model_surface_tokens: None,
+            model_surface_chars: None,
+            protocol_result_tokens: None,
+            protocol_result_chars: None,
+            is_error: None,
+            error: Some(error.to_string()),
+        });
+    }
+    let result = response
+        .get("result")
+        .with_context(|| format!("MCP {} response missing result", case.request.surface()))?;
+    let model_surface = case.request.model_surface(result)?;
+    let protocol_result = serde_json::to_string(result).context("serializing MCP result")?;
+    Ok(McpTokenBenchRow {
+        case: case.name.to_string(),
+        surface: case.request.surface().to_string(),
+        model_surface_tokens: Some(tokenizer.encode_with_special_tokens(&model_surface).len()),
+        model_surface_chars: Some(model_surface.chars().count()),
+        protocol_result_tokens: Some(tokenizer.encode_with_special_tokens(&protocol_result).len()),
+        protocol_result_chars: Some(protocol_result.chars().count()),
+        is_error: Some(
+            result
+                .get("isError")
+                .or_else(|| result.get("is_error"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        ),
+        error: None,
+    })
+}
+
+fn default_mcp_token_cases() -> Vec<McpTokenCase> {
+    let mut cases = mcp_context_token_cases();
+    cases.extend(discovery_mcp_token_cases());
+    cases.extend(sql_mcp_token_cases());
+    cases
+}
+
+fn mcp_context_token_cases() -> Vec<McpTokenCase> {
+    vec![
+        McpTokenCase {
+            name: "context.initialize",
+            request: McpTokenRequest::Request {
+                method: "initialize",
+                params: json!({
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "coral-mcp-token-bench-context",
+                        "version": "0.0.0"
+                    }
+                }),
+                surface: McpModelSurface::Result,
+            },
+        },
+        McpTokenCase {
+            name: "context.tools_list",
+            request: McpTokenRequest::Request {
+                method: "tools/list",
+                params: json!({}),
+                surface: McpModelSurface::Result,
+            },
+        },
+        McpTokenCase {
+            name: "context.resources_list",
+            request: McpTokenRequest::Request {
+                method: "resources/list",
+                params: json!({}),
+                surface: McpModelSurface::Result,
+            },
+        },
+        McpTokenCase {
+            name: "context.resource_guide",
+            request: McpTokenRequest::Request {
+                method: "resources/read",
+                params: json!({
+                    "uri": "coral://guide"
+                }),
+                surface: McpModelSurface::ResourceText,
+            },
+        },
+        McpTokenCase {
+            name: "context.resource_tables",
+            request: McpTokenRequest::Request {
+                method: "resources/read",
+                params: json!({
+                    "uri": "coral://tables"
+                }),
+                surface: McpModelSurface::ResourceText,
+            },
+        },
+    ]
+}
+
+fn discovery_mcp_token_cases() -> Vec<McpTokenCase> {
+    vec![
+        McpTokenCase {
+            name: "discovery.search.github_pull",
+            request: tool_case(
+                "search_catalog",
+                json!({
+                    "pattern": "github|pull|request|pr",
+                    "limit": 20
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "discovery.search.slack_messages",
+            request: tool_case(
+                "search_catalog",
+                json!({
+                    "pattern": "slack|message|channel",
+                    "limit": 20
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "discovery.search.table_functions",
+            request: tool_case(
+                "search_catalog",
+                json!({
+                    "pattern": "logs|events|search",
+                    "kind": "table_function",
+                    "limit": 20
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "discovery.list.github_tables",
+            request: tool_case(
+                "list_catalog",
+                json!({
+                    "schema": "github",
+                    "kind": "table",
+                    "limit": 20
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "discovery.list.table_functions",
+            request: tool_case(
+                "list_catalog",
+                json!({
+                    "kind": "table_function",
+                    "limit": 20
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "discovery.columns.github_pulls",
+            request: tool_case(
+                "list_columns",
+                json!({
+                    "schema": "github",
+                    "table": "pulls",
+                    "limit": 50
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "discovery.columns.github_pulls_required",
+            request: tool_case(
+                "list_columns",
+                json!({
+                    "schema": "github",
+                    "table": "pulls",
+                    "required_only": true,
+                    "limit": 50
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "discovery.columns.github_pulls_search",
+            request: tool_case(
+                "list_columns",
+                json!({
+                    "schema": "github",
+                    "table": "pulls",
+                    "pattern": "body|title|state|user",
+                    "limit": 20
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "discovery.describe.github_pulls",
+            request: tool_case(
+                "describe_table",
+                json!({
+                    "schema": "github",
+                    "table": "pulls"
+                }),
+            ),
+        },
+    ]
+}
+
+fn sql_mcp_token_cases() -> Vec<McpTokenCase> {
+    vec![
+        McpTokenCase {
+            name: "sql.wide_coral_tables",
+            request: tool_case(
+                "sql",
+                json!({
+                    "sql": "SELECT * FROM coral.tables LIMIT 20"
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "sql.narrow_many_tables",
+            request: tool_case(
+                "sql",
+                json!({
+                    "sql": "SELECT schema_name, table_name FROM coral.tables LIMIT 50"
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "sql.long_catalog_text",
+            request: tool_case(
+                "sql",
+                json!({
+                    "sql": "SELECT schema_name, table_name, description, guide FROM coral.tables WHERE schema_name IN ('github','slack') LIMIT 20"
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "sql.github_pulls_columns",
+            request: tool_case(
+                "sql",
+                json!({
+                    "sql": "SELECT schema_name, table_name, column_name, data_type, description FROM coral.columns WHERE schema_name = 'github' AND table_name = 'pulls' LIMIT 100"
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "sql.empty_result",
+            request: tool_case(
+                "sql",
+                json!({
+                    "sql": "SELECT schema_name, table_name FROM coral.tables WHERE schema_name = 'definitely_nope' LIMIT 20"
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "sql.headroom_contents",
+            request: tool_case(
+                "sql",
+                json!({
+                    "sql": "SELECT name, type, path, size FROM github.contents WHERE owner = 'chopratejas' AND repo = 'headroom' AND path = '' LIMIT 20"
+                }),
+            ),
+        },
+        McpTokenCase {
+            name: "sql.invalid_statement",
+            request: tool_case(
+                "sql",
+                json!({
+                    "sql": "DELETE FROM coral.tables"
+                }),
+            ),
+        },
+    ]
+}
+
+fn print_mcp_token_report(report: &McpTokenBenchReport) {
+    println!("model: {}", report.model);
+    println!("coral_bin: {}", report.coral_bin);
+    println!("config_dir: {}", report.config_dir);
+    println!(
+        "| case | surface | is error | model surface tokens | model surface chars | protocol result tokens | protocol result chars |"
+    );
+    println!("|---|---:|---:|---:|---:|---:|---:|");
+    for row in &report.rows {
+        match row.model_surface_tokens {
+            Some(model_surface_tokens) => println!(
+                "| {} | {} | {} | {} | {} | {} | {} |",
+                row.case,
+                row.surface,
+                row.is_error.unwrap_or(false),
+                model_surface_tokens,
+                row.model_surface_chars.unwrap_or_default(),
+                row.protocol_result_tokens.unwrap_or_default(),
+                row.protocol_result_chars.unwrap_or_default()
+            ),
+            None => println!("| {} | {} | | ERROR | | | |", row.case, row.surface),
+        }
+    }
+    let total_model_surface_tokens: usize = report
+        .rows
+        .iter()
+        .filter_map(|row| row.model_surface_tokens)
+        .sum();
+    let total_protocol_result_tokens: usize = report
+        .rows
+        .iter()
+        .filter_map(|row| row.protocol_result_tokens)
+        .sum();
+    println!();
+    println!("total_model_surface_tokens: {total_model_surface_tokens}");
+    println!("total_protocol_result_tokens: {total_protocol_result_tokens}");
 }
 
 fn require_command(command: &str) -> Result<()> {
@@ -232,6 +601,206 @@ fn shell_quote(value: &str) -> String {
 struct HyperfineResult {
     mean: f64,
     stddev: f64,
+}
+
+struct McpTokenCase {
+    name: &'static str,
+    request: McpTokenRequest,
+}
+
+enum McpTokenRequest {
+    Tool {
+        name: &'static str,
+        arguments: Value,
+    },
+    Request {
+        method: &'static str,
+        params: Value,
+        surface: McpModelSurface,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum McpModelSurface {
+    Result,
+    ResourceText,
+}
+
+fn tool_case(name: &'static str, arguments: Value) -> McpTokenRequest {
+    McpTokenRequest::Tool { name, arguments }
+}
+
+impl McpTokenRequest {
+    fn surface(&self) -> &str {
+        match self {
+            Self::Tool { name, .. } => name,
+            Self::Request { method, .. } => method,
+        }
+    }
+
+    fn model_surface(&self, result: &Value) -> Result<String> {
+        match self {
+            Self::Tool { .. } => Ok(model_text_from_tool_result(result)),
+            Self::Request { surface, .. } => match surface {
+                McpModelSurface::Result => {
+                    serde_json::to_string(result).context("serializing MCP result")
+                }
+                McpModelSurface::ResourceText => Ok(model_text_from_resource_result(result)),
+            },
+        }
+    }
+}
+
+fn model_text_from_tool_result(result: &Value) -> String {
+    result
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|content| content.first())
+        .and_then(|content| content.get("text"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn model_text_from_resource_result(result: &Value) -> String {
+    result
+        .get("contents")
+        .and_then(Value::as_array)
+        .and_then(|contents| contents.first())
+        .and_then(|content| content.get("text"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+#[derive(Debug, Serialize)]
+struct McpTokenBenchReport {
+    model: String,
+    coral_bin: String,
+    config_dir: String,
+    rows: Vec<McpTokenBenchRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct McpTokenBenchRow {
+    case: String,
+    surface: String,
+    model_surface_tokens: Option<usize>,
+    model_surface_chars: Option<usize>,
+    protocol_result_tokens: Option<usize>,
+    protocol_result_chars: Option<usize>,
+    is_error: Option<bool>,
+    error: Option<String>,
+}
+
+struct McpStdioClient {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+}
+
+impl McpStdioClient {
+    fn start(coral_bin: &Path, config_dir: Option<&Path>) -> Result<Self> {
+        let mut command = Command::new(coral_bin);
+        command
+            .arg("mcp-stdio")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        if let Some(config_dir) = config_dir {
+            command.env("CORAL_CONFIG_DIR", config_dir);
+        }
+        let mut child = command
+            .spawn()
+            .with_context(|| format!("starting {} mcp-stdio", coral_bin.display()))?;
+        let stdin = child.stdin.take().context("MCP child stdin missing")?;
+        let stdout = child.stdout.take().context("MCP child stdout missing")?;
+        Ok(Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            next_id: 1,
+        })
+    }
+
+    fn initialize(&mut self) -> Result<()> {
+        self.request(
+            "initialize",
+            &json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "coral-mcp-token-bench",
+                    "version": "0.0.0"
+                }
+            }),
+        )?;
+        self.notification("notifications/initialized", &json!({}))?;
+        Ok(())
+    }
+
+    fn call_tool(&mut self, name: &str, arguments: &Value) -> Result<Value> {
+        self.request(
+            "tools/call",
+            &json!({
+                "name": name,
+                "arguments": arguments
+            }),
+        )
+    }
+
+    fn request(&mut self, method: &str, params: &Value) -> Result<Value> {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.write_message(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params
+        }))?;
+        self.read_response(id)
+    }
+
+    fn notification(&mut self, method: &str, params: &Value) -> Result<()> {
+        self.write_message(&json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params
+        }))
+    }
+
+    fn write_message(&mut self, message: &Value) -> Result<()> {
+        serde_json::to_writer(&mut self.stdin, message).context("writing MCP JSON-RPC message")?;
+        writeln!(self.stdin).context("terminating MCP JSON-RPC message")?;
+        self.stdin.flush().context("flushing MCP stdin")
+    }
+
+    fn read_response(&mut self, expected_id: u64) -> Result<Value> {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let bytes = self
+                .stdout
+                .read_line(&mut line)
+                .context("reading MCP stdout")?;
+            if bytes == 0 {
+                bail!("MCP server exited before response id {expected_id}");
+            }
+            let message: Value =
+                serde_json::from_str(line.trim()).context("parsing MCP JSON-RPC response")?;
+            if message.get("id").and_then(Value::as_u64) == Some(expected_id) {
+                return Ok(message);
+            }
+        }
+    }
+}
+
+impl Drop for McpStdioClient {
+    fn drop(&mut self) {
+        if let Err(_error) = self.child.kill() {}
+        if let Err(_error) = self.child.wait() {}
+    }
 }
 
 struct TempDir {


### PR DESCRIPTION
## Intent

Add a repeatable live MCP token benchmark for Coral's model-visible MCP surface. The command launches a real `coral mcp-stdio` server, calls real MCP methods, and counts both model-surface tokens and full protocol-result tokens with `tiktoken-rs`.

This now measures more than `tools/call` result text:

- `initialize`
- `tools/list`
- `resources/list`
- `resources/read` for `coral://guide`
- `resources/read` for `coral://tables`
- representative `tools/call` cases for discovery, SQL, empty results, and errors

## Benchmark command

```shell
cargo run --locked -p xtask -- mcp-token-bench --coral-bin target/debug/coral
```

By default it uses the real live Coral config. Pass `--config-dir` only for explicit fixture work.

## Real live run used for the stack

Binaries measured:

```text
/tmp/coral-token-bins/coral-main
/tmp/coral-token-bins/coral-pr1
/tmp/coral-token-bins/coral-pr2
target/debug/coral          # PR4 top
```

Config: default live Coral config. Transport: real `coral mcp-stdio`. Tokenizer: `gpt-5` / `o200k_base`.

Incremental stack results:

| PR slice | Comparison | Model-surface before | Model-surface after | Saved vs parent | Protocol before | Protocol after | Saved vs parent |
|---|---|---:|---:|---:|---:|---:|---:|
| PR1 compact JSON tool text | `main` -> PR1 | 173224 | 154598 | 18626 / 10.8% | 237895 | 210775 | 27120 / 11.4% |
| PR2 compact catalog page text | PR1 -> PR2 | 154598 | 140254 | 14344 / 9.3% | 210775 | 195393 | 15382 / 7.3% |
| PR3 benchmark harness | PR2 -> PR3 | 140254 | 140254 | 0 / 0.0% | 195393 | 195393 | 0 / 0.0% |
| PR4 compact `coral://tables` JSON | PR3 -> PR4 | 140254 | 117362 | 22892 / 16.3% | 195393 | 163386 | 32007 / 16.4% |

Cumulative after PR4: model-surface tokens drop from `173224` to `117362`, saving `55862 / 32.2%`; protocol-result tokens drop from `237895` to `163386`, saving `74509 / 31.3%`.

Context surface rows after PR2 showed the next hotspot clearly:

| case | surface | PR2 model-surface tokens | PR4 model-surface tokens | PR4 saved |
|---|---|---:|---:|---:|
| `context.initialize` | `initialize` | 169 | 169 | 0 |
| `context.tools_list` | `tools/list` | 2447 | 2447 | 0 |
| `context.resources_list` | `resources/list` | 84 | 84 | 0 |
| `context.resource_guide` | `resources/read` | 1576 | 1576 | 0 |
| `context.resource_tables` | `resources/read` | 111424 | 88532 | 22892 |

The earlier 16-case tool-call-only totals are still useful for PR1/PR2 isolation, but they missed the larger `coral://tables` resource surface. This PR keeps the benchmark pointed at the full model-visible MCP footprint.

## Actual before/after output examples

PR3 itself does not change product output. The same benchmark produced the output examples used in the product PRs:

- PR1: pretty JSON tool text -> compact JSON tool text
- PR2: compact JSON catalog page text -> compact tab-separated catalog page text
- PR4: pretty JSON `coral://tables` resource -> compact JSON `coral://tables` resource

Each product PR body includes the exact abbreviated before/after snippets for its changed surface.

## Validation

- `cargo check --locked -p xtask`
- `cargo run --locked -p xtask -- mcp-token-bench --coral-bin /tmp/coral-token-bins/coral-main --json`
- `cargo run --locked -p xtask -- mcp-token-bench --coral-bin /tmp/coral-token-bins/coral-pr1 --json`
- `cargo run --locked -p xtask -- mcp-token-bench --coral-bin /tmp/coral-token-bins/coral-pr2 --json`
- `cargo run --locked -p xtask -- mcp-token-bench --coral-bin target/debug/coral --json`
- `make docs-check`