### PR TITLE
perf(mcp): compact catalog tool text

### DIFF
--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -26,13 +26,13 @@ use tonic::Request;
 use crate::{
     McpOptions,
     surface::{
-        CatalogToolKind, build_tool_result, describe_table_arguments, describe_table_tool,
-        describe_table_value, feedback_tool, guide_resource, guide_resource_content,
-        initial_instructions, list_catalog_arguments, list_catalog_tool, list_catalog_value,
-        list_columns_arguments, list_columns_tool, list_columns_value, required_string_argument,
-        search_catalog_arguments, search_catalog_tool, search_catalog_value, sql_tool,
-        status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
-        tool_error_result,
+        CatalogToolKind, build_tool_result, build_tool_result_with_text, catalog_items_text,
+        columns_text, describe_table_arguments, describe_table_tool, describe_table_value,
+        feedback_tool, guide_resource, guide_resource_content, initial_instructions,
+        list_catalog_arguments, list_catalog_tool, list_catalog_value, list_columns_arguments,
+        list_columns_tool, list_columns_value, required_string_argument, search_catalog_arguments,
+        search_catalog_tool, search_catalog_value, sql_tool, status_to_error_data, tables_resource,
+        tables_resource_content, tool_error_from_status, tool_error_result,
     },
     telemetry,
 };
@@ -44,7 +44,10 @@ const CATALOG_KIND_TABLE: ProtoCatalogItemKind = ProtoCatalogItemKind::Table;
 const CATALOG_KIND_TABLE_FUNCTION: ProtoCatalogItemKind = ProtoCatalogItemKind::TableFunction;
 
 enum ToolCallOutcome {
-    Success(Value),
+    Success {
+        value: Value,
+        text: Option<String>,
+    },
     ToolError {
         operation: &'static str,
         status: tonic::Status,
@@ -68,9 +71,28 @@ fn serialize_tool_value(value: impl Serialize) -> Result<Value, tonic::Status> {
 }
 
 impl ToolCallOutcome {
+    fn success(value: Value) -> Self {
+        Self::Success { value, text: None }
+    }
+
+    fn success_with_text_if_smaller(value: Value, text: Option<String>) -> Self {
+        let Some(text) = text else {
+            return Self::success(value);
+        };
+        let compact_json = serde_json::to_string(&value).expect("tool value serializes");
+        if text.len() < compact_json.len() {
+            Self::Success {
+                value,
+                text: Some(text),
+            }
+        } else {
+            Self::success(value)
+        }
+    }
+
     fn from_value_result(operation: &'static str, result: Result<Value, tonic::Status>) -> Self {
         match result {
-            Ok(value) => Self::Success(value),
+            Ok(value) => Self::success(value),
             Err(status) => Self::ToolError { operation, status },
         }
     }
@@ -283,7 +305,10 @@ impl CoralMcpServer {
             .await
             .map(|response| search_catalog_value(&response.into_inner()))
         {
-            Ok(value) => Ok(ToolCallOutcome::Success(value)),
+            Ok(value) => {
+                let text = catalog_items_text(&value);
+                Ok(ToolCallOutcome::success_with_text_if_smaller(value, text))
+            }
             Err(status) if status.code() == tonic::Code::InvalidArgument => {
                 Err(status_to_error_data(&status))
             }
@@ -312,10 +337,16 @@ impl CoralMcpServer {
             }))
             .await
             .map(|response| list_catalog_value(&response.into_inner()));
-        Ok(ToolCallOutcome::from_value_result(
-            "Catalog listing",
-            result,
-        ))
+        Ok(match result {
+            Ok(value) => {
+                let text = catalog_items_text(&value);
+                ToolCallOutcome::success_with_text_if_smaller(value, text)
+            }
+            Err(status) => ToolCallOutcome::ToolError {
+                operation: "Catalog listing",
+                status,
+            },
+        })
     }
 
     async fn describe_table_tool_result(
@@ -327,7 +358,7 @@ impl CoralMcpServer {
             .load_table_description(&arguments.schema, &arguments.table)
             .await
         {
-            Ok(response) => Ok(ToolCallOutcome::Success(describe_table_value(
+            Ok(response) => Ok(ToolCallOutcome::success(describe_table_value(
                 &arguments.schema,
                 &arguments.table,
                 &response,
@@ -406,11 +437,12 @@ impl CoralMcpServer {
             }))
             .await
         {
-            Ok(response) => Ok(ToolCallOutcome::Success(list_columns_value(
-                &arguments.schema,
-                &arguments.table,
-                &response.into_inner(),
-            ))),
+            Ok(response) => {
+                let value =
+                    list_columns_value(&arguments.schema, &arguments.table, &response.into_inner());
+                let text = columns_text(&value);
+                Ok(ToolCallOutcome::success_with_text_if_smaller(value, text))
+            }
             Err(status) if status.code() == tonic::Code::InvalidArgument => {
                 Err(status_to_error_data(&status))
             }
@@ -419,7 +451,7 @@ impl CoralMcpServer {
                     .load_table_description(&arguments.schema, &arguments.table)
                     .await
                 {
-                    Ok(response) => Ok(ToolCallOutcome::Success(describe_table_value(
+                    Ok(response) => Ok(ToolCallOutcome::success(describe_table_value(
                         &arguments.schema,
                         &arguments.table,
                         &response,
@@ -557,8 +589,11 @@ fn finish_tool_call(
     outcome: Result<ToolCallOutcome, ErrorData>,
 ) -> Result<CallToolResult, ErrorData> {
     match outcome {
-        Ok(ToolCallOutcome::Success(value)) => {
-            let result = build_tool_result(value);
+        Ok(ToolCallOutcome::Success { value, text }) => {
+            let result = match text {
+                Some(text) => Ok(build_tool_result_with_text(value, text)),
+                None => build_tool_result(value),
+            };
             telemetry::record_protocol_result(span, &result);
             result
         }

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -7,6 +7,7 @@ use coral_api::v1::{
 };
 use serde::Serialize;
 use serde_json::{Map, Value};
+use std::fmt::Write as _;
 
 use super::values::{
     format_schema_table_equivalent, format_sql_identifier, insert_pagination_fields,
@@ -161,6 +162,195 @@ pub(crate) fn list_columns_value(
     ]);
     insert_pagination_fields(&mut value, &pagination);
     Value::Object(value)
+}
+
+pub(crate) fn catalog_items_text(value: &Value) -> Option<String> {
+    let items = value.get("items")?.as_array()?;
+    let mut text = collection_header("items", items.len(), value);
+    text.push('\n');
+    text.push_str("kind\tname\tsql_reference\tdescription\tdetails\tmatched_fields");
+    for item in items {
+        let item = item.as_object()?;
+        text.push('\n');
+        write!(
+            text,
+            "{}\t{}\t{}\t{}\t{}\t{}",
+            field_text(item, "kind"),
+            field_text(item, "name"),
+            field_text(item, "sql_reference"),
+            field_text(item, "description"),
+            catalog_item_details(item),
+            field_text(item, "matched_fields")
+        )
+        .expect("writing to String cannot fail");
+    }
+    Some(text)
+}
+
+pub(crate) fn columns_text(value: &Value) -> Option<String> {
+    let columns = value.get("columns")?.as_array()?;
+    let schema_name = value.get("schema_name").and_then(Value::as_str)?;
+    let table_name = value.get("table_name").and_then(Value::as_str)?;
+    let mut text = format!(
+        "table={}.{} {}",
+        sanitize_text(schema_name),
+        sanitize_text(table_name),
+        collection_header("columns", columns.len(), value)
+    );
+    text.push('\n');
+    text.push_str(
+        "ordinal\tcolumn_name\tdata_type\tis_nullable\tis_virtual\tis_required_filter\tdescription\tmatched_fields",
+    );
+    for column in columns {
+        let column = column.as_object()?;
+        text.push('\n');
+        write!(
+            text,
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            field_text(column, "ordinal_position"),
+            field_text(column, "column_name"),
+            field_text(column, "data_type"),
+            field_text(column, "is_nullable"),
+            field_text(column, "is_virtual"),
+            field_text(column, "is_required_filter"),
+            field_text(column, "description"),
+            field_text(column, "matched_fields")
+        )
+        .expect("writing to String cannot fail");
+    }
+    Some(text)
+}
+
+fn collection_header(collection_name: &str, visible_count: usize, value: &Value) -> String {
+    let mut text = format!("{collection_name}={visible_count}");
+    for key in ["total", "limit", "offset", "has_more", "next_offset"] {
+        if let Some(value) = value.get(key) {
+            write!(text, " {key}={}", compact_value(value)).expect("writing to String cannot fail");
+        }
+    }
+    text
+}
+
+fn catalog_item_details(item: &Map<String, Value>) -> String {
+    if let Some(table) = item.get("table").and_then(Value::as_object) {
+        let mut details = format!("table_name={}", field_text(table, "table_name"));
+        let required_filters = field_text(table, "required_filters");
+        if !required_filters.is_empty() {
+            write!(details, ";required_filters=[{required_filters}]")
+                .expect("writing to String cannot fail");
+        }
+        let guide = field_text(table, "guide");
+        if !guide.is_empty() {
+            write!(details, ";guide={guide}").expect("writing to String cannot fail");
+        }
+        return details;
+    }
+
+    if let Some(function) = item.get("table_function").and_then(Value::as_object) {
+        let mut details = format!("function_name={}", field_text(function, "function_name"));
+        let call = field_text(item, "sql_call_example");
+        if !call.is_empty() {
+            write!(details, ";call={call}").expect("writing to String cannot fail");
+        }
+        let arguments = compact_table_function_arguments(function.get("arguments"));
+        if !arguments.is_empty() {
+            write!(details, ";args={arguments}").expect("writing to String cannot fail");
+        }
+        let result_columns = compact_table_function_result_columns(function.get("result_columns"));
+        if !result_columns.is_empty() {
+            write!(details, ";result_columns={result_columns}")
+                .expect("writing to String cannot fail");
+        }
+        return details;
+    }
+
+    String::new()
+}
+
+fn compact_table_function_arguments(arguments: Option<&Value>) -> String {
+    let Some(arguments) = arguments.and_then(Value::as_array) else {
+        return String::new();
+    };
+    arguments
+        .iter()
+        .filter_map(Value::as_object)
+        .map(|argument| {
+            let name = field_text(argument, "name");
+            let required = if argument
+                .get("required")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                "!"
+            } else {
+                ""
+            };
+            let values = field_text(argument, "values");
+            if values.is_empty() {
+                format!("{name}{required}")
+            } else {
+                format!("{name}{required}=[{values}]")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn compact_table_function_result_columns(columns: Option<&Value>) -> String {
+    let Some(columns) = columns.and_then(Value::as_array) else {
+        return String::new();
+    };
+    columns
+        .iter()
+        .filter_map(Value::as_object)
+        .map(|column| {
+            let nullable = if column
+                .get("is_nullable")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                "?"
+            } else {
+                ""
+            };
+            let mut text = format!(
+                "{}:{}{}",
+                field_text(column, "column_name"),
+                field_text(column, "data_type"),
+                nullable
+            );
+            let description = field_text(column, "description");
+            if !description.is_empty() {
+                write!(text, " {description}").expect("writing to String cannot fail");
+            }
+            text
+        })
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+fn field_text(object: &Map<String, Value>, key: &str) -> String {
+    object.get(key).map(compact_value).unwrap_or_default()
+}
+
+fn compact_value(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::String(value) => sanitize_text(value),
+        Value::Array(values) => values
+            .iter()
+            .map(compact_value)
+            .filter(|value| !value.is_empty())
+            .collect::<Vec<_>>()
+            .join(","),
+        Value::Object(_) => sanitize_text(&value.to_string()),
+    }
+}
+
+fn sanitize_text(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn column_search_result_value(result: &ColumnSearchResult) -> Option<Value> {
@@ -376,5 +566,126 @@ impl<'a> From<&'a coral_api::v1::Column> for ColumnValue<'a> {
             description: &column.description,
             ordinal_position: column.ordinal_position,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{catalog_items_text, columns_text};
+
+    #[test]
+    fn catalog_items_text_renders_table_and_function_rows() {
+        let value = json!({
+            "items": [
+                {
+                    "kind": "table",
+                    "name": "github.pulls",
+                    "sql_reference": "github.pulls",
+                    "description": "Pull requests",
+                    "matched_fields": ["description", "table.name"],
+                    "table": {
+                        "table_name": "pulls",
+                        "guide": "Use owner\nand repo filters.",
+                        "required_filters": ["owner", "repo"]
+                    }
+                },
+                {
+                    "kind": "table_function",
+                    "name": "datadog.logs",
+                    "sql_reference": "datadog.logs",
+                    "sql_call_example": "datadog.logs(start => '<value>')",
+                    "description": "Datadog logs",
+                    "table_function": {
+                        "function_name": "logs",
+                        "arguments": [
+                            {"name": "start", "required": true, "values": []},
+                            {"name": "env", "required": false, "values": ["prod", "dev"]}
+                        ],
+                        "result_columns": [
+                            {
+                                "column_name": "message",
+                                "data_type": "Utf8",
+                                "is_nullable": false,
+                                "description": "Log message"
+                            },
+                            {
+                                "column_name": "host",
+                                "data_type": "Utf8",
+                                "is_nullable": true,
+                                "description": ""
+                            }
+                        ]
+                    }
+                }
+            ],
+            "total": 2,
+            "limit": 20,
+            "offset": 0,
+            "has_more": false
+        });
+
+        let text = catalog_items_text(&value).expect("catalog text");
+
+        assert_eq!(
+            text,
+            concat!(
+                "items=2 total=2 limit=20 offset=0 has_more=false\n",
+                "kind\tname\tsql_reference\tdescription\tdetails\tmatched_fields\n",
+                "table\tgithub.pulls\tgithub.pulls\tPull requests\t",
+                "table_name=pulls;required_filters=[owner,repo];guide=Use owner and repo filters.\t",
+                "description,table.name\n",
+                "table_function\tdatadog.logs\tdatadog.logs\tDatadog logs\t",
+                "function_name=logs;call=datadog.logs(start => '<value>');",
+                "args=start!,env=[prod,dev];result_columns=message:Utf8 Log message;host:Utf8?\t"
+            )
+        );
+    }
+
+    #[test]
+    fn columns_text_renders_column_flags() {
+        let value = json!({
+            "schema_name": "github",
+            "table_name": "pulls",
+            "columns": [
+                {
+                    "column_name": "number",
+                    "data_type": "Int64",
+                    "is_nullable": false,
+                    "is_virtual": false,
+                    "is_required_filter": false,
+                    "description": "Pull request number",
+                    "ordinal_position": 1
+                },
+                {
+                    "column_name": "owner",
+                    "data_type": "Utf8",
+                    "is_nullable": false,
+                    "is_virtual": true,
+                    "is_required_filter": true,
+                    "description": "Repository owner",
+                    "ordinal_position": 2,
+                    "matched_fields": ["name", "description"]
+                }
+            ],
+            "total": 2,
+            "limit": 50,
+            "offset": 0,
+            "has_more": false
+        });
+
+        let text = columns_text(&value).expect("columns text");
+
+        assert_eq!(
+            text,
+            concat!(
+                "table=github.pulls columns=2 total=2 limit=50 offset=0 has_more=false\n",
+                "ordinal\tcolumn_name\tdata_type\tis_nullable\tis_virtual\t",
+                "is_required_filter\tdescription\tmatched_fields\n",
+                "1\tnumber\tInt64\tfalse\tfalse\tfalse\tPull request number\t\n",
+                "2\towner\tUtf8\tfalse\ttrue\ttrue\tRepository owner\tname,description"
+            )
+        );
     }
 }

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -8,7 +8,8 @@ mod tools;
 mod values;
 
 pub(crate) use catalog::{
-    describe_table_value, list_catalog_value, list_columns_value, search_catalog_value,
+    catalog_items_text, columns_text, describe_table_value, list_catalog_value, list_columns_value,
+    search_catalog_value,
 };
 pub(crate) use discovery::{Pagination, parse_pagination, parse_pagination_with_limits};
 pub(crate) use errors::{status_to_error_data, tool_error_from_status, tool_error_result};
@@ -17,8 +18,8 @@ pub(crate) use resources::{
     tables_resource_content,
 };
 pub(crate) use tools::{
-    CatalogToolKind, build_tool_result, describe_table_arguments, describe_table_tool,
-    feedback_tool, list_catalog_arguments, list_catalog_tool, list_columns_arguments,
-    list_columns_tool, required_string_argument, search_catalog_arguments, search_catalog_tool,
-    sql_tool,
+    CatalogToolKind, build_tool_result, build_tool_result_with_text, describe_table_arguments,
+    describe_table_tool, feedback_tool, list_catalog_arguments, list_catalog_tool,
+    list_columns_arguments, list_columns_tool, required_string_argument, search_catalog_arguments,
+    search_catalog_tool, sql_tool,
 };

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -371,10 +371,10 @@ pub(crate) fn list_columns_arguments(
 }
 
 pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
-    let pretty = serde_json::to_string_pretty(&value)
+    let compact = serde_json::to_string(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
     let mut result = CallToolResult::structured(value);
-    result.content = vec![Content::text(pretty)];
+    result.content = vec![Content::text(compact)];
     Ok(result)
 }
 
@@ -799,9 +799,41 @@ fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{Map, Value};
+    use serde_json::{Map, Value, json};
 
-    use super::{list_catalog_arguments, search_catalog_arguments};
+    use super::{build_tool_result, list_catalog_arguments, search_catalog_arguments};
+
+    #[test]
+    fn success_tool_result_text_uses_compact_json() {
+        let value = json!({
+            "rows": [
+                {
+                    "id": 1,
+                    "text": "hello"
+                },
+                {
+                    "id": 2,
+                    "text": "world"
+                }
+            ]
+        });
+
+        let result = build_tool_result(value.clone()).expect("tool result");
+
+        let text = result
+            .content
+            .first()
+            .and_then(|content| content.as_text())
+            .expect("text content");
+        assert_eq!(
+            text.text,
+            r#"{"rows":[{"id":1,"text":"hello"},{"id":2,"text":"world"}]}"#
+        );
+        assert_eq!(
+            result.structured_content.expect("structured content"),
+            value
+        );
+    }
 
     #[test]
     fn catalog_kind_argument_accepts_null_as_all_kinds() {

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -373,9 +373,13 @@ pub(crate) fn list_columns_arguments(
 pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
     let compact = serde_json::to_string(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+    Ok(build_tool_result_with_text(value, compact))
+}
+
+pub(crate) fn build_tool_result_with_text(value: Value, text: String) -> CallToolResult {
     let mut result = CallToolResult::structured(value);
-    result.content = vec![Content::text(compact)];
-    Ok(result)
+    result.content = vec![Content::text(text)];
+    result
 }
 
 fn sql_tool_description(visible_table_count: usize) -> String {

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -26,6 +26,8 @@ Clients see the same database catalog and query results as `coral sql`. You set 
 
 Agents should treat the discovery tools as catalog helpers, not as replacement provider APIs. For data questions, prefer a single `sql` call using `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions over multiple tool calls that fetch rows and combine them in the agent.
 
+Successful tool responses include complete MCP `structuredContent`. The text fallback is compact for model context: general results use compact JSON, and catalog discovery pages may use tab-separated rows when that is shorter. Clients that need a stable machine-readable shape should read `structuredContent`, not parse the fallback text.
+
 ### Discovery tools
 
 **`list_catalog`**: paginated list of database tables and parameterized table functions.


### PR DESCRIPTION
## Summary

- compact the MCP text fallback for catalog discovery tools:
  `search_catalog`, `list_catalog`, and `list_columns`
- keep the full machine-readable `structuredContent` unchanged
- leave `sql`, `describe_table`, and error text unchanged
- use the compact text renderer only when it is byte-shorter than compact JSON;
  token savings are measured separately below

Comparison base: this PR is measured against PR #1197, not `main`. The GitHub
diff includes #1197 because this is part of a Graphite stack.

This PR changes what the model sees in `content[0].text` for catalog discovery
results. It does not change the structured MCP result contract.

## What Changed

Before this PR, catalog discovery text was compact JSON. That preserved the data
but repeated field names for every row:

```json
{"items":[{"kind":"table_function","schema_name":"datadog","name":"datadog.apm_dependencies","sql_reference":"datadog.apm_dependencies","sql_call_example":"datadog.apm_dependencies(service => '<value>')","description":"Datadog APM service dependencies for a target service.","table_function":{"function_name":"apm_dependencies","arguments":[{"name":"service","required":true},...]}}]}
```

After this PR, the same text fallback is a compact tab-separated discovery page:

```text
items=20 total=983 limit=20 offset=0 has_more=true next_offset=20
kind	name	sql_reference	description	details	matched_fields
table_function	datadog.apm_dependencies	datadog.apm_dependencies	Datadog APM service dependencies for a target service.	function_name=apm_dependencies;call=datadog.apm_dependencies(service => '<value>');args=service!,env,start,end,primary_tag;result_columns=name:Utf8? Service name;called_by:Utf8? Comma-separated upstream services;calls:Utf8? Comma-separated downstream services	arguments
...
```

The first line is page metadata. The second line is the column header. Each
following line is one catalog item. `structuredContent` still contains the full
original JSON object.

## Why

The previous SQL-row compaction attempt did not save enough tokens. Catalog
discovery results were the measured hotspot because they repeat the same object
keys across many catalog rows.

This PR applies the Headroom lesson that helped here: route by output shape.
Catalog discovery output is tabular, so its text fallback can be tabular while
the structured result stays JSON.

## Live Token Measurement

Command used from the benchmark branch after this stack was restacked:

```shell
cargo run --locked -p xtask -- mcp-token-bench --coral-bin /tmp/coral-token-bins/coral-pr1 --json
cargo run --locked -p xtask -- mcp-token-bench --coral-bin /tmp/coral-token-bins/coral-pr2 --json
```

- Config: default live Coral config
- Transport: real `coral mcp-stdio`
- Tokenizer: `gpt-5` / `o200k_base`
- Cases: 16 live MCP `tools/call` requests
- Before state: PR #1197, not `main`

Totals versus PR #1197:

| Metric | Before | After | Saved | Savings |
| --- | ---: | ---: | ---: | ---: |
| Text tokens | 38,898 | 24,554 | 14,344 | 36.9% |
| Protocol result tokens | 80,312 | 64,930 | 15,382 | 19.2% |

Catalog discovery cases:

| Case | Tool | Before text | After text | Saved |
| --- | --- | ---: | ---: | ---: |
| `discovery.search.github_pull` | `search_catalog` | 2,372 | 1,492 | 880 |
| `discovery.search.slack_messages` | `search_catalog` | 6,172 | 4,012 | 2,160 |
| `discovery.search.table_functions` | `search_catalog` | 10,222 | 5,220 | 5,002 |
| `discovery.list.github_tables` | `list_catalog` | 1,614 | 1,184 | 430 |
| `discovery.list.table_functions` | `list_catalog` | 8,195 | 4,168 | 4,027 |
| `discovery.columns.github_pulls` | `list_columns` | 2,030 | 809 | 1,221 |
| `discovery.columns.github_pulls_required` | `list_columns` | 123 | 80 | 43 |
| `discovery.columns.github_pulls_search` | `list_columns` | 1,030 | 449 | 581 |
| `discovery.describe.github_pulls` | `describe_table` | 176 | 176 | 0 |

SQL and error cases show `0` incremental text-token change by design.

Alternative formats checked on the same nine live discovery cases:

| Discovery text format | Model-surface tokens |
| --- | ---: |
| This PR's custom discovery text | 17,590 |
| Raw TOON over full `structuredContent` | 26,143 |
| Compact JSON over full `structuredContent` | 31,934 |

Raw TOON is better than compact JSON, but worse than this PR's reduced
discovery projection. The full JSON still remains available in
`structuredContent`.

## Output Examples

### `search_catalog`

Before:

```json
{"items":[{"kind":"table_function","schema_name":"datadog","name":"datadog.apm_dependencies","sql_reference":"datadog.apm_dependencies","sql_call_example":"datadog.apm_dependencies(service => '<value>')","description":"Datadog APM service dependencies for a target service.","table_function":{"function_name":"apm_dependencies","arguments":[{"name":"service","...
```

After:

```text
items=20 total=983 limit=20 offset=0 has_more=true next_offset=20
kind	name	sql_reference	description	details	matched_fields
table_function	datadog.apm_dependencies	datadog.apm_dependencies	Datadog APM service dependencies for a target service.	function_name=apm_dependencies;call=datadog.apm_dependencies(service => '<value>');args=service!,env,start,end,primary_tag;result_columns=name:Utf8? Service name;called_by:Utf8? Comma-separated upstream services;calls:Utf8? Comma-separated downstream services	arguments
```

### `list_columns`

Before:

```json
{"schema_name":"github","table_name":"pulls","columns":[{"column_name":"_links","data_type":"Utf8","is_nullable":true,"is_virtual":false,"is_required_filter":false,"description":"","ordinal_position":0},{"column_name":"_links__comments","data_type":"Utf8","...
```

After:

```text
table=github.pulls columns=50 total=432 limit=50 offset=0 has_more=true next_offset=50
ordinal	column_name	data_type	is_nullable	is_virtual	is_required_filter	description	matched_fields
0	_links	Utf8	true	false	false		
1	_links__comments	Utf8	true	false	false	Hypermedia Link	
2	_links__comments__href	Utf8	true	false	false	Hypermedia Link	
...
```

## Validation

- `cargo test --locked -p coral-mcp`
- `make docs-check`
- `make rust-checks`
- Live benchmark reports: `/tmp/coral-token-pr1.json`, `/tmp/coral-token-pr2.json`
