### PR TITLE
perf(mcp): compact tables resource JSON

### DIFF
--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -86,7 +86,7 @@ FROM coral.columns WHERE schema_name = '{schema_name}' AND table_name = '{table_
 pub(crate) fn tables_resource_content(
     tables: &[TableSummary],
 ) -> Result<String, serde_json::Error> {
-    serde_json::to_string_pretty(&TablesResourceContent {
+    serde_json::to_string(&TablesResourceContent {
         tables: queryable_table_summary_values(tables),
     })
 }
@@ -126,7 +126,7 @@ fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str)> {
 mod tests {
     use coral_api::v1::{Source, SourceCredentialStorage, TableSummary, Workspace};
 
-    use super::{guide_resource_content, initial_instructions};
+    use super::{guide_resource_content, initial_instructions, tables_resource_content};
     use crate::surface::values::format_schema_table_equivalent;
 
     fn source(name: &str) -> Source {
@@ -201,6 +201,17 @@ mod tests {
         assert!(content.contains("Visible schemas:"));
         assert!(content.contains("- searchy"));
         assert!(!content.contains("No user-visible schemas are currently available."));
+    }
+
+    #[test]
+    fn tables_resource_content_uses_compact_json() {
+        let content = tables_resource_content(&[table("slack", "messages")])
+            .expect("tables resource content serializes");
+
+        assert!(content.starts_with("{\"tables\":[{\"schema_name\":\"slack\""));
+        assert!(!content.contains('\n'));
+        assert!(content.contains("\"sql_reference\":\"slack.messages\""));
+        assert!(content.contains("\"guide\":\"Query messages.\""));
     }
 
     #[test]

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -20,7 +20,7 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Tool     | `describe_table` | Show compact metadata for one database table            |
 | Tool     | `list_columns`   | List columns for one database table with pagination     |
 | Resource | `coral://guide`  | Database workflow guide for agents                     |
-| Resource | `coral://tables` | JSON summaries of database tables and required filters  |
+| Resource | `coral://tables` | Compact JSON summaries of database tables and required filters |
 
 Clients see the same database catalog and query results as `coral sql`. You set up sources with the CLI, then agents query Coral over MCP as SQL schemas and tables.
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -228,7 +228,7 @@ This server exposes:
 | Tool     | `describe_table` | Show compact database table metadata |
 | Tool     | `list_columns`   | List columns for one database table |
 | Resource | `coral://guide`  | Database workflow guide for agents |
-| Resource | `coral://tables` | Database table summaries         |
+| Resource | `coral://tables` | Compact JSON database table summaries |
 
 ## `coral completion <SHELL>`
 


### PR DESCRIPTION
## Intent

Compact the `coral://tables` MCP resource from pretty JSON to compact JSON. The resource keeps the same JSON object shape, the same table fields, and the same `application/json` MIME type; only whitespace changes.

## Why this slice

After expanding the MCP token benchmark beyond `tools/call`, `coral://tables` was the dominant remaining hotspot. On Brad's live Coral config it contained 796 table summaries and cost `111424` model-surface tokens after PR2.

The larger TSV rewrite would save more characters, but it changes the resource format. This PR takes the contract-preserving win first.

## Real live token measurement

Command used from the benchmark branch:

```shell
cargo run --locked -p xtask -- mcp-token-bench --coral-bin /tmp/coral-token-bins/coral-pr2 --json
cargo run --locked -p xtask -- mcp-token-bench --coral-bin target/debug/coral --json
```

- Config: default live Coral config
- Transport: real `coral mcp-stdio`
- Tokenizer: `gpt-5` / `o200k_base`

`coral://tables` row:

| Metric | Before PR4 | After PR4 | Saved | Savings |
|---|---:|---:|---:|---:|
| Model-surface tokens | 111424 | 88532 | 22892 | 20.5% |
| Model-surface chars | 486754 | 418328 | 68426 | 14.1% |
| Protocol-result tokens | 126088 | 94081 | 32007 | 25.4% |
| Protocol-result chars | 521319 | 443816 | 77503 | 14.9% |

Expanded benchmark totals:

| Metric | Before PR4 | After PR4 | Saved | Savings |
|---|---:|---:|---:|---:|
| Model-surface tokens | 140254 | 117362 | 22892 | 16.3% |
| Protocol-result tokens | 195393 | 163386 | 32007 | 16.4% |

## Actual output example

Abbreviated actual `resources/read` text for `coral://tables` from the same live config.

Before:

```text
{\n  "tables": [\n    {\n      "schema_name": "datadog",\n      "table_name": "dashboards",\n      "name": "datadog.dashboards",\n      "sql_reference": "datadog.dashboards",\n      "description": "Datadog dashboards",\n      "guide": "Use this table for dashboard inventory and ownership review. In large orgs, narrow first by author_handle or layout_type before scanning title and url; it only exposes dashboard metadata, not widget contents.\\n",\n      "required_filters": []\n    },\n    {\n      "schema_name": "datadog",\n      "table_name": "downtimes",\n      "name": "datadog.downtimes",\n      "sql_reference": "datadog.downtimes",\n      "description": "Datadog scheduled downtimes",\n      "guide": "Use this table for maintenance-window and alert-suppression review. Start with status or scope to cut large result sets before inspecting monitor_identifier; monitor_identifier can be null when a downtime is scope-only.\\n",\n      "requ ...
```

After:

```text
{"tables":[{"schema_name":"datadog","table_name":"dashboards","name":"datadog.dashboards","sql_reference":"datadog.dashboards","description":"Datadog dashboards","guide":"Use this table for dashboard inventory and ownership review. In large orgs, narrow first by author_handle or layout_type before scanning title and url; it only exposes dashboard metadata, not widget contents.\\n","required_filters":[]},{"schema_name":"datadog","table_name":"downtimes","name":"datadog.downtimes","sql_reference":"datadog.downtimes","description":"Datadog scheduled downtimes","guide":"Use this table for maintenance-window and alert-suppression review. Start with status or scope to cut large result sets before inspecting monitor_identifier; monitor_identifier can be null when a downtime is scope-only.\\n","required_filters":[]},{"schema_name":"datadog","table_name":"hosts","name":"datadog.hosts","sql_reference":"datadog.hosts","description":"Datadog infras ...
```

## Validation

- `cargo test --locked -p coral-mcp`
- `cargo check --locked -p xtask`
- `cargo run --locked -p xtask -- mcp-token-bench --coral-bin target/debug/coral --json`
- `make docs-check`