### PR TITLE
perf(mcp): compact sql text with toon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,6 +1399,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-types",
+ "toon-format",
  "tracing",
  "tracing-opentelemetry",
 ]
@@ -5731,6 +5732,18 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "toon-format"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f89570c1a68d73941f728cca32a4345b2ffca36667ad921af336c60309a3e7e"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ strsim = "0.11"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
+toon-format = { version = "0.5.0", default-features = false }
 toml = "0.9"
 toml_edit = "0.25.10"
 tonic = "0.14.2"

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -16,6 +16,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+toon-format.workspace = true
 tonic.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -31,8 +31,9 @@ use crate::{
         feedback_tool, guide_resource, guide_resource_content, initial_instructions,
         list_catalog_arguments, list_catalog_tool, list_catalog_value, list_columns_arguments,
         list_columns_tool, list_columns_value, required_string_argument, search_catalog_arguments,
-        search_catalog_tool, search_catalog_value, sql_tool, status_to_error_data, tables_resource,
-        tables_resource_content, tool_error_from_status, tool_error_result,
+        search_catalog_tool, search_catalog_value, sql_result_toon_text, sql_tool,
+        status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
+        tool_error_result,
     },
     telemetry,
 };
@@ -377,10 +378,16 @@ impl CoralMcpServer {
         match request.name.as_ref() {
             "sql" => {
                 let sql = required_string_argument(request.arguments.as_ref(), "sql")?;
-                Ok(ToolCallOutcome::from_value_result(
-                    "Query",
-                    self.execute_sql_value(&sql).await,
-                ))
+                Ok(match self.execute_sql_value(&sql).await {
+                    Ok(value) => {
+                        let text = sql_result_toon_text(&value);
+                        ToolCallOutcome::success_with_text_if_smaller(value, text)
+                    }
+                    Err(status) => ToolCallOutcome::ToolError {
+                        operation: "Query",
+                        status,
+                    },
+                })
             }
             "list_catalog" => {
                 self.list_catalog_tool_result(request.arguments.as_ref())

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -21,5 +21,5 @@ pub(crate) use tools::{
     CatalogToolKind, build_tool_result, build_tool_result_with_text, describe_table_arguments,
     describe_table_tool, feedback_tool, list_catalog_arguments, list_catalog_tool,
     list_columns_arguments, list_columns_tool, required_string_argument, search_catalog_arguments,
-    search_catalog_tool, sql_tool,
+    search_catalog_tool, sql_result_toon_text, sql_tool,
 };

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -5,6 +5,7 @@ use rmcp::{
     model::{CallToolResult, Content, Tool, ToolAnnotations},
 };
 use serde_json::{Map, Value, json};
+use toon_format::{Delimiter, EncodeOptions};
 
 use super::{Pagination, parse_pagination, parse_pagination_with_limits};
 
@@ -374,6 +375,34 @@ pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorDat
     let compact = serde_json::to_string(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
     Ok(build_tool_result_with_text(value, compact))
+}
+
+pub(crate) fn sql_result_toon_text(value: &Value) -> Option<String> {
+    let rows = value.get("rows")?.as_array()?;
+    if rows.is_empty() {
+        return None;
+    }
+    if value.as_object()?.len() != 1 {
+        return None;
+    }
+
+    let compact_json = serde_json::to_string(value).ok()?;
+    shortest_strict_toon(value).filter(|text| text.len() < compact_json.len())
+}
+
+fn shortest_strict_toon(value: &Value) -> Option<String> {
+    let delimiters = [Delimiter::Comma, Delimiter::Tab, Delimiter::Pipe];
+    delimiters
+        .into_iter()
+        .filter_map(|delimiter| strict_toon(value, delimiter))
+        .min_by_key(String::len)
+}
+
+fn strict_toon(value: &Value, delimiter: Delimiter) -> Option<String> {
+    let options = EncodeOptions::new().with_delimiter(delimiter);
+    let text = toon_format::encode(value, &options).ok()?;
+    let decoded: Value = toon_format::decode_strict(&text).ok()?;
+    if decoded == *value { Some(text) } else { None }
 }
 
 pub(crate) fn build_tool_result_with_text(value: Value, text: String) -> CallToolResult {
@@ -805,7 +834,9 @@ fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
 mod tests {
     use serde_json::{Map, Value, json};
 
-    use super::{build_tool_result, list_catalog_arguments, search_catalog_arguments};
+    use super::{
+        build_tool_result, list_catalog_arguments, search_catalog_arguments, sql_result_toon_text,
+    };
 
     #[test]
     fn success_tool_result_text_uses_compact_json() {
@@ -837,6 +868,35 @@ mod tests {
             result.structured_content.expect("structured content"),
             value
         );
+    }
+
+    #[test]
+    fn sql_result_text_uses_toon_when_shorter() {
+        let value = json!({
+            "rows": [
+                {
+                    "id": 1,
+                    "text": "hello"
+                },
+                {
+                    "id": 2,
+                    "text": "world"
+                }
+            ]
+        });
+
+        let text = sql_result_toon_text(&value).expect("TOON text");
+
+        assert_eq!(text, "rows[2]{id,text}:\n  1,hello\n  2,world");
+        let decoded: Value = toon_format::decode_strict(&text).expect("TOON decodes");
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn sql_result_text_keeps_empty_rows_as_json() {
+        let value = json!({ "rows": [] });
+
+        assert_eq!(sql_result_toon_text(&value), None);
     }
 
     #[test]

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -26,7 +26,7 @@ Clients see the same database catalog and query results as `coral sql`. You set 
 
 Agents should treat the discovery tools as catalog helpers, not as replacement provider APIs. For data questions, prefer a single `sql` call using `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions over multiple tool calls that fetch rows and combine them in the agent.
 
-Successful tool responses include complete MCP `structuredContent`. The text fallback is compact for model context: general results use compact JSON, and catalog discovery pages may use tab-separated rows when that is shorter. Clients that need a stable machine-readable shape should read `structuredContent`, not parse the fallback text.
+Successful tool responses include complete MCP `structuredContent`. The text fallback is compact for model context: general results use compact JSON, `sql` results may use TOON when that is shorter, and catalog discovery pages may use tab-separated rows when that is shorter. Clients that need a stable machine-readable shape should read `structuredContent`, not parse the fallback text.
 
 ### Discovery tools
 
@@ -62,7 +62,7 @@ Some sources expose native search endpoints (for example, GitHub issue search) a
 
 ## Query result format
 
-The `sql` tool returns rows as a JSON array of objects. To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
+In `structuredContent`, the `sql` tool returns rows as a JSON array of objects. Its text fallback may use TOON for model-token efficiency, but clients should treat `structuredContent` as the stable machine-readable contract. To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
 
 - `Int64` (`BIGINT`) and `UInt64`
 - `Decimal32`, `Decimal64`, `Decimal128`, and `Decimal256`


### PR DESCRIPTION
## Summary

- render successful non-empty MCP `sql` text fallback as TOON when it is shorter than compact JSON
- keep `structuredContent` as the unchanged JSON contract; TOON is only fallback text
- strict-roundtrip every candidate TOON string back to the original JSON value before using it, and fall back to compact JSON for empty rows, invalid TOON, or longer output

## Why

PR #1198's hand-rolled SQL row text did not move the aggregate benchmark enough and was closed. The follow-up TOON benchmark showed successful SQL responses were still a small but real hotspot after PR #1201. This slice applies TOON only where the live benchmark proves savings, without changing the machine-readable MCP contract.

## Actual live benchmark

Command:

`CARGO_TARGET_DIR=/tmp/coral-toon-target cargo run --locked -p xtask -- mcp-token-bench --coral-bin /tmp/coral-toon-target/debug/coral --json > /tmp/coral-token-pr5-toon-sql.json`

Config: default live Coral config.

Comparison: PR #1201 -> this PR.

| Case | Model before | Model after | Model saved | Protocol before | Protocol after | Protocol saved |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Full 21-case benchmark | 117,362 | 114,978 | 2,384 / 2.0% | 163,386 | 160,862 | 2,524 / 1.5% |
| `sql.wide_coral_tables` | 1,413 | 1,135 | 278 | 2,901 | 2,657 | 244 |
| `sql.narrow_many_tables` | 595 | 347 | 248 | 1,310 | 963 | 347 |
| `sql.long_catalog_text` | 1,008 | 826 | 182 | 2,096 | 1,894 | 202 |
| `sql.github_pulls_columns` | 3,432 | 1,917 | 1,515 | 7,005 | 5,450 | 1,555 |
| `sql.empty_result` | 4 | 4 | 0 | 28 | 28 | 0 |
| `sql.headroom_contents` | 464 | 303 | 161 | 988 | 812 | 176 |
| `sql.invalid_statement` | 48 | 48 | 0 | 137 | 137 | 0 |

Non-SQL benchmark rows were unchanged.

## Actual output shape

`structuredContent` remains the same JSON object. Only `content[0].text` changes.

`sql.narrow_many_tables` before:

```json
{"rows":[{"schema_name":"datadog","table_name":"dashboards"},{"schema_name":"datadog","table_name":"downtimes"},{"schema_name":"datadog","table_name":"hosts"},...]}
```

After:

```toon
rows[50]{schema_name,table_name}:
  datadog,dashboards
  datadog,downtimes
  datadog,hosts
  datadog,incidents
  datadog,metric_names
  ...
```

`sql.github_pulls_columns` before:

```json
{"rows":[{"schema_name":"github","table_name":"pulls","column_name":"_links","data_type":"Utf8","description":""},{"schema_name":"github","table_name":"pulls","column_name":"_links__comments","data_type":"Utf8","description":"Hypermedia Link"},...]}
```

After:

```toon
rows[100]{schema_name,table_name,column_name,data_type,description}:
  github,pulls,_links,Utf8,""
  github,pulls,_links__comments,Utf8,Hypermedia Link
  github,pulls,_links__comments__href,Utf8,Hypermedia Link
  github,pulls,_links__commits,Utf8,Hypermedia Link
  ...
```

`sql.headroom_contents` before:

```json
{"rows":[{"name":".actrc","type":"file","path":".actrc","size":"382"},{"name":".actrc.local.example","type":"file","path":".actrc.local.example","size":"538"},...]}
```

After:

```toon
rows[20]{name,type,path,size}:
  .actrc,file,.actrc,"382"
  .actrc.local.example,file,.actrc.local.example,"538"
  .changelog.md,file,.changelog.md,"28"
  ".claude-plugin",dir,".claude-plugin","0"
  ...
```

Empty results stay compact JSON:

```json
{"rows":[]}
```

Invalid SQL errors stay plain text:

```text
Error: Query request is invalid
Detail: invalid input: DML not supported: Delete
Hint: Check the SQL and retry. Use `coral://guide`, `coral.tables`, and `coral.columns` for discovery.
```

## Validation

- `CARGO_TARGET_DIR=/tmp/coral-toon-target cargo test --locked -p coral-mcp`
- `CARGO_TARGET_DIR=/tmp/coral-toon-target cargo check --locked -p xtask`
- `CARGO_TARGET_DIR=/tmp/coral-toon-target cargo build --locked -p coral-cli --bin coral`
- `CARGO_TARGET_DIR=/tmp/coral-toon-target cargo run --locked -p xtask -- mcp-token-bench --coral-bin /tmp/coral-toon-target/debug/coral --json > /tmp/coral-token-pr5-toon-sql.json`
- `CARGO_TARGET_DIR=/tmp/coral-toon-target make docs-check`
- `CARGO_TARGET_DIR=/tmp/coral-toon-target make rust-checks`
