### PR TITLE
perf(mcp): compact SQL tool text rendering

### DIFF
--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -7,7 +7,7 @@ use coral_api::v1::{
     TableSummary as ProtoTableSummary, catalog_item,
 };
 use coral_client::{
-    AppClient, CatalogClient, FeedbackClient, QueryClient, SourceClient,
+    AppClient, CatalogClient, CollectedQueryResult, FeedbackClient, QueryClient, SourceClient,
     batches_to_json_rows_json_safe_numbers, decode_execute_sql_response, default_workspace,
 };
 use rmcp::{
@@ -26,13 +26,13 @@ use tonic::Request;
 use crate::{
     McpOptions,
     surface::{
-        CatalogToolKind, build_tool_result, describe_table_arguments, describe_table_tool,
-        describe_table_value, feedback_tool, guide_resource, guide_resource_content,
-        initial_instructions, list_catalog_arguments, list_catalog_tool, list_catalog_value,
-        list_columns_arguments, list_columns_tool, list_columns_value, required_string_argument,
-        search_catalog_arguments, search_catalog_tool, search_catalog_value, sql_tool,
-        status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
-        tool_error_result,
+        CatalogToolKind, build_tool_result, build_tool_result_with_text, describe_table_arguments,
+        describe_table_tool, describe_table_value, feedback_tool, guide_resource,
+        guide_resource_content, initial_instructions, list_catalog_arguments, list_catalog_tool,
+        list_catalog_value, list_columns_arguments, list_columns_tool, list_columns_value,
+        required_string_argument, search_catalog_arguments, search_catalog_tool,
+        search_catalog_value, sql_tool, status_to_error_data, tables_resource,
+        tables_resource_content, tool_error_from_status, tool_error_result,
     },
     telemetry,
 };
@@ -44,7 +44,10 @@ const CATALOG_KIND_TABLE: ProtoCatalogItemKind = ProtoCatalogItemKind::Table;
 const CATALOG_KIND_TABLE_FUNCTION: ProtoCatalogItemKind = ProtoCatalogItemKind::TableFunction;
 
 enum ToolCallOutcome {
-    Success(Value),
+    Success {
+        value: Value,
+        text: Option<String>,
+    },
     ToolError {
         operation: &'static str,
         status: tonic::Status,
@@ -54,6 +57,18 @@ enum ToolCallOutcome {
 #[derive(Serialize)]
 struct SqlRowsValue {
     rows: Vec<Value>,
+}
+
+#[derive(Serialize)]
+struct SqlColumnarTextValue<'a> {
+    columns: &'a [String],
+    rows: Vec<Vec<Value>>,
+    row_count: usize,
+}
+
+struct SqlToolValue {
+    structured: Value,
+    text: String,
 }
 
 #[derive(Serialize)]
@@ -67,10 +82,40 @@ fn serialize_tool_value(value: impl Serialize) -> Result<Value, tonic::Status> {
     serde_json::to_value(value).map_err(|error| tonic::Status::internal(error.to_string()))
 }
 
+fn sql_columnar_text(
+    columns: &[String],
+    rows: &[Value],
+    row_count: usize,
+) -> Result<String, tonic::Status> {
+    let rows = rows
+        .iter()
+        .map(|row| sql_columnar_row(columns, row))
+        .collect::<Vec<_>>();
+    serde_json::to_string(&SqlColumnarTextValue {
+        columns,
+        rows,
+        row_count,
+    })
+    .map_err(|error| tonic::Status::internal(error.to_string()))
+}
+
+fn sql_columnar_row(columns: &[String], row: &Value) -> Vec<Value> {
+    let Some(object) = row.as_object() else {
+        return match columns {
+            [_single] => vec![row.clone()],
+            _ => vec![Value::Null; columns.len()],
+        };
+    };
+    columns
+        .iter()
+        .map(|column| object.get(column).cloned().unwrap_or(Value::Null))
+        .collect()
+}
+
 impl ToolCallOutcome {
     fn from_value_result(operation: &'static str, result: Result<Value, tonic::Status>) -> Self {
         match result {
-            Ok(value) => Self::Success(value),
+            Ok(value) => Self::Success { value, text: None },
             Err(status) => Self::ToolError { operation, status },
         }
     }
@@ -215,7 +260,7 @@ impl CoralMcpServer {
         Ok((sources, tables, table_function_schema_names))
     }
 
-    async fn query_rows(&self, sql: &str) -> Result<Vec<Value>, tonic::Status> {
+    async fn query_result(&self, sql: &str) -> Result<CollectedQueryResult, tonic::Status> {
         let mut query_client = self.query.clone();
         let response = query_client
             .execute_sql(Request::new(ExecuteSqlRequest {
@@ -224,16 +269,36 @@ impl CoralMcpServer {
             }))
             .await?
             .into_inner();
-        let result = decode_execute_sql_response(&response)
-            .map_err(|error| tonic::Status::internal(error.to_string()))?;
-        batches_to_json_rows_json_safe_numbers(result.batches())
+        decode_execute_sql_response(&response)
             .map_err(|error| tonic::Status::internal(error.to_string()))
     }
 
-    async fn execute_sql_value(&self, sql: &str) -> Result<Value, tonic::Status> {
-        serialize_tool_value(SqlRowsValue {
-            rows: self.query_rows(sql).await?,
-        })
+    async fn execute_sql_tool_value(&self, sql: &str) -> Result<SqlToolValue, tonic::Status> {
+        let result = self.query_result(sql).await?;
+        let columns = result
+            .schema()
+            .fields()
+            .iter()
+            .map(|field| field.name().clone())
+            .collect::<Vec<_>>();
+        let rows = batches_to_json_rows_json_safe_numbers(result.batches())
+            .map_err(|error| tonic::Status::internal(error.to_string()))?;
+        let text = sql_columnar_text(&columns, &rows, result.row_count())?;
+        let structured = serialize_tool_value(SqlRowsValue { rows })?;
+        Ok(SqlToolValue { structured, text })
+    }
+
+    async fn execute_sql_outcome(&self, sql: &str) -> ToolCallOutcome {
+        match self.execute_sql_tool_value(sql).await {
+            Ok(value) => ToolCallOutcome::Success {
+                value: value.structured,
+                text: Some(value.text),
+            },
+            Err(status) => ToolCallOutcome::ToolError {
+                operation: "Query",
+                status,
+            },
+        }
     }
 
     async fn submit_feedback_value(
@@ -283,7 +348,7 @@ impl CoralMcpServer {
             .await
             .map(|response| search_catalog_value(&response.into_inner()))
         {
-            Ok(value) => Ok(ToolCallOutcome::Success(value)),
+            Ok(value) => Ok(ToolCallOutcome::Success { value, text: None }),
             Err(status) if status.code() == tonic::Code::InvalidArgument => {
                 Err(status_to_error_data(&status))
             }
@@ -327,11 +392,10 @@ impl CoralMcpServer {
             .load_table_description(&arguments.schema, &arguments.table)
             .await
         {
-            Ok(response) => Ok(ToolCallOutcome::Success(describe_table_value(
-                &arguments.schema,
-                &arguments.table,
-                &response,
-            ))),
+            Ok(response) => Ok(ToolCallOutcome::Success {
+                value: describe_table_value(&arguments.schema, &arguments.table, &response),
+                text: None,
+            }),
             Err(status) => Ok(ToolCallOutcome::ToolError {
                 operation: "Table description",
                 status,
@@ -346,10 +410,7 @@ impl CoralMcpServer {
         match request.name.as_ref() {
             "sql" => {
                 let sql = required_string_argument(request.arguments.as_ref(), "sql")?;
-                Ok(ToolCallOutcome::from_value_result(
-                    "Query",
-                    self.execute_sql_value(&sql).await,
-                ))
+                Ok(self.execute_sql_outcome(&sql).await)
             }
             "list_catalog" => {
                 self.list_catalog_tool_result(request.arguments.as_ref())
@@ -406,11 +467,14 @@ impl CoralMcpServer {
             }))
             .await
         {
-            Ok(response) => Ok(ToolCallOutcome::Success(list_columns_value(
-                &arguments.schema,
-                &arguments.table,
-                &response.into_inner(),
-            ))),
+            Ok(response) => Ok(ToolCallOutcome::Success {
+                value: list_columns_value(
+                    &arguments.schema,
+                    &arguments.table,
+                    &response.into_inner(),
+                ),
+                text: None,
+            }),
             Err(status) if status.code() == tonic::Code::InvalidArgument => {
                 Err(status_to_error_data(&status))
             }
@@ -419,11 +483,10 @@ impl CoralMcpServer {
                     .load_table_description(&arguments.schema, &arguments.table)
                     .await
                 {
-                    Ok(response) => Ok(ToolCallOutcome::Success(describe_table_value(
-                        &arguments.schema,
-                        &arguments.table,
-                        &response,
-                    ))),
+                    Ok(response) => Ok(ToolCallOutcome::Success {
+                        value: describe_table_value(&arguments.schema, &arguments.table, &response),
+                        text: None,
+                    }),
                     Err(status) => Ok(ToolCallOutcome::ToolError {
                         operation: "Column listing",
                         status,
@@ -557,8 +620,11 @@ fn finish_tool_call(
     outcome: Result<ToolCallOutcome, ErrorData>,
 ) -> Result<CallToolResult, ErrorData> {
     match outcome {
-        Ok(ToolCallOutcome::Success(value)) => {
-            let result = build_tool_result(value);
+        Ok(ToolCallOutcome::Success { value, text }) => {
+            let result = match text {
+                Some(text) => Ok(build_tool_result_with_text(value, text)),
+                None => build_tool_result(value),
+            };
             telemetry::record_protocol_result(span, &result);
             result
         }

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -17,8 +17,8 @@ pub(crate) use resources::{
     tables_resource_content,
 };
 pub(crate) use tools::{
-    CatalogToolKind, build_tool_result, describe_table_arguments, describe_table_tool,
-    feedback_tool, list_catalog_arguments, list_catalog_tool, list_columns_arguments,
-    list_columns_tool, required_string_argument, search_catalog_arguments, search_catalog_tool,
-    sql_tool,
+    CatalogToolKind, build_tool_result, build_tool_result_with_text, describe_table_arguments,
+    describe_table_tool, feedback_tool, list_catalog_arguments, list_catalog_tool,
+    list_columns_arguments, list_columns_tool, required_string_argument, search_catalog_arguments,
+    search_catalog_tool, sql_tool,
 };

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -371,10 +371,10 @@ pub(crate) fn list_columns_arguments(
 }
 
 pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
-    let pretty = serde_json::to_string_pretty(&value)
+    let compact = serde_json::to_string(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
     let mut result = CallToolResult::structured(value);
-    result.content = vec![Content::text(pretty)];
+    result.content = vec![Content::text(compact)];
     Ok(result)
 }
 
@@ -799,9 +799,41 @@ fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{Map, Value};
+    use serde_json::{Map, Value, json};
 
-    use super::{list_catalog_arguments, search_catalog_arguments};
+    use super::{build_tool_result, list_catalog_arguments, search_catalog_arguments};
+
+    #[test]
+    fn success_tool_result_text_uses_compact_json() {
+        let value = json!({
+            "rows": [
+                {
+                    "id": 1,
+                    "text": "hello"
+                },
+                {
+                    "id": 2,
+                    "text": "world"
+                }
+            ]
+        });
+
+        let result = build_tool_result(value.clone()).expect("tool result");
+
+        let text = result
+            .content
+            .first()
+            .and_then(|content| content.as_text())
+            .expect("text content");
+        assert_eq!(
+            text.text,
+            r#"{"rows":[{"id":1,"text":"hello"},{"id":2,"text":"world"}]}"#
+        );
+        assert_eq!(
+            result.structured_content.expect("structured content"),
+            value
+        );
+    }
 
     #[test]
     fn catalog_kind_argument_accepts_null_as_all_kinds() {

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -373,9 +373,13 @@ pub(crate) fn list_columns_arguments(
 pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
     let compact = serde_json::to_string(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+    Ok(build_tool_result_with_text(value, compact))
+}
+
+pub(crate) fn build_tool_result_with_text(value: Value, text: String) -> CallToolResult {
     let mut result = CallToolResult::structured(value);
-    result.content = vec![Content::text(compact)];
-    Ok(result)
+    result.content = vec![Content::text(text)];
+    result
 }
 
 fn sql_tool_description(visible_table_count: usize) -> String {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -251,6 +251,14 @@ fn text_content(result: &rmcp::model::ReadResourceResult) -> &str {
     }
 }
 
+fn tool_text_content(result: &rmcp::model::CallToolResult) -> &str {
+    result.content[0]
+        .as_text()
+        .expect("text content")
+        .text
+        .as_str()
+}
+
 fn tool_by_name<'a>(tools: &'a [Tool], name: &str) -> &'a Tool {
     tools
         .iter()
@@ -1032,8 +1040,13 @@ async fn mcp_tool_error_does_not_end_session() {
         )
         .await
         .expect("sql");
+    let sql_text: Value =
+        serde_json::from_str(tool_text_content(&sql)).expect("sql text content should be JSON");
+    assert_eq!(sql_text["columns"], json!(["text"]));
+    assert_eq!(sql_text["rows"], json!([["hello"], ["world"]]));
+    assert_eq!(sql_text["row_count"], 2);
     assert_eq!(
-        sql.structured_content.expect("structured content")["rows"][0]["text"],
+        sql.structured_content.as_ref().expect("structured content")["rows"][0]["text"],
         "hello"
     );
     assert_eq!(sql.is_error, Some(false));
@@ -1098,11 +1111,16 @@ async fn mcp_sql_returns_large_int64_as_string() {
         .expect("sql");
     assert_eq!(sql.is_error, Some(false));
 
-    let rows = &sql.structured_content.expect("structured content")["rows"];
+    let rows = &sql.structured_content.as_ref().expect("structured content")["rows"];
     assert_eq!(
         rows[0]["user_id"],
         Value::String("-8504475857937456387".to_string()),
     );
+    let sql_text: Value =
+        serde_json::from_str(tool_text_content(&sql)).expect("sql text content should be JSON");
+    assert_eq!(sql_text["columns"], json!(["user_id"]));
+    assert_eq!(sql_text["rows"], json!([["-8504475857937456387"]]));
+    assert_eq!(sql_text["row_count"], 1);
 
     session.shutdown().await;
 }

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -60,12 +60,18 @@ Some sources expose native search endpoints (for example, GitHub issue search) a
 
 ## Query result format
 
-The `sql` tool returns rows as a JSON array of objects. To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
+The `sql` tool's structured result returns rows as a JSON array of objects. Its text content is optimized for agent context size and renders the same result in compact columnar form:
+
+```json
+{"columns":["id","title"],"rows":[["1","Fix auth"],["2","Add docs"]],"row_count":2}
+```
+
+To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
 
 - `Int64` (`BIGINT`) and `UInt64`
 - `Decimal32`, `Decimal64`, `Decimal128`, and `Decimal256`
 
-This applies wherever these types appear, including nested inside `Struct`, `List`, and `Map` columns. The column's declared SQL type does not change — `describe_table`, `list_columns`, and `coral.columns` still report `Int64` or `Decimal(p, s)`; only the JSON encoding of the value is a string. A `BIGINT` `user_id`, for example, comes back as `{ "user_id": "-8504475857937456387" }`.
+This applies wherever these types appear, including nested inside `Struct`, `List`, and `Map` columns. The column's declared SQL type does not change — `describe_table`, `list_columns`, and `coral.columns` still report `Int64` or `Decimal(p, s)`; only the JSON encoding of the value is a string. A `BIGINT` `user_id`, for example, comes back in structured content as `{ "user_id": "-8504475857937456387" }` and in text content as `{"columns":["user_id"],"rows":[["-8504475857937456387"]],"row_count":1}`.
 
 Coral does this because MCP uses JSON-RPC, and many clients — JavaScript/TypeScript `JSON.parse` and most MCP hosts — decode JSON numbers as IEEE-754 doubles. Values beyond 2^53 silently lose precision when read as a number.
 


### PR DESCRIPTION
## Summary
- stop emitting pretty-printed MCP success text and keep non-SQL tool text as compact JSON
- render MCP `sql` tool text as compact columnar JSON with `columns`, positional `rows`, and `row_count`
- preserve `structured_content` as the existing row-object shape for MCP client compatibility
- document the MCP SQL text format and cover the columnar contract in MCP tests

## Before / After Result Shape
For a SQL result with one `text` column and two rows, MCP text used to repeat row-object keys and pretty-print whitespace:

```json
{
  "rows": [
    {
      "text": "hello"
    },
    {
      "text": "world"
    }
  ]
}
```

After this PR, MCP `sql` text is compact columnar JSON:

```json
{"columns":["text"],"rows":[["hello"],["world"]],"row_count":2}
```

`structured_content` remains the existing object-row shape for MCP clients; only the text payload optimized for model context changes.

## Performance
Local MCP SQL text-size benchmark against the same SQL scenarios used during development:

| Version | Total chars | Estimated tokens | Reduction vs main | Reduction vs PR #1197 |
| --- | ---: | ---: | ---: | ---: |
| main, pretty object rows | 2,274 | 569 | baseline | n/a |
| PR #1197, compact object rows | 1,562 | 391 | 31.3% | baseline |
| this branch, compact columnar SQL text | 1,050 | 263 | 53.8% | 32.7% |

Wide `10x7` SQL result: PR #1197 compact object rows emitted 1,518 chars; columnar SQL text emitted 987 chars, a 35.0% reduction.

Tiny `2x1` SQL result: compact object rows remain smaller, 44 chars vs 63 chars, because column metadata overhead dominates. The intended win is wider or repeated-row SQL output where repeated object keys dominate context size.

## Validation
- `cargo test -p coral-mcp mcp_tool_error_does_not_end_session`
- `cargo test -p coral-mcp mcp_sql_returns_large_int64_as_string`