### PR TITLE
feat(app): per-workspace episode store (BENCH-496)

### DIFF
--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -86,6 +86,13 @@ pub const CORAL_EPISODE_ID_METADATA_KEY: &str = "coral-episode-id";
 /// server- and client-side so the contract stays in one place.
 pub const CORAL_EPISODE_ID_MAX_LEN: usize = 128;
 
+/// Maximum length of an episode `intent`, in characters. Generous for a task
+/// description while bounding the per-record size of the episode log. Owned here
+/// (rather than in `coral-app`) so the `OpenEpisode` request contract — the
+/// exact bound generated clients can prevalidate against — lives in one place
+/// and a change is visible as a `coral-api` diff.
+pub const CORAL_EPISODE_INTENT_MAX_CHARS: usize = 4096;
+
 /// Machine-readable reason for a configured source lookup miss.
 pub const CORAL_ERROR_REASON_SOURCE_NOT_FOUND: &str = "SOURCE_NOT_FOUND";
 

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -76,6 +76,16 @@ pub const CORAL_ERROR_DOMAIN: &str = "coral.withcoral.com";
 /// Canonical default workspace name used across local Coral surfaces.
 pub const DEFAULT_WORKSPACE_ID: &str = "default";
 
+/// gRPC metadata key carrying the originating episode id on Coral calls after
+/// `EpisodeService.OpenEpisode`. The single source of truth for the wire
+/// contract; consumed by both the server (`coral-app`) and clients
+/// (`coral-client`).
+pub const CORAL_EPISODE_ID_METADATA_KEY: &str = "coral-episode-id";
+
+/// Maximum length of a `coral-episode-id` value, in bytes. Validated identically
+/// server- and client-side so the contract stays in one place.
+pub const CORAL_EPISODE_ID_MAX_LEN: usize = 128;
+
 /// Machine-readable reason for a configured source lookup miss.
 pub const CORAL_ERROR_REASON_SOURCE_NOT_FOUND: &str = "SOURCE_NOT_FOUND";
 

--- a/crates/coral-app/src/episode/id.rs
+++ b/crates/coral-app/src/episode/id.rs
@@ -9,11 +9,9 @@
 
 use std::fmt;
 
-use crate::bootstrap::AppError;
+use coral_api::CORAL_EPISODE_ID_MAX_LEN;
 
-/// Maximum length of an episode id, in bytes — generous for a UUID/ULID while
-/// bounding the `coral-episode-id` metadata value and per-record on-disk size.
-const MAX_EPISODE_ID_LEN: usize = 128;
+use crate::bootstrap::AppError;
 
 /// App-owned identity for one validated, client-minted episode id.
 ///
@@ -28,15 +26,15 @@ pub(crate) struct EpisodeId(String);
 
 impl EpisodeId {
     /// Parse and validate a client-minted episode id. Rejects an empty id, one
-    /// longer than [`MAX_EPISODE_ID_LEN`] bytes, or one containing any byte
+    /// longer than [`CORAL_EPISODE_ID_MAX_LEN`] bytes, or one containing any byte
     /// outside graphic ASCII (`0x21..=0x7E`) — see the `OpenEpisode` proto.
     pub(crate) fn parse(id: &str) -> Result<Self, AppError> {
         if id.is_empty() {
             return Err(AppError::InvalidInput("missing episode id".to_string()));
         }
-        if id.len() > MAX_EPISODE_ID_LEN {
+        if id.len() > CORAL_EPISODE_ID_MAX_LEN {
             return Err(AppError::InvalidInput(format!(
-                "episode id must be at most {MAX_EPISODE_ID_LEN} bytes"
+                "episode id must be at most {CORAL_EPISODE_ID_MAX_LEN} bytes"
             )));
         }
         if !id.bytes().all(|byte| byte.is_ascii_graphic()) {
@@ -64,7 +62,9 @@ impl fmt::Display for EpisodeId {
 
 #[cfg(test)]
 mod tests {
-    use super::{EpisodeId, MAX_EPISODE_ID_LEN};
+    use coral_api::CORAL_EPISODE_ID_MAX_LEN;
+
+    use super::EpisodeId;
 
     #[test]
     fn accepts_uuid_and_ulid() {
@@ -83,8 +83,8 @@ mod tests {
 
     #[test]
     fn enforces_max_length() {
-        EpisodeId::parse(&"a".repeat(MAX_EPISODE_ID_LEN)).expect("max length is valid");
-        EpisodeId::parse(&"a".repeat(MAX_EPISODE_ID_LEN + 1))
+        EpisodeId::parse(&"a".repeat(CORAL_EPISODE_ID_MAX_LEN)).expect("max length is valid");
+        EpisodeId::parse(&"a".repeat(CORAL_EPISODE_ID_MAX_LEN + 1))
             .expect_err("over-long id must be rejected");
     }
 }

--- a/crates/coral-app/src/episode/id.rs
+++ b/crates/coral-app/src/episode/id.rs
@@ -1,0 +1,90 @@
+//! Validated, client-minted episode identifier.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "EpisodeId is consumed by the store and the OpenEpisode handler — next PRs in the stack"
+    )
+)]
+
+use std::fmt;
+
+use crate::bootstrap::AppError;
+
+/// Maximum length of an episode id, in bytes — generous for a UUID/ULID while
+/// bounding the `coral-episode-id` metadata value and per-record on-disk size.
+const MAX_EPISODE_ID_LEN: usize = 128;
+
+/// App-owned identity for one validated, client-minted episode id.
+///
+/// The id round-trips as the `coral-episode-id` gRPC metadata value on every
+/// subsequent Coral call, so it is constrained to graphic ASCII (no whitespace,
+/// control bytes, or non-ASCII) with a bounded length — a UUID or ULID fits.
+/// Like [`WorkspaceName`](crate::workspaces::WorkspaceName), the validated id is
+/// carried as a narrow type so the store and the service boundary never handle
+/// an unvalidated string.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct EpisodeId(String);
+
+impl EpisodeId {
+    /// Parse and validate a client-minted episode id. Rejects an empty id, one
+    /// longer than [`MAX_EPISODE_ID_LEN`] bytes, or one containing any byte
+    /// outside graphic ASCII (`0x21..=0x7E`) — see the `OpenEpisode` proto.
+    pub(crate) fn parse(id: &str) -> Result<Self, AppError> {
+        if id.is_empty() {
+            return Err(AppError::InvalidInput("missing episode id".to_string()));
+        }
+        if id.len() > MAX_EPISODE_ID_LEN {
+            return Err(AppError::InvalidInput(format!(
+                "episode id must be at most {MAX_EPISODE_ID_LEN} bytes"
+            )));
+        }
+        if !id.bytes().all(|byte| byte.is_ascii_graphic()) {
+            return Err(AppError::InvalidInput(
+                "episode id must be graphic ASCII (no spaces, control, or non-ASCII bytes)"
+                    .to_string(),
+            ));
+        }
+        Ok(Self(id.to_string()))
+    }
+
+    /// Borrow the validated id for metadata and persistence boundaries that
+    /// operate on strings.
+    #[must_use]
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for EpisodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EpisodeId, MAX_EPISODE_ID_LEN};
+
+    #[test]
+    fn accepts_uuid_and_ulid() {
+        EpisodeId::parse("550e8400-e29b-41d4-a716-446655440000").expect("uuid is valid");
+        EpisodeId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("ulid is valid");
+    }
+
+    #[test]
+    fn rejects_empty_whitespace_and_non_ascii() {
+        EpisodeId::parse("").expect_err("empty id must be rejected");
+        EpisodeId::parse("   ").expect_err("whitespace id must be rejected");
+        EpisodeId::parse("has space").expect_err("embedded space must be rejected");
+        EpisodeId::parse("tab\tid").expect_err("control byte must be rejected");
+        EpisodeId::parse("épisode").expect_err("non-ASCII must be rejected");
+    }
+
+    #[test]
+    fn enforces_max_length() {
+        EpisodeId::parse(&"a".repeat(MAX_EPISODE_ID_LEN)).expect("max length is valid");
+        EpisodeId::parse(&"a".repeat(MAX_EPISODE_ID_LEN + 1))
+            .expect_err("over-long id must be rejected");
+    }
+}

--- a/crates/coral-app/src/episode/mod.rs
+++ b/crates/coral-app/src/episode/mod.rs
@@ -4,4 +4,7 @@
 //! by default). PR 1 lands the store; the `OpenEpisode` handler and the
 //! `coral-episode-id` span attribution stack on top.
 
+pub(crate) mod id;
 mod store;
+
+pub(crate) use id::EpisodeId;

--- a/crates/coral-app/src/episode/mod.rs
+++ b/crates/coral-app/src/episode/mod.rs
@@ -1,0 +1,7 @@
+//! Trajectory-memory episodes: persist the intent (and parent) of a task-attempt,
+//! keyed by a client-minted episode id, so the read side can join a task's queries
+//! to the intent they served. Experimental — gated by the `episodes` feature (off
+//! by default). PR 1 lands the store; the `OpenEpisode` handler and the
+//! `coral-episode-id` span attribution stack on top.
+
+mod store;

--- a/crates/coral-app/src/episode/store.rs
+++ b/crates/coral-app/src/episode/store.rs
@@ -20,21 +20,26 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
+use super::EpisodeId;
 use crate::state::AppStateLayout;
 use crate::storage::fs::{self as storage_fs, FileLock};
 use crate::workspaces::WorkspaceName;
 
+/// Maximum intent length, in characters — generous for a task description while
+/// bounding the per-record size of the append-only log.
+const MAX_INTENT_CHARS: usize = 4096;
+
 /// A registered episode — one task-attempt's intent and lineage.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Episode {
-    /// Client-minted, opaque episode id.
-    pub(crate) id: String,
+    /// Client-minted, validated episode id.
+    pub(crate) id: EpisodeId,
     /// Workspace that scopes the episode (per-tenant isolation).
     pub(crate) workspace: WorkspaceName,
     /// Natural-language task description — the retrieval handle.
     pub(crate) intent: String,
     /// Parent episode id for a child sub-task; `None` for a root.
-    pub(crate) parent_episode_id: Option<String>,
+    pub(crate) parent_episode_id: Option<EpisodeId>,
     /// Registration time, unix nanoseconds.
     pub(crate) created_at_unix_nanos: u128,
 }
@@ -54,10 +59,13 @@ struct PersistedEpisode {
 impl PersistedEpisode {
     fn from_episode(episode: &Episode) -> Self {
         Self {
-            id: episode.id.clone(),
+            id: episode.id.as_str().to_string(),
             workspace: episode.workspace.as_str().to_string(),
             intent: episode.intent.clone(),
-            parent_episode_id: episode.parent_episode_id.clone(),
+            parent_episode_id: episode
+                .parent_episode_id
+                .as_ref()
+                .map(|parent| parent.as_str().to_string()),
             created_at_unix_nanos: episode.created_at_unix_nanos,
         }
     }
@@ -77,6 +85,12 @@ pub(crate) enum EpisodeStoreError {
     Conflict {
         /// The conflicting episode id.
         episode_id: String,
+    },
+    /// The intent is empty or exceeds the maximum length.
+    #[error("episode intent must be non-empty and at most {max} characters")]
+    InvalidIntent {
+        /// The configured maximum intent length, in characters.
+        max: usize,
     },
 }
 
@@ -101,18 +115,25 @@ impl EpisodeStore {
     /// The shared state lock is held across the read-then-append so the
     /// idempotency/conflict check and the write are atomic against concurrent
     /// opens. Intent may be PII, so the log is written with private (0600)
-    /// permissions.
+    /// permissions. The id is already validated ([`EpisodeId`]); intent is
+    /// checked here as a safety net for callers that bypass the service boundary.
     pub(crate) fn open_episode(&self, episode: &Episode) -> Result<(), EpisodeStoreError> {
+        if episode.intent.trim().is_empty() || episode.intent.chars().count() > MAX_INTENT_CHARS {
+            return Err(EpisodeStoreError::InvalidIntent {
+                max: MAX_INTENT_CHARS,
+            });
+        }
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
         let path = self.layout.episodes_file(&episode.workspace);
-        if let Some(existing) = read_episode(&path, &episode.id)? {
+        if let Some(existing) = read_episode(&path, episode.id.as_str())? {
             return if existing.intent == episode.intent
-                && existing.parent_episode_id == episode.parent_episode_id
+                && existing.parent_episode_id.as_deref()
+                    == episode.parent_episode_id.as_ref().map(EpisodeId::as_str)
             {
                 Ok(())
             } else {
                 Err(EpisodeStoreError::Conflict {
-                    episode_id: episode.id.clone(),
+                    episode_id: episode.id.as_str().to_string(),
                 })
             };
         }
@@ -160,7 +181,10 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use super::{Episode, EpisodeStore, EpisodeStoreError, now_unix_nanos, read_episode};
+    use super::{
+        Episode, EpisodeId, EpisodeStore, EpisodeStoreError, MAX_INTENT_CHARS, now_unix_nanos,
+        read_episode,
+    };
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
 
@@ -173,12 +197,28 @@ mod tests {
 
     fn episode(workspace: &WorkspaceName, id: &str, intent: &str, parent: Option<&str>) -> Episode {
         Episode {
-            id: id.to_string(),
+            id: EpisodeId::parse(id).expect("valid episode id"),
             workspace: workspace.clone(),
             intent: intent.to_string(),
-            parent_episode_id: parent.map(str::to_string),
+            parent_episode_id: parent.map(|parent| EpisodeId::parse(parent).expect("valid parent")),
             created_at_unix_nanos: now_unix_nanos(),
         }
+    }
+
+    #[test]
+    fn open_rejects_blank_and_overlong_intent() {
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout);
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let blank = store
+            .open_episode(&episode(&workspace, "ep_blank", "   ", None))
+            .expect_err("blank intent must be rejected");
+        assert!(matches!(blank, EpisodeStoreError::InvalidIntent { .. }));
+        let overlong = "x".repeat(MAX_INTENT_CHARS + 1);
+        let too_long = store
+            .open_episode(&episode(&workspace, "ep_long", &overlong, None))
+            .expect_err("overlong intent must be rejected");
+        assert!(matches!(too_long, EpisodeStoreError::InvalidIntent { .. }));
     }
 
     #[test]

--- a/crates/coral-app/src/episode/store.rs
+++ b/crates/coral-app/src/episode/store.rs
@@ -14,7 +14,7 @@
 )]
 
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -166,30 +166,39 @@ pub(crate) fn now_unix_nanos() -> u128 {
 }
 
 /// Returns the most recent record for `episode_id` in `path`, if any.
+///
+/// Reads raw bytes and splits on newlines so a torn final record is skipped
+/// whether the crash broke JSON *or* UTF-8 (it can truncate a multi-byte intent
+/// mid-character) — one torn write must never brick reads for the workspace.
 fn read_episode(
     path: &Path,
     episode_id: &str,
 ) -> Result<Option<PersistedEpisode>, EpisodeStoreError> {
-    let file = match File::open(path) {
-        Ok(file) => file,
+    let contents = match std::fs::read(path) {
+        Ok(contents) => contents,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error.into()),
     };
     let mut found = None;
-    for line in BufReader::new(file).lines() {
-        let line = line?;
+    for raw_line in contents.split(|&byte| byte == b'\n') {
+        // A torn final record can be invalid UTF-8 (e.g. a truncated non-ASCII
+        // intent); skip it rather than failing the whole read.
+        let Ok(line) = std::str::from_utf8(raw_line) else {
+            tracing::warn!("skipping episode record with invalid UTF-8 (likely a torn write)");
+            continue;
+        };
         if line.trim().is_empty() {
             continue;
         }
-        match serde_json::from_str::<PersistedEpisode>(&line) {
+        match serde_json::from_str::<PersistedEpisode>(line) {
             Ok(episode) => {
                 if episode.id == episode_id {
                     found = Some(episode);
                 }
             }
-            // A crash mid-append can leave a torn record; skip it rather than
-            // bricking every read for the workspace. An unacknowledged torn write
-            // is simply re-appended when the client retries `OpenEpisode`.
+            // A crash mid-append can also leave a syntactically torn (but valid
+            // UTF-8) record; skip it too. An unacknowledged torn write is simply
+            // re-appended when the client retries `OpenEpisode`.
             Err(error) => {
                 tracing::warn!(%error, "skipping unparsable episode record");
             }
@@ -323,6 +332,32 @@ mod tests {
             .expect("read")
             .expect("ep_2 present after recovery");
         assert_eq!(recovered.intent, "second intent");
+    }
+
+    #[test]
+    fn read_tolerates_a_torn_record_with_invalid_utf8() {
+        use std::io::Write as _;
+
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let path = layout.episodes_file(&workspace);
+        store
+            .open_episode(&episode(&workspace, "ep_1", "first intent", None))
+            .expect("open");
+        // A crash can truncate a multi-byte (non-ASCII) intent mid-character,
+        // leaving invalid UTF-8 at the tail — `{` then the first two bytes of a
+        // 4-byte emoji.
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open for append")
+            .write_all(&[b'{', 0xF0, 0x9F])
+            .expect("write torn invalid-utf8 record");
+        let read = read_episode(&path, "ep_1")
+            .expect("read tolerates an invalid-UTF-8 tail")
+            .expect("ep_1 present");
+        assert_eq!(read.intent, "first intent");
     }
 
     #[test]

--- a/crates/coral-app/src/episode/store.rs
+++ b/crates/coral-app/src/episode/store.rs
@@ -1,0 +1,259 @@
+//! Per-workspace, append-only episode store.
+//!
+//! Persists `{ episode_id -> intent, parent }` for an episode (one task-attempt),
+//! written once by `OpenEpisode` into the per-workspace episode log resolved by
+//! [`AppStateLayout`]. Minimal by design for PR 1: a private, locked JSONL append.
+//! JSONL→Parquet compaction, retention/eviction, and the queryable
+//! `coral.episodes` surface land in PR 2.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the store is consumed by the OpenEpisode handler — next PR in the stack"
+    )
+)]
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::state::AppStateLayout;
+use crate::storage::fs::{self as storage_fs, FileLock};
+use crate::workspaces::WorkspaceName;
+
+/// A registered episode — one task-attempt's intent and lineage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Episode {
+    /// Client-minted, opaque episode id.
+    pub(crate) id: String,
+    /// Workspace that scopes the episode (per-tenant isolation).
+    pub(crate) workspace: WorkspaceName,
+    /// Natural-language task description — the retrieval handle.
+    pub(crate) intent: String,
+    /// Parent episode id for a child sub-task; `None` for a root.
+    pub(crate) parent_episode_id: Option<String>,
+    /// Registration time, unix nanoseconds.
+    pub(crate) created_at_unix_nanos: u128,
+}
+
+/// On-disk JSONL shape for an [`Episode`]. The workspace is also encoded in the
+/// per-workspace file path; it is persisted here too so each record is
+/// self-describing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PersistedEpisode {
+    id: String,
+    workspace: String,
+    intent: String,
+    parent_episode_id: Option<String>,
+    created_at_unix_nanos: u128,
+}
+
+impl PersistedEpisode {
+    fn from_episode(episode: &Episode) -> Self {
+        Self {
+            id: episode.id.clone(),
+            workspace: episode.workspace.as_str().to_string(),
+            intent: episode.intent.clone(),
+            parent_episode_id: episode.parent_episode_id.clone(),
+            created_at_unix_nanos: episode.created_at_unix_nanos,
+        }
+    }
+}
+
+/// Errors from the episode store.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum EpisodeStoreError {
+    /// Filesystem error reading or writing the store.
+    #[error("episode store io: {0}")]
+    Io(#[from] std::io::Error),
+    /// JSON (de)serialization error.
+    #[error("episode store serialization: {0}")]
+    Serde(#[from] serde_json::Error),
+    /// The `episode_id` is already registered with a different intent/parent.
+    #[error("episode {episode_id:?} is already open with a different intent/parent")]
+    Conflict {
+        /// The conflicting episode id.
+        episode_id: String,
+    },
+}
+
+/// Append-only, per-workspace JSONL episode store. Paths and the shared state
+/// lock are resolved through [`AppStateLayout`].
+pub(crate) struct EpisodeStore {
+    layout: AppStateLayout,
+}
+
+impl EpisodeStore {
+    /// Creates a store that persists under `layout`.
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
+    /// Registers `episode`, idempotently.
+    ///
+    /// Re-opening the same `episode_id` with an identical `{ intent, parent }` is a
+    /// no-op; a different intent/parent returns [`EpisodeStoreError::Conflict`]
+    /// (intent is immutable per episode — a change is a new child/sibling).
+    ///
+    /// The shared state lock is held across the read-then-append so the
+    /// idempotency/conflict check and the write are atomic against concurrent
+    /// opens. Intent may be PII, so the log is written with private (0600)
+    /// permissions.
+    pub(crate) fn open_episode(&self, episode: &Episode) -> Result<(), EpisodeStoreError> {
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        let path = self.layout.episodes_file(&episode.workspace);
+        if let Some(existing) = read_episode(&path, &episode.id)? {
+            return if existing.intent == episode.intent
+                && existing.parent_episode_id == episode.parent_episode_id
+            {
+                Ok(())
+            } else {
+                Err(EpisodeStoreError::Conflict {
+                    episode_id: episode.id.clone(),
+                })
+            };
+        }
+        let mut line = serde_json::to_vec(&PersistedEpisode::from_episode(episode))?;
+        line.push(b'\n');
+        storage_fs::append_file_private(&path, &line)?;
+        Ok(())
+    }
+}
+
+/// Unix-nanoseconds timestamp for `created_at_unix_nanos`.
+pub(crate) fn now_unix_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_nanos())
+}
+
+/// Returns the most recent record for `episode_id` in `path`, if any.
+fn read_episode(
+    path: &Path,
+    episode_id: &str,
+) -> Result<Option<PersistedEpisode>, EpisodeStoreError> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let mut found = None;
+    for line in BufReader::new(file).lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let episode: PersistedEpisode = serde_json::from_str(&line)?;
+        if episode.id == episode_id {
+            found = Some(episode);
+        }
+    }
+    Ok(found)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::{Episode, EpisodeStore, EpisodeStoreError, now_unix_nanos, read_episode};
+    use crate::state::AppStateLayout;
+    use crate::workspaces::WorkspaceName;
+
+    fn layout() -> (TempDir, AppStateLayout) {
+        let dir = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(dir.path().join("coral-config")))
+            .expect("layout should resolve");
+        (dir, layout)
+    }
+
+    fn episode(workspace: &WorkspaceName, id: &str, intent: &str, parent: Option<&str>) -> Episode {
+        Episode {
+            id: id.to_string(),
+            workspace: workspace.clone(),
+            intent: intent.to_string(),
+            parent_episode_id: parent.map(str::to_string),
+            created_at_unix_nanos: now_unix_nanos(),
+        }
+    }
+
+    #[test]
+    fn open_then_read_round_trips() {
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let ep = episode(&workspace, "ep_1", "find the HR onboarding form", None);
+        store.open_episode(&ep).expect("open");
+        let read = read_episode(&layout.episodes_file(&workspace), "ep_1")
+            .expect("read")
+            .expect("episode should be present");
+        assert_eq!(read.id, "ep_1");
+        assert_eq!(read.workspace, "acme");
+        assert_eq!(read.intent, "find the HR onboarding form");
+        assert_eq!(read.parent_episode_id, None);
+        assert_eq!(read.created_at_unix_nanos, ep.created_at_unix_nanos);
+    }
+
+    #[test]
+    fn reopen_identical_is_idempotent() {
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let ep = episode(&workspace, "ep_1", "same intent", None);
+        store.open_episode(&ep).expect("first open");
+        store.open_episode(&ep).expect("idempotent reopen");
+        let lines = fs::read_to_string(layout.episodes_file(&workspace))
+            .expect("read file")
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .count();
+        assert_eq!(lines, 1, "idempotent reopen must not append a duplicate");
+    }
+
+    #[test]
+    fn reopen_with_different_intent_conflicts() {
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout);
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        store
+            .open_episode(&episode(&workspace, "ep_1", "intent A", None))
+            .expect("first open");
+        let error = store
+            .open_episode(&episode(&workspace, "ep_1", "intent B", None))
+            .expect_err("changed intent must conflict");
+        assert!(matches!(error, EpisodeStoreError::Conflict { .. }));
+    }
+
+    #[test]
+    fn same_id_in_different_workspaces_is_isolated() {
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout.clone());
+        let acme = WorkspaceName::parse("acme").expect("workspace");
+        let globex = WorkspaceName::parse("globex").expect("workspace");
+        store
+            .open_episode(&episode(&acme, "ep_1", "in acme", None))
+            .expect("acme");
+        // Same id, different workspace → isolated, no conflict.
+        store
+            .open_episode(&episode(&globex, "ep_1", "in globex", None))
+            .expect("globex");
+        assert_eq!(
+            read_episode(&layout.episodes_file(&acme), "ep_1")
+                .unwrap()
+                .unwrap()
+                .intent,
+            "in acme"
+        );
+        assert_eq!(
+            read_episode(&layout.episodes_file(&globex), "ep_1")
+                .unwrap()
+                .unwrap()
+                .intent,
+            "in globex"
+        );
+    }
+}

--- a/crates/coral-app/src/episode/store.rs
+++ b/crates/coral-app/src/episode/store.rs
@@ -18,16 +18,13 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use coral_api::CORAL_EPISODE_INTENT_MAX_CHARS;
 use serde::{Deserialize, Serialize};
 
 use super::EpisodeId;
 use crate::state::AppStateLayout;
 use crate::storage::fs::{self as storage_fs, FileLock};
 use crate::workspaces::WorkspaceName;
-
-/// Maximum intent length, in characters — generous for a task description while
-/// bounding the per-record size of the append-only log.
-const MAX_INTENT_CHARS: usize = 4096;
 
 /// A registered episode — one task-attempt's intent and lineage.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -124,9 +121,9 @@ impl EpisodeStore {
         // immutable key — a retry with an accidental trailing space must stay
         // idempotent, not conflict.
         let intent = episode.intent.trim();
-        if intent.is_empty() || intent.chars().count() > MAX_INTENT_CHARS {
+        if intent.is_empty() || intent.chars().count() > CORAL_EPISODE_INTENT_MAX_CHARS {
             return Err(EpisodeStoreError::InvalidIntent {
-                max: MAX_INTENT_CHARS,
+                max: CORAL_EPISODE_INTENT_MAX_CHARS,
             });
         }
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
@@ -233,8 +230,8 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        Episode, EpisodeId, EpisodeStore, EpisodeStoreError, MAX_INTENT_CHARS, now_unix_nanos,
-        read_episode,
+        CORAL_EPISODE_INTENT_MAX_CHARS, Episode, EpisodeId, EpisodeStore, EpisodeStoreError,
+        now_unix_nanos, read_episode,
     };
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
@@ -265,7 +262,7 @@ mod tests {
             .open_episode(&episode(&workspace, "ep_blank", "   ", None))
             .expect_err("blank intent must be rejected");
         assert!(matches!(blank, EpisodeStoreError::InvalidIntent { .. }));
-        let overlong = "x".repeat(MAX_INTENT_CHARS + 1);
+        let overlong = "x".repeat(CORAL_EPISODE_INTENT_MAX_CHARS + 1);
         let too_long = store
             .open_episode(&episode(&workspace, "ep_long", &overlong, None))
             .expect_err("overlong intent must be rejected");
@@ -404,6 +401,75 @@ mod tests {
         let error = store
             .open_episode(&episode(&workspace, "ep_1", "intent B", None))
             .expect_err("changed intent must conflict");
+        assert!(matches!(error, EpisodeStoreError::Conflict { .. }));
+    }
+
+    #[test]
+    fn open_child_round_trips_parent() {
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        store
+            .open_episode(&episode(&workspace, "root_ep", "root task", None))
+            .expect("open root");
+        let child = episode(&workspace, "child_ep", "sub task", Some("root_ep"));
+        store.open_episode(&child).expect("open child");
+        let read = read_episode(&layout.episodes_file(&workspace), "child_ep")
+            .expect("read")
+            .expect("child should be present");
+        assert_eq!(
+            read.parent_episode_id.as_deref(),
+            Some("root_ep"),
+            "the parent link must persist and round-trip"
+        );
+        assert_eq!(read.intent, "sub task");
+    }
+
+    #[test]
+    fn reopen_child_with_identical_parent_is_idempotent() {
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let child = episode(&workspace, "child_ep", "sub task", Some("root_ep"));
+        store.open_episode(&child).expect("first open");
+        store
+            .open_episode(&child)
+            .expect("identical reopen (same id/intent/parent) is idempotent");
+        let lines = fs::read_to_string(layout.episodes_file(&workspace))
+            .expect("read file")
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .count();
+        assert_eq!(
+            lines, 1,
+            "reopening with an identical parent must not append a duplicate"
+        );
+    }
+
+    #[test]
+    fn reopen_same_intent_different_parent_conflicts() {
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout);
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        store
+            .open_episode(&episode(
+                &workspace,
+                "child_ep",
+                "sub task",
+                Some("parent_a"),
+            ))
+            .expect("first open");
+        // Same id and intent, but a different parent. The parent is half of the
+        // idempotency key, so this must conflict rather than silently re-parent
+        // the child's lineage.
+        let error = store
+            .open_episode(&episode(
+                &workspace,
+                "child_ep",
+                "sub task",
+                Some("parent_b"),
+            ))
+            .expect_err("changed parent must conflict");
         assert!(matches!(error, EpisodeStoreError::Conflict { .. }));
     }
 

--- a/crates/coral-app/src/episode/store.rs
+++ b/crates/coral-app/src/episode/store.rs
@@ -14,7 +14,7 @@
 )]
 
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -57,11 +57,13 @@ struct PersistedEpisode {
 }
 
 impl PersistedEpisode {
-    fn from_episode(episode: &Episode) -> Self {
+    /// Builds the on-disk record, storing the already-normalized `intent` (rather
+    /// than `episode.intent`) so persisted/compared values stay consistent.
+    fn from_episode(episode: &Episode, intent: &str) -> Self {
         Self {
             id: episode.id.as_str().to_string(),
             workspace: episode.workspace.as_str().to_string(),
-            intent: episode.intent.clone(),
+            intent: intent.to_string(),
             parent_episode_id: episode
                 .parent_episode_id
                 .as_ref()
@@ -118,7 +120,11 @@ impl EpisodeStore {
     /// permissions. The id is already validated ([`EpisodeId`]); intent is
     /// checked here as a safety net for callers that bypass the service boundary.
     pub(crate) fn open_episode(&self, episode: &Episode) -> Result<(), EpisodeStoreError> {
-        if episode.intent.trim().is_empty() || episode.intent.chars().count() > MAX_INTENT_CHARS {
+        // Normalize intent once so surrounding whitespace never becomes part of the
+        // immutable key — a retry with an accidental trailing space must stay
+        // idempotent, not conflict.
+        let intent = episode.intent.trim();
+        if intent.is_empty() || intent.chars().count() > MAX_INTENT_CHARS {
             return Err(EpisodeStoreError::InvalidIntent {
                 max: MAX_INTENT_CHARS,
             });
@@ -126,7 +132,7 @@ impl EpisodeStore {
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
         let path = self.layout.episodes_file(&episode.workspace);
         if let Some(existing) = read_episode(&path, episode.id.as_str())? {
-            return if existing.intent == episode.intent
+            return if existing.intent == intent
                 && existing.parent_episode_id.as_deref()
                     == episode.parent_episode_id.as_ref().map(EpisodeId::as_str)
             {
@@ -137,9 +143,17 @@ impl EpisodeStore {
                 })
             };
         }
-        let mut line = serde_json::to_vec(&PersistedEpisode::from_episode(episode))?;
-        line.push(b'\n');
-        storage_fs::append_file_private(&path, &line)?;
+        let record = serde_json::to_vec(&PersistedEpisode::from_episode(episode, intent))?;
+        let mut bytes = Vec::with_capacity(record.len() + 2);
+        // A prior torn append can leave the file without a trailing newline; start
+        // this record on its own line so the incomplete one stays separately
+        // skippable instead of merging with (and corrupting) this record.
+        if file_needs_leading_newline(&path)? {
+            bytes.push(b'\n');
+        }
+        bytes.extend_from_slice(&record);
+        bytes.push(b'\n');
+        storage_fs::append_file_private(&path, &bytes)?;
         Ok(())
     }
 }
@@ -167,12 +181,40 @@ fn read_episode(
         if line.trim().is_empty() {
             continue;
         }
-        let episode: PersistedEpisode = serde_json::from_str(&line)?;
-        if episode.id == episode_id {
-            found = Some(episode);
+        match serde_json::from_str::<PersistedEpisode>(&line) {
+            Ok(episode) => {
+                if episode.id == episode_id {
+                    found = Some(episode);
+                }
+            }
+            // A crash mid-append can leave a torn record; skip it rather than
+            // bricking every read for the workspace. An unacknowledged torn write
+            // is simply re-appended when the client retries `OpenEpisode`.
+            Err(error) => {
+                tracing::warn!(%error, "skipping unparsable episode record");
+            }
         }
     }
     Ok(found)
+}
+
+/// Whether an append to `path` must start with a newline: the file exists, is
+/// non-empty, and does not already end in one (e.g. after a torn append). Keeps
+/// an incomplete trailing record on its own line so it never merges with the
+/// next record.
+fn file_needs_leading_newline(path: &Path) -> Result<bool, EpisodeStoreError> {
+    let mut file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    if file.seek(SeekFrom::End(0))? == 0 {
+        return Ok(false);
+    }
+    file.seek(SeekFrom::End(-1))?;
+    let mut last = [0_u8; 1];
+    file.read_exact(&mut last)?;
+    Ok(last[0] != b'\n')
 }
 
 #[cfg(test)]
@@ -219,6 +261,68 @@ mod tests {
             .open_episode(&episode(&workspace, "ep_long", &overlong, None))
             .expect_err("overlong intent must be rejected");
         assert!(matches!(too_long, EpisodeStoreError::InvalidIntent { .. }));
+    }
+
+    #[test]
+    fn intent_whitespace_is_normalized_and_does_not_fork_the_key() {
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        store
+            .open_episode(&episode(&workspace, "ep_1", "find the form", None))
+            .expect("open");
+        // A retry with accidental surrounding whitespace stays idempotent.
+        store
+            .open_episode(&episode(&workspace, "ep_1", "  find the form  ", None))
+            .expect("whitespace-only difference is idempotent");
+        let read = read_episode(&layout.episodes_file(&workspace), "ep_1")
+            .expect("read")
+            .expect("present");
+        assert_eq!(read.intent, "find the form", "stored intent is normalized");
+        let lines = fs::read_to_string(layout.episodes_file(&workspace))
+            .expect("read file")
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .count();
+        assert_eq!(
+            lines, 1,
+            "whitespace-only difference must not append a record"
+        );
+    }
+
+    #[test]
+    fn read_tolerates_a_torn_trailing_record() {
+        use std::io::Write as _;
+
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let path = layout.episodes_file(&workspace);
+        store
+            .open_episode(&episode(&workspace, "ep_1", "first intent", None))
+            .expect("open");
+        // Simulate a crash mid-append: a complete record followed by a torn line
+        // with no trailing newline.
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open for append")
+            .write_all(b"{\"id\":\"ep_2\",\"workspace\":\"acme\"")
+            .expect("write torn record");
+        // The torn line is skipped, not fatal.
+        let read = read_episode(&path, "ep_1")
+            .expect("read tolerates the torn tail")
+            .expect("ep_1 present");
+        assert_eq!(read.intent, "first intent");
+        // The next append starts on a fresh line (no merge), so the new record is
+        // readable and the torn one stays isolated.
+        store
+            .open_episode(&episode(&workspace, "ep_2", "second intent", None))
+            .expect("open after torn tail");
+        let recovered = read_episode(&path, "ep_2")
+            .expect("read")
+            .expect("ep_2 present after recovery");
+        assert_eq!(recovered.intent, "second intent");
     }
 
     #[test]

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -37,6 +37,7 @@
 pub mod bootstrap;
 mod catalog;
 mod credentials;
+mod episode;
 pub mod features;
 mod feedback;
 mod identity;

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -86,6 +86,15 @@ impl AppStateLayout {
         self.feedback_dir(workspace_name).join("reports.jsonl")
     }
 
+    /// Per-workspace episode log (JSONL) for experimental trajectory memory. The
+    /// episode store appends here; the `OpenEpisode` handler that reads it lands in
+    /// a later PR.
+    pub(crate) fn episodes_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.workspace_dir(workspace_name)
+            .join("episodes")
+            .join("episodes.jsonl")
+    }
+
     pub(crate) fn source_dir(
         &self,
         workspace_name: &WorkspaceName,
@@ -225,6 +234,14 @@ mod tests {
                 .join("default")
                 .join("feedback")
                 .join("reports.jsonl")
+        );
+        assert_eq!(
+            layout.episodes_file(&workspace_name),
+            config_dir
+                .join("workspaces")
+                .join("default")
+                .join("episodes")
+                .join("episodes.jsonl")
         );
         assert_eq!(
             layout.local_trace_store_dir(),

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -50,9 +50,11 @@ pub(crate) fn append_file_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
     set_file_permissions_private(path)?;
     file.write_all(bytes)?;
     file.sync_all()?;
-    // Durably link the (possibly freshly created) file into its directory so a
-    // crash after we return `Ok` cannot lose the file or its newest record —
-    // mirrors `replace_atomic`'s parent-directory fsync.
+    // Best-effort: try to durably link the (possibly freshly created) file into
+    // its directory so a crash is less likely to lose it. Like `replace_atomic`,
+    // the parent-directory fsync is best-effort — opening or fsyncing a directory
+    // is not portable (e.g. it fails on Windows), so a failure here is ignored
+    // rather than surfaced.
     if let Some(parent) = path.parent()
         && let Ok(dir) = fs::File::open(parent)
     {

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -49,7 +49,16 @@ pub(crate) fn append_file_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
     let mut file = open_append_file_private(path)?;
     set_file_permissions_private(path)?;
     file.write_all(bytes)?;
-    file.sync_all()
+    file.sync_all()?;
+    // Durably link the (possibly freshly created) file into its directory so a
+    // crash after we return `Ok` cannot lose the file or its newest record —
+    // mirrors `replace_atomic`'s parent-directory fsync.
+    if let Some(parent) = path.parent()
+        && let Ok(dir) = fs::File::open(parent)
+    {
+        drop(dir.sync_all());
+    }
+    Ok(())
 }
 
 pub(crate) fn replace_atomic(from: &Path, to: &Path) -> io::Result<()> {


### PR DESCRIPTION
## Episode store — 2nd PR in the BENCH-496 stack

Stacked on #1169 (feature flag + `OpenEpisode` proto). Full design: [Linear BENCH-496](https://linear.app/withcoral/issue/BENCH-496/episodes-associate-each-query-with-the-intent-it-served).

Adds the **per-workspace, append-only episode store** that records `{ episode_id → intent, parent }` for an episode (one task-attempt), keyed by a **client-minted** id.

- **Idempotent:** re-opening the same `episode_id` with an identical `{intent, parent}` is a no-op; a different intent/parent **conflicts** (intent is immutable per episode → a change is a new child/sibling).
- **Per-workspace files** (tenant isolation).
- **Minimal by design:** a JSONL append. The JSONL→Parquet compaction, retention/eviction, and the queryable `coral.episodes` surface are deferred to the capture work (the plan's PR 2).
- Gated by the off-by-default `episodes` feature; **unused until the `OpenEpisode` handler** stacks on top (`#[allow(dead_code)]` until then).

Tests (all green): `open_then_read_round_trips`, `reopen_identical_is_idempotent`, `reopen_with_different_intent_conflicts`, `same_id_in_different_workspaces_is_isolated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
