### PR TITLE
feat(sources/community): add kafka_connect source spec

### DIFF
--- a/sources/community/kafka_connect/README.md
+++ b/sources/community/kafka_connect/README.md
@@ -1,0 +1,379 @@
+# Kafka Connect
+
+Query Kafka Connect connector inventory, config, and runtime state using SQL
+via the Kafka Connect REST API.
+
+## Local Setup
+
+The example below starts Kafka and Kafka Connect locally with no auth so you
+can test this source quickly.
+
+```bash
+# 1. Create a network
+
+docker network create kafka-net
+
+# 2. Start Kafka in KRaft mode
+
+docker run -d \
+  --network kafka-net \
+  --name kafka-mq \
+  -p 9092:9092 \
+  -e KAFKA_NODE_ID=1 \
+  -e KAFKA_PROCESS_ROLES=broker,controller \
+  -e KAFKA_LISTENERS="PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093" \
+  -e KAFKA_ADVERTISED_LISTENERS="PLAINTEXT://kafka-mq:9092" \
+  -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+  -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP="CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT" \
+  -e KAFKA_CONTROLLER_QUORUM_VOTERS="1@kafka-mq:9093" \
+  -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+  -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 \
+  -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1 \
+  -e KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0 \
+  apache/kafka:4.2.0
+
+# 3. Start Kafka Connect REST API (port 8083)
+
+docker run -d \
+  --network kafka-net \
+  --name kafka-connect \
+  -p 8083:8083 \
+  -e CONNECT_BOOTSTRAP_SERVERS=kafka-mq:9092 \
+  -e CONNECT_REST_ADVERTISED_HOST_NAME=kafka-connect \
+  -e CONNECT_REST_PORT=8083 \
+  -e CONNECT_GROUP_ID=connect-cluster \
+  -e CONNECT_CONFIG_STORAGE_TOPIC=connect-configs \
+  -e CONNECT_OFFSET_STORAGE_TOPIC=connect-offsets \
+  -e CONNECT_STATUS_STORAGE_TOPIC=connect-status \
+  -e CONNECT_KEY_CONVERTER=org.apache.kafka.connect.storage.StringConverter \
+  -e CONNECT_VALUE_CONVERTER=org.apache.kafka.connect.storage.StringConverter \
+  -e CONNECT_INTERNAL_KEY_CONVERTER=org.apache.kafka.connect.json.JsonConverter \
+  -e CONNECT_INTERNAL_VALUE_CONVERTER=org.apache.kafka.connect.json.JsonConverter \
+  -e CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR=1 \
+  -e CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR=1 \
+  -e CONNECT_STATUS_STORAGE_REPLICATION_FACTOR=1 \
+  confluentinc/cp-kafka-connect:8.2.1
+```
+
+Kafka Connect REST API will be available at `http://localhost:8083`.
+
+## Configuration
+
+| Input                    | Kind     | Required | Default                 | Description |
+|--------------------------|----------|----------|-------------------------|-------------|
+| `KAFKA_CONNECT_URL`      | variable | no       | `http://localhost:8083` | Kafka Connect API base URL reachable without adding auth headers in this source |
+
+## Required Permissions
+
+This source requires read-only access to Kafka Connect REST API endpoints:
+
+| Endpoint | Required Permission | Typical Role |
+|----------|-------------------|--------------|
+| `GET /connectors` | Read connector list | Connector Viewer |
+| `GET /connectors/{name}/config` | Read connector config | Connector Viewer |
+| `GET /connectors/{name}/status` | Read connector status | Connector Viewer |
+
+For self-hosted Kafka Connect clusters, ensure the calling user or service account has HTTP read permissions on these endpoints.
+This v1 source is intended for endpoints reachable without extra auth headers,
+such as local no-auth Kafka Connect, or an authenticating reverse proxy/gateway
+in front of Kafka Connect.
+
+## Tables Reference
+
+| Table | Description | Required Filters | Contains |
+|-------|-------------|------------------|----------|
+| `connectors` | Connector inventory with types, classes, and runtime state | none | Connector metadata and current state across the worker |
+| `connector_configs` | Key-value configuration pairs for a connector | `connector_name` (required) | Config keys and values as flat key-value rows |
+| `connector_statuses` | Runtime status including state and worker assignment | `connector_name` (required) | High-level connector state, worker info, and error traces |
+| `connector_tasks` | Task-level status for each connector task | `connector_name` (required) | Per-task state, worker assignment, and error traces |
+
+## Cross-table Relationships
+
+- **connectors.connector_name** ↔ **connector_configs.connector_name**: Get full config for a connector
+- **connectors.connector_name** ↔ **connector_statuses.connector_name**: Get detailed status and worker assignment
+- **connectors.connector_name** ↔ **connector_tasks.connector_name**: Get per-task status and assignment
+
+## Validation
+
+After following the Local Setup steps above, you can verify the source is working:
+
+```bash
+# 1. Lint the manifest
+cargo run -p coral-cli -- source lint sources/community/kafka_connect/manifest.yaml
+# Output: Manifest is valid
+
+# 2. Add the source to Coral
+export KAFKA_CONNECT_URL=http://localhost:8083
+cargo run -p coral-cli -- source add --file sources/community/kafka_connect/manifest.yaml
+
+# 3. Run source tests explicitly
+cargo run -p coral-cli -- source test kafka_connect
+
+# 4. Create a test connector to query real data
+curl -s -X POST http://localhost:8083/connectors \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "test-source-connector",
+    "config": {
+      "connector.class": "org.apache.kafka.connect.mirror.MirrorSourceConnector",
+      "source.cluster.alias": "src",
+      "target.cluster.alias": "tgt",
+      "source.cluster.bootstrap.servers": "kafka-mq:9092",
+      "target.cluster.bootstrap.servers": "kafka-mq:9092",
+      "topics": "test-topic",
+      "groups": "test-group",
+      "tasks.max": "2"
+    }
+  }' | jq .
+
+# 5. Run representative SQL queries
+cargo run -p coral-cli -- sql "SELECT connector_name, connector_type, state FROM kafka_connect.connectors ORDER BY connector_name LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT connector_name, state, worker_id FROM kafka_connect.connector_statuses WHERE connector_name = 'test-source-connector'"
+cargo run -p coral-cli -- sql "SELECT config_key, config_value FROM kafka_connect.connector_configs WHERE connector_name = 'test-source-connector' ORDER BY config_key LIMIT 8"
+
+```
+
+Current-head captured output (2026-06-13):
+
+```text
+$ cargo run -p coral-cli -- source add --file sources/community/kafka_connect/manifest.yaml
+Added source kafka_connect (secrets: none)
+
+  ✓ kafka_connect connected successfully
+  Secrets: none
+
+    kafka_connect (4 tables)
+    ├─ connector_configs
+    ├─ connector_statuses
+    ├─ connector_tasks
+    └─ connectors
+    Query tests
+    1 declared · 1 passed · 0 failed
+
+    ✓ SELECT connector_name, connector_type, state FROM kafka_connect.connectors LIMIT 1
+      0 rows
+
+$ cargo run -p coral-cli -- source test kafka_connect
+
+  ✓ kafka_connect connected successfully
+  Secrets: none
+
+    kafka_connect (4 tables)
+    ├─ connector_configs
+    ├─ connector_statuses
+    ├─ connector_tasks
+    └─ connectors
+    Query tests
+    1 declared · 1 passed · 0 failed
+
+    ✓ SELECT connector_name, connector_type, state FROM kafka_connect.connectors LIMIT 1
+      0 rows
+
+$ cargo run -p coral-cli -- sql "SELECT connector_name, connector_type, state FROM kafka_connect.connectors ORDER BY connector_name LIMIT 5"
++-----------------------+----------------+-------+
+| connector_name        | connector_type | state |
++-----------------------+----------------+-------+
+| test-source-connector |                |       |
++-----------------------+----------------+-------+
+
+$ cargo run -p coral-cli -- sql "SELECT connector_name, state, worker_id FROM kafka_connect.connector_statuses WHERE connector_name = 'test-source-connector'"
++-----------------------+---------+--------------------+
+| connector_name        | state   | worker_id          |
++-----------------------+---------+--------------------+
+| test-source-connector | RUNNING | kafka-connect:8083 |
++-----------------------+---------+--------------------+
+
+$ cargo run -p coral-cli -- sql "SELECT config_key, config_value FROM kafka_connect.connector_configs WHERE connector_name = 'test-source-connector' ORDER BY config_key LIMIT 8"
++----------------------------------+--------------------------------------------------------------+
+| config_key                       | config_value                                                 |
++----------------------------------+--------------------------------------------------------------+
+| connector.class                  | org.apache.kafka.connect.mirror.MirrorSourceConnector        |
+| groups                           | test-group                                                   |
+| name                             | test-source-connector                                        |
+| source.cluster.alias             | src                                                          |
+| source.cluster.bootstrap.servers | kafka-mq:9092                                                |
+| target.cluster.alias             | tgt                                                          |
+| target.cluster.bootstrap.servers | kafka-mq:9092                                                |
+| tasks.max                        | 2                                                            |
++----------------------------------+--------------------------------------------------------------+
+```
+
+## Schema
+
+### `connectors`
+
+One row per connector with connector type, class, and current runtime state.
+
+| Column | Type | Nullable | Description |
+|--------|------|----------|-------------|
+| `connector_name` | Utf8 | no | Connector name |
+| `connector_type` | Utf8 | yes | `source` or `sink` |
+| `connector_class` | Utf8 | yes | Implementation class (e.g. `org.apache.kafka.connect.mirror.MirrorSourceConnector`) |
+| `tasks_max` | Utf8 | yes | Configured max task count |
+| `state` | Utf8 | yes | Runtime state: `RUNNING`, `PAUSED`, `FAILED`, etc. |
+| `worker_id` | Utf8 | yes | Worker hostname:port currently managing this connector |
+| `trace` | Utf8 | yes | Error trace if connector is in failed state |
+
+**Example output:**
+```
+connector_name          | connector_type | state   | worker_id
+------------------------+----------------+---------+---------------------
+test-source-connector   | source         | RUNNING | kafka-connect:8083
+```
+
+### `connector_configs`
+
+One row per config key-value pair. **Requires** `connector_name` filter.
+
+Warning: Kafka Connect masks sensitive/password configuration fields by default.
+If `connect.password.field.masking.disable=true` is set on the Kafka Connect
+worker, sensitive config values may be returned in clear text by
+`GET /connectors/{name}/config` and therefore appear in this table. Review
+access and output handling before querying configs in shared environments.
+Reference: https://docs.confluent.io/platform/current/connect/references/restapi.html#connectors
+
+| Column | Type | Nullable | Description |
+|--------|------|----------|-------------|
+| `connector_name` | Utf8 | no | Connector name (from filter) |
+| `config_key` | Utf8 | no | Configuration property name |
+| `config_value` | Utf8 | yes | Configuration property value |
+
+**Example output:**
+```
+connector_name          | config_key                      | config_value
+------------------------+---------------------------------+-------------------------------------
+test-source-connector   | connector.class                 | org.apache.kafka.connect.mirror.MirrorSourceConnector
+test-source-connector   | source.cluster.alias            | src
+test-source-connector   | target.cluster.alias            | tgt
+test-source-connector   | source.cluster.bootstrap.servers| kafka-mq:9092
+test-source-connector   | target.cluster.bootstrap.servers| kafka-mq:9092
+test-source-connector   | topics                          | test-topic
+test-source-connector   | groups                          | test-group
+test-source-connector   | tasks.max                       | 2
+```
+
+### `connector_statuses`
+
+Current runtime status for one connector. **Requires** `connector_name` filter.
+
+| Column | Type | Nullable | Description |
+|--------|------|----------|-------------|
+| `connector_name` | Utf8 | no | Connector name |
+| `connector_type` | Utf8 | yes | `source` or `sink` |
+| `state` | Utf8 | yes | Runtime state |
+| `worker_id` | Utf8 | yes | Worker managing this connector |
+| `trace` | Utf8 | yes | Error details if applicable |
+| `requested_connector_name` | Utf8 | yes | Virtual column echoing filter value |
+
+**Example output:**
+```
+connector_name          | connector_type | state   | worker_id          | trace
+------------------------+----------------+---------+--------------------+-------
+test-source-connector   | source         | RUNNING | kafka-connect:8083 | NULL
+```
+
+### `connector_tasks`
+
+One row per task in a connector. **Requires** `connector_name` filter.
+
+| Column | Type | Nullable | Description |
+|--------|------|----------|-------------|
+| `connector_name` | Utf8 | no | Connector name (from filter) |
+| `task_id` | Int64 | no | Task ID (0-based index) |
+| `state` | Utf8 | yes | Task state: `RUNNING`, `PAUSED`, `FAILED`, etc. |
+| `worker_id` | Utf8 | yes | Worker running this task |
+| `trace` | Utf8 | yes | Error trace if task failed |
+
+**Example output (empty tasks, normal for status queries):**
+```
+connector_name          | task_id | state | worker_id | trace
+------------------------+---------+-------+-----------+-------
+```
+
+## Example Queries
+
+### Basic Inventory and Status
+
+```sql
+-- List all connectors with their current state
+SELECT connector_name, connector_type, state, worker_id
+FROM kafka_connect.connectors
+ORDER BY connector_name;
+
+-- Get config for a specific connector
+SELECT config_key, config_value
+FROM kafka_connect.connector_configs
+WHERE connector_name = 'my-connector'
+ORDER BY config_key;
+
+-- Check connector-level status
+SELECT connector_name, connector_type, state, worker_id
+FROM kafka_connect.connector_statuses
+WHERE connector_name = 'my-connector';
+
+-- List tasks for a connector
+SELECT task_id, state, worker_id
+FROM kafka_connect.connector_tasks
+WHERE connector_name = 'my-connector'
+ORDER BY task_id;
+```
+
+### Troubleshooting Patterns
+
+```sql
+-- Find failed or unhealthy connectors
+SELECT connector_name, state, trace
+FROM kafka_connect.connectors
+WHERE state != 'RUNNING'
+LIMIT 10;
+
+-- Check if a connector has failed tasks
+SELECT connector_name, task_id, state, trace
+FROM kafka_connect.connector_tasks
+WHERE connector_name = 'my-connector'
+  AND state NOT IN ('RUNNING', 'PAUSED')
+LIMIT 10;
+
+-- Step 1: Find all failed connectors
+SELECT connector_name, state
+FROM kafka_connect.connectors
+WHERE state = 'FAILED'
+LIMIT 10;
+
+-- Step 2: Get config for one specific failed connector
+SELECT config_key, config_value
+FROM kafka_connect.connector_configs
+WHERE connector_name = 'my-failed-connector'
+ORDER BY config_key;
+
+-- Check status of a specific connector
+SELECT connector_name, state, worker_id
+FROM kafka_connect.connector_statuses
+WHERE connector_name = 'my-connector';
+```
+
+## Notes
+
+- Kafka Connect REST endpoints used here are read-only and non-paginated; they return complete result sets.
+- This source focuses on connector inventory, configuration, and status discovery (v1 scope).
+- Available connector classes depend on your Kafka Connect image and installed plugins.
+- This source does not add auth headers itself; for secured clusters, use a
+  base URL where authentication is handled upstream (for example, an
+  authenticating reverse proxy or gateway).
+
+## Out of Scope for v1
+
+- Creating, modifying, or deleting connectors (use Kafka Connect REST API directly or CLI)
+- Restarting connectors or tasks
+- Worker metrics or logs
+- Producer/consumer lag monitoring (use Kafka metrics sources or Prometheus)
+- Plugin discovery or installation
+- Connector classification or type filtering
+
+## Performance Considerations
+
+- Kafka Connect REST API `/connectors` endpoint returns all connectors in one request (no server-side pagination).
+- SQL `LIMIT` reduces rows returned by Coral, but does not reduce provider-side work for `/connectors` because Kafka Connect returns the full expanded connector map before Coral applies projection/limit.
+- Default result fetch: Full connector list is returned; Coral respects manifest `pagination.mode: none`.
+- Queries are read-only and do not modify cluster state.
+- Each query translates to 1-2 HTTP calls to Kafka Connect (varies by table).

--- a/sources/community/kafka_connect/README.md
+++ b/sources/community/kafka_connect/README.md
@@ -170,11 +170,11 @@ $ cargo run -p coral-cli -- source test kafka_connect
       0 rows
 
 $ cargo run -p coral-cli -- sql "SELECT connector_name, connector_type, state FROM kafka_connect.connectors ORDER BY connector_name LIMIT 5"
-+-----------------------+----------------+-------+
-| connector_name        | connector_type | state |
-+-----------------------+----------------+-------+
-| test-source-connector |                |       |
-+-----------------------+----------------+-------+
++-----------------------+----------------+---------+
+| connector_name        | connector_type | state   |
++-----------------------+----------------+---------+
+| test-source-connector | source         | RUNNING |
++-----------------------+----------------+---------+
 
 $ cargo run -p coral-cli -- sql "SELECT connector_name, state, worker_id FROM kafka_connect.connector_statuses WHERE connector_name = 'test-source-connector'"
 +-----------------------+---------+--------------------+
@@ -184,18 +184,18 @@ $ cargo run -p coral-cli -- sql "SELECT connector_name, state, worker_id FROM ka
 +-----------------------+---------+--------------------+
 
 $ cargo run -p coral-cli -- sql "SELECT config_key, config_value FROM kafka_connect.connector_configs WHERE connector_name = 'test-source-connector' ORDER BY config_key LIMIT 8"
-+----------------------------------+--------------------------------------------------------------+
-| config_key                       | config_value                                                 |
-+----------------------------------+--------------------------------------------------------------+
-| connector.class                  | org.apache.kafka.connect.mirror.MirrorSourceConnector        |
-| groups                           | test-group                                                   |
-| name                             | test-source-connector                                        |
-| source.cluster.alias             | src                                                          |
-| source.cluster.bootstrap.servers | kafka-mq:9092                                                |
-| target.cluster.alias             | tgt                                                          |
-| target.cluster.bootstrap.servers | kafka-mq:9092                                                |
-| tasks.max                        | 2                                                            |
-+----------------------------------+--------------------------------------------------------------+
++----------------------------------+-------------------------------------------------------+
+| config_key                       | config_value                                          |
++----------------------------------+-------------------------------------------------------+
+| connector.class                  | org.apache.kafka.connect.mirror.MirrorSourceConnector |
+| groups                           | test-group                                            |
+| name                             | test-source-connector                                 |
+| source.cluster.alias             | src                                                   |
+| source.cluster.bootstrap.servers | kafka-mq:9092                                         |
+| target.cluster.alias             | tgt                                                   |
+| target.cluster.bootstrap.servers | kafka-mq:9092                                         |
+| tasks.max                        | 2                                                     |
++----------------------------------+-------------------------------------------------------+
 ```
 
 ## Schema
@@ -284,7 +284,7 @@ One row per task in a connector. **Requires** `connector_name` filter.
 | `worker_id` | Utf8 | yes | Worker running this task |
 | `trace` | Utf8 | yes | Error trace if task failed |
 
-**Example output (empty tasks, normal for status queries):**
+**Example output (this local fixture returned no task rows):**
 ```
 connector_name          | task_id | state | worker_id | trace
 ------------------------+---------+-------+-----------+-------

--- a/sources/community/kafka_connect/manifest.yaml
+++ b/sources/community/kafka_connect/manifest.yaml
@@ -61,32 +61,32 @@ tables:
         type: Utf8
         nullable: true
         description: Connector type returned by Kafka Connect (source or sink).
-        expr: {kind: path, path: [_value, info, type]}
+        expr: {kind: path, path: [info, type]}
       - name: connector_class
         type: Utf8
         nullable: true
         description: Connector implementation class.
-        expr: {kind: path, path: [_value, info, config, connector.class]}
+        expr: {kind: path, path: [info, config, connector.class]}
       - name: tasks_max
         type: Utf8
         nullable: true
         description: Configured max task count.
-        expr: {kind: path, path: [_value, info, config, tasks.max]}
+        expr: {kind: path, path: [info, config, tasks.max]}
       - name: state
         type: Utf8
         nullable: true
         description: Current connector runtime state.
-        expr: {kind: path, path: [_value, status, connector, state]}
+        expr: {kind: path, path: [status, connector, state]}
       - name: worker_id
         type: Utf8
         nullable: true
         description: Worker that currently owns connector coordination.
-        expr: {kind: path, path: [_value, status, connector, worker_id]}
+        expr: {kind: path, path: [status, connector, worker_id]}
       - name: trace
         type: Utf8
         nullable: true
         description: Last connector-level error trace when returned.
-        expr: {kind: path, path: [_value, status, connector, trace]}
+        expr: {kind: path, path: [status, connector, trace]}
 
   - name: connector_configs
     description: Effective key-value config entries for one connector.

--- a/sources/community/kafka_connect/manifest.yaml
+++ b/sources/community/kafka_connect/manifest.yaml
@@ -1,0 +1,214 @@
+name: kafka_connect
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query connector inventory, configs, status, and task state from Apache
+  Kafka Connect clusters via the Kafka Connect REST API. Read-only v1; use a
+  base URL that is directly reachable without adding auth headers in this
+  source.
+
+inputs:
+  KAFKA_CONNECT_URL:
+    kind: variable
+    default: "http://localhost:8083"
+    hint: |
+      Kafka Connect API base URL that Coral can call without extra auth headers.
+      Examples: http://localhost:8083, http://kafka-connect:8083, http://192.168.1.10:8083
+      You may also point to an authenticating reverse proxy or gateway in front
+      of Kafka Connect.
+      Do not include trailing slash. For self-hosted Kafka Connect, verify the REST API
+      is enabled with CONNECT_REST_PORT and CONNECT_REST_ADVERTISED_HOST_NAME.
+
+base_url: "{{input.KAFKA_CONNECT_URL}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT connector_name, connector_type, state FROM kafka_connect.connectors LIMIT 1
+
+tables:
+  - name: connectors
+    description: Kafka Connect connectors visible to this worker.
+    guide: |
+      Returns one row per connector by expanding connector info and status
+      from the Kafka Connect REST API. Use connector_name to query
+      connector-specific detail tables.
+    request:
+      method: GET
+      path: /connectors
+      query:
+        - name: expand
+          from: literal
+          value: info
+        - name: expand
+          from: literal
+          value: status
+    response:
+      row_strategy: dict_entries
+    pagination:
+      mode: none
+    columns:
+      - name: connector_name
+        type: Utf8
+        nullable: false
+        description: Connector name (map key).
+        expr: {kind: path, path: [_key]}
+      - name: connector_type
+        type: Utf8
+        nullable: true
+        description: Connector type returned by Kafka Connect (source or sink).
+        expr: {kind: path, path: [_value, info, type]}
+      - name: connector_class
+        type: Utf8
+        nullable: true
+        description: Connector implementation class.
+        expr: {kind: path, path: [_value, info, config, connector.class]}
+      - name: tasks_max
+        type: Utf8
+        nullable: true
+        description: Configured max task count.
+        expr: {kind: path, path: [_value, info, config, tasks.max]}
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Current connector runtime state.
+        expr: {kind: path, path: [_value, status, connector, state]}
+      - name: worker_id
+        type: Utf8
+        nullable: true
+        description: Worker that currently owns connector coordination.
+        expr: {kind: path, path: [_value, status, connector, worker_id]}
+      - name: trace
+        type: Utf8
+        nullable: true
+        description: Last connector-level error trace when returned.
+        expr: {kind: path, path: [_value, status, connector, trace]}
+
+  - name: connector_configs
+    description: Effective key-value config entries for one connector.
+    guide: |
+      Requires connector_name. Each row is one configuration key and value
+      from GET /connectors/{name}/config.
+    filters:
+      - name: connector_name
+        required: true
+    request:
+      method: GET
+      path: /connectors/{{filter.connector_name}}/config
+    response:
+      row_strategy: dict_entries
+    pagination:
+      mode: none
+    columns:
+      - name: connector_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Connector name from the required filter.
+        expr: {kind: from_filter, key: connector_name}
+      - name: config_key
+        type: Utf8
+        nullable: false
+        description: Connector config key.
+        expr: {kind: path, path: [_key]}
+      - name: config_value
+        type: Utf8
+        nullable: true
+        description: Connector config value.
+        expr: {kind: path, path: [_value]}
+
+  - name: connector_statuses
+    description: Runtime status for one connector.
+    guide: |
+      Requires connector_name. Returns connector state plus task status
+      summary fields from GET /connectors/{name}/status.
+    filters:
+      - name: connector_name
+        required: true
+    request:
+      method: GET
+      path: /connectors/{{filter.connector_name}}/status
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: connector_name
+        type: Utf8
+        nullable: false
+        description: Connector name.
+        expr: {kind: path, path: [name]}
+      - name: connector_type
+        type: Utf8
+        nullable: true
+        description: Connector type (source or sink) when returned.
+        expr: {kind: path, path: [type]}
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Connector runtime state.
+        expr: {kind: path, path: [connector, state]}
+      - name: worker_id
+        type: Utf8
+        nullable: true
+        description: Worker currently running connector coordination.
+        expr: {kind: path, path: [connector, worker_id]}
+      - name: trace
+        type: Utf8
+        nullable: true
+        description: Last connector-level error trace when returned.
+        expr: {kind: path, path: [connector, trace]}
+      - name: requested_connector_name
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Connector name from the required filter.
+        expr: {kind: from_filter, key: connector_name}
+
+  - name: connector_tasks
+    description: Task-level runtime status for one connector.
+    guide: |
+      Requires connector_name. Each row is one task from
+      GET /connectors/{name}/status.
+    filters:
+      - name: connector_name
+        required: true
+    request:
+      method: GET
+      path: /connectors/{{filter.connector_name}}/status
+    response:
+      rows_path: [tasks]
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: connector_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Connector name from the required filter.
+        expr: {kind: from_filter, key: connector_name}
+      - name: task_id
+        type: Int64
+        nullable: false
+        description: Task ID within the connector.
+        expr: {kind: path, path: [id]}
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Task runtime state.
+        expr: {kind: path, path: [state]}
+      - name: worker_id
+        type: Utf8
+        nullable: true
+        description: Worker currently running this task.
+        expr: {kind: path, path: [worker_id]}
+      - name: trace
+        type: Utf8
+        nullable: true
+        description: Task-level error trace when returned.
+        expr: {kind: path, path: [trace]}


### PR DESCRIPTION

## Kafka Connect Source (Community)

Adding this source provides SQL-based operational visibility for Apache Kafka Connect deployments, including CDC connectors such as Debezium.

This pull request introduces a new community source for Apache Kafka Connect so users can query connector inventory, configuration, runtime status, and task state through the Kafka Connect REST API.

### Most Important Changes

#### New Source Implementation
- Added `sources/community/kafka_connect/manifest.yaml` for the `kafka_connect` source
- Implemented four tables:
  - `connectors`
  - `connector_configs`
  - `connector_statuses`
  - `connector_tasks`
- Added required `connector_name` filtering for detail tables
- Added virtual filter-propagation columns where helpful

#### Authentication Model
- No in-source auth headers are added by this source
- Intended for:
  - local no-auth Kafka Connect endpoints
  - environments where authentication is handled upstream (for example, authenticating reverse proxy or gateway)

#### Documentation and Usage Guide
- Added comprehensive `sources/community/kafka_connect/README.md` with:
  - local Docker setup (Kafka + Kafka Connect)
  - configuration and permissions guidance
  - schema and table reference
  - cross-table relationships
  - troubleshooting query examples
  - out-of-scope clarifications
  - performance considerations

### Features
- 4 tables for connector, config, status, and task-level data
- Required `connector_name` filtering for detail tables
- Clear no-auth-plus-upstream-auth deployment guidance
- Real command evidence included for:
  - `coral source add`
  - `coral source test kafka_connect`
  - representative `coral sql` queries

### Tables
- `connectors`: Connector inventory with type, class, and runtime state
- `connector_configs`: Key-value config pairs (requires `connector_name`)
- `connector_statuses`: Runtime status and worker assignment (requires `connector_name`)
- `connector_tasks`: Task-level status (requires `connector_name`)

### Validation
- Schema: manifest is valid per Coral source spec
- Declared test queries in manifest: `1`
- Current-head command output captured in README for add/test/sql evidence
- Input hints include deployment guidance consistent with no-auth source behavior

### Additional Notes
- README includes a warning about potential sensitive config exposure if Kafka Connect masking is disabled (`connect.password.field.masking.disable=true`)
- LIMIT wording clarifies that provider-side work for `/connectors` is not reduced, because Kafka Connect returns the full expanded connector map before Coral applies output limiting

