### PR TITLE
fix(spec): reject whitespace-only names consistently

### DIFF
--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -23,7 +23,8 @@ use crate::inputs::{
 use crate::{
     ColumnSpec, DeclaredRelation, FilterSpec, ManifestDataType, ManifestError, ManifestInputSpec,
     ParsedTemplate, Result, SourceBackend, SourceManifestCommon, TableCommon, TemplateNamespace,
-    TemplatePart, validate_columns, validate_declared_relation_namespace, validate_test_queries,
+    TemplatePart, validate_columns, validate_declared_relation_namespace, validate_source_name,
+    validate_test_queries,
 };
 
 /// Validated top-level manifest for a native file-backed source.
@@ -698,6 +699,7 @@ impl FileSourceManifest {
             inputs: _inputs,
             tables,
         } = raw;
+        validate_source_name(&name)?;
         validate_test_queries(&name, &test_queries)?;
         validate_declared_relation_namespace(
             &name,

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     validate::validate_template,
     validate_declared_relation_namespace, validate_detail_hint_references, validate_http_function,
-    validate_http_table, validate_test_queries,
+    validate_http_table, validate_source_name, validate_test_queries,
 };
 
 /// Source-level authentication requirements for HTTP-backed source specs.
@@ -288,6 +288,7 @@ impl HttpSourceManifest {
                 "source '{name}' must define at least one table or function"
             )));
         }
+        validate_source_name(&name)?;
         validate_test_queries(&name, &test_queries)?;
         validate_declared_relation_namespace(
             &name,

--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -19,7 +19,7 @@ use crate::{
         collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
     },
     validate_columns, validate_declared_relation_namespace, validate_filters_and_column_exprs,
-    validate_identifier, validate_test_queries, validate_unique_values,
+    validate_identifier, validate_source_name, validate_test_queries, validate_unique_values,
 };
 
 /// Validated top-level manifest for a Model Context Protocol-backed source.
@@ -397,6 +397,7 @@ impl McpSourceManifest {
                 "source '{name}' must define at least one function or table"
             )));
         }
+        validate_source_name(&name)?;
         validate_test_queries(&name, &test_queries)?;
         validate_server(&name, &server, &declared_inputs)?;
         validate_declared_relation_namespace(
@@ -915,6 +916,11 @@ fn validate_function_binding<'a>(
     binding: &'a FunctionArgBinding,
     request_arg_names: &mut HashSet<&'a str>,
 ) -> Result<()> {
+    if binding.arg.trim().is_empty() {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' function '{function_name}' tool arg name must not be empty"
+        )));
+    }
     if !request_arg_names.insert(binding.arg.as_str()) {
         return Err(ManifestError::validation(format!(
             "source '{source_name}' function '{function_name}' has multiple bindings for tool arg '{}'",
@@ -1000,6 +1006,61 @@ mod tests {
             error.to_string(),
             "source 'demo' function 'lookup' must define columns"
         );
+    }
+
+    #[test]
+    fn rejects_mcp_function_with_empty_tool_arg_bindings() {
+        for arg in ["", "   "] {
+            let error = McpSourceManifest::parse_manifest_value(json!({
+                "dsl_version": 3,
+                "name": "demo",
+                "version": "0.1.0",
+                "backend": "mcp",
+                "server": {
+                    "transport": "stdio",
+                    "command": "demo-mcp-server"
+                },
+                "functions": [{
+                    "name": "lookup",
+                    "tool": "lookup",
+                    "args": [{
+                        "name": "query",
+                        "bind": { "arg": arg }
+                    }],
+                    "columns": [{ "name": "title", "type": "Utf8" }]
+                }]
+            }))
+            .expect_err("empty tool arg binding should fail");
+
+            assert_eq!(
+                error.to_string(),
+                "source 'demo' function 'lookup' tool arg name must not be empty"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_mcp_function_with_non_empty_tool_arg_binding() {
+        McpSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "mcp",
+            "server": {
+                "transport": "stdio",
+                "command": "demo-mcp-server"
+            },
+            "functions": [{
+                "name": "lookup",
+                "tool": "lookup",
+                "args": [{
+                    "name": "query",
+                    "bind": { "arg": "query" }
+                }],
+                "columns": [{ "name": "title", "type": "Utf8" }]
+            }]
+        }))
+        .expect("non-empty tool arg binding should remain valid");
     }
 
     #[test]

--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -455,11 +455,7 @@ fn validate_stdio_server(source_name: &str, command: &str, env: &[McpEnvSpec]) -
 
     let mut env_names = HashSet::new();
     for env in env {
-        if env.name.trim().is_empty() {
-            return Err(ManifestError::validation(format!(
-                "source '{source_name}' MCP server env name must not be empty"
-            )));
-        }
+        validate_stdio_env_name(source_name, &env.name)?;
         if !env_names.insert(env.name.as_str()) {
             return Err(ManifestError::validation(format!(
                 "source '{source_name}' MCP server env '{}' is declared more than once",
@@ -467,6 +463,20 @@ fn validate_stdio_server(source_name: &str, command: &str, env: &[McpEnvSpec]) -
             )));
         }
         validate_server_env_value_source(source_name, env)?;
+    }
+    Ok(())
+}
+
+fn validate_stdio_env_name(source_name: &str, name: &str) -> Result<()> {
+    if name.trim().is_empty() {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' MCP server env name must not be empty"
+        )));
+    }
+    if name.contains('=') || name.contains('\0') {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' MCP server env '{name}' must not contain '=' or NUL"
+        )));
     }
     Ok(())
 }
@@ -1526,6 +1536,68 @@ mod tests {
             error
                 .to_string()
                 .contains("MCP server env 'FILTERED' template references table filter 'state'"),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_mcp_server_env_name_with_equals() {
+        let error = McpSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "mcp",
+            "server": {
+                "transport": "stdio",
+                "command": "demo-mcp-server",
+                "env": [{
+                    "name": "BAD=KEY",
+                    "from": "literal",
+                    "value": "ignored"
+                }]
+            },
+            "tables": [{
+                "name": "issues",
+                "tool": "list_issues",
+                "columns": [{ "name": "id", "type": "Utf8" }]
+            }]
+        }))
+        .expect_err("env name containing equals should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("MCP server env 'BAD=KEY' must not contain '=' or NUL"),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_mcp_server_env_name_with_nul() {
+        let error = McpSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "mcp",
+            "server": {
+                "transport": "stdio",
+                "command": "demo-mcp-server",
+                "env": [{
+                    "name": "BAD\0KEY",
+                    "from": "literal",
+                    "value": "ignored"
+                }]
+            },
+            "tables": [{
+                "name": "issues",
+                "tool": "list_issues",
+                "columns": [{ "name": "id", "type": "Utf8" }]
+            }]
+        }))
+        .expect_err("env name containing NUL should fail");
+
+        assert!(
+            error.to_string().contains("must not contain '=' or NUL"),
             "got: {error}"
         );
     }

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -119,5 +119,5 @@ pub(crate) use validate::{
     DeclaredRelation, DetailHintDeclaringSurface, DetailHintTargetTable, validate_columns,
     validate_declared_relation_namespace, validate_detail_hint_references,
     validate_filters_and_column_exprs, validate_http_function, validate_http_table,
-    validate_identifier, validate_unique_values,
+    validate_identifier, validate_source_name, validate_unique_values,
 };

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -13,7 +13,7 @@ use crate::backends::http::HttpSourceManifest;
 use crate::backends::mcp::McpSourceManifest;
 use crate::schema::validate_manifest_schema_for_dsl_version;
 use crate::v4::V4SourceManifest;
-use crate::{ManifestError, ManifestInputSpec, Result, SourceBackend};
+use crate::{ManifestError, ManifestInputSpec, Result, SourceBackend, validate_source_name};
 
 /// Validated top-level source spec for one registered source.
 ///
@@ -215,6 +215,9 @@ pub fn parse_source_manifest_yaml(raw: &str) -> Result<ValidatedSourceManifest> 
 /// rules.
 pub fn parse_source_manifest_value(value: Value) -> Result<ValidatedSourceManifest> {
     let dsl_version = parse_dsl_version(&value)?;
+    if let Some(source_name) = value.get("name").and_then(Value::as_str) {
+        validate_source_name(source_name)?;
+    }
     validate_manifest_schema_for_dsl_version(&value, dsl_version)?;
     if dsl_version == 4 {
         return Ok(ValidatedSourceManifest {
@@ -287,6 +290,58 @@ tables:
         .expect("manifest should parse");
 
         assert_eq!(manifest.test_queries(), &["SELECT 1", "SELECT 2"]);
+    }
+
+    #[test]
+    fn parse_source_manifest_rejects_empty_source_names() {
+        for name in [r#""""#, r#""   ""#] {
+            let manifest = format!(
+                r#"
+name: {name}
+version: 1.0.0
+dsl_version: 3
+backend: file
+tables:
+  - name: messages
+    description: Demo messages
+    format: jsonl
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+"#
+            );
+
+            let error =
+                parse_source_manifest_yaml(&manifest).expect_err("empty source name should fail");
+
+            assert_eq!(error.to_string(), "source name must not be empty");
+        }
+    }
+
+    #[test]
+    fn parse_source_manifest_accepts_non_empty_source_names() {
+        let manifest = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: file
+tables:
+  - name: messages
+    description: Demo messages
+    format: jsonl
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+",
+        )
+        .expect("non-empty source name should remain valid");
+
+        assert_eq!(manifest.schema_name(), "demo");
     }
 
     #[test]

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -20,12 +20,7 @@ impl DeclaredRelationKind {
     fn validate_name(self, source_name: &str, name: &str) -> Result<()> {
         match self {
             Self::Table => {
-                if name.trim().is_empty() {
-                    return Err(ManifestError::validation(format!(
-                        "source '{source_name}' table name must not be empty"
-                    )));
-                }
-                Ok(())
+                validate_non_empty_name(name, &format!("source '{source_name}' table name"))
             }
             Self::Function => {
                 validate_identifier(name, &format!("source '{source_name}' function name"))
@@ -91,6 +86,10 @@ pub(crate) fn validate_declared_relation_namespace<'a>(
     Ok(())
 }
 
+pub(crate) fn validate_source_name(name: &str) -> Result<()> {
+    validate_non_empty_name(name, "source name")
+}
+
 #[expect(
     clippy::too_many_arguments,
     reason = "HTTP table validation mirrors the source-spec fields it validates."
@@ -128,7 +127,12 @@ pub(crate) fn validate_http_table(
     validate_request_bindings(schema, table_name, request, &known_filters)?;
 
     for route in requests {
-        for filter_name in &route.when_filters {
+        for (index, filter_name) in route.when_filters.iter().enumerate() {
+            if filter_name.trim().is_empty() {
+                return Err(ManifestError::validation(format!(
+                    "{schema}.{table_name} requests.when_filters[{index}] must not be empty"
+                )));
+            }
             if !known_filters.contains(filter_name) {
                 return Err(ManifestError::validation(format!(
                     "{schema}.{table_name} requests.when_filters references unknown filter '{filter_name}'"
@@ -227,6 +231,7 @@ pub(crate) fn validate_filters_and_column_exprs(
 ) -> Result<HashSet<String>> {
     let mut known_filters = HashSet::new();
     for filter in filters {
+        validate_non_empty_name(&filter.name, &format!("{schema}.{table} filter name"))?;
         if !known_filters.insert(filter.name.clone()) {
             return Err(ManifestError::validation(format!(
                 "{schema}.{table} has duplicate filter '{}'",
@@ -470,6 +475,7 @@ pub(crate) fn validate_unique_values(values: &[String], context: &str) -> Result
 pub(crate) fn validate_columns(columns: &[ColumnSpec], schema: &str, table: &str) -> Result<()> {
     let mut seen_columns = HashSet::new();
     for col in columns {
+        validate_non_empty_name(&col.name, &format!("{schema}.{table} column name"))?;
         col.manifest_data_type().map_err(|error| {
             ManifestError::validation(format!(
                 "{schema}.{table} column '{}' has invalid type '{}': {error}",
@@ -600,6 +606,11 @@ fn validate_function_binding<'a>(
     binding: &'a FunctionArgBinding,
     request_arg_names: &mut HashSet<&'a str>,
 ) -> Result<()> {
+    if binding.arg.trim().is_empty() {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' function '{function_name}' request arg name must not be empty"
+        )));
+    }
     if !request_arg_names.insert(binding.arg.as_str()) {
         return Err(ManifestError::validation(format!(
             "source '{source_name}' function '{function_name}' has multiple bindings for request arg '{}'",
@@ -764,7 +775,17 @@ fn validate_arg_template(
     Ok(())
 }
 
+fn validate_non_empty_name(value: &str, context: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(ManifestError::validation(format!(
+            "{context} must not be empty"
+        )));
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_identifier(value: &str, context: &str) -> Result<()> {
+    validate_non_empty_name(value, context)?;
     let mut chars = value.chars();
     let Some(first) = chars.next() else {
         return Err(ManifestError::validation(format!(
@@ -978,6 +999,56 @@ mod tests {
         );
     }
 
+    #[test]
+    fn validate_columns_rejects_empty_column_names() {
+        for name in ["", "   "] {
+            let mut column = test_column();
+            column.name = name.to_string();
+
+            let error = validate_columns(&[column], "demo", "messages")
+                .expect_err("empty column names should be rejected");
+
+            assert_eq!(
+                error.to_string(),
+                "demo.messages column name must not be empty"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_columns_accepts_non_empty_column_names() {
+        validate_columns(&[test_column()], "demo", "messages")
+            .expect("non-empty column name should remain valid");
+    }
+
+    #[test]
+    fn validate_filters_rejects_empty_filter_names() {
+        for name in ["", "   "] {
+            let filters = vec![FilterSpec {
+                name: name.to_string(),
+                data_type: "Utf8".to_string(),
+                required: false,
+                mode: FilterMode::Equality,
+                description: String::new(),
+            }];
+
+            let error =
+                validate_filters_and_column_exprs(&filters, &[test_column()], "demo", "messages")
+                    .expect_err("empty filter names should be rejected");
+
+            assert_eq!(
+                error.to_string(),
+                "demo.messages filter name must not be empty"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_filters_accepts_non_empty_filter_names() {
+        validate_filters_and_column_exprs(&test_filters(), &[test_column()], "demo", "messages")
+            .expect("non-empty filter name should remain valid");
+    }
+
     fn base_request() -> RequestSpec {
         RequestSpec {
             path: ParsedTemplate::parse("/messages").expect("request path"),
@@ -1094,6 +1165,32 @@ mod tests {
         }
     }
 
+    fn function_with_binding_arg(binding_arg: &str) -> SourceTableFunctionSpec {
+        SourceTableFunctionSpec {
+            name: "lookup".to_string(),
+            kind: SourceTableFunctionKind::Table,
+            description: String::new(),
+            fetch_limit_default: None,
+            search_limits: None,
+            detail_hints: Vec::new(),
+            args: vec![TableFunctionArgSpec {
+                name: "query".to_string(),
+                required: true,
+                values: vec![],
+                bind: FunctionArgBinding {
+                    arg: binding_arg.to_string(),
+                },
+            }],
+            request: RequestSpec {
+                path: ParsedTemplate::parse("/lookup").expect("request path"),
+                ..RequestSpec::default()
+            },
+            response: crate::ResponseSpec::default(),
+            pagination: PaginationSpec::default(),
+            columns: vec![test_column()],
+        }
+    }
+
     #[test]
     fn validate_declared_relation_namespace_rejects_duplicate_tables_that_differ_only_by_case() {
         let relations = [
@@ -1177,19 +1274,33 @@ mod tests {
 
     #[test]
     fn validate_declared_relation_namespace_rejects_empty_table_names() {
-        let relations = [DeclaredRelation::table("  ")];
+        for name in ["", "   "] {
+            let relations = [DeclaredRelation::table(name)];
 
-        let error = validate_declared_relation_namespace("demo", relations)
-            .expect_err("expected empty table name to be rejected");
+            let error = validate_declared_relation_namespace("demo", relations)
+                .expect_err("expected empty table name to be rejected");
 
-        assert_eq!(
-            error.to_string(),
-            "source 'demo' table name must not be empty"
-        );
+            assert_eq!(
+                error.to_string(),
+                "source 'demo' table name must not be empty"
+            );
+        }
     }
 
     #[test]
     fn validate_declared_relation_namespace_rejects_invalid_function_names() {
+        for name in ["", "   "] {
+            let relations = [DeclaredRelation::function(name)];
+
+            let error = validate_declared_relation_namespace("demo", relations)
+                .expect_err("expected empty function name to be rejected");
+
+            assert_eq!(
+                error.to_string(),
+                "source 'demo' function name must not be empty"
+            );
+        }
+
         let relations = [DeclaredRelation::function("1search")];
 
         let error = validate_declared_relation_namespace("demo", relations)
@@ -1198,6 +1309,78 @@ mod tests {
         assert!(error.to_string().contains(
             "source 'demo' function name '1search' must start with a letter or underscore"
         ));
+    }
+
+    #[test]
+    fn validate_http_table_rejects_empty_route_filter_bindings() {
+        for filter_name in ["", "   "] {
+            let route = RequestRouteSpec {
+                when_filters: vec![filter_name.to_string()],
+                request: base_request(),
+            };
+
+            let error = validate_http_table(
+                "demo",
+                "messages",
+                &test_filters(),
+                &[test_column()],
+                &base_request(),
+                &[route],
+                &PaginationSpec::default(),
+                None,
+                &[],
+            )
+            .expect_err("empty route filter binding should be rejected");
+
+            assert_eq!(
+                error.to_string(),
+                "demo.messages requests.when_filters[0] must not be empty"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_http_table_accepts_non_empty_route_filter_bindings() {
+        let route = RequestRouteSpec {
+            when_filters: vec!["id".to_string()],
+            request: base_request(),
+        };
+
+        validate_http_table(
+            "demo",
+            "messages",
+            &test_filters(),
+            &[test_column()],
+            &base_request(),
+            &[route],
+            &PaginationSpec::default(),
+            None,
+            &[],
+        )
+        .expect("non-empty route filter binding should remain valid");
+    }
+
+    #[test]
+    fn validate_http_function_rejects_empty_request_arg_bindings() {
+        for binding_arg in ["", "   "] {
+            let function = function_with_binding_arg(binding_arg);
+
+            let error = validate_http_function("demo", &function)
+                .expect_err("empty request arg binding should be rejected");
+
+            assert_eq!(
+                error.to_string(),
+                "source 'demo' function 'lookup' request arg name must not be empty"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_http_function_accepts_non_empty_request_arg_bindings() {
+        let function = function_with_binding_arg("query");
+
+        validate_http_function("demo", &function)
+            .expect("non-empty request arg binding should remain valid");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR improves coral-spec validation consistency by rejecting empty and whitespace-only names across multiple spec validation paths.

## Changes

- Reject empty and whitespace-only source names
- Reject empty and whitespace-only column names
- Reject empty and whitespace-only filter names
- Reject empty and whitespace-only HTTP route bindings
- Reject empty and whitespace-only HTTP request argument bindings
- Reject empty and whitespace-only MCP tool argument bindings
- Improve path-aware validation error messages

## Tests

- Added empty string, whitespace-only, and valid-name coverage
- Ran `cargo fmt --package coral-spec`
- Ran `cargo test -p coral-spec`

Result: 245 unit tests and 1 doctest passed.