### PR TITLE
feat(app): attribute episode.id on coral.query spans from request metadata (BENCH-496)

### DIFF
--- a/crates/coral-app/src/query/attribution.rs
+++ b/crates/coral-app/src/query/attribution.rs
@@ -1,0 +1,18 @@
+//! Transport-free attribution for a query's originating context.
+
+use crate::episode::EpisodeId;
+
+/// Request-scoped attribution threaded from the gRPC service edge into the query
+/// manager, so transport concerns (gRPC metadata, OpenTelemetry baggage) stay
+/// out of the manager and off the deeper query path.
+///
+/// Today it carries the optional originating episode; the manager stamps
+/// `episode.id` on the `coral.query` span so trajectory-memory capture can join
+/// a task's queries to the intent registered by `OpenEpisode`. Intent itself is
+/// never carried here — only the opaque id.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct QueryAttribution {
+    /// The episode whose intent this query served, when the caller supplied a
+    /// valid `coral-episode-id`; `None` for an untagged query.
+    pub(crate) episode_id: Option<EpisodeId>,
+}

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -17,6 +17,8 @@ use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
+use crate::episode::EpisodeId;
+use crate::query::QueryAttribution;
 use crate::query::extensions::{
     CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
 };
@@ -133,11 +135,13 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         sql: &str,
+        attribution: &QueryAttribution,
     ) -> Result<QueryExecution, QueryManagerError> {
         run_query_operation(
             QueryOperation::ExecuteSql,
             workspace_name,
             sql,
+            attribution.episode_id.as_ref(),
             async {
                 let config = self
                     .config_store
@@ -162,11 +166,13 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         sql: &str,
+        attribution: &QueryAttribution,
     ) -> Result<QueryPlan, QueryManagerError> {
         run_query_operation(
             QueryOperation::ExplainSql,
             workspace_name,
             sql,
+            attribution.episode_id.as_ref(),
             async {
                 let config = self
                     .config_store
@@ -376,6 +382,7 @@ async fn run_query_operation<T, Fut, RowCount>(
     operation: QueryOperation,
     workspace_name: &WorkspaceName,
     sql: &str,
+    episode_id: Option<&EpisodeId>,
     query: Fut,
     row_count: RowCount,
 ) -> Result<T, QueryManagerError>
@@ -384,7 +391,7 @@ where
     RowCount: FnOnce(&T) -> Option<u64>,
 {
     let started_at = Instant::now();
-    let query_span = create_query_span(operation, workspace_name, sql);
+    let query_span = create_query_span(operation, workspace_name, sql, episode_id);
     let result = query.instrument(query_span.clone()).await;
 
     let metrics = crate::telemetry::metrics::metrics();
@@ -420,20 +427,29 @@ fn create_query_span(
     operation: QueryOperation,
     workspace_name: &WorkspaceName,
     sql: &str,
+    episode_id: Option<&EpisodeId>,
 ) -> tracing::Span {
     let operation = operation.as_str();
-    tracing::info_span!(
+    let span = tracing::info_span!(
         "coral.query",
         otel.name = "coral.query",
         operation = operation,
         workspace = %workspace_name.as_str(),
         sql = %sql,
+        // Trajectory-memory attribution: present only when the caller tagged the
+        // call with a valid `coral-episode-id`. Joins to the intent registered by
+        // `OpenEpisode`; never carries the intent text itself.
+        episode.id = tracing::field::Empty,
         row_count = tracing::field::Empty,
         status = tracing::field::Empty,
         error.kind = tracing::field::Empty,
         error.type = tracing::field::Empty,
         exception.message = tracing::field::Empty,
-    )
+    );
+    if let Some(episode_id) = episode_id {
+        span.record("episode.id", episode_id.as_str());
+    }
+    span
 }
 
 fn query_error_kind(error: &QueryManagerError) -> &'static str {
@@ -569,6 +585,60 @@ mod tests {
             _temp: temp,
             manager,
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_sql_stamps_episode_id_on_query_span() {
+        use coral_api::v1::query_service_server::QueryService as QueryServiceApi;
+        use coral_api::v1::{ExecuteSqlRequest, Workspace};
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+        use tonic::Request;
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        use crate::query::service::QueryService;
+
+        // Capture finished spans into memory via a scoped subscriber so the
+        // assertion exercises the real metadata -> manager -> span path end to end.
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("episode-attribution-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        let service = QueryService::new(fixture.manager.clone());
+
+        let mut request = Request::new(ExecuteSqlRequest {
+            workspace: Some(Workspace {
+                name: WorkspaceName::default().as_str().to_string(),
+            }),
+            sql: "SELECT 1".to_string(),
+        });
+        request.metadata_mut().insert(
+            "coral-episode-id",
+            "ep_trace_1".parse().expect("ascii value"),
+        );
+
+        // The query may fail (the fixture has no installed sources); the
+        // `coral.query` span is created and stamped before execution regardless.
+        let _result = service.execute_sql(request).await;
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let query_span = spans
+            .iter()
+            .find(|span| span.name == "coral.query")
+            .expect("coral.query span recorded");
+        let episode_attr = query_span
+            .attributes
+            .iter()
+            .find(|attribute| attribute.key.as_str() == "episode.id")
+            .expect("episode.id attribute present");
+        assert_eq!(episode_attr.value.as_str(), "ep_trace_1");
     }
 
     fn execution_to_rows(execution: &QueryExecution) -> Vec<Value> {
@@ -761,6 +831,7 @@ surfaces:
             .execute_sql(
                 &workspace_name,
                 "SELECT id, title FROM github_v4_query.issues",
+                &QueryAttribution::default(),
             )
             .await
             .expect("query executes");

--- a/crates/coral-app/src/query/mod.rs
+++ b/crates/coral-app/src/query/mod.rs
@@ -1,5 +1,8 @@
 //! Query orchestration and transport adapters.
 
+pub(crate) mod attribution;
 pub(crate) mod extensions;
 pub(crate) mod manager;
 pub(crate) mod service;
+
+pub(crate) use attribution::QueryAttribution;

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -11,8 +11,11 @@ use coral_api::v1::{
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::core_status;
+use crate::query::QueryAttribution;
 use crate::query::manager::QueryManager;
-use crate::transport::{grpc_span, instrument_grpc, query_status, workspace_name_from_proto};
+use crate::transport::{
+    episode_id_from_metadata, grpc_span, instrument_grpc, query_status, workspace_name_from_proto,
+};
 
 #[derive(Clone)]
 pub(crate) struct QueryService {
@@ -35,11 +38,14 @@ impl QueryServiceApi for QueryService {
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
+        let attribution = QueryAttribution {
+            episode_id: episode_id_from_metadata(request.metadata()),
+        };
         Box::pin(instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
             let execution = queries
-                .execute_sql(&workspace_name, &inner.sql)
+                .execute_sql(&workspace_name, &inner.sql, &attribution)
                 .await
                 .map_err(query_status)?;
             let response = ExecuteSqlResponse {
@@ -62,11 +68,14 @@ impl QueryServiceApi for QueryService {
     ) -> Result<Response<ExplainSqlResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
+        let attribution = QueryAttribution {
+            episode_id: episode_id_from_metadata(request.metadata()),
+        };
         Box::pin(instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
             let plan = queries
-                .explain_sql(&workspace_name, &inner.sql)
+                .explain_sql(&workspace_name, &inner.sql, &attribution)
                 .await
                 .map_err(query_status)?;
             Ok(Response::new(ExplainSqlResponse {

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -3,7 +3,7 @@
 use std::future::Future;
 
 use coral_api::{
-    CORAL_ERROR_DOMAIN, grpc_response_status_code,
+    CORAL_EPISODE_ID_METADATA_KEY, CORAL_ERROR_DOMAIN, grpc_response_status_code,
     v1::{
         CatalogItem as ProtoCatalogItem, CatalogSearchResult as ProtoCatalogSearchResult, Column,
         ColumnSearchResult as ProtoColumnSearchResult,
@@ -29,10 +29,6 @@ use crate::catalog::discovery::{
 use crate::episode::EpisodeId;
 use crate::query::manager::QueryManagerError;
 use crate::workspaces::WorkspaceName;
-
-/// gRPC metadata key carrying the originating episode id on every Coral call
-/// after `OpenEpisode` (see `crates/coral-api/proto/coral/v1/episode.proto`).
-const CORAL_EPISODE_ID_METADATA_KEY: &str = "coral-episode-id";
 
 struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
 

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -26,8 +26,13 @@ use crate::catalog::discovery::{
     CatalogItem, CatalogMetadataField, CatalogSearchResult, ColumnMetadataField,
     ColumnSearchResult, DescribeTableResult,
 };
+use crate::episode::EpisodeId;
 use crate::query::manager::QueryManagerError;
 use crate::workspaces::WorkspaceName;
+
+/// gRPC metadata key carrying the originating episode id on every Coral call
+/// after `OpenEpisode` (see `crates/coral-api/proto/coral/v1/episode.proto`).
+const CORAL_EPISODE_ID_METADATA_KEY: &str = "coral-episode-id";
 
 struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
 
@@ -251,6 +256,24 @@ pub(crate) fn workspace_to_proto(workspace_name: &WorkspaceName) -> Workspace {
     }
 }
 
+/// Extracts and validates the originating episode from request metadata.
+///
+/// Episode attribution is best-effort: a missing `coral-episode-id` yields
+/// `None`, and a present-but-malformed value is ignored (debug-logged) rather
+/// than failing the call — the query is valid regardless of its trajectory tag.
+pub(crate) fn episode_id_from_metadata(
+    metadata: &tonic::metadata::MetadataMap,
+) -> Option<EpisodeId> {
+    let value = metadata.get(CORAL_EPISODE_ID_METADATA_KEY)?.to_str().ok()?;
+    match EpisodeId::parse(value) {
+        Ok(episode_id) => Some(episode_id),
+        Err(error) => {
+            tracing::debug!(%error, "ignoring malformed coral-episode-id metadata");
+            None
+        }
+    }
+}
+
 pub(crate) fn table_to_proto(
     workspace_name: &WorkspaceName,
     table: coral_engine::TableInfo,
@@ -471,7 +494,7 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        GrpcMethodMetadata, GrpcServerMethod, grpc_method, query_status,
+        GrpcMethodMetadata, GrpcServerMethod, episode_id_from_metadata, grpc_method, query_status,
         query_test_result_to_proto, table_summary_to_proto, table_to_proto,
         workspace_name_from_proto, workspace_to_proto,
     };
@@ -559,6 +582,35 @@ mod tests {
             workspace_name_from_proto(Some(&workspace)).expect("workspace should parse");
 
         assert_eq!(workspace_name.as_str(), "default");
+    }
+
+    #[test]
+    fn episode_id_from_metadata_extracts_valid_id() {
+        let mut metadata = tonic::metadata::MetadataMap::new();
+        metadata.insert("coral-episode-id", "ep_123".parse().expect("ascii value"));
+
+        let episode_id = episode_id_from_metadata(&metadata).expect("valid id is extracted");
+
+        assert_eq!(episode_id.as_str(), "ep_123");
+    }
+
+    #[test]
+    fn episode_id_from_metadata_ignores_absent_and_malformed() {
+        let absent = tonic::metadata::MetadataMap::new();
+        assert!(
+            episode_id_from_metadata(&absent).is_none(),
+            "a missing coral-episode-id yields no attribution"
+        );
+
+        let mut malformed = tonic::metadata::MetadataMap::new();
+        malformed.insert(
+            "coral-episode-id",
+            "has space".parse().expect("ascii value"),
+        );
+        assert!(
+            episode_id_from_metadata(&malformed).is_none(),
+            "a malformed id is ignored, not surfaced"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## BENCH-496 — server-side episode attribution

**Stacked on #1225.** The next slice after `OpenEpisode`: read the `coral-episode-id` gRPC metadata on each query call and stamp `episode.id` on the `coral.query` span, so trajectory-memory capture can join a task's queries to the intent registered by `OpenEpisode`. **Only the opaque id reaches the span — never the intent text.**

### Design
- Metadata is parsed at the service edge into a **transport-free `QueryAttribution`** and threaded into `QueryManager` (per the layering note on #1169 — the manager never parses gRPC metadata).
- **Best-effort:** a missing/malformed `coral-episode-id` is ignored; the query is valid regardless of its trajectory tag.
- **Inert when unused:** with no client sending the header, no `episode.id` is recorded (byte-identical), matching the always-registered `OpenEpisode` handler.

### Tests
- `episode_id_from_metadata` — valid / absent / malformed.
- `execute_sql_stamps_episode_id_on_query_span` — drives `QueryService` with `coral-episode-id` metadata and asserts the recorded `coral.query` span carries `episode.id` (full server path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)