### PR TITLE
feat(client): tag outgoing Coral calls with coral-episode-id (BENCH-496)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ dependencies = [
  "opentelemetry_sdk",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tonic",
  "tonic-types",
  "tracing",

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -30,6 +30,10 @@ use crate::episode::EpisodeId;
 use crate::query::manager::QueryManagerError;
 use crate::workspaces::WorkspaceName;
 
+/// gRPC metadata key carrying the originating episode id on every Coral call
+/// after `OpenEpisode` (see `crates/coral-api/proto/coral/v1/episode.proto`).
+const CORAL_EPISODE_ID_METADATA_KEY: &str = "coral-episode-id";
+
 struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
 
 impl Extractor for MetadataExtractor<'_> {

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -30,10 +30,6 @@ use crate::episode::EpisodeId;
 use crate::query::manager::QueryManagerError;
 use crate::workspaces::WorkspaceName;
 
-/// gRPC metadata key carrying the originating episode id on every Coral call
-/// after `OpenEpisode` (see `crates/coral-api/proto/coral/v1/episode.proto`).
-const CORAL_EPISODE_ID_METADATA_KEY: &str = "coral-episode-id";
-
 struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
 
 impl Extractor for MetadataExtractor<'_> {

--- a/crates/coral-client/Cargo.toml
+++ b/crates/coral-client/Cargo.toml
@@ -16,6 +16,7 @@ opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tonic.workspace = true
 tonic-types.workspace = true
 tracing.workspace = true

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -11,6 +11,7 @@ use coral_api::{
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint};
 
+use crate::episode::EpisodeIdInterceptor;
 use crate::error::ClientError;
 use crate::grpc::{GrpcClientEndpoint, InstrumentedGrpcService};
 use crate::propagation::TraceContextInterceptor;
@@ -26,7 +27,8 @@ pub fn default_workspace() -> Workspace {
     }
 }
 
-type RawGrpcService = InterceptedService<Channel, TraceContextInterceptor>;
+type TracedService = InterceptedService<Channel, TraceContextInterceptor>;
+type RawGrpcService = InterceptedService<TracedService, EpisodeIdInterceptor>;
 type GrpcService = InstrumentedGrpcService<RawGrpcService>;
 
 /// Public source-management gRPC client.
@@ -107,8 +109,9 @@ impl AppClient {
 }
 
 fn grpc_service(channel: Channel, endpoint: &GrpcClientEndpoint) -> GrpcService {
+    let traced = InterceptedService::new(channel, TraceContextInterceptor);
     InstrumentedGrpcService::new(
-        InterceptedService::new(channel, TraceContextInterceptor),
+        InterceptedService::new(traced, EpisodeIdInterceptor),
         endpoint.clone(),
     )
 }

--- a/crates/coral-client/src/episode.rs
+++ b/crates/coral-client/src/episode.rs
@@ -1,0 +1,159 @@
+//! Client-side episode tagging.
+//!
+//! Carries the active episode id on outgoing Coral calls as the
+//! `coral-episode-id` gRPC metadata value, so the server can attribute each
+//! query's `coral.query` span to the episode (and thus the intent registered by
+//! `OpenEpisode`). Mirrors the trace-context interceptor: an interceptor reads
+//! ambient per-task state and injects it into outgoing request metadata.
+
+use std::future::Future;
+
+use tonic::metadata::MetadataValue;
+use tonic::service::Interceptor;
+
+/// gRPC metadata key the Coral server reads to attribute a call to an episode.
+pub const CORAL_EPISODE_ID_METADATA_KEY: &str = "coral-episode-id";
+
+/// Maximum episode id length, in bytes. Kept in sync with the server contract
+/// (`coral-app` `episode/id.rs` `EpisodeId::parse`) and the `OpenEpisode` proto.
+const MAX_EPISODE_ID_LEN: usize = 128;
+
+/// Whether `id` satisfies the server's `coral-episode-id` contract: non-empty,
+/// at most [`MAX_EPISODE_ID_LEN`] bytes, and entirely graphic ASCII
+/// (`0x21..=0x7E` — no whitespace, control bytes, or non-ASCII).
+///
+/// Mirrors `coral-app`'s `EpisodeId::parse` so the client drops ids the server
+/// would reject *before* sending them, rather than emitting metadata that gets
+/// ignored server-side.
+fn is_valid_episode_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= MAX_EPISODE_ID_LEN
+        && id.bytes().all(|byte| byte.is_ascii_graphic())
+}
+
+tokio::task_local! {
+    static ACTIVE_EPISODE_ID: String;
+}
+
+/// Runs `future` with `episode_id` tagged onto every Coral call it makes.
+///
+/// While the returned future runs, [`EpisodeIdInterceptor`] attaches the
+/// `coral-episode-id` metadata to outgoing requests. Calls made outside any
+/// `with_episode_id` scope carry no tag.
+pub async fn with_episode_id<F>(episode_id: String, future: F) -> F::Output
+where
+    F: Future,
+{
+    ACTIVE_EPISODE_ID.scope(episode_id, future).await
+}
+
+/// tonic client interceptor that injects the active episode id (set via
+/// [`with_episode_id`]) as the `coral-episode-id` request metadata.
+///
+/// A no-op when no episode is in scope, or when the active id fails the
+/// `coral-episode-id` contract (`is_valid_episode_id`) — episode attribution is
+/// best-effort and never fails a call.
+#[derive(Clone)]
+pub struct EpisodeIdInterceptor;
+
+impl Interceptor for EpisodeIdInterceptor {
+    fn call(
+        &mut self,
+        mut request: tonic::Request<()>,
+    ) -> Result<tonic::Request<()>, tonic::Status> {
+        // `Err` simply means no episode is in scope — the common, untagged case.
+        let _scoped = ACTIVE_EPISODE_ID.try_with(|episode_id| {
+            // Validate against the server contract before injecting so a tagged
+            // call never carries metadata the server would reject/ignore.
+            if !is_valid_episode_id(episode_id) {
+                // The id is arbitrary caller input, so log its length (a length
+                // mismatch is the common cause) rather than the raw value.
+                tracing::debug!(
+                    episode_id_len = episode_id.len(),
+                    "dropping invalid coral-episode-id; call sent untagged"
+                );
+                return;
+            }
+            if let Ok(value) = MetadataValue::try_from(episode_id.as_str()) {
+                request
+                    .metadata_mut()
+                    .insert(CORAL_EPISODE_ID_METADATA_KEY, value);
+            }
+        });
+        Ok(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::service::Interceptor as _;
+
+    use super::{
+        CORAL_EPISODE_ID_METADATA_KEY, EpisodeIdInterceptor, MAX_EPISODE_ID_LEN, with_episode_id,
+    };
+
+    /// Runs the interceptor with `episode_id` in scope and returns the resulting
+    /// `coral-episode-id` metadata value, if any.
+    async fn tagged_value(episode_id: String) -> Option<String> {
+        let request = with_episode_id(episode_id, async {
+            let mut interceptor = EpisodeIdInterceptor;
+            interceptor
+                .call(tonic::Request::new(()))
+                .expect("interceptor succeeds")
+        })
+        .await;
+        request
+            .metadata()
+            .get(CORAL_EPISODE_ID_METADATA_KEY)
+            .map(|value| value.to_str().expect("ascii value").to_string())
+    }
+
+    #[tokio::test]
+    async fn injects_active_episode_id() {
+        assert_eq!(
+            tagged_value("ep_42".to_string()).await.as_deref(),
+            Some("ep_42")
+        );
+        // A maximum-length id is still valid and injected.
+        let max = "a".repeat(MAX_EPISODE_ID_LEN);
+        assert_eq!(
+            tagged_value(max.clone()).await.as_deref(),
+            Some(max.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn drops_ids_violating_the_server_contract() {
+        let invalid = [
+            String::new(),                      // empty
+            "   ".to_string(),                  // whitespace only
+            "has space".to_string(),            // embedded space
+            "tab\tid".to_string(),              // control byte
+            "épisode".to_string(),              // non-ASCII
+            "a".repeat(MAX_EPISODE_ID_LEN + 1), // over-long
+        ];
+        for id in invalid {
+            assert_eq!(
+                tagged_value(id.clone()).await,
+                None,
+                "invalid id {id:?} must not be injected"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn no_tag_without_scope() {
+        let mut interceptor = EpisodeIdInterceptor;
+        let request = interceptor
+            .call(tonic::Request::new(()))
+            .expect("interceptor succeeds");
+
+        assert!(
+            request
+                .metadata()
+                .get(CORAL_EPISODE_ID_METADATA_KEY)
+                .is_none(),
+            "untagged calls carry no episode metadata"
+        );
+    }
+}

--- a/crates/coral-client/src/episode.rs
+++ b/crates/coral-client/src/episode.rs
@@ -8,26 +8,20 @@
 
 use std::future::Future;
 
+use coral_api::{CORAL_EPISODE_ID_MAX_LEN, CORAL_EPISODE_ID_METADATA_KEY};
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
 
-/// gRPC metadata key the Coral server reads to attribute a call to an episode.
-pub const CORAL_EPISODE_ID_METADATA_KEY: &str = "coral-episode-id";
-
-/// Maximum episode id length, in bytes. Kept in sync with the server contract
-/// (`coral-app` `episode/id.rs` `EpisodeId::parse`) and the `OpenEpisode` proto.
-const MAX_EPISODE_ID_LEN: usize = 128;
-
 /// Whether `id` satisfies the server's `coral-episode-id` contract: non-empty,
-/// at most [`MAX_EPISODE_ID_LEN`] bytes, and entirely graphic ASCII
+/// at most [`CORAL_EPISODE_ID_MAX_LEN`] bytes, and entirely graphic ASCII
 /// (`0x21..=0x7E` — no whitespace, control bytes, or non-ASCII).
 ///
-/// Mirrors `coral-app`'s `EpisodeId::parse` so the client drops ids the server
-/// would reject *before* sending them, rather than emitting metadata that gets
-/// ignored server-side.
+/// Validates against the shared coral-api contract so the client drops ids the
+/// server would reject *before* sending them, rather than emitting metadata that
+/// gets ignored server-side.
 fn is_valid_episode_id(id: &str) -> bool {
     !id.is_empty()
-        && id.len() <= MAX_EPISODE_ID_LEN
+        && id.len() <= CORAL_EPISODE_ID_MAX_LEN
         && id.bytes().all(|byte| byte.is_ascii_graphic())
 }
 
@@ -88,9 +82,9 @@ impl Interceptor for EpisodeIdInterceptor {
 mod tests {
     use tonic::service::Interceptor as _;
 
-    use super::{
-        CORAL_EPISODE_ID_METADATA_KEY, EpisodeIdInterceptor, MAX_EPISODE_ID_LEN, with_episode_id,
-    };
+    use coral_api::{CORAL_EPISODE_ID_MAX_LEN, CORAL_EPISODE_ID_METADATA_KEY};
+
+    use super::{EpisodeIdInterceptor, with_episode_id};
 
     /// Runs the interceptor with `episode_id` in scope and returns the resulting
     /// `coral-episode-id` metadata value, if any.
@@ -115,7 +109,7 @@ mod tests {
             Some("ep_42")
         );
         // A maximum-length id is still valid and injected.
-        let max = "a".repeat(MAX_EPISODE_ID_LEN);
+        let max = "a".repeat(CORAL_EPISODE_ID_MAX_LEN);
         assert_eq!(
             tagged_value(max.clone()).await.as_deref(),
             Some(max.as_str())
@@ -125,12 +119,12 @@ mod tests {
     #[tokio::test]
     async fn drops_ids_violating_the_server_contract() {
         let invalid = [
-            String::new(),                      // empty
-            "   ".to_string(),                  // whitespace only
-            "has space".to_string(),            // embedded space
-            "tab\tid".to_string(),              // control byte
-            "épisode".to_string(),              // non-ASCII
-            "a".repeat(MAX_EPISODE_ID_LEN + 1), // over-long
+            String::new(),                            // empty
+            "   ".to_string(),                        // whitespace only
+            "has space".to_string(),                  // embedded space
+            "tab\tid".to_string(),                    // control byte
+            "épisode".to_string(),                    // non-ASCII
+            "a".repeat(CORAL_EPISODE_ID_MAX_LEN + 1), // over-long
         ];
         for id in invalid {
             assert_eq!(

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -16,6 +16,7 @@
 //! bootstrap seams as the default client surface.
 
 mod client;
+mod episode;
 mod error;
 mod grpc;
 pub mod local;
@@ -43,6 +44,7 @@ pub use client::{
     AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, QueryClient, SourceClient,
     default_workspace,
 };
+pub use episode::{CORAL_EPISODE_ID_METADATA_KEY, EpisodeIdInterceptor, with_episode_id};
 pub use error::{ClientError, QueryResultError};
 pub use sources::{SourceInputDecodeError, manifest_input_from_proto};
 pub use status_error::{

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -44,7 +44,8 @@ pub use client::{
     AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, QueryClient, SourceClient,
     default_workspace,
 };
-pub use episode::{CORAL_EPISODE_ID_METADATA_KEY, EpisodeIdInterceptor, with_episode_id};
+pub use coral_api::CORAL_EPISODE_ID_METADATA_KEY;
+pub use episode::{EpisodeIdInterceptor, with_episode_id};
 pub use error::{ClientError, QueryResultError};
 pub use sources::{SourceInputDecodeError, manifest_input_from_proto};
 pub use status_error::{


### PR DESCRIPTION
## BENCH-496 — client-side episode tagging (completes Rust client/server tagging)

**Stacked on** #1227**.** The final link: let a client _send_ the `coral-episode-id` the server now reads.

- `with_episode_id(id, future)` sets a **tokio task-local**; `EpisodeIdInterceptor` injects `coral-episode-id` into every outgoing call made within that scope. Wired into `AppClient` alongside the trace-context interceptor.
- Mirrors the existing `TraceContextInterceptor` (ambient per-task state → request metadata); the task-local follows the task across awaits/threads.
- **Best-effort & inert:** no scope (or a non-ASCII id) → no metadata, so untagged callers are unaffected.

### End-to-end (each link tested)

`OpenEpisode` records intent (#1225) → client tags calls with `coral-episode-id` (this PR) → server stamps `episode.id` on the `coral.query` span (#1227) → joinable to the intent.

### Tests

- header injected within `with_episode_id`; absent without a scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)