### PR TITLE
feat(sources/community/razorpay): add Razorpay community source

### DIFF
--- a/sources/community/razorpay/README.md
+++ b/sources/community/razorpay/README.md
@@ -1,0 +1,476 @@
+# Razorpay Source
+
+Query Razorpay payments, orders, refunds, customers, invoices, payment links, and settlements through Coral SQL.
+
+## Summary
+
+This source lets Coral query read-only Razorpay Payment Gateway inventory: payment rows, order rows, refund rows, customers, invoices, standard payment links, and settlements. It also exposes `razorpay.payments_summary` for collection-level connectivity checks when a test account has no payments yet.
+
+## Provider docs
+
+- Authentication: https://razorpay.com/docs/api/authentication/
+- Pagination and rate limits: https://razorpay.com/docs/api/pagination/
+- Payments: https://razorpay.com/docs/api/payments/fetch-all-payments/
+- Orders: https://razorpay.com/docs/api/orders/
+- Refunds: https://razorpay.com/docs/api/refunds/fetch-all/
+- Customers: https://razorpay.com/docs/api/customers/fetch-all/
+- Invoices: https://razorpay.com/docs/api/payments/invoices/fetch-all/
+- Payment Links: https://razorpay.com/docs/api/payments/payment-links/fetch-all-standard/
+- Settlements: https://razorpay.com/docs/api/settlements/fetch-all/
+
+## Authentication
+
+Razorpay APIs use HTTP Basic Auth with a Key ID and Key Secret.
+
+Generate test or live keys in the Razorpay Dashboard under Account & Settings -> API Keys, then add the community source:
+
+```bash
+RAZORPAY_API_KEY=rzp_test_... \
+RAZORPAY_KEY_SECRET=... \
+coral source add --file sources/community/razorpay/manifest.yaml
+```
+
+Use test mode keys for validation. Use live keys only when you intentionally want Coral queries to read live Razorpay account data.
+
+## Request limits
+
+This source performs live read-only Razorpay API requests. List tables use Razorpay's `count` and `skip` pagination with a maximum page size of 100. Razorpay applies API rate limits; retry or reduce query volume if the API returns HTTP 429.
+
+## Source shape
+
+The source exposes eight tables:
+
+- `razorpay.payments_summary` returns top-level metadata and raw items from `GET /v1/payments`.
+- `razorpay.payments` returns one row per payment from `GET /v1/payments`.
+- `razorpay.orders` returns one row per order from `GET /v1/orders`.
+- `razorpay.refunds` returns one row per refund from `GET /v1/refunds`.
+- `razorpay.customers` returns one row per customer from `GET /v1/customers`.
+- `razorpay.invoices` returns one row per invoice from `GET /v1/invoices`.
+- `razorpay.payment_links` returns one row per standard payment link from `GET /v1/payment_links`.
+- `razorpay.settlements` returns one row per settlement from `GET /v1/settlements`.
+
+## Source scope
+
+- Targets Razorpay Payment Gateway APIs through `RAZORPAY_BASE_URL`, defaulting to `https://api.razorpay.com`.
+- Requires `RAZORPAY_API_KEY` and `RAZORPAY_KEY_SECRET`.
+- Keeps the first version read-only.
+- SQL columns named `from_timestamp` and `to_timestamp` map to Razorpay's `from` and `to` API query parameters.
+- Mutating operations such as payment capture, order creation, refund creation, customer updates, invoice creation, payment-link creation/cancellation, and settlement actions are intentionally omitted.
+- RazorpayX payout APIs are intentionally omitted from this Payment Gateway-focused first version.
+
+## Limitations
+
+- Razorpay API keys are account-mode specific. Test keys read test-mode data, and live keys read live-mode data.
+- A fresh test account can validly return zero rows for the list tables. `razorpay.payments_summary` is included so source add/test can still prove authenticated connectivity.
+- Payouts, fund accounts, contacts, and other RazorpayX APIs are outside this first version.
+- The source does not expand nested payment card/EMI/offer details; it preserves nested objects such as `notes`, `acquirer_data`, `customer`, and `line_items` as JSON.
+
+## Tables
+
+### `razorpay.payments_summary`
+
+Returns the top-level payments collection response.
+
+```sql
+SELECT entity, count, substr(CAST(items AS VARCHAR), 1, 80) AS items_preview
+FROM razorpay.payments_summary
+LIMIT 1;
+```
+
+### `razorpay.payments`
+
+Returns one row per Razorpay payment.
+
+```sql
+SELECT id, amount, currency, status, method, order_id, created_at
+FROM razorpay.payments
+LIMIT 10;
+```
+
+### `razorpay.orders`
+
+Returns one row per Razorpay order.
+
+```sql
+SELECT id, amount, amount_paid, amount_due, currency, status, receipt, created_at
+FROM razorpay.orders
+LIMIT 10;
+```
+
+### `razorpay.refunds`
+
+Returns one row per Razorpay refund.
+
+```sql
+SELECT id, payment_id, amount, currency, status, speed_processed, created_at
+FROM razorpay.refunds
+LIMIT 10;
+```
+
+### `razorpay.customers`
+
+Returns one row per Razorpay customer.
+
+```sql
+SELECT id, name, email, contact, created_at
+FROM razorpay.customers
+LIMIT 10;
+```
+
+### `razorpay.invoices`
+
+Returns one row per Razorpay invoice.
+
+```sql
+SELECT id, type, invoice_number, status, customer_id, amount, currency, created_at
+FROM razorpay.invoices
+LIMIT 10;
+```
+
+### `razorpay.payment_links`
+
+Returns one row per standard Razorpay payment link.
+
+```sql
+SELECT id, amount, currency, status, reference_id, short_url, created_at
+FROM razorpay.payment_links
+LIMIT 10;
+```
+
+### `razorpay.settlements`
+
+Returns one row per Razorpay settlement.
+
+```sql
+SELECT id, amount, status, fees, tax, utr, created_at
+FROM razorpay.settlements
+LIMIT 10;
+```
+
+## Live validation output
+
+Run these checks after setting `RAZORPAY_API_KEY` and `RAZORPAY_KEY_SECRET`.
+
+```bash
+$ coral source lint sources/community/razorpay/manifest.yaml
+Manifest is valid
+```
+
+```bash
+$ coral source add --file sources/community/razorpay/manifest.yaml
+Added source razorpay
+
+  PASS razorpay connected successfully
+
+    razorpay (8 tables)
+    - customers
+    - invoices
+    - orders
+    - payment_links
+    - payments
+    - payments_summary
+    - refunds
+    - settlements
+    Query tests
+    1 declared - 1 passed - 0 failed
+
+    PASS SELECT entity, count FROM razorpay.payments_summary LIMIT 1
+      1 row
+```
+
+```bash
+$ coral source test razorpay
+  PASS razorpay connected successfully
+
+    razorpay (8 tables)
+    - customers
+    - invoices
+    - orders
+    - payment_links
+    - payments
+    - payments_summary
+    - refunds
+    - settlements
+    Query tests
+    1 declared - 1 passed - 0 failed
+
+    PASS SELECT entity, count FROM razorpay.payments_summary LIMIT 1
+      1 row
+```
+
+```sql
+SELECT table_name
+FROM coral.tables
+WHERE schema_name = 'razorpay'
+ORDER BY table_name;
+```
+
+```text
++------------------+
+| table_name       |
++------------------+
+| customers        |
+| invoices         |
+| orders           |
+| payment_links    |
+| payments         |
+| payments_summary |
+| refunds          |
+| settlements      |
++------------------+
+```
+
+```sql
+SELECT key, kind, required
+FROM coral.inputs
+WHERE schema_name = 'razorpay'
+ORDER BY key;
+```
+
+```text
++---------------------+----------+----------+
+| key                 | kind     | required |
++---------------------+----------+----------+
+| RAZORPAY_API_KEY    | secret   | true     |
+| RAZORPAY_BASE_URL   | variable | false    |
+| RAZORPAY_KEY_SECRET | secret   | true     |
++---------------------+----------+----------+
+```
+
+```sql
+SELECT table_name, column_name, data_type
+FROM coral.columns
+WHERE schema_name = 'razorpay'
+ORDER BY table_name, ordinal_position;
+```
+
+```text
++------------------+--------------------+-----------+
+| table_name       | column_name        | data_type |
++------------------+--------------------+-----------+
+| customers        | id                 | Utf8      |
+| customers        | entity             | Utf8      |
+| customers        | name               | Utf8      |
+| customers        | email              | Utf8      |
+| customers        | contact            | Utf8      |
+| customers        | gstin              | Utf8      |
+| customers        | created_at         | Timestamp |
+| customers        | notes              | Json      |
+| customers        | shipping_address   | Json      |
+| invoices         | type_filter        | Utf8      |
+| invoices         | payment_id_filter  | Utf8      |
+| invoices         | receipt_filter     | Utf8      |
+| invoices         | customer_id_filter | Utf8      |
+| invoices         | id                 | Utf8      |
+| invoices         | entity             | Utf8      |
+| invoices         | type               | Utf8      |
+| invoices         | invoice_number     | Utf8      |
+| invoices         | receipt            | Utf8      |
+| invoices         | status             | Utf8      |
+| invoices         | customer_id        | Utf8      |
+| invoices         | order_id           | Utf8      |
+| invoices         | payment_id         | Utf8      |
+| invoices         | amount             | Int64     |
+| invoices         | currency           | Utf8      |
+| invoices         | created_at         | Timestamp |
+| invoices         | customer_details   | Json      |
+| invoices         | line_items         | Json      |
+| invoices         | notes              | Json      |
+| orders           | from_timestamp     | Int64     |
+| orders           | to_timestamp       | Int64     |
+| orders           | receipt_filter     | Utf8      |
+| orders           | id                 | Utf8      |
+| orders           | entity             | Utf8      |
+| orders           | amount             | Int64     |
+| orders           | amount_paid        | Int64     |
+| orders           | amount_due         | Int64     |
+| orders           | currency           | Utf8      |
+| orders           | receipt            | Utf8      |
+| orders           | status             | Utf8      |
+| orders           | attempts           | Int64     |
+| orders           | created_at         | Timestamp |
+| orders           | notes              | Json      |
+| payment_links    | id                 | Utf8      |
+| payment_links    | entity             | Utf8      |
+| payment_links    | amount             | Int64     |
+| payment_links    | currency           | Utf8      |
+| payment_links    | status             | Utf8      |
+| payment_links    | description        | Utf8      |
+| payment_links    | reference_id       | Utf8      |
+| payment_links    | short_url          | Utf8      |
+| payment_links    | customer           | Json      |
+| payment_links    | notify             | Json      |
+| payment_links    | notes              | Json      |
+| payment_links    | created_at         | Timestamp |
+| payments         | from_timestamp     | Int64     |
+| payments         | to_timestamp       | Int64     |
+| payments         | id                 | Utf8      |
+| payments         | entity             | Utf8      |
+| payments         | amount             | Int64     |
+| payments         | currency           | Utf8      |
+| payments         | status             | Utf8      |
+| payments         | method             | Utf8      |
+| payments         | order_id           | Utf8      |
+| payments         | invoice_id         | Utf8      |
+| payments         | captured           | Boolean   |
+| payments         | amount_refunded    | Int64     |
+| payments         | refund_status      | Utf8      |
+| payments         | email              | Utf8      |
+| payments         | contact            | Utf8      |
+| payments         | created_at         | Timestamp |
+| payments         | notes              | Json      |
+| payments         | acquirer_data      | Json      |
+| payments         | error_code         | Utf8      |
+| payments         | error_description  | Utf8      |
+| payments_summary | from_timestamp     | Int64     |
+| payments_summary | to_timestamp       | Int64     |
+| payments_summary | entity             | Utf8      |
+| payments_summary | count              | Int64     |
+| payments_summary | items              | Json      |
+| refunds          | from_timestamp     | Int64     |
+| refunds          | to_timestamp       | Int64     |
+| refunds          | payment_id_filter  | Utf8      |
+| refunds          | id                 | Utf8      |
+| refunds          | entity             | Utf8      |
+| refunds          | payment_id         | Utf8      |
+| refunds          | amount             | Int64     |
+| refunds          | currency           | Utf8      |
+| refunds          | status             | Utf8      |
+| refunds          | receipt            | Utf8      |
+| refunds          | speed_requested    | Utf8      |
+| refunds          | speed_processed    | Utf8      |
+| refunds          | created_at         | Timestamp |
+| refunds          | notes              | Json      |
+| settlements      | from_timestamp     | Int64     |
+| settlements      | to_timestamp       | Int64     |
+| settlements      | id                 | Utf8      |
+| settlements      | entity             | Utf8      |
+| settlements      | amount             | Int64     |
+| settlements      | status             | Utf8      |
+| settlements      | fees               | Int64     |
+| settlements      | tax                | Int64     |
+| settlements      | utr                | Utf8      |
+| settlements      | created_at         | Timestamp |
++------------------+--------------------+-----------+
+```
+
+```sql
+SELECT entity, count, substr(CAST(items AS VARCHAR), 1, 80) AS items_preview
+FROM razorpay.payments_summary
+LIMIT 1;
+```
+
+```text
++------------+-------+---------------+
+| entity     | count | items_preview |
++------------+-------+---------------+
+| collection | 0     | []            |
++------------+-------+---------------+
+```
+
+```sql
+SELECT entity, count, from_timestamp, to_timestamp
+FROM razorpay.payments_summary
+WHERE from_timestamp = 1704067200
+  AND to_timestamp = 1893456000
+LIMIT 1;
+```
+
+```text
++------------+-------+----------------+--------------+
+| entity     | count | from_timestamp | to_timestamp |
++------------+-------+----------------+--------------+
+| collection | 0     | 1704067200     | 1893456000   |
++------------+-------+----------------+--------------+
+```
+
+```sql
+SELECT id, amount, currency, status, method, order_id, created_at
+FROM razorpay.payments
+LIMIT 10;
+```
+
+```text
++----+--------+----------+--------+--------+----------+------------+
+| id | amount | currency | status | method | order_id | created_at |
++----+--------+----------+--------+--------+----------+------------+
++----+--------+----------+--------+--------+----------+------------+
+```
+
+```sql
+SELECT id, amount, amount_paid, amount_due, currency, status, receipt, created_at
+FROM razorpay.orders
+LIMIT 10;
+```
+
+```text
++----+--------+-------------+------------+----------+--------+---------+------------+
+| id | amount | amount_paid | amount_due | currency | status | receipt | created_at |
++----+--------+-------------+------------+----------+--------+---------+------------+
++----+--------+-------------+------------+----------+--------+---------+------------+
+```
+
+```sql
+SELECT id, payment_id, amount, currency, status, speed_processed, created_at
+FROM razorpay.refunds
+LIMIT 10;
+```
+
+```text
++----+------------+--------+----------+--------+-----------------+------------+
+| id | payment_id | amount | currency | status | speed_processed | created_at |
++----+------------+--------+----------+--------+-----------------+------------+
++----+------------+--------+----------+--------+-----------------+------------+
+```
+
+```sql
+SELECT id, name, email, contact, created_at
+FROM razorpay.customers
+LIMIT 10;
+```
+
+```text
++----+------+-------+---------+------------+
+| id | name | email | contact | created_at |
++----+------+-------+---------+------------+
++----+------+-------+---------+------------+
+```
+
+```sql
+SELECT id, type, invoice_number, status, customer_id, amount, currency, created_at
+FROM razorpay.invoices
+LIMIT 10;
+```
+
+```text
++----+------+----------------+--------+-------------+--------+----------+------------+
+| id | type | invoice_number | status | customer_id | amount | currency | created_at |
++----+------+----------------+--------+-------------+--------+----------+------------+
++----+------+----------------+--------+-------------+--------+----------+------------+
+```
+
+```sql
+SELECT id, amount, currency, status, reference_id, short_url, created_at
+FROM razorpay.payment_links
+LIMIT 10;
+```
+
+```text
++----+--------+----------+--------+--------------+-----------+------------+
+| id | amount | currency | status | reference_id | short_url | created_at |
++----+--------+----------+--------+--------------+-----------+------------+
++----+--------+----------+--------+--------------+-----------+------------+
+```
+
+```sql
+SELECT id, amount, status, fees, tax, utr, created_at
+FROM razorpay.settlements
+LIMIT 10;
+```
+
+```text
++----+--------+--------+------+-----+-----+------------+
+| id | amount | status | fees | tax | utr | created_at |
++----+--------+--------+------+-----+-----+------------+
++----+--------+--------+------+-----+-----+------------+
+```

--- a/sources/community/razorpay/README.md
+++ b/sources/community/razorpay/README.md
@@ -137,6 +137,8 @@ FROM razorpay.payment_links
 LIMIT 10;
 ```
 
+`payment_id` and `reference_id` filters are pushed down to Razorpay.
+
 ### `razorpay.settlements`
 
 Returns one row per Razorpay settlement.
@@ -290,6 +292,7 @@ ORDER BY table_name, ordinal_position;
 | orders           | attempts           | Int64     |
 | orders           | created_at         | Timestamp |
 | orders           | notes              | Json      |
+| payment_links    | payment_id         | Utf8      |
 | payment_links    | id                 | Utf8      |
 | payment_links    | entity             | Utf8      |
 | payment_links    | amount             | Int64     |
@@ -460,6 +463,21 @@ LIMIT 10;
 | id | amount | currency | status | reference_id | short_url | created_at |
 +----+--------+----------+--------+--------------+-----------+------------+
 +----+--------+----------+--------+--------------+-----------+------------+
+```
+
+```sql
+SELECT id, reference_id, payment_id, status
+FROM razorpay.payment_links
+WHERE reference_id = 'sample-reference'
+  AND payment_id = 'pay_sample'
+LIMIT 10;
+```
+
+```text
++----+--------------+------------+--------+
+| id | reference_id | payment_id | status |
++----+--------------+------------+--------+
++----+--------------+------------+--------+
 ```
 
 ```sql

--- a/sources/community/razorpay/manifest.yaml
+++ b/sources/community/razorpay/manifest.yaml
@@ -1,0 +1,756 @@
+name: razorpay
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Query Razorpay payments, orders, refunds, customers, invoices, payment links, and settlements through SQL.
+base_url: "{{input.RAZORPAY_BASE_URL}}"
+
+inputs:
+  RAZORPAY_BASE_URL:
+    kind: variable
+    default: https://api.razorpay.com
+    hint: |
+      Razorpay REST API base URL.
+
+      Default:
+      https://api.razorpay.com
+  RAZORPAY_API_KEY:
+    kind: secret
+    hint: |
+      Razorpay Key ID for HTTP Basic Auth.
+
+      Generate test or live API keys in the Razorpay Dashboard under
+      Account & Settings -> API Keys. Use test mode keys for validation.
+  RAZORPAY_KEY_SECRET:
+    kind: secret
+    hint: |
+      Razorpay Key Secret paired with RAZORPAY_API_KEY.
+
+      Razorpay only shows the key secret when it is generated. Treat it as
+      sensitive; this source sends it only as the HTTP Basic Auth password.
+
+auth:
+  type: BasicAuth
+  username: "{{input.RAZORPAY_API_KEY}}"
+  password: "{{input.RAZORPAY_KEY_SECRET}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT entity, count FROM razorpay.payments_summary LIMIT 1
+
+tables:
+  - name: payments_summary
+    description: Razorpay payments collection metadata from GET /v1/payments.
+    guide: |
+      This table returns one row with Razorpay's top-level collection metadata.
+      Use it for connection checks, especially when a test account has no
+      payment rows yet.
+    filters:
+      - name: from_timestamp
+      - name: to_timestamp
+    request:
+      method: GET
+      path: /v1/payments
+      query:
+        - name: from
+          from: filter_int
+          key: from_timestamp
+        - name: to
+          from: filter_int
+          key: to_timestamp
+        - name: count
+          from: literal
+          value: 1
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: from_timestamp
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional Unix timestamp lower bound supplied in SQL.
+        expr: {kind: from_filter, key: from_timestamp}
+      - name: to_timestamp
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional Unix timestamp upper bound supplied in SQL.
+        expr: {kind: from_filter, key: to_timestamp}
+      - name: entity
+        type: Utf8
+        nullable: true
+        description: Razorpay collection entity type.
+      - name: count
+        type: Int64
+        nullable: true
+        description: Number of payments returned in this collection response.
+      - name: items
+        type: Json
+        nullable: true
+        description: Raw payments array returned in the collection response.
+
+  - name: payments
+    description: Razorpay payment rows from GET /v1/payments.
+    guide: |
+      Uses Razorpay count/skip pagination. Optional SQL filters
+      `from_timestamp` and `to_timestamp` map to Razorpay's `from` and `to` query
+      parameters, which are Unix timestamps in seconds. This table is
+      read-only; it does not capture or update payments.
+    fetch_limit_default: 100
+    filters:
+      - name: from_timestamp
+      - name: to_timestamp
+    request:
+      method: GET
+      path: /v1/payments
+      query:
+        - name: from
+          from: filter_int
+          key: from_timestamp
+        - name: to
+          from: filter_int
+          key: to_timestamp
+    response:
+      rows_path: [items]
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: from_timestamp
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional Unix timestamp lower bound supplied in SQL.
+        expr: {kind: from_filter, key: from_timestamp}
+      - name: to_timestamp
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional Unix timestamp upper bound supplied in SQL.
+        expr: {kind: from_filter, key: to_timestamp}
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Razorpay payment ID.
+      - name: entity
+        type: Utf8
+        nullable: true
+        description: Razorpay entity type.
+      - name: amount
+        type: Int64
+        nullable: true
+        description: Payment amount in currency subunits.
+      - name: currency
+        type: Utf8
+        nullable: true
+        description: Payment currency.
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Payment status.
+      - name: method
+        type: Utf8
+        nullable: true
+        description: Payment method.
+      - name: order_id
+        type: Utf8
+        nullable: true
+        description: Associated Razorpay order ID.
+      - name: invoice_id
+        type: Utf8
+        nullable: true
+        description: Associated Razorpay invoice ID.
+      - name: captured
+        type: Boolean
+        nullable: true
+        description: Whether the payment was captured.
+      - name: amount_refunded
+        type: Int64
+        nullable: true
+        description: Amount refunded in currency subunits.
+      - name: refund_status
+        type: Utf8
+        nullable: true
+        description: Refund status for the payment.
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Customer email on the payment.
+      - name: contact
+        type: Utf8
+        nullable: true
+        description: Customer contact on the payment.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Payment creation time.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [created_at]}
+      - name: notes
+        type: Json
+        nullable: true
+        description: Raw Razorpay notes object.
+      - name: acquirer_data
+        type: Json
+        nullable: true
+        description: Raw acquirer data object.
+      - name: error_code
+        type: Utf8
+        nullable: true
+        description: Razorpay payment error code when present.
+      - name: error_description
+        type: Utf8
+        nullable: true
+        description: Razorpay payment error description when present.
+
+  - name: orders
+    description: Razorpay order rows from GET /v1/orders.
+    guide: |
+      Uses Razorpay count/skip pagination. Optional SQL filters
+      `from_timestamp`, `to_timestamp`, and `receipt_filter` map to Razorpay's
+      `from`, `to`, and `receipt` query parameters.
+    fetch_limit_default: 100
+    filters:
+      - name: from_timestamp
+      - name: to_timestamp
+      - name: receipt
+    request:
+      method: GET
+      path: /v1/orders
+      query:
+        - name: from
+          from: filter_int
+          key: from_timestamp
+        - name: to
+          from: filter_int
+          key: to_timestamp
+        - name: receipt
+          from: filter
+          key: receipt
+    response:
+      rows_path: [items]
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: from_timestamp
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional Unix timestamp lower bound supplied in SQL.
+        expr: {kind: from_filter, key: from_timestamp}
+      - name: to_timestamp
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional Unix timestamp upper bound supplied in SQL.
+        expr: {kind: from_filter, key: to_timestamp}
+      - name: receipt_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional receipt filter supplied in SQL.
+        expr: {kind: from_filter, key: receipt}
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Razorpay order ID.
+      - name: entity
+        type: Utf8
+        nullable: true
+        description: Razorpay entity type.
+      - name: amount
+        type: Int64
+        nullable: true
+        description: Order amount in currency subunits.
+      - name: amount_paid
+        type: Int64
+        nullable: true
+        description: Amount paid against the order.
+      - name: amount_due
+        type: Int64
+        nullable: true
+        description: Amount due against the order.
+      - name: currency
+        type: Utf8
+        nullable: true
+        description: Order currency.
+      - name: receipt
+        type: Utf8
+        nullable: true
+        description: Receipt value supplied while creating the order.
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Order status.
+      - name: attempts
+        type: Int64
+        nullable: true
+        description: Number of payment attempts.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Order creation time.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [created_at]}
+      - name: notes
+        type: Json
+        nullable: true
+        description: Raw Razorpay notes object.
+
+  - name: refunds
+    description: Razorpay refund rows from GET /v1/refunds.
+    guide: |
+      Uses Razorpay count/skip pagination. Optional SQL filters
+      `from_timestamp`, `to_timestamp`, and `payment_id_filter` map to Razorpay's
+      `from`, `to`, and `payment_id` query parameters.
+    fetch_limit_default: 100
+    filters:
+      - name: from_timestamp
+      - name: to_timestamp
+      - name: payment_id
+    request:
+      method: GET
+      path: /v1/refunds
+      query:
+        - name: from
+          from: filter_int
+          key: from_timestamp
+        - name: to
+          from: filter_int
+          key: to_timestamp
+        - name: payment_id
+          from: filter
+          key: payment_id
+    response:
+      rows_path: [items]
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: from_timestamp
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional Unix timestamp lower bound supplied in SQL.
+        expr: {kind: from_filter, key: from_timestamp}
+      - name: to_timestamp
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional Unix timestamp upper bound supplied in SQL.
+        expr: {kind: from_filter, key: to_timestamp}
+      - name: payment_id_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional payment_id filter supplied in SQL.
+        expr: {kind: from_filter, key: payment_id}
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Razorpay refund ID.
+      - name: entity
+        type: Utf8
+        nullable: true
+        description: Razorpay entity type.
+      - name: payment_id
+        type: Utf8
+        nullable: true
+        description: Payment ID associated with the refund.
+      - name: amount
+        type: Int64
+        nullable: true
+        description: Refund amount in currency subunits.
+      - name: currency
+        type: Utf8
+        nullable: true
+        description: Refund currency.
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Refund status.
+      - name: receipt
+        type: Utf8
+        nullable: true
+        description: Refund receipt value.
+      - name: speed_requested
+        type: Utf8
+        nullable: true
+        description: Requested refund speed.
+      - name: speed_processed
+        type: Utf8
+        nullable: true
+        description: Processed refund speed.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Refund creation time.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [created_at]}
+      - name: notes
+        type: Json
+        nullable: true
+        description: Raw Razorpay notes object.
+
+  - name: customers
+    description: Razorpay customer rows from GET /v1/customers.
+    guide: |
+      Uses Razorpay count/skip pagination. This table is read-only and does not
+      create or update customers.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /v1/customers
+    response:
+      rows_path: [items]
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Razorpay customer ID.
+      - name: entity
+        type: Utf8
+        nullable: true
+        description: Razorpay entity type.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Customer name.
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Customer email.
+      - name: contact
+        type: Utf8
+        nullable: true
+        description: Customer contact number.
+      - name: gstin
+        type: Utf8
+        nullable: true
+        description: Customer GSTIN when returned.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Customer creation time.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [created_at]}
+      - name: notes
+        type: Json
+        nullable: true
+        description: Raw Razorpay notes object.
+      - name: shipping_address
+        type: Json
+        nullable: true
+        description: Raw shipping address object.
+
+  - name: invoices
+    description: Razorpay invoice rows from GET /v1/invoices.
+    guide: |
+      Uses Razorpay collection pagination when available. Optional SQL filters
+      `type_filter`, `payment_id_filter`, `receipt_filter`, and
+      `customer_id_filter` map to Razorpay's corresponding query parameters.
+    fetch_limit_default: 100
+    filters:
+      - name: type
+      - name: payment_id
+      - name: receipt
+      - name: customer_id
+    request:
+      method: GET
+      path: /v1/invoices
+      query:
+        - name: type
+          from: filter
+          key: type
+        - name: payment_id
+          from: filter
+          key: payment_id
+        - name: receipt
+          from: filter
+          key: receipt
+        - name: customer_id
+          from: filter
+          key: customer_id
+    response:
+      rows_path: [items]
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: type_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional invoice type filter supplied in SQL.
+        expr: {kind: from_filter, key: type}
+      - name: payment_id_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional payment_id filter supplied in SQL.
+        expr: {kind: from_filter, key: payment_id}
+      - name: receipt_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional receipt filter supplied in SQL.
+        expr: {kind: from_filter, key: receipt}
+      - name: customer_id_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional customer_id filter supplied in SQL.
+        expr: {kind: from_filter, key: customer_id}
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Razorpay invoice ID.
+      - name: entity
+        type: Utf8
+        nullable: true
+        description: Razorpay entity type.
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Invoice type.
+      - name: invoice_number
+        type: Utf8
+        nullable: true
+        description: Razorpay invoice number.
+      - name: receipt
+        type: Utf8
+        nullable: true
+        description: Invoice receipt value.
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Invoice status.
+      - name: customer_id
+        type: Utf8
+        nullable: true
+        description: Razorpay customer ID associated with the invoice.
+      - name: order_id
+        type: Utf8
+        nullable: true
+        description: Razorpay order ID associated with the invoice.
+      - name: payment_id
+        type: Utf8
+        nullable: true
+        description: Payment ID associated with the invoice.
+      - name: amount
+        type: Int64
+        nullable: true
+        description: Invoice amount in currency subunits.
+      - name: currency
+        type: Utf8
+        nullable: true
+        description: Invoice currency.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Invoice creation time.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [created_at]}
+      - name: customer_details
+        type: Json
+        nullable: true
+        description: Raw customer_details object.
+      - name: line_items
+        type: Json
+        nullable: true
+        description: Raw invoice line items array.
+      - name: notes
+        type: Json
+        nullable: true
+        description: Raw Razorpay notes object.
+
+  - name: payment_links
+    description: Razorpay standard payment link rows from GET /v1/payment_links.
+    guide: |
+      Returns standard Payment Links. This table is read-only and does not
+      create, update, notify, or cancel payment links.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /v1/payment_links
+    response:
+      rows_path: [payment_links]
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Razorpay payment link ID.
+      - name: entity
+        type: Utf8
+        nullable: true
+        description: Razorpay entity type.
+      - name: amount
+        type: Int64
+        nullable: true
+        description: Payment link amount in currency subunits.
+      - name: currency
+        type: Utf8
+        nullable: true
+        description: Payment link currency.
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Payment link status.
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Payment link description.
+      - name: reference_id
+        type: Utf8
+        nullable: true
+        description: Merchant reference ID when returned.
+      - name: short_url
+        type: Utf8
+        nullable: true
+        description: Short URL for the payment link.
+      - name: customer
+        type: Json
+        nullable: true
+        description: Raw customer object.
+      - name: notify
+        type: Json
+        nullable: true
+        description: Raw notification settings object.
+      - name: notes
+        type: Json
+        nullable: true
+        description: Raw Razorpay notes object.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Payment link creation time.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [created_at]}
+
+  - name: settlements
+    description: Razorpay settlement rows from GET /v1/settlements.
+    guide: |
+      Uses Razorpay count/skip pagination. Optional SQL filters
+      `from_timestamp` and `to_timestamp` map to Razorpay's `from` and `to` query
+      parameters, which are Unix timestamps in seconds.
+    fetch_limit_default: 100
+    filters:
+      - name: from_timestamp
+      - name: to_timestamp
+    request:
+      method: GET
+      path: /v1/settlements
+      query:
+        - name: from
+          from: filter_int
+          key: from_timestamp
+        - name: to
+          from: filter_int
+          key: to_timestamp
+    response:
+      rows_path: [items]
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: from_timestamp
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional Unix timestamp lower bound supplied in SQL.
+        expr: {kind: from_filter, key: from_timestamp}
+      - name: to_timestamp
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional Unix timestamp upper bound supplied in SQL.
+        expr: {kind: from_filter, key: to_timestamp}
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Razorpay settlement ID.
+      - name: entity
+        type: Utf8
+        nullable: true
+        description: Razorpay entity type.
+      - name: amount
+        type: Int64
+        nullable: true
+        description: Settlement amount in currency subunits.
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Settlement status.
+      - name: fees
+        type: Int64
+        nullable: true
+        description: Fees charged on the settlement.
+      - name: tax
+        type: Int64
+        nullable: true
+        description: Tax charged on fees.
+      - name: utr
+        type: Utf8
+        nullable: true
+        description: Settlement UTR when returned.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Settlement creation time.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [created_at]}

--- a/sources/community/razorpay/manifest.yaml
+++ b/sources/community/razorpay/manifest.yaml
@@ -608,11 +608,22 @@ tables:
     description: Razorpay standard payment link rows from GET /v1/payment_links.
     guide: |
       Returns standard Payment Links. This table is read-only and does not
-      create, update, notify, or cancel payment links.
+      create, update, notify, or cancel payment links. Optional `payment_id`
+      and `reference_id` filters are pushed down to Razorpay.
     fetch_limit_default: 100
+    filters:
+      - name: payment_id
+      - name: reference_id
     request:
       method: GET
       path: /v1/payment_links
+      query:
+        - name: payment_id
+          from: filter
+          key: payment_id
+        - name: reference_id
+          from: filter
+          key: reference_id
     response:
       rows_path: [payment_links]
     pagination:
@@ -623,6 +634,12 @@ tables:
         max: 100
         query_param: count
     columns:
+      - name: payment_id
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional payment_id filter supplied in SQL.
+        expr: {kind: from_filter, key: payment_id}
       - name: id
         type: Utf8
         nullable: false


### PR DESCRIPTION
﻿Closes #1231

Query Razorpay payments, orders, refunds, customers, invoices, payment links, and settlements through Coral SQL.

## Summary

This source lets Coral query read-only Razorpay Payment Gateway inventory: payment rows, order rows, refund rows, customers, invoices, standard payment links, and settlements. It also exposes `razorpay.payments_summary` for collection-level connectivity checks when a test account has no payments yet.

## Provider docs

- Authentication: https://razorpay.com/docs/api/authentication/
- Pagination and rate limits: https://razorpay.com/docs/api/pagination/
- Payments: https://razorpay.com/docs/api/payments/fetch-all-payments/
- Orders: https://razorpay.com/docs/api/orders/
- Refunds: https://razorpay.com/docs/api/refunds/fetch-all/
- Customers: https://razorpay.com/docs/api/customers/fetch-all/
- Invoices: https://razorpay.com/docs/api/payments/invoices/fetch-all/
- Payment Links: https://razorpay.com/docs/api/payments/payment-links/fetch-all-standard/
- Settlements: https://razorpay.com/docs/api/settlements/fetch-all/

## Authentication

Razorpay APIs use HTTP Basic Auth with a Key ID and Key Secret.

Generate test or live keys in the Razorpay Dashboard under Account & Settings -> API Keys, then add the community source:

```bash
RAZORPAY_API_KEY=rzp_test_... \
RAZORPAY_KEY_SECRET=... \
coral source add --file sources/community/razorpay/manifest.yaml
```

Use test mode keys for validation. Use live keys only when you intentionally want Coral queries to read live Razorpay account data.

## Request limits

This source performs live read-only Razorpay API requests. List tables use Razorpay's `count` and `skip` pagination with a maximum page size of 100. Razorpay applies API rate limits; retry or reduce query volume if the API returns HTTP 429.

## Source shape

The source exposes eight tables:

- `razorpay.payments_summary` returns top-level metadata and raw items from `GET /v1/payments`.
- `razorpay.payments` returns one row per payment from `GET /v1/payments`.
- `razorpay.orders` returns one row per order from `GET /v1/orders`.
- `razorpay.refunds` returns one row per refund from `GET /v1/refunds`.
- `razorpay.customers` returns one row per customer from `GET /v1/customers`.
- `razorpay.invoices` returns one row per invoice from `GET /v1/invoices`.
- `razorpay.payment_links` returns one row per standard payment link from `GET /v1/payment_links`.
- `razorpay.settlements` returns one row per settlement from `GET /v1/settlements`.

## Source scope

- Targets Razorpay Payment Gateway APIs through `RAZORPAY_BASE_URL`, defaulting to `https://api.razorpay.com`.
- Requires `RAZORPAY_API_KEY` and `RAZORPAY_KEY_SECRET`.
- Keeps the first version read-only.
- SQL columns named `from_timestamp` and `to_timestamp` map to Razorpay's `from` and `to` API query parameters.
- Mutating operations such as payment capture, order creation, refund creation, customer updates, invoice creation, payment-link creation/cancellation, and settlement actions are intentionally omitted.
- RazorpayX payout APIs are intentionally omitted from this Payment Gateway-focused first version.

## Limitations

- Razorpay API keys are account-mode specific. Test keys read test-mode data, and live keys read live-mode data.
- A fresh test account can validly return zero rows for the list tables. `razorpay.payments_summary` is included so source add/test can still prove authenticated connectivity.
- Payouts, fund accounts, contacts, and other RazorpayX APIs are outside this first version.
- The source does not expand nested payment card/EMI/offer details; it preserves nested objects such as `notes`, `acquirer_data`, `customer`, and `line_items` as JSON.

## Tables

### `razorpay.payments_summary`

Returns the top-level payments collection response.

```sql
SELECT entity, count, substr(CAST(items AS VARCHAR), 1, 80) AS items_preview
FROM razorpay.payments_summary
LIMIT 1;
```

### `razorpay.payments`

Returns one row per Razorpay payment.

```sql
SELECT id, amount, currency, status, method, order_id, created_at
FROM razorpay.payments
LIMIT 10;
```

### `razorpay.orders`

Returns one row per Razorpay order.

```sql
SELECT id, amount, amount_paid, amount_due, currency, status, receipt, created_at
FROM razorpay.orders
LIMIT 10;
```

### `razorpay.refunds`

Returns one row per Razorpay refund.

```sql
SELECT id, payment_id, amount, currency, status, speed_processed, created_at
FROM razorpay.refunds
LIMIT 10;
```

### `razorpay.customers`

Returns one row per Razorpay customer.

```sql
SELECT id, name, email, contact, created_at
FROM razorpay.customers
LIMIT 10;
```

### `razorpay.invoices`

Returns one row per Razorpay invoice.

```sql
SELECT id, type, invoice_number, status, customer_id, amount, currency, created_at
FROM razorpay.invoices
LIMIT 10;
```

### `razorpay.payment_links`

Returns one row per standard Razorpay payment link.

```sql
SELECT id, amount, currency, status, reference_id, short_url, created_at
FROM razorpay.payment_links
LIMIT 10;
```

`payment_id` and `reference_id` filters are pushed down to Razorpay.

### `razorpay.settlements`

Returns one row per Razorpay settlement.

```sql
SELECT id, amount, status, fees, tax, utr, created_at
FROM razorpay.settlements
LIMIT 10;
```

## Live validation output

Run these checks after setting `RAZORPAY_API_KEY` and `RAZORPAY_KEY_SECRET`.

```bash
$ coral source lint sources/community/razorpay/manifest.yaml
Manifest is valid
```

```bash
$ coral source add --file sources/community/razorpay/manifest.yaml
Added source razorpay

  PASS razorpay connected successfully

    razorpay (8 tables)
    - customers
    - invoices
    - orders
    - payment_links
    - payments
    - payments_summary
    - refunds
    - settlements
    Query tests
    1 declared - 1 passed - 0 failed

    PASS SELECT entity, count FROM razorpay.payments_summary LIMIT 1
      1 row
```

```bash
$ coral source test razorpay
  PASS razorpay connected successfully

    razorpay (8 tables)
    - customers
    - invoices
    - orders
    - payment_links
    - payments
    - payments_summary
    - refunds
    - settlements
    Query tests
    1 declared - 1 passed - 0 failed

    PASS SELECT entity, count FROM razorpay.payments_summary LIMIT 1
      1 row
```

```sql
SELECT table_name
FROM coral.tables
WHERE schema_name = 'razorpay'
ORDER BY table_name;
```

```text
+------------------+
| table_name       |
+------------------+
| customers        |
| invoices         |
| orders           |
| payment_links    |
| payments         |
| payments_summary |
| refunds          |
| settlements      |
+------------------+
```

```sql
SELECT key, kind, required
FROM coral.inputs
WHERE schema_name = 'razorpay'
ORDER BY key;
```

```text
+---------------------+----------+----------+
| key                 | kind     | required |
+---------------------+----------+----------+
| RAZORPAY_API_KEY    | secret   | true     |
| RAZORPAY_BASE_URL   | variable | false    |
| RAZORPAY_KEY_SECRET | secret   | true     |
+---------------------+----------+----------+
```

```sql
SELECT table_name, column_name, data_type
FROM coral.columns
WHERE schema_name = 'razorpay'
ORDER BY table_name, ordinal_position;
```

```text
+------------------+--------------------+-----------+
| table_name       | column_name        | data_type |
+------------------+--------------------+-----------+
| customers        | id                 | Utf8      |
| customers        | entity             | Utf8      |
| customers        | name               | Utf8      |
| customers        | email              | Utf8      |
| customers        | contact            | Utf8      |
| customers        | gstin              | Utf8      |
| customers        | created_at         | Timestamp |
| customers        | notes              | Json      |
| customers        | shipping_address   | Json      |
| invoices         | type_filter        | Utf8      |
| invoices         | payment_id_filter  | Utf8      |
| invoices         | receipt_filter     | Utf8      |
| invoices         | customer_id_filter | Utf8      |
| invoices         | id                 | Utf8      |
| invoices         | entity             | Utf8      |
| invoices         | type               | Utf8      |
| invoices         | invoice_number     | Utf8      |
| invoices         | receipt            | Utf8      |
| invoices         | status             | Utf8      |
| invoices         | customer_id        | Utf8      |
| invoices         | order_id           | Utf8      |
| invoices         | payment_id         | Utf8      |
| invoices         | amount             | Int64     |
| invoices         | currency           | Utf8      |
| invoices         | created_at         | Timestamp |
| invoices         | customer_details   | Json      |
| invoices         | line_items         | Json      |
| invoices         | notes              | Json      |
| orders           | from_timestamp     | Int64     |
| orders           | to_timestamp       | Int64     |
| orders           | receipt_filter     | Utf8      |
| orders           | id                 | Utf8      |
| orders           | entity             | Utf8      |
| orders           | amount             | Int64     |
| orders           | amount_paid        | Int64     |
| orders           | amount_due         | Int64     |
| orders           | currency           | Utf8      |
| orders           | receipt            | Utf8      |
| orders           | status             | Utf8      |
| orders           | attempts           | Int64     |
| orders           | created_at         | Timestamp |
| orders           | notes              | Json      |
| payment_links    | payment_id         | Utf8      |
| payment_links    | id                 | Utf8      |
| payment_links    | entity             | Utf8      |
| payment_links    | amount             | Int64     |
| payment_links    | currency           | Utf8      |
| payment_links    | status             | Utf8      |
| payment_links    | description        | Utf8      |
| payment_links    | reference_id       | Utf8      |
| payment_links    | short_url          | Utf8      |
| payment_links    | customer           | Json      |
| payment_links    | notify             | Json      |
| payment_links    | notes              | Json      |
| payment_links    | created_at         | Timestamp |
| payments         | from_timestamp     | Int64     |
| payments         | to_timestamp       | Int64     |
| payments         | id                 | Utf8      |
| payments         | entity             | Utf8      |
| payments         | amount             | Int64     |
| payments         | currency           | Utf8      |
| payments         | status             | Utf8      |
| payments         | method             | Utf8      |
| payments         | order_id           | Utf8      |
| payments         | invoice_id         | Utf8      |
| payments         | captured           | Boolean   |
| payments         | amount_refunded    | Int64     |
| payments         | refund_status      | Utf8      |
| payments         | email              | Utf8      |
| payments         | contact            | Utf8      |
| payments         | created_at         | Timestamp |
| payments         | notes              | Json      |
| payments         | acquirer_data      | Json      |
| payments         | error_code         | Utf8      |
| payments         | error_description  | Utf8      |
| payments_summary | from_timestamp     | Int64     |
| payments_summary | to_timestamp       | Int64     |
| payments_summary | entity             | Utf8      |
| payments_summary | count              | Int64     |
| payments_summary | items              | Json      |
| refunds          | from_timestamp     | Int64     |
| refunds          | to_timestamp       | Int64     |
| refunds          | payment_id_filter  | Utf8      |
| refunds          | id                 | Utf8      |
| refunds          | entity             | Utf8      |
| refunds          | payment_id         | Utf8      |
| refunds          | amount             | Int64     |
| refunds          | currency           | Utf8      |
| refunds          | status             | Utf8      |
| refunds          | receipt            | Utf8      |
| refunds          | speed_requested    | Utf8      |
| refunds          | speed_processed    | Utf8      |
| refunds          | created_at         | Timestamp |
| refunds          | notes              | Json      |
| settlements      | from_timestamp     | Int64     |
| settlements      | to_timestamp       | Int64     |
| settlements      | id                 | Utf8      |
| settlements      | entity             | Utf8      |
| settlements      | amount             | Int64     |
| settlements      | status             | Utf8      |
| settlements      | fees               | Int64     |
| settlements      | tax                | Int64     |
| settlements      | utr                | Utf8      |
| settlements      | created_at         | Timestamp |
+------------------+--------------------+-----------+
```

```sql
SELECT entity, count, substr(CAST(items AS VARCHAR), 1, 80) AS items_preview
FROM razorpay.payments_summary
LIMIT 1;
```

```text
+------------+-------+---------------+
| entity     | count | items_preview |
+------------+-------+---------------+
| collection | 0     | []            |
+------------+-------+---------------+
```

```sql
SELECT entity, count, from_timestamp, to_timestamp
FROM razorpay.payments_summary
WHERE from_timestamp = 1704067200
  AND to_timestamp = 1893456000
LIMIT 1;
```

```text
+------------+-------+----------------+--------------+
| entity     | count | from_timestamp | to_timestamp |
+------------+-------+----------------+--------------+
| collection | 0     | 1704067200     | 1893456000   |
+------------+-------+----------------+--------------+
```

```sql
SELECT id, amount, currency, status, method, order_id, created_at
FROM razorpay.payments
LIMIT 10;
```

```text
+----+--------+----------+--------+--------+----------+------------+
| id | amount | currency | status | method | order_id | created_at |
+----+--------+----------+--------+--------+----------+------------+
+----+--------+----------+--------+--------+----------+------------+
```

```sql
SELECT id, amount, amount_paid, amount_due, currency, status, receipt, created_at
FROM razorpay.orders
LIMIT 10;
```

```text
+----+--------+-------------+------------+----------+--------+---------+------------+
| id | amount | amount_paid | amount_due | currency | status | receipt | created_at |
+----+--------+-------------+------------+----------+--------+---------+------------+
+----+--------+-------------+------------+----------+--------+---------+------------+
```

```sql
SELECT id, payment_id, amount, currency, status, speed_processed, created_at
FROM razorpay.refunds
LIMIT 10;
```

```text
+----+------------+--------+----------+--------+-----------------+------------+
| id | payment_id | amount | currency | status | speed_processed | created_at |
+----+------------+--------+----------+--------+-----------------+------------+
+----+------------+--------+----------+--------+-----------------+------------+
```

```sql
SELECT id, name, email, contact, created_at
FROM razorpay.customers
LIMIT 10;
```

```text
+----+------+-------+---------+------------+
| id | name | email | contact | created_at |
+----+------+-------+---------+------------+
+----+------+-------+---------+------------+
```

```sql
SELECT id, type, invoice_number, status, customer_id, amount, currency, created_at
FROM razorpay.invoices
LIMIT 10;
```

```text
+----+------+----------------+--------+-------------+--------+----------+------------+
| id | type | invoice_number | status | customer_id | amount | currency | created_at |
+----+------+----------------+--------+-------------+--------+----------+------------+
+----+------+----------------+--------+-------------+--------+----------+------------+
```

```sql
SELECT id, amount, currency, status, reference_id, short_url, created_at
FROM razorpay.payment_links
LIMIT 10;
```

```text
+----+--------+----------+--------+--------------+-----------+------------+
| id | amount | currency | status | reference_id | short_url | created_at |
+----+--------+----------+--------+--------------+-----------+------------+
+----+--------+----------+--------+--------------+-----------+------------+
```

```sql
SELECT id, reference_id, payment_id, status
FROM razorpay.payment_links
WHERE reference_id = 'sample-reference'
  AND payment_id = 'pay_sample'
LIMIT 10;
```

```text
+----+--------------+------------+--------+
| id | reference_id | payment_id | status |
+----+--------------+------------+--------+
+----+--------------+------------+--------+
```

```sql
SELECT id, amount, status, fees, tax, utr, created_at
FROM razorpay.settlements
LIMIT 10;
```

```text
+----+--------+--------+------+-----+-----+------------+
| id | amount | status | fees | tax | utr | created_at |
+----+--------+--------+------+-----+-----+------------+
+----+--------+--------+------+-----+-----+------------+
```

