### PR TITLE
refactor(app): encapsulate source artifact persistence

### DIFF
--- a/crates/coral-app/src/sources/artifacts.rs
+++ b/crates/coral-app/src/sources/artifacts.rs
@@ -1,0 +1,445 @@
+//! Filesystem artifact ownership for installed source state.
+
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+use crate::bootstrap::AppError;
+use crate::sources::SourceName;
+use crate::sources::model::{InstalledSource, SourceOrigin};
+use crate::state::AppStateLayout;
+use crate::storage::fs as storage_fs;
+use crate::workspaces::WorkspaceName;
+
+#[derive(Clone)]
+pub(crate) struct SourceArtifactStore {
+    layout: AppStateLayout,
+}
+
+#[derive(Debug)]
+pub(crate) struct SourceDirRollback {
+    target: PathBuf,
+    staged: PathBuf,
+}
+
+#[derive(Debug)]
+pub(crate) struct MaterializationBuild {
+    temp_dir: PathBuf,
+}
+
+/// Rollback token for a materialization install that has not yet been
+/// committed by the source config update.
+#[derive(Debug)]
+pub(crate) struct MaterializationRollback {
+    target: PathBuf,
+    previous: Option<PathBuf>,
+    marker: PathBuf,
+}
+
+const MATERIALIZATION_ROLLBACK_MARKER_PREFIX: &str = ".install.rollback.";
+
+impl SourceArtifactStore {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
+    pub(crate) fn manifest_snapshot(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<Option<String>, AppError> {
+        match source.origin {
+            SourceOrigin::Bundled => Ok(None),
+            SourceOrigin::Imported => self
+                .read_imported_manifest(workspace_name, &source.name)
+                .map(Some),
+        }
+    }
+
+    pub(crate) fn read_imported_manifest(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<String, AppError> {
+        Ok(std::fs::read_to_string(
+            self.layout.manifest_file(workspace_name, source_name),
+        )?)
+    }
+
+    pub(crate) fn persist_manifest(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        manifest_yaml: Option<&str>,
+    ) -> Result<(), AppError> {
+        let manifest_path = self.layout.manifest_file(workspace_name, source_name);
+        match manifest_yaml {
+            Some(manifest_yaml) => {
+                if let Some(parent) = manifest_path.parent() {
+                    storage_fs::ensure_private_dir(parent)?;
+                }
+                storage_fs::write_atomic(&manifest_path, manifest_yaml.as_bytes())?;
+            }
+            None => {
+                storage_fs::remove_file_if_exists(&manifest_path)?;
+            }
+        }
+        self.cleanup_empty_source_parents_from(manifest_path.parent());
+        Ok(())
+    }
+
+    pub(crate) fn stage_source_dir_for_delete(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<SourceDirRollback>, AppError> {
+        let target = self.layout.source_dir(workspace_name, source_name);
+        if !target.exists() {
+            return Ok(None);
+        }
+
+        let staged =
+            target.with_file_name(format!("{source_name}.delete.rollback.{}", Uuid::new_v4()));
+        storage_fs::remove_dir_all_if_exists(&staged)?;
+        storage_fs::rename_path(&target, &staged)?;
+        Ok(Some(SourceDirRollback { target, staged }))
+    }
+
+    pub(crate) fn restore_source_dir_rollback(
+        &self,
+        rollback: &SourceDirRollback,
+    ) -> Result<(), AppError> {
+        if rollback.target.exists() {
+            return Err(AppError::FailedPrecondition(format!(
+                "cannot restore source directory from '{}': target '{}' already exists",
+                rollback.staged.display(),
+                rollback.target.display()
+            )));
+        }
+        if rollback.staged.exists() {
+            storage_fs::rename_path(&rollback.staged, &rollback.target)?;
+        }
+        self.cleanup_empty_source_parents_from(rollback.staged.parent());
+        Ok(())
+    }
+
+    pub(crate) fn discard_source_dir_rollback(
+        &self,
+        rollback: SourceDirRollback,
+    ) -> Result<(), AppError> {
+        let SourceDirRollback { target, staged } = rollback;
+        storage_fs::remove_dir_all_if_exists(&staged)?;
+        self.cleanup_empty_source_parents_from(target.parent());
+        Ok(())
+    }
+
+    pub(crate) fn remove_source_dir_if(
+        &self,
+        should_remove: bool,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), AppError> {
+        if !should_remove {
+            return Ok(());
+        }
+        let source_dir = self.layout.source_dir(workspace_name, source_name);
+        storage_fs::remove_dir_all_if_exists(&source_dir)?;
+        self.cleanup_empty_source_parents_from(source_dir.parent());
+        Ok(())
+    }
+
+    pub(crate) fn prepare_v4_materialization_tmp(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        temp_suffix: &str,
+    ) -> Result<MaterializationBuild, AppError> {
+        let temp_dir =
+            self.layout
+                .v4_materialized_tmp_dir(workspace_name, source_name, temp_suffix);
+        storage_fs::remove_dir_all_if_exists(&temp_dir)?;
+        storage_fs::ensure_private_dir(&temp_dir)?;
+        Ok(MaterializationBuild { temp_dir })
+    }
+
+    pub(crate) fn install_v4_materialization(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        build: &MaterializationBuild,
+    ) -> Result<MaterializationRollback, AppError> {
+        let target = self.layout.v4_materialized_dir(workspace_name, source_name);
+        let previous = self.layout.v4_materialized_tmp_dir(
+            workspace_name,
+            source_name,
+            &format!("rollback.{}", Uuid::new_v4()),
+        );
+        if let Some(parent) = target.parent() {
+            storage_fs::ensure_private_dir(parent)?;
+        }
+        let marker_name = format!("{MATERIALIZATION_ROLLBACK_MARKER_PREFIX}{}", Uuid::new_v4());
+        storage_fs::write_atomic(build.temp_dir().join(&marker_name).as_path(), b"pending\n")?;
+        storage_fs::remove_dir_all_if_exists(&previous)?;
+        let had_existing = target.exists();
+        if had_existing {
+            storage_fs::rename_path(&target, &previous)?;
+        }
+        if let Err(error) = storage_fs::rename_path(build.temp_dir(), &target) {
+            if had_existing
+                && previous.exists()
+                && let Err(rollback_error) = storage_fs::rename_path(&previous, &target)
+            {
+                return Err(AppError::FailedPrecondition(format!(
+                    "failed to install DSL v4 materialization for source '{source_name}': {error}; failed to restore previous materialization from '{}': {rollback_error}",
+                    previous.display()
+                )));
+            }
+            return Err(error.into());
+        }
+        Ok(MaterializationRollback {
+            marker: target.join(marker_name),
+            target,
+            previous: had_existing.then_some(previous),
+        })
+    }
+
+    pub(crate) fn restore_v4_materialization_rollback(
+        &self,
+        rollback: Option<MaterializationRollback>,
+    ) -> Result<(), AppError> {
+        if let Some(rollback) = rollback {
+            if rollback.target.exists() {
+                if !rollback.marker.exists() {
+                    return Err(AppError::FailedPrecondition(format!(
+                        "cannot restore DSL v4 materialization from '{}': target '{}' is not marked as this rollback's install",
+                        rollback
+                            .previous
+                            .as_ref()
+                            .unwrap_or(&rollback.target)
+                            .display(),
+                        rollback.target.display()
+                    )));
+                }
+                storage_fs::remove_dir_all_if_exists(&rollback.target)?;
+            }
+            if let Some(previous) = rollback.previous
+                && previous.exists()
+            {
+                storage_fs::rename_path(&previous, &rollback.target)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn cleanup_v4_materialization_tmp(&self, build: Option<&MaterializationBuild>) {
+        if let Some(build) = build {
+            drop(storage_fs::remove_dir_all_if_exists(build.temp_dir()));
+        }
+    }
+
+    pub(crate) fn discard_v4_materialization_rollback(
+        &self,
+        rollback: Option<MaterializationRollback>,
+    ) {
+        if let Some(rollback) = rollback {
+            drop(storage_fs::remove_file_if_exists(&rollback.marker));
+            if let Some(previous) = rollback.previous {
+                drop(storage_fs::remove_dir_all_if_exists(&previous));
+            }
+        }
+    }
+
+    fn cleanup_empty_source_parents_from(&self, path: Option<&Path>) {
+        let Some(mut current) = path.map(Path::to_path_buf) else {
+            return;
+        };
+        let root = self.layout.workspaces_root();
+        while current.starts_with(&root) && current != root {
+            let Ok(mut entries) = std::fs::read_dir(&current) else {
+                break;
+            };
+            if entries.next().is_some() {
+                break;
+            }
+            let next = current.parent().unwrap_or(&root).to_path_buf();
+            if storage_fs::remove_empty_dir(&current).is_err() {
+                break;
+            }
+            current = next;
+        }
+    }
+}
+
+impl SourceDirRollback {
+    pub(crate) fn staged_path(&self) -> &Path {
+        &self.staged
+    }
+}
+
+impl MaterializationBuild {
+    pub(crate) fn temp_dir(&self) -> &Path {
+        &self.temp_dir
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn layout(temp: &TempDir) -> AppStateLayout {
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        layout
+    }
+
+    fn workspace_name() -> WorkspaceName {
+        WorkspaceName::default()
+    }
+
+    fn source_name() -> SourceName {
+        SourceName::parse("github_v4_artifact_test").expect("source name")
+    }
+
+    #[test]
+    fn restoring_source_dir_rollback_refuses_occupied_target() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = layout(&temp);
+        let store = SourceArtifactStore::new(layout.clone());
+        let workspace = workspace_name();
+        let source = source_name();
+        let target = layout.source_dir(&workspace, &source);
+        std::fs::create_dir_all(&target).expect("create source dir");
+        std::fs::write(target.join("marker"), "original").expect("write original marker");
+        let rollback = store
+            .stage_source_dir_for_delete(&workspace, &source)
+            .expect("stage source dir")
+            .expect("source dir rollback");
+        std::fs::create_dir_all(&target).expect("recreate source dir");
+        std::fs::write(target.join("marker"), "concurrent").expect("write concurrent marker");
+
+        let error = store
+            .restore_source_dir_rollback(&rollback)
+            .expect_err("occupied target should block rollback");
+
+        assert!(
+            error.to_string().contains("target"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(target.join("marker")).expect("read target marker"),
+            "concurrent"
+        );
+        assert_eq!(
+            std::fs::read_to_string(rollback.staged_path().join("marker"))
+                .expect("read staged marker"),
+            "original"
+        );
+    }
+
+    #[test]
+    fn restoring_new_v4_materialization_removes_installed_target() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = layout(&temp);
+        let store = SourceArtifactStore::new(layout.clone());
+        let workspace = workspace_name();
+        let source = source_name();
+        let build = store
+            .prepare_v4_materialization_tmp(&workspace, &source, "new")
+            .expect("prepare temp materialization");
+        std::fs::write(build.temp_dir().join("marker"), "new").expect("write marker");
+
+        let rollback = store
+            .install_v4_materialization(&workspace, &source, &build)
+            .expect("install materialization");
+        let target = layout.v4_materialized_dir(&workspace, &source);
+        assert_eq!(
+            std::fs::read_to_string(target.join("marker")).expect("read marker"),
+            "new"
+        );
+
+        store
+            .restore_v4_materialization_rollback(Some(rollback))
+            .expect("restore rollback");
+
+        assert!(
+            !target.exists(),
+            "new materialization should be removed on rollback"
+        );
+    }
+
+    #[test]
+    fn restoring_replaced_v4_materialization_reinstalls_previous_target() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = layout(&temp);
+        let store = SourceArtifactStore::new(layout.clone());
+        let workspace = workspace_name();
+        let source = source_name();
+        let target = layout.v4_materialized_dir(&workspace, &source);
+        std::fs::create_dir_all(&target).expect("create existing target");
+        std::fs::write(target.join("marker"), "old").expect("write old marker");
+        let build = store
+            .prepare_v4_materialization_tmp(&workspace, &source, "replacement")
+            .expect("prepare temp materialization");
+        std::fs::write(build.temp_dir().join("marker"), "new").expect("write new marker");
+
+        let rollback = store
+            .install_v4_materialization(&workspace, &source, &build)
+            .expect("install materialization");
+        assert_eq!(
+            std::fs::read_to_string(target.join("marker")).expect("read marker"),
+            "new"
+        );
+
+        store
+            .restore_v4_materialization_rollback(Some(rollback))
+            .expect("restore rollback");
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("marker")).expect("read marker"),
+            "old"
+        );
+    }
+
+    #[test]
+    fn restoring_v4_materialization_refuses_unmarked_occupied_target() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = layout(&temp);
+        let store = SourceArtifactStore::new(layout.clone());
+        let workspace = workspace_name();
+        let source = source_name();
+        let target = layout.v4_materialized_dir(&workspace, &source);
+        std::fs::create_dir_all(&target).expect("create existing target");
+        std::fs::write(target.join("marker"), "old").expect("write old marker");
+        let build = store
+            .prepare_v4_materialization_tmp(&workspace, &source, "replacement")
+            .expect("prepare temp materialization");
+        std::fs::write(build.temp_dir().join("marker"), "new").expect("write new marker");
+        let rollback = store
+            .install_v4_materialization(&workspace, &source, &build)
+            .expect("install materialization");
+        let previous = rollback.previous.clone().expect("previous materialization");
+        std::fs::remove_dir_all(&target).expect("remove installed target");
+        std::fs::create_dir_all(&target).expect("recreate target");
+        std::fs::write(target.join("marker"), "concurrent").expect("write concurrent marker");
+
+        let error = store
+            .restore_v4_materialization_rollback(Some(rollback))
+            .expect_err("unmarked target should block rollback");
+
+        assert!(
+            error.to_string().contains("not marked"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(target.join("marker")).expect("read target marker"),
+            "concurrent"
+        );
+        assert_eq!(
+            std::fs::read_to_string(previous.join("marker")).expect("read previous marker"),
+            "old"
+        );
+    }
+}

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -1,7 +1,6 @@
 //! Owns the source lifecycle workflow for the local app.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::PathBuf;
 
 use coral_spec::v4::SurfaceDescriptor;
 use serde_yaml::Value as YamlValue;
@@ -16,29 +15,27 @@ use crate::credentials::{
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialsError,
 };
 use crate::sources::SourceName;
+use crate::sources::artifacts::{MaterializationBuild, SourceArtifactStore};
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
 };
 use crate::sources::materialization::{
-    MaterializationBuild, build_v4_materialization_tmp, canonicalize_file_descriptor,
-    cleanup_materialization_backup, cleanup_materialization_tmp, new_materialization_suffix,
-    replace_v4_materialization, restore_materialization_backup,
+    build_v4_materialization_tmp, canonicalize_file_descriptor, new_materialization_suffix,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore};
-use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
-use uuid::Uuid;
 
 #[derive(Clone)]
 pub(crate) struct SourceManager {
     config_store: ConfigStore,
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
+    artifacts: SourceArtifactStore,
     layout: AppStateLayout,
 }
 
@@ -147,7 +144,7 @@ struct PersistSourceRequest<'a> {
     bindings: ValidatedBindings,
     origin: SourceOrigin,
     credential_storage: Option<CredentialStorageKind>,
-    materialization_tmp: Option<PathBuf>,
+    materialization_tmp: Option<MaterializationBuild>,
 }
 
 struct SourceRollbackState {
@@ -166,6 +163,7 @@ impl SourceManager {
             config_store,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
+            artifacts: SourceArtifactStore::new(layout.clone()),
             layout,
         }
     }
@@ -359,15 +357,13 @@ impl SourceManager {
                 bindings,
                 origin,
                 credential_storage,
-                materialization_tmp: self
-                    .prepare_v4_materialization(
-                        workspace_name,
-                        candidate,
-                        materialization_manifest_yaml,
-                        origin,
-                        "tmp",
-                    )?
-                    .map(|build| build.temp_dir),
+                materialization_tmp: self.prepare_v4_materialization(
+                    workspace_name,
+                    candidate,
+                    materialization_manifest_yaml,
+                    origin,
+                    "tmp",
+                )?,
             },
         )
     }
@@ -425,15 +421,13 @@ impl SourceManager {
                 bindings,
                 origin,
                 credential_storage,
-                materialization_tmp: self
-                    .prepare_v4_materialization(
-                        workspace_name,
-                        candidate,
-                        materialization_manifest_yaml,
-                        origin,
-                        "tmp",
-                    )?
-                    .map(|build| build.temp_dir),
+                materialization_tmp: self.prepare_v4_materialization(
+                    workspace_name,
+                    candidate,
+                    materialization_manifest_yaml,
+                    origin,
+                    "tmp",
+                )?,
             },
         )
     }
@@ -445,7 +439,6 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let stored = self.config_store.get_source(workspace_name, source_name)?;
         let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
-        let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
         let credential_guard = self
             .credential_manager
@@ -456,12 +449,7 @@ impl SourceManager {
             .transpose()?;
         let previous = SourceRollbackState {
             source: stored,
-            manifest_yaml: match removed.origin {
-                SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
-            },
+            manifest_yaml: self.artifacts.manifest_snapshot(workspace_name, &removed)?,
             credential_material,
         };
         if let Some(credential_storage) = credential_storage
@@ -476,14 +464,12 @@ impl SourceManager {
             );
             return Err(error);
         }
-        let source_dir_backup =
-            source_dir.with_file_name(format!("{source_name}.delete.rollback.{}", Uuid::new_v4()));
-        let had_source_dir = source_dir.exists();
-        if had_source_dir {
-            if source_dir_backup.exists() {
-                std::fs::remove_dir_all(&source_dir_backup)?;
-            }
-            if let Err(error) = std::fs::rename(&source_dir, &source_dir_backup) {
+        let source_dir_rollback = match self
+            .artifacts
+            .stage_source_dir_for_delete(workspace_name, source_name)
+        {
+            Ok(rollback) => rollback,
+            Err(error) => {
                 self.restore_source_rollback_state(
                     workspace_name,
                     source_name,
@@ -491,17 +477,18 @@ impl SourceManager {
                     None,
                     &credential_guard,
                 );
-                return Err(error.into());
+                return Err(error);
             }
-        }
+        };
         if let Err(error) = self.config_store.remove_source(workspace_name, source_name) {
-            if had_source_dir
-                && source_dir_backup.exists()
-                && let Err(restore_error) = std::fs::rename(&source_dir_backup, &source_dir)
+            if let Some(source_dir_rollback) = source_dir_rollback.as_ref()
+                && let Err(restore_error) = self
+                    .artifacts
+                    .restore_source_dir_rollback(source_dir_rollback)
             {
                 return Err(AppError::FailedPrecondition(format!(
                     "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
-                    source_dir_backup.display()
+                    source_dir_rollback.staged_path().display()
                 )));
             }
             self.restore_source_rollback_state(
@@ -513,14 +500,10 @@ impl SourceManager {
             );
             return Err(error);
         }
-        if source_dir_backup.exists() {
-            std::fs::remove_dir_all(&source_dir_backup)?;
+        if let Some(source_dir_rollback) = source_dir_rollback {
+            self.artifacts
+                .discard_source_dir_rollback(source_dir_rollback)?;
         }
-        cleanup_empty_parent(&self.layout.workspaces_root(), source_dir.parent());
-        cleanup_empty_parent(
-            &self.layout.workspaces_root(),
-            self.layout.workspace_dir(workspace_name).parent(),
-        );
         Ok(removed)
     }
 
@@ -551,9 +534,11 @@ impl SourceManager {
         let previous =
             self.load_source_rollback_state(workspace_name, &source_name, &credential_guard)?;
         if let Err(error) =
-            self.persist_manifest_artifact(workspace_name, &source_name, request.manifest_yaml)
+            self.artifacts
+                .persist_manifest(workspace_name, &source_name, request.manifest_yaml)
         {
-            cleanup_materialization_tmp(request.materialization_tmp.as_deref());
+            self.artifacts
+                .cleanup_v4_materialization_tmp(request.materialization_tmp.as_ref());
             self.restore_source_rollback_state(
                 workspace_name,
                 &source_name,
@@ -594,7 +579,8 @@ impl SourceManager {
                 ) {
                     Ok(outcome) => outcome,
                     Err(error) => {
-                        cleanup_materialization_tmp(request.materialization_tmp.as_deref());
+                        self.artifacts
+                            .cleanup_v4_materialization_tmp(request.materialization_tmp.as_ref());
                         self.restore_source_rollback_state(
                             workspace_name,
                             &source_name,
@@ -615,17 +601,17 @@ impl SourceManager {
                 (Vec::new(), None)
             };
 
-        let materialization_backup =
+        let materialization_rollback =
             if let Some(materialization_tmp) = request.materialization_tmp.as_ref() {
-                match replace_v4_materialization(
-                    &self.layout,
+                match self.artifacts.install_v4_materialization(
                     workspace_name,
                     &source_name,
                     materialization_tmp,
                 ) {
-                    Ok(backup) => backup,
+                    Ok(rollback) => Some(rollback),
                     Err(error) => {
-                        cleanup_materialization_tmp(request.materialization_tmp.as_deref());
+                        self.artifacts
+                            .cleanup_v4_materialization_tmp(request.materialization_tmp.as_ref());
                         self.restore_source_rollback_state(
                             workspace_name,
                             &source_name,
@@ -656,27 +642,34 @@ impl SourceManager {
             .config_store
             .upsert_source(workspace_name, stored.clone())
         {
-            let restore_result = restore_materialization_backup(
-                &self.layout,
-                workspace_name,
-                &source_name,
-                materialization_backup,
-            );
-            self.restore_source_rollback_state(
-                workspace_name,
-                &source_name,
-                previous,
-                credential_storage,
-                &credential_guard,
-            );
-            if let Err(restore_error) = restore_result {
-                return Err(AppError::FailedPrecondition(format!(
-                    "failed to persist source '{source_name}': {error}; failed to restore previous DSL v4 materialization: {restore_error}"
-                )));
+            let restore_result = self
+                .artifacts
+                .restore_v4_materialization_rollback(materialization_rollback);
+            match restore_result {
+                Ok(()) => self.restore_source_rollback_state(
+                    workspace_name,
+                    &source_name,
+                    previous,
+                    credential_storage,
+                    &credential_guard,
+                ),
+                Err(restore_error) => {
+                    self.restore_source_rollback_state_without_artifact_cleanup(
+                        workspace_name,
+                        &source_name,
+                        previous,
+                        credential_storage,
+                        &credential_guard,
+                    );
+                    return Err(AppError::FailedPrecondition(format!(
+                        "failed to persist source '{source_name}': {error}; failed to restore previous DSL v4 materialization: {restore_error}"
+                    )));
+                }
             }
             return Err(error);
         }
-        cleanup_materialization_backup(materialization_backup);
+        self.artifacts
+            .discard_v4_materialization_rollback(materialization_rollback);
         let mut resolved = stored;
         resolved.version.clone_from(&request.candidate.version);
         Ok(resolved)
@@ -709,7 +702,7 @@ impl SourceManager {
             )));
         }
         build_v4_materialization_tmp(
-            &self.layout,
+            &self.artifacts,
             workspace_name,
             &candidate.name,
             manifest_yaml,
@@ -967,12 +960,7 @@ impl SourceManager {
             .map(|credential_storage| credential_material.snapshot_material(credential_storage))
             .transpose()?;
         Ok(Some(SourceRollbackState {
-            manifest_yaml: match source.origin {
-                SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
-            },
+            manifest_yaml: self.artifacts.manifest_snapshot(workspace_name, &source)?,
             source,
             credential_material,
         }))
@@ -986,25 +974,50 @@ impl SourceManager {
         new_material_storage: Option<CredentialStorageKind>,
         credential_material: &CredentialMaterialGuard<'_>,
     ) {
+        self.restore_source_rollback_state_inner(
+            workspace_name,
+            source_name,
+            previous,
+            new_material_storage,
+            credential_material,
+            true,
+        );
+    }
+
+    fn restore_source_rollback_state_without_artifact_cleanup(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        previous: Option<SourceRollbackState>,
+        new_material_storage: Option<CredentialStorageKind>,
+        credential_material: &CredentialMaterialGuard<'_>,
+    ) {
+        self.restore_source_rollback_state_inner(
+            workspace_name,
+            source_name,
+            previous,
+            new_material_storage,
+            credential_material,
+            false,
+        );
+    }
+
+    fn restore_source_rollback_state_inner(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        previous: Option<SourceRollbackState>,
+        new_material_storage: Option<CredentialStorageKind>,
+        credential_material: &CredentialMaterialGuard<'_>,
+        cleanup_new_artifacts: bool,
+    ) {
         if let Some(previous) = previous {
-            let manifest_path = self.layout.manifest_file(workspace_name, source_name);
-            match previous.manifest_yaml {
-                Some(manifest_yaml) => {
-                    if let Some(parent) = manifest_path.parent()
-                        && let Err(e) = fs::ensure_dir(parent)
-                    {
-                        warn!("rollback: failed to create manifest parent dir: {e}");
-                    }
-                    if let Err(e) = fs::write_atomic(&manifest_path, manifest_yaml.as_bytes()) {
-                        warn!("rollback: failed to restore manifest file: {e}");
-                    }
-                }
-                None if manifest_path.exists() => {
-                    if let Err(e) = std::fs::remove_file(&manifest_path) {
-                        warn!("rollback: failed to remove manifest file: {e}");
-                    }
-                }
-                None => {}
+            if let Err(e) = self.artifacts.persist_manifest(
+                workspace_name,
+                source_name,
+                previous.manifest_yaml.as_deref(),
+            ) {
+                warn!("rollback: failed to restore source manifest artifact: {e}");
             }
             match previous.credential_material {
                 Some(snapshot) => {
@@ -1027,10 +1040,11 @@ impl SourceManager {
                 warn!("rollback: failed to restore source config: {e}");
             }
         } else {
-            let source_dir = self.layout.source_dir(workspace_name, source_name);
-            if source_dir.exists()
-                && let Err(e) = std::fs::remove_dir_all(&source_dir)
-            {
+            if let Err(e) = self.artifacts.remove_source_dir_if(
+                cleanup_new_artifacts,
+                workspace_name,
+                source_name,
+            ) {
                 warn!("rollback: failed to remove source directory: {e}");
             }
             if let Some(storage) = new_material_storage
@@ -1039,29 +1053,6 @@ impl SourceManager {
                 warn!("rollback: failed to remove source credential material: {e}");
             }
         }
-    }
-
-    fn persist_manifest_artifact(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-        manifest_yaml: Option<&str>,
-    ) -> Result<(), AppError> {
-        let manifest_path = self.layout.manifest_file(workspace_name, source_name);
-        match manifest_yaml {
-            Some(manifest_yaml) => {
-                if let Some(parent) = manifest_path.parent() {
-                    fs::ensure_dir(parent)?;
-                }
-                fs::write_atomic(&manifest_path, manifest_yaml.as_bytes())?;
-            }
-            None if manifest_path.exists() => {
-                std::fs::remove_file(&manifest_path)?;
-            }
-            None => {}
-        }
-        cleanup_empty_parent(&self.layout.workspaces_root(), manifest_path.parent());
-        Ok(())
     }
 
     fn populate_source_version(
@@ -1366,25 +1357,6 @@ fn durable_import_manifest_yaml(
         );
     }
     serde_yaml::to_string(&value).map_err(AppError::from)
-}
-
-fn cleanup_empty_parent(root: &std::path::Path, path: Option<&std::path::Path>) {
-    let Some(mut current) = path.map(std::path::Path::to_path_buf) else {
-        return;
-    };
-    while current.starts_with(root) && current != root {
-        let Ok(mut entries) = std::fs::read_dir(&current) else {
-            break;
-        };
-        if entries.next().is_some() {
-            break;
-        }
-        let next = current.parent().unwrap_or(root).to_path_buf();
-        if std::fs::remove_dir(&current).is_err() {
-            break;
-        }
-        current = next;
-    }
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -23,115 +23,33 @@ use uuid::Uuid;
 
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
+use crate::sources::artifacts::{MaterializationBuild, SourceArtifactStore};
 use crate::state::AppStateLayout;
-use crate::storage::fs;
+use crate::storage::fs as storage_fs;
 use crate::workspaces::WorkspaceName;
 
 const DESCRIPTOR_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_DESCRIPTOR_BYTES: u64 = 16 * 1024 * 1024;
 const DESCRIPTOR_USER_AGENT: &str = "coral-dsl-v4-materializer";
 
-#[derive(Debug)]
-pub(crate) struct MaterializationBuild {
-    pub(crate) temp_dir: PathBuf,
-}
-
 pub(crate) fn build_v4_materialization_tmp(
-    layout: &AppStateLayout,
+    artifacts: &SourceArtifactStore,
     workspace_name: &WorkspaceName,
     source_name: &SourceName,
     manifest_yaml: &str,
     manifest: &V4SourceManifest,
     temp_suffix: &str,
 ) -> Result<MaterializationBuild, AppError> {
-    let temp_dir = layout.v4_materialized_tmp_dir(workspace_name, source_name, temp_suffix);
-    if temp_dir.exists() {
-        std::fs::remove_dir_all(&temp_dir)?;
-    }
-    fs::ensure_private_dir(&temp_dir)?;
+    let build =
+        artifacts.prepare_v4_materialization_tmp(workspace_name, source_name, temp_suffix)?;
 
-    match write_materialization(&temp_dir, manifest_yaml, manifest) {
-        Ok(()) => Ok(MaterializationBuild { temp_dir }),
+    match write_materialization(build.temp_dir(), manifest_yaml, manifest) {
+        Ok(()) => Ok(build),
         Err(error) => {
-            if temp_dir.exists() {
-                drop(std::fs::remove_dir_all(&temp_dir));
-            }
+            artifacts.cleanup_v4_materialization_tmp(Some(&build));
             Err(error)
         }
     }
-}
-
-pub(crate) fn replace_v4_materialization(
-    layout: &AppStateLayout,
-    workspace_name: &WorkspaceName,
-    source_name: &SourceName,
-    temp_dir: &Path,
-) -> Result<Option<PathBuf>, AppError> {
-    let target = layout.v4_materialized_dir(workspace_name, source_name);
-    let backup = layout.v4_materialized_tmp_dir(
-        workspace_name,
-        source_name,
-        &format!("rollback.{}", Uuid::new_v4()),
-    );
-    if let Some(parent) = target.parent() {
-        fs::ensure_private_dir(parent)?;
-    }
-    if backup.exists() {
-        std::fs::remove_dir_all(&backup)?;
-    }
-    let had_existing = target.exists();
-    if had_existing {
-        std::fs::rename(&target, &backup)?;
-    }
-    if let Err(error) = std::fs::rename(temp_dir, &target) {
-        if had_existing
-            && backup.exists()
-            && let Err(rollback_error) = std::fs::rename(&backup, &target)
-        {
-            return Err(AppError::FailedPrecondition(format!(
-                "failed to install DSL v4 materialization for source '{source_name}': {error}; failed to restore previous materialization from '{}': {rollback_error}",
-                backup.display()
-            )));
-        }
-        return Err(error.into());
-    }
-    Ok(had_existing.then_some(backup))
-}
-
-pub(crate) fn cleanup_materialization_backup(backup: Option<PathBuf>) {
-    if let Some(backup) = backup
-        && backup.exists()
-    {
-        drop(std::fs::remove_dir_all(backup));
-    }
-}
-
-pub(crate) fn cleanup_materialization_tmp(temp_dir: Option<&Path>) {
-    if let Some(temp_dir) = temp_dir
-        && temp_dir.exists()
-    {
-        drop(std::fs::remove_dir_all(temp_dir));
-    }
-}
-
-pub(crate) fn restore_materialization_backup(
-    layout: &AppStateLayout,
-    workspace_name: &WorkspaceName,
-    source_name: &SourceName,
-    backup: Option<PathBuf>,
-) -> Result<(), AppError> {
-    let target = layout.v4_materialized_dir(workspace_name, source_name);
-    if let Some(backup) = backup {
-        if target.exists() {
-            std::fs::remove_dir_all(&target)?;
-        }
-        if backup.exists() {
-            std::fs::rename(backup, target)?;
-        }
-    } else if target.exists() {
-        std::fs::remove_dir_all(target)?;
-    }
-    Ok(())
 }
 
 pub(crate) fn load_v4_materialization(
@@ -508,12 +426,12 @@ fn write_materialization(
             ))
         })?;
         let surface_dir = temp_dir.join("surfaces").join(&surface.id);
-        fs::ensure_private_dir(&surface_dir)?;
-        std::fs::write(surface_dir.join("source-document.raw"), &bytes)?;
-        std::fs::write(
-            surface_dir.join("source-document.yaml"),
-            normalize_source_document(&bytes)
-                .map_err(|error| AppError::FailedPrecondition(error.to_string()))?,
+        write_bytes(&surface_dir.join("source-document.raw"), &bytes)?;
+        let normalized = normalize_source_document(&bytes)
+            .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
+        write_bytes(
+            &surface_dir.join("source-document.yaml"),
+            normalized.as_bytes(),
         )?;
         write_yaml(&surface_dir.join("semantic-ir.yaml"), &semantic_ir)?;
         materialized_surfaces.push(MaterializedSurface {
@@ -863,11 +781,15 @@ fn read_artifact_yaml<T: serde::de::DeserializeOwned>(
 }
 
 fn write_yaml<T: serde::Serialize>(path: &Path, value: &T) -> Result<(), AppError> {
-    if let Some(parent) = path.parent() {
-        fs::ensure_private_dir(parent)?;
-    }
     let bytes = serde_yaml::to_string(value)?;
-    fs::write_atomic(path, bytes.as_bytes())?;
+    write_bytes(path, bytes.as_bytes())
+}
+
+fn write_bytes(path: &Path, bytes: &[u8]) -> Result<(), AppError> {
+    if let Some(parent) = path.parent() {
+        storage_fs::ensure_private_dir(parent)?;
+    }
+    storage_fs::write_atomic(path, bytes)?;
     Ok(())
 }
 
@@ -942,8 +864,9 @@ surfaces:
             .as_v4()
             .expect("v4")
             .clone();
+        let artifacts = SourceArtifactStore::new(layout.clone());
         let build = build_v4_materialization_tmp(
-            &layout,
+            &artifacts,
             &workspace_name(),
             &source_name(),
             &manifest_yaml,
@@ -951,8 +874,10 @@ surfaces:
             "test",
         )
         .expect("build materialization");
-        replace_v4_materialization(&layout, &workspace_name(), &source_name(), &build.temp_dir)
+        let rollback = artifacts
+            .install_v4_materialization(&workspace_name(), &source_name(), &build)
             .expect("install materialization");
+        artifacts.discard_v4_materialization_rollback(Some(rollback));
         (state_temp, descriptor_temp, layout, manifest_yaml, manifest)
     }
 

--- a/crates/coral-app/src/sources/mod.rs
+++ b/crates/coral-app/src/sources/mod.rs
@@ -1,5 +1,6 @@
 //! Source lifecycle workflow, catalog inspection, and transport adapters.
 
+pub(crate) mod artifacts;
 pub(crate) mod catalog;
 pub(crate) mod manager;
 pub(crate) mod materialization;

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -54,13 +54,45 @@ pub(crate) fn append_file_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
 
 pub(crate) fn replace_atomic(from: &Path, to: &Path) -> io::Result<()> {
     rename_with_fallback(from, to)?;
+    sync_parent(to);
 
-    if let Some(parent) = to.parent()
-        && let Ok(dir) = fs::File::open(parent)
-    {
-        drop(dir.sync_all());
+    Ok(())
+}
+
+pub(crate) fn rename_path(from: &Path, to: &Path) -> io::Result<()> {
+    fs::rename(from, to)?;
+    sync_parent(from);
+    if from.parent() != to.parent() {
+        sync_parent(to);
     }
+    Ok(())
+}
 
+pub(crate) fn remove_file_if_exists(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => {
+            sync_parent(path);
+            Ok(())
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+pub(crate) fn remove_dir_all_if_exists(path: &Path) -> io::Result<()> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => {
+            sync_parent(path);
+            Ok(())
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+pub(crate) fn remove_empty_dir(path: &Path) -> io::Result<()> {
+    fs::remove_dir(path)?;
+    sync_parent(path);
     Ok(())
 }
 
@@ -153,6 +185,14 @@ fn temp_path_for(path: &Path) -> PathBuf {
         .and_then(|name| name.to_str())
         .unwrap_or("private-file");
     path.with_file_name(format!("{file_name}.tmp.{}", std::process::id()))
+}
+
+fn sync_parent(path: &Path) {
+    if let Some(parent) = path.parent()
+        && let Ok(dir) = fs::File::open(parent)
+    {
+        drop(dir.sync_all());
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Intent
Move installed source artifact filesystem lifecycle out of `SourceManager` and DSL v4 materialization code so persistence, rollback, and cleanup live behind a dedicated source artifact store.

## What it enables
This keeps source lifecycle orchestration focused on config and credentials while `SourceArtifactStore` owns manifest writes, source-dir rollback, and v4 materialization install rollback with guarded restore behavior.

## Usage examples
Source installs and deletes continue to use the existing CLI/API paths; internally, v4 materialization installs now use typed rollback handles instead of raw path juggling.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p coral-app --lib sources::artifacts::tests`
- `cargo test -p coral-app --lib sources::`
- `python3 /Users/saul/.codex/skills/autoreview/scripts/autoreview --mode local --engine codex --parallel-tests 'cargo test -p coral-app --lib sources::' --stream-engine-output`
