### PR TITLE
feat(engine): add response.require_array_rows for fail-closed HTTP sources

### DIFF
--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -174,31 +174,39 @@ pub(super) async fn fetch_rows(
             break;
         };
 
+        let provider_failure = |detail: String| {
+            DataFusionError::External(Box::new(ProviderQueryError::ApiRequest {
+                source_schema: client.source_schema.clone(),
+                table: target.name().to_string(),
+                status: None,
+                method: None,
+                url: None,
+                filters: filter_values.clone(),
+                detail,
+            }))
+        };
+
         if !target.response().ok_path.is_empty() {
             let ok = get_path_value(&payload, &target.response().ok_path)
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
             if !ok {
-                let err = if target.response().error_path.is_empty() {
-                    "unknown source API error".to_string()
-                } else {
-                    get_path_value(&payload, &target.response().error_path)
-                        .and_then(Value::as_str)
-                        .unwrap_or("unknown source API error")
-                        .to_string()
-                };
-                return Err(DataFusionError::External(Box::new(
-                    ProviderQueryError::ApiRequest {
-                        source_schema: client.source_schema.clone(),
-                        table: target.name().to_string(),
-                        status: None,
-                        method: None,
-                        url: None,
-                        filters: filter_values.clone(),
-                        detail: err,
-                    },
+                return Err(provider_failure(response_error_detail(
+                    &target.response().error_path,
+                    &payload,
                 )));
             }
+        }
+
+        // Fail closed when the provider returns HTTP 200 with a non-array value
+        // at `rows_path` (e.g. an error string where a data array is expected).
+        if target.response().require_array_rows
+            && !get_path_value(&payload, &target.response().rows_path).is_some_and(Value::is_array)
+        {
+            return Err(provider_failure(response_error_detail(
+                &target.response().error_path,
+                &payload,
+            )));
         }
 
         let mut rows = extract_rows(target.response(), &payload);
@@ -284,5 +292,19 @@ fn resolve_fetch_limits(target: &HttpFetchTarget, sql_limit: Option<usize>) -> F
         effective_limit: Some(requested_top_k.min(max_candidates)),
         page_size_limit: Some(requested_top_k.min(search_limits.max_top_k)),
         max_search_calls: Some(search_limits.max_calls_per_query),
+    }
+}
+
+/// Builds the error-detail string for a provider failure: the value at
+/// `error_path` rendered as a string, or a generic message when `error_path`
+/// is empty or missing.
+fn response_error_detail(error_path: &[String], payload: &Value) -> String {
+    if error_path.is_empty() {
+        "unknown source API error".to_string()
+    } else {
+        get_path_value(payload, error_path)
+            .and_then(Value::as_str)
+            .unwrap_or("unknown source API error")
+            .to_string()
     }
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -2160,3 +2160,102 @@ async fn legacy_json_body_array_form_still_works() {
 
     assert_eq!(rows, users_rows());
 }
+
+/// A source whose `rows_path` holds a data array on success but an error scalar
+/// on failure (the Etherscan shape), guarded by `require_array_rows`.
+fn require_array_rows_manifest(base_url: &str) -> Value {
+    json!({
+        "name": "arr_src",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": base_url,
+        "tables": [{
+            "name": "items",
+            "description": "rows array on success, error scalar on failure",
+            "request": { "method": "GET", "path": "/api/items" },
+            "response": {
+                "rows_path": ["result"],
+                "require_array_rows": true,
+                "error_path": ["result"]
+            },
+            "columns": [
+                {
+                    "name": "hash",
+                    "type": "Utf8",
+                    "nullable": true,
+                    "expr": { "kind": "path", "path": ["hash"] }
+                }
+            ]
+        }]
+    })
+}
+
+#[tokio::test]
+async fn require_array_rows_returns_rows_for_array_result() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({ "status": "1", "message": "OK", "result": [{ "hash": "0xabc" }] }),
+        ))
+        .mount(&server)
+        .await;
+
+    let source = build_source(require_array_rows_manifest(&server.uri()));
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(&[source], test_runtime(), "SELECT hash FROM arr_src.items")
+            .await
+            .expect("array result should succeed"),
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["hash"], "0xabc");
+}
+
+#[tokio::test]
+async fn require_array_rows_allows_empty_array_result() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({ "status": "0", "message": "No transactions found", "result": [] }),
+        ))
+        .mount(&server)
+        .await;
+
+    let source = build_source(require_array_rows_manifest(&server.uri()));
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(&[source], test_runtime(), "SELECT hash FROM arr_src.items")
+            .await
+            .expect("empty array result should succeed with zero rows"),
+    );
+
+    assert!(
+        rows.is_empty(),
+        "empty array must yield zero rows, got: {rows:?}"
+    );
+}
+
+#[tokio::test]
+async fn require_array_rows_fails_closed_on_scalar_result() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({ "status": "0", "message": "NOTOK", "result": "Invalid API Key" }),
+        ))
+        .mount(&server)
+        .await;
+
+    let source = build_source(require_array_rows_manifest(&server.uri()));
+    let error =
+        CoralQuery::execute_sql(&[source], test_runtime(), "SELECT hash FROM arr_src.items")
+            .await
+            .expect_err("a scalar `result` must fail closed instead of becoming a row");
+
+    assert!(
+        format!("{error:?}").contains("Invalid API Key"),
+        "provider error detail should surface; got: {error:?}"
+    );
+}

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -511,6 +511,12 @@ pub struct ResponseSpec {
     pub error_path: Vec<String>,
     #[serde(default)]
     pub allow_404_empty: bool,
+    /// When `true`, a non-array value at `rows_path` is treated as a provider
+    /// error (surfaced via `error_path`) instead of being coerced into rows.
+    /// Use for APIs that return HTTP 200 with a data array on success but an
+    /// error scalar at the same path on failure (e.g. Etherscan's `result`).
+    #[serde(default)]
+    pub require_array_rows: bool,
     #[serde(default)]
     pub row_strategy: RowStrategy,
 }

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -1206,6 +1206,7 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "allow_404_empty": { "type": "boolean" },
+        "require_array_rows": { "type": "boolean" },
         "row_strategy": {
           "type": "string",
           "enum": ["direct", "series_point_list", "dict_entries"]

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -993,6 +993,7 @@ The `response` object controls how Coral extracts rows from an HTTP response bod
 | `ok_path`         | list of strings | `[]`     | JSON path to a field indicating success                                                                                                                                                                                                  |
 | `error_path`      | list of strings | `[]`     | JSON path to a field containing an error message                                                                                                                                                                                         |
 | `allow_404_empty` | boolean         | `false`  | Treat HTTP 404 as an empty result set instead of an error                                                                                                                                                                                |
+| `require_array_rows` | boolean      | `false`  | Fail closed when the value at `rows_path` is not a JSON array. Use for providers that return HTTP 200 with a data array on success but an error scalar at the same path on failure; the error is surfaced via `error_path`.               |
 | `row_strategy`    | string          | `direct` | How to convert the selected value into rows. `direct` uses the array or object as-is. `dict_entries` maps a JSON object's key-value pairs into rows. `series_point_list` flattens specialized timeseries arrays (e.g., Datadog metrics). |
 
 Example with `rows_path`:
@@ -1002,6 +1003,34 @@ response:
   rows_path:
     - data
     - items
+  row_strategy: direct
+```
+
+#### `require_array_rows`
+
+Some providers return HTTP 200 for failures, placing an error string where the
+data array normally goes. For example, Etherscan returns `result` as an array
+on success (including an empty array when there are no matches) but as an error
+string on failure:
+
+```json
+{ "status": "1", "message": "OK", "result": [ /* … */ ] }      // success
+{ "status": "0", "message": "No transactions found", "result": [] }  // empty, still success
+{ "status": "0", "message": "NOTOK", "result": "Invalid API Key" }   // failure
+```
+
+A boolean `ok_path` can't model this (the status is the string `"0"` for both
+the empty and failure cases). Set `require_array_rows: true` so a non-array at
+`rows_path` is treated as a provider error, with the detail taken from
+`error_path`, while a legitimately empty array still yields zero rows:
+
+```yaml
+response:
+  rows_path:
+    - result
+  require_array_rows: true
+  error_path:
+    - result
   row_strategy: direct
 ```
 


### PR DESCRIPTION
## Summary

Adds an opt-in `response.require_array_rows` so HTTP sources can **fail closed** when a provider returns HTTP 200 with an error scalar where a data array is expected. This resolves #1064 and unblocks the Etherscan community source (#947).

## Motivation

Some providers signal failures as HTTP 200 with an error string at the same JSON path that holds the data array on success. A boolean `ok_path` can't model this. Etherscan is the canonical case — I verified the live API:

| Response | `status` | `result` |
|---|---|---|
| Has rows | `"1"` | array |
| Valid query, **no results** | `"0"` | **empty array `[]`** |
| Invalid key / rate-limit / bad chain | `"0"` | **string** (error text) |

Note `status` is `"0"` for **both** the empty-but-valid case and real errors, so the commonly-suggested `ok_path:[status]` + `ok_equals:"1"` approach would wrongly reject legitimate empty results. The reliable discriminator is **`result` is an array (success/empty) vs a string (error)**.

## Change

`response.require_array_rows: bool` (default `false`). When `true`, a non-array value at `rows_path` is raised as a provider error (detail from `error_path`) instead of being coerced into a row. Backward compatible — existing sources (e.g. boolean `ok_path:[ok]`) are untouched.

- `coral-spec`: `ResponseSpec.require_array_rows` + JSON schema entry
- HTTP backend ([`http/fetch.rs`](crates/coral-engine/src/backends/http/fetch.rs)): array check after the existing `ok_path` check; the `error_path`→detail logic is factored into a shared `response_error_detail` helper and reused by both branches
- Tests: array → rows, empty array → 0 rows, scalar → fails closed
- Docs: response-fields table + an Etherscan example

## Verification

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test -p coral-engine -p coral-spec` (all green; 3 new tests). End-to-end against the live Etherscan V2 API with the `require_array_rows` manifest:

- valid key → `coral source test` passes
- empty block range (`status:"0"`, `result:[]`) → **0 rows, no error**
- invalid key (`status:"0"`, `result:"Invalid API Key"`) → query **fails** with `Invalid API Key` surfaced (previously became a bogus all-null row)

## Scope note

Implemented in the HTTP backend (where the need is). The field lives on the shared `ResponseSpec`; MCP-backend parity can follow if useful, but is out of scope here to keep the change focused.