### PR TITLE
feat(sources/community): add Cloudinary community source

### DIFF
--- a/sources/community/cloudinary/README.md
+++ b/sources/community/cloudinary/README.md
@@ -1,0 +1,209 @@
+# Cloudinary
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 5
+**Base URL:** `https://api.cloudinary.com/v1_1/<cloud_name>`
+
+Query assets, folders, upload presets, usage details, and metadata fields from Cloudinary — the media management platform for image and video optimization, transformation, and delivery.
+
+## Authentication
+
+Requires a `CLOUDINARY_CLOUD_NAME` variable and a `CLOUDINARY_BASIC_AUTH` secret (base64-encoded `api_key:api_secret`).
+
+### Generating the Basic Auth Token
+
+```bash
+printf '%s:%s' YOUR_API_KEY YOUR_API_SECRET | base64
+```
+
+### Finding Your Credentials
+
+1. Log in to the [Cloudinary Console](https://console.cloudinary.com).
+2. Navigate to **Settings → Access Keys** (or **Programmable Media Dashboard** for the cloud name).
+3. Copy the **API Key** and **API Secret** (or generate a new key pair if none exists).
+4. Base64-encode `api_key:api_secret` as shown above.
+
+### Recommended Permissions
+
+Standard API Key/Secret credentials provide read access to all Admin API endpoints listed below. No additional scopes or permissions configuration is required.
+
+```bash
+CLOUDINARY_CLOUD_NAME=your_cloud_name
+CLOUDINARY_BASIC_AUTH=$(printf '%s:%s' YOUR_API_KEY YOUR_API_SECRET | base64)
+export CLOUDINARY_CLOUD_NAME CLOUDINARY_BASIC_AUTH
+coral source add --file sources/community/cloudinary/manifest.yaml
+```
+
+API docs: https://cloudinary.com/documentation/admin_api
+
+## Tables
+
+| Table | Description | Required filters | Optional filters |
+|---|---|---|---|
+| `resources` | Assets (images, videos, raw files) with metadata | — | `resource_type`, `type`, `prefix`, `start_at`, `direction`, `tags`, `context`, `metadata` |
+| `folders` | Top-level asset folders | — | — |
+| `upload_presets` | Upload presets with default settings | — | — |
+| `usage` | Current plan usage (credits, storage, bandwidth, transformations) | — | — |
+| `metadata_fields` | Structured metadata field definitions | — | — |
+
+### Key design notes
+
+- **`resources` is the richest table.** It supports filtering by resource type, folder prefix, upload date, and can include tags, context metadata, and structured metadata fields in the response.
+- **`folders` returns top-level folders only.** Use the `prefix` filter on `resources` to browse assets in subfolder paths.
+- **`usage` returns exactly one row.** It includes nested fields for credits, storage, bandwidth, transformations, and object counts with their limits.
+- **`tags` endpoint (GET /tags) is not available** on Free plan accounts — it has been excluded from this source. Use the `tags` filter on `resources` to retrieve tag data per asset.
+- **No pagination for `metadata_fields`.** The Cloudinary Admin API returns all metadata fields in a single response.
+- **`usage` has no pagination.** It is a single-object response, not an array.
+
+### resources filter values
+
+| Filter | Description |
+|---|---|
+| `resource_type` | Filter by type (`image`, `video`, `raw`, `auto`) |
+| `type` | Filter by delivery type (`upload`, `private`, `authenticated`) |
+| `prefix` | Filter by folder prefix (e.g. `myfolder/subfolder`) |
+| `start_at` | Filter by minimum `created_at` date (ISO 8601, e.g. `2024-01-01T00:00:00Z`) |
+| `direction` | Sort direction (`asc` or `desc`, default: `desc` by date) |
+| `tags` | Set to `true` to include `tags` JSON column |
+| `context` | Set to `true` to include `context` JSON column |
+| `metadata` | Set to `true` to include `metadata_fields` JSON column |
+
+### Rate Limits & Fetch Limits
+
+Cloudinary enforces plan-based rate limits on its Admin API. Free plan accounts have a limit of **500 credits/hour** for Admin API calls. The `resources` table has a default fetch limit of **100 assets**. You can override this limit in your SQL query by specifying a `LIMIT` clause (e.g. `LIMIT 500`).
+
+## Quick start
+
+```bash
+# Step 1 — list recent assets
+coral sql "
+  SELECT public_id, resource_type, format, bytes, width, height, created_at
+  FROM cloudinary.resources
+  LIMIT 20
+"
+
+# Step 2 — list all top-level folders
+coral sql "SELECT name, path FROM cloudinary.folders"
+
+# Step 3 — view current usage and plan limits
+coral sql "
+  SELECT plan, credits_usage, credits_limit, storage_bytes,
+         storage_limit_bytes, bandwidth_bytes
+  FROM cloudinary.usage
+"
+
+# Step 4 — list all upload presets
+coral sql "SELECT name, unsigned, settings FROM cloudinary.upload_presets"
+
+# Step 5 — list all metadata field definitions
+coral sql "
+  SELECT external_id, label, type, mandatory, default_value
+  FROM cloudinary.metadata_fields
+"
+```
+
+## Example queries
+
+### All images with dimensions
+
+```sql
+SELECT
+  public_id,
+  format,
+  width,
+  height,
+  bytes,
+  secure_url,
+  created_at
+FROM cloudinary.resources
+WHERE resource_type = 'image'
+LIMIT 50;
+```
+
+### Largest assets by file size
+
+```sql
+SELECT
+  public_id,
+  resource_type,
+  format,
+  bytes,
+  width,
+  height,
+  created_at
+FROM cloudinary.resources
+ORDER BY bytes DESC
+LIMIT 20;
+```
+
+### Assets in a specific folder
+
+```sql
+SELECT
+  public_id,
+  format,
+  resource_type,
+  bytes,
+  created_at
+FROM cloudinary.resources
+WHERE prefix = 'myfolder/subfolder'
+LIMIT 50;
+```
+
+### Assets with tags and context metadata
+
+```sql
+SELECT
+  public_id,
+  format,
+  resource_type,
+  tags,
+  context,
+  created_at
+FROM cloudinary.resources
+WHERE tags = true AND context = true
+LIMIT 20;
+```
+
+### Current storage and bandwidth usage
+
+```sql
+SELECT
+  plan,
+  credits_usage,
+  credits_limit,
+  credits_used_percentage,
+  storage_bytes,
+  storage_limit_bytes,
+  bandwidth_bytes,
+  bandwidth_limit_bytes,
+  transformations_used,
+  transformations_limit,
+  objects_count,
+  objects_limit
+FROM cloudinary.usage;
+```
+
+### Upload presets
+
+```sql
+SELECT
+  name,
+  unsigned,
+  settings
+FROM cloudinary.upload_presets;
+```
+
+### Metadata field definitions
+
+```sql
+SELECT
+  external_id,
+  label,
+  type,
+  mandatory,
+  default_value,
+  validation
+FROM cloudinary.metadata_fields;
+```

--- a/sources/community/cloudinary/README.md
+++ b/sources/community/cloudinary/README.md
@@ -224,7 +224,7 @@ Added source cloudinary
     Query tests
     2 declared · 2 passed · 0 failed
 
-    ✓ SELECT resource_type, type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' AND type = 'upload' LIMIT 5
+    ✓ SELECT public_id, resource_type, type, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' AND type = 'upload' LIMIT 5
       5 rows
 
     ✓ SELECT name FROM cloudinary.folders LIMIT 5

--- a/sources/community/cloudinary/README.md
+++ b/sources/community/cloudinary/README.md
@@ -168,7 +168,7 @@ Structured metadata field definitions configured in the Cloudinary product envir
 | `label` | Utf8 | Display label for the metadata field |
 | `type` | Utf8 | Data type of the metadata field (integer, string, date, etc.) |
 | `mandatory` | Boolean | Whether the field is required when uploading assets |
-| `default_value` | Json | Default value(s). Single values are strings; multi-select fields return an array |
+| `default_value` | Json | Default value(s). Single values are JSON scalars (strings, numbers, etc.); multi-select fields return an array |
 | `validation` | Json | JSON object defining validation rules for the field |
 
 ## Live request costs
@@ -324,13 +324,13 @@ LIMIT 5;
 ```
 
 ```text
-+--------------+---------------+--------+--------+--------+-------+----------------------+
-| public_id    | resource_type | type   | format | bytes  | width | created_at           |
-+--------------+---------------+--------+--------+--------+-------+----------------------+
-| cld-sample-4 | image         | upload | jpg    | 818600 | 1870  | 2025-06-29T20:26:30Z |
-| cld-sample-3 | image         | upload | jpg    | 905834 | 1870  | 2025-06-29T20:26:30Z |
-| cld-sample-5 | image         | upload | jpg    | 379132 | 1870  | 2025-06-29T20:26:31Z |
-| cld-sample-2 | image         | upload | jpg    | 592235 | 1870  | 2025-06-29T20:26:30Z |
-| cld-sample   | image         | upload | jpg    | 476846 | 1870  | 2025-06-29T20:26:30Z |
-+--------------+---------------+--------+--------+--------+-------+----------------------+
++--------------+---------------+--------+--------+--------+-------+--------+----------------------+
+| public_id    | resource_type | type   | format | bytes  | width | height | created_at           |
++--------------+---------------+--------+--------+--------+-------+--------+----------------------+
+| cld-sample-4 | image         | upload | jpg    | 818600 | 1870  | 1250   | 2025-06-29T20:26:30Z |
+| cld-sample-3 | image         | upload | jpg    | 905834 | 1870  | 1250   | 2025-06-29T20:26:30Z |
+| cld-sample-5 | image         | upload | jpg    | 379132 | 1870  | 1250   | 2025-06-29T20:26:31Z |
+| cld-sample-2 | image         | upload | jpg    | 592235 | 1870  | 1250   | 2025-06-29T20:26:30Z |
+| cld-sample   | image         | upload | jpg    | 476846 | 1870  | 1250   | 2025-06-29T20:26:30Z |
++--------------+---------------+--------+--------+--------+-------+--------+----------------------+
 ```

--- a/sources/community/cloudinary/README.md
+++ b/sources/community/cloudinary/README.md
@@ -33,7 +33,7 @@ printf '%s:%s' YOUR_API_KEY YOUR_API_SECRET | base64
 
 ```bash
 export CLOUDINARY_CLOUD_NAME="your-cloud-name"
-export CLOUDINARY_BASIC_AUTH="base64-encoded-api-key:api-secret"
+export CLOUDINARY_BASIC_AUTH="MTIzNDU2Nzg5MDEyMzQ1Njo3N0FCY2RlZnVnaGlqazAxMjM0NTY="
 ```
 
 ## Quick Start
@@ -43,9 +43,10 @@ export CLOUDINARY_BASIC_AUTH="base64-encoded-api-key:api-secret"
 SELECT plan, credits_usage, credits_limit, storage_bytes, bandwidth_bytes
 FROM cloudinary.usage;
 
--- List recent assets
+-- List recent image assets
 SELECT public_id, resource_type, format, bytes, width, height, created_at
 FROM cloudinary.resources
+WHERE resource_type = 'image'
 LIMIT 10;
 
 -- List all top-level folders
@@ -71,8 +72,7 @@ Assets (images, videos, raw files, etc.) stored in your Cloudinary product envir
 
 | Filter | Type | Required | Description |
 |--------|------|----------|-------------|
-| `resource_type` | Utf8 | | Filter by type (image, video, raw, auto) |
-| `type` | Utf8 | | Filter by delivery type (upload, private, authenticated) |
+| `resource_type` | Utf8 | Yes | Filter by type (image, raw, video). Used as URL path segment |
 | `prefix` | Utf8 | | Filter by folder prefix (e.g. myfolder/subfolder) |
 | `start_at` | Utf8 | | Filter by minimum created_at date (ISO 8601) |
 | `direction` | Utf8 | | Sort direction (asc or desc, default: desc by date) |
@@ -88,7 +88,7 @@ Assets (images, videos, raw files, etc.) stored in your Cloudinary product envir
 | `asset_id` | Utf8 | Immutable asset identifier |
 | `format` | Utf8 | File format extension (e.g. jpg, png, mp4) |
 | `version` | Int64 | Version number of the asset |
-| `resource_type` | Utf8 | Type of resource (image, video, raw, auto) |
+| `resource_type` | Utf8 | Type of resource (image, raw, video) |
 | `type` | Utf8 | Delivery type (upload, private, authenticated, etc.) |
 | `created_at` | Timestamp | When the asset was created (ISO 8601) |
 | `bytes` | Int64 | File size in bytes |
@@ -171,16 +171,16 @@ Structured metadata field definitions configured in the Cloudinary product envir
 
 ## Live request costs
 
-Each table query performs at least one live API call to `https://api.cloudinary.com/v1_1/<cloud_name>`. Cursor-based pagination on `resources`, `folders`, and `upload_presets` may trigger additional calls when `LIMIT` exceeds a single page's results. See the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api) for rate limit details.
+Each table query performs at least one live API call to `https://api.cloudinary.com/v1_1/<cloud_name>`. Cursor-based pagination on `resources` and `upload_presets` may trigger additional calls when `LIMIT` exceeds a single page's results. See the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api) for rate limit details.
 
 ## Source scope
 
 - Targets the Cloudinary Admin API at `https://api.cloudinary.com/v1_1/<cloud_name>`.
 - Requires `CLOUDINARY_CLOUD_NAME` (base URL variable) and `CLOUDINARY_BASIC_AUTH` (HTTP Basic Auth header).
 - Covers read-only access: asset listing with filters, folder listing, upload preset listing, usage details, and metadata field definitions.
-- Cursor-based pagination (`next_cursor` query param) on `resources`, `folders`, and `upload_presets` — uses `response_cursor_path` for response cursor extraction.
+- Cursor-based pagination (`next_cursor` query param) on `resources` and `upload_presets` — uses `response_cursor_path` for response cursor extraction. The `folders` table has no pagination (root folders only).
 - The `usage` table exposes nested child objects (credits, storage, bandwidth, transformations, objects) as flat columns with nullable types — the API may omit deeply nested fields depending on plan.
-- 8 optional filters on `resources` for filtering by resource type, delivery type, folder prefix, date range, sort direction, and inclusion of tags/context/metadata.
+- 7 optional filters on `resources` for filtering by resource type (required), folder prefix, date range, sort direction, and inclusion of tags/context/metadata. The `type` response column is not used as a request filter (Cloudinary requires it as a URL path segment, available only when filtering by a specific resource type).
 - 2 declared test queries (resources + folders LIMIT 5) are source-independent and work on any account regardless of data.
 - Column definitions are validated against the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api).
 
@@ -223,8 +223,8 @@ Added source cloudinary
     Query tests
     2 declared · 2 passed · 0 failed
 
-    ✓ SELECT public_id, resource_type, format, bytes, created_at FROM cloudinary.resources LIMIT 5
-      0 rows
+    ✓ SELECT public_id, resource_type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' LIMIT 5
+      5 rows
 
     ✓ SELECT name FROM cloudinary.folders LIMIT 5
       0 rows
@@ -240,15 +240,15 @@ ORDER BY table_name;
 ```
 
 ```text
-+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
-| table_name      | description                                                                                                                                                                             | required_filters |
-+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
-| folders         | Top-level asset folders in your Cloudinary product environment. Only returns folders, not subfolders (use the prefix filter on the resources table to browse subfolder contents). |                  |
-| metadata_fields | Structured metadata field definitions configured in the Cloudinary product environment. Includes field type, label, default value, validation rules, and mandatory status.              |                  |
-| resources       | Assets (images, videos, raw files, etc.) stored in your Cloudinary product environment. Returns metadata such as public ID, format, dimensions, file size, tags, and context.           |                  |
-| upload_presets  | Upload presets configured in your Cloudinary product environment. Each preset defines default settings for uploaded assets such as transformation, folder, tags, and access control.    |                  |
-| usage           | Current usage details for the Cloudinary product environment, including plan type, credits consumption, storage usage, bandwidth, and transformations performed.                        |                  |
-+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
++-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| table_name      | description                                                                                                                                                                          | required_filters |
++-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| folders         | Top-level asset folders in your Cloudinary product environment. Only returns folders, not subfolders (use the prefix filter on the resources table to browse subfolder contents).    |                  |
+| metadata_fields | Structured metadata field definitions configured in the Cloudinary product environment. Includes field type, label, default value, validation rules, and mandatory status.           |                  |
+| resources       | Assets (images, videos, raw files, etc.) stored in your Cloudinary product environment. Returns metadata such as public ID, format, dimensions, file size, tags, and context.        | resource_type    |
+| upload_presets  | Upload presets configured in your Cloudinary product environment. Each preset defines default settings for uploaded assets such as transformation, folder, tags, and access control. |                  |
+| usage           | Current usage details for the Cloudinary product environment, including plan type, credits consumption, storage usage, bandwidth, and transformations performed.                     |                  |
++-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
 ```
 
 **Inputs introspection:**
@@ -282,7 +282,7 @@ FROM cloudinary.usage;
 +------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
 | plan | credits_usage | credits_limit | credits_used_percentage | storage_bytes | storage_limit_bytes | bandwidth_bytes | bandwidth_limit_bytes |
 +------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
-| Free | 1             | 25            | 4.36                    | 572942739     |                     | 601556002       |                       |
+| Free | 1             | 25            | 4.64                    | 572942739     |                     | 680717670       |                       |
 +------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
 ```
 
@@ -317,9 +317,18 @@ FROM cloudinary.upload_presets;
 ```sql
 SELECT public_id, resource_type, format, bytes, width, height, created_at
 FROM cloudinary.resources
+WHERE resource_type = 'image'
 LIMIT 5;
 ```
 
 ```text
-(0 rows — account currently has no uploaded assets)
++--------------+---------------+--------+--------+-------+--------+----------------------+
+| public_id    | resource_type | format | bytes  | width | height | created_at           |
++--------------+---------------+--------+--------+-------+--------+----------------------+
+| cld-sample-4 | image         | jpg    | 818600 | 1870  | 1250   | 2025-06-29T20:26:30Z |
+| cld-sample-3 | image         | jpg    | 905834 | 1870  | 1250   | 2025-06-29T20:26:30Z |
+| cld-sample-5 | image         | jpg    | 379132 | 1870  | 1250   | 2025-06-29T20:26:31Z |
+| cld-sample-2 | image         | jpg    | 592235 | 1870  | 1250   | 2025-06-29T20:26:30Z |
+| cld-sample   | image         | jpg    | 476846 | 1870  | 1250   | 2025-06-29T20:26:30Z |
++--------------+---------------+--------+--------+-------+--------+----------------------+
 ```

--- a/sources/community/cloudinary/README.md
+++ b/sources/community/cloudinary/README.md
@@ -209,7 +209,7 @@ Manifest is valid
 ```
 
 ```bash
-$ CLOUDINARY_CLOUD_NAME=... CLOUDINARY_BASIC_AUTH=... coral source add --file sources/community/cloudinary/manifest.yaml
+$ coral source add --file sources/community/cloudinary/manifest.yaml
 Added source cloudinary
 
   ✓ cloudinary connected successfully

--- a/sources/community/cloudinary/README.md
+++ b/sources/community/cloudinary/README.md
@@ -43,10 +43,10 @@ export CLOUDINARY_BASIC_AUTH="MTIzNDU2Nzg5MDEyMzQ1Njo3N0FCY2RlZnVnaGlqazAxMjM0NT
 SELECT plan, credits_usage, credits_limit, storage_bytes, bandwidth_bytes
 FROM cloudinary.usage;
 
--- List recent image assets
-SELECT public_id, resource_type, format, bytes, width, height, created_at
+-- List recent uploaded image assets
+SELECT public_id, resource_type, type, format, bytes, width, height, created_at
 FROM cloudinary.resources
-WHERE resource_type = 'image'
+WHERE resource_type = 'image' AND type = 'upload'
 LIMIT 10;
 
 -- List all top-level folders
@@ -73,7 +73,9 @@ Assets (images, videos, raw files, etc.) stored in your Cloudinary product envir
 | Filter | Type | Required | Description |
 |--------|------|----------|-------------|
 | `resource_type` | Utf8 | Yes | Filter by type (image, raw, video). Used as URL path segment |
-| `prefix` | Utf8 | | Filter by folder prefix (e.g. myfolder/subfolder) |
+| `type` | Utf8 | Yes | Filter by delivery type (upload, private, authenticated, etc.). Used as URL path segment |
+| `prefix` | Utf8 | | Filter by public ID prefix (not asset folder) |
+| `asset_folder` | Utf8 | | Filter by asset folder name (dynamic folders mode) |
 | `start_at` | Utf8 | | Filter by minimum created_at date (ISO 8601) |
 | `direction` | Utf8 | | Sort direction (asc or desc, default: desc by date) |
 | `tags` | Boolean | | Set to true to include tags JSON column |
@@ -166,21 +168,21 @@ Structured metadata field definitions configured in the Cloudinary product envir
 | `label` | Utf8 | Display label for the metadata field |
 | `type` | Utf8 | Data type of the metadata field (integer, string, date, etc.) |
 | `mandatory` | Boolean | Whether the field is required when uploading assets |
-| `default_value` | Utf8 | Default value assigned when no value is provided |
+| `default_value` | Json | Default value(s). Single values are strings; multi-select fields return an array |
 | `validation` | Json | JSON object defining validation rules for the field |
 
 ## Live request costs
 
-Each table query performs at least one live API call to `https://api.cloudinary.com/v1_1/<cloud_name>`. Cursor-based pagination on `resources`, `folders`, and `upload_presets` may trigger additional calls when `LIMIT` exceeds a single page's results. See the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api) for rate limit details.
+Each table query performs at least one live API call to `https://api.cloudinary.com/v1_1/<cloud_name>`. Cursor-based pagination on `resources` and `upload_presets` may trigger additional calls when `LIMIT` exceeds a single page's results. See the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api) for rate limit details.
 
 ## Source scope
 
 - Targets the Cloudinary Admin API at `https://api.cloudinary.com/v1_1/<cloud_name>`.
 - Requires `CLOUDINARY_CLOUD_NAME` (base URL variable) and `CLOUDINARY_BASIC_AUTH` (HTTP Basic Auth header).
 - Covers read-only access: asset listing with filters, folder listing, upload preset listing, usage details, and metadata field definitions.
-- Cursor-based pagination (`next_cursor` query param) on `resources`, `folders`, and `upload_presets` — uses `response_cursor_path` for response cursor extraction.
+- Cursor-based pagination (`next_cursor` query param) on `resources` and `upload_presets` — uses `response_cursor_path` for response cursor extraction. The `folders` table has no pagination (single response, up to 2000 root folders).
 - The `usage` table exposes nested child objects (credits, storage, bandwidth, transformations, objects) as flat columns with nullable types — the API may omit deeply nested fields depending on plan.
-- 7 optional filters on `resources` for filtering by resource type (required), folder prefix, date range, sort direction, and inclusion of tags/context/metadata. The `type` response column is not used as a request filter (Cloudinary requires it as a URL path segment, available only when filtering by a specific resource type).
+- 9 filters on `resources` including 2 required (`resource_type`, `type` as URL path segments) and optional (`prefix`, `asset_folder`, `start_at`, `direction`, `tags`, `context`, `metadata`).
 - 2 declared test queries (resources + folders LIMIT 5) are source-independent and work on any account regardless of data.
 - Column definitions are validated against the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api).
 
@@ -191,7 +193,7 @@ Each table query performs at least one live API call to `https://api.cloudinary.
 - The `folders` table returns only top-level folders. Subfolder navigation requires the `prefix` filter on `resources`.
 - `metadata_fields` has no pagination — the API returns all metadata fields in a single response (typically a small set).
 - The `usage` table has no pagination — it is a single-object response.
-- Cloudinary enforces plan-based rate limits. Free plan accounts have a limit of 500 credits per hour for Admin API calls.
+- Cloudinary enforces plan-based rate limits. Free plan accounts have a limit of 500 Admin API requests per hour.
 
 ## Provider docs
 
@@ -223,7 +225,7 @@ Added source cloudinary
     Query tests
     2 declared · 2 passed · 0 failed
 
-    ✓ SELECT public_id, resource_type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' LIMIT 5
+    ✓ SELECT public_id, resource_type, type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' AND type = 'upload' LIMIT 5
       5 rows
 
     ✓ SELECT name FROM cloudinary.folders LIMIT 5
@@ -240,15 +242,15 @@ ORDER BY table_name;
 ```
 
 ```text
-+-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
-| table_name      | description                                                                                                                                                                          | required_filters |
-+-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
-| folders         | Top-level asset folders in your Cloudinary product environment. Only returns folders, not subfolders (use the prefix filter on the resources table to browse subfolder contents).    |                  |
-| metadata_fields | Structured metadata field definitions configured in the Cloudinary product environment. Includes field type, label, default value, validation rules, and mandatory status.           |                  |
-| resources       | Assets (images, videos, raw files, etc.) stored in your Cloudinary product environment. Returns metadata such as public ID, format, dimensions, file size, tags, and context.        | resource_type    |
-| upload_presets  | Upload presets configured in your Cloudinary product environment. Each preset defines default settings for uploaded assets such as transformation, folder, tags, and access control. |                  |
-| usage           | Current usage details for the Cloudinary product environment, including plan type, credits consumption, storage usage, bandwidth, and transformations performed.                     |                  |
-+-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
++-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
+| table_name      | description                                                                                                                                                                          | required_filters   |
++-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
+| folders         | Top-level asset folders in your Cloudinary product environment. Only returns folders, not subfolders (use the prefix filter on the resources table to browse subfolder contents).    |                    |
+| metadata_fields | Structured metadata field definitions configured in the Cloudinary product environment. Includes field type, label, default value, validation rules, and mandatory status.           |                    |
+| resources       | Assets (images, videos, raw files, etc.) stored in your Cloudinary product environment. Returns metadata such as public ID, format, dimensions, file size, tags, and context.        | resource_type,type |
+| upload_presets  | Upload presets configured in your Cloudinary product environment. Each preset defines default settings for uploaded assets such as transformation, folder, tags, and access control. |                    |
+| usage           | Current usage details for the Cloudinary product environment, including plan type, credits consumption, storage usage, bandwidth, and transformations performed.                     |                    |
++-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
 ```
 
 **Inputs introspection:**
@@ -315,20 +317,20 @@ FROM cloudinary.upload_presets;
 **Live resources proof:**
 
 ```sql
-SELECT public_id, resource_type, format, bytes, width, height, created_at
+SELECT public_id, resource_type, type, format, bytes, width, height, created_at
 FROM cloudinary.resources
-WHERE resource_type = 'image'
+WHERE resource_type = 'image' AND type = 'upload'
 LIMIT 5;
 ```
 
 ```text
-+--------------+---------------+--------+--------+-------+--------+----------------------+
-| public_id    | resource_type | format | bytes  | width | height | created_at           |
-+--------------+---------------+--------+--------+-------+--------+----------------------+
-| cld-sample-4 | image         | jpg    | 818600 | 1870  | 1250   | 2025-06-29T20:26:30Z |
-| cld-sample-3 | image         | jpg    | 905834 | 1870  | 1250   | 2025-06-29T20:26:30Z |
-| cld-sample-5 | image         | jpg    | 379132 | 1870  | 1250   | 2025-06-29T20:26:31Z |
-| cld-sample-2 | image         | jpg    | 592235 | 1870  | 1250   | 2025-06-29T20:26:30Z |
-| cld-sample   | image         | jpg    | 476846 | 1870  | 1250   | 2025-06-29T20:26:30Z |
-+--------------+---------------+--------+--------+-------+--------+----------------------+
++--------------+---------------+--------+--------+--------+-------+----------------------+
+| public_id    | resource_type | type   | format | bytes  | width | created_at           |
++--------------+---------------+--------+--------+--------+-------+----------------------+
+| cld-sample-4 | image         | upload | jpg    | 818600 | 1870  | 2025-06-29T20:26:30Z |
+| cld-sample-3 | image         | upload | jpg    | 905834 | 1870  | 2025-06-29T20:26:30Z |
+| cld-sample-5 | image         | upload | jpg    | 379132 | 1870  | 2025-06-29T20:26:31Z |
+| cld-sample-2 | image         | upload | jpg    | 592235 | 1870  | 2025-06-29T20:26:30Z |
+| cld-sample   | image         | upload | jpg    | 476846 | 1870  | 2025-06-29T20:26:30Z |
++--------------+---------------+--------+--------+--------+-------+----------------------+
 ```

--- a/sources/community/cloudinary/README.md
+++ b/sources/community/cloudinary/README.md
@@ -107,7 +107,7 @@ Assets (images, videos, raw files, etc.) stored in your Cloudinary product envir
 
 ### `folders`
 
-Top-level asset folders in your Cloudinary product environment. Only returns root folders. Subfolder contents can be queried via the `resources` table using `WHERE prefix = 'folder_path/'`.
+Top-level asset folders in your Cloudinary product environment. The `prefix` filter on the `resources` table filters by public ID prefix, not by asset folder. Dynamic asset-folder content lookup is not supported in this version.
 
 **Columns**
 
@@ -176,7 +176,7 @@ Each table query performs at least one live API call to `https://api.cloudinary.
 
 ## Source scope
 
-- Targets the Cloudinary Admin API at `https://api.cloudinary.com/v1_1/<cloud_name>`.
+- Targets the Cloudinary Admin API at `https://api.cloudinary.com/v1_1/<cloud_name>` (US default data center endpoint; EU and AP data center endpoints are not supported in this version).
 - Requires `CLOUDINARY_CLOUD_NAME` (base URL variable) and `CLOUDINARY_BASIC_AUTH` (HTTP Basic Auth header).
 - Covers read-only access: asset listing with filters, folder listing, upload preset listing, usage details, and metadata field definitions.
 - Cursor-based pagination (`next_cursor` query param) on `resources` and `upload_presets` — uses `response_cursor_path` for response cursor extraction. The `folders` table has no pagination (single response, up to 2000 root folders).
@@ -193,6 +193,7 @@ Each table query performs at least one live API call to `https://api.cloudinary.
 - `metadata_fields` has no pagination — the API returns all metadata fields in a single response (typically a small set).
 - The `usage` table has no pagination — it is a single-object response.
 - Cloudinary enforces plan-based rate limits. Free plan accounts have a limit of 500 Admin API requests per hour.
+- The API base URL is hard-coded to the US default data center endpoint (`https://api.cloudinary.com`). EU (`api-eu.cloudinary.com`) and AP (`api-ap.cloudinary.com`) data center endpoints are not supported in this version.
 
 ## Provider docs
 
@@ -241,15 +242,15 @@ ORDER BY table_name;
 ```
 
 ```text
-+-----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
-| table_name      | description                                                                                                                                                                               | required_filters   |
-+-----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
-| folders         | Top-level asset folders in your Cloudinary product environment. Only returns root folders. Subfolder contents can be queried via the resources table using WHERE prefix = 'folder_path/'. |                    |
-| metadata_fields | Structured metadata field definitions configured in the Cloudinary product environment. Includes field type, label, default value, validation rules, and mandatory status.                |                    |
-| resources       | Assets (images, videos, raw files, etc.) stored in your Cloudinary product environment. Returns metadata such as public ID, format, dimensions, file size, tags, and context.             | resource_type,type |
-| upload_presets  | Upload presets configured in your Cloudinary product environment. Each preset defines default settings for uploaded assets such as transformation, folder, tags, and access control.      |                    |
-| usage           | Current usage details for the Cloudinary product environment, including plan type, credits consumption, storage usage, bandwidth, and transformations performed.                          |                    |
-+-----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
++-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
+| table_name      | description                                                                                                                                                                                                                      | required_filters   |
++-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
+| folders         | Top-level asset folders in your Cloudinary product environment. The prefix filter on the resources table filters by public ID prefix, not by asset folder. Dynamic asset-folder content lookup is not supported in this version. |                    |
+| metadata_fields | Structured metadata field definitions configured in the Cloudinary product environment. Includes field type, label, default value, validation rules, and mandatory status.                                                       |                    |
+| resources       | Assets (images, videos, raw files, etc.) stored in your Cloudinary product environment. Returns metadata such as public ID, format, dimensions, file size, tags, and context.                                                    | resource_type,type |
+| upload_presets  | Upload presets configured in your Cloudinary product environment. Each preset defines default settings for uploaded assets such as transformation, folder, tags, and access control.                                             |                    |
+| usage           | Current usage details for the Cloudinary product environment, including plan type, credits consumption, storage usage, bandwidth, and transformations performed.                                                                 |                    |
++-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
 ```
 
 **Inputs introspection:**

--- a/sources/community/cloudinary/README.md
+++ b/sources/community/cloudinary/README.md
@@ -74,8 +74,7 @@ Assets (images, videos, raw files, etc.) stored in your Cloudinary product envir
 |--------|------|----------|-------------|
 | `resource_type` | Utf8 | Yes | Filter by type (image, raw, video). Used as URL path segment |
 | `type` | Utf8 | Yes | Filter by delivery type (upload, private, authenticated, etc.). Used as URL path segment |
-| `prefix` | Utf8 | | Filter by public ID prefix (not asset folder) |
-| `asset_folder` | Utf8 | | Filter by asset folder name (dynamic folders mode) |
+| `prefix` | Utf8 | | Filter by public ID prefix |
 | `start_at` | Utf8 | | Filter by minimum created_at date (ISO 8601) |
 | `direction` | Utf8 | | Sort direction (asc or desc, default: desc by date) |
 | `tags` | Boolean | | Set to true to include tags JSON column |
@@ -108,7 +107,7 @@ Assets (images, videos, raw files, etc.) stored in your Cloudinary product envir
 
 ### `folders`
 
-Top-level asset folders in your Cloudinary product environment. Only returns folders, not subfolders (use the `prefix` filter on the `resources` table to browse subfolder contents).
+Top-level asset folders in your Cloudinary product environment. Only returns root folders. Subfolder contents can be queried via the `resources` table using `WHERE prefix = 'folder_path/'`.
 
 **Columns**
 
@@ -182,7 +181,7 @@ Each table query performs at least one live API call to `https://api.cloudinary.
 - Covers read-only access: asset listing with filters, folder listing, upload preset listing, usage details, and metadata field definitions.
 - Cursor-based pagination (`next_cursor` query param) on `resources` and `upload_presets` — uses `response_cursor_path` for response cursor extraction. The `folders` table has no pagination (single response, up to 2000 root folders).
 - The `usage` table exposes nested child objects (credits, storage, bandwidth, transformations, objects) as flat columns with nullable types — the API may omit deeply nested fields depending on plan.
-- 9 filters on `resources` including 2 required (`resource_type`, `type` as URL path segments) and optional (`prefix`, `asset_folder`, `start_at`, `direction`, `tags`, `context`, `metadata`).
+- 8 filters on `resources` including 2 required (`resource_type`, `type` as URL path segments) and optional (`prefix`, `start_at`, `direction`, `tags`, `context`, `metadata`).
 - 2 declared test queries (resources + folders LIMIT 5) are source-independent and work on any account regardless of data.
 - Column definitions are validated against the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api).
 
@@ -190,7 +189,7 @@ Each table query performs at least one live API call to `https://api.cloudinary.
 
 - The source provides read-only access. Asset upload, deletion, transformation, and other mutating operations are intentionally out of scope.
 - The `tags` endpoint (`GET /tags`) is excluded — it returns `404 Not Found` on Free plan accounts. Tag data is still accessible via the `tags` boolean filter on the `resources` table.
-- The `folders` table returns only top-level folders. Subfolder navigation requires the `prefix` filter on `resources`.
+- The `folders` table returns only root folders. The `prefix` filter on `resources` filters by public ID prefix (not asset folder).
 - `metadata_fields` has no pagination — the API returns all metadata fields in a single response (typically a small set).
 - The `usage` table has no pagination — it is a single-object response.
 - Cloudinary enforces plan-based rate limits. Free plan accounts have a limit of 500 Admin API requests per hour.
@@ -225,7 +224,7 @@ Added source cloudinary
     Query tests
     2 declared · 2 passed · 0 failed
 
-    ✓ SELECT public_id, resource_type, type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' AND type = 'upload' LIMIT 5
+    ✓ SELECT resource_type, type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' AND type = 'upload' LIMIT 5
       5 rows
 
     ✓ SELECT name FROM cloudinary.folders LIMIT 5
@@ -242,15 +241,15 @@ ORDER BY table_name;
 ```
 
 ```text
-+-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
-| table_name      | description                                                                                                                                                                          | required_filters   |
-+-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
-| folders         | Top-level asset folders in your Cloudinary product environment. Only returns folders, not subfolders (use the prefix filter on the resources table to browse subfolder contents).    |                    |
-| metadata_fields | Structured metadata field definitions configured in the Cloudinary product environment. Includes field type, label, default value, validation rules, and mandatory status.           |                    |
-| resources       | Assets (images, videos, raw files, etc.) stored in your Cloudinary product environment. Returns metadata such as public ID, format, dimensions, file size, tags, and context.        | resource_type,type |
-| upload_presets  | Upload presets configured in your Cloudinary product environment. Each preset defines default settings for uploaded assets such as transformation, folder, tags, and access control. |                    |
-| usage           | Current usage details for the Cloudinary product environment, including plan type, credits consumption, storage usage, bandwidth, and transformations performed.                     |                    |
-+-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
++-----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
+| table_name      | description                                                                                                                                                                               | required_filters   |
++-----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
+| folders         | Top-level asset folders in your Cloudinary product environment. Only returns root folders. Subfolder contents can be queried via the resources table using WHERE prefix = 'folder_path/'. |                    |
+| metadata_fields | Structured metadata field definitions configured in the Cloudinary product environment. Includes field type, label, default value, validation rules, and mandatory status.                |                    |
+| resources       | Assets (images, videos, raw files, etc.) stored in your Cloudinary product environment. Returns metadata such as public ID, format, dimensions, file size, tags, and context.             | resource_type,type |
+| upload_presets  | Upload presets configured in your Cloudinary product environment. Each preset defines default settings for uploaded assets such as transformation, folder, tags, and access control.      |                    |
+| usage           | Current usage details for the Cloudinary product environment, including plan type, credits consumption, storage usage, bandwidth, and transformations performed.                          |                    |
++-----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
 ```
 
 **Inputs introspection:**

--- a/sources/community/cloudinary/README.md
+++ b/sources/community/cloudinary/README.md
@@ -227,7 +227,7 @@ Added source cloudinary
       0 rows
 
     ✓ SELECT name FROM cloudinary.folders LIMIT 5
-      1 row
+      0 rows
 ```
 
 **Table introspection:**
@@ -282,7 +282,7 @@ FROM cloudinary.usage;
 +------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
 | plan | credits_usage | credits_limit | credits_used_percentage | storage_bytes | storage_limit_bytes | bandwidth_bytes | bandwidth_limit_bytes |
 +------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
-| Free | 0             | 25            | 0.0                     | 0             |                     | 0               |                       |
+| Free | 1             | 25            | 4.36                    | 572942739     |                     | 601556002       |                       |
 +------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
 ```
 
@@ -294,11 +294,22 @@ FROM cloudinary.folders;
 ```
 
 ```text
-+---------+---------+
-| name    | path    |
-+---------+---------+
-| samples | samples |
-+---------+---------+
+(0 rows — account has no top-level folders)
+```
+
+**Live upload_presets proof:**
+
+```sql
+SELECT name, unsigned, settings
+FROM cloudinary.upload_presets;
+```
+
+```text
++------------+----------+---------------------------------------------------------------+
+| name       | unsigned | settings                                                      |
++------------+----------+---------------------------------------------------------------+
+| ml_default | false    | {"overwrite":true,"use_filename":true,"unique_filename":true} |
++------------+----------+---------------------------------------------------------------+
 ```
 
 **Live resources proof:**

--- a/sources/community/cloudinary/README.md
+++ b/sources/community/cloudinary/README.md
@@ -5,205 +5,310 @@
 **Tables:** 5
 **Base URL:** `https://api.cloudinary.com/v1_1/<cloud_name>`
 
-Query assets, folders, upload presets, usage details, and metadata fields from Cloudinary — the media management platform for image and video optimization, transformation, and delivery.
+Query assets, folders, upload presets, usage details, and metadata fields from Cloudinary via the Cloudinary Admin API. Provides read-only access to media asset inventory and account configuration using API Key and API Secret authentication.
 
-## Authentication
+## Installation
 
-Requires a `CLOUDINARY_CLOUD_NAME` variable and a `CLOUDINARY_BASIC_AUTH` secret (base64-encoded `api_key:api_secret`).
+Install the source via the CLI:
 
-### Generating the Basic Auth Token
+```bash
+coral source add --file sources/community/cloudinary/manifest.yaml
+```
+
+## Credentials
+
+To use this source, you need your Cloudinary cloud name and API credentials.
+
+1. Log in to the [Cloudinary Console](https://console.cloudinary.com).
+2. Copy your **cloud name** from the Account Details section at the top of the dashboard.
+3. Navigate to **Settings → Access Keys**.
+4. Copy the **API Key** and **API Secret** (or generate a new key pair if none exists).
+5. Base64-encode `api_key:api_secret` to create the Basic auth token:
 
 ```bash
 printf '%s:%s' YOUR_API_KEY YOUR_API_SECRET | base64
 ```
 
-### Finding Your Credentials
-
-1. Log in to the [Cloudinary Console](https://console.cloudinary.com).
-2. Navigate to **Settings → Access Keys** (or **Programmable Media Dashboard** for the cloud name).
-3. Copy the **API Key** and **API Secret** (or generate a new key pair if none exists).
-4. Base64-encode `api_key:api_secret` as shown above.
-
-### Recommended Permissions
-
-Standard API Key/Secret credentials provide read access to all Admin API endpoints listed below. No additional scopes or permissions configuration is required.
+6. Provide all values as environment variables or when prompted by `coral source add`:
 
 ```bash
-CLOUDINARY_CLOUD_NAME=your_cloud_name
-CLOUDINARY_BASIC_AUTH=$(printf '%s:%s' YOUR_API_KEY YOUR_API_SECRET | base64)
-export CLOUDINARY_CLOUD_NAME CLOUDINARY_BASIC_AUTH
-coral source add --file sources/community/cloudinary/manifest.yaml
+export CLOUDINARY_CLOUD_NAME="your-cloud-name"
+export CLOUDINARY_BASIC_AUTH="base64-encoded-api-key:api-secret"
 ```
 
-API docs: https://cloudinary.com/documentation/admin_api
+## Quick Start
+
+```sql
+-- Verify connectivity and get usage details
+SELECT plan, credits_usage, credits_limit, storage_bytes, bandwidth_bytes
+FROM cloudinary.usage;
+
+-- List recent assets
+SELECT public_id, resource_type, format, bytes, width, height, created_at
+FROM cloudinary.resources
+LIMIT 10;
+
+-- List all top-level folders
+SELECT name, path
+FROM cloudinary.folders;
+
+-- List all upload presets
+SELECT name, unsigned, settings
+FROM cloudinary.upload_presets;
+
+-- List all metadata field definitions
+SELECT external_id, label, type, mandatory
+FROM cloudinary.metadata_fields;
+```
 
 ## Tables
 
-| Table | Description | Required filters | Optional filters |
-|---|---|---|---|
-| `resources` | Assets (images, videos, raw files) with metadata | — | `resource_type`, `type`, `prefix`, `start_at`, `direction`, `tags`, `context`, `metadata` |
-| `folders` | Top-level asset folders | — | — |
-| `upload_presets` | Upload presets with default settings | — | — |
-| `usage` | Current plan usage (credits, storage, bandwidth, transformations) | — | — |
-| `metadata_fields` | Structured metadata field definitions | — | — |
+### `resources`
 
-### Key design notes
+Assets (images, videos, raw files, etc.) stored in your Cloudinary product environment. Returns metadata such as public ID, format, dimensions, file size, tags, and context.
 
-- **`resources` is the richest table.** It supports filtering by resource type, folder prefix, upload date, and can include tags, context metadata, and structured metadata fields in the response.
-- **`folders` returns top-level folders only.** Use the `prefix` filter on `resources` to browse assets in subfolder paths.
-- **`usage` returns exactly one row.** It includes nested fields for credits, storage, bandwidth, transformations, and object counts with their limits.
-- **`tags` endpoint (GET /tags) is not available** on Free plan accounts — it has been excluded from this source. Use the `tags` filter on `resources` to retrieve tag data per asset.
-- **No pagination for `metadata_fields`.** The Cloudinary Admin API returns all metadata fields in a single response.
-- **`usage` has no pagination.** It is a single-object response, not an array.
+**Filters**
 
-### resources filter values
+| Filter | Type | Required | Description |
+|--------|------|----------|-------------|
+| `resource_type` | Utf8 | | Filter by type (image, video, raw, auto) |
+| `type` | Utf8 | | Filter by delivery type (upload, private, authenticated) |
+| `prefix` | Utf8 | | Filter by folder prefix (e.g. myfolder/subfolder) |
+| `start_at` | Utf8 | | Filter by minimum created_at date (ISO 8601) |
+| `direction` | Utf8 | | Sort direction (asc or desc, default: desc by date) |
+| `tags` | Boolean | | Set to true to include tags JSON column |
+| `context` | Boolean | | Set to true to include context JSON column |
+| `metadata` | Boolean | | Set to true to include metadata_fields JSON column |
 
-| Filter | Description |
-|---|---|
-| `resource_type` | Filter by type (`image`, `video`, `raw`, `auto`) |
-| `type` | Filter by delivery type (`upload`, `private`, `authenticated`) |
-| `prefix` | Filter by folder prefix (e.g. `myfolder/subfolder`) |
-| `start_at` | Filter by minimum `created_at` date (ISO 8601, e.g. `2024-01-01T00:00:00Z`) |
-| `direction` | Sort direction (`asc` or `desc`, default: `desc` by date) |
-| `tags` | Set to `true` to include `tags` JSON column |
-| `context` | Set to `true` to include `context` JSON column |
-| `metadata` | Set to `true` to include `metadata_fields` JSON column |
+**Columns**
 
-### Rate Limits & Fetch Limits
+| Column | Type | Description |
+|--------|------|-------------|
+| `public_id` | Utf8 | Unique identifier for the asset |
+| `asset_id` | Utf8 | Immutable asset identifier |
+| `format` | Utf8 | File format extension (e.g. jpg, png, mp4) |
+| `version` | Int64 | Version number of the asset |
+| `resource_type` | Utf8 | Type of resource (image, video, raw, auto) |
+| `type` | Utf8 | Delivery type (upload, private, authenticated, etc.) |
+| `created_at` | Timestamp | When the asset was created (ISO 8601) |
+| `bytes` | Int64 | File size in bytes |
+| `width` | Int64 | Width of the asset in pixels |
+| `height` | Int64 | Height of the asset in pixels |
+| `url` | Utf8 | HTTP URL of the asset |
+| `secure_url` | Utf8 | HTTPS URL of the asset |
+| `tags` | Json | JSON array of tag strings. Populated when tags=true filter is set |
+| `context` | Json | JSON object of custom context metadata. Populated when context=true filter is set |
+| `metadata_fields` | Json | JSON object of structured metadata field values. Populated when metadata=true filter is set |
+| `etag` | Utf8 | ETag of the uploaded file |
+| `placeholder` | Boolean | Whether the asset is a placeholder |
 
-Cloudinary enforces plan-based rate limits on its Admin API. Free plan accounts have a limit of **500 credits/hour** for Admin API calls. The `resources` table has a default fetch limit of **100 assets**. You can override this limit in your SQL query by specifying a `LIMIT` clause (e.g. `LIMIT 500`).
+---
 
-## Quick start
+### `folders`
+
+Top-level asset folders in your Cloudinary product environment. Only returns folders, not subfolders (use the `prefix` filter on the `resources` table to browse subfolder contents).
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `name` | Utf8 | Display name of the folder |
+| `path` | Utf8 | Full path of the folder |
+
+---
+
+### `upload_presets`
+
+Upload presets configured in your Cloudinary product environment. Each preset defines default settings for uploaded assets such as transformation, folder, tags, and access control.
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `name` | Utf8 | Name of the upload preset |
+| `unsigned` | Boolean | Whether the preset allows unsigned uploads |
+| `settings` | Json | JSON object of preset settings (folder, tags, transformations, etc.) |
+
+---
+
+### `usage`
+
+Current usage details for the Cloudinary product environment, including plan type, credits consumption, storage usage, bandwidth, and transformations performed. Returns exactly one row.
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `plan` | Utf8 | Cloudinary plan name (e.g. Free, Advanced, Enterprise) |
+| `credits_usage` | Int64 | Credits consumed in the current billing period |
+| `credits_limit` | Int64 | Total credits available in the current billing period |
+| `credits_used_percentage` | Float64 | Percentage of credits used |
+| `storage_bytes` | Int64 | Total storage used in bytes |
+| `storage_limit_bytes` | Int64 | Storage limit in bytes |
+| `bandwidth_bytes` | Int64 | Bandwidth used in bytes |
+| `bandwidth_limit_bytes` | Int64 | Bandwidth limit in bytes |
+| `transformations_used` | Int64 | Number of transformations performed |
+| `transformations_limit` | Int64 | Transformation limit |
+| `objects_count` | Int64 | Total number of assets stored |
+| `objects_limit` | Int64 | Asset count limit |
+
+---
+
+### `metadata_fields`
+
+Structured metadata field definitions configured in the Cloudinary product environment. Includes field type, label, default value, validation rules, and mandatory status.
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `external_id` | Utf8 | Unique identifier for the metadata field |
+| `label` | Utf8 | Display label for the metadata field |
+| `type` | Utf8 | Data type of the metadata field (integer, string, date, etc.) |
+| `mandatory` | Boolean | Whether the field is required when uploading assets |
+| `default_value` | Utf8 | Default value assigned when no value is provided |
+| `validation` | Json | JSON object defining validation rules for the field |
+
+## Live request costs
+
+Each table query performs at least one live API call to `https://api.cloudinary.com/v1_1/<cloud_name>`. Cursor-based pagination on `resources`, `folders`, and `upload_presets` may trigger additional calls when `LIMIT` exceeds a single page's results. See the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api) for rate limit details.
+
+## Source scope
+
+- Targets the Cloudinary Admin API at `https://api.cloudinary.com/v1_1/<cloud_name>`.
+- Requires `CLOUDINARY_CLOUD_NAME` (base URL variable) and `CLOUDINARY_BASIC_AUTH` (HTTP Basic Auth header).
+- Covers read-only access: asset listing with filters, folder listing, upload preset listing, usage details, and metadata field definitions.
+- Cursor-based pagination (`next_cursor` query param) on `resources`, `folders`, and `upload_presets` — uses `response_cursor_path` for response cursor extraction.
+- The `usage` table exposes nested child objects (credits, storage, bandwidth, transformations, objects) as flat columns with nullable types — the API may omit deeply nested fields depending on plan.
+- 8 optional filters on `resources` for filtering by resource type, delivery type, folder prefix, date range, sort direction, and inclusion of tags/context/metadata.
+- 2 declared test queries (resources + folders LIMIT 5) are source-independent and work on any account regardless of data.
+- Column definitions are validated against the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api).
+
+## Limitations
+
+- The source provides read-only access. Asset upload, deletion, transformation, and other mutating operations are intentionally out of scope.
+- The `tags` endpoint (`GET /tags`) is excluded — it returns `404 Not Found` on Free plan accounts. Tag data is still accessible via the `tags` boolean filter on the `resources` table.
+- The `folders` table returns only top-level folders. Subfolder navigation requires the `prefix` filter on `resources`.
+- `metadata_fields` has no pagination — the API returns all metadata fields in a single response (typically a small set).
+- The `usage` table has no pagination — it is a single-object response.
+- Cloudinary enforces plan-based rate limits. Free plan accounts have a limit of 500 credits per hour for Admin API calls.
+
+## Provider docs
+
+- Cloudinary Admin API reference: https://cloudinary.com/documentation/admin_api
+- Cloudinary Console (credentials): https://console.cloudinary.com
+- Authentication: https://cloudinary.com/documentation/admin_api#authentication
+
+## Live validation output
+
+Validated against a live Cloudinary Free plan account with a valid `CLOUDINARY_CLOUD_NAME` and `CLOUDINARY_BASIC_AUTH`.
 
 ```bash
-# Step 1 — list recent assets
-coral sql "
-  SELECT public_id, resource_type, format, bytes, width, height, created_at
-  FROM cloudinary.resources
-  LIMIT 20
-"
-
-# Step 2 — list all top-level folders
-coral sql "SELECT name, path FROM cloudinary.folders"
-
-# Step 3 — view current usage and plan limits
-coral sql "
-  SELECT plan, credits_usage, credits_limit, storage_bytes,
-         storage_limit_bytes, bandwidth_bytes
-  FROM cloudinary.usage
-"
-
-# Step 4 — list all upload presets
-coral sql "SELECT name, unsigned, settings FROM cloudinary.upload_presets"
-
-# Step 5 — list all metadata field definitions
-coral sql "
-  SELECT external_id, label, type, mandatory, default_value
-  FROM cloudinary.metadata_fields
-"
+$ coral source lint sources/community/cloudinary/manifest.yaml
+Manifest is valid
 ```
 
-## Example queries
+```bash
+$ CLOUDINARY_CLOUD_NAME=... CLOUDINARY_BASIC_AUTH=... coral source add --file sources/community/cloudinary/manifest.yaml
+Added source cloudinary
 
-### All images with dimensions
+  ✓ cloudinary connected successfully
 
-```sql
-SELECT
-  public_id,
-  format,
-  width,
-  height,
-  bytes,
-  secure_url,
-  created_at
-FROM cloudinary.resources
-WHERE resource_type = 'image'
-LIMIT 50;
+    cloudinary (5 tables)
+    ├─ folders
+    ├─ metadata_fields
+    ├─ resources
+    ├─ upload_presets
+    └─ usage
+    Query tests
+    2 declared · 2 passed · 0 failed
+
+    ✓ SELECT public_id, resource_type, format, bytes, created_at FROM cloudinary.resources LIMIT 5
+      0 rows
+
+    ✓ SELECT name FROM cloudinary.folders LIMIT 5
+      1 row
 ```
 
-### Largest assets by file size
+**Table introspection:**
 
 ```sql
-SELECT
-  public_id,
-  resource_type,
-  format,
-  bytes,
-  width,
-  height,
-  created_at
-FROM cloudinary.resources
-ORDER BY bytes DESC
-LIMIT 20;
+SELECT table_name, description, required_filters
+FROM coral.tables
+WHERE schema_name = 'cloudinary'
+ORDER BY table_name;
 ```
 
-### Assets in a specific folder
-
-```sql
-SELECT
-  public_id,
-  format,
-  resource_type,
-  bytes,
-  created_at
-FROM cloudinary.resources
-WHERE prefix = 'myfolder/subfolder'
-LIMIT 50;
+```text
++-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| table_name      | description                                                                                                                                                                             | required_filters |
++-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| folders         | Top-level asset folders in your Cloudinary product environment. Only returns folders, not subfolders (use the prefix filter on the resources table to browse subfolder contents). |                  |
+| metadata_fields | Structured metadata field definitions configured in the Cloudinary product environment. Includes field type, label, default value, validation rules, and mandatory status.              |                  |
+| resources       | Assets (images, videos, raw files, etc.) stored in your Cloudinary product environment. Returns metadata such as public ID, format, dimensions, file size, tags, and context.           |                  |
+| upload_presets  | Upload presets configured in your Cloudinary product environment. Each preset defines default settings for uploaded assets such as transformation, folder, tags, and access control.    |                  |
+| usage           | Current usage details for the Cloudinary product environment, including plan type, credits consumption, storage usage, bandwidth, and transformations performed.                        |                  |
++-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
 ```
 
-### Assets with tags and context metadata
+**Inputs introspection:**
 
 ```sql
-SELECT
-  public_id,
-  format,
-  resource_type,
-  tags,
-  context,
-  created_at
-FROM cloudinary.resources
-WHERE tags = true AND context = true
-LIMIT 20;
+SELECT key, kind, required, is_set
+FROM coral.inputs
+WHERE schema_name = 'cloudinary'
+ORDER BY key;
 ```
 
-### Current storage and bandwidth usage
+```text
++-----------------------+----------+----------+--------+
+| key                   | kind     | required | is_set |
++-----------------------+----------+----------+--------+
+| CLOUDINARY_BASIC_AUTH | secret   | true     | true   |
+| CLOUDINARY_CLOUD_NAME | variable | true     | true   |
++-----------------------+----------+----------+--------+
+```
+
+**Live usage proof:**
 
 ```sql
-SELECT
-  plan,
-  credits_usage,
-  credits_limit,
-  credits_used_percentage,
-  storage_bytes,
-  storage_limit_bytes,
-  bandwidth_bytes,
-  bandwidth_limit_bytes,
-  transformations_used,
-  transformations_limit,
-  objects_count,
-  objects_limit
+SELECT plan, credits_usage, credits_limit, credits_used_percentage,
+       storage_bytes, storage_limit_bytes, bandwidth_bytes,
+       bandwidth_limit_bytes
 FROM cloudinary.usage;
 ```
 
-### Upload presets
-
-```sql
-SELECT
-  name,
-  unsigned,
-  settings
-FROM cloudinary.upload_presets;
+```text
++------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
+| plan | credits_usage | credits_limit | credits_used_percentage | storage_bytes | storage_limit_bytes | bandwidth_bytes | bandwidth_limit_bytes |
++------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
+| Free | 0             | 25            | 0.0                     | 0             |                     | 0               |                       |
++------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
 ```
 
-### Metadata field definitions
+**Live folders proof:**
 
 ```sql
-SELECT
-  external_id,
-  label,
-  type,
-  mandatory,
-  default_value,
-  validation
-FROM cloudinary.metadata_fields;
+SELECT name, path
+FROM cloudinary.folders;
+```
+
+```text
++---------+---------+
+| name    | path    |
++---------+---------+
+| samples | samples |
++---------+---------+
+```
+
+**Live resources proof:**
+
+```sql
+SELECT public_id, resource_type, format, bytes, width, height, created_at
+FROM cloudinary.resources
+LIMIT 5;
+```
+
+```text
+(0 rows — account currently has no uploaded assets)
 ```

--- a/sources/community/cloudinary/README.md
+++ b/sources/community/cloudinary/README.md
@@ -171,14 +171,14 @@ Structured metadata field definitions configured in the Cloudinary product envir
 
 ## Live request costs
 
-Each table query performs at least one live API call to `https://api.cloudinary.com/v1_1/<cloud_name>`. Cursor-based pagination on `resources` and `upload_presets` may trigger additional calls when `LIMIT` exceeds a single page's results. See the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api) for rate limit details.
+Each table query performs at least one live API call to `https://api.cloudinary.com/v1_1/<cloud_name>`. Cursor-based pagination on `resources`, `folders`, and `upload_presets` may trigger additional calls when `LIMIT` exceeds a single page's results. See the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api) for rate limit details.
 
 ## Source scope
 
 - Targets the Cloudinary Admin API at `https://api.cloudinary.com/v1_1/<cloud_name>`.
 - Requires `CLOUDINARY_CLOUD_NAME` (base URL variable) and `CLOUDINARY_BASIC_AUTH` (HTTP Basic Auth header).
 - Covers read-only access: asset listing with filters, folder listing, upload preset listing, usage details, and metadata field definitions.
-- Cursor-based pagination (`next_cursor` query param) on `resources` and `upload_presets` — uses `response_cursor_path` for response cursor extraction. The `folders` table has no pagination (root folders only).
+- Cursor-based pagination (`next_cursor` query param) on `resources`, `folders`, and `upload_presets` — uses `response_cursor_path` for response cursor extraction.
 - The `usage` table exposes nested child objects (credits, storage, bandwidth, transformations, objects) as flat columns with nullable types — the API may omit deeply nested fields depending on plan.
 - 7 optional filters on `resources` for filtering by resource type (required), folder prefix, date range, sort direction, and inclusion of tags/context/metadata. The `type` response column is not used as a request filter (Cloudinary requires it as a URL path segment, available only when filtering by a specific resource type).
 - 2 declared test queries (resources + folders LIMIT 5) are source-independent and work on any account regardless of data.

--- a/sources/community/cloudinary/manifest.yaml
+++ b/sources/community/cloudinary/manifest.yaml
@@ -1,0 +1,553 @@
+name: cloudinary
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query assets, folders, upload presets, usage, and metadata fields
+  from Cloudinary.
+base_url: https://api.cloudinary.com/v1_1/{{input.CLOUDINARY_CLOUD_NAME}}
+
+inputs:
+  CLOUDINARY_CLOUD_NAME:
+    kind: variable
+    hint: |
+      Your Cloudinary cloud name. Found in the Cloudinary Console dashboard
+      at the top of the Account Details section.
+      Example: "mycompany" (not the full URL).
+  CLOUDINARY_BASIC_AUTH:
+    kind: secret
+    hint: |
+      Base64-encoded "api_key:api_secret" Basic auth token.
+      Generate from your API Key and API Secret (found in Cloudinary Console
+      under Settings > Access Keys):
+        printf '%s:%s' YOUR_API_KEY YOUR_API_SECRET | base64
+      The result will be a string like "MTIzNDU2Nzg5MDEyMzQ1Njo3N0FCY2Rl..."
+      Paste that full string as the value.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Basic {{input.CLOUDINARY_BASIC_AUTH}}"
+
+test_queries:
+  - SELECT public_id, resource_type, format, bytes, created_at FROM cloudinary.resources LIMIT 5
+  - SELECT name FROM cloudinary.folders LIMIT 5
+
+tables:
+
+  # --------------------------------------------------------------------------
+  # cloudinary.resources — List all assets
+  # GET /resources
+  # Paginated array at response.resources. Cursor pagination (next_cursor).
+  # --------------------------------------------------------------------------
+  - name: resources
+    description: >-
+      Assets (images, videos, raw files, etc.) stored in your Cloudinary
+      product environment. Returns metadata such as public ID, format,
+      dimensions, file size, tags, and context.
+    guide: |
+      No required filters. Start with:
+        SELECT public_id, resource_type, format, bytes, created_at
+        FROM cloudinary.resources LIMIT 10
+      Use WHERE resource_type = 'image' to filter by resource type.
+      Use WHERE prefix = 'folder/subfolder' to list assets in a path.
+      Use WHERE tags = true to include tag data (JSON array).
+      Use WHERE context = true to include context metadata (JSON object).
+      The `tags` column is a JSON array when returned; `context` is JSON.
+    filters:
+      - name: resource_type
+      - name: type
+      - name: prefix
+      - name: start_at
+      - name: direction
+      - name: tags
+      - name: context
+      - name: metadata
+    request:
+      method: GET
+      path: /resources
+      query:
+        - name: resource_type
+          from: filter
+          key: resource_type
+        - name: type
+          from: filter
+          key: type
+        - name: prefix
+          from: filter
+          key: prefix
+        - name: start_at
+          from: filter
+          key: start_at
+        - name: direction
+          from: filter
+          key: direction
+        - name: tags
+          from: filter_bool
+          key: tags
+        - name: context
+          from: filter_bool
+          key: context
+        - name: metadata
+          from: filter_bool
+          key: metadata
+    response:
+      rows_path:
+        - resources
+    pagination:
+      mode: cursor_query
+      cursor_param: next_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 500
+        query_param: max_results
+    fetch_limit_default: 100
+    columns:
+      - name: public_id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the asset.
+        expr:
+          kind: path
+          path:
+            - public_id
+      - name: asset_id
+        type: Utf8
+        nullable: false
+        description: Immutable asset identifier.
+        expr:
+          kind: path
+          path:
+            - asset_id
+      - name: format
+        type: Utf8
+        nullable: true
+        description: File format extension (e.g. jpg, png, mp4).
+        expr:
+          kind: path
+          path:
+            - format
+      - name: version
+        type: Int64
+        nullable: false
+        description: Version number of the asset.
+        expr:
+          kind: path
+          path:
+            - version
+      - name: resource_type
+        type: Utf8
+        nullable: false
+        description: Type of resource (image, video, raw, auto).
+        expr:
+          kind: path
+          path:
+            - resource_type
+      - name: type
+        type: Utf8
+        nullable: false
+        description: Delivery type (upload, private, authenticated, etc.).
+        expr:
+          kind: path
+          path:
+            - type
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: When the asset was created (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: bytes
+        type: Int64
+        nullable: false
+        description: File size in bytes.
+        expr:
+          kind: path
+          path:
+            - bytes
+      - name: width
+        type: Int64
+        nullable: true
+        description: Width of the asset in pixels.
+        expr:
+          kind: path
+          path:
+            - width
+      - name: height
+        type: Int64
+        nullable: true
+        description: Height of the asset in pixels.
+        expr:
+          kind: path
+          path:
+            - height
+      - name: url
+        type: Utf8
+        nullable: true
+        description: HTTP URL of the asset.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: secure_url
+        type: Utf8
+        nullable: true
+        description: HTTPS URL of the asset.
+        expr:
+          kind: path
+          path:
+            - secureUrl
+      - name: tags
+        type: Json
+        nullable: true
+        description: JSON array of tag strings assigned to the asset. Populated when tags=true filter is set.
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: context
+        type: Json
+        nullable: true
+        description: JSON object of custom context metadata. Populated when context=true filter is set.
+        expr:
+          kind: path
+          path:
+            - context
+      - name: metadata_fields
+        type: Json
+        nullable: true
+        description: JSON object of structured metadata field values. Populated when metadata=true filter is set.
+        expr:
+          kind: path
+          path:
+            - metadata
+      - name: etag
+        type: Utf8
+        nullable: true
+        description: ETag of the uploaded file.
+        expr:
+          kind: path
+          path:
+            - etag
+      - name: placeholder
+        type: Boolean
+        nullable: false
+        description: Whether the asset is a placeholder.
+        expr:
+          kind: path
+          path:
+            - placeholder
+
+  # --------------------------------------------------------------------------
+  # cloudinary.folders — List root folders
+  # GET /folders
+  # Paginated array at response.folders. Cursor pagination (next_cursor).
+  # --------------------------------------------------------------------------
+  - name: folders
+    description: >-
+      Top-level asset folders in your Cloudinary product environment.
+      Only returns folders, not subfolders (use the asset_folder filter
+      on the resources table to browse subfolder contents).
+    guide: |
+      No required filters. Start with:
+        SELECT name, path FROM cloudinary.folders
+      Use the folder name with WHERE prefix = 'folder_name' on the
+      resources table to list assets inside a folder.
+    request:
+      method: GET
+      path: /folders
+    response:
+      rows_path:
+        - folders
+    pagination:
+      mode: cursor_query
+      cursor_param: next_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 500
+        query_param: max_results
+    fetch_limit_default: 100
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Display name of the folder.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: path
+        type: Utf8
+        nullable: true
+        description: Full path of the folder.
+        expr:
+          kind: path
+          path:
+            - path
+
+  # --------------------------------------------------------------------------
+  # cloudinary.upload_presets — List upload presets
+  # GET /upload_presets
+  # Paginated array at response.presets. Cursor pagination.
+  # --------------------------------------------------------------------------
+  - name: upload_presets
+    description: >-
+      Upload presets configured in your Cloudinary product environment.
+      Each preset defines default settings for uploaded assets such as
+      transformation, folder, tags, and access control.
+    guide: |
+      No required filters. Start with:
+        SELECT name, unsigned FROM cloudinary.upload_presets
+      Use the preset name with the Upload API to apply preset settings
+      to new uploads.
+    request:
+      method: GET
+      path: /upload_presets
+    response:
+      rows_path:
+        - presets
+    pagination:
+      mode: cursor_query
+      cursor_param: next_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 500
+        query_param: max_results
+    fetch_limit_default: 100
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Name of the upload preset.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: unsigned
+        type: Boolean
+        nullable: false
+        description: Whether the preset allows unsigned uploads.
+        expr:
+          kind: path
+          path:
+            - unsigned
+      - name: settings
+        type: Json
+        nullable: true
+        description: JSON object of preset settings (folder, tags, transformations, etc.).
+        expr:
+          kind: path
+          path:
+            - settings
+
+  # --------------------------------------------------------------------------
+  # cloudinary.usage — Usage details
+  # GET /usage
+  # Single response object (no array). Returns plan, credits, storage, etc.
+  # --------------------------------------------------------------------------
+  - name: usage
+    description: >-
+      Current usage details for the Cloudinary product environment,
+      including plan type, credits consumption, storage usage,
+      bandwidth, and transformations performed.
+    guide: |
+      Returns exactly one row. Start with:
+        SELECT plan, credits_usage, credits_limit, storage_bytes,
+               bandwidth_bytes FROM cloudinary.usage
+    request:
+      method: GET
+      path: /usage
+    response: {}
+    columns:
+      - name: plan
+        type: Utf8
+        nullable: false
+        description: Cloudinary plan name (e.g. Free, Advanced, Enterprise).
+        expr:
+          kind: path
+          path:
+            - plan
+      - name: credits_usage
+        type: Int64
+        nullable: true
+        description: Credits consumed in the current billing period.
+        expr:
+          kind: path
+          path:
+            - credits
+            - usage
+      - name: credits_limit
+        type: Int64
+        nullable: true
+        description: Total credits available in the current billing period.
+        expr:
+          kind: path
+          path:
+            - credits
+            - limit
+      - name: credits_used_percentage
+        type: Float64
+        nullable: true
+        description: Percentage of credits used.
+        expr:
+          kind: path
+          path:
+            - credits
+            - used_percent
+      - name: storage_bytes
+        type: Int64
+        nullable: true
+        description: Total storage used in bytes.
+        expr:
+          kind: path
+          path:
+            - storage
+            - usage
+      - name: storage_limit_bytes
+        type: Int64
+        nullable: true
+        description: Storage limit in bytes.
+        expr:
+          kind: path
+          path:
+            - storage
+            - limit
+      - name: bandwidth_bytes
+        type: Int64
+        nullable: true
+        description: Bandwidth used in bytes.
+        expr:
+          kind: path
+          path:
+            - bandwidth
+            - usage
+      - name: bandwidth_limit_bytes
+        type: Int64
+        nullable: true
+        description: Bandwidth limit in bytes.
+        expr:
+          kind: path
+          path:
+            - bandwidth
+            - limit
+      - name: transformations_used
+        type: Int64
+        nullable: true
+        description: Number of transformations performed.
+        expr:
+          kind: path
+          path:
+            - transformations
+            - usage
+      - name: transformations_limit
+        type: Int64
+        nullable: true
+        description: Transformation limit.
+        expr:
+          kind: path
+          path:
+            - transformations
+            - limit
+      - name: objects_count
+        type: Int64
+        nullable: true
+        description: Total number of assets stored.
+        expr:
+          kind: path
+          path:
+            - objects
+            - usage
+      - name: objects_limit
+        type: Int64
+        nullable: true
+        description: Asset count limit.
+        expr:
+          kind: path
+          path:
+            - objects
+            - limit
+
+  # --------------------------------------------------------------------------
+  # cloudinary.metadata_fields — List structured metadata fields
+  # GET /metadata_fields
+  # Array at response.metadata_fields (no pagination).
+  # --------------------------------------------------------------------------
+  - name: metadata_fields
+    description: >-
+      Structured metadata field definitions configured in the Cloudinary
+      product environment. Includes field type, label, default value,
+      validation rules, and mandatory status.
+    guide: |
+      No required filters. Start with:
+        SELECT external_id, label, type, mandatory
+        FROM cloudinary.metadata_fields
+      Use the external_id to reference metadata fields when querying
+      the resources table with metadata=true.
+    request:
+      method: GET
+      path: /metadata_fields
+    response:
+      rows_path:
+        - metadata_fields
+    columns:
+      - name: external_id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the metadata field.
+        expr:
+          kind: path
+          path:
+            - external_id
+      - name: label
+        type: Utf8
+        nullable: false
+        description: Display label for the metadata field.
+        expr:
+          kind: path
+          path:
+            - label
+      - name: type
+        type: Utf8
+        nullable: false
+        description: Data type of the metadata field (integer, string, date, etc.).
+        expr:
+          kind: path
+          path:
+            - type
+      - name: mandatory
+        type: Boolean
+        nullable: false
+        description: Whether the field is required when uploading assets.
+        expr:
+          kind: path
+          path:
+            - mandatory
+      - name: default_value
+        type: Utf8
+        nullable: true
+        description: Default value assigned when no value is provided.
+        expr:
+          kind: path
+          path:
+            - default_value
+      - name: validation
+        type: Json
+        nullable: true
+        description: JSON object defining validation rules for the field.
+        expr:
+          kind: path
+          path:
+            - validation

--- a/sources/community/cloudinary/manifest.yaml
+++ b/sources/community/cloudinary/manifest.yaml
@@ -165,7 +165,7 @@ tables:
           expr:
             kind: path
             path:
-              - createdAt
+              - created_at
       - name: bytes
         type: Int64
         nullable: false
@@ -205,7 +205,7 @@ tables:
         expr:
           kind: path
           path:
-            - secureUrl
+            - secure_url
       - name: tags
         type: Json
         nullable: true
@@ -255,7 +255,7 @@ tables:
   - name: folders
     description: >-
       Top-level asset folders in your Cloudinary product environment.
-      Only returns folders, not subfolders (use the asset_folder filter
+      Only returns folders, not subfolders (use the prefix filter
       on the resources table to browse subfolder contents).
     guide: |
       No required filters. Start with:

--- a/sources/community/cloudinary/manifest.yaml
+++ b/sources/community/cloudinary/manifest.yaml
@@ -32,7 +32,7 @@ auth:
       template: "Basic {{input.CLOUDINARY_BASIC_AUTH}}"
 
 test_queries:
-  - SELECT public_id, resource_type, type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' AND type = 'upload' LIMIT 5
+  - SELECT resource_type, type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' AND type = 'upload' LIMIT 5
   - SELECT name FROM cloudinary.folders LIMIT 5
 
 tables:
@@ -54,10 +54,9 @@ tables:
         SELECT public_id, resource_type, type, format, bytes, created_at
         FROM cloudinary.resources
         WHERE resource_type = 'image' AND type = 'upload' LIMIT 10
-      Use WHERE prefix = 'my_public_id_prefix' to filter by public ID.
-      Use WHERE asset_folder = 'folder_name' to filter by asset folder
-      (dynamic folders mode — distinct from public ID prefix).
-      Both are URL path segments and must be URL-encoded if they contain
+      Use WHERE prefix = 'my_public_id_prefix' to filter by public ID prefix.
+      Both resource_type and type are URL path segments and must be
+      URL-encoded if they contain
       reserved characters. Accepted resource_type values: image, raw, video.
       Accepted type values: upload, private, authenticated, etc.
       Use WHERE tags = true to include tag data (JSON array).
@@ -69,7 +68,6 @@ tables:
       - name: type
         required: true
       - name: prefix
-      - name: asset_folder
       - name: start_at
       - name: direction
       - name: tags
@@ -82,9 +80,6 @@ tables:
         - name: prefix
           from: filter
           key: prefix
-        - name: asset_folder
-          from: filter
-          key: asset_folder
         - name: start_at
           from: filter
           key: start_at
@@ -262,13 +257,13 @@ tables:
   - name: folders
     description: >-
       Top-level asset folders in your Cloudinary product environment.
-      Only returns folders, not subfolders (use the prefix filter
-      on the resources table to browse subfolder contents).
+      Only returns root folders. Subfolder contents can be queried via
+      the resources table using WHERE prefix = 'folder_path/'.
     guide: |
       No required filters. Start with:
         SELECT name, path FROM cloudinary.folders
-      Use the folder name with WHERE prefix = 'folder_name' on the
-      resources table to list assets inside a folder.
+      To list assets with a given public ID prefix, use WHERE prefix on
+      the resources table.
     request:
       method: GET
       path: /folders

--- a/sources/community/cloudinary/manifest.yaml
+++ b/sources/community/cloudinary/manifest.yaml
@@ -32,7 +32,7 @@ auth:
       template: "Basic {{input.CLOUDINARY_BASIC_AUTH}}"
 
 test_queries:
-  - SELECT resource_type, type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' AND type = 'upload' LIMIT 5
+  - SELECT public_id, resource_type, type, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' AND type = 'upload' LIMIT 5
   - SELECT name FROM cloudinary.folders LIMIT 5
 
 tables:

--- a/sources/community/cloudinary/manifest.yaml
+++ b/sources/community/cloudinary/manifest.yaml
@@ -32,16 +32,16 @@ auth:
       template: "Basic {{input.CLOUDINARY_BASIC_AUTH}}"
 
 test_queries:
-  - SELECT public_id, resource_type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' LIMIT 5
+  - SELECT public_id, resource_type, type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' AND type = 'upload' LIMIT 5
   - SELECT name FROM cloudinary.folders LIMIT 5
 
 tables:
 
   # --------------------------------------------------------------------------
-  # cloudinary.resources — List assets by type
-  # GET /resources/:resource_type
+  # cloudinary.resources — List assets by resource type and delivery type
+  # GET /resources/:resource_type/:type
   # Paginated array at response.resources. Cursor pagination (next_cursor).
-  # The resource_type must be specified as a WHERE clause (image, raw, video).
+  # Both resource_type and type are required as URL path segments.
   # --------------------------------------------------------------------------
   - name: resources
     description: >-
@@ -49,20 +49,24 @@ tables:
       product environment. Returns metadata such as public ID, format,
       dimensions, file size, tags, and context.
     guide: |
-      resource_type is required (image, raw, or video). Start with:
-        SELECT public_id, resource_type, format, bytes, created_at
+      resource_type (image, raw, video) and type (upload, private,
+      authenticated, etc.) are both required. Start with:
+        SELECT public_id, resource_type, type, format, bytes, created_at
         FROM cloudinary.resources
-        WHERE resource_type = 'image' LIMIT 10
-      Use WHERE prefix = 'folder/subfolder' to list assets in a path.
+        WHERE resource_type = 'image' AND type = 'upload' LIMIT 10
+      Use WHERE prefix = 'my_public_id_prefix' to filter by public ID.
+      Use WHERE asset_folder = 'folder_name' to filter by asset folder
+      (dynamic folders mode — distinct from public ID prefix).
       Use WHERE tags = true to include tag data (JSON array).
       Use WHERE context = true to include context metadata (JSON object).
       The `tags` column is a JSON array when returned; `context` is JSON.
-      The `type` column is a response field (upload, private, etc.) and is
-      not used as a request filter.
     filters:
       - name: resource_type
         required: true
+      - name: type
+        required: true
       - name: prefix
+      - name: asset_folder
       - name: start_at
       - name: direction
       - name: tags
@@ -70,11 +74,14 @@ tables:
       - name: metadata
     request:
       method: GET
-      path: /resources/{{filter.resource_type}}
+      path: /resources/{{filter.resource_type}}/{{filter.type}}
       query:
         - name: prefix
           from: filter
           key: prefix
+        - name: asset_folder
+          from: filter
+          key: asset_folder
         - name: start_at
           from: filter
           key: start_at
@@ -247,7 +254,7 @@ tables:
   # --------------------------------------------------------------------------
   # cloudinary.folders — List root folders
   # GET /folders
-  # Paginated array at response.folders. Cursor pagination (next_cursor).
+  # Array at response.folders. No pagination (single response, up to 2000).
   # --------------------------------------------------------------------------
   - name: folders
     description: >-
@@ -266,15 +273,7 @@ tables:
       rows_path:
         - folders
     pagination:
-      mode: cursor_query
-      cursor_param: next_cursor
-      response_cursor_path:
-        - next_cursor
-      page_size:
-        default: 100
-        max: 500
-        query_param: max_results
-    fetch_limit_default: 100
+      mode: none
     columns:
       - name: name
         type: Utf8
@@ -533,9 +532,9 @@ tables:
           path:
             - mandatory
       - name: default_value
-        type: Utf8
+        type: Json
         nullable: true
-        description: Default value assigned when no value is provided.
+        description: Default value(s). Single values are strings; multi-select fields return an array.
         expr:
           kind: path
           path:

--- a/sources/community/cloudinary/manifest.yaml
+++ b/sources/community/cloudinary/manifest.yaml
@@ -57,6 +57,9 @@ tables:
       Use WHERE prefix = 'my_public_id_prefix' to filter by public ID.
       Use WHERE asset_folder = 'folder_name' to filter by asset folder
       (dynamic folders mode — distinct from public ID prefix).
+      Both are URL path segments and must be URL-encoded if they contain
+      reserved characters. Accepted resource_type values: image, raw, video.
+      Accepted type values: upload, private, authenticated, etc.
       Use WHERE tags = true to include tag data (JSON array).
       Use WHERE context = true to include context metadata (JSON object).
       The `tags` column is a JSON array when returned; `context` is JSON.
@@ -534,7 +537,7 @@ tables:
       - name: default_value
         type: Json
         nullable: true
-        description: Default value(s). Single values are strings; multi-select fields return an array.
+        description: Default value(s). Single values are JSON scalars (strings, numbers, etc.); multi-select fields return an array.
         expr:
           kind: path
           path:

--- a/sources/community/cloudinary/manifest.yaml
+++ b/sources/community/cloudinary/manifest.yaml
@@ -39,7 +39,7 @@ tables:
 
   # --------------------------------------------------------------------------
   # cloudinary.resources — List assets by type
-  # GET /resources/:resource_type(/:type)
+  # GET /resources/:resource_type
   # Paginated array at response.resources. Cursor pagination (next_cursor).
   # The resource_type must be specified as a WHERE clause (image, raw, video).
   # --------------------------------------------------------------------------
@@ -247,7 +247,7 @@ tables:
   # --------------------------------------------------------------------------
   # cloudinary.folders — List root folders
   # GET /folders
-  # Array at response.folders. No pagination (root folders only).
+  # Paginated array at response.folders. Cursor pagination (next_cursor).
   # --------------------------------------------------------------------------
   - name: folders
     description: >-
@@ -266,7 +266,15 @@ tables:
       rows_path:
         - folders
     pagination:
-      mode: none
+      mode: cursor_query
+      cursor_param: next_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 500
+        query_param: max_results
+    fetch_limit_default: 100
     columns:
       - name: name
         type: Utf8

--- a/sources/community/cloudinary/manifest.yaml
+++ b/sources/community/cloudinary/manifest.yaml
@@ -32,15 +32,16 @@ auth:
       template: "Basic {{input.CLOUDINARY_BASIC_AUTH}}"
 
 test_queries:
-  - SELECT public_id, resource_type, format, bytes, created_at FROM cloudinary.resources LIMIT 5
+  - SELECT public_id, resource_type, format, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' LIMIT 5
   - SELECT name FROM cloudinary.folders LIMIT 5
 
 tables:
 
   # --------------------------------------------------------------------------
-  # cloudinary.resources — List all assets
-  # GET /resources
+  # cloudinary.resources — List assets by type
+  # GET /resources/:resource_type(/:type)
   # Paginated array at response.resources. Cursor pagination (next_cursor).
+  # The resource_type must be specified as a WHERE clause (image, raw, video).
   # --------------------------------------------------------------------------
   - name: resources
     description: >-
@@ -48,17 +49,19 @@ tables:
       product environment. Returns metadata such as public ID, format,
       dimensions, file size, tags, and context.
     guide: |
-      No required filters. Start with:
+      resource_type is required (image, raw, or video). Start with:
         SELECT public_id, resource_type, format, bytes, created_at
-        FROM cloudinary.resources LIMIT 10
-      Use WHERE resource_type = 'image' to filter by resource type.
+        FROM cloudinary.resources
+        WHERE resource_type = 'image' LIMIT 10
       Use WHERE prefix = 'folder/subfolder' to list assets in a path.
       Use WHERE tags = true to include tag data (JSON array).
       Use WHERE context = true to include context metadata (JSON object).
       The `tags` column is a JSON array when returned; `context` is JSON.
+      The `type` column is a response field (upload, private, etc.) and is
+      not used as a request filter.
     filters:
       - name: resource_type
-      - name: type
+        required: true
       - name: prefix
       - name: start_at
       - name: direction
@@ -67,14 +70,8 @@ tables:
       - name: metadata
     request:
       method: GET
-      path: /resources
+      path: /resources/{{filter.resource_type}}
       query:
-        - name: resource_type
-          from: filter
-          key: resource_type
-        - name: type
-          from: filter
-          key: type
         - name: prefix
           from: filter
           key: prefix
@@ -142,7 +139,7 @@ tables:
       - name: resource_type
         type: Utf8
         nullable: false
-        description: Type of resource (image, video, raw, auto).
+        description: Type of resource (image, raw, video).
         expr:
           kind: path
           path:
@@ -240,7 +237,7 @@ tables:
             - etag
       - name: placeholder
         type: Boolean
-        nullable: false
+        nullable: true
         description: Whether the asset is a placeholder.
         expr:
           kind: path
@@ -250,7 +247,7 @@ tables:
   # --------------------------------------------------------------------------
   # cloudinary.folders — List root folders
   # GET /folders
-  # Paginated array at response.folders. Cursor pagination (next_cursor).
+  # Array at response.folders. No pagination (root folders only).
   # --------------------------------------------------------------------------
   - name: folders
     description: >-
@@ -269,15 +266,7 @@ tables:
       rows_path:
         - folders
     pagination:
-      mode: cursor_query
-      cursor_param: next_cursor
-      response_cursor_path:
-        - next_cursor
-      page_size:
-        default: 100
-        max: 500
-        query_param: max_results
-    fetch_limit_default: 100
+      mode: none
     columns:
       - name: name
         type: Utf8

--- a/sources/community/cloudinary/manifest.yaml
+++ b/sources/community/cloudinary/manifest.yaml
@@ -257,13 +257,14 @@ tables:
   - name: folders
     description: >-
       Top-level asset folders in your Cloudinary product environment.
-      Only returns root folders. Subfolder contents can be queried via
-      the resources table using WHERE prefix = 'folder_path/'.
+      The prefix filter on the resources table filters by public ID
+      prefix, not by asset folder. Dynamic asset-folder content lookup
+      is not supported in this version.
     guide: |
       No required filters. Start with:
         SELECT name, path FROM cloudinary.folders
-      To list assets with a given public ID prefix, use WHERE prefix on
-      the resources table.
+      Use WHERE prefix on the resources table to filter by public ID
+      prefix (not by asset folder).
     request:
       method: GET
       path: /folders


### PR DESCRIPTION
## Summary

Add a Cloudinary community source so Coral can query assets, folders, upload presets, usage details, and metadata fields through SQL. The source provides 5 tables for reading Cloudinary media asset inventory and account configuration.

## Why this source

Cloudinary is a widely used media management platform powering image and video optimization for thousands of applications. Coral does not currently include a media management source under `sources/core` or `sources/community`. Adding Cloudinary enables users to query asset inventory, inspect storage usage, list upload presets, and monitor account activity—all through Coral SQL.

## Provider docs

- Cloudinary Admin API reference: https://cloudinary.com/documentation/admin_api
- Authentication: https://cloudinary.com/documentation/admin_api#authentication
- Assets: https://cloudinary.com/documentation/admin_api#get_resources
- Folders: https://cloudinary.com/documentation/admin_api#get_folders
- Upload Presets: https://cloudinary.com/documentation/admin_api#get_upload_presets
- Usage: https://cloudinary.com/documentation/admin_api#get_usage
- Metadata Fields: https://cloudinary.com/documentation/admin_api#get_metadata_fields
- Data center endpoints: https://cloudinary.com/documentation/admin_api#eu_or_ap_data_centers_and_endpoints_premium_feature

## Source shape

| Table | Description | Required filters |
| --- | --- | --- |
| `resources` | Assets with metadata (17 columns) | resource_type, type |
| `folders` | Top-level asset folders (2 columns) | |
| `upload_presets` | Upload presets with default settings (3 columns) | |
| `usage` | Current plan usage including credits, storage, bandwidth, transformations, objects (12 columns) | |
| `metadata_fields` | Structured metadata field definitions (6 columns) | |

## Source scope

- Targets the Cloudinary Admin API at `https://api.cloudinary.com/v1_1/<cloud_name>` (US default data center endpoint; EU and AP data center endpoints are not supported in this version).
- Authentication via HTTP Basic Auth with a base64-encoded `api_key:api_secret` token (`CLOUDINARY_BASIC_AUTH` secret) plus `CLOUDINARY_CLOUD_NAME` variable.
- Provides read-only access to media asset inventory and account configuration.
- Cursor-based pagination (`next_cursor`) on `resources` and `upload_presets` via `response_cursor_path` and `cursor_query` mode. The `folders` table has no pagination (single response, up to 2000 root folders).
- No pagination on `usage` (single-object response) or `metadata_fields` (returns all fields at once).
- Nested columns in `usage` (credits, storage, bandwidth, transformations, objects) are nullable — Cloudinary may return `null` for deeply nested fields depending on plan.
- 8 filters on `resources` including 2 required (`resource_type`, `type` as URL path segments) and 6 optional (`prefix` for public ID prefix filtering, `start_at`, `direction`, `tags`, `context`, `metadata`).
- The `tags` endpoint (`GET /tags`) returns 404 on Free plan accounts so it is excluded from this source. Tag data is still accessible via the `tags` filter on `resources`.
- The `folders` table returns only root folders. The `prefix` filter on `resources` filters by public ID prefix, not by asset folder. Dynamic asset-folder content lookup is not supported in this version.
- 2 declared test queries (resources + folders LIMIT 5) are source-independent and work on any account regardless of data.
- Column definitions validated against the [Cloudinary Admin API reference](https://cloudinary.com/documentation/admin_api).
- Mutating operations (upload, delete, transform, etc.) are intentionally out of scope.

## Validation

```bash
$ coral source lint sources/community/cloudinary/manifest.yaml
Manifest is valid
```

```bash
$ coral source add --file sources/community/cloudinary/manifest.yaml
Added source cloudinary

  ✓ cloudinary connected successfully

    cloudinary (5 tables)
    ├─ folders
    ├─ metadata_fields
    ├─ resources
    ├─ upload_presets
    └─ usage
    Query tests
    2 declared · 2 passed · 0 failed

    ✓ SELECT public_id, resource_type, type, bytes, created_at FROM cloudinary.resources WHERE resource_type = 'image' AND type = 'upload' LIMIT 5
      5 rows

    ✓ SELECT name FROM cloudinary.folders LIMIT 5
      0 rows
```

**Table introspection:**

```sql
SELECT table_name, description, required_filters
FROM coral.tables
WHERE schema_name = 'cloudinary'
ORDER BY table_name;
```

```text
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
| table_name      | description                                                                                                                                                                                                                      | required_filters   |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
| folders         | Top-level asset folders in your Cloudinary product environment. The prefix filter on the resources table filters by public ID prefix, not by asset folder. Dynamic asset-folder content lookup is not supported in this version. |                    |
| metadata_fields | Structured metadata field definitions configured in the Cloudinary product environment. Includes field type, label, default value, validation rules, and mandatory status.                                                       |                    |
| resources       | Assets (images, videos, raw files, etc.) stored in your Cloudinary product environment. Returns metadata such as public ID, format, dimensions, file size, tags, and context.                                                    | resource_type,type |
| upload_presets  | Upload presets configured in your Cloudinary product environment. Each preset defines default settings for uploaded assets such as transformation, folder, tags, and access control.                                             |                    |
| usage           | Current usage details for the Cloudinary product environment, including plan type, credits consumption, storage usage, bandwidth, and transformations performed.                                                                 |                    |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
```

**Live usage proof:**

```sql
SELECT plan, credits_usage, credits_limit, credits_used_percentage,
       storage_bytes, storage_limit_bytes, bandwidth_bytes,
       bandwidth_limit_bytes
FROM cloudinary.usage;
```

```text
+------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
| plan | credits_usage | credits_limit | credits_used_percentage | storage_bytes | storage_limit_bytes | bandwidth_bytes | bandwidth_limit_bytes |
+------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
| Free | 1             | 25            | 4.64                    | 572942739     |                     | 680717670       |                       |
+------+---------------+---------------+-------------------------+---------------+---------------------+-----------------+-----------------------+
```

**Live folders proof:**

```sql
SELECT name, path
FROM cloudinary.folders;
```

```text
(0 rows — account has no top-level folders)
```

**Live resources proof:**

```sql
SELECT public_id, resource_type, type, format, bytes, width, height, created_at
FROM cloudinary.resources
WHERE resource_type = 'image' AND type = 'upload'
LIMIT 5;
```

```text
+--------------+---------------+--------+--------+--------+-------+--------+----------------------+
| public_id    | resource_type | type   | format | bytes  | width | height | created_at           |
+--------------+---------------+--------+--------+--------+-------+--------+----------------------+
| cld-sample-4 | image         | upload | jpg    | 818600 | 1870  | 1250   | 2025-06-29T20:26:30Z |
| cld-sample-3 | image         | upload | jpg    | 905834 | 1870  | 1250   | 2025-06-29T20:26:30Z |
| cld-sample-5 | image         | upload | jpg    | 379132 | 1870  | 1250   | 2025-06-29T20:26:31Z |
| cld-sample-2 | image         | upload | jpg    | 592235 | 1870  | 1250   | 2025-06-29T20:26:30Z |
| cld-sample   | image         | upload | jpg    | 476846 | 1870  | 1250   | 2025-06-29T20:26:30Z |
+--------------+---------------+--------+--------+--------+-------+--------+----------------------+
```

**Live upload_presets proof:**

```sql
SELECT name, unsigned, settings
FROM cloudinary.upload_presets
LIMIT 5;
```

```text
+------------+----------+---------------------------------------------------------------+
| name       | unsigned | settings                                                      |
+------------+----------+---------------------------------------------------------------+
| ml_default | false    | {"overwrite":true,"use_filename":true,"unique_filename":true} |
+------------+----------+---------------------------------------------------------------+
```

**Live metadata_fields proof:**

```sql
SELECT external_id, label, type, mandatory
FROM cloudinary.metadata_fields
LIMIT 5;
```

```text
(0 rows — account has no metadata fields configured)
```

Closes #1241