### PR TITLE
feat(cli): add identity management commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4802,6 +4802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5630,9 +5631,11 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "rustls-native-certs",
  "socket2",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 toml = "0.9"
 toml_edit = "0.25.10"
-tonic = "0.14.2"
+tonic = { version = "0.14.2", features = ["tls-native-roots", "tls-ring"] }
 tonic-prost = "0.14.2"
 tonic-types = "0.14.2"
 tonic-web = "0.14.5"

--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -83,6 +83,27 @@ message ListUserOwnedIdentitiesResponse {
   repeated Identity identities = 1;
 }
 
+// Fetches one user-owned identity for the request Coral user principal.
+message GetUserOwnedIdentityRequest {
+  // Stored identity name.
+  string name = 1;
+}
+
+// Returns one user-owned identity.
+message GetUserOwnedIdentityResponse {
+  // Stored identity.
+  Identity identity = 1;
+}
+
+// Deletes one user-owned identity for the request Coral user principal.
+message DeleteUserOwnedIdentityRequest {
+  // Stored identity name.
+  string name = 1;
+}
+
+// Confirms user-owned identity deletion.
+message DeleteUserOwnedIdentityResponse {}
+
 // Stored identity APIs.
 service IdentityService {
   // Creates or replaces one OAuth identity owned by the request Coral user principal.
@@ -94,4 +115,9 @@ service IdentityService {
   // Lists user-owned identities.
   rpc ListUserOwnedIdentities(ListUserOwnedIdentitiesRequest)
       returns (ListUserOwnedIdentitiesResponse);
+  // Fetches one user-owned identity.
+  rpc GetUserOwnedIdentity(GetUserOwnedIdentityRequest) returns (GetUserOwnedIdentityResponse);
+  // Deletes one user-owned identity.
+  rpc DeleteUserOwnedIdentity(DeleteUserOwnedIdentityRequest)
+      returns (DeleteUserOwnedIdentityResponse);
 }

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1343,7 +1343,10 @@ enabled = false
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
         let user_owned_identity_manager =
             UserOwnedIdentityManager::new(layout.clone(), identity_spec_manager.clone());
-        let extension_context = ServerExtensionContext::new(user_owned_identity_manager.handle());
+        let extension_context = ServerExtensionContext::new(
+            user_owned_identity_manager.handle(),
+            SourceManagementHandle::new(source_manager.clone()),
+        );
         start_server(ServerServices {
             source_manager,
             query_manager,

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -46,7 +46,7 @@ use crate::credentials::config::CredentialStorageConfig;
 use crate::credentials::{CredentialManager, CredentialStore};
 use crate::episode::service::EpisodeService;
 use crate::episode::store::EpisodeStore;
-use crate::features::{FeatureOverrides, FeatureStore};
+use crate::features::{FeatureOverrides, FeatureStore, Features};
 use crate::feedback::manager::FeedbackManager;
 use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
@@ -58,10 +58,12 @@ use crate::identities::{
 use crate::identity_specs::{IdentitySpecManager, IdentitySpecRegistry, IdentitySpecService};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
+use crate::source_artifacts::{LocalSourceArtifactStore, SourceArtifactStore};
+use crate::source_management::SourceManagementHandle;
 use crate::source_registry::SourceRegistry;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
-use crate::state::ConfigStore;
+use crate::state::{AppStateLayout, ConfigStore};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcRequestContextLayer;
@@ -97,12 +99,17 @@ type SourceIdentityProviderFactory =
 #[derive(Clone)]
 pub struct ServerExtensionContext {
     identity_management: IdentityManagementHandle,
+    source_management: SourceManagementHandle,
 }
 
 impl ServerExtensionContext {
-    fn new(identity_management: IdentityManagementHandle) -> Self {
+    fn new(
+        identity_management: IdentityManagementHandle,
+        source_management: SourceManagementHandle,
+    ) -> Self {
         Self {
             identity_management,
+            source_management,
         }
     }
 
@@ -110,6 +117,12 @@ impl ServerExtensionContext {
     #[must_use]
     pub fn identity_management(&self) -> &IdentityManagementHandle {
         &self.identity_management
+    }
+
+    /// Returns the shared source management handle for this server.
+    #[must_use]
+    pub fn source_management(&self) -> &SourceManagementHandle {
+        &self.source_management
     }
 }
 
@@ -153,6 +166,7 @@ pub struct ServerBuilder {
     source_identity_provider_factories: Vec<SourceIdentityProviderFactory>,
     identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
     source_registry: Option<Arc<dyn SourceRegistry>>,
+    source_artifact_store: Option<Arc<dyn SourceArtifactStore>>,
     identity_spec_registry: Option<Arc<dyn IdentitySpecRegistry>>,
     user_owned_identity_store: Option<Arc<dyn UserOwnedIdentityStore>>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
@@ -182,6 +196,7 @@ impl ServerBuilder {
             source_identity_provider_factories: Vec::new(),
             identity_spec_usage_providers: Vec::new(),
             source_registry: None,
+            source_artifact_store: None,
             identity_spec_registry: None,
             user_owned_identity_store: None,
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
@@ -337,6 +352,21 @@ impl ServerBuilder {
     }
 
     #[must_use]
+    /// Sets the durable artifact store used for installed source manifests and
+    /// DSL v4 materialized artifacts.
+    ///
+    /// The default store persists artifacts in the local Coral config
+    /// directory. Product-specific siblings can install a store backed by their
+    /// own durable control-plane storage.
+    pub fn with_source_artifact_store(
+        mut self,
+        source_artifact_store: Arc<dyn SourceArtifactStore>,
+    ) -> Self {
+        self.source_artifact_store = Some(source_artifact_store);
+        self
+    }
+
+    #[must_use]
     /// Sets the durable registry used for global identity specs.
     ///
     /// The default registry persists identity specs in local app state.
@@ -467,17 +497,21 @@ impl ServerBuilder {
             internal_trace_store_dir.clone(),
         )?;
         let config_store = ConfigStore::new(layout.clone());
-        let source_registry = self
-            .source_registry
-            .unwrap_or_else(|| Arc::new(config_store.clone()));
+        let (source_registry, source_artifact_store) = source_stores(
+            layout.clone(),
+            config_store.clone(),
+            self.source_registry,
+            self.source_artifact_store,
+        );
         let features =
             FeatureStore::new(layout.clone()).load_with_overrides(&self.feature_overrides)?;
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store.clone());
-        let source_manager = SourceManager::new_with_features_and_source_registry(
+        let source_manager = SourceManager::new_with_features_source_registry_and_artifact_store(
             Arc::clone(&source_registry),
+            Arc::clone(&source_artifact_store),
             credential_manager.clone(),
             layout.clone(),
             features.clone(),
@@ -491,40 +525,34 @@ impl ServerBuilder {
         let query_runtime_context = env
             .query_runtime_context()
             .with_body_capture_max_bytes(body_capture_max_bytes);
-        let identity_spec_manager =
-            if let Some(identity_spec_registry) = self.identity_spec_registry {
-                IdentitySpecManager::new_with_registry(
-                    layout.clone(),
-                    identity_spec_registry,
-                    features.clone(),
-                    self.identity_spec_usage_providers,
-                )
-            } else {
-                IdentitySpecManager::new_with_credential_store(
-                    layout.clone(),
-                    credential_store,
-                    features.clone(),
-                    self.identity_spec_usage_providers,
-                )
-            };
+        let identity_spec_manager = identity_spec_manager(
+            layout.clone(),
+            credential_store,
+            features.clone(),
+            self.identity_spec_registry,
+            self.identity_spec_usage_providers,
+        );
         let user_owned_identity_manager = if let Some(store) = self.user_owned_identity_store {
             UserOwnedIdentityManager::new_with_store(identity_spec_manager.clone(), store)
         } else {
             UserOwnedIdentityManager::new(layout.clone(), identity_spec_manager.clone())
         };
-        let extension_context = ServerExtensionContext::new(user_owned_identity_manager.handle());
+        let extension_context = ServerExtensionContext::new(
+            user_owned_identity_manager.handle(),
+            SourceManagementHandle::new(source_manager.clone()),
+        );
         let mut source_identity_providers = self.source_identity_providers;
         for source_identity_provider_factory in self.source_identity_provider_factories {
             source_identity_providers.push(source_identity_provider_factory(&extension_context));
         }
         source_identity_providers.push(Arc::new(user_owned_identity_manager.clone()));
 
-        let query_manager = QueryManager::new_with_features_and_source_registry(
+        let query_manager = QueryManager::new_with_features_source_registry_and_artifact_store(
             config_store,
             source_registry,
+            source_artifact_store,
             credential_manager,
             query_runtime_context,
-            layout.clone(),
             self.engine_extensions_providers,
             source_identity_providers,
             features,
@@ -550,6 +578,42 @@ impl ServerBuilder {
             extension_context,
         })
         .await
+    }
+}
+
+fn source_stores(
+    layout: AppStateLayout,
+    config_store: ConfigStore,
+    source_registry: Option<Arc<dyn SourceRegistry>>,
+    source_artifact_store: Option<Arc<dyn SourceArtifactStore>>,
+) -> (Arc<dyn SourceRegistry>, Arc<dyn SourceArtifactStore>) {
+    let source_registry = source_registry.unwrap_or_else(|| Arc::new(config_store));
+    let source_artifact_store =
+        source_artifact_store.unwrap_or_else(|| Arc::new(LocalSourceArtifactStore::new(layout)));
+    (source_registry, source_artifact_store)
+}
+
+fn identity_spec_manager(
+    layout: AppStateLayout,
+    credential_store: CredentialStore,
+    features: Features,
+    identity_spec_registry: Option<Arc<dyn IdentitySpecRegistry>>,
+    identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+) -> IdentitySpecManager {
+    if let Some(identity_spec_registry) = identity_spec_registry {
+        IdentitySpecManager::new_with_registry(
+            layout,
+            identity_spec_registry,
+            features,
+            identity_spec_usage_providers,
+        )
+    } else {
+        IdentitySpecManager::new_with_credential_store(
+            layout,
+            credential_store,
+            features,
+            identity_spec_usage_providers,
+        )
     }
 }
 
@@ -971,7 +1035,7 @@ mod tests {
     use crate::workspaces::WorkspaceName;
     use crate::{
         AppError, AwsEngineExtensionsProvider, NoopEngineExtensionsProvider,
-        SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider,
+        SingleUserPrincipalProvider, SourceManagementHandle, UserPrincipal, UserPrincipalProvider,
     };
 
     fn default_workspace() -> Workspace {
@@ -1023,13 +1087,17 @@ enabled = false
         let identity_spec_manager = IdentitySpecManager::new(layout.clone());
         let user_owned_identity_manager =
             UserOwnedIdentityManager::new(layout.clone(), identity_spec_manager.clone());
-        let extension_context = ServerExtensionContext::new(user_owned_identity_manager.handle());
+        let source_manager = SourceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+        );
+        let extension_context = ServerExtensionContext::new(
+            user_owned_identity_manager.handle(),
+            SourceManagementHandle::new(source_manager.clone()),
+        );
         let server = start_server(ServerServices {
-            source_manager: SourceManager::new(
-                config_store.clone(),
-                credential_manager.clone(),
-                layout.clone(),
-            ),
+            source_manager,
             query_manager: QueryManager::new(
                 config_store,
                 credential_manager,

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1503,6 +1503,7 @@ oauth:
     fn resolution_request(identity_name: &str) -> SourceIdentityResolutionRequest {
         SourceIdentityResolutionRequest {
             workspace_name: "default".to_string(),
+            request_principal: UserPrincipal::local(),
             subject: SourceIdentitySubject::User("local".to_string()),
             source_name: "github".to_string(),
             surface_id: "rest".to_string(),
@@ -1783,6 +1784,7 @@ oauth:
 
         let request = SourceIdentitySelectionRequest {
             workspace_name: "default".to_string(),
+            request_principal: principal.clone(),
             subject: SourceIdentitySubject::User("saul".to_string()),
             source_name: "github_v4".to_string(),
             surface_id: "rest".to_string(),
@@ -1797,6 +1799,7 @@ oauth:
         assert_eq!(resolved, selection);
 
         let missing_user = SourceIdentitySelectionRequest {
+            request_principal: UserPrincipal::for_user("tina").expect("principal"),
             subject: SourceIdentitySubject::User("tina".to_string()),
             ..request
         };

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -579,7 +579,7 @@ impl UserOwnedIdentityManager {
         self.store
             .load_identity(owner, &identity_name)
             .await?
-            .ok_or_else(|| AppError::IdentityNotFound(identity_name))
+            .ok_or_else(|| AppError::IdentityNotFound(identity_name.to_string()))
     }
 
     pub(crate) async fn get_user_owned_identity(
@@ -610,11 +610,10 @@ impl UserOwnedIdentityManager {
         let span = info_span!("coral.app.identities.delete_user_owned");
         let _guard = span.enter();
         let owner = IdentityOwnerKey::for_user_principal(principal)?;
-        let identity_name = validate_identity_name(identity_name)?;
-        if self.delete_identity(&owner, &identity_name).await? {
+        if self.delete_identity(&owner, identity_name).await? {
             Ok(())
         } else {
-            Err(AppError::IdentityNotFound(identity_name))
+            Err(AppError::IdentityNotFound(identity_name.to_string()))
         }
     }
 

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -570,6 +570,29 @@ impl UserOwnedIdentityManager {
         self.list_identities(&owner).await
     }
 
+    async fn get_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        let identity_name = validate_identity_name(identity_name)?;
+        self.store
+            .load_identity(owner, &identity_name)
+            .await?
+            .ok_or_else(|| AppError::IdentityNotFound(identity_name))
+    }
+
+    pub(crate) async fn get_user_owned_identity(
+        &self,
+        principal: &UserPrincipal,
+        identity_name: &str,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        let span = info_span!("coral.app.identities.get_user_owned");
+        let _guard = span.enter();
+        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+        self.get_identity(&owner, identity_name).await
+    }
+
     async fn delete_identity(
         &self,
         owner: &IdentityOwnerKey,
@@ -577,6 +600,22 @@ impl UserOwnedIdentityManager {
     ) -> Result<bool, AppError> {
         let identity_name = validate_identity_name(identity_name)?;
         self.store.delete_identity(owner, &identity_name).await
+    }
+
+    pub(crate) async fn delete_user_owned_identity(
+        &self,
+        principal: &UserPrincipal,
+        identity_name: &str,
+    ) -> Result<(), AppError> {
+        let span = info_span!("coral.app.identities.delete_user_owned");
+        let _guard = span.enter();
+        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+        let identity_name = validate_identity_name(identity_name)?;
+        if self.delete_identity(&owner, &identity_name).await? {
+            Ok(())
+        } else {
+            Err(AppError::IdentityNotFound(identity_name))
+        }
     }
 
     pub(crate) async fn replace_user_owned_source_identity_binding(
@@ -1659,6 +1698,51 @@ oauth:
             .await
             .expect("list identities");
         assert_eq!(listed, vec![record]);
+    }
+
+    #[tokio::test]
+    async fn gets_user_owned_identity_record() {
+        let (_temp, manager, _identity_specs) = manager();
+        let principal = UserPrincipal::local();
+        let record = github_local_record("github_oauth", "oauth");
+
+        manager
+            .store
+            .replace_identity(
+                &local_owner(),
+                &record,
+                &material(OAUTH_ACCESS_TOKEN_MATERIAL_KEY, "gho_token"),
+            )
+            .await
+            .expect("write identity");
+
+        let loaded = manager
+            .get_user_owned_identity(&principal, "github_local")
+            .await
+            .expect("get identity");
+        assert_eq!(loaded, record);
+    }
+
+    #[tokio::test]
+    async fn deletes_user_owned_identity_record() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        create_github_local(&manager, "token").await;
+
+        manager
+            .delete_user_owned_identity(&UserPrincipal::local(), "github_local")
+            .await
+            .expect("delete identity");
+
+        let listed = manager
+            .list_user_owned_identities(&UserPrincipal::local())
+            .await
+            .expect("list identities");
+        assert!(listed.is_empty(), "identity should be removed");
+        let error = manager
+            .delete_user_owned_identity(&UserPrincipal::local(), "github_local")
+            .await
+            .expect_err("second delete should report missing identity");
+        assert!(matches!(error, AppError::IdentityNotFound(name) if name == "github_local"));
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -130,20 +130,20 @@ impl IdentityServiceApi for IdentityService {
         &self,
         request: Request<GetUserOwnedIdentityRequest>,
     ) -> Result<Response<GetUserOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
         let identities = self.identities.clone();
-        instrument_authenticated_grpc(
-            &self.user_principal_provider,
-            request,
-            |principal, request| async move {
-                let record = identities
-                    .get_user_owned_identity(&principal, &request.name)
-                    .await
-                    .map_err(app_status)?;
-                Ok(Response::new(GetUserOwnedIdentityResponse {
-                    identity: Some(identity_record_to_proto(record)),
-                }))
-            },
-        )
+        instrument_grpc(span, async move {
+            let request_context = RequestContext::from_request(&request)?;
+            let principal = request_context.principal().clone();
+            let request = request.into_inner();
+            let record = identities
+                .get_user_owned_identity(&principal, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(GetUserOwnedIdentityResponse {
+                identity: Some(identity_record_to_proto(record)),
+            }))
+        })
         .await
     }
 
@@ -151,18 +151,18 @@ impl IdentityServiceApi for IdentityService {
         &self,
         request: Request<DeleteUserOwnedIdentityRequest>,
     ) -> Result<Response<DeleteUserOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
         let identities = self.identities.clone();
-        instrument_authenticated_grpc(
-            &self.user_principal_provider,
-            request,
-            |principal, request| async move {
-                identities
-                    .delete_user_owned_identity(&principal, &request.name)
-                    .await
-                    .map_err(app_status)?;
-                Ok(Response::new(DeleteUserOwnedIdentityResponse {}))
-            },
-        )
+        instrument_grpc(span, async move {
+            let request_context = RequestContext::from_request(&request)?;
+            let principal = request_context.principal().clone();
+            let request = request.into_inner();
+            identities
+                .delete_user_owned_identity(&principal, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(DeleteUserOwnedIdentityResponse {}))
+        })
         .await
     }
 }

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -6,8 +6,10 @@ use coral_api::v1::identity_service_server::IdentityService as IdentityServiceAp
 use coral_api::v1::{
     CreateUserOwnedIdentityWithFixedTokenRequest, CreateUserOwnedIdentityWithFixedTokenResponse,
     CreateUserOwnedIdentityWithOAuthRequest, CreateUserOwnedIdentityWithOAuthResponse,
-    CredentialMetadata, Identity, IdentityOwner, ListUserOwnedIdentitiesRequest,
-    ListUserOwnedIdentitiesResponse, create_user_owned_identity_with_o_auth_response,
+    CredentialMetadata, DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse,
+    GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse, Identity, IdentityOwner,
+    ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
+    create_user_owned_identity_with_o_auth_response,
 };
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
@@ -121,6 +123,46 @@ impl IdentityServiceApi for IdentityService {
                 identities: records.into_iter().map(identity_record_to_proto).collect(),
             }))
         })
+        .await
+    }
+
+    async fn get_user_owned_identity(
+        &self,
+        request: Request<GetUserOwnedIdentityRequest>,
+    ) -> Result<Response<GetUserOwnedIdentityResponse>, Status> {
+        let identities = self.identities.clone();
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |principal, request| async move {
+                let record = identities
+                    .get_user_owned_identity(&principal, &request.name)
+                    .await
+                    .map_err(app_status)?;
+                Ok(Response::new(GetUserOwnedIdentityResponse {
+                    identity: Some(identity_record_to_proto(record)),
+                }))
+            },
+        )
+        .await
+    }
+
+    async fn delete_user_owned_identity(
+        &self,
+        request: Request<DeleteUserOwnedIdentityRequest>,
+    ) -> Result<Response<DeleteUserOwnedIdentityResponse>, Status> {
+        let identities = self.identities.clone();
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |principal, request| async move {
+                identities
+                    .delete_user_owned_identity(&principal, &request.name)
+                    .await
+                    .map_err(app_status)?;
+                Ok(Response::new(DeleteUserOwnedIdentityResponse {}))
+            },
+        )
         .await
     }
 }

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -334,6 +334,8 @@ impl SourceIdentitySelection {
 pub struct SourceIdentitySelectionRequest {
     /// Workspace selected by the request.
     pub workspace_name: String,
+    /// User principal that initiated the request.
+    pub request_principal: UserPrincipal,
     /// Subject selected by Coral for this binding; user-owned bindings carry
     /// the request user id (`subject.user_id()`).
     pub subject: SourceIdentitySubject,
@@ -350,6 +352,8 @@ pub struct SourceIdentitySelectionRequest {
 pub struct SourceIdentityResolutionRequest {
     /// Workspace selected by the request.
     pub workspace_name: String,
+    /// User principal that initiated the request.
+    pub request_principal: UserPrincipal,
     /// Subject selected by Coral for this binding.
     ///
     /// User-owned bindings carry the request user id. Workspace-owned bindings

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -54,6 +54,8 @@ mod identity;
 mod identity_specs;
 mod query;
 mod request_context;
+mod source_artifacts;
+mod source_management;
 mod source_registry;
 mod sources;
 mod state;
@@ -72,6 +74,10 @@ pub use bootstrap::{
 pub use coral_engine::{
     EngineExtensions, QuerySource, RequestIdentityResolutionContext, RequestIdentityResolver,
     RequestIdentityResolverError,
+};
+pub use coral_spec::v4::{
+    Diagnostic, Fingerprint, MaterializedSurface, ProjectionCatalog, SemanticIr,
+    V4MaterializedSource, V4SourceManifest, validate_materialized_source,
 };
 pub use credentials::oauth::{OAuthProgressEvent, OAuthProgressEventSender};
 pub use identities::{
@@ -94,6 +100,8 @@ pub use identity_specs::{
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };
+pub use source_artifacts::{SourceArtifactBackup, SourceArtifactStore};
+pub use source_management::{ImportManagedSourceCommand, ManagedSource, SourceManagementHandle};
 pub use source_registry::{
     BundleIdentityInputDiscoveryError, BundleIdentityInputKind, BundleIdentityInputSpec,
     SourceRegistry, SourceRegistryCredentialStorage, SourceRegistryOrigin, SourceRegistryRecord,

--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -13,8 +13,8 @@ use coral_spec::ManifestInputKind;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
+use crate::source_registry::{SourceRegistry, installed_source_from_record};
 use crate::sources::SourceName;
-use crate::state::ConfigStore;
 use crate::workspaces::WorkspaceName;
 
 /// App-layer provider that selects engine extensions for one runtime build.
@@ -55,7 +55,7 @@ impl EngineExtensionsProvider for AwsEngineExtensionsProvider {
 #[derive(Clone)]
 pub(crate) struct CredentialRefreshingInputResolver {
     workspace_name: WorkspaceName,
-    config_store: ConfigStore,
+    source_registry: Arc<dyn SourceRegistry>,
     credential_manager: CredentialManager,
     delegate: Option<Arc<dyn SourceInputResolver>>,
 }
@@ -63,13 +63,13 @@ pub(crate) struct CredentialRefreshingInputResolver {
 impl CredentialRefreshingInputResolver {
     pub(crate) fn new(
         workspace_name: WorkspaceName,
-        config_store: ConfigStore,
+        source_registry: Arc<dyn SourceRegistry>,
         credential_manager: CredentialManager,
         delegate: Option<Arc<dyn SourceInputResolver>>,
     ) -> Self {
         Self {
             workspace_name,
-            config_store,
+            source_registry,
             credential_manager,
             delegate,
         }
@@ -95,8 +95,16 @@ impl SourceInputResolver for CredentialRefreshingInputResolver {
             .map_err(|error| SourceInputResolverError::invalid_input(error.to_string()))?;
         let credential_set_id = CredentialSetId::for_source(&source_name);
         let installed_source = self
-            .config_store
-            .get_source(&self.workspace_name, &source_name)
+            .source_registry
+            .get_source(self.workspace_name.as_str(), source_name.as_str())
+            .and_then(|record| {
+                record
+                    .map(|record| installed_source_from_record(&self.workspace_name, record))
+                    .transpose()?
+                    .ok_or_else(|| {
+                        AppError::SourceNotFound(format!("{}:{source_name}", self.workspace_name))
+                    })
+            })
             .map_err(source_input_error)?;
         let material =
             if let Some(credential_storage) = installed_source.credential_storage_for_material() {

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -659,6 +659,7 @@ impl LazyRuntimeIdentityResolver {
             .identity_manager
             .resolve_source_identity_selection(SourceIdentitySelectionRequest {
                 workspace_name: self.workspace_name.as_str().to_string(),
+                request_principal: self.request_principal.clone(),
                 subject: subject.clone(),
                 source_name: identity.source_name().to_string(),
                 surface_id: identity.surface_id().to_string(),
@@ -675,6 +676,7 @@ impl LazyRuntimeIdentityResolver {
             .identity_manager
             .resolve_source_identity(SourceIdentityResolutionRequest {
                 workspace_name: self.workspace_name.as_str().to_string(),
+                request_principal: self.request_principal.clone(),
                 subject,
                 source_name: identity.source_name().to_string(),
                 surface_id: identity.surface_id().to_string(),

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -550,7 +550,7 @@ impl QueryManager {
         let provider_input_resolver = extensions.source_input_resolver.take();
         extensions.source_input_resolver = Some(Arc::new(CredentialRefreshingInputResolver::new(
             workspace_name.clone(),
-            self.config_store.clone(),
+            Arc::clone(&self.source_registry),
             self.credential_manager.clone(),
             provider_input_resolver,
         )));

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -31,15 +31,18 @@ use crate::query::QueryContext;
 use crate::query::extensions::{
     CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
 };
+#[cfg(test)]
+use crate::source_artifacts::LocalSourceArtifactStore;
+use crate::source_artifacts::SourceArtifactStore;
 use crate::source_registry::{SourceRegistry, installed_source_from_record};
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest_with_imported_yaml;
-use crate::sources::materialization::{
-    incompatible_materialization_error, load_v4_materialization,
-};
+use crate::sources::materialization::incompatible_materialization_error;
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::runtime_components_for_v4_source;
-use crate::state::{AppConfig, AppStateLayout, ConfigStore};
+#[cfg(test)]
+use crate::state::AppStateLayout;
+use crate::state::{AppConfig, ConfigStore};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug)]
@@ -72,9 +75,9 @@ struct RegistryQuerySource {
 pub(crate) struct QueryManager {
     config_store: ConfigStore,
     source_registry: Arc<dyn SourceRegistry>,
+    artifact_store: Arc<dyn SourceArtifactStore>,
     credential_manager: CredentialManager,
     runtime_context: QueryRuntimeContext,
-    layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     identity_manager: IdentityManager,
     features: Features,
@@ -126,6 +129,7 @@ impl QueryManager {
         clippy::too_many_arguments,
         reason = "one-time wiring constructor; every argument is a distinct runtime dependency"
     )]
+    #[cfg(test)]
     pub(crate) fn new_with_features_and_source_registry(
         config_store: ConfigStore,
         source_registry: Arc<dyn SourceRegistry>,
@@ -136,12 +140,38 @@ impl QueryManager {
         identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
         features: Features,
     ) -> Self {
+        Self::new_with_features_source_registry_and_artifact_store(
+            config_store,
+            source_registry,
+            Arc::new(LocalSourceArtifactStore::new(layout)),
+            credential_manager,
+            runtime_context,
+            engine_extensions_providers,
+            identity_providers,
+            features,
+        )
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one-time wiring constructor; every argument is a distinct runtime dependency"
+    )]
+    pub(crate) fn new_with_features_source_registry_and_artifact_store(
+        config_store: ConfigStore,
+        source_registry: Arc<dyn SourceRegistry>,
+        artifact_store: Arc<dyn SourceArtifactStore>,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
+        features: Features,
+    ) -> Self {
         Self {
             config_store,
             source_registry,
+            artifact_store,
             credential_manager,
             runtime_context,
-            layout,
             engine_extensions_providers,
             identity_manager: IdentityManager::new(identity_providers),
             features,
@@ -405,15 +435,14 @@ impl QueryManager {
             workspace_name,
             source,
             imported_manifest_yaml,
-            &self.layout,
+            self.artifact_store.as_ref(),
         )?;
         let source_spec = installed.source_spec;
         let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
             self.features.ensure_dsl_v4_enabled()?;
-            let materialized = load_v4_materialization(
-                &self.layout,
-                workspace_name,
-                &source.name,
+            let materialized = self.artifact_store.load_v4_materialization(
+                workspace_name.as_str(),
+                source.name.as_str(),
                 &installed.manifest_yaml,
                 v4,
             )?;
@@ -972,6 +1001,7 @@ mod tests {
 
     struct QueryManagerFixture {
         _temp: TempDir,
+        layout: AppStateLayout,
         manager: QueryManager,
     }
 
@@ -1003,13 +1033,14 @@ mod tests {
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             runtime_context,
-            layout,
+            layout.clone(),
             providers,
             identity_providers,
             features,
         );
         QueryManagerFixture {
             _temp: temp,
+            layout,
             manager,
         }
     }
@@ -1269,11 +1300,11 @@ mod tests {
     /// Ensures the fixture layout exists and returns a v4-enabled source
     /// manager that shares the fixture's stores.
     fn v4_source_manager(fixture: &QueryManagerFixture) -> SourceManager {
-        fixture.manager.layout.ensure().expect("ensure layout");
+        fixture.layout.ensure().expect("ensure layout");
         SourceManager::new_with_features(
             fixture.manager.config_store.clone(),
             fixture.manager.credential_manager.clone(),
-            fixture.manager.layout.clone(),
+            fixture.layout.clone(),
             dsl_v4_features(),
         )
     }
@@ -1438,10 +1469,9 @@ surfaces:
         source_name: &str,
         manifest_yaml: &str,
     ) -> SourceName {
-        fixture.manager.layout.ensure().expect("ensure layout");
+        fixture.layout.ensure().expect("ensure layout");
         let source_name = SourceName::parse(source_name).expect("source name");
         let manifest_path = fixture
-            .manager
             .layout
             .manifest_file(&WorkspaceName::default(), &source_name);
         std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))

--- a/crates/coral-app/src/source_artifacts.rs
+++ b/crates/coral-app/src/source_artifacts.rs
@@ -1,0 +1,324 @@
+//! Source artifact storage extension seam.
+
+use std::any::Any;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use coral_spec::v4::{V4MaterializedSource, V4SourceManifest};
+use uuid::Uuid;
+
+use crate::bootstrap::AppError;
+use crate::sources::SourceName;
+use crate::sources::materialization::{
+    load_v4_materialization, replace_v4_materialization, restore_materialization_backup,
+};
+use crate::state::AppStateLayout;
+use crate::storage::fs;
+use crate::workspaces::WorkspaceName;
+
+/// Store-specific source artifact backup used to roll back failed source mutations.
+pub trait SourceArtifactBackup: fmt::Debug + Send + Sync + 'static {
+    /// Returns this backup as [`Any`] so the store that created it can recover
+    /// its concrete state.
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T> SourceArtifactBackup for T
+where
+    T: fmt::Debug + Send + Sync + 'static,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Durable storage backend for source manifest and DSL v4 materialized artifacts.
+///
+/// The default implementation stores artifacts under Coral's local config
+/// directory. Product runtimes can install an implementation that stores the
+/// authoritative artifact package elsewhere while preserving the source
+/// lifecycle logic in `SourceManager`.
+pub trait SourceArtifactStore: fmt::Debug + Send + Sync + 'static {
+    /// Reads the installed imported-source manifest, returning `None` when no
+    /// manifest artifact exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be read.
+    fn read_manifest_artifact(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<String>, AppError>;
+
+    /// Writes or removes the installed imported-source manifest artifact.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be updated.
+    fn persist_manifest_artifact(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        manifest_yaml: Option<&str>,
+    ) -> Result<(), AppError>;
+
+    /// Removes all artifacts for one source and returns a rollback backup when
+    /// the store had prior artifacts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be updated.
+    fn remove_source_artifacts(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<Box<dyn SourceArtifactBackup>>, AppError>;
+
+    /// Restores a backup produced by [`SourceArtifactStore::remove_source_artifacts`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be restored.
+    fn restore_source_artifacts_backup(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        backup: Option<Box<dyn SourceArtifactBackup>>,
+    ) -> Result<(), AppError>;
+
+    /// Cleans up a backup produced by [`SourceArtifactStore::remove_source_artifacts`].
+    fn cleanup_source_artifacts_backup(&self, backup: Option<Box<dyn SourceArtifactBackup>>);
+
+    /// Replaces the installed DSL v4 materialization from a prepared temporary
+    /// materialization directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be updated.
+    fn replace_v4_materialization(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        temp_dir: &Path,
+    ) -> Result<Option<Box<dyn SourceArtifactBackup>>, AppError>;
+
+    /// Restores a backup produced by [`SourceArtifactStore::replace_v4_materialization`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be restored.
+    fn restore_v4_materialization_backup(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        backup: Option<Box<dyn SourceArtifactBackup>>,
+    ) -> Result<(), AppError>;
+
+    /// Cleans up a backup produced by [`SourceArtifactStore::replace_v4_materialization`].
+    fn cleanup_v4_materialization_backup(&self, backup: Option<Box<dyn SourceArtifactBackup>>);
+
+    /// Loads and validates the installed DSL v4 materialization for query-time
+    /// runtime assembly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when artifacts are missing, incompatible, or cannot
+    /// be read.
+    fn load_v4_materialization(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        manifest_yaml: &str,
+        manifest: &V4SourceManifest,
+    ) -> Result<V4MaterializedSource, AppError>;
+}
+
+#[derive(Debug)]
+pub(crate) struct LocalSourceArtifactStore {
+    layout: AppStateLayout,
+}
+
+#[derive(Debug)]
+struct LocalPathBackup {
+    path: PathBuf,
+}
+
+impl LocalSourceArtifactStore {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
+    fn source_paths(
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<(WorkspaceName, SourceName), AppError> {
+        Ok((
+            WorkspaceName::parse(workspace_id)?,
+            SourceName::parse(source_name)?,
+        ))
+    }
+
+    fn backup_path(backup: &dyn SourceArtifactBackup) -> Result<PathBuf, AppError> {
+        backup
+            .as_any()
+            .downcast_ref::<LocalPathBackup>()
+            .map(|backup| backup.path.clone())
+            .ok_or_else(|| {
+                AppError::InvalidInput(
+                    "source artifact backup was not produced by the local artifact store"
+                        .to_string(),
+                )
+            })
+    }
+}
+
+impl SourceArtifactStore for LocalSourceArtifactStore {
+    fn read_manifest_artifact(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<String>, AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        let manifest_path = self.layout.manifest_file(&workspace_name, &source_name);
+        if !manifest_path.exists() {
+            return Ok(None);
+        }
+        std::fs::read_to_string(manifest_path)
+            .map(Some)
+            .map_err(Into::into)
+    }
+
+    fn persist_manifest_artifact(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        manifest_yaml: Option<&str>,
+    ) -> Result<(), AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        let manifest_path = self.layout.manifest_file(&workspace_name, &source_name);
+        match manifest_yaml {
+            Some(manifest_yaml) => {
+                if let Some(parent) = manifest_path.parent() {
+                    fs::ensure_dir(parent)?;
+                }
+                fs::write_atomic(&manifest_path, manifest_yaml.as_bytes())?;
+            }
+            None if manifest_path.exists() => {
+                std::fs::remove_file(&manifest_path)?;
+            }
+            None => {}
+        }
+        cleanup_empty_parent(&self.layout.workspaces_root(), manifest_path.parent());
+        Ok(())
+    }
+
+    fn remove_source_artifacts(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<Box<dyn SourceArtifactBackup>>, AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        let source_dir = self.layout.source_dir(&workspace_name, &source_name);
+        if !source_dir.exists() {
+            return Ok(None);
+        }
+        let backup =
+            source_dir.with_file_name(format!("{source_name}.delete.rollback.{}", Uuid::new_v4()));
+        if backup.exists() {
+            std::fs::remove_dir_all(&backup)?;
+        }
+        std::fs::rename(&source_dir, &backup)?;
+        Ok(Some(Box::new(LocalPathBackup { path: backup })))
+    }
+
+    fn restore_source_artifacts_backup(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        backup: Option<Box<dyn SourceArtifactBackup>>,
+    ) -> Result<(), AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        let source_dir = self.layout.source_dir(&workspace_name, &source_name);
+        if let Some(backup) = backup {
+            let backup = Self::backup_path(backup.as_ref())?;
+            if source_dir.exists() {
+                std::fs::remove_dir_all(&source_dir)?;
+            }
+            if backup.exists() {
+                std::fs::rename(backup, source_dir)?;
+            }
+        } else if source_dir.exists() {
+            std::fs::remove_dir_all(&source_dir)?;
+        }
+        Ok(())
+    }
+
+    fn cleanup_source_artifacts_backup(&self, backup: Option<Box<dyn SourceArtifactBackup>>) {
+        if let Some(backup) = backup
+            && let Ok(path) = Self::backup_path(backup.as_ref())
+            && path.exists()
+        {
+            drop(std::fs::remove_dir_all(path));
+        }
+    }
+
+    fn replace_v4_materialization(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        temp_dir: &Path,
+    ) -> Result<Option<Box<dyn SourceArtifactBackup>>, AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        replace_v4_materialization(&self.layout, &workspace_name, &source_name, temp_dir).map(
+            |backup| {
+                backup
+                    .map(|path| Box::new(LocalPathBackup { path }) as Box<dyn SourceArtifactBackup>)
+            },
+        )
+    }
+
+    fn restore_v4_materialization_backup(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        backup: Option<Box<dyn SourceArtifactBackup>>,
+    ) -> Result<(), AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        let backup = backup.as_deref().map(Self::backup_path).transpose()?;
+        restore_materialization_backup(&self.layout, &workspace_name, &source_name, backup)
+    }
+
+    fn cleanup_v4_materialization_backup(&self, backup: Option<Box<dyn SourceArtifactBackup>>) {
+        self.cleanup_source_artifacts_backup(backup);
+    }
+
+    fn load_v4_materialization(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        manifest_yaml: &str,
+        manifest: &V4SourceManifest,
+    ) -> Result<V4MaterializedSource, AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        load_v4_materialization(
+            &self.layout,
+            &workspace_name,
+            &source_name,
+            manifest_yaml,
+            manifest,
+        )
+    }
+}
+
+fn cleanup_empty_parent(root: &std::path::Path, path: Option<&std::path::Path>) {
+    let Some(path) = path else {
+        return;
+    };
+    if path == root || !path.starts_with(root) {
+        return;
+    }
+    if std::fs::remove_dir(path).is_ok() {
+        cleanup_empty_parent(root, path.parent());
+    }
+}

--- a/crates/coral-app/src/source_management.rs
+++ b/crates/coral-app/src/source_management.rs
@@ -1,0 +1,97 @@
+//! Public source-management handle for product-specific services.
+
+use std::collections::BTreeMap;
+
+use crate::bootstrap::AppError;
+use crate::identity::SourceIdentityBinding;
+use crate::sources::SourceName;
+use crate::sources::manager::{
+    ImportSourceCommand as ManagerImportSourceCommand, SourceBinding, SourceBindings, SourceManager,
+};
+use crate::workspaces::WorkspaceName;
+
+/// Source import command accepted by [`SourceManagementHandle`].
+pub struct ImportManagedSourceCommand {
+    /// Source manifest YAML to install into the workspace.
+    pub manifest_yaml: String,
+    /// Non-secret source variables.
+    pub variables: BTreeMap<String, String>,
+    /// Source-surface identity bindings.
+    pub identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+    /// Whether supplied identity bindings replace existing bindings.
+    pub replace_identity_bindings: bool,
+}
+
+/// Source installed or removed through [`SourceManagementHandle`].
+pub struct ManagedSource {
+    /// Installed source name.
+    pub name: String,
+    /// Authored source version, when available.
+    pub version: Option<String>,
+}
+
+/// Narrow source lifecycle handle exposed to product-specific server services.
+#[derive(Clone)]
+pub struct SourceManagementHandle {
+    sources: SourceManager,
+}
+
+impl SourceManagementHandle {
+    pub(crate) fn new(sources: SourceManager) -> Self {
+        Self { sources }
+    }
+
+    /// Imports a source into a workspace using the shared OSS source lifecycle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the workspace or source input is invalid, or
+    /// when source installation fails.
+    pub fn import_source(
+        &self,
+        workspace_id: &str,
+        command: ImportManagedSourceCommand,
+    ) -> Result<ManagedSource, AppError> {
+        let workspace_name = WorkspaceName::parse(workspace_id)?;
+        let installed = self.sources.import_source(
+            &workspace_name,
+            &ManagerImportSourceCommand {
+                manifest_yaml: command.manifest_yaml,
+                bindings: SourceBindings {
+                    variables: command
+                        .variables
+                        .into_iter()
+                        .map(|(key, value)| SourceBinding { key, value })
+                        .collect(),
+                    secrets: Vec::new(),
+                },
+                identity_bindings: command.identity_bindings,
+                replace_identity_bindings: command.replace_identity_bindings,
+            },
+        )?;
+        Ok(ManagedSource {
+            name: installed.name.as_str().to_string(),
+            version: installed.version,
+        })
+    }
+
+    /// Deletes a source from a workspace using the shared OSS source lifecycle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the workspace/source input is invalid, or when
+    /// source removal fails.
+    pub fn delete_source(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<ManagedSource, AppError> {
+        let workspace_name = WorkspaceName::parse(workspace_id)?;
+        let source_name = SourceName::parse(source_name)?;
+        let removed = self.sources.delete_source(&workspace_name, &source_name)?;
+        Ok(ManagedSource {
+            name: removed.name.as_str().to_string(),
+            version: removed.version,
+        })
+    }
+}

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -5,9 +5,9 @@ use std::collections::BTreeSet;
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 
 use crate::bootstrap::AppError;
+use crate::source_artifacts::SourceArtifactStore;
 use crate::sources::SourceName;
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
-use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 
 include!(concat!(env!("OUT_DIR"), "/bundled_sources.rs"));
@@ -63,21 +63,33 @@ pub(crate) fn load_bundled_source(name: &SourceName) -> Result<BundledSourceMani
 pub(crate) fn resolve_installed_manifest(
     workspace_name: &WorkspaceName,
     source: &InstalledSource,
-    layout: &AppStateLayout,
+    artifacts: &dyn SourceArtifactStore,
 ) -> Result<InstalledSourceManifest, AppError> {
-    resolve_installed_manifest_with_imported_yaml(workspace_name, source, None, layout)
+    resolve_installed_manifest_with_imported_yaml(workspace_name, source, None, artifacts)
 }
 
 pub(crate) fn resolve_installed_manifest_with_imported_yaml(
     workspace_name: &WorkspaceName,
     source: &InstalledSource,
     imported_manifest_yaml: Option<&str>,
-    layout: &AppStateLayout,
+    artifacts: &dyn SourceArtifactStore,
 ) -> Result<InstalledSourceManifest, AppError> {
     let manifest_yaml = match source.origin {
         SourceOrigin::Bundled => load_bundled_source(&source.name)?.manifest_yaml,
         SourceOrigin::Imported => imported_manifest_yaml.map_or_else(
-            || std::fs::read_to_string(layout.manifest_file(workspace_name, &source.name)),
+            || {
+                artifacts
+                    .read_manifest_artifact(workspace_name.as_str(), source.name.as_str())?
+                    .ok_or_else(|| {
+                        AppError::Io(std::io::Error::new(
+                            std::io::ErrorKind::NotFound,
+                            format!(
+                                "source '{}' is missing installed manifest artifact",
+                                source.name
+                            ),
+                        ))
+                    })
+            },
             |manifest_yaml| Ok(manifest_yaml.to_string()),
         )?,
     };

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -16,6 +16,9 @@ use crate::credentials::{
     CORAL_INTERNAL_KEY_PREFIX, CredentialManager, CredentialMaterialGuard,
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialsError,
 };
+#[cfg(test)]
+use crate::source_artifacts::LocalSourceArtifactStore;
+use crate::source_artifacts::SourceArtifactStore;
 use crate::source_registry::{
     SourceRegistry, installed_source_from_record, record_from_installed_source,
 };
@@ -25,19 +28,16 @@ use crate::sources::catalog::{
 };
 use crate::sources::materialization::{
     MaterializationBuild, MaterializationInputs, build_v4_materialization_tmp,
-    canonicalize_file_descriptor, cleanup_materialization_backup, cleanup_materialization_tmp,
-    new_materialization_suffix, replace_v4_materialization, restore_materialization_backup,
+    canonicalize_file_descriptor, cleanup_materialization_tmp, new_materialization_suffix,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
 #[cfg(test)]
 use crate::state::ConfigStore;
-use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tracing::warn;
-use uuid::Uuid;
 
 use crate::features::Features;
 use crate::identity::{SourceIdentityBinding, SourceIdentityOwner};
@@ -45,6 +45,7 @@ use crate::identity::{SourceIdentityBinding, SourceIdentityOwner};
 #[derive(Clone)]
 pub(crate) struct SourceManager {
     source_registry: Arc<dyn SourceRegistry>,
+    artifact_store: Arc<dyn SourceArtifactStore>,
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
     layout: AppStateLayout,
@@ -185,14 +186,32 @@ impl SourceManager {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn new_with_features_and_source_registry(
         source_registry: Arc<dyn SourceRegistry>,
         credential_manager: CredentialManager,
         layout: AppStateLayout,
         features: Features,
     ) -> Self {
+        Self::new_with_features_source_registry_and_artifact_store(
+            source_registry,
+            Arc::new(LocalSourceArtifactStore::new(layout.clone())),
+            credential_manager,
+            layout,
+            features,
+        )
+    }
+
+    pub(crate) fn new_with_features_source_registry_and_artifact_store(
+        source_registry: Arc<dyn SourceRegistry>,
+        artifact_store: Arc<dyn SourceArtifactStore>,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+        features: Features,
+    ) -> Self {
         Self {
             source_registry,
+            artifact_store,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
             layout,
@@ -260,9 +279,12 @@ impl SourceManager {
     ) -> Result<CandidateSource, AppError> {
         match self.get_registry_source(workspace_name, source_name) {
             Ok(Some(source)) => {
-                return Ok(
-                    resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
-                );
+                return Ok(resolve_installed_manifest(
+                    workspace_name,
+                    &source,
+                    self.artifact_store.as_ref(),
+                )?
+                .candidate);
             }
             Ok(None) => {}
             Err(error) => return Err(error),
@@ -551,7 +573,6 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let stored = self.require_registry_source(workspace_name, source_name)?;
         let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
-        let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
         let credential_guard = self
             .credential_manager
@@ -564,9 +585,9 @@ impl SourceManager {
             source: stored,
             manifest_yaml: match removed.origin {
                 SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
+                SourceOrigin::Imported => self
+                    .artifact_store
+                    .read_manifest_artifact(workspace_name.as_str(), source_name.as_str())?,
             },
             credential_material,
         };
@@ -582,14 +603,12 @@ impl SourceManager {
             );
             return Err(error);
         }
-        let source_dir_backup =
-            source_dir.with_file_name(format!("{source_name}.delete.rollback.{}", Uuid::new_v4()));
-        let had_source_dir = source_dir.exists();
-        if had_source_dir {
-            if source_dir_backup.exists() {
-                std::fs::remove_dir_all(&source_dir_backup)?;
-            }
-            if let Err(error) = std::fs::rename(&source_dir, &source_dir_backup) {
+        let artifact_backup = match self
+            .artifact_store
+            .remove_source_artifacts(workspace_name.as_str(), source_name.as_str())
+        {
+            Ok(backup) => backup,
+            Err(error) => {
                 self.restore_source_rollback_state(
                     workspace_name,
                     source_name,
@@ -597,20 +616,20 @@ impl SourceManager {
                     None,
                     &credential_guard,
                 );
-                return Err(error.into());
+                return Err(error);
             }
-        }
+        };
         if let Err(error) = self
             .source_registry
             .remove_source(workspace_name.as_str(), source_name.as_str())
         {
-            if had_source_dir
-                && source_dir_backup.exists()
-                && let Err(restore_error) = std::fs::rename(&source_dir_backup, &source_dir)
-            {
+            if let Err(restore_error) = self.artifact_store.restore_source_artifacts_backup(
+                workspace_name.as_str(),
+                source_name.as_str(),
+                artifact_backup,
+            ) {
                 return Err(AppError::FailedPrecondition(format!(
-                    "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
-                    source_dir_backup.display()
+                    "failed to remove source '{source_name}': {error}; failed to restore source artifacts: {restore_error}"
                 )));
             }
             self.restore_source_rollback_state(
@@ -622,14 +641,8 @@ impl SourceManager {
             );
             return Err(error);
         }
-        if source_dir_backup.exists() {
-            std::fs::remove_dir_all(&source_dir_backup)?;
-        }
-        cleanup_empty_parent(&self.layout.workspaces_root(), source_dir.parent());
-        cleanup_empty_parent(
-            &self.layout.workspaces_root(),
-            self.layout.workspace_dir(workspace_name).parent(),
-        );
+        self.artifact_store
+            .cleanup_source_artifacts_backup(artifact_backup);
         Ok(removed)
     }
 
@@ -659,9 +672,11 @@ impl SourceManager {
             .material_guard(workspace_name, &credential_set_id)?;
         let previous =
             self.load_source_rollback_state(workspace_name, &source_name, &credential_guard)?;
-        if let Err(error) =
-            self.persist_manifest_artifact(workspace_name, &source_name, request.manifest_yaml)
-        {
+        if let Err(error) = self.artifact_store.persist_manifest_artifact(
+            workspace_name.as_str(),
+            source_name.as_str(),
+            request.manifest_yaml,
+        ) {
             cleanup_materialization_tmp(request.materialization_tmp.as_deref());
             self.restore_source_rollback_state(
                 workspace_name,
@@ -726,10 +741,9 @@ impl SourceManager {
 
         let materialization_backup =
             if let Some(materialization_tmp) = request.materialization_tmp.as_ref() {
-                match replace_v4_materialization(
-                    &self.layout,
-                    workspace_name,
-                    &source_name,
+                match self.artifact_store.replace_v4_materialization(
+                    workspace_name.as_str(),
+                    source_name.as_str(),
                     materialization_tmp,
                 ) {
                     Ok(backup) => backup,
@@ -765,10 +779,9 @@ impl SourceManager {
         let mut record = record_from_installed_source(workspace_name, stored.clone());
         record.manifest_yaml = request.manifest_yaml.map(ToString::to_string);
         if let Err(error) = self.source_registry.upsert_source(record) {
-            let restore_result = restore_materialization_backup(
-                &self.layout,
-                workspace_name,
-                &source_name,
+            let restore_result = self.artifact_store.restore_v4_materialization_backup(
+                workspace_name.as_str(),
+                source_name.as_str(),
                 materialization_backup,
             );
             self.restore_source_rollback_state(
@@ -785,7 +798,8 @@ impl SourceManager {
             }
             return Err(error);
         }
-        cleanup_materialization_backup(materialization_backup);
+        self.artifact_store
+            .cleanup_v4_materialization_backup(materialization_backup);
         let mut resolved = stored;
         resolved.version.clone_from(&request.candidate.version);
         Ok(resolved)
@@ -835,8 +849,11 @@ impl SourceManager {
             if installed.name == *candidate_name {
                 continue;
             }
-            let installed_manifest =
-                resolve_installed_manifest(workspace_name, &installed, &self.layout)?;
+            let installed_manifest = resolve_installed_manifest(
+                workspace_name,
+                &installed,
+                self.artifact_store.as_ref(),
+            )?;
             let installed_schema_names = runtime_schema_names(&installed_manifest.source_spec);
             if let Some(schema_name) = candidate_schema_names
                 .intersection(&installed_schema_names)
@@ -1119,9 +1136,9 @@ impl SourceManager {
         Ok(Some(SourceRollbackState {
             manifest_yaml: match source.origin {
                 SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
+                SourceOrigin::Imported => self
+                    .artifact_store
+                    .read_manifest_artifact(workspace_name.as_str(), source_name.as_str())?,
             },
             source,
             credential_material,
@@ -1137,25 +1154,13 @@ impl SourceManager {
         credential_material: &CredentialMaterialGuard<'_>,
     ) {
         if let Some(previous) = previous {
-            let manifest_path = self.layout.manifest_file(workspace_name, source_name);
             let previous_manifest_yaml = previous.manifest_yaml.clone();
-            match previous.manifest_yaml {
-                Some(manifest_yaml) => {
-                    if let Some(parent) = manifest_path.parent()
-                        && let Err(e) = fs::ensure_dir(parent)
-                    {
-                        warn!("rollback: failed to create manifest parent dir: {e}");
-                    }
-                    if let Err(e) = fs::write_atomic(&manifest_path, manifest_yaml.as_bytes()) {
-                        warn!("rollback: failed to restore manifest file: {e}");
-                    }
-                }
-                None if manifest_path.exists() => {
-                    if let Err(e) = std::fs::remove_file(&manifest_path) {
-                        warn!("rollback: failed to remove manifest file: {e}");
-                    }
-                }
-                None => {}
+            if let Err(e) = self.artifact_store.persist_manifest_artifact(
+                workspace_name.as_str(),
+                source_name.as_str(),
+                previous.manifest_yaml.as_deref(),
+            ) {
+                warn!("rollback: failed to restore source manifest artifact: {e}");
             }
             match previous.credential_material {
                 Some(snapshot) => {
@@ -1177,11 +1182,12 @@ impl SourceManager {
                 warn!("rollback: failed to restore source config: {e}");
             }
         } else {
-            let source_dir = self.layout.source_dir(workspace_name, source_name);
-            if source_dir.exists()
-                && let Err(e) = std::fs::remove_dir_all(&source_dir)
-            {
-                warn!("rollback: failed to remove source directory: {e}");
+            if let Err(e) = self.artifact_store.restore_source_artifacts_backup(
+                workspace_name.as_str(),
+                source_name.as_str(),
+                None,
+            ) {
+                warn!("rollback: failed to remove source artifacts: {e}");
             }
             if let Some(storage) = new_material_storage
                 && let Err(e) = credential_material.remove_material(storage)
@@ -1191,37 +1197,15 @@ impl SourceManager {
         }
     }
 
-    fn persist_manifest_artifact(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-        manifest_yaml: Option<&str>,
-    ) -> Result<(), AppError> {
-        let manifest_path = self.layout.manifest_file(workspace_name, source_name);
-        match manifest_yaml {
-            Some(manifest_yaml) => {
-                if let Some(parent) = manifest_path.parent() {
-                    fs::ensure_dir(parent)?;
-                }
-                fs::write_atomic(&manifest_path, manifest_yaml.as_bytes())?;
-            }
-            None if manifest_path.exists() => {
-                std::fs::remove_file(&manifest_path)?;
-            }
-            None => {}
-        }
-        cleanup_empty_parent(&self.layout.workspaces_root(), manifest_path.parent());
-        Ok(())
-    }
-
     fn populate_source_version(
         &self,
         workspace_name: &WorkspaceName,
         mut source: InstalledSource,
     ) -> Result<InstalledSource, AppError> {
-        source.version = resolve_installed_manifest(workspace_name, &source, &self.layout)?
-            .candidate
-            .version;
+        source.version =
+            resolve_installed_manifest(workspace_name, &source, self.artifact_store.as_ref())?
+                .candidate
+                .version;
         Ok(source)
     }
 
@@ -1589,25 +1573,6 @@ fn durable_import_manifest_yaml(
         );
     }
     serde_yaml::to_string(&value).map_err(AppError::from)
-}
-
-fn cleanup_empty_parent(root: &std::path::Path, path: Option<&std::path::Path>) {
-    let Some(mut current) = path.map(std::path::Path::to_path_buf) else {
-        return;
-    };
-    while current.starts_with(root) && current != root {
-        let Ok(mut entries) = std::fs::read_dir(&current) else {
-            break;
-        };
-        if entries.next().is_some() {
-            break;
-        }
-        let next = current.parent().unwrap_or(root).to_path_buf();
-        if std::fs::remove_dir(&current).is_err() {
-            break;
-        }
-        current = next;
-    }
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -107,14 +107,6 @@ pub(crate) fn replace_v4_materialization(
     Ok(had_existing.then_some(backup))
 }
 
-pub(crate) fn cleanup_materialization_backup(backup: Option<PathBuf>) {
-    if let Some(backup) = backup
-        && backup.exists()
-    {
-        drop(std::fs::remove_dir_all(backup));
-    }
-}
-
 pub(crate) fn cleanup_materialization_tmp(temp_dir: Option<&Path>) {
     if let Some(temp_dir) = temp_dir
         && temp_dir.exists()

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -460,21 +460,26 @@ where
 }
 
 async fn import_source_with_identity_specs(
-    sources: &SourceManager,
+    sources: SourceManager,
     identity_import: IdentitySpecImportContext<'_>,
-    workspace_name: &WorkspaceName,
-    command: &ImportSourceCommand,
+    workspace_name: WorkspaceName,
+    command: ImportSourceCommand,
 ) -> Result<InstalledSource, AppError> {
     let rollback = install_and_validate_identity_specs_for_import(
-        sources,
+        &sources,
         identity_import,
-        workspace_name,
+        &workspace_name,
         &command.manifest_yaml,
         &command.identity_bindings,
         command.replace_identity_bindings,
     )
     .await?;
-    match sources.import_source(workspace_name, command) {
+    let span = tracing::Span::current();
+    let import = tokio::task::spawn_blocking(move || {
+        span.in_scope(|| sources.import_source(&workspace_name, &command))
+    })
+    .await?;
+    match import {
         Ok(source) => Ok(source),
         Err(error) => {
             rollback_identity_specs_for_import(identity_import.identity_specs, rollback);
@@ -613,10 +618,10 @@ async fn import_source_without_credentials(
     command: ImportSourceCommand,
 ) -> Result<Response<ImportSourceResponseStreamBox>, Status> {
     let installed = import_source_with_identity_specs(
-        &sources,
+        sources,
         identity_context.as_import_context(),
-        &workspace_name,
-        &command,
+        workspace_name.clone(),
+        command,
     )
     .await
     .map_err(app_status)?;

--- a/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
+++ b/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
@@ -23,6 +23,9 @@ use tonic::{Code, Request};
 
 use crate::harness::{GrpcHarness, fixture_manifest_yaml, source_dir};
 
+const ASYNC_TEST_TIMEOUT: Duration = Duration::from_secs(30);
+const BLOCKED_IMPORT_CHECK: Duration = Duration::from_millis(200);
+
 #[tokio::test]
 async fn query_refreshes_expired_oauth_access_token_at_request_time() {
     let fixture = RefreshingHttpFixture::new().await;
@@ -395,7 +398,7 @@ async fn manual_credential_replacement_waits_for_in_flight_refresh() {
     let mut source_client = harness.source_client();
     let import_manifest_yaml = oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url);
     let import_base_url = fixture.base_url.clone();
-    let import = tokio::spawn(async move {
+    let mut import = tokio::spawn(async move {
         let mut stream = source_client
             .import_source(Request::new(ImportSourceRequest {
                 workspace: Some(default_workspace()),
@@ -428,15 +431,22 @@ async fn manual_credential_replacement_waits_for_in_flight_refresh() {
             })
             .expect("import source response")
     });
-    tokio::time::sleep(Duration::from_millis(50)).await;
     assert!(
-        !import.is_finished(),
+        tokio::time::timeout(BLOCKED_IMPORT_CHECK, &mut import)
+            .await
+            .is_err(),
         "manual credential replacement should wait for the in-flight refresh"
     );
     fixture.allow_token_response();
 
-    let rows = query.await.expect("query task");
-    import.await.expect("import task");
+    let rows = tokio::time::timeout(ASYNC_TEST_TIMEOUT, query)
+        .await
+        .expect("query should complete after token response is released")
+        .expect("query task");
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, import)
+        .await
+        .expect("manual replacement should complete after refresh lock is released")
+        .expect("import task");
 
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["id"], "ok");
@@ -804,7 +814,9 @@ impl RefreshingHttpFixture {
     }
 
     async fn wait_for_token_request(&self) {
-        self.token_request_seen.notified().await;
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, self.token_request_seen.notified())
+            .await
+            .expect("query should request an OAuth token refresh");
     }
 
     fn allow_token_response(&self) {

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -66,6 +66,10 @@ enum Command {
     Sql(SqlArgs),
     /// Manage data sources
     Source(SourceArgs),
+    /// Manage stored user-owned identities
+    Identity(IdentityArgs),
+    /// Manage global identity specs used by source identity requirements
+    IdentitySpec(IdentitySpecArgs),
     /// Interactive wizard to set up Coral and explore use cases
     Onboard,
     /// Start the MCP server over stdio
@@ -312,6 +316,72 @@ enum SourceCommand {
     },
 }
 
+#[derive(Debug, Args)]
+/// Manage stored user-owned identities
+struct IdentityArgs {
+    #[command(subcommand)]
+    command: IdentityCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum IdentityCommand {
+    /// List stored user-owned identities
+    List,
+    /// Show a stored user-owned identity
+    Info {
+        /// Identity name
+        name: String,
+    },
+    /// Create or replace a user-owned identity from an identity spec
+    Add {
+        /// Identity name used by source identity bindings
+        name: String,
+        /// Installed identity spec name
+        #[arg(long = "identity-spec")]
+        identity_spec: String,
+        /// Read the fixed-token credential from stdin instead of prompting
+        #[arg(long = "token-stdin")]
+        token_stdin: bool,
+    },
+    /// Remove a stored user-owned identity
+    Remove {
+        /// Identity name
+        name: String,
+    },
+}
+
+#[derive(Debug, Args)]
+/// Manage global identity specs used by source identity requirements
+struct IdentitySpecArgs {
+    #[command(subcommand)]
+    command: IdentitySpecCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum IdentitySpecCommand {
+    /// List installed identity specs
+    List,
+    /// Show an installed identity spec
+    Info {
+        /// Identity spec name
+        name: String,
+    },
+    /// Install an identity spec or replace an unused existing spec from a manifest file
+    Add {
+        /// Path to an identity spec YAML file
+        #[arg(long)]
+        file: PathBuf,
+    },
+    /// Remove an installed identity spec
+    Remove {
+        /// Identity spec name
+        name: String,
+        /// Confirm removal when stored identity instances would become orphaned
+        #[arg(long)]
+        force: bool,
+    },
+}
+
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 /// Output format for rendered SQL query results.
 pub enum OutputFormat {
@@ -382,9 +452,12 @@ impl CliError {
 impl Command {
     fn required_runtime(&self) -> RequiredRuntime {
         match self {
-            Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
-                RequiredRuntime::AppClient
-            }
+            Command::Sql(_)
+            | Command::Source(_)
+            | Command::Identity(_)
+            | Command::IdentitySpec(_)
+            | Command::Onboard
+            | Command::McpStdio(_) => RequiredRuntime::AppClient,
             Command::Features(_) | Command::Completion(_) => RequiredRuntime::None,
             #[cfg(feature = "embedded-ui")]
             Command::Ui(_) => RequiredRuntime::None,
@@ -651,7 +724,12 @@ async fn run_no_runtime_command(
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args).await.map_err(Into::into),
-        Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
+        Command::Sql(_)
+        | Command::Source(_)
+        | Command::Identity(_)
+        | Command::IdentitySpec(_)
+        | Command::Onboard
+        | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
         }
     }
@@ -668,6 +746,8 @@ async fn run_app_command(
             run_sql(&app, default_workspace(), args.sql, args.format).await?;
         }
         Command::Source(args) => run_source(&app, args).await?,
+        Command::Identity(args) => run_identity(&app, args).await?,
+        Command::IdentitySpec(args) => run_identity_spec(&app, args).await?,
         Command::Onboard => {
             onboard::run(&app).await?;
         }
@@ -790,6 +870,163 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
         }
         SourceCommand::Remove { name } => {
             source_ops::remove_and_print(app, &name).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn run_identity(app: &AppClient, args: IdentityArgs) -> Result<(), CliError> {
+    match args.command {
+        IdentityCommand::List => {
+            let identities = source_ops::list_user_owned_identities(app).await?;
+            if identities.is_empty() {
+                println!("No identities configured.");
+            } else {
+                let rows = identities.into_iter().map(|identity| {
+                    [
+                        identity.name,
+                        identity.identity_spec,
+                        identity.issuer,
+                        identity.identity_type,
+                        source_ops::identity_owner_label(identity.owner).to_string(),
+                    ]
+                });
+                print_text_table(
+                    ["Identity", "Identity Spec", "Issuer", "Type", "Owner"],
+                    rows,
+                );
+            }
+        }
+        IdentityCommand::Info { name } => {
+            let identity = source_ops::get_user_owned_identity(app, &name).await?;
+            print_identity_info(&identity);
+        }
+        IdentityCommand::Add {
+            name,
+            identity_spec,
+            token_stdin,
+        } => {
+            let identity_spec_record = source_ops::get_identity_spec(app, &identity_spec).await?;
+            let manifest =
+                coral_spec::parse_identity_manifest_yaml(&identity_spec_record.manifest_yaml)
+                    .map_err(anyhow::Error::from)?;
+            let identity = match manifest.identity_type {
+                coral_spec::IdentitySpecType::OAuth => {
+                    if token_stdin {
+                        return Err(anyhow::anyhow!(
+                            "--token-stdin is only supported for fixed-token identity specs"
+                        )
+                        .into());
+                    }
+                    source_ops::require_interactive_for("identity OAuth setup")?;
+                    let selected = source_ops::identity_oauth_method(&manifest)?;
+                    source_ops::print_oauth_hint(selected.hint);
+                    let credential_inputs =
+                        source_ops::prompt_identity_oauth_inputs(&manifest, selected.oauth)?;
+                    source_ops::create_user_owned_identity_with_oauth(
+                        app,
+                        &name,
+                        &identity_spec,
+                        credential_inputs,
+                        &selected.label,
+                    )
+                    .await?
+                }
+                coral_spec::IdentitySpecType::FixedToken => {
+                    let token = if token_stdin {
+                        source_ops::read_fixed_token_identity_token_from_stdin()?
+                    } else {
+                        source_ops::require_interactive_for("fixed-token identity setup")?;
+                        source_ops::prompt_fixed_token_identity_token(&identity_spec)?
+                    };
+                    source_ops::create_user_owned_identity_with_fixed_token(
+                        app,
+                        &name,
+                        &identity_spec,
+                        token,
+                    )
+                    .await?
+                }
+            };
+            println!(
+                "Created identity {} ({})",
+                identity.name, identity.identity_spec
+            );
+        }
+        IdentityCommand::Remove { name } => {
+            source_ops::delete_user_owned_identity(app, &name).await?;
+            println!("Removed identity {name}");
+        }
+    }
+    Ok(())
+}
+
+fn print_identity_info(identity: &coral_api::v1::Identity) {
+    println!("{}", identity.name);
+    println!("  Identity spec: {}", identity.identity_spec);
+    println!("  Issuer:        {}", identity.issuer);
+    println!("  Type:          {}", identity.identity_type);
+    println!(
+        "  Owner:         {}",
+        source_ops::identity_owner_label(identity.owner)
+    );
+    if !identity.metadata.is_empty() {
+        println!("  Metadata:");
+        for item in &identity.metadata {
+            println!("    {}: {}", item.key, item.value);
+        }
+    }
+}
+
+async fn run_identity_spec(app: &AppClient, args: IdentitySpecArgs) -> Result<(), CliError> {
+    match args.command {
+        IdentitySpecCommand::List => {
+            let identity_specs = source_ops::list_identity_specs(app).await?;
+            if identity_specs.is_empty() {
+                println!("No identity specs installed.");
+            } else {
+                let rows = identity_specs.into_iter().map(|identity_spec| {
+                    [
+                        identity_spec.name,
+                        source_ops::display_version(&identity_spec.version),
+                        identity_spec.issuer,
+                        identity_spec.identity_type,
+                    ]
+                });
+                print_text_table(["Identity Spec", "Version", "Issuer", "Type"], rows);
+            }
+        }
+        IdentitySpecCommand::Info { name } => {
+            let identity_spec = source_ops::get_identity_spec(app, &name).await?;
+            print!("{}", identity_spec.manifest_yaml);
+        }
+        IdentitySpecCommand::Add { file } => {
+            let manifest_yaml = source_ops::load_validated_identity_spec_file(&file)?;
+            let manifest = coral_spec::parse_identity_manifest_yaml(&manifest_yaml)
+                .map_err(anyhow::Error::from)?;
+            let inputs = source_ops::identity_spec_inputs_for_add(
+                &manifest,
+                format!(
+                    "coral identity-spec add --file {}",
+                    source_ops::shell_quote_arg(&file.display().to_string())
+                ),
+            )?;
+            let (identity_spec, replaced) =
+                source_ops::add_identity_spec(app, manifest_yaml, inputs).await?;
+            let action = if replaced { "Replaced" } else { "Added" };
+            println!(
+                "{action} identity spec {} ({})",
+                identity_spec.name,
+                source_ops::display_version(&identity_spec.version)
+            );
+        }
+        IdentitySpecCommand::Remove { name, force } => {
+            let orphaned = source_ops::remove_identity_spec(app, &name, force).await?;
+            if orphaned == 0 {
+                println!("Removed identity spec {name}");
+            } else {
+                println!("Removed identity spec {name} (orphaned identities: {orphaned})");
+            }
         }
     }
     Ok(())

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -13,12 +13,14 @@ use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
     AddIdentitySpecRequest, CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
     CreateUserOwnedIdentityWithFixedTokenRequest, CreateUserOwnedIdentityWithOAuthRequest,
-    DeleteSourceRequest, DiscoverSourcesRequest, GetIdentitySpecRequest, GetSourceInfoRequest,
-    Identity, IdentitySpec, IdentitySpecImportInputs, IdentitySpecInput, ImportSourceRequest,
-    ListSourcesRequest, ListUserOwnedIdentitiesRequest, OAuthCredentialInput,
-    OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source, SourceCredentialStorage,
-    SourceIdentityBinding, SourceIdentityOwner, SourceInfo, SourceOrigin, SourceSecret,
-    SourceVariable, UserSourceIdentityBinding, ValidateSourceRequest, ValidateSourceResponse,
+    DeleteIdentitySpecRequest, DeleteSourceRequest, DeleteUserOwnedIdentityRequest,
+    DiscoverSourcesRequest, GetIdentitySpecRequest, GetSourceInfoRequest,
+    GetUserOwnedIdentityRequest, Identity, IdentityOwner, IdentitySpec, IdentitySpecImportInputs,
+    IdentitySpecInput, ImportSourceRequest, ListIdentitySpecsRequest, ListSourcesRequest,
+    ListUserOwnedIdentitiesRequest, OAuthCredentialInput, OAuthCredentialRetrieval,
+    QueryTestFailure, QueryTestSuccess, Source, SourceCredentialStorage, SourceIdentityBinding,
+    SourceIdentityOwner, SourceInfo, SourceOrigin, SourceSecret, SourceVariable,
+    UserSourceIdentityBinding, ValidateSourceRequest, ValidateSourceResponse,
     create_bundled_source_with_o_auth_response, create_user_owned_identity_with_o_auth_response,
     import_source_response, query_test_result, source_input_spec::Input as ProtoSourceInput,
 };
@@ -117,6 +119,12 @@ macro_rules! rpc_fn {
 }
 
 rpc_fn! {
+    fn list_identity_specs() -> Vec<IdentitySpec>;
+    identity_spec_client.list_identity_specs(ListIdentitySpecsRequest {});
+    |response| response.identity_specs
+}
+
+rpc_fn! {
     fn get_identity_spec(name: &str) -> IdentitySpec;
     identity_spec_client.get_identity_spec(GetIdentitySpecRequest {
         name: name.to_string(),
@@ -144,9 +152,38 @@ rpc_fn! {
 }
 
 rpc_fn! {
+    fn remove_identity_spec(name: &str, force: bool) -> u32;
+    identity_spec_client.delete_identity_spec(DeleteIdentitySpecRequest {
+        name: name.to_string(),
+        force,
+    });
+    |response| response.orphaned_identities
+}
+
+rpc_fn! {
     fn list_user_owned_identities() -> Vec<Identity>;
     identity_client.list_user_owned_identities(ListUserOwnedIdentitiesRequest {});
     |response| response.identities
+}
+
+rpc_fn! {
+    fn get_user_owned_identity(name: &str) -> Identity;
+    identity_client.get_user_owned_identity(GetUserOwnedIdentityRequest {
+        name: name.to_string(),
+    });
+    |response| response
+        .identity
+        .ok_or_else(|| anyhow::anyhow!("get user-owned identity response missing identity"))?
+}
+
+rpc_fn! {
+    fn delete_user_owned_identity(name: &str) -> ();
+    identity_client.delete_user_owned_identity(DeleteUserOwnedIdentityRequest {
+        name: name.to_string(),
+    });
+    |response| {
+        let _ = response;
+    }
 }
 
 pub(crate) async fn create_user_owned_identity_with_oauth(
@@ -736,6 +773,18 @@ pub(crate) fn prompt_fixed_token_identity_token(
     Ok(token)
 }
 
+pub(crate) fn read_fixed_token_identity_token_from_stdin() -> Result<String, anyhow::Error> {
+    let mut token = String::new();
+    stdin().read_to_string(&mut token)?;
+    let token = token.trim_end_matches(['\r', '\n']).to_string();
+    if token.is_empty() {
+        return Err(anyhow::anyhow!(
+            "fixed token identity token must not be empty"
+        ));
+    }
+    Ok(token)
+}
+
 async fn identity_spec_manifest_cached(
     app: &AppClient,
     identity_specs: &mut BTreeMap<String, IdentityManifest>,
@@ -977,6 +1026,12 @@ pub(crate) fn load_validated_manifest_file(
 ) -> Result<(String, ValidatedSourceManifest), anyhow::Error> {
     let bundle = load_validated_manifest_bundle_file(file)?;
     Ok((bundle.source_manifest_yaml, bundle.source_manifest))
+}
+
+pub(crate) fn load_validated_identity_spec_file(file: &Path) -> Result<String, anyhow::Error> {
+    let raw = std::fs::read_to_string(file)?;
+    parse_identity_manifest_yaml(&raw)?;
+    Ok(raw)
 }
 
 pub(crate) struct ValidatedManifestBundleFile {
@@ -1492,6 +1547,13 @@ pub(crate) fn source_credential_storage_label(storage: i32) -> &'static str {
         Ok(SourceCredentialStorage::File) => "file (plaintext)",
         Ok(SourceCredentialStorage::Keychain) => "keychain",
         Err(_) => "unknown",
+    }
+}
+
+pub(crate) fn identity_owner_label(owner: i32) -> &'static str {
+    match IdentityOwner::try_from(owner) {
+        Ok(IdentityOwner::User) => "user",
+        Ok(IdentityOwner::Unspecified) | Err(_) => "unknown",
     }
 }
 

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -18,8 +18,8 @@ use arrow::record_batch::RecordBatch;
 use assert_cmd::Command;
 use assert_cmd::assert::Assert;
 use coral_api::v1::{
-    DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, Source,
-    SourceCredentialStorage, SourceInfo, SourceOrigin,
+    DiscoverSourcesResponse, ExecuteSqlResponse, GetIdentitySpecResponse, IdentitySpec,
+    ListSourcesResponse, Source, SourceCredentialStorage, SourceInfo, SourceOrigin,
 };
 use tempfile::{TempDir, tempdir};
 use tonic::Code;
@@ -866,6 +866,160 @@ tables:
     assert!(
         !requests[0].manifest_yaml.contains("kind: identity"),
         "source manifest sent to import should contain only the source document"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_commands_use_identity_spec_service() {
+    let server = MockServer::start().await;
+    let source_dir = tempdir().expect("identity spec dir");
+    let identity_file = write_yaml(
+        &source_dir,
+        "github_oauth.yaml",
+        &fixed_token_spec_yaml("github_oauth"),
+    );
+
+    add_file_cmd(&server, "identity-spec", &identity_file)
+        .assert()
+        .success();
+    run_cli(&server, &["identity-spec", "list"]).success();
+    run_cli(&server, &["identity-spec", "info", "github_oauth"]).success();
+    run_cli(
+        &server,
+        &["identity-spec", "remove", "github_oauth", "--force"],
+    )
+    .success();
+
+    assert_eq!(server.add_identity_spec_requests().len(), 1);
+    assert_eq!(server.list_identity_specs_requests().len(), 1);
+    assert_eq!(server.get_identity_spec_requests()[0].name, "github_oauth");
+    let delete_requests = server.delete_identity_spec_requests();
+    assert_eq!(delete_requests[0].name, "github_oauth");
+    assert!(delete_requests[0].force);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_add_noninteractive_does_not_send_manifest_defaults_as_inputs() {
+    let server = MockServer::start().await;
+    let source_dir = tempdir().expect("identity spec dir");
+    let identity_file = write_yaml(
+        &source_dir,
+        "demo_oauth.yaml",
+        r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+description: Demo OAuth identity.
+issuer: demo
+type: oauth
+audience:
+  host: example.test
+inputs:
+  DEMO_TENANT:
+    kind: variable
+    default: tenant-a
+  DEMO_OAUTH_CLIENT_SECRET:
+    kind: secret
+oauth:
+  method:
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    endpoints:
+      authorization_url: https://{{input.DEMO_TENANT}}.example.test/oauth/authorize
+      token_url: https://{{input.DEMO_TENANT}}.example.test/oauth/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+        transport: request_body
+",
+    );
+
+    add_file_cmd(&server, "identity-spec", &identity_file)
+        .env_remove("DEMO_TENANT")
+        .env("DEMO_OAUTH_CLIENT_SECRET", "client-secret")
+        .assert()
+        .success();
+
+    let requests = server.add_identity_spec_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].inputs.len(), 1);
+    assert_eq!(requests[0].inputs[0].key, "DEMO_OAUTH_CLIENT_SECRET");
+    assert_eq!(requests[0].inputs[0].value, "client-secret");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_commands_use_identity_service() {
+    let server = MockServer::start().await;
+
+    run_cli(&server, &["identity", "list"]).success();
+    run_cli(&server, &["identity", "info", "github_local"]).success();
+    run_cli(&server, &["identity", "remove", "github_local"]).success();
+
+    assert_eq!(server.list_user_owned_identities_requests().len(), 1);
+    assert_eq!(
+        server.get_user_owned_identity_requests()[0].name,
+        "github_local"
+    );
+    assert_eq!(
+        server.delete_user_owned_identity_requests()[0].name,
+        "github_local"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_add_fixed_token_reads_token_from_stdin() {
+    let server = MockServer::start_with_config(MockServerConfig::default().with_get_identity_spec(
+        GetIdentitySpecResponse {
+            identity_spec: Some(IdentitySpec {
+                name: "github_pat".to_string(),
+                version: "0.1.0".to_string(),
+                description: "GitHub PAT identity.".to_string(),
+                issuer: "github".to_string(),
+                identity_type: "fixed_token".to_string(),
+                manifest_yaml: fixed_token_spec_yaml("github_pat"),
+            }),
+        },
+    ))
+    .await;
+
+    server
+        .cmd()
+        .args([
+            "identity",
+            "add",
+            "github_local",
+            "--identity-spec",
+            "github_pat",
+            "--token-stdin",
+        ])
+        .write_stdin("pat-token\n")
+        .assert()
+        .success();
+
+    assert_eq!(server.get_identity_spec_requests()[0].name, "github_pat");
+    let requests = server.create_user_owned_identity_with_fixed_token_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].name, "github_local");
+    assert_eq!(requests[0].identity_spec, "github_pat");
+    assert_eq!(requests[0].token, "pat-token");
+    assert!(
+        server
+            .create_user_owned_identity_with_oauth_requests()
+            .is_empty(),
+        "fixed-token identity add must not use OAuth creation"
     );
 
     server.shutdown().await;

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -25,17 +25,19 @@ use coral_api::v1::{
     CreateBundledSourceWithOAuthResponse, CreateUserOwnedIdentityWithFixedTokenRequest,
     CreateUserOwnedIdentityWithFixedTokenResponse, CreateUserOwnedIdentityWithOAuthRequest,
     CreateUserOwnedIdentityWithOAuthResponse, DeleteIdentitySpecRequest,
-    DeleteIdentitySpecResponse, DeleteSourceRequest, DeleteSourceResponse, DescribeTableRequest,
+    DeleteIdentitySpecResponse, DeleteSourceRequest, DeleteSourceResponse,
+    DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse, DescribeTableRequest,
     DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest,
     ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse, GetIdentitySpecRequest,
     GetIdentitySpecResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
-    GetSourceResponse, Identity, IdentityOwner, IdentitySpec, ImportSourceRequest,
-    ImportSourceResponse, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
-    ListColumnsResponse, ListIdentitySpecsRequest, ListIdentitySpecsResponse, ListSourcesRequest,
-    ListSourcesResponse, ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
-    PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse,
-    Source, SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput,
-    Table, TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
+    GetSourceResponse, GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse, Identity,
+    IdentityOwner, IdentitySpec, ImportSourceRequest, ImportSourceResponse, ListCatalogRequest,
+    ListCatalogResponse, ListColumnsRequest, ListColumnsResponse, ListIdentitySpecsRequest,
+    ListIdentitySpecsResponse, ListSourcesRequest, ListSourcesResponse,
+    ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse, PaginationRequest,
+    PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse, Source,
+    SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table,
+    TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
     create_bundled_source_with_o_auth_response, create_user_owned_identity_with_o_auth_response,
     import_source_response, source_input_spec::Input as ProtoSourceInput,
 };
@@ -490,6 +492,8 @@ pub(crate) struct MockServerConfig {
     discover_sources: MockResult<DiscoverSourcesResponse>,
     list_sources: MockResult<ListSourcesResponse>,
     list_user_owned_identities: MockResult<ListUserOwnedIdentitiesResponse>,
+    get_user_owned_identity: MockResult<GetUserOwnedIdentityResponse>,
+    delete_user_owned_identity: MockResult<()>,
     list_identity_specs: MockResult<ListIdentitySpecsResponse>,
     get_identity_spec: MockResult<GetIdentitySpecResponse>,
     delete_identity_spec: MockResult<()>,
@@ -511,6 +515,10 @@ impl Default for MockServerConfig {
             list_user_owned_identities: MockResult::ok(ListUserOwnedIdentitiesResponse {
                 identities: vec![mock_identity()],
             }),
+            get_user_owned_identity: MockResult::ok(GetUserOwnedIdentityResponse {
+                identity: Some(mock_identity()),
+            }),
+            delete_user_owned_identity: MockResult::ok(()),
             delete_identity_spec: MockResult::ok(()),
             list_sources: MockResult::ok(ListSourcesResponse {
                 sources: vec![
@@ -685,6 +693,9 @@ captured_requests! {
         CreateUserOwnedIdentityWithFixedTokenRequest,
     list_user_owned_identities as list_user_owned_identities_requests:
         ListUserOwnedIdentitiesRequest,
+    get_user_owned_identity as get_user_owned_identity_requests: GetUserOwnedIdentityRequest,
+    delete_user_owned_identity as delete_user_owned_identity_requests:
+        DeleteUserOwnedIdentityRequest,
     delete_source as delete_source_requests: DeleteSourceRequest,
     validate_source as validate_source_requests: ValidateSourceRequest,
 }
@@ -986,6 +997,15 @@ mock_service! {
         fn list_user_owned_identities(list_user_owned_identities, ListUserOwnedIdentitiesRequest)
             -> ListUserOwnedIdentitiesResponse =
             |cfg, _request| cfg.list_user_owned_identities.clone().into_tonic_result()?;
+        fn get_user_owned_identity(get_user_owned_identity, GetUserOwnedIdentityRequest)
+            -> GetUserOwnedIdentityResponse =
+            |cfg, _request| cfg.get_user_owned_identity.clone().into_tonic_result()?;
+        fn delete_user_owned_identity(delete_user_owned_identity, DeleteUserOwnedIdentityRequest)
+            -> DeleteUserOwnedIdentityResponse =
+            |cfg, _request| {
+                cfg.delete_user_owned_identity.clone().into_tonic_result()?;
+                DeleteUserOwnedIdentityResponse {}
+            };
     }
 }
 

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -96,7 +96,7 @@ impl AppClient {
         I: IntoIterator<Item = (K, V)>,
     {
         let static_metadata = StaticClientMetadata::try_from_pairs(metadata)?;
-        let endpoint = Endpoint::from_shared(endpoint_uri.to_string())?
+        let endpoint = Endpoint::new(endpoint_uri.to_string())?
             .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE);
         let grpc_endpoint = GrpcClientEndpoint::from_endpoint_uri(endpoint_uri);
         let channel = endpoint.connect().await?;

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -193,6 +193,99 @@ Remove an installed source.
 coral source remove github
 ```
 
+## `coral identity`
+
+Manage stored user-owned identities (see the
+[identity spec reference](/reference/identity-spec-reference) for what
+user-owned identities are and how DSL v4 sources resolve them).
+
+### `coral identity list`
+
+List stored user-owned identities.
+
+```shellscript
+coral identity list
+```
+
+### `coral identity info <NAME>`
+
+Show one stored user-owned identity without revealing credential material.
+
+```shellscript
+coral identity info github_local
+```
+
+### `coral identity add <NAME> --identity-spec <SPEC> [--token-stdin]`
+
+Create or replace a user-owned identity from an installed OAuth or fixed-token
+identity spec. For OAuth specs, Coral runs the spec's OAuth setup method. For
+fixed-token specs, Coral prompts for the bearer token by default, or reads it
+from stdin when `--token-stdin` is set. In both cases, Coral stores provider
+identity material for the local Coral user principal.
+
+```shellscript
+coral identity add github_local --identity-spec github_oauth
+printf '%s\n' "$GITHUB_TOKEN" | coral identity add github_pat --identity-spec github_pat --token-stdin
+```
+
+### `coral identity remove <NAME>`
+
+Remove one stored user-owned identity and its local credential material.
+
+```shellscript
+coral identity remove github_local
+```
+
+## `coral identity-spec`
+
+Manage global identity specs used by DSL v4 source `identity_requirements`.
+Identity specs are installed once for the local Coral app and are visible to all
+workspaces. Installing a spec does not instantiate an identity; use
+`coral identity add` for that.
+
+### `coral identity-spec list`
+
+List installed identity specs.
+
+```shellscript
+coral identity-spec list
+```
+
+### `coral identity-spec info <NAME>`
+
+Print one installed identity spec manifest.
+
+```shellscript
+coral identity-spec info github_oauth
+```
+
+### `coral identity-spec add --file <PATH>`
+
+Install one identity spec from a YAML file. If a spec with the same name already
+exists, Coral replaces it only when no stored identities reference it, or when
+the new manifest is equivalent to the installed manifest.
+
+If the identity spec declares `inputs`, `coral identity-spec add` collects those
+values when the spec is installed. In an interactive terminal Coral prompts for
+missing values; otherwise it reads environment variables matching the input
+keys. Secret inputs are stored as identity-spec material and are not stored on
+identities created from the spec.
+
+```shellscript
+coral identity-spec add --file ./github-oauth.identity.yaml
+```
+
+### `coral identity-spec remove <NAME>`
+
+Remove one installed identity spec. Stored identities that depend on the spec
+become orphaned (see
+[identity spec reference](/reference/identity-spec-reference)); when any exist,
+the command fails unless `--force` is passed.
+
+```shellscript
+coral identity-spec remove github_oauth --force
+```
+
 ## `coral onboard`
 
 Run the guided source setup flow.

--- a/examples/github-v4-identity/README.md
+++ b/examples/github-v4-identity/README.md
@@ -1,0 +1,85 @@
+# GitHub DSL v4 Identity Example
+
+This example installs a preview DSL v4 GitHub source from a YAML stream that
+bundles:
+
+- `github_oauth`, a GitHub device-code OAuth identity spec with a default Coral
+  client ID.
+- `github_oauth_app`, a GitHub authorization-code OAuth identity spec for a
+  user-provided GitHub OAuth app.
+- `github_v4`, a DSL v4 OpenAPI source that binds its REST surface to one of
+  those identities.
+
+Use it to test this PR's bundled identity-spec import and user-owned
+source-surface identity binding flow.
+
+## Prerequisites
+
+- A GitHub account that can authorize the requested scopes.
+- A local build of this branch.
+- An isolated Coral config directory, so the test does not change your normal
+  Coral state.
+
+```shell
+export CORAL_CONFIG_DIR="$(mktemp -d)"
+cargo run -p coral-cli -- features enable dsl_v4
+```
+
+## Install The Example Source
+
+From the repository root, run:
+
+```shell
+cargo run -p coral-cli -- source add --interactive --file examples/github-v4-identity/github-v4-identity-bundle.yaml
+```
+
+Choose `github_oauth` when prompted to create an identity. Coral will show a
+GitHub device code and verification URL; complete that flow in your browser.
+
+The alternate `github_oauth_app` path is useful only if you want to test a
+custom GitHub OAuth app. Register the app with this callback URL before
+selecting it:
+
+```text
+http://127.0.0.1:53682/oauth/callback
+```
+
+## Smoke Test
+
+After install, verify that the identity specs, source, and generated projections
+are present:
+
+```shell
+cargo run -p coral-cli -- identity-spec list
+cargo run -p coral-cli -- identity list
+cargo run -p coral-cli -- source info github_v4 --verbose
+cargo run -p coral-cli -- sql "SELECT id, number, title, state FROM github_v4.repos_issues WHERE owner = 'octocat' AND repo = 'Hello-World' LIMIT 5"
+```
+
+You can also run the manifest's declared checks:
+
+```shell
+cargo run -p coral-cli -- source test github_v4
+```
+
+## Rebinding The Source
+
+Re-run the source add command to choose a different compatible identity for the
+same local user:
+
+```shell
+cargo run -p coral-cli -- source add --interactive --file examples/github-v4-identity/github-v4-identity-bundle.yaml
+```
+
+The source remains `github_v4`; Coral replaces the local user's selected
+identity for the `rest` surface.
+
+## Cleanup
+
+If you used the temporary `CORAL_CONFIG_DIR` above, remove that directory when
+you are done:
+
+```shell
+rm -rf "$CORAL_CONFIG_DIR"
+unset CORAL_CONFIG_DIR
+```

--- a/examples/github-v4-identity/github-v4-identity-bundle.yaml
+++ b/examples/github-v4-identity/github-v4-identity-bundle.yaml
@@ -1,0 +1,106 @@
+---
+kind: identity
+spec_version: 1
+name: github_oauth
+version: 0.1.0
+description: GitHub OAuth access token for GitHub Cloud REST APIs.
+issuer: github
+type: oauth
+audience:
+  host: github.com
+oauth:
+  method:
+    label: Connect with GitHub device code
+    description: Sign in to GitHub with a device code.
+    hint: |
+      Signs you in through GitHub, with no app setup or client secret needed.
+      Requests the `repo`, `read:org`, `read:user`, and `user:email` scopes.
+      To use your own GitHub app instead, install a separate identity spec for
+      that app's OAuth flow.
+    flow:
+      type: device_code
+    endpoints:
+      device_authorization_url: https://github.com/login/device/code
+      token_url: https://github.com/login/oauth/access_token
+    client:
+      id:
+        default: Iv23liJHis6Bs8NO1DAI
+        input: GITHUB_OAUTH_CLIENT_ID
+    scopes:
+      scope:
+        delimiter: space
+        values:
+          - repo
+          - read:org
+          - read:user
+          - user:email
+---
+kind: identity
+spec_version: 1
+name: github_oauth_app
+version: 0.1.0
+description: GitHub OAuth app access token for GitHub Cloud REST APIs.
+issuer: github
+type: oauth
+audience:
+  host: github.com
+oauth:
+  method:
+    label: Connect with GitHub OAuth app
+    description: Sign in through a GitHub OAuth app in your browser.
+    hint: |
+      Uses your own GitHub OAuth app. Register one with its Authorization
+      callback URL set to `http://127.0.0.1:53682/oauth/callback`, then enter
+      the app's Client ID and Client secret below. Requests the `repo`,
+      `read:org`, `read:user`, and `user:email` scopes.
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    redirect_uri_port_mode: fixed
+    endpoints:
+      authorization_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+    client:
+      id:
+        input: GITHUB_OAUTH_CLIENT_ID
+      secret:
+        input: GITHUB_OAUTH_CLIENT_SECRET
+        transport: request_body
+    scopes:
+      scope:
+        delimiter: space
+        values:
+          - repo
+          - read:org
+          - read:user
+          - user:email
+---
+name: github_v4
+version: 0.1.0
+dsl_version: 4
+description: GitHub Cloud REST API source using a resolved GitHub identity.
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://raw.githubusercontent.com/github/rest-api-description/9be34b1f355a4330ec7c04381dd081e4865ac820/descriptions/api.github.com/api.github.com.yaml
+    sha256: a7ad0985d8ae06726c499bee10fc69e5e99dbd237ff25cfcdf3a75547373da90
+    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+            - github_oauth_app
+          audience:
+            host: github.com
+    request_headers:
+      - name: X-GitHub-Api-Version
+        from: literal
+        value: "2022-11-28"
+      - name: User-Agent
+        from: literal
+        value: coral-dsl-v4
+test_queries:
+  - SELECT id, number, title, state FROM github_v4.repos_issues WHERE owner = 'octocat' AND repo = 'Hello-World' LIMIT 5
+  - SELECT id, number, title FROM github_v4.get_issue(owner => 'octocat', repo => 'Hello-World', issue_number => 1)
+  - SELECT id, number, title FROM github_v4.search_issues(q => 'repo:octocat/Hello-World is:issue') LIMIT 5


### PR DESCRIPTION
## Intent

Split the identity-management CLI surface into its own stacked PR above the DSL v4 identity management seams. This restores the useful command layer from the older local branch without replaying stale app/UI churn or reviving workspace-owned identity material in OSS.

## What it enables

- Adds `coral identity` commands to list, inspect, create, and remove user-owned identities.
- Adds `coral identity-spec` commands to list, inspect, install, and remove identity specs.
- Adds user-owned identity get/delete gRPC methods needed by the CLI.
- Documents the new commands in the CLI reference.

## Usage examples

```shellscript
coral identity-spec add --file ./github-oauth.identity.yaml
coral identity-spec list
coral identity add github_local --identity-spec github_oauth
printf '%s\n' "$GITHUB_TOKEN" | coral identity add github_pat --identity-spec github_pat --token-stdin
coral identity info github_local
coral identity remove github_local
```