### PR TITLE
feat(engine): plan source functions as logical nodes

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -1,7 +1,6 @@
 //! Shared internal backend contracts and registry-visible metadata.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::fmt::Write;
 use std::sync::{Arc, OnceLock};
 
 use crate::{QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceInputResolver};
@@ -11,12 +10,25 @@ use coral_spec::{
     SearchLimitsSpec, SourceBackend, SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
-use datafusion::catalog::TableFunctionImpl;
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
+use datafusion::logical_expr::Expr;
 use datafusion::prelude::SessionContext;
 
-pub(crate) type SourceTableFunctions = HashMap<String, Arc<dyn TableFunctionImpl>>;
+/// Provider factory for one registered source-scoped table function.
+///
+/// Implementations bind one call site's positional arguments (manifest order,
+/// NULL meaning "absent") into a scannable provider. Binding is pure argument
+/// validation plus request-value capture — no I/O happens until the returned
+/// provider is scanned.
+pub(crate) trait SourceFunctionProviderFactory: std::fmt::Debug + Send + Sync {
+    /// Manifest-declared result schema for this function.
+    fn schema(&self) -> SchemaRef;
+
+    /// Binds positional call arguments into a provider for one call site.
+    fn provider_for_args(&self, args: &[Expr])
+    -> datafusion::error::Result<Arc<dyn TableProvider>>;
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct RegisteredColumn {
@@ -44,7 +56,7 @@ pub(crate) struct RegisteredTable {
 pub(crate) struct RegisteredTableFunction {
     pub(crate) schema_name: String,
     pub(crate) function_name: String,
-    pub(crate) internal_name: String,
+    pub(crate) factory: Arc<dyn SourceFunctionProviderFactory>,
     pub(crate) kind: String,
     pub(crate) description: String,
     pub(crate) arguments: Vec<RegisteredTableFunctionArgument>,
@@ -105,29 +117,7 @@ pub(crate) struct BackendRegistration {
 
 pub(crate) struct BackendSchemaRegistration {
     pub(crate) tables: HashMap<String, Arc<dyn TableProvider>>,
-    pub(crate) table_functions: SourceTableFunctions,
     pub(crate) source: RegisteredSource,
-}
-
-/// Build a collision-free `DataFusion` UDTF name for a source-scoped function.
-///
-/// `DataFusion`'s UDTF registry is flat, so both source schema and public
-/// function name are hex-encoded to preserve arbitrary valid identifiers
-/// without delimiter collisions.
-pub(crate) fn internal_table_function_name(schema: &str, function: &str) -> String {
-    format!(
-        "__coral_udtf_{}_{}",
-        hex_encode(schema),
-        hex_encode(function)
-    )
-}
-
-fn hex_encode(value: &str) -> String {
-    let mut encoded = String::with_capacity(value.len() * 2);
-    for byte in value.as_bytes() {
-        write!(&mut encoded, "{byte:02x}").expect("writing to a String never fails");
-    }
-    encoded
 }
 
 pub(crate) struct BackendCompileRequest<'a> {
@@ -340,7 +330,7 @@ pub(crate) fn build_registered_table(
 pub(crate) fn build_registered_table_function(
     schema_name: &str,
     function: &SourceTableFunctionSpec,
-    internal_name: String,
+    factory: Arc<dyn SourceFunctionProviderFactory>,
 ) -> RegisteredTableFunction {
     let arguments = function
         .args
@@ -364,7 +354,7 @@ pub(crate) fn build_registered_table_function(
     RegisteredTableFunction {
         schema_name: schema_name.to_string(),
         function_name: function.name.clone(),
-        internal_name,
+        factory,
         kind: function.kind.as_str().to_string(),
         description: function.description.clone(),
         arguments,
@@ -418,6 +408,41 @@ pub(crate) fn schema_from_columns(
     }
     Ok(Arc::new(Schema::new(fields)))
 }
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    /// Minimal factory for tests that need `RegisteredTableFunction` metadata
+    /// without a live backend.
+    #[derive(Debug)]
+    pub(crate) struct StubSourceFunctionFactory {
+        schema: SchemaRef,
+    }
+
+    impl Default for StubSourceFunctionFactory {
+        fn default() -> Self {
+            Self {
+                schema: Arc::new(Schema::new(vec![Field::new("value", DataType::Utf8, true)])),
+            }
+        }
+    }
+
+    impl SourceFunctionProviderFactory for StubSourceFunctionFactory {
+        fn schema(&self) -> SchemaRef {
+            Arc::clone(&self.schema)
+        }
+
+        fn provider_for_args(
+            &self,
+            _args: &[Expr],
+        ) -> datafusion::error::Result<Arc<dyn TableProvider>> {
+            Err(DataFusionError::Internal(
+                "stub source function factory cannot bind arguments".to_string(),
+            ))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/coral-engine/src/backends/composite.rs
+++ b/crates/coral-engine/src/backends/composite.rs
@@ -11,7 +11,7 @@ use datafusion::prelude::SessionContext;
 use crate::backends::{
     BackendRegistration, BackendRegistrationContext, BackendSchemaRegistration,
     CompiledBackendSource, RegisteredInput, RegisteredSource, RegisteredTable,
-    RegisteredTableFunction, SourceTableFunctions,
+    RegisteredTableFunction,
 };
 
 struct CompositeCompiledSource {
@@ -68,22 +68,17 @@ impl CompiledBackendSource for CompositeCompiledSource {
                         )));
                     }
                 }
-                for (name, function) in schema.table_functions {
-                    if target
-                        .table_functions
-                        .insert(name.clone(), function)
-                        .is_some()
-                    {
+                for function in schema.source.table_functions {
+                    let function_name = function.function_name.clone();
+                    if !target.function_keys.insert(function_name.clone()) {
                         return Err(DataFusionError::Execution(format!(
-                            "source '{}' schema '{schema_name}' registered duplicate table function '{name}'",
+                            "source '{}' schema '{schema_name}' registered duplicate table function '{function_name}'",
                             self.source_name
                         )));
                     }
+                    target.registered_functions.push(function);
                 }
                 target.registered_tables.extend(schema.source.tables);
-                target
-                    .registered_functions
-                    .extend(schema.source.table_functions);
                 for input in schema.source.inputs {
                     if target.input_keys.insert(input.key.clone()) {
                         target.inputs.push(input);
@@ -104,7 +99,7 @@ impl CompiledBackendSource for CompositeCompiledSource {
 struct CompositeSchemaRegistration {
     schema_name: String,
     tables: HashMap<String, Arc<dyn TableProvider>>,
-    table_functions: SourceTableFunctions,
+    function_keys: BTreeSet<String>,
     registered_tables: Vec<RegisteredTable>,
     registered_functions: Vec<RegisteredTableFunction>,
     inputs: Vec<RegisteredInput>,
@@ -116,7 +111,7 @@ impl CompositeSchemaRegistration {
         Self {
             schema_name,
             tables: HashMap::new(),
-            table_functions: SourceTableFunctions::new(),
+            function_keys: BTreeSet::new(),
             registered_tables: Vec::new(),
             registered_functions: Vec::new(),
             inputs: Vec::new(),
@@ -127,7 +122,6 @@ impl CompositeSchemaRegistration {
     fn into_registration(self) -> BackendSchemaRegistration {
         BackendSchemaRegistration {
             tables: self.tables,
-            table_functions: self.table_functions,
             source: RegisteredSource {
                 schema_name: self.schema_name,
                 tables: self.registered_tables,

--- a/crates/coral-engine/src/backends/file/mod.rs
+++ b/crates/coral-engine/src/backends/file/mod.rs
@@ -149,7 +149,6 @@ impl CompiledBackendSource for FileCompiledSource {
         Ok(BackendRegistration {
             schemas: vec![BackendSchemaRegistration {
                 tables,
-                table_functions: HashMap::default(),
                 source: RegisteredSource {
                     schema_name,
                     tables: table_infos,

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -1,9 +1,11 @@
-//! `DataFusion` table functions for manifest-driven HTTP-backed sources.
+//! Source table functions for manifest-driven HTTP-backed sources.
 //!
-//! `TableFunctionImpl::call` runs while `DataFusion` is planning a query. At
-//! that point we validate the positional call arguments and bind them into HTTP
-//! request values. The returned table provider is scanned later during
-//! execution, using the same `http_json_exec` path as manifest-backed tables.
+//! Binding runs when Coral resolves a parked source-function call — at
+//! relation planning for fully-literal calls, or in the analyzer once query
+//! parameters are bound. It validates the positional call arguments and
+//! captures them as HTTP request values. The returned table provider is
+//! scanned later during execution, using the same `http_json_exec` path as
+//! manifest-backed tables.
 
 use std::any::Any;
 use std::collections::HashMap;
@@ -12,12 +14,12 @@ use std::sync::Arc;
 
 use coral_spec::SourceTableFunctionSpec;
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::catalog::TableFunctionImpl;
 use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 
+use crate::backends::SourceFunctionProviderFactory;
 use crate::backends::http::HttpSourceClient;
 use crate::backends::http::provider::{HttpJsonExecRequest, http_json_exec};
 use crate::backends::http::target::HttpFetchTarget;
@@ -77,8 +79,12 @@ impl HttpSourceTableFunction {
     }
 }
 
-impl TableFunctionImpl for HttpSourceTableFunction {
-    fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+impl SourceFunctionProviderFactory for HttpSourceTableFunction {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.state.schema)
+    }
+
+    fn provider_for_args(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
         let arg_values = bind_function_args(&self.state.source_schema, &self.spec, args)?;
         Ok(Arc::new(HttpSourceFunctionCallTableProvider {
             state: Arc::clone(&self.state),

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -12,9 +12,9 @@ use datafusion::prelude::SessionContext;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
     BackendSchemaRegistration, CompiledBackendSource, RegisteredSource, RegisteredTable,
-    SourceTableFunctions, build_registered_inputs, build_registered_table,
-    build_registered_table_function, internal_table_function_name, registered_columns_from_specs,
-    required_filter_names, validate_lookup_key_filter_backend_support,
+    SourceFunctionProviderFactory, build_registered_inputs, build_registered_table,
+    build_registered_table_function, registered_columns_from_specs, required_filter_names,
+    validate_lookup_key_filter_backend_support,
 };
 use crate::{RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver};
 use coral_spec::SourceBackend;
@@ -138,23 +138,18 @@ impl CompiledBackendSource for HttpCompiledSource {
             tables.insert(table.name().to_string(), provider);
             table_infos.push(registered_table(table));
         }
-        let mut table_functions =
-            SourceTableFunctions::with_capacity(self.manifest.functions.len());
         let mut table_function_infos = Vec::with_capacity(self.manifest.functions.len());
         for function in &self.manifest.functions {
-            let internal_name =
-                internal_table_function_name(&self.manifest.common.name, &function.name);
-            let function_impl: Arc<dyn datafusion::catalog::TableFunctionImpl> =
+            let factory: Arc<dyn SourceFunctionProviderFactory> =
                 Arc::new(function::HttpSourceTableFunction::new(
                     backend.clone(),
                     self.manifest.common.name.clone(),
                     function.clone(),
                 )?);
-            table_functions.insert(internal_name.clone(), function_impl);
             table_function_infos.push(build_registered_table_function(
                 &self.manifest.common.name,
                 function,
-                internal_name,
+                factory,
             ));
         }
 
@@ -174,7 +169,6 @@ impl CompiledBackendSource for HttpCompiledSource {
         Ok(BackendRegistration {
             schemas: vec![BackendSchemaRegistration {
                 tables,
-                table_functions,
                 source: RegisteredSource {
                     schema_name,
                     tables: table_infos,

--- a/crates/coral-engine/src/backends/mcp/function.rs
+++ b/crates/coral-engine/src/backends/mcp/function.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use coral_spec::ResponseSpec;
 use coral_spec::backends::mcp::{McpPaginationSpec, McpTableFunctionSpec};
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::catalog::TableFunctionImpl;
 use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
@@ -17,6 +16,7 @@ use serde_json::Value;
 use super::client::McpSourceClient;
 use super::error::McpProviderQueryError;
 use super::fetch::McpFetchPlan;
+use crate::backends::SourceFunctionProviderFactory;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::json_exec::JsonExec;
 use crate::backends::shared::mapping::convert_items;
@@ -89,8 +89,12 @@ impl McpSourceTableFunction {
     }
 }
 
-impl TableFunctionImpl for McpSourceTableFunction {
-    fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+impl SourceFunctionProviderFactory for McpSourceTableFunction {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.state.schema)
+    }
+
+    fn provider_for_args(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
         let arg_values = bind_function_args(&self.state.source_schema, &self.spec, args)?;
         Ok(Arc::new(McpFunctionCallTableProvider {
             state: Arc::clone(&self.state),

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -19,7 +19,6 @@ use async_trait::async_trait;
 use coral_spec::backends::mcp::{McpServerSpec, McpSourceManifest, McpTableSpec};
 use coral_spec::v4::McpToolCatalog;
 use coral_spec::{ManifestInputSpec, SourceBackend, resolve_inputs};
-use datafusion::catalog::TableFunctionImpl;
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 
@@ -29,9 +28,9 @@ use self::provider::McpTableProvider;
 use self::transport::{StdioMcpToolCaller, StreamableHttpMcpToolCaller};
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
-    BackendSchemaRegistration, CompiledBackendSource, RegisteredSource, SourceTableFunctions,
-    build_registered_inputs, build_registered_table, build_registered_table_function,
-    internal_table_function_name, registered_columns_from_specs, required_filter_names,
+    BackendSchemaRegistration, CompiledBackendSource, RegisteredSource,
+    SourceFunctionProviderFactory, build_registered_inputs, build_registered_table,
+    build_registered_table_function, registered_columns_from_specs, required_filter_names,
     validate_lookup_key_filter_backend_support,
 };
 use crate::runtime::error::datafusion_to_core;
@@ -197,23 +196,19 @@ impl CompiledBackendSource for McpCompiledSource {
         _ctx: &datafusion::prelude::SessionContext,
         _registration: &BackendRegistrationContext,
     ) -> Result<BackendRegistration> {
-        let mut table_functions =
-            SourceTableFunctions::with_capacity(self.manifest.functions.len());
         let mut table_function_infos = Vec::with_capacity(self.manifest.functions.len());
 
         for function in &self.manifest.functions {
-            let internal_name =
-                internal_table_function_name(&self.manifest.common.name, function.name());
-            let function_impl: Arc<dyn TableFunctionImpl> = Arc::new(McpSourceTableFunction::new(
-                self.caller.clone(),
-                self.manifest.common.name.clone(),
-                function.clone(),
-            )?);
-            table_functions.insert(internal_name.clone(), function_impl);
+            let factory: Arc<dyn SourceFunctionProviderFactory> =
+                Arc::new(McpSourceTableFunction::new(
+                    self.caller.clone(),
+                    self.manifest.common.name.clone(),
+                    function.clone(),
+                )?);
             table_function_infos.push(build_registered_table_function(
                 &self.manifest.common.name,
                 &function.common,
-                internal_name,
+                factory,
             ));
         }
 
@@ -252,7 +247,6 @@ impl CompiledBackendSource for McpCompiledSource {
         Ok(BackendRegistration {
             schemas: vec![BackendSchemaRegistration {
                 tables,
-                table_functions,
                 source: RegisteredSource {
                     schema_name,
                     tables: table_infos,

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -367,7 +367,8 @@ fn register_test_sources(ctx: &SessionContext, sources: Vec<CompiledQuerySource>
             .iter()
             .flat_map(|source| source.table_functions.iter()),
     );
-    ctx.register_relation_planner(Arc::new(source_functions))
+    source_functions
+        .install(ctx)
         .expect("source function planner should register");
 }
 
@@ -380,7 +381,8 @@ fn register_test_sources_with_catalog(ctx: &SessionContext, sources: Vec<Compile
             .iter()
             .flat_map(|source| source.table_functions.iter()),
     );
-    ctx.register_relation_planner(Arc::new(source_functions))
+    source_functions
+        .install(ctx)
         .expect("source function planner should register");
 }
 

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -11,7 +11,7 @@
 //! |---|---|---|
 //! | `mod.rs` | Module entry. `CompiledBackendSource` impl, `compile_source` / `compile_manifest`, internal module declarations. | always |
 //! | `provider.rs` | `DataFusion` `TableProvider` implementation. | if the backend exposes tables |
-//! | `function.rs` | `DataFusion` `TableFunctionImpl` for source-scoped UDTFs. | only if the backend exposes table functions |
+//! | `function.rs` | Source-function provider factory and `build_registered_table_function` wiring. | only if the backend exposes table functions |
 //! | `client.rs` | Configured stateful wrapper (the value the rest of the backend talks to) and any transport-abstracting trait. | if the backend has a per-source client; skip if config is per-table (file backend) |
 //! | `transport.rs` | Per-instance transport impls (HTTP requests, stdio child spawn, object-store wiring, ...). | if there are multiple transports or transport code is non-trivial |
 //! | `response.rs` | Decode one response from the backend into the JSON payload that `shared/response_rows::extract_rows` consumes. | if response decoding is non-trivial |
@@ -81,8 +81,8 @@ mod composite;
 pub(crate) use common::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
     BackendSchemaRegistration, CompiledBackendSource, RegisteredInput, RegisteredSource,
-    RegisteredTable, RegisteredTableFunction, SourceTableFunctions, build_registered_inputs,
-    build_registered_table, build_registered_table_function, internal_table_function_name,
+    RegisteredTable, RegisteredTableFunction, SourceFunctionProviderFactory,
+    build_registered_inputs, build_registered_table, build_registered_table_function,
     registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
     schema_from_columns, validate_lookup_key_filter_backend_support,
 };

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -940,6 +940,9 @@ fn catalog_columns_batch(schema: Arc<Schema>, rows: &[CatalogColumn]) -> Result<
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use crate::backends::common::test_support::StubSourceFunctionFactory;
     use crate::backends::{RegisteredSource, RegisteredTableFunction};
 
     use super::collect_table_functions;
@@ -952,7 +955,7 @@ mod tests {
             table_functions: vec![RegisteredTableFunction {
                 schema_name: "function_schema".to_string(),
                 function_name: "search".to_string(),
-                internal_name: "internal_search".to_string(),
+                factory: Arc::new(StubSourceFunctionFactory::default()),
                 kind: "search".to_string(),
                 description: String::new(),
                 arguments: Vec::new(),

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -158,7 +158,8 @@ async fn build_registered_runtime(
             .flat_map(|source| source.table_functions.iter()),
     );
     if !source_functions.is_empty() {
-        ctx.register_relation_planner(Arc::new(source_functions))
+        source_functions
+            .install(&ctx)
             .map_err(|err| datafusion_to_core(&err, &tables))?;
     }
     for failure in &registration.failures {

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -9,7 +9,7 @@ use tracing::{Instrument as _, info_span};
 
 use crate::backends::{
     BackendRegistration, BackendRegistrationContext, BackendSchemaRegistration,
-    CompiledBackendSource, RegisteredSource, SourceTableFunctions,
+    CompiledBackendSource, RegisteredSource,
 };
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
@@ -134,7 +134,6 @@ async fn register_sources_inner(
                 {
                     Ok(registration) => {
                         register_backend_registration(
-                            ctx,
                             catalog.as_ref(),
                             source_decorators,
                             query_source,
@@ -243,7 +242,6 @@ async fn register_source(
 }
 
 fn register_backend_registration(
-    ctx: &SessionContext,
     catalog: &dyn datafusion::catalog::CatalogProvider,
     source_decorators: &mut [Box<dyn SourceDecorator>],
     query_source: &QuerySource,
@@ -255,21 +253,15 @@ fn register_backend_registration(
     for schema_registration in registration.schemas {
         let BackendSchemaRegistration {
             tables,
-            table_functions,
             source: registered_source,
         } = schema_registration;
         let schema_name = registered_source.schema_name.clone();
         let decorated_tables = decorate_source_tables(source_decorators, query_source, tables)?;
-        staged.push((
-            schema_name,
-            decorated_tables,
-            table_functions,
-            registered_source,
-        ));
+        staged.push((schema_name, decorated_tables, registered_source));
     }
 
     let mut registered_schema_names = Vec::with_capacity(staged.len());
-    for (schema_name, decorated_tables, _table_functions, _registered_source) in &mut staged {
+    for (schema_name, decorated_tables, _registered_source) in &mut staged {
         match catalog.register_schema(
             schema_name,
             Arc::new(StaticSchemaProvider::new(std::mem::take(decorated_tables))),
@@ -290,8 +282,7 @@ fn register_backend_registration(
         }
     }
 
-    for (_schema_name, _decorated_tables, table_functions, registered_source) in staged {
-        register_table_functions(ctx, table_functions);
+    for (_schema_name, _decorated_tables, registered_source) in staged {
         result.active_sources.push(registered_source);
     }
     Ok(())
@@ -329,12 +320,6 @@ fn push_source_failure(
         "skipping source"
     );
     result.failures.push(failure);
-}
-
-fn register_table_functions(ctx: &SessionContext, table_functions: SourceTableFunctions) {
-    for (internal_name, function) in table_functions {
-        ctx.register_udtf(&internal_name, function);
-    }
 }
 
 fn prepare_source_decorators(

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -1,47 +1,45 @@
 //! Source-scoped table function relation planning.
 //!
-//! `DataFusion` registers UDTFs in one flat namespace. Coral exposes source
-//! functions as scoped SQL relations like `github.find_issues(...)`. Backends
-//! therefore register hidden internal UDTF names, and this planner rewrites the
-//! scoped relation into the hidden function call before handing planning back
-//! to `DataFusion`.
+//! Coral exposes source functions as scoped SQL relations like
+//! `github.find_issues(...)`. The relation planner intercepts those calls,
+//! validates the named-argument syntax, and parks the call as a
+//! [`SourceFunctionNode`] logical-plan extension. Argument values stay logical
+//! expressions long enough for `DataFusion` query parameters
+//! (`owner => $owner`) to bind into them; [`SourceFunctionAnalyzerRule`] then
+//! resolves each fully-bound node into an ordinary provider table scan before
+//! optimization, so projection and limit pushdown behave exactly as they do
+//! for any registered table.
 
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
+use datafusion::common::{DFSchema, DFSchemaRef, ScalarValue, TableReference};
+use datafusion::datasource::provider_as_source;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::planner::{
     PlannedRelation, RelationPlanner, RelationPlannerContext, RelationPlanning,
 };
 use datafusion::logical_expr::sqlparser::ast::{
-    Expr, FunctionArg, FunctionArgExpr, Ident, ObjectName, TableFactor, TableFunctionArgs, Value,
+    Expr as SqlExpr, FunctionArg, FunctionArgExpr, Ident, TableAlias, TableFactor,
+    TableFunctionArgs,
 };
+use datafusion::logical_expr::{
+    Expr, Extension, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNodeCore,
+};
+use datafusion::optimizer::AnalyzerRule;
+use datafusion::prelude::SessionContext;
 
-use crate::backends::RegisteredTableFunction;
+use crate::backends::{RegisteredTableFunction, SourceFunctionProviderFactory};
 
 #[derive(Debug)]
 pub(crate) struct SourceFunctionRegistry {
     functions: HashMap<FunctionLookupKey, SourceFunction>,
     source_schemas: HashSet<String>,
-}
-
-#[derive(Debug)]
-struct SourceFunction {
-    internal_name: String,
-    display_name: String,
-    arg_names: Vec<String>,
-    known_args: HashSet<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct FunctionLookupKey {
-    schema: String,
-    function: String,
-}
-
-#[derive(Debug)]
-struct SourceFunctionCall {
-    lookup_key: FunctionLookupKey,
-    display_name: String,
 }
 
 impl SourceFunctionRegistry {
@@ -65,6 +63,15 @@ impl SourceFunctionRegistry {
 
     pub(crate) fn is_empty(&self) -> bool {
         self.functions.is_empty()
+    }
+
+    /// Installs this relation planner together with the analyzer rule that
+    /// resolves the nodes it parks. The two are a pair: any session that can
+    /// plan source-function calls must also be able to bind them.
+    pub(crate) fn install(self, ctx: &SessionContext) -> Result<()> {
+        ctx.register_relation_planner(Arc::new(self))?;
+        ctx.add_analyzer_rule(Arc::new(SourceFunctionAnalyzerRule));
+        Ok(())
     }
 
     fn find(&self, call: &SourceFunctionCall) -> Option<&SourceFunction> {
@@ -111,28 +118,63 @@ impl RelationPlanner for SourceFunctionRegistry {
             return Ok(original_relation(relation));
         };
 
-        let rewritten = rewrite_to_internal_udtf(relation, &call, function, context)?;
-        let plan = context.plan(rewritten)?;
+        reject_unsupported_modifiers(&call, &relation)?;
+        let (call_args, alias) = call_parts(relation);
+        reject_settings(&call, &call_args)?;
+
+        let args = lower_named_args_to_positional_exprs(function, &call_args, context)?;
+        let node = SourceFunctionNode::new(function, args)?;
+
+        // Fully-literal calls validate eagerly so argument-value errors keep
+        // surfacing at planning time, exactly as they did when binding ran
+        // inside SQL planning. Binding is pure value capture (no I/O), so the
+        // analyzer repeating it later is cheap.
+        if !node.has_parameter_placeholders() {
+            node.factory.provider_for_args(&node.args)?;
+        }
+
+        let plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(node),
+        });
         Ok(RelationPlanning::Planned(Box::new(PlannedRelation::new(
-            plan, None,
+            plan, alias,
         ))))
     }
+}
+
+#[derive(Debug)]
+struct SourceFunction {
+    display_name: String,
+    table_reference: TableReference,
+    arg_names: Vec<String>,
+    known_args: HashSet<String>,
+    factory: Arc<dyn SourceFunctionProviderFactory>,
 }
 
 impl SourceFunction {
     fn from_registered(function: &RegisteredTableFunction) -> Self {
         let arg_names = function.arg_names.clone();
         Self {
-            internal_name: function.internal_name.clone(),
             display_name: qualified_name(&function.schema_name, &function.function_name),
+            table_reference: TableReference::partial(
+                function.schema_name.clone(),
+                function.function_name.clone(),
+            ),
             known_args: arg_names.iter().cloned().collect(),
             arg_names,
+            factory: Arc::clone(&function.factory),
         }
     }
 
     fn contains(&self, name: &str) -> bool {
         self.known_args.contains(name)
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FunctionLookupKey {
+    schema: String,
+    function: String,
 }
 
 impl FunctionLookupKey {
@@ -149,6 +191,12 @@ impl FunctionLookupKey {
             function: context.normalize_ident(function),
         }
     }
+}
+
+#[derive(Debug)]
+struct SourceFunctionCall {
+    lookup_key: FunctionLookupKey,
+    display_name: String,
 }
 
 impl SourceFunctionCall {
@@ -187,6 +235,194 @@ impl SourceFunctionCall {
     }
 }
 
+/// One parked source-function call inside a logical plan.
+///
+/// The call's arguments are exposed through
+/// [`UserDefinedLogicalNodeCore::expressions`], which is what lets
+/// `DataFrame::with_param_values` rewrite `$name` placeholders inside the node
+/// before [`SourceFunctionAnalyzerRule`] binds the call.
+///
+/// The node snapshots everything it needs from its [`SourceFunction`] registry
+/// entry: plans are `'static` and outlive planning, so the node cannot borrow
+/// from the registry.
+#[derive(Debug, Clone)]
+pub(crate) struct SourceFunctionNode {
+    display_name: String,
+    /// Two-part `schema.function` reference, so result columns qualify the
+    /// same way table columns do (`github.pulls.id`, `pulls.id`).
+    table_reference: TableReference,
+    arg_names: Vec<String>,
+    args: Vec<Expr>,
+    schema: DFSchemaRef,
+    factory: Arc<dyn SourceFunctionProviderFactory>,
+}
+
+impl SourceFunctionNode {
+    fn new(function: &SourceFunction, args: Vec<Expr>) -> Result<Self> {
+        let schema = Arc::new(DFSchema::try_from_qualified_schema(
+            function.table_reference.clone(),
+            function.factory.schema().as_ref(),
+        )?);
+        Ok(Self {
+            display_name: function.display_name.clone(),
+            table_reference: function.table_reference.clone(),
+            arg_names: function.arg_names.clone(),
+            args,
+            schema,
+            factory: Arc::clone(&function.factory),
+        })
+    }
+
+    fn has_parameter_placeholders(&self) -> bool {
+        self.args.iter().any(|arg| find_placeholder(arg).is_some())
+    }
+
+    fn reject_unbound_parameters(&self) -> Result<()> {
+        for (name, arg) in self.arg_names.iter().zip(&self.args) {
+            if let Some(placeholder) = find_placeholder(arg) {
+                return Err(DataFusionError::Plan(format!(
+                    "{} argument '{name}' is bound to parameter {placeholder}, \
+                     but no value was provided for it",
+                    self.display_name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn to_provider_scan(&self) -> Result<LogicalPlan> {
+        self.reject_unbound_parameters()?;
+        let provider = self.factory.provider_for_args(&self.args)?;
+        LogicalPlanBuilder::scan(
+            self.table_reference.clone(),
+            provider_as_source(provider),
+            None,
+        )?
+        .build()
+    }
+}
+
+fn find_placeholder(expr: &Expr) -> Option<String> {
+    let mut found = None;
+    expr.apply(|expr| {
+        if let Expr::Placeholder(placeholder) = expr {
+            found = Some(placeholder.id.clone());
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .expect("placeholder search never fails");
+    found
+}
+
+// Node identity is the function name plus its argument expressions; `schema`
+// participates so renamed manifests never compare equal. The remaining fields
+// are derived from the same registry entry as `display_name` (and `factory`
+// cannot implement `PartialEq`), so they are deliberately excluded.
+impl PartialEq for SourceFunctionNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.display_name == other.display_name
+            && self.args == other.args
+            && self.schema == other.schema
+    }
+}
+
+impl Eq for SourceFunctionNode {}
+
+impl Hash for SourceFunctionNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.display_name.hash(state);
+        self.args.hash(state);
+        self.schema.hash(state);
+    }
+}
+
+impl PartialOrd for SourceFunctionNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self == other {
+            return Some(Ordering::Equal);
+        }
+        Some(format!("{self:?}").cmp(&format!("{other:?}")))
+    }
+}
+
+impl UserDefinedLogicalNodeCore for SourceFunctionNode {
+    fn name(&self) -> &'static str {
+        "CoralSourceFunction"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        Vec::new()
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        self.args.clone()
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SourceFunction: {}", self.display_name)
+    }
+
+    fn with_exprs_and_inputs(&self, exprs: Vec<Expr>, inputs: Vec<LogicalPlan>) -> Result<Self> {
+        if !inputs.is_empty() {
+            return Err(DataFusionError::Plan(format!(
+                "source function {} takes no plan inputs",
+                self.display_name
+            )));
+        }
+        if exprs.len() != self.args.len() {
+            return Err(DataFusionError::Plan(format!(
+                "source function {} expected {} argument expressions, got {}",
+                self.display_name,
+                self.args.len(),
+                exprs.len()
+            )));
+        }
+        // Plan rewrites (parameter substitution in particular) alias rewritten
+        // expressions to preserve their display names. Arguments are
+        // positional here, so the alias carries no meaning — strip it before
+        // binding sees the value.
+        Ok(Self {
+            args: exprs.into_iter().map(Expr::unalias).collect(),
+            ..self.clone()
+        })
+    }
+}
+
+/// Resolves parked [`SourceFunctionNode`]s into provider table scans.
+///
+/// Runs after `DataFrame::with_param_values` has bound query parameters and
+/// before the optimizer, so the optimized plan is the same provider scan the
+/// engine has always produced and pushdown rules apply unchanged.
+#[derive(Debug, Default)]
+pub(crate) struct SourceFunctionAnalyzerRule;
+
+impl AnalyzerRule for SourceFunctionAnalyzerRule {
+    fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
+        // Subquery plans live inside expressions, not in the plan's child
+        // list — a plain transform_up would never see a source-function call
+        // written inside EXISTS/IN/scalar subqueries.
+        plan.transform_up_with_subqueries(|plan| {
+            let LogicalPlan::Extension(extension) = &plan else {
+                return Ok(Transformed::no(plan));
+            };
+            let Some(node) = extension.node.as_any().downcast_ref::<SourceFunctionNode>() else {
+                return Ok(Transformed::no(plan));
+            };
+            Ok(Transformed::yes(node.to_provider_scan()?))
+        })
+        .map(|transformed| transformed.data)
+    }
+
+    fn name(&self) -> &'static str {
+        "coral_source_functions"
+    }
+}
+
 fn qualified_name(schema: &str, function: &str) -> String {
     format!("{schema}.{function}")
 }
@@ -195,33 +431,66 @@ fn original_relation(relation: TableFactor) -> RelationPlanning {
     RelationPlanning::Original(Box::new(relation))
 }
 
-fn rewrite_to_internal_udtf(
-    mut relation: TableFactor,
-    call: &SourceFunctionCall,
-    function: &SourceFunction,
-    context: &dyn RelationPlannerContext,
-) -> Result<TableFactor> {
+/// Takes ownership of a committed call's argument list and alias.
+///
+/// Shape-checking and destructuring are split on purpose:
+/// [`SourceFunctionCall::parse`] inspects the relation by reference because
+/// the not-our-function fallthroughs must hand the relation back to
+/// `DataFusion` untouched. Only once the call is committed may the relation
+/// be consumed, which is what makes the `unreachable!` here truly so.
+fn call_parts(relation: TableFactor) -> (TableFunctionArgs, Option<TableAlias>) {
     let TableFactor::Table {
-        name,
-        args: table_args,
+        args: Some(args),
+        alias,
         ..
-    } = &mut relation
+    } = relation
+    else {
+        unreachable!("SourceFunctionCall::parse only matches table function calls");
+    };
+    (args, alias)
+}
+
+/// Rejects table-factor modifiers the source-function planner does not
+/// support, so user-written SQL semantics are never silently dropped.
+///
+/// Destructures every field without `..` on purpose: a sqlparser upgrade that
+/// adds a new modifier must fail compilation here and force a decision,
+/// instead of executing while ignoring the modifier.
+fn reject_unsupported_modifiers(call: &SourceFunctionCall, relation: &TableFactor) -> Result<()> {
+    let TableFactor::Table {
+        name: _,
+        alias: _,
+        args: _,
+        with_hints,
+        version,
+        with_ordinality,
+        partitions,
+        json_path,
+        sample,
+        index_hints,
+    } = relation
     else {
         unreachable!("SourceFunctionCall::parse only matches table relations");
     };
 
-    let call_args = table_args
-        .as_ref()
-        .expect("SourceFunctionCall::parse only matches function calls");
-    reject_settings(call, call_args)?;
-
-    *name = ObjectName::from(vec![Ident::new(function.internal_name.clone())]);
-    *table_args = Some(TableFunctionArgs {
-        args: lower_named_args_to_internal_positions(function, call_args, context)?,
-        settings: None,
-    });
-
-    Ok(relation)
+    let unsupported_modifiers = [
+        (*with_ordinality, "WITH ORDINALITY"),
+        (sample.is_some(), "TABLESAMPLE"),
+        (!with_hints.is_empty(), "table hints"),
+        (!index_hints.is_empty(), "index hints"),
+        (version.is_some(), "time-travel syntax"),
+        (!partitions.is_empty(), "PARTITION selection"),
+        (json_path.is_some(), "JSON path access"),
+    ];
+    for (present, modifier) in unsupported_modifiers {
+        if present {
+            return Err(DataFusionError::Plan(format!(
+                "source table function {} does not support {modifier}",
+                call.display_name
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn reject_settings(call: &SourceFunctionCall, args: &TableFunctionArgs) -> Result<()> {
@@ -234,31 +503,32 @@ fn reject_settings(call: &SourceFunctionCall, args: &TableFunctionArgs) -> Resul
     Ok(())
 }
 
-fn lower_named_args_to_internal_positions(
+/// Lowers named call arguments into positional logical expressions in manifest
+/// order. Missing optional args become NULL literals; the backend binder
+/// treats NULL as absent and performs required-argument validation after that
+/// interpretation.
+fn lower_named_args_to_positional_exprs(
     function: &SourceFunction,
     args: &TableFunctionArgs,
-    context: &dyn RelationPlannerContext,
-) -> Result<Vec<FunctionArg>> {
+    context: &mut dyn RelationPlannerContext,
+) -> Result<Vec<Expr>> {
     let mut supplied = collect_named_args(function, args, context)?;
 
-    // The internal UDTF is positional. Missing optional args are represented as
-    // NULL placeholders; the backend binder treats NULL as absent and performs
-    // required-argument validation after that interpretation.
-    Ok(function
+    function
         .arg_names
         .iter()
-        .map(|name| {
-            let expr = supplied.remove(name).unwrap_or_else(null_arg);
-            FunctionArg::Unnamed(expr)
+        .map(|name| match supplied.remove(name) {
+            Some(sql_expr) => context.sql_to_expr(sql_expr, &DFSchema::empty()),
+            None => Ok(Expr::Literal(ScalarValue::Null, None)),
         })
-        .collect())
+        .collect()
 }
 
 fn collect_named_args(
     function: &SourceFunction,
     args: &TableFunctionArgs,
     context: &dyn RelationPlannerContext,
-) -> Result<HashMap<String, FunctionArgExpr>> {
+) -> Result<HashMap<String, SqlExpr>> {
     let mut supplied = HashMap::new();
     let mut seen = HashSet::new();
 
@@ -274,7 +544,7 @@ fn collect_named_args(
 
 fn insert_named_arg(
     function: &SourceFunction,
-    supplied: &mut HashMap<String, FunctionArgExpr>,
+    supplied: &mut HashMap<String, SqlExpr>,
     seen: &mut HashSet<String>,
     name: &Ident,
     arg: &FunctionArgExpr,
@@ -293,25 +563,13 @@ fn insert_named_arg(
             function.display_name, name.value
         )));
     }
-    reject_wildcard_arg(function, name, arg)?;
-    supplied.insert(lookup_name, arg.clone());
-    Ok(())
-}
-
-fn reject_wildcard_arg(
-    function: &SourceFunction,
-    name: &Ident,
-    arg: &FunctionArgExpr,
-) -> Result<()> {
-    if matches!(
-        arg,
-        FunctionArgExpr::Wildcard | FunctionArgExpr::QualifiedWildcard(_)
-    ) {
+    let FunctionArgExpr::Expr(sql_expr) = arg else {
         return Err(DataFusionError::Plan(format!(
             "{} argument '{}' does not support wildcard values",
             function.display_name, name.value
         )));
-    }
+    };
+    supplied.insert(lookup_name, sql_expr.clone());
     Ok(())
 }
 
@@ -327,8 +585,4 @@ fn non_named_arg_error(function: &SourceFunction, arg: &FunctionArg) -> DataFusi
         )),
         FunctionArg::Named { .. } => unreachable!("named arguments are handled by the caller"),
     }
-}
-
-fn null_arg() -> FunctionArgExpr {
-    FunctionArgExpr::Expr(Expr::value(Value::Null))
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -209,8 +209,8 @@ fn notionish_search_function_manifest(base_url: &str) -> Value {
 }
 
 fn internal_table_function_name(schema: &str, function: &str) -> String {
-    // PR #306 only registers DataFusion's flat internal UDTF. The public
-    // source-scoped planner in the next stack PR owns this mapping for users.
+    // Mangled names from the retired hidden-UDTF design. Kept only to prove
+    // the engine no longer registers them as a callable surface.
     format!(
         "__coral_udtf_{}_{}",
         hex_encode(schema),
@@ -1094,13 +1094,23 @@ async fn complete_search_fetch_preserves_candidates_for_residual_filters() {
 }
 
 #[tokio::test]
-async fn internal_table_function_builds_http_search_request() {
+async fn internal_table_function_names_are_not_registered() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("search", &server.uri()));
     let function_name = internal_table_function_name("search", "search_issues");
-    assert_search_function_query(&format!(
-        "SELECT title, score \
-         FROM {function_name}('flaky cleanup repo:withcoral/coral', 'hybrid')"
-    ))
-    .await;
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        &format!("SELECT title FROM {function_name}('flaky')"),
+    )
+    .await
+    .expect_err("internal UDTF names must not be a callable surface");
+
+    assert!(
+        error.to_string().contains("not found"),
+        "unexpected error: {error}"
+    );
 }
 
 #[tokio::test]
@@ -1573,6 +1583,141 @@ async fn assert_search_function_query(sql: &str) {
 }
 
 #[tokio::test]
+async fn source_scoped_table_function_columns_qualify_like_table_columns() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("qual_search", &server.uri()));
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT qual_search.search_issues.title, search_issues.score \
+             FROM qual_search.search_issues(q => 'flaky')",
+        )
+        .await
+        .expect("function result columns should qualify like table columns"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_resolves_inside_scalar_subquery() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("scalar_subquery", &server.uri()));
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT (SELECT count(*) FROM scalar_subquery.search_issues(q => 'flaky')) AS n",
+        )
+        .await
+        .expect("source function calls should resolve inside scalar subqueries"),
+    );
+
+    assert_eq!(rows, vec![json!({ "n": 1 })]);
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_resolves_inside_exists_subquery() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("exists_subquery", &server.uri()));
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT 1 AS ok \
+             WHERE EXISTS (SELECT 1 FROM exists_subquery.search_issues(q => 'flaky'))",
+        )
+        .await
+        .expect("source function calls should resolve inside EXISTS subqueries"),
+    );
+
+    assert_eq!(rows, vec![json!({ "ok": 1 })]);
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_rejects_unsupported_relation_modifiers() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("modifier_search", &server.uri()));
+
+    let cases = [
+        (
+            "SELECT title FROM modifier_search.search_issues(q => 'flaky') WITH ORDINALITY",
+            "WITH ORDINALITY",
+        ),
+        (
+            "SELECT title FROM modifier_search.search_issues(q => 'flaky') \
+             TABLESAMPLE BERNOULLI(50)",
+            "TABLESAMPLE",
+        ),
+        (
+            "SELECT title FROM modifier_search.search_issues(q => 'flaky') AS s WITH (NOLOCK)",
+            "table hints",
+        ),
+    ];
+
+    for (sql, modifier) in cases {
+        let error = CoralQuery::execute_sql(std::slice::from_ref(&source), test_runtime(), sql)
+            .await
+            .expect_err("unsupported relation modifiers must fail instead of being ignored");
+        assert!(
+            error.to_string().contains(&format!(
+                "modifier_search.search_issues does not support {modifier}"
+            )),
+            "unexpected error for {modifier}: {error}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn table_function_treats_typed_null_as_omitted_optional_argument() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
@@ -1590,16 +1735,13 @@ async fn table_function_treats_typed_null_as_omitted_optional_argument() {
         .await;
 
     let source = build_source(search_function_manifest("null_arg_search", &server.uri()));
-    let function_name = internal_table_function_name("null_arg_search", "search_issues");
 
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
             test_runtime(),
-            &format!(
-                "SELECT title, score FROM {function_name}(\
-                 'flaky cleanup repo:withcoral/coral', CAST(NULL AS VARCHAR))"
-            ),
+            "SELECT title, score FROM null_arg_search.search_issues(\
+             q => 'flaky cleanup repo:withcoral/coral', mode => CAST(NULL AS VARCHAR))",
         )
         .await
         .expect("typed null optional argument should be omitted"),
@@ -1693,12 +1835,11 @@ async fn table_function_request_headers_do_not_resolve_filters_from_args() {
         "template": "{{filter.q}}"
     }]);
     let source = build_source(manifest);
-    let function_name = internal_table_function_name("function_filter_header", "search_issues");
 
     let error = CoralQuery::execute_sql(
         &[source],
         test_runtime(),
-        &format!("SELECT title FROM {function_name}('flaky')"),
+        "SELECT title FROM function_filter_header.search_issues(q => 'flaky')",
     )
     .await
     .expect_err("function args must not populate table filters");


### PR DESCRIPTION
## Why

Source-scoped table functions (`github.pulls(owner => 'x')`) are planned today by rewriting the call into a hidden, name-mangled DataFusion UDTF registered in the flat UDTF namespace. That design has two structural problems:

1. **Wrong phase for parameters.** `TableFunctionImpl::call` runs while DataFusion converts SQL into a logical plan — before `with_param_values` substitutes `$name` placeholders. Parameterized source-function calls (`owner => $owner`) are therefore impossible. The upcoming recipe work needs exactly that (a recipe's declared arguments bind into its stored SQL); without this change, recipes would have to own their own SQL-rewriting layer to splice values in as literals.
2. **A shadow callable surface.** Every function has a hidden globally-registered twin (`__coral_udtf_<hex>_<hex>`) that exists only as a rewrite target, yet is technically callable by anyone who discovers the name.

## What

- The relation planner still intercepts and validates the call, but now parks it as a `SourceFunctionNode` logical-plan extension carrying the argument expressions (positional, manifest order, NULL = absent) and the manifest result schema.
- A new analyzer rule (`coral_source_functions`) resolves each node into an ordinary provider `TableScan` before the optimizer runs — so plan shape, projection/limit pushdown, and execution are exactly what the UDTF path produced. `SourceFunctionRegistry::install()` registers planner and rule as a pair.
- Backends implement a Coral-owned `SourceFunctionProviderFactory` trait (previously DataFusion's `TableFunctionImpl`); the factory travels inside `RegisteredTableFunction`, and the hidden-UDTF machinery — name mangling, `register_udtf`, the separate factory map — is deleted.

## Behavior

Unchanged for every existing query. Fully-literal calls validate eagerly at relation-planning time, so all argument errors (unknown function/argument, duplicates, wildcards, SETTINGS, missing required, allowed-values) keep their existing messages **and** their existing phase. The pre-existing engine suite passes unmodified, except three tests that invoked the mangled internal name directly; one of those is repurposed into a negative test pinning that the internal surface no longer exists.

Deliberate, visible changes:
- A stray `$name` placeholder in a call argument now fails with `github.pulls argument 'q' is bound to parameter $q, but no value was provided for it` (previously a confusing `must be a literal`). No surface can supply parameter values yet; the binder arrives with the recipe stack, where the node's `expressions()` / `with_exprs_and_inputs()` contract lets `with_param_values` reach the arguments.
- Unoptimized EXPLAIN shows `SourceFunction: github.pulls`; optimized and physical plans are unchanged in shape, with table references reading `github.pulls` instead of the mangled hex name.
- Mangled internal names are no longer callable.
- Unsupported relation modifiers on function calls (`WITH ORDINALITY`, `TABLESAMPLE`, table/index hints, time-travel, PARTITION, JSON path) now fail with clear errors instead of executing while silently ignoring the modifier — main inherits DataFusion's silent-ignore for these (verified empirically; plain tables still behave that way engine-wide). The rejection destructures every `TableFactor::Table` field without `..`, so a sqlparser upgrade that adds a modifier fails compilation here and forces a decision.
- Qualified column references on function results now resolve like table columns: `SELECT github.pulls.id FROM github.pulls(...)` and `SELECT pulls.id FROM ...` both work. Previously the scan was named by the mangled identifier, so no user-writable qualifier could ever match (the unknown-column hint suggested quoting the mangled name). The scan now carries `TableReference::partial(schema, function)`.
- `DESCRIBE SELECT * FROM github.pulls(owner => $owner)` with an unbound placeholder now returns the result schema instead of failing at planning. The parked node carries the manifest-declared schema, so plan-time schema introspection works without argument values — the same operation recipe schema inference will perform.

Coverage note: the analyzer resolves nodes through subquery plans (`transform_up_with_subqueries`) — source-function calls inside scalar/EXISTS/IN subqueries are pinned by dedicated tests, since subqueries live in expressions and a plain plan walk misses them.

## Validation

- `make rust-checks` passes (1181 tests).
- `make perf-check` passes: `coral.tables` mean 196 ms against the 750 ms threshold (source registration no longer touches the UDTF registry).
- Exercised against a real workspace (github + linear sources): catalog listing, literal function calls returning live API results, alias usage, and the new unbound-placeholder error.
