### PR TITLE
feat(episode): bound the per-workspace log by bytes with oldest-out eviction (BENCH-496)

### DIFF
--- a/crates/coral-app/src/episode/store.rs
+++ b/crates/coral-app/src/episode/store.rs
@@ -233,9 +233,15 @@ fn append_within_budget(
 ) -> Result<(), EpisodeStoreError> {
     let line_len = serde_json::to_vec(&record)?.len() as u64 + 1;
     // Fast path: it fits on top of what's already on disk. `file_len` counts physical
-    // bytes (so any torn-record bytes are included conservatively), avoiding a rewrite
-    // in the common case.
-    if file_len(path)?.saturating_add(line_len) <= max_bytes {
+    // bytes (so any torn-record bytes are included conservatively); add the separator
+    // newline `append_record` will prepend when the file lacks a trailing one, so a
+    // torn-tailed file at the boundary doesn't slip one byte over the ceiling.
+    let leading = u64::from(file_needs_leading_newline(path)?);
+    if file_len(path)?
+        .saturating_add(line_len)
+        .saturating_add(leading)
+        <= max_bytes
+    {
         return append_record(path, &record);
     }
 
@@ -691,6 +697,38 @@ mod tests {
             .unwrap()
             .expect("present");
         assert_eq!(read.intent, "new intent");
+    }
+
+    #[test]
+    fn byte_ceiling_holds_when_the_log_has_a_torn_tail() {
+        // Regression: the fast-path budget must account for the separator newline
+        // `append_record` prepends to a file with no trailing newline, or a torn-tailed
+        // file sitting at the boundary slips one byte over the ceiling.
+        let (_dir, layout) = layout();
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let one = record_bytes(&workspace, "ep_1", "task");
+        let path = layout.episodes_file(&workspace);
+
+        // Seed a single valid record with NO trailing newline (a torn tail), so its
+        // on-disk size is `one - 1`.
+        let seed = serde_json::to_vec(&PersistedEpisode::from_episode(
+            &episode(&workspace, "ep_1", "task", None),
+            "task",
+        ))
+        .expect("serialize");
+        fs::create_dir_all(path.parent().unwrap()).expect("mkdir");
+        fs::write(&path, &seed).expect("seed torn-tail log");
+
+        // Ceiling = exactly the torn record + one new record. The old fast path would
+        // append (adding a leading newline) and land at `2*one`, one over.
+        let store = EpisodeStore::new(layout).with_max_bytes(2 * one - 1);
+        store
+            .open_episode(&episode(&workspace, "ep_2", "task", None))
+            .expect("open within budget");
+        assert!(
+            fs::metadata(&path).unwrap().len() < 2 * one,
+            "the log must not exceed the ceiling even when it had a torn tail"
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/episode/store.rs
+++ b/crates/coral-app/src/episode/store.rs
@@ -129,6 +129,13 @@ impl EpisodeStore {
     /// no-op; a different intent/parent returns [`EpisodeStoreError::Conflict`]
     /// (intent is immutable per episode — a change is a new child/sibling).
     ///
+    /// The conflict guarantee covers records still **retained** in the log. Because
+    /// the byte ceiling evicts the oldest records (below), an id whose record has been
+    /// evicted is treated as new rather than conflicting — bounding the log without
+    /// unbounded id-tracking inherently means forgetting old ids. Episode ids are
+    /// client-minted and unique per attempt (ULID/UUID), so an evicted id is never
+    /// reused in practice and the guarantee holds for all real callers.
+    ///
     /// A new record is appended within the per-workspace byte ceiling: if it would
     /// push the log over, the oldest records are evicted to make room (the log is a
     /// byte-bounded FIFO; the newest record is always kept). The shared state lock is

--- a/crates/coral-app/src/episode/store.rs
+++ b/crates/coral-app/src/episode/store.rs
@@ -2,9 +2,14 @@
 //!
 //! Persists `{ episode_id -> intent, parent }` for an episode (one task-attempt),
 //! written once by `OpenEpisode` into the per-workspace episode log resolved by
-//! [`AppStateLayout`]. Minimal by design for PR 1: a private, locked JSONL append.
-//! JSONL→Parquet compaction, retention/eviction, and the queryable
-//! `coral.episodes` surface land in a later PR.
+//! [`AppStateLayout`]: a private (0600), locked JSONL append, bounded by a
+//! per-workspace **byte ceiling with oldest-out eviction** — when a new record
+//! would exceed the limit, the oldest records are dropped to make room, so the log
+//! keeps the most recent episodes within budget (a byte-bounded FIFO; no time
+//! component). The idempotency scan already reads every record, so eviction folds
+//! into the same pass. The always-registered `OpenEpisode` route makes an unbounded
+//! log a real fill-the-disk surface, which this prevents. JSONL→Parquet compaction
+//! and the queryable `coral.episodes` surface land in a later PR.
 
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
@@ -18,6 +23,12 @@ use super::EpisodeId;
 use crate::state::AppStateLayout;
 use crate::storage::fs::{self as storage_fs, FileLock};
 use crate::workspaces::WorkspaceName;
+
+/// Per-workspace byte ceiling on the raw log. A new record that would push the log
+/// over this evicts the oldest records first (the newest is always kept, even if it
+/// alone exceeds the ceiling). Generous — bounds disk without losing recent history;
+/// becomes a `[episodes]` config knob alongside JSONL→Parquet compaction later.
+const MAX_EPISODE_BYTES_PER_WORKSPACE: u64 = 256 * 1024 * 1024;
 
 /// A registered episode — one task-attempt's intent and lineage.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,17 +97,30 @@ pub(crate) enum EpisodeStoreError {
     },
 }
 
-/// Append-only, per-workspace JSONL episode store. Paths and the shared state
-/// lock are resolved through [`AppStateLayout`].
+/// Append-only, per-workspace JSONL episode store, bounded by a byte ceiling with
+/// oldest-out eviction. Paths and the shared state lock are resolved through
+/// [`AppStateLayout`].
 #[derive(Clone)]
 pub(crate) struct EpisodeStore {
     layout: AppStateLayout,
+    max_bytes: u64,
 }
 
 impl EpisodeStore {
-    /// Creates a store that persists under `layout`.
+    /// Creates a store that persists under `layout` with the default byte ceiling.
     pub(crate) fn new(layout: AppStateLayout) -> Self {
-        Self { layout }
+        Self {
+            layout,
+            max_bytes: MAX_EPISODE_BYTES_PER_WORKSPACE,
+        }
+    }
+
+    /// Overrides the per-workspace byte ceiling so tests can exercise eviction with a
+    /// tiny value; production uses [`MAX_EPISODE_BYTES_PER_WORKSPACE`].
+    #[cfg(test)]
+    pub(crate) fn with_max_bytes(mut self, max_bytes: u64) -> Self {
+        self.max_bytes = max_bytes;
+        self
     }
 
     /// Registers `episode`, idempotently.
@@ -105,11 +129,13 @@ impl EpisodeStore {
     /// no-op; a different intent/parent returns [`EpisodeStoreError::Conflict`]
     /// (intent is immutable per episode — a change is a new child/sibling).
     ///
-    /// The shared state lock is held across the read-then-append so the
-    /// idempotency/conflict check and the write are atomic against concurrent
-    /// opens. Intent may be PII, so the log is written with private (0600)
-    /// permissions. The id is already validated ([`EpisodeId`]); intent is
-    /// checked here as a safety net for callers that bypass the service boundary.
+    /// A new record is appended within the per-workspace byte ceiling: if it would
+    /// push the log over, the oldest records are evicted to make room (the log is a
+    /// byte-bounded FIFO; the newest record is always kept). The shared state lock is
+    /// held across read-then-write so the idempotency check and the
+    /// evict-and-append are atomic against concurrent opens. Intent may be PII, so
+    /// the log is written 0600. The id is already validated ([`EpisodeId`]); intent
+    /// is checked here as a safety net for callers that bypass the service boundary.
     pub(crate) fn open_episode(&self, episode: &Episode) -> Result<(), EpisodeStoreError> {
         // Normalize intent once so surrounding whitespace never becomes part of the
         // immutable key — a retry with an accidental trailing space must stay
@@ -122,7 +148,14 @@ impl EpisodeStore {
         }
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
         let path = self.layout.episodes_file(&episode.workspace);
-        if let Some(existing) = read_episode(&path, episode.id.as_str())? {
+
+        // One read serves both the idempotency check and eviction (file order is
+        // chronological — oldest first).
+        let records = read_all_records(&path)?;
+        if let Some(existing) = records
+            .iter()
+            .rfind(|record| record.id == episode.id.as_str())
+        {
             return if existing.intent == intent
                 && existing.parent_episode_id.as_deref()
                     == episode.parent_episode_id.as_ref().map(EpisodeId::as_str)
@@ -134,18 +167,13 @@ impl EpisodeStore {
                 })
             };
         }
-        let record = serde_json::to_vec(&PersistedEpisode::from_episode(episode, intent))?;
-        let mut bytes = Vec::with_capacity(record.len() + 2);
-        // A prior torn append can leave the file without a trailing newline; start
-        // this record on its own line so the incomplete one stays separately
-        // skippable instead of merging with (and corrupting) this record.
-        if file_needs_leading_newline(&path)? {
-            bytes.push(b'\n');
-        }
-        bytes.extend_from_slice(&record);
-        bytes.push(b'\n');
-        storage_fs::append_file_private(&path, &bytes)?;
-        Ok(())
+
+        append_within_budget(
+            &path,
+            records,
+            PersistedEpisode::from_episode(episode, intent),
+            self.max_bytes,
+        )
     }
 }
 
@@ -156,46 +184,130 @@ pub(crate) fn now_unix_nanos() -> u128 {
         .map_or(0, |elapsed| elapsed.as_nanos())
 }
 
-/// Returns the most recent record for `episode_id` in `path`, if any.
+/// Parses every intact record in `contents`, in file order, skipping blank lines
+/// and torn records.
 ///
-/// Reads raw bytes and splits on newlines so a torn final record is skipped
-/// whether the crash broke JSON *or* UTF-8 (it can truncate a multi-byte intent
-/// mid-character) — one torn write must never brick reads for the workspace.
+/// Splits on newlines so a torn record is skipped whether the crash broke JSON *or*
+/// UTF-8 (a crash can truncate a multi-byte intent mid-character) — one torn write
+/// must never brick reads for the workspace. An unacknowledged torn write is simply
+/// re-appended when the client retries `OpenEpisode`.
+fn parse_records(contents: &[u8]) -> impl Iterator<Item = PersistedEpisode> + '_ {
+    contents
+        .split(|&byte| byte == b'\n')
+        .filter_map(|raw_line| {
+            let Ok(line) = std::str::from_utf8(raw_line) else {
+                tracing::warn!("skipping episode record with invalid UTF-8 (likely a torn write)");
+                return None;
+            };
+            if line.trim().is_empty() {
+                return None;
+            }
+            match serde_json::from_str::<PersistedEpisode>(line) {
+                Ok(record) => Some(record),
+                Err(error) => {
+                    tracing::warn!(%error, "skipping unparsable episode record");
+                    None
+                }
+            }
+        })
+}
+
+/// Reads every intact record in `path`, in file order (empty if the log is absent).
+fn read_all_records(path: &Path) -> Result<Vec<PersistedEpisode>, EpisodeStoreError> {
+    let contents = match std::fs::read(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.into()),
+    };
+    Ok(parse_records(&contents).collect())
+}
+
+/// Appends `record` to `path`, evicting the oldest records first if needed to keep
+/// the log within `max_bytes`. `existing` is the current log in file order (oldest
+/// first). The newest record is always kept, even if it alone exceeds `max_bytes`.
+fn append_within_budget(
+    path: &Path,
+    existing: Vec<PersistedEpisode>,
+    record: PersistedEpisode,
+    max_bytes: u64,
+) -> Result<(), EpisodeStoreError> {
+    let line_len = serde_json::to_vec(&record)?.len() as u64 + 1;
+    // Fast path: it fits on top of what's already on disk. `file_len` counts physical
+    // bytes (so any torn-record bytes are included conservatively), avoiding a rewrite
+    // in the common case.
+    if file_len(path)?.saturating_add(line_len) <= max_bytes {
+        return append_record(path, &record);
+    }
+
+    // Over budget: rebuild the log keeping the newest records (and always `record`)
+    // that fit, dropping the oldest. Rewriting also compacts away torn records.
+    let mut kept = existing;
+    kept.push(record);
+    let encoded: Vec<Vec<u8>> = kept
+        .iter()
+        .map(serde_json::to_vec)
+        .collect::<Result<_, _>>()?;
+    let record_count = encoded.len();
+    let mut total: u64 = encoded.iter().map(|line| line.len() as u64 + 1).sum();
+    // Drop oldest (front) records until within budget, but never the newest (last).
+    let mut dropped = 0;
+    for line in &encoded {
+        if total <= max_bytes || dropped + 1 >= record_count {
+            break;
+        }
+        total -= line.len() as u64 + 1;
+        dropped += 1;
+    }
+    let mut bytes = Vec::new();
+    for line in encoded.iter().skip(dropped) {
+        bytes.extend_from_slice(line);
+        bytes.push(b'\n');
+    }
+    // `write_atomic` (temp-file + rename) does not create the parent dir, so ensure
+    // it for the first-ever write. Crash-safe, so a crash mid-eviction never
+    // truncates the log.
+    if let Some(parent) = path.parent() {
+        storage_fs::ensure_dir(parent)?;
+    }
+    storage_fs::write_atomic(path, &bytes)?;
+    Ok(())
+}
+
+/// Current on-disk size of `path` in bytes, or 0 if the log does not exist yet.
+fn file_len(path: &Path) -> Result<u64, EpisodeStoreError> {
+    match std::fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.len()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(0),
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// Appends one record to `path` as a private (0600) JSONL line.
+fn append_record(path: &Path, record: &PersistedEpisode) -> Result<(), EpisodeStoreError> {
+    let encoded = serde_json::to_vec(record)?;
+    let mut bytes = Vec::with_capacity(encoded.len() + 2);
+    // A prior torn append can leave the file without a trailing newline; start this
+    // record on its own line so the incomplete one stays separately skippable
+    // instead of merging with (and corrupting) this record.
+    if file_needs_leading_newline(path)? {
+        bytes.push(b'\n');
+    }
+    bytes.extend_from_slice(&encoded);
+    bytes.push(b'\n');
+    storage_fs::append_file_private(path, &bytes)?;
+    Ok(())
+}
+
+/// Returns the most recent record for `episode_id` in `path`, if any. Test-only:
+/// production reads go through [`read_all_records`].
+#[cfg(test)]
 fn read_episode(
     path: &Path,
     episode_id: &str,
 ) -> Result<Option<PersistedEpisode>, EpisodeStoreError> {
-    let contents = match std::fs::read(path) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error.into()),
-    };
-    let mut found = None;
-    for raw_line in contents.split(|&byte| byte == b'\n') {
-        // A torn final record can be invalid UTF-8 (e.g. a truncated non-ASCII
-        // intent); skip it rather than failing the whole read.
-        let Ok(line) = std::str::from_utf8(raw_line) else {
-            tracing::warn!("skipping episode record with invalid UTF-8 (likely a torn write)");
-            continue;
-        };
-        if line.trim().is_empty() {
-            continue;
-        }
-        match serde_json::from_str::<PersistedEpisode>(line) {
-            Ok(episode) => {
-                if episode.id == episode_id {
-                    found = Some(episode);
-                }
-            }
-            // A crash mid-append can also leave a syntactically torn (but valid
-            // UTF-8) record; skip it too. An unacknowledged torn write is simply
-            // re-appended when the client retries `OpenEpisode`.
-            Err(error) => {
-                tracing::warn!(%error, "skipping unparsable episode record");
-            }
-        }
-    }
-    Ok(found)
+    Ok(read_all_records(path)?
+        .into_iter()
+        .rfind(|record| record.id == episode_id))
 }
 
 /// Whether an append to `path` must start with a newline: the file exists, is
@@ -225,10 +337,17 @@ mod tests {
 
     use super::{
         CORAL_EPISODE_INTENT_MAX_CHARS, Episode, EpisodeId, EpisodeStore, EpisodeStoreError,
-        now_unix_nanos, read_episode,
+        PersistedEpisode, now_unix_nanos, read_episode,
     };
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
+
+    /// On-disk byte size of one record (serialized JSON + newline), for sizing the
+    /// byte ceiling in eviction tests.
+    fn record_bytes(workspace: &WorkspaceName, id: &str, intent: &str) -> u64 {
+        let record = PersistedEpisode::from_episode(&episode(workspace, id, intent, None), intent);
+        serde_json::to_vec(&record).expect("serialize").len() as u64 + 1
+    }
 
     fn layout() -> (TempDir, AppStateLayout) {
         let dir = TempDir::new().expect("temp dir");
@@ -494,5 +613,105 @@ mod tests {
                 .intent,
             "in globex"
         );
+    }
+
+    #[test]
+    fn open_evicts_oldest_to_stay_under_the_byte_ceiling() {
+        let (_dir, layout) = layout();
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        // Size the ceiling to hold exactly two records (ids and intent are uniform, so
+        // every record serializes to the same length).
+        let one = record_bytes(&workspace, "ep_0", "task");
+        let store = EpisodeStore::new(layout.clone()).with_max_bytes(one * 2);
+        for id in ["ep_1", "ep_2", "ep_3"] {
+            store
+                .open_episode(&episode(&workspace, id, "task", None))
+                .expect("open");
+        }
+
+        let path = layout.episodes_file(&workspace);
+        assert!(
+            read_episode(&path, "ep_1").unwrap().is_none(),
+            "the oldest record must be evicted"
+        );
+        assert!(read_episode(&path, "ep_2").unwrap().is_some());
+        assert!(read_episode(&path, "ep_3").unwrap().is_some());
+        assert!(
+            fs::metadata(&path).unwrap().len() <= one * 2,
+            "the log must stay within the byte ceiling"
+        );
+    }
+
+    #[test]
+    fn the_newest_record_is_kept_even_when_it_alone_exceeds_the_ceiling() {
+        let (_dir, layout) = layout();
+        // A ceiling smaller than any record: each open evicts everything older, so the
+        // log always holds exactly the most recent episode — never rejects.
+        let store = EpisodeStore::new(layout.clone()).with_max_bytes(1);
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        store
+            .open_episode(&episode(&workspace, "ep_1", "first", None))
+            .expect("first kept");
+        store
+            .open_episode(&episode(&workspace, "ep_2", "second", None))
+            .expect("second evicts first, never rejects");
+
+        let path = layout.episodes_file(&workspace);
+        assert!(read_episode(&path, "ep_1").unwrap().is_none());
+        assert_eq!(
+            read_episode(&path, "ep_2").unwrap().unwrap().intent,
+            "second"
+        );
+        let lines = fs::read_to_string(&path)
+            .unwrap()
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .count();
+        assert_eq!(lines, 1, "only the newest record remains");
+    }
+
+    #[test]
+    fn reopening_an_evicted_id_is_a_fresh_episode() {
+        let (_dir, layout) = layout();
+        let store = EpisodeStore::new(layout.clone()).with_max_bytes(1);
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        store
+            .open_episode(&episode(&workspace, "ep_1", "old intent", None))
+            .expect("open ep_1");
+        // ep_1 is evicted to make room for ep_2.
+        store
+            .open_episode(&episode(&workspace, "ep_2", "other", None))
+            .expect("open ep_2 evicts ep_1");
+        // Re-using ep_1's id with a different intent is a fresh episode, not a
+        // conflict — its old record is gone.
+        store
+            .open_episode(&episode(&workspace, "ep_1", "new intent", None))
+            .expect("evicted id is reusable");
+        let read = read_episode(&layout.episodes_file(&workspace), "ep_1")
+            .unwrap()
+            .expect("present");
+        assert_eq!(read.intent, "new intent");
+    }
+
+    #[test]
+    fn eviction_preserves_idempotency_for_surviving_records() {
+        let (_dir, layout) = layout();
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let one = record_bytes(&workspace, "ep_0", "task");
+        let store = EpisodeStore::new(layout.clone()).with_max_bytes(one * 2);
+        for id in ["ep_1", "ep_2", "ep_3"] {
+            store
+                .open_episode(&episode(&workspace, id, "task", None))
+                .expect("open");
+        }
+        // ep_2 survived the eviction of ep_1, so reopening it is still idempotent and a
+        // changed intent still conflicts.
+        store
+            .open_episode(&episode(&workspace, "ep_2", "task", None))
+            .expect("surviving record is idempotent");
+        let conflict = store
+            .open_episode(&episode(&workspace, "ep_2", "different", None))
+            .expect_err("surviving record still conflicts on a changed intent");
+        assert!(matches!(conflict, EpisodeStoreError::Conflict { .. }));
     }
 }


### PR DESCRIPTION
## BENCH-496 — bound the raw episode log

The `OpenEpisode` route is always-registered (and callable today via the generated `EpisodeServiceClient`), so the per-workspace `episodes.jsonl` can grow without bound. This bounds it.

### Design: byte ceiling + oldest-out eviction (byte-bounded FIFO)
- A per-workspace **byte ceiling** (default **256 MiB**). When a new record would push the log over, the **oldest records are evicted** to make room — the log keeps the most recent episodes within budget.
- The **newest record is always kept** (even if it alone exceeds the ceiling); the store **never rejects** an open.
- **No time-based retention, no background job.** The idempotency/conflict scan already reads the whole log on every open, so eviction folds into the same pass.

### Why this shape (decisions captured in-thread)
- **Disk-only, no in-memory index.** The write-side index (the O(N²)-scan fix) was deliberately dropped: the read-side index/representation should be co-designed with retrieval (it may live compacted on disk, not in RAM), so committing to an in-memory shape now is premature. At alpha volume the O(N) scan is fine.
- **Bytes, not time.** Time-based age-out would drop episode history by clock; a byte-FIFO keeps the most recent N MiB regardless of age, which is what "bound disk, keep recent" wants.
- **Shares the right layer.** Reuses `storage_fs` (`write_atomic` for the eviction rewrite, `append_file_private` for the common append, `FileLock`) — the same low-level layer telemetry/feedback use. The trace store's higher-level `RollingJsonlWriter`/time-prune is intentionally *not* reused: episodes are read-modify-write + byte-FIFO + single-file, vs traces' write-only + time-pruned + rolling. (That machinery is a natural extraction later for the write-only `trajectory_steps.jsonl` capture.)

### Cost
The common under-budget open is a cheap append. Once a workspace sits at the ceiling, each new open rewrites the surviving log (O(N)) — acceptable at alpha volume; the real fix is compaction (PR-P1).

### Tests
- evicts oldest to stay under the ceiling; newest kept even when it alone exceeds; an evicted id is reusable (not a conflict); surviving records keep idempotency/conflict semantics. Existing torn-write / parent-lineage / idempotency tests unchanged.

`make rust-checks` locally: fmt ✅ · clippy `-D warnings` ✅ · tests ✅ · rustdoc `-D warnings` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)