### PR TITLE
feat(engine): bind named query parameters

### DIFF
--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -12,9 +12,9 @@ pub use catalog::{
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
     DependentJoinConfig, DependentJoinSourceConfig, EffectiveDependentJoinConfig, QueryExecution,
-    QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTestFailure,
-    QueryTestResult, QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage,
-    SourceValidationReport,
+    QueryParameterValue, QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
+    QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
+    RuntimeSourcePackage, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -348,6 +348,29 @@ impl QueryRuntimeContext {
     }
 }
 
+/// Named SQL query parameters, keyed by parameter name without the `$`
+/// prefix: binding `owner` supplies `$owner` in the statement.
+pub type QueryParameters = BTreeMap<String, QueryParameterValue>;
+
+/// Value bound to one named SQL query parameter (`$name`).
+///
+/// Values are data, never SQL text: they bind into the planned statement
+/// through `DataFusion` parameter substitution, so no quoting or escaping
+/// rules apply anywhere in the request path.
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryParameterValue {
+    /// UTF-8 string value.
+    String(String),
+    /// 64-bit signed integer value.
+    Integer(i64),
+    /// 64-bit floating point value.
+    Float(f64),
+    /// Boolean value.
+    Boolean(bool),
+    /// SQL NULL.
+    Null,
+}
+
 /// Owned runtime-build inputs needed while compiling and registering sources.
 #[derive(Default)]
 pub struct QueryRuntimeConfig {

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -67,11 +67,11 @@ pub use composition::{
 };
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
-    DescribeTableInfo, EffectiveDependentJoinConfig, QueryExecution, QueryPlan, QueryRuntimeConfig,
-    QueryRuntimeContext, QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess,
-    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport, StatusCode,
-    StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
-    TableFunctionResultColumnInfo, TableInfo,
+    DescribeTableInfo, EffectiveDependentJoinConfig, QueryExecution, QueryParameterValue,
+    QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
+    RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
+    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// High-level query operations for the local query engine.
@@ -153,13 +153,30 @@ impl CoralQuery {
         runtime: QueryRuntimeConfig,
         sql: &str,
     ) -> Result<QueryExecution, CoreError> {
+        Self::execute_sql_with_params(sources, runtime, sql, QueryParameters::new()).await
+    }
+
+    /// Executes one `SQL` statement with named query parameter values bound
+    /// into its `$name` placeholders.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the SQL is empty, if source compilation fails,
+    /// if a supplied parameter is not referenced by the statement, or if the
+    /// runtime cannot execute the statement.
+    pub async fn execute_sql_with_params(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        sql: &str,
+        params: QueryParameters,
+    ) -> Result<QueryExecution, CoreError> {
         if sql.trim().is_empty() {
             return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
         }
 
         runtime::query::build_runtime(sources, runtime)
             .await?
-            .execute_sql(sql)
+            .execute_sql(sql, &params)
             .await
     }
 
@@ -177,13 +194,30 @@ impl CoralQuery {
         runtime: QueryRuntimeConfig,
         sql: &str,
     ) -> Result<QueryPlan, CoreError> {
+        Self::explain_sql_with_params(sources, runtime, sql, QueryParameters::new()).await
+    }
+
+    /// Explains one `SQL` statement with named query parameter values bound
+    /// into its `$name` placeholders before planning output is rendered.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the SQL is empty, if source compilation fails,
+    /// if a supplied parameter is not referenced by the statement, or if the
+    /// query engine cannot explain the statement.
+    pub async fn explain_sql_with_params(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        sql: &str,
+        params: QueryParameters,
+    ) -> Result<QueryPlan, CoreError> {
         if sql.trim().is_empty() {
             return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
         }
 
         runtime::query::build_runtime(sources, runtime)
             .await?
-            .explain_sql(sql)
+            .explain_sql(sql, &params)
             .await
     }
 
@@ -227,7 +261,10 @@ impl CoralQuery {
 
         let mut query_tests = Vec::with_capacity(test_queries.len());
         for sql in test_queries {
-            match query_runtime.execute_sql(sql).await {
+            match query_runtime
+                .execute_sql(sql, &QueryParameters::new())
+                .await
+            {
                 Ok(execution) => query_tests.push(QueryTestResult::success(
                     sql.clone(),
                     execution.row_count() as u64,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -3,10 +3,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use datafusion::common::ScalarValue;
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::displayable;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
 use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
@@ -31,10 +33,10 @@ use crate::runtime::registry::{
 };
 use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
-    CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, QueryExecution, QueryPlan,
-    QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext,
-    QuerySource, RequestAuthenticator, SourceDecorator, SourceInputResolver, TableFunctionInfo,
-    TableInfo,
+    CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, QueryExecution,
+    QueryParameterValue, QueryParameters, QueryPlan, QueryResultObserver, QueryResultObserverError,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceDecorator,
+    SourceInputResolver, TableFunctionInfo, TableInfo,
 };
 
 pub(crate) struct QueryRuntimeAdapter {
@@ -322,8 +324,12 @@ impl QueryRuntimeAdapter {
             .find(|failure| failure.schema_name == source_name)
     }
 
-    pub(crate) async fn execute_sql(&self, sql: &str) -> Result<QueryExecution, CoreError> {
-        match self.execute_sql_once(&self.ctx, sql).await {
+    pub(crate) async fn execute_sql(
+        &self,
+        sql: &str,
+        params: &QueryParameters,
+    ) -> Result<QueryExecution, CoreError> {
+        match self.execute_sql_once(&self.ctx, sql, params).await {
             Ok(execution) => Ok(execution),
             Err(SqlExecutionFailure::Collection(error)) => {
                 // Resolver-row overflow is a dependent-join buffering limit, not
@@ -352,7 +358,7 @@ impl QueryRuntimeAdapter {
                     .get_or_build_without_dependent_join()
                     .await?;
 
-                match self.execute_sql_once(&fallback.ctx, sql).await {
+                match self.execute_sql_once(&fallback.ctx, sql, params).await {
                     Ok(execution) => Ok(execution),
                     Err(error) => {
                         if is_missing_required_filter_failure(&error) {
@@ -371,11 +377,13 @@ impl QueryRuntimeAdapter {
         &self,
         ctx: &SessionContext,
         sql: &str,
+        params: &QueryParameters,
     ) -> Result<QueryExecution, SqlExecutionFailure> {
         let df = ctx
             .sql_with_options(sql, read_only_sql_options())
             .await
             .map_err(SqlExecutionFailure::Planning)?;
+        let df = apply_query_parameters(df, params).map_err(SqlExecutionFailure::Planning)?;
         let arrow_schema = Arc::new(df.schema().as_arrow().clone());
         let batches = df
             .collect()
@@ -415,8 +423,12 @@ impl QueryRuntimeAdapter {
         Ok(())
     }
 
-    pub(crate) async fn explain_sql(&self, sql: &str) -> Result<QueryPlan, CoreError> {
-        let df = self.sql_dataframe(sql).await?;
+    pub(crate) async fn explain_sql(
+        &self,
+        sql: &str,
+        params: &QueryParameters,
+    ) -> Result<QueryPlan, CoreError> {
+        let df = self.sql_dataframe(sql, params).await?;
         let unoptimized_logical_plan = df.logical_plan().display_indent_schema().to_string();
         let (session_state, logical_plan) = df.into_parts();
         let optimized_logical_plan = session_state
@@ -441,8 +453,13 @@ impl QueryRuntimeAdapter {
         ))
     }
 
-    async fn sql_dataframe(&self, sql: &str) -> Result<DataFrame, CoreError> {
-        self.ctx
+    async fn sql_dataframe(
+        &self,
+        sql: &str,
+        params: &QueryParameters,
+    ) -> Result<DataFrame, CoreError> {
+        let df = self
+            .ctx
             .sql_with_options(sql, read_only_sql_options())
             .await
             .map_err(|err| {
@@ -452,7 +469,74 @@ impl QueryRuntimeAdapter {
                     &self.table_functions,
                     Some(sql),
                 )
-            })
+            })?;
+        apply_query_parameters(df, params).map_err(|err| {
+            datafusion_to_core_with_sql_and_table_functions(
+                &err,
+                &self.tables,
+                &self.table_functions,
+                Some(sql),
+            )
+        })
+    }
+}
+
+/// Binds named query parameter values into a planned statement.
+///
+/// Rejects parameters the statement never references, then substitutes the
+/// values into the logical plan via `DataFusion` parameter binding — values
+/// stay data and are never rendered into SQL text.
+fn apply_query_parameters(
+    df: DataFrame,
+    params: &QueryParameters,
+) -> Result<DataFrame, DataFusionError> {
+    if params.is_empty() {
+        return Ok(df);
+    }
+    reject_unknown_parameters(df.logical_plan(), params)?;
+    let values: Vec<(String, ScalarValue)> = params
+        .iter()
+        .map(|(name, value)| (name.clone(), parameter_scalar_value(value)))
+        .collect();
+    df.with_param_values(values)
+}
+
+fn reject_unknown_parameters(
+    plan: &LogicalPlan,
+    params: &QueryParameters,
+) -> Result<(), DataFusionError> {
+    let referenced = plan.get_parameter_names()?;
+    let mut unknown: Vec<&str> = params
+        .keys()
+        .map(String::as_str)
+        .filter(|name| !referenced.contains(&format!("${name}")))
+        .collect();
+    if unknown.is_empty() {
+        return Ok(());
+    }
+    unknown.sort_unstable();
+
+    let mut placeholders: Vec<&str> = referenced.iter().map(String::as_str).collect();
+    placeholders.sort_unstable();
+    let placeholder_hint = if placeholders.is_empty() {
+        "the statement has no parameter placeholders".to_string()
+    } else {
+        format!("the statement references: {}", placeholders.join(", "))
+    };
+
+    Err(DataFusionError::Plan(format!(
+        "unknown query parameter(s): {}; {placeholder_hint}",
+        unknown.join(", ")
+    )))
+}
+
+fn parameter_scalar_value(value: &QueryParameterValue) -> ScalarValue {
+    match value {
+        QueryParameterValue::String(value) => ScalarValue::Utf8(Some(value.clone())),
+        QueryParameterValue::Integer(value) => ScalarValue::Int64(Some(*value)),
+        QueryParameterValue::Float(value) => ScalarValue::Float64(Some(*value)),
+        QueryParameterValue::Boolean(value) => ScalarValue::Boolean(Some(*value)),
+        QueryParameterValue::Null => ScalarValue::Null,
     }
 }
 

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -9,8 +9,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use coral_engine::{
-    CoralQuery, CoreError, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext,
-    RequestAuthenticator, RequestAuthenticatorError, StatusCode,
+    CoralQuery, CoreError, EngineExtensions, QueryParameterValue, QueryParameters,
+    QueryRuntimeConfig, QueryRuntimeContext, RequestAuthenticator, RequestAuthenticatorError,
+    StatusCode,
 };
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use serde_json::{Value, json};
@@ -2972,4 +2973,204 @@ async fn legacy_json_body_array_form_still_works() {
     );
 
     assert_eq!(rows, users_rows());
+}
+
+fn string_param(name: &str, value: &str) -> (String, QueryParameterValue) {
+    (
+        name.to_string(),
+        QueryParameterValue::String(value.to_string()),
+    )
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_binds_query_parameters() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param("search_type", "hybrid"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("param_search", &server.uri()));
+    let params = QueryParameters::from([
+        string_param("q", "flaky cleanup repo:withcoral/coral"),
+        string_param("mode", "hybrid"),
+    ]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[source],
+            test_runtime(),
+            "SELECT title, score FROM param_search.search_issues(q => $q, mode => $mode)",
+            params,
+        )
+        .await
+        .expect("parameterized source function call should bind and execute"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_rejects_unbound_parameter() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("unbound_search", &server.uri()));
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM unbound_search.search_issues(q => $q)",
+    )
+    .await
+    .expect_err("an unbound parameter in a source function call should fail");
+
+    assert!(
+        error.to_string().contains(
+            "unbound_search.search_issues argument 'q' is bound to parameter $q, \
+             but no value was provided for it"
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn query_parameters_reject_unknown_names() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("strict_params", &server.uri()));
+    let params = QueryParameters::from([string_param("typo", "hybrid")]);
+
+    let error = CoralQuery::execute_sql_with_params(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM strict_params.search_issues(q => $q)",
+        params,
+    )
+    .await
+    .expect_err("parameters the statement never references should fail");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("unknown query parameter(s): typo"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        message.contains("the statement references: $q"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn null_query_parameter_is_treated_as_omitted_optional_argument() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param_is_missing("search_type"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("null_param_search", &server.uri()));
+    let params = QueryParameters::from([
+        string_param("q", "flaky cleanup repo:withcoral/coral"),
+        ("mode".to_string(), QueryParameterValue::Null),
+    ]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[source],
+            test_runtime(),
+            "SELECT title, score FROM null_param_search.search_issues(q => $q, mode => $mode)",
+            params,
+        )
+        .await
+        .expect("null parameter for an optional argument should be omitted"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn null_query_parameter_for_required_argument_fails() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("null_required", &server.uri()));
+    let params = QueryParameters::from([("q".to_string(), QueryParameterValue::Null)]);
+
+    let error = CoralQuery::execute_sql_with_params(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM null_required.search_issues(q => $q)",
+        params,
+    )
+    .await
+    .expect_err("null parameter for a required argument should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("null_required.search_issues missing required argument(s): q"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn query_parameters_bind_in_where_clauses() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "cleanup"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [
+                { "title": "Flaky workspace cleanup", "score": 9.5 },
+                { "title": "Unrelated issue", "score": 1.0 }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("where_params", &server.uri()));
+    let params = QueryParameters::from([
+        string_param("q", "cleanup"),
+        string_param("title", "Flaky workspace cleanup"),
+    ]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[source],
+            test_runtime(),
+            "SELECT title FROM where_params.search_issues(q => $q) WHERE title = $title",
+            params,
+        )
+        .await
+        .expect("parameters should bind in both call arguments and WHERE clauses"),
+    );
+
+    assert_eq!(rows, vec![json!({ "title": "Flaky workspace cleanup" })]);
 }


### PR DESCRIPTION
Add QueryParameters to the engine contract and execute/explain entry
points. Values bind through DataFusion parameter substitution — never
rendered into SQL text — and reach source-function arguments via the
parked logical node. Unknown parameter names and unbound placeholders
fail with attributable errors.