### PR TITLE
chore(app): quarantine mechanical refactors ahead of identity work

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -37,7 +37,6 @@ use tower::{Layer, Service};
 
 use super::env::AppEnvironment;
 use super::error::AppError;
-use crate::EngineExtensionsProvider;
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
 use crate::credentials::{CredentialManager, CredentialStore};
@@ -48,7 +47,6 @@ use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
-use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
@@ -57,6 +55,7 @@ use crate::state::ConfigStore;
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
+use crate::{EngineExtensionsProvider, SingleUserPrincipalProvider, UserPrincipalProvider};
 
 /// A static asset (e.g., a built SPA file) served on the same port as
 /// gRPC-Web.
@@ -75,69 +74,6 @@ pub trait StaticAssetsProvider: Send + Sync + 'static {
     /// Returns the asset stored at `path` (relative, no leading slash), or
     /// `None` if the asset does not exist.
     fn get(&self, path: &str) -> Option<StaticAsset>;
-}
-
-/// Server-side bootstrap configuration for the Coral server.
-#[derive(Clone)]
-pub(crate) struct ServerConfig {
-    config_dir: Option<PathBuf>,
-    mode: ServerMode,
-    engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-    user_principal_provider: Arc<dyn UserPrincipalProvider>,
-    feedback_publisher: Arc<dyn FeedbackPublisher>,
-    enable_stderr_logs: bool,
-}
-
-impl Default for ServerConfig {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ServerConfig {
-    pub(crate) fn new() -> Self {
-        Self {
-            config_dir: None,
-            mode: ServerMode::NativeGrpc,
-            engine_extensions_providers: Vec::new(),
-            user_principal_provider: Arc::new(SingleUserPrincipalProvider),
-            feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
-            enable_stderr_logs: false,
-        }
-    }
-
-    pub(crate) fn with_config_dir(mut self, config_dir: impl Into<PathBuf>) -> Self {
-        self.config_dir = Some(config_dir.into());
-        self
-    }
-
-    pub(crate) fn with_mode(mut self, mode: ServerMode) -> Self {
-        self.mode = mode;
-        self
-    }
-
-    pub(crate) fn add_engine_extensions_provider(
-        mut self,
-        engine_extensions_provider: Arc<dyn EngineExtensionsProvider>,
-    ) -> Self {
-        self.engine_extensions_providers
-            .push(engine_extensions_provider);
-        self
-    }
-
-    pub(crate) fn with_user_principal_provider(
-        mut self,
-        user_principal_provider: Arc<dyn UserPrincipalProvider>,
-    ) -> Self {
-        self.user_principal_provider = user_principal_provider;
-        self
-    }
-
-    #[must_use]
-    pub(crate) fn with_stderr_logs(mut self, enable_stderr_logs: bool) -> Self {
-        self.enable_stderr_logs = enable_stderr_logs;
-        self
-    }
 }
 
 /// Concrete local server mode.
@@ -167,9 +103,21 @@ impl ServerMode {
 }
 
 /// Builder for the Coral server runtime.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ServerBuilder {
-    config: ServerConfig,
+    // Defaults preserve single-user local-first behavior; see `Self::new`.
+    config_dir: Option<PathBuf>,
+    mode: ServerMode,
+    engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    feedback_publisher: Arc<dyn FeedbackPublisher>,
+    enable_stderr_logs: bool,
+}
+
+impl Default for ServerBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ServerBuilder {
@@ -177,7 +125,12 @@ impl ServerBuilder {
     /// Creates a builder for the default native gRPC local server.
     pub fn new() -> Self {
         Self {
-            config: ServerConfig::new(),
+            config_dir: None,
+            mode: ServerMode::NativeGrpc,
+            engine_extensions_providers: Vec::new(),
+            user_principal_provider: Arc::new(SingleUserPrincipalProvider),
+            feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
+            enable_stderr_logs: false,
         }
     }
 
@@ -202,14 +155,14 @@ impl ServerBuilder {
     #[must_use]
     /// Selects the local server mode.
     pub fn with_mode(mut self, mode: ServerMode) -> Self {
-        self.config = self.config.with_mode(mode);
+        self.mode = mode;
         self
     }
 
     #[must_use]
     /// Overrides the Coral config directory used by the local server.
     pub fn with_config_dir(mut self, config_dir: impl Into<PathBuf>) -> Self {
-        self.config = self.config.with_config_dir(config_dir);
+        self.config_dir = Some(config_dir.into());
         self
     }
 
@@ -222,9 +175,8 @@ impl ServerBuilder {
         mut self,
         engine_extensions_provider: Arc<dyn EngineExtensionsProvider>,
     ) -> Self {
-        self.config = self
-            .config
-            .add_engine_extensions_provider(engine_extensions_provider);
+        self.engine_extensions_providers
+            .push(engine_extensions_provider);
         self
     }
 
@@ -239,9 +191,7 @@ impl ServerBuilder {
         mut self,
         user_principal_provider: Arc<dyn UserPrincipalProvider>,
     ) -> Self {
-        self.config = self
-            .config
-            .with_user_principal_provider(user_principal_provider);
+        self.user_principal_provider = user_principal_provider;
         self
     }
 
@@ -252,7 +202,7 @@ impl ServerBuilder {
     /// stdout reserved for protocol messages. Other command surfaces should
     /// leave it disabled and rely on OTEL export for logs.
     pub fn with_stderr_logs(mut self, enable_stderr_logs: bool) -> Self {
-        self.config = self.config.with_stderr_logs(enable_stderr_logs);
+        self.enable_stderr_logs = enable_stderr_logs;
         self
     }
 
@@ -260,7 +210,7 @@ impl ServerBuilder {
     #[doc(hidden)]
     #[must_use]
     pub fn with_noop_feedback_uploads(mut self) -> Self {
-        self.config.feedback_publisher = Arc::new(NoopFeedbackPublisher);
+        self.feedback_publisher = Arc::new(NoopFeedbackPublisher);
         self
     }
 
@@ -276,7 +226,7 @@ impl ServerBuilder {
     /// fail to initialize, or the gRPC server cannot be started.
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
-        let layout = env.app_state_layout(self.config.config_dir)?;
+        let layout = env.app_state_layout(self.config_dir)?;
         layout.ensure()?;
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
@@ -285,7 +235,7 @@ impl ServerBuilder {
             .then(|| layout.local_trace_store_dir());
         let installed_trace_store = crate::telemetry::init_tracing(
             &telemetry_config,
-            self.config.enable_stderr_logs,
+            self.enable_stderr_logs,
             internal_trace_store_dir.clone(),
         )?;
         let config_store = ConfigStore::new(layout.clone());
@@ -299,7 +249,7 @@ impl ServerBuilder {
             layout.clone(),
         );
         let feedback_manager =
-            FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
+            FeedbackManager::with_publisher(layout.clone(), self.feedback_publisher);
         let episode_store = EpisodeStore::new(layout.clone());
         let body_capture_max_bytes = telemetry_config
             .trace_history
@@ -313,22 +263,22 @@ impl ServerBuilder {
             credential_manager,
             query_runtime_context,
             layout,
-            self.config.engine_extensions_providers,
+            self.engine_extensions_providers,
         );
         let trace_service = if telemetry_config.trace_history.enabled {
             installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))
         } else {
             None
         };
-        start_server(
+        start_server(ServerServices {
             source_manager,
             query_manager,
+            user_principal_provider: self.user_principal_provider,
             feedback_manager,
             episode_store,
             trace_service,
-            self.config.user_principal_provider,
-            self.config.mode,
-        )
+            mode: self.mode,
+        })
         .await
     }
 }
@@ -403,15 +353,26 @@ impl Drop for RunningServer {
     }
 }
 
-async fn start_server(
+struct ServerServices {
     source_manager: SourceManager,
     query_manager: QueryManager,
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
     feedback_manager: FeedbackManager,
     episode_store: EpisodeStore,
     trace_service: Option<TraceService>,
-    user_principal_provider: Arc<dyn UserPrincipalProvider>,
     mode: ServerMode,
-) -> Result<RunningServer, AppError> {
+}
+
+async fn start_server(services: ServerServices) -> Result<RunningServer, AppError> {
+    let ServerServices {
+        source_manager,
+        query_manager,
+        user_principal_provider,
+        feedback_manager,
+        episode_store,
+        trace_service,
+        mode,
+    } = services;
     let source_service = SourceService::new(
         source_manager,
         query_manager.clone(),
@@ -669,28 +630,33 @@ mod tests {
     )]
 
     use std::borrow::Cow;
+    use std::future::Future;
     use std::net::{Ipv4Addr, TcpListener};
     use std::path::Path;
     use std::sync::Arc;
     use std::time::Duration;
 
+    use coral_api::v1::catalog_service_client::CatalogServiceClient;
     use coral_api::v1::episode_service_client::EpisodeServiceClient;
+    use coral_api::v1::feedback_service_client::FeedbackServiceClient;
     use coral_api::v1::query_service_client::QueryServiceClient;
     use coral_api::v1::source_service_client::SourceServiceClient;
     use coral_api::v1::trace_service_client::TraceServiceClient;
     use coral_api::v1::{
-        ExecuteSqlRequest, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
-        ListTracesRequest, OpenEpisodeRequest, Workspace, import_source_response,
+        ExecuteSqlRequest, ExecuteSqlResponse, ImportSourceRequest, ImportSourceResponse,
+        ListCatalogRequest, ListSourcesRequest, ListTracesRequest, ListTracesResponse,
+        OpenEpisodeRequest, SubmitFeedbackRequest, Workspace, import_source_response,
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
+
     use tempfile::TempDir;
-    use tonic::transport::Endpoint;
+    use tonic::transport::{Channel, Endpoint};
     use tonic::{Code, Request};
 
     use super::{
-        ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider, is_grpc_web_content_type,
-        is_native_grpc_content_type, start_server,
+        RunningServer, ServerBuilder, ServerMode, ServerServices, StaticAsset,
+        StaticAssetsProvider, is_grpc_web_content_type, is_native_grpc_content_type, start_server,
     };
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::episode::store::EpisodeStore;
@@ -710,20 +676,6 @@ mod tests {
         workspace_to_proto(&WorkspaceName::default())
     }
 
-    fn disable_internal_tracing(config_dir: &Path) {
-        std::fs::create_dir_all(config_dir).expect("create config dir");
-        std::fs::write(
-            config_dir.join("config.toml"),
-            r"
-version = 1
-
-[trace_history]
-enabled = false
-",
-        )
-        .expect("write telemetry config");
-    }
-
     #[derive(Debug)]
     struct RejectingUserPrincipalProvider;
 
@@ -739,42 +691,138 @@ enabled = false
         }
     }
 
-    #[tokio::test]
-    async fn grpc_services_reject_unauthenticated_requests() {
-        let temp = TempDir::new().expect("temp dir");
-        let server = ServerBuilder::new()
-            .with_config_dir(temp.path().join("coral-config"))
-            .with_user_principal_provider(Arc::new(RejectingUserPrincipalProvider))
-            .start()
-            .await
-            .expect("start server");
-        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+    fn disable_internal_tracing(config_dir: &Path) {
+        std::fs::create_dir_all(config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            r"
+version = 1
+
+[trace_history]
+enabled = false
+",
+        )
+        .expect("write telemetry config");
+    }
+
+    /// Starts a native-gRPC server whose services are all built from a fresh
+    /// layout under `temp`, returning it with a connected channel.
+    async fn start_test_server(
+        temp: &TempDir,
+        runtime_context: QueryRuntimeContext,
+        trace_service: Option<TraceService>,
+    ) -> (RunningServer, Channel) {
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout dirs");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let server = start_server(ServerServices {
+            source_manager: SourceManager::new(
+                config_store.clone(),
+                credential_manager.clone(),
+                layout.clone(),
+            ),
+            query_manager: QueryManager::new(
+                config_store,
+                credential_manager,
+                runtime_context,
+                layout.clone(),
+                vec![Arc::new(NoopEngineExtensionsProvider)],
+            ),
+            user_principal_provider: Arc::new(SingleUserPrincipalProvider),
+            feedback_manager: FeedbackManager::new(layout.clone()),
+            episode_store: EpisodeStore::new(layout.clone()),
+            trace_service,
+            mode: ServerMode::NativeGrpc,
+        })
+        .await
+        .expect("start server");
+        let channel = connect(&server).await;
+        (server, channel)
+    }
+
+    /// Connects with the client-side header budget raised to the app's limit.
+    async fn connect(server: &RunningServer) -> Channel {
+        Endpoint::from_shared(server.endpoint_uri().to_string())
             .expect("endpoint")
+            .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
             .connect()
             .await
-            .expect("connect");
-        let mut source_client = SourceServiceClient::new(channel.clone());
-        let mut query_client = QueryServiceClient::new(channel);
+            .expect("connect")
+    }
 
-        let status = source_client
-            .list_sources(Request::new(ListSourcesRequest {
-                workspace: Some(default_workspace()),
-            }))
+    /// An `ImportSourceRequest` for the default workspace with no bindings.
+    fn import_source_request(manifest_yaml: String) -> ImportSourceRequest {
+        ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml,
+            ..ImportSourceRequest::default()
+        }
+    }
+
+    /// Imports a manifest over gRPC and returns the imported source's name.
+    async fn import_source_name_over_grpc(
+        source_client: &mut SourceServiceClient<Channel>,
+        manifest_yaml: String,
+    ) -> String {
+        let mut import_stream = source_client
+            .import_source(Request::new(import_source_request(manifest_yaml)))
             .await
-            .expect_err("source list should require a request principal");
+            .expect("create source")
+            .into_inner();
+        import_stream
+            .message()
+            .await
+            .expect("import source stream")
+            .and_then(|response| match response.event {
+                Some(import_source_response::Event::Source(source)) => Some(source),
+                _ => None,
+            })
+            .expect("import source response")
+            .name
+    }
 
-        assert_eq!(status.code(), Code::Unauthenticated);
+    fn list_sources_request() -> ListSourcesRequest {
+        ListSourcesRequest {
+            workspace: Some(default_workspace()),
+        }
+    }
 
-        let status = query_client
+    /// Issues `ExecuteSql` for `sql` against the default workspace.
+    async fn execute_sql(
+        client: &mut QueryServiceClient<Channel>,
+        sql: &str,
+    ) -> Result<tonic::Response<ExecuteSqlResponse>, tonic::Status> {
+        client
             .execute_sql(Request::new(ExecuteSqlRequest {
                 workspace: Some(default_workspace()),
-                sql: "SELECT 1".to_string(),
+                sql: sql.to_string(),
             }))
             .await
-            .expect_err("query should require a request principal");
+    }
 
-        assert_eq!(status.code(), Code::Unauthenticated);
-        server.shutdown().await.expect("shutdown");
+    /// Issues a default first-page `ListTraces` request.
+    async fn list_traces(
+        client: &mut TraceServiceClient<Channel>,
+    ) -> Result<tonic::Response<ListTracesResponse>, tonic::Status> {
+        client
+            .list_traces(Request::new(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
+            }))
+            .await
+    }
+
+    /// Asserts that `call` is rejected with `Unauthenticated`.
+    async fn expect_unauthenticated<T: std::fmt::Debug>(
+        label: &str,
+        call: impl Future<Output = Result<T, tonic::Status>>,
+    ) {
+        let status = call
+            .await
+            .expect_err(&format!("{label} should require a request principal"));
+        assert_eq!(status.code(), Code::Unauthenticated, "{label}");
     }
 
     #[tokio::test]
@@ -787,18 +835,9 @@ enabled = false
             .start()
             .await
             .expect("start server");
-        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
-            .expect("endpoint")
-            .connect()
-            .await
-            .expect("connect");
-        let mut trace_client = TraceServiceClient::new(channel);
+        let mut trace_client = TraceServiceClient::new(connect(&server).await);
 
-        let status = trace_client
-            .list_traces(Request::new(ListTracesRequest {
-                page_size: 10,
-                page_token: String::new(),
-            }))
+        let status = list_traces(&mut trace_client)
             .await
             .expect_err("trace service should be disabled");
 
@@ -855,51 +894,13 @@ enabled = false
     #[tokio::test]
     async fn trace_service_lists_empty_store() {
         let temp = TempDir::new().expect("temp dir");
-        let config_dir = temp.path().join("coral-config");
-        let layout = AppStateLayout::discover(Some(config_dir)).expect("layout");
-        layout.ensure().expect("layout dirs");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
-            config_store.clone(),
-            credential_manager.clone(),
-            layout.clone(),
-        );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
-        let query_manager = QueryManager::new(
-            config_store,
-            credential_manager,
-            QueryRuntimeContext::default(),
-            layout,
-            vec![Arc::new(NoopEngineExtensionsProvider)],
-        );
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
-        let server = start_server(
-            source_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
-            Some(trace_service),
-            Arc::new(SingleUserPrincipalProvider),
-            ServerMode::NativeGrpc,
-        )
-        .await
-        .expect("start server");
-        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
-            .expect("endpoint")
-            .connect()
-            .await
-            .expect("connect");
+        let (server, channel) =
+            start_test_server(&temp, QueryRuntimeContext::default(), Some(trace_service)).await;
         let mut trace_client = TraceServiceClient::new(channel);
 
-        let response = trace_client
-            .list_traces(Request::new(ListTracesRequest {
-                page_size: 10,
-                page_token: String::new(),
-            }))
+        let response = list_traces(&mut trace_client)
             .await
             .expect("list traces")
             .into_inner();
@@ -910,9 +911,7 @@ enabled = false
     }
 
     fn grpc_web_body(message: &impl prost::Message) -> Vec<u8> {
-        let mut encoded = Vec::new();
-        prost::Message::encode(message, &mut encoded).expect("encode protobuf");
-
+        let encoded = message.encode_to_vec();
         let mut body = Vec::with_capacity(5 + encoded.len());
         body.push(0);
         body.extend_from_slice(
@@ -928,20 +927,46 @@ enabled = false
 
     impl StaticAssetsProvider for StubAssets {
         fn get(&self, path: &str) -> Option<StaticAsset> {
-            if path.is_empty() || path == "index.html" {
-                Some(StaticAsset {
-                    bytes: Cow::Borrowed(b"<html><body>Coral UI</body></html>"),
-                    content_type: Cow::Borrowed("text/html; charset=utf-8"),
-                })
-            } else if path == "assets/app.js" {
-                Some(StaticAsset {
-                    bytes: Cow::Borrowed(b"console.log('coral')"),
-                    content_type: Cow::Borrowed("application/javascript"),
-                })
-            } else {
-                None
-            }
+            let (bytes, content_type): (&'static [u8], &'static str) = match path {
+                "" | "index.html" => (
+                    b"<html><body>Coral UI</body></html>",
+                    "text/html; charset=utf-8",
+                ),
+                "assets/app.js" => (b"console.log('coral')", "application/javascript"),
+                _ => return None,
+            };
+            Some(StaticAsset {
+                bytes: Cow::Borrowed(bytes),
+                content_type: Cow::Borrowed(content_type),
+            })
         }
+    }
+
+    /// Starts an embedded-UI loopback server that serves [`StubAssets`].
+    async fn start_embedded_ui_server() -> (TempDir, RunningServer, reqwest::Client) {
+        let temp = TempDir::new().expect("temp dir");
+        let running = ServerBuilder::embedded_ui_loopback(0, Arc::new(StubAssets))
+            .with_config_dir(temp.path().join("coral-config"))
+            .start()
+            .await
+            .expect("start embedded UI server");
+        (temp, running, reqwest::Client::new())
+    }
+
+    /// POSTs a gRPC-Web framed `message` to `path`.
+    async fn post_grpc_web(
+        client: &reqwest::Client,
+        path: &str,
+        message: &impl prost::Message,
+    ) -> reqwest::Response {
+        client
+            .post(path)
+            .header("content-type", "application/grpc-web+proto")
+            .header("x-grpc-web", "1")
+            .body(grpc_web_body(message))
+            .send()
+            .await
+            .expect("gRPC-Web request")
     }
 
     #[test]
@@ -951,58 +976,82 @@ enabled = false
             .add_engine_extensions_provider(Arc::new(NoopEngineExtensionsProvider));
     }
 
+    #[tokio::test]
+    async fn grpc_services_reject_unauthenticated_requests() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_user_principal_provider(Arc::new(RejectingUserPrincipalProvider))
+            .start()
+            .await
+            .expect("start server");
+        let channel = connect(&server).await;
+        let mut source_client = SourceServiceClient::new(channel.clone());
+        let mut query_client = QueryServiceClient::new(channel.clone());
+        let mut catalog_client = CatalogServiceClient::new(channel.clone());
+        let mut feedback_client = FeedbackServiceClient::new(channel.clone());
+        let mut trace_client = TraceServiceClient::new(channel);
+
+        expect_unauthenticated(
+            "source list",
+            source_client.list_sources(list_sources_request()),
+        )
+        .await;
+        expect_unauthenticated("query", execute_sql(&mut query_client, "SELECT 1")).await;
+        expect_unauthenticated(
+            "catalog",
+            catalog_client.list_catalog(ListCatalogRequest {
+                workspace: Some(default_workspace()),
+                ..ListCatalogRequest::default()
+            }),
+        )
+        .await;
+        expect_unauthenticated(
+            "feedback",
+            feedback_client.submit_feedback(SubmitFeedbackRequest {
+                workspace: Some(default_workspace()),
+                trying_to_do: "test".to_string(),
+                tried: "test".to_string(),
+                stuck: "test".to_string(),
+            }),
+        )
+        .await;
+        expect_unauthenticated("traces", list_traces(&mut trace_client)).await;
+
+        server.shutdown().await.expect("shutdown");
+    }
+
     #[test]
     fn native_grpc_content_type_detection_excludes_grpc_web() {
-        assert!(is_native_grpc_content_type(Some(
-            &"application/grpc".parse().expect("header")
-        )));
-        assert!(is_native_grpc_content_type(Some(
-            &"application/grpc+proto; charset=utf-8"
-                .parse()
-                .expect("header")
-        )));
-        assert!(!is_native_grpc_content_type(Some(
-            &"application/grpc-web+proto".parse().expect("header")
-        )));
+        for (header, native) in [
+            ("application/grpc", true),
+            ("application/grpc+proto; charset=utf-8", true),
+            ("application/grpc-web+proto", false),
+        ] {
+            let v = header.parse().expect("header");
+            assert_eq!(is_native_grpc_content_type(Some(&v)), native, "{header}");
+        }
     }
 
     #[test]
     fn grpc_web_content_type_detection_accepts_grpc_web() {
-        assert!(is_grpc_web_content_type(Some(
-            &"application/grpc-web".parse().expect("header")
-        )));
-        assert!(is_grpc_web_content_type(Some(
-            &"application/grpc-web+proto; charset=utf-8"
-                .parse()
-                .expect("header")
-        )));
-        assert!(!is_grpc_web_content_type(Some(
-            &"application/grpc+proto".parse().expect("header")
-        )));
+        for (header, web) in [
+            ("application/grpc-web", true),
+            ("application/grpc-web+proto; charset=utf-8", true),
+            ("application/grpc+proto", false),
+        ] {
+            let v = header.parse().expect("header");
+            assert_eq!(is_grpc_web_content_type(Some(&v)), web, "{header}");
+        }
     }
 
     #[tokio::test]
     async fn embedded_ui_server_accepts_browser_requests_and_rejects_native_grpc() {
-        let temp = TempDir::new().expect("temp dir");
-        let running = ServerBuilder::embedded_ui_loopback(0, Arc::new(StubAssets))
-            .with_config_dir(temp.path().join("coral-config"))
-            .start()
-            .await
-            .expect("start embedded UI server");
+        let (_temp, running, client) = start_embedded_ui_server().await;
         let endpoint = running.endpoint_uri();
         let path = format!("{endpoint}/coral.v1.SourceService/ListSources");
-        let client = reqwest::Client::new();
 
-        let response = client
-            .post(&path)
-            .header("content-type", "application/grpc-web+proto")
-            .header("x-grpc-web", "1")
-            .body(grpc_web_body(&ListSourcesRequest {
-                workspace: Some(default_workspace()),
-            }))
-            .send()
-            .await
-            .expect("gRPC-Web request");
+        let response = post_grpc_web(&client, &path, &list_sources_request()).await;
         assert_eq!(response.status(), reqwest::StatusCode::OK);
         assert!(
             !response
@@ -1030,23 +1079,10 @@ enabled = false
 
     #[tokio::test]
     async fn embedded_ui_server_streams_import_source_over_grpc_web() {
-        let temp = TempDir::new().expect("temp dir");
-        let running = ServerBuilder::embedded_ui_loopback(0, Arc::new(StubAssets))
-            .with_config_dir(temp.path().join("coral-config"))
-            .start()
-            .await
-            .expect("start embedded UI server");
+        let (_temp, running, client) = start_embedded_ui_server().await;
         let endpoint = running.endpoint_uri();
         let path = format!("{endpoint}/coral.v1.SourceService/ImportSource");
-        let client = reqwest::Client::new();
-
-        let response = client
-            .post(&path)
-            .header("content-type", "application/grpc-web+proto")
-            .header("x-grpc-web", "1")
-            .body(grpc_web_body(&ImportSourceRequest {
-                workspace: Some(default_workspace()),
-                manifest_yaml: r#"
+        let yaml = r#"
 name: stream_test
 version: 0.1.0
 dsl_version: 3
@@ -1062,21 +1098,19 @@ tables:
     columns:
       - name: id
         type: Utf8
-"#
-                .to_string(),
-                variables: Vec::new(),
-                secrets: Vec::new(),
-                oauth_credential_retrievals: Vec::new(),
-            }))
-            .send()
-            .await
-            .expect("gRPC-Web streaming request");
+"#;
+
+        let response =
+            post_grpc_web(&client, &path, &import_source_request(yaml.to_string())).await;
         assert_eq!(response.status(), reqwest::StatusCode::OK);
         let body = response.bytes().await.expect("gRPC-Web streaming body");
         let body = body.as_ref();
+        let frame_len = |at: usize| {
+            u32::from_be_bytes([body[at], body[at + 1], body[at + 2], body[at + 3]]) as usize
+        };
         assert!(body.len() >= 5, "expected framed gRPC-Web response body");
         assert_eq!(body[0], 0, "expected first frame to be a data frame");
-        let len = u32::from_be_bytes([body[1], body[2], body[3], body[4]]) as usize;
+        let len = frame_len(1);
         let frame = body.get(5..5 + len).expect("complete gRPC-Web data frame");
         let trailer_offset = 5 + len;
         assert!(
@@ -1087,13 +1121,7 @@ tables:
             body[trailer_offset], 0x80,
             "expected final frame to be uncompressed trailers"
         );
-        let trailer_len = u32::from_be_bytes([
-            body[trailer_offset + 1],
-            body[trailer_offset + 2],
-            body[trailer_offset + 3],
-            body[trailer_offset + 4],
-        ]) as usize;
-        let trailer_end = trailer_offset + 5 + trailer_len;
+        let trailer_end = trailer_offset + 5 + frame_len(trailer_offset + 1);
         let trailers = body
             .get(trailer_offset + 5..trailer_end)
             .expect("complete gRPC-Web trailer frame");
@@ -1126,81 +1154,41 @@ tables:
 
     #[tokio::test]
     async fn embedded_ui_server_serves_static_assets_alongside_grpc_web() {
-        let temp = TempDir::new().expect("temp dir");
-        let running = ServerBuilder::embedded_ui_loopback(0, Arc::new(StubAssets))
-            .with_config_dir(temp.path().join("coral-config"))
-            .start()
-            .await
-            .expect("start embedded UI server");
+        let (_temp, running, client) = start_embedded_ui_server().await;
         let endpoint = running.endpoint_uri().to_string();
-        let client = reqwest::Client::new();
 
-        // Root serves index.html
-        let root = client.get(&endpoint).send().await.expect("root request");
-        assert_eq!(root.status(), reqwest::StatusCode::OK);
-        assert_eq!(
-            root.headers()
-                .get("content-type")
-                .and_then(|v| v.to_str().ok()),
-            Some("text/html; charset=utf-8")
-        );
-        let body = root.text().await.expect("root body");
-        assert!(body.contains("Coral UI"), "unexpected body: {body}");
-
-        // Asset path serves the asset
-        let asset = client
-            .get(format!("{endpoint}/assets/app.js"))
-            .send()
-            .await
-            .expect("asset request");
-        assert_eq!(asset.status(), reqwest::StatusCode::OK);
-        assert_eq!(
-            asset
-                .headers()
-                .get("content-type")
-                .and_then(|v| v.to_str().ok()),
-            Some("application/javascript")
-        );
-
-        // Unknown path falls back to index.html (SPA fallback).
-        let route = client
-            .get(format!("{endpoint}/some/spa/route"))
-            .send()
-            .await
-            .expect("spa route request");
-        assert_eq!(route.status(), reqwest::StatusCode::OK);
-        assert_eq!(
-            route
-                .headers()
-                .get("content-type")
-                .and_then(|v| v.to_str().ok()),
-            Some("text/html; charset=utf-8")
-        );
+        // Root serves index.html, assets serve their own content type, and
+        // unknown paths fall back to index.html (SPA fallback).
+        for (path, content_type) in [
+            ("", "text/html; charset=utf-8"),
+            ("/assets/app.js", "application/javascript"),
+            ("/some/spa/route", "text/html; charset=utf-8"),
+        ] {
+            let url = format!("{endpoint}{path}");
+            let response = client.get(&url).send().await.expect("GET request");
+            assert_eq!(response.status(), reqwest::StatusCode::OK, "{url}");
+            assert_eq!(
+                response
+                    .headers()
+                    .get("content-type")
+                    .and_then(|v| v.to_str().ok()),
+                Some(content_type),
+                "{url}"
+            );
+            if path.is_empty() {
+                let body = response.text().await.expect("root body");
+                assert!(body.contains("Coral UI"), "unexpected body: {body}");
+            }
+        }
 
         // gRPC-Web still works on the same port
         let grpc_path = format!("{endpoint}/coral.v1.SourceService/ListSources");
-        let response = client
-            .post(&grpc_path)
-            .header("content-type", "application/grpc-web+proto")
-            .header("x-grpc-web", "1")
-            .body(grpc_web_body(&ListSourcesRequest {
-                workspace: Some(default_workspace()),
-            }))
-            .send()
-            .await
-            .expect("gRPC-Web request");
+        let response = post_grpc_web(&client, &grpc_path, &list_sources_request()).await;
         assert_eq!(response.status(), reqwest::StatusCode::OK);
 
-        let unknown_grpc = client
-            .post(format!("{endpoint}/unknown.Service/Method"))
-            .header("content-type", "application/grpc-web+proto")
-            .header("x-grpc-web", "1")
-            .body(grpc_web_body(&ListSourcesRequest {
-                workspace: Some(default_workspace()),
-            }))
-            .send()
-            .await
-            .expect("unknown gRPC-Web request");
+        // Unknown gRPC-Web services report a plain not-found response.
+        let unknown_path = format!("{endpoint}/unknown.Service/Method");
+        let unknown_grpc = post_grpc_web(&client, &unknown_path, &list_sources_request()).await;
         assert_eq!(unknown_grpc.status(), reqwest::StatusCode::NOT_FOUND);
         assert_eq!(
             unknown_grpc
@@ -1227,7 +1215,6 @@ tables:
 
         let temp = TempDir::new().expect("temp dir");
         let fake_home = temp.path().join("fake-home");
-        let config_dir = temp.path().join("coral-config");
         let data_dir = fake_home.join("fixture-data");
         std::fs::create_dir_all(&data_dir).expect("create data dir");
         std::fs::write(
@@ -1238,52 +1225,22 @@ tables:
         )
         .expect("write fixture");
 
-        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
-            config_store.clone(),
-            credential_manager.clone(),
-            layout.clone(),
-        );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
-        let query_manager = QueryManager::new(
-            config_store,
-            credential_manager,
+        let (_running, channel) = start_test_server(
+            &temp,
             QueryRuntimeContext {
                 home_dir: Some(fake_home.clone()),
                 ..QueryRuntimeContext::default()
             },
-            layout,
-            vec![Arc::new(NoopEngineExtensionsProvider)],
-        );
-        let running = start_server(
-            source_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
             None,
-            Arc::new(SingleUserPrincipalProvider),
-            ServerMode::NativeGrpc,
         )
-        .await
-        .expect("start server");
-        let channel = Endpoint::from_shared(running.endpoint_uri().to_string())
-            .expect("endpoint")
-            .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
-            .connect()
-            .await
-            .expect("connect");
+        .await;
         let mut source_client = SourceServiceClient::new(channel.clone());
         let mut query_client = QueryServiceClient::new(channel)
             .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
 
-        let mut import_stream = source_client
-            .import_source(Request::new(ImportSourceRequest {
-                workspace: Some(default_workspace()),
-                manifest_yaml: r#"
+        let imported = import_source_name_over_grpc(
+            &mut source_client,
+            r#"
 name: tilde_demo
 version: 0.1.0
 dsl_version: 3
@@ -1301,30 +1258,13 @@ tables:
       - name: text
         type: Utf8
 "#
-                .to_string(),
-                variables: Vec::new(),
-                secrets: Vec::new(),
-                oauth_credential_retrievals: Vec::new(),
-            }))
-            .await
-            .expect("create source")
-            .into_inner();
-        let imported = import_stream
-            .message()
-            .await
-            .expect("import source stream")
-            .and_then(|response| match response.event {
-                Some(import_source_response::Event::Source(source)) => Some(source),
-                _ => None,
-            })
-            .expect("import source response");
-        assert_eq!(imported.name, "tilde_demo");
+            .to_string(),
+        )
+        .await;
+        assert_eq!(imported, "tilde_demo");
 
-        let response = query_client
-            .execute_sql(Request::new(ExecuteSqlRequest {
-                workspace: Some(default_workspace()),
-                sql: "SELECT text FROM tilde_demo.messages ORDER BY text".to_string(),
-            }))
+        let sql = "SELECT text FROM tilde_demo.messages ORDER BY text";
+        let response = execute_sql(&mut query_client, sql)
             .await
             .expect("execute sql")
             .into_inner();
@@ -1341,54 +1281,15 @@ tables:
     #[tokio::test]
     async fn execute_sql_response_above_default_4mb_limit_round_trips() {
         let temp = TempDir::new().expect("temp dir");
-        let config_dir = temp.path().join("coral-config");
-
-        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
-            config_store.clone(),
-            credential_manager.clone(),
-            layout.clone(),
-        );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
-        let query_manager = QueryManager::new(
-            config_store,
-            credential_manager,
-            QueryRuntimeContext::default(),
-            layout,
-            vec![Arc::new(NoopEngineExtensionsProvider)],
-        );
-        let running = start_server(
-            source_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
-            None,
-            Arc::new(SingleUserPrincipalProvider),
-            ServerMode::NativeGrpc,
-        )
-        .await
-        .expect("start server");
-        let channel = Endpoint::from_shared(running.endpoint_uri().to_string())
-            .expect("endpoint")
-            .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
-            .connect()
-            .await
-            .expect("connect");
+        let (_running, channel) =
+            start_test_server(&temp, QueryRuntimeContext::default(), None).await;
         let mut query_client = QueryServiceClient::new(channel)
             .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
 
         // No underscore separator — DataFusion's SQL parser is conservative
         // about numeric literal formats.
         let sql = "SELECT repeat('x', 5000000) AS pad";
-        let response = query_client
-            .execute_sql(Request::new(ExecuteSqlRequest {
-                workspace: Some(default_workspace()),
-                sql: sql.to_string(),
-            }))
+        let response = execute_sql(&mut query_client, sql)
             .await
             .expect("execute_sql >4MB response")
             .into_inner();
@@ -1421,7 +1322,6 @@ tables:
         use crate::bootstrap::MAX_STATUS_DETAIL_BYTES;
 
         let temp = TempDir::new().expect("temp dir");
-        let config_dir = temp.path().join("coral-config");
         let data_dir = temp.path().join("wide-data");
         std::fs::create_dir_all(&data_dir).expect("create data dir");
         // No rows needed — the test cares only about schema width.
@@ -1445,72 +1345,17 @@ tables:
                 .expect("write to String");
         }
 
-        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
-            config_store.clone(),
-            credential_manager.clone(),
-            layout.clone(),
-        );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
-        let query_manager = QueryManager::new(
-            config_store,
-            credential_manager,
-            QueryRuntimeContext::default(),
-            layout,
-            vec![Arc::new(NoopEngineExtensionsProvider)],
-        );
-        let running = start_server(
-            source_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
-            None,
-            Arc::new(SingleUserPrincipalProvider),
-            ServerMode::NativeGrpc,
-        )
-        .await
-        .expect("start server");
-        let channel = Endpoint::from_shared(running.endpoint_uri().to_string())
-            .expect("endpoint")
-            .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
-            .connect()
-            .await
-            .expect("connect");
+        let (_running, channel) =
+            start_test_server(&temp, QueryRuntimeContext::default(), None).await;
         let mut source_client = SourceServiceClient::new(channel.clone());
         let mut query_client = QueryServiceClient::new(channel)
             .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
 
-        let mut import_stream = source_client
-            .import_source(Request::new(ImportSourceRequest {
-                workspace: Some(default_workspace()),
-                manifest_yaml: manifest,
-                variables: Vec::new(),
-                secrets: Vec::new(),
-                oauth_credential_retrievals: Vec::new(),
-            }))
-            .await
-            .expect("import wide source")
-            .into_inner();
-        let imported = import_stream
-            .message()
-            .await
-            .expect("import wide source stream")
-            .and_then(|response| match response.event {
-                Some(import_source_response::Event::Source(source)) => Some(source),
-                _ => None,
-            })
-            .expect("import wide source response");
-        assert_eq!(imported.name, "wide_demo");
+        let imported = import_source_name_over_grpc(&mut source_client, manifest).await;
+        assert_eq!(imported, "wide_demo");
 
-        let status = query_client
-            .execute_sql(Request::new(ExecuteSqlRequest {
-                workspace: Some(default_workspace()),
-                sql: "SELECT bogus_column FROM wide_demo.wide LIMIT 0".to_string(),
-            }))
+        let sql = "SELECT bogus_column FROM wide_demo.wide LIMIT 0";
+        let status = execute_sql(&mut query_client, sql)
             .await
             .expect_err("expected gRPC Status, not a transport-level PROTOCOL_ERROR");
 

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use sha2::{Digest as _, Sha256};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::TcpListener;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use url::{Url, form_urlencoded};
 use uuid::Uuid;
 
@@ -35,7 +35,7 @@ const MAX_CALLBACK_BYTES: usize = 8 * 1024;
 const REFRESH_EXPIRY_SKEW_SECONDS: i64 = 60;
 const TOKEN_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct OAuthCredentialService {
     http: reqwest::Client,
 }
@@ -47,19 +47,93 @@ pub(crate) struct StartOAuthCredentialRequest<'a> {
     pub(crate) credential_inputs: Vec<(String, String)>,
 }
 
-pub(super) struct RefreshOAuthCredentialRequest<'a> {
+/// Progress event emitted while an OAuth credential authorization runs.
+#[derive(Debug, Clone)]
+#[expect(unreachable_pub, reason = "re-exported from lib.rs in a later PR")]
+pub enum OAuthProgressEvent {
+    /// OAuth authorization URL or device-code details are ready for the user.
+    OAuthAuthorization {
+        /// Credential input key being authorized.
+        input_key: String,
+        /// Authorization URL to open.
+        authorization_url: String,
+        /// Seconds until the authorization request expires.
+        expires_in_seconds: u64,
+        /// Optional device-flow user code.
+        user_code: Option<String>,
+        /// Optional device-flow verification URI.
+        verification_uri: Option<String>,
+        /// Optional complete device-flow verification URI.
+        verification_uri_complete: Option<String>,
+    },
+    /// OAuth credential retrieval completed.
+    OAuthCompleted {
+        /// Credential input key that completed authorization.
+        input_key: String,
+        /// Safe metadata about the authorized credential.
+        metadata: BTreeMap<String, String>,
+    },
+}
+
+/// Acknowledged progress-event sink bridging an OAuth-driven manager
+/// operation to its gRPC response stream. `send` resolves only once the
+/// consumer dequeued the event, so progress cannot outrun the stream.
+#[derive(Clone)]
+#[expect(unreachable_pub, reason = "re-exported from lib.rs in a later PR")]
+pub struct OAuthProgressEventSender {
+    tx: mpsc::Sender<PendingOAuthProgressEvent>,
+    closed_message: &'static str,
+}
+
+pub(crate) struct PendingOAuthProgressEvent {
+    event: OAuthProgressEvent,
+    delivered: oneshot::Sender<()>,
+}
+
+impl OAuthProgressEventSender {
+    pub(crate) fn new(
+        tx: mpsc::Sender<PendingOAuthProgressEvent>,
+        closed_message: &'static str,
+    ) -> Self {
+        Self { tx, closed_message }
+    }
+
+    pub(crate) async fn send(&self, event: OAuthProgressEvent) -> Result<(), AppError> {
+        let (delivered, delivered_rx) = oneshot::channel();
+        self.tx
+            .send(PendingOAuthProgressEvent { event, delivered })
+            .await
+            .map_err(|_closed| AppError::FailedPrecondition(self.closed_message.to_string()))?;
+        delivered_rx
+            .await
+            .map_err(|_closed| AppError::FailedPrecondition(self.closed_message.to_string()))
+    }
+}
+
+impl PendingOAuthProgressEvent {
+    pub(crate) fn into_event(self) -> OAuthProgressEvent {
+        let _delivery = self.delivered.send(());
+        self.event
+    }
+}
+
+pub(crate) struct RefreshOAuthCredentialRequest<'a> {
     access_token_material_key: &'a str,
+    material_label: String,
+    reconnect_label: &'static str,
     metadata_prefix: String,
     oauth: &'a ManifestOAuthCredentialSpec,
 }
 
 impl<'a> RefreshOAuthCredentialRequest<'a> {
-    pub(super) fn for_source_input(
+    pub(crate) fn for_source_input(
         input_key: &'a str,
         oauth: &'a ManifestOAuthCredentialSpec,
     ) -> Self {
         Self {
             access_token_material_key: input_key,
+            material_label: format!("source secret '{input_key}'"),
+            reconnect_label: "reconnect the source",
             metadata_prefix: oauth_metadata_prefix(input_key),
             oauth,
         }
@@ -165,6 +239,39 @@ impl OAuthCredentialService {
         }
     }
 
+    /// Runs [`Self::authorize`] while reporting progress on `events`, keying
+    /// the emitted events by `event_key`.
+    pub(crate) async fn authorize_with_progress(
+        &self,
+        request: StartOAuthCredentialRequest<'_>,
+        event_key: String,
+        events: &OAuthProgressEventSender,
+    ) -> Result<OAuthCredentialMaterial, AppError> {
+        let authorization_events = events.clone();
+        let authorization_key = event_key.clone();
+        let material = self
+            .authorize(request, move |authorization| async move {
+                authorization_events
+                    .send(OAuthProgressEvent::OAuthAuthorization {
+                        input_key: authorization_key,
+                        authorization_url: authorization.authorization_url,
+                        expires_in_seconds: authorization.expires_in_seconds,
+                        user_code: authorization.user_code,
+                        verification_uri: authorization.verification_uri,
+                        verification_uri_complete: authorization.verification_uri_complete,
+                    })
+                    .await
+            })
+            .await?;
+        events
+            .send(OAuthProgressEvent::OAuthCompleted {
+                input_key: event_key,
+                metadata: material.safe_metadata.clone(),
+            })
+            .await?;
+        Ok(material)
+    }
+
     pub(crate) async fn authorize<F, Fut>(
         &self,
         request: StartOAuthCredentialRequest<'_>,
@@ -180,39 +287,28 @@ impl OAuthCredentialService {
         reject_unknown_credential_inputs(&oauth, &credential_inputs)?;
         let client_id = resolve_client_id(&oauth, &credential_inputs)?;
         let client_secret = resolve_client_secret(&oauth, &credential_inputs)?;
-        match oauth.flow.kind {
+        let flow_kind = oauth.flow.kind;
+        let common = OAuthSessionCommon {
+            input_key: request.input_key.to_string(),
+            oauth,
+            endpoints,
+            client_id,
+            client_secret,
+        };
+        match flow_kind {
             ManifestOAuthFlowKind::AuthorizationCode => {
-                self.authorize_authorization_code(
-                    request.input_key.to_string(),
-                    oauth,
-                    endpoints,
-                    client_id,
-                    client_secret,
-                    on_authorization,
-                )
-                .await
+                self.authorize_authorization_code(common, on_authorization)
+                    .await
             }
             ManifestOAuthFlowKind::DeviceCode => {
-                self.authorize_device_code(
-                    request.input_key.to_string(),
-                    oauth,
-                    endpoints,
-                    client_id,
-                    client_secret,
-                    on_authorization,
-                )
-                .await
+                self.authorize_device_code(common, on_authorization).await
             }
         }
     }
 
     async fn authorize_authorization_code<F, Fut>(
         &self,
-        input_key: String,
-        oauth: ManifestOAuthCredentialSpec,
-        endpoints: ManifestOAuthEndpointUrls,
-        client_id: String,
-        client_secret: Option<String>,
+        common: OAuthSessionCommon,
         on_authorization: F,
     ) -> Result<OAuthCredentialMaterial, AppError>
     where
@@ -220,25 +316,18 @@ impl OAuthCredentialService {
         Fut: Future<Output = Result<(), AppError>>,
     {
         let (listener, callback_path, provider_redirect_uri) =
-            bind_redirect_listener(&oauth).await?;
+            bind_redirect_listener(&common.oauth).await?;
         let state = random_token();
-        let code_verifier = pkce_code_verifier(&oauth);
+        let code_verifier = pkce_code_verifier(&common.oauth);
         let authorization_url = build_authorization_url(
-            &oauth,
-            &endpoints,
+            &common.oauth,
+            &common.endpoints,
             &provider_redirect_uri,
-            &client_id,
+            &common.client_id,
             &state,
             code_verifier.as_deref(),
         )?;
         let expires_at = Instant::now() + SESSION_TTL;
-        let common = OAuthSessionCommon {
-            input_key,
-            oauth,
-            endpoints,
-            client_id,
-            client_secret,
-        };
         let session = AuthorizationCodeSessionConfig {
             common,
             state,
@@ -298,13 +387,14 @@ impl OAuthCredentialService {
 
     /// Uses persisted credential material as both the refresh input
     /// (expiry, refresh token, client metadata) and output (new token values).
-    pub(super) async fn refresh_if_needed(
+    pub(crate) async fn refresh_if_needed(
         &self,
         request: RefreshOAuthCredentialRequest<'_>,
         credential_material: &mut BTreeMap<String, String>,
     ) -> Result<bool, AppError> {
         let Some(refresh) = oauth_refresh_config(
-            request.access_token_material_key,
+            request.material_label.as_str(),
+            request.reconnect_label,
             request.metadata_prefix.as_str(),
             request.oauth,
             credential_material,
@@ -324,27 +414,23 @@ impl OAuthCredentialService {
 
     async fn authorize_device_code<F, Fut>(
         &self,
-        input_key: String,
-        oauth: ManifestOAuthCredentialSpec,
-        endpoints: ManifestOAuthEndpointUrls,
-        client_id: String,
-        client_secret: Option<String>,
+        mut common: OAuthSessionCommon,
         on_authorization: F,
     ) -> Result<OAuthCredentialMaterial, AppError>
     where
         F: FnOnce(OAuthAuthorization) -> Fut,
         Fut: Future<Output = Result<(), AppError>>,
     {
-        if client_secret.is_some() {
+        if common.client_secret.is_some() {
             return Err(AppError::InvalidInput(
                 "device_code OAuth methods must not declare a client secret".to_string(),
             ));
         }
         let device = request_device_code(
             &self.http,
-            &oauth,
-            &endpoints,
-            &client_id,
+            &common.oauth,
+            &common.endpoints,
+            &common.client_id,
             DEVICE_CODE_REQUEST_TIMEOUT,
         )
         .await?;
@@ -356,13 +442,7 @@ impl OAuthCredentialService {
         let verification_uri = device.verification_uri.clone();
         let verification_uri_complete = device.verification_uri_complete.clone();
         let expires_in = device.expires_in;
-        let common = OAuthSessionCommon {
-            input_key,
-            oauth,
-            endpoints,
-            client_id,
-            client_secret: None,
-        };
+        common.client_secret = None;
         let session = DeviceCodeSessionConfig {
             common,
             device_code: device.device_code,
@@ -998,7 +1078,8 @@ async fn poll_device_token(
                 }
                 "expired_token" => {
                     return Err(AppError::FailedPrecondition(
-                        "OAuth device code expired; rerun `coral source add`".to_string(),
+                        "OAuth device code expired; start a new OAuth credential retrieval"
+                            .to_string(),
                     ));
                 }
                 "access_denied" => {
@@ -1026,7 +1107,7 @@ async fn poll_device_token(
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             return Err(AppError::FailedPrecondition(
-                "OAuth device code expired; rerun `coral source add`".to_string(),
+                "OAuth device code expired; start a new OAuth credential retrieval".to_string(),
             ));
         }
         tokio::time::sleep(interval.min(remaining)).await;
@@ -1282,7 +1363,8 @@ fn oauth_metadata_prefix(input_key: &str) -> String {
 }
 
 fn oauth_refresh_config(
-    access_token_material_key: &str,
+    material_label: &str,
+    reconnect_label: &str,
     metadata_prefix: &str,
     oauth: &ManifestOAuthCredentialSpec,
     material: &BTreeMap<String, String>,
@@ -1301,7 +1383,7 @@ fn oauth_refresh_config(
     let expires_at = DateTime::parse_from_rfc3339(expires_at)
         .map_err(|error| {
             AppError::FailedPrecondition(format!(
-                "stored OAuth access token expiry for source secret '{access_token_material_key}' is invalid: {error}"
+                "stored OAuth access token expiry for {material_label} is invalid: {error}"
             ))
         })?
         .with_timezone(&Utc);
@@ -1318,7 +1400,7 @@ fn oauth_refresh_config(
             return Ok(None);
         }
         return Err(AppError::FailedPrecondition(format!(
-            "OAuth access token for source secret '{access_token_material_key}' expired and cannot be refreshed because no refresh token is stored; reconnect the source"
+            "OAuth access token for {material_label} expired and cannot be refreshed because no refresh token is stored; {reconnect_label}"
         )));
     };
     let client_id = material
@@ -1329,7 +1411,7 @@ fn oauth_refresh_config(
         .filter(|value| !value.is_empty())
         .ok_or_else(|| {
             AppError::FailedPrecondition(format!(
-                "OAuth access token for source secret '{access_token_material_key}' expired and cannot be refreshed because client ID metadata is missing"
+                "OAuth access token for {material_label} expired and cannot be refreshed because client ID metadata is missing"
             ))
         })?;
     let token_url = material
@@ -1342,7 +1424,7 @@ fn oauth_refresh_config(
         .map(|value| {
             ManifestOAuthClientSecretTransport::from_label(value).ok_or_else(|| {
                 AppError::FailedPrecondition(format!(
-                    "stored OAuth client secret transport for source secret '{access_token_material_key}' is invalid: {value}"
+                    "stored OAuth client secret transport for {material_label} is invalid: {value}"
                 ))
             })
         })
@@ -1354,7 +1436,7 @@ fn oauth_refresh_config(
         .cloned();
     if client_secret_transport.is_some() && client_secret.is_none() {
         return Err(AppError::FailedPrecondition(format!(
-            "OAuth access token for source secret '{access_token_material_key}' expired and cannot be refreshed because client secret metadata is missing"
+            "OAuth access token for {material_label} expired and cannot be refreshed because client secret metadata is missing"
         )));
     }
     Ok(Some(OAuthRefreshConfig {
@@ -1449,11 +1531,13 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        AuthorizationCodeSessionConfig, OAuthCredentialService, OAuthSessionCommon,
-        RefreshOAuthCredentialRequest, StartOAuthCredentialRequest, basic_client_authorization,
-        join_scope_values, material_key_belongs_to_input, oauth_metadata_prefix,
-        parse_token_response, pkce_challenge, receive_callback, request_device_code,
+        AuthorizationCodeSessionConfig, OAuthAuthorization, OAuthCredentialMaterial,
+        OAuthCredentialService, OAuthSessionCommon, RefreshOAuthCredentialRequest,
+        StartOAuthCredentialRequest, basic_client_authorization, join_scope_values,
+        material_key_belongs_to_input, oauth_metadata_prefix, parse_token_response, pkce_challenge,
+        receive_callback, request_device_code,
     };
+    use crate::bootstrap::AppError;
     use coral_spec::{
         ManifestOAuthClientIdSpec, ManifestOAuthClientSecretSpec,
         ManifestOAuthClientSecretTransport, ManifestOAuthClientSpec, ManifestOAuthCredentialSpec,
@@ -1467,6 +1551,9 @@ mod tests {
     use url::Url;
 
     static EMPTY_SOURCE_INPUTS: LazyLock<BTreeMap<String, String>> = LazyLock::new(BTreeMap::new);
+
+    const REFRESHED_TOKEN_RESPONSE: &str =
+        r#"{"access_token":"refreshed-token","token_type":"Bearer","expires_in":3600}"#;
 
     #[test]
     fn joins_scope_values_with_configured_delimiter() {
@@ -1521,152 +1608,74 @@ mod tests {
         let fixture = OAuthFixture::new(Some(
             r#"{"access_token":"refreshed-token","refresh_token":"rotated-refresh-token","token_type":"Bearer","scope":"repo read:org","expires_in":3600}"#,
         ));
-        let oauth = oauth_spec(
-            &fixture.token_url,
-            free_loopback_port(),
-            ManifestOAuthPkceMode::Disabled,
-            ManifestOAuthClientSpec {
-                id: ManifestOAuthClientIdSpec {
-                    default: Some("default-client".to_string()),
-                    input: None,
-                },
-                secret: None,
-            },
+        let oauth = public_spec(&fixture.token_url, free_loopback_port());
+        let mut material = stored_oauth_material(
+            "API_TOKEN",
+            "expired-token",
+            chrono::Duration::minutes(-5),
+            &[
+                ("refresh_token", "stored-refresh-token"),
+                ("client_id", "stored-client"),
+                ("token_url", &fixture.token_url),
+            ],
         );
-        let prefix = oauth_metadata_prefix("API_TOKEN");
-        let mut material = BTreeMap::from([
-            ("API_TOKEN".to_string(), "expired-token".to_string()),
-            (format!("{prefix}method"), "oauth".to_string()),
-            (
-                format!("{prefix}access_token_expires_at"),
-                (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
-            ),
-            (
-                format!("{prefix}refresh_token"),
-                "stored-refresh-token".to_string(),
-            ),
-            (format!("{prefix}client_id"), "stored-client".to_string()),
-            (format!("{prefix}token_url"), fixture.token_url.clone()),
-        ]);
-        let service = OAuthCredentialService::new();
 
-        let refreshed = service
-            .refresh_if_needed(
-                RefreshOAuthCredentialRequest::for_source_input("API_TOKEN", &oauth),
-                &mut material,
-            )
+        let refreshed = refresh_source_input("API_TOKEN", &oauth, &mut material)
             .await
             .expect("refresh oauth material");
         let captured = fixture.token_server.await.expect("token server");
 
         assert!(refreshed);
-        assert_eq!(
-            captured.form.get("grant_type").map(String::as_str),
-            Some("refresh_token")
+        assert_entry(&captured.form, "grant_type", Some("refresh_token"));
+        assert_entry(
+            &captured.form,
+            "refresh_token",
+            Some("stored-refresh-token"),
         );
-        assert_eq!(
-            captured.form.get("refresh_token").map(String::as_str),
-            Some("stored-refresh-token")
-        );
-        assert_eq!(
-            captured.form.get("client_id").map(String::as_str),
-            Some("stored-client")
-        );
-        assert_eq!(
-            material.get("API_TOKEN").map(String::as_str),
-            Some("refreshed-token")
-        );
-        assert_eq!(
-            material
-                .get(&format!("{prefix}refresh_token"))
-                .map(String::as_str),
-            Some("rotated-refresh-token")
+        assert_entry(&captured.form, "client_id", Some("stored-client"));
+        assert_entry(&material, "API_TOKEN", Some("refreshed-token"));
+        assert_oauth_meta(
+            &material,
+            "API_TOKEN",
+            &[("refresh_token", Some("rotated-refresh-token"))],
         );
         assert!(captured.authorization.is_none());
     }
 
     #[tokio::test]
     async fn unexpired_oauth_material_does_not_refresh_access_token() {
-        let oauth = oauth_spec(
-            "http://127.0.0.1:9/token",
-            53682,
-            ManifestOAuthPkceMode::Disabled,
-            ManifestOAuthClientSpec {
-                id: ManifestOAuthClientIdSpec {
-                    default: Some("default-client".to_string()),
-                    input: None,
-                },
-                secret: None,
-            },
+        let oauth = public_spec("http://127.0.0.1:9/token", 53682);
+        let mut material = stored_oauth_material(
+            "API_TOKEN",
+            "fresh-token",
+            chrono::Duration::minutes(5),
+            &[("refresh_token", "stored-refresh-token")],
         );
-        let prefix = oauth_metadata_prefix("API_TOKEN");
-        let mut material = BTreeMap::from([
-            ("API_TOKEN".to_string(), "fresh-token".to_string()),
-            (format!("{prefix}method"), "oauth".to_string()),
-            (
-                format!("{prefix}access_token_expires_at"),
-                (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339(),
-            ),
-            (
-                format!("{prefix}refresh_token"),
-                "stored-refresh-token".to_string(),
-            ),
-        ]);
-        let service = OAuthCredentialService::new();
 
-        let refreshed = service
-            .refresh_if_needed(
-                RefreshOAuthCredentialRequest::for_source_input("API_TOKEN", &oauth),
-                &mut material,
-            )
+        let refreshed = refresh_source_input("API_TOKEN", &oauth, &mut material)
             .await
             .expect("refresh oauth material");
 
         assert!(!refreshed);
-        assert_eq!(
-            material.get("API_TOKEN").map(String::as_str),
-            Some("fresh-token")
-        );
+        assert_entry(&material, "API_TOKEN", Some("fresh-token"));
     }
 
     #[tokio::test]
     async fn near_expiry_oauth_material_without_refresh_token_remains_usable() {
-        let oauth = oauth_spec(
-            "http://127.0.0.1:9/token",
-            53682,
-            ManifestOAuthPkceMode::Disabled,
-            ManifestOAuthClientSpec {
-                id: ManifestOAuthClientIdSpec {
-                    default: Some("default-client".to_string()),
-                    input: None,
-                },
-                secret: None,
-            },
+        let oauth = public_spec("http://127.0.0.1:9/token", 53682);
+        let mut material = stored_oauth_material(
+            "API_TOKEN",
+            "near-expiry-token",
+            chrono::Duration::seconds(30),
+            &[],
         );
-        let prefix = oauth_metadata_prefix("API_TOKEN");
-        let mut material = BTreeMap::from([
-            ("API_TOKEN".to_string(), "near-expiry-token".to_string()),
-            (format!("{prefix}method"), "oauth".to_string()),
-            (
-                format!("{prefix}access_token_expires_at"),
-                (chrono::Utc::now() + chrono::Duration::seconds(30)).to_rfc3339(),
-            ),
-        ]);
-        let service = OAuthCredentialService::new();
 
-        let refreshed = service
-            .refresh_if_needed(
-                RefreshOAuthCredentialRequest::for_source_input("API_TOKEN", &oauth),
-                &mut material,
-            )
+        let refreshed = refresh_source_input("API_TOKEN", &oauth, &mut material)
             .await
             .expect("near-expiry token without refresh token should still be usable");
 
         assert!(!refreshed);
-        assert_eq!(
-            material.get("API_TOKEN").map(String::as_str),
-            Some("near-expiry-token")
-        );
+        assert_entry(&material, "API_TOKEN", Some("near-expiry-token"));
     }
 
     #[tokio::test]
@@ -1687,33 +1696,17 @@ mod tests {
                 .expect("read stalled token request");
             tokio::time::sleep(Duration::from_mins(1)).await;
         });
-        let oauth = oauth_spec(
-            &token_url,
-            53682,
-            ManifestOAuthPkceMode::Disabled,
-            ManifestOAuthClientSpec {
-                id: ManifestOAuthClientIdSpec {
-                    default: Some("default-client".to_string()),
-                    input: None,
-                },
-                secret: None,
-            },
+        let oauth = public_spec(&token_url, 53682);
+        let mut material = stored_oauth_material(
+            "API_TOKEN",
+            "expired-token",
+            chrono::Duration::minutes(-5),
+            &[
+                ("refresh_token", "stored-refresh-token"),
+                ("client_id", "stored-client"),
+                ("token_url", &token_url),
+            ],
         );
-        let prefix = oauth_metadata_prefix("API_TOKEN");
-        let mut material = BTreeMap::from([
-            ("API_TOKEN".to_string(), "expired-token".to_string()),
-            (format!("{prefix}method"), "oauth".to_string()),
-            (
-                format!("{prefix}access_token_expires_at"),
-                (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
-            ),
-            (
-                format!("{prefix}refresh_token"),
-                "stored-refresh-token".to_string(),
-            ),
-            (format!("{prefix}client_id"), "stored-client".to_string()),
-            (format!("{prefix}token_url"), token_url),
-        ]);
         let service = OAuthCredentialService::with_token_request_timeout(Duration::from_millis(50));
 
         let error = service
@@ -1730,202 +1723,91 @@ mod tests {
                 .contains("OAuth token refresh request failed"),
             "unexpected error: {error:#}"
         );
-        assert_eq!(
-            material.get("API_TOKEN").map(String::as_str),
-            Some("expired-token")
-        );
+        assert_entry(&material, "API_TOKEN", Some("expired-token"));
         server.abort();
     }
 
     #[tokio::test]
     async fn confidential_oauth_refresh_uses_stored_basic_auth_client_secret() {
-        let fixture = OAuthFixture::new(Some(
-            r#"{"access_token":"refreshed-token","token_type":"Bearer","expires_in":3600}"#,
-        ));
-        let oauth = oauth_spec(
-            &fixture.token_url,
-            free_loopback_port(),
-            ManifestOAuthPkceMode::Disabled,
-            confidential_client(ManifestOAuthClientSecretTransport::BasicAuth),
+        let fixture = OAuthFixture::new(Some(REFRESHED_TOKEN_RESPONSE));
+        let oauth = confidential_basic_spec(&fixture.token_url, free_loopback_port());
+        let mut material = stored_oauth_material(
+            "API_TOKEN",
+            "expired-token",
+            chrono::Duration::minutes(-5),
+            &[
+                ("refresh_token", "stored-refresh-token"),
+                ("client_id", "stored-client"),
+                ("client_secret", "stored-secret"),
+                ("client_secret_transport", "basic_auth"),
+                ("token_url", &fixture.token_url),
+            ],
         );
-        let prefix = oauth_metadata_prefix("API_TOKEN");
-        let mut material = BTreeMap::from([
-            ("API_TOKEN".to_string(), "expired-token".to_string()),
-            (format!("{prefix}method"), "oauth".to_string()),
-            (
-                format!("{prefix}access_token_expires_at"),
-                (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
-            ),
-            (
-                format!("{prefix}refresh_token"),
-                "stored-refresh-token".to_string(),
-            ),
-            (format!("{prefix}client_id"), "stored-client".to_string()),
-            (
-                format!("{prefix}client_secret"),
-                "stored-secret".to_string(),
-            ),
-            (
-                format!("{prefix}client_secret_transport"),
-                "basic_auth".to_string(),
-            ),
-            (format!("{prefix}token_url"), fixture.token_url.clone()),
-        ]);
-        let service = OAuthCredentialService::new();
 
-        let refreshed = service
-            .refresh_if_needed(
-                RefreshOAuthCredentialRequest::for_source_input("API_TOKEN", &oauth),
-                &mut material,
-            )
+        let refreshed = refresh_source_input("API_TOKEN", &oauth, &mut material)
             .await
             .expect("refresh oauth material");
         let captured = fixture.token_server.await.expect("token server");
 
         assert!(refreshed);
-        let expected_authorization = basic_client_authorization("stored-client", "stored-secret");
-        assert_eq!(
-            captured.authorization.as_deref(),
-            Some(expected_authorization.as_str())
-        );
+        assert_basic_auth(&captured, "stored-client", "stored-secret");
         assert!(!captured.form.contains_key("client_secret"));
-        assert_eq!(
-            material.get("API_TOKEN").map(String::as_str),
-            Some("refreshed-token")
-        );
+        assert_entry(&material, "API_TOKEN", Some("refreshed-token"));
     }
 
     #[tokio::test]
     async fn public_pkce_oauth_session_exchanges_and_returns_token_material() {
         let fixture = OAuthFixture::new(None);
-        let redirect_port = free_loopback_port();
         let oauth = oauth_spec(
             &fixture.token_url,
-            redirect_port,
+            free_loopback_port(),
             ManifestOAuthPkceMode::Required,
             ManifestOAuthClientSpec {
-                id: ManifestOAuthClientIdSpec {
-                    default: Some("default-client".to_string()),
-                    input: Some("OAUTH_CLIENT_ID".to_string()),
-                },
+                id: client_id_spec(Some("default-client"), Some("OAUTH_CLIENT_ID")),
                 secret: None,
             },
         );
-        let service = OAuthCredentialService::new();
 
-        let (authorization_tx, authorization_rx) = oneshot::channel();
-        let authorize = service.authorize(
-            StartOAuthCredentialRequest {
-                input_key: "API_TOKEN",
-                oauth: &oauth,
-                source_inputs: &EMPTY_SOURCE_INPUTS,
-                credential_inputs: vec![(
-                    "OAUTH_CLIENT_ID".to_string(),
-                    "override-client".to_string(),
-                )],
+        let (completed, captured) = run_authorization_code_session(
+            fixture,
+            &oauth,
+            &[("OAUTH_CLIENT_ID", "override-client")],
+            |authorization_url| {
+                let query = query_pairs(authorization_url);
+                assert_entry(&query, "client_id", Some("override-client"));
+                assert_entry(&query, "scope", Some("repo read:org"));
+                assert_entry(&query, "code_challenge_method", Some("S256"));
+                assert!(!query.contains_key("client_secret"));
             },
-            move |authorization| async move {
-                authorization_tx
-                    .send(authorization.authorization_url)
-                    .map_err(|_authorization_url| {
-                        crate::bootstrap::AppError::FailedPrecondition(
-                            "authorization receiver closed".to_string(),
-                        )
-                    })
-            },
-        );
-        let callback = async {
-            let authorization_url = authorization_rx.await.expect("authorization url");
-            let authorization_url = Url::parse(&authorization_url).expect("authorization url");
-            let query = query_pairs(&authorization_url);
-            assert_eq!(
-                query.get("client_id").map(String::as_str),
-                Some("override-client")
-            );
-            assert_eq!(
-                query.get("scope").map(String::as_str),
-                Some("repo read:org")
-            );
-            assert_eq!(
-                query.get("code_challenge_method").map(String::as_str),
-                Some("S256")
-            );
-            assert!(!query.contains_key("client_secret"));
-            let callback_url = format!(
-                "http://127.0.0.1:{redirect_port}/oauth/callback?state={}&code=test-code",
-                query.get("state").expect("state")
-            );
-            reqwest::get(callback_url)
-                .await
-                .expect("callback response")
-                .error_for_status()
-                .expect("callback success");
-        };
+        )
+        .await;
 
-        let (completed, ()) = tokio::join!(authorize, callback);
-        let completed = completed.expect("authorize oauth");
-        let captured = fixture.token_server.await.expect("token server");
-
-        assert_eq!(completed.input_key, "API_TOKEN");
         assert_eq!(completed.access_token, "access-token");
-        assert_eq!(
-            captured.form.get("client_id").map(String::as_str),
-            Some("override-client")
-        );
-        assert_eq!(
-            captured.form.get("code").map(String::as_str),
-            Some("test-code")
-        );
+        assert_entry(&captured.form, "client_id", Some("override-client"));
+        assert_entry(&captured.form, "code", Some("test-code"));
         assert!(captured.form.contains_key("code_verifier"));
         assert!(!captured.form.contains_key("client_secret"));
         assert!(captured.authorization.is_none());
-        assert_eq!(
-            completed
-                .internal_metadata
-                .get(&format!(
-                    "{}refresh_token",
-                    oauth_metadata_prefix("API_TOKEN")
-                ))
-                .map(String::as_str),
-            Some("refresh-token")
+        assert_oauth_meta(
+            &completed.internal_metadata,
+            "API_TOKEN",
+            &[
+                ("refresh_token", Some("refresh-token")),
+                ("client_id", Some("override-client")),
+            ],
         );
-        assert_eq!(
-            completed
-                .internal_metadata
-                .get(&format!("{}client_id", oauth_metadata_prefix("API_TOKEN")))
-                .map(String::as_str),
-            Some("override-client")
-        );
-        assert_eq!(
-            completed.safe_metadata.get("scope").map(String::as_str),
-            Some("repo read:org")
-        );
+        assert_entry(&completed.safe_metadata, "scope", Some("repo read:org"));
     }
 
     #[tokio::test]
     async fn device_code_oauth_session_polls_and_stores_token_material() {
         let fixture = DeviceOAuthFixture::new();
         let oauth = device_oauth_spec(&fixture.device_url, &fixture.token_url);
-        let service = OAuthCredentialService::new();
 
-        let (authorization_tx, authorization_rx) = oneshot::channel();
-        let authorize = service.authorize(
-            StartOAuthCredentialRequest {
-                input_key: "API_TOKEN",
-                oauth: &oauth,
-                source_inputs: &EMPTY_SOURCE_INPUTS,
-                credential_inputs: vec![(
-                    "OAUTH_CLIENT_ID".to_string(),
-                    "device-client".to_string(),
-                )],
-            },
-            move |authorization| async move {
-                authorization_tx.send(authorization).map_err(|_error| {
-                    crate::bootstrap::AppError::FailedPrecondition(
-                        "authorization receiver closed".to_string(),
-                    )
-                })
-            },
+        let (authorize, authorization_rx) = start_authorize(
+            &oauth,
+            &EMPTY_SOURCE_INPUTS,
+            &[("OAUTH_CLIENT_ID", "device-client")],
         );
         let authorization = async {
             let authorization = authorization_rx.await.expect("authorization");
@@ -1946,29 +1828,19 @@ mod tests {
 
         assert_eq!(completed.input_key, "API_TOKEN");
         assert_eq!(completed.access_token, "access-token");
-        assert_eq!(
-            captured.device.form.get("client_id").map(String::as_str),
-            Some("device-client")
+        assert_entry(&captured.device.form, "client_id", Some("device-client"));
+        assert_entry(&captured.device.form, "scope", Some("repo read:org"));
+        assert_entry(
+            &captured.token.form,
+            "grant_type",
+            Some("urn:ietf:params:oauth:grant-type:device_code"),
         );
-        assert_eq!(
-            captured.device.form.get("scope").map(String::as_str),
-            Some("repo read:org")
-        );
-        assert_eq!(
-            captured.token.form.get("grant_type").map(String::as_str),
-            Some("urn:ietf:params:oauth:grant-type:device_code")
-        );
-        assert_eq!(
-            captured.token.form.get("device_code").map(String::as_str),
-            Some("device-code")
-        );
+        assert_entry(&captured.token.form, "device_code", Some("device-code"));
         assert!(!captured.token.form.contains_key("client_secret"));
-        assert_eq!(
-            completed
-                .internal_metadata
-                .get(&format!("{}client_id", oauth_metadata_prefix("API_TOKEN")))
-                .map(String::as_str),
-            Some("device-client")
+        assert_oauth_meta(
+            &completed.internal_metadata,
+            "API_TOKEN",
+            &[("client_id", Some("device-client"))],
         );
     }
 
@@ -1987,30 +1859,20 @@ mod tests {
         let rendered_token_url = fixture
             .token_url
             .replace("/access_token", "/organizations/access_token");
-        let service = OAuthCredentialService::new();
 
-        let authorize = service.authorize(
-            StartOAuthCredentialRequest {
-                input_key: "API_TOKEN",
-                oauth: &oauth,
-                source_inputs: &source_inputs,
-                credential_inputs: vec![(
-                    "OAUTH_CLIENT_ID".to_string(),
-                    "device-client".to_string(),
-                )],
-            },
-            |_authorization| async { Ok(()) },
+        let (authorize, _authorization_rx) = start_authorize(
+            &oauth,
+            &source_inputs,
+            &[("OAUTH_CLIENT_ID", "device-client")],
         );
 
         let completed = authorize.await.expect("authorize oauth");
         let _captured = fixture.server.await.expect("device server");
         assert_eq!(completed.access_token, "access-token");
-        assert_eq!(
-            completed
-                .internal_metadata
-                .get(&format!("{}token_url", oauth_metadata_prefix("API_TOKEN")))
-                .map(String::as_str),
-            Some(rendered_token_url.as_str())
+        assert_oauth_meta(
+            &completed.internal_metadata,
+            "API_TOKEN",
+            &[("token_url", Some(rendered_token_url.as_str()))],
         );
     }
 
@@ -2055,69 +1917,36 @@ mod tests {
                 .contains("OAuth device code request timed out"),
             "unexpected error: {error}"
         );
-        assert_eq!(
-            captured.form.get("client_id").map(String::as_str),
-            Some("device-client")
-        );
+        assert_entry(&captured.form, "client_id", Some("device-client"));
     }
 
     #[tokio::test]
     async fn confidential_oauth_session_uses_basic_auth_secret_transport() {
         let fixture = OAuthFixture::new(None);
-        let redirect_port = free_loopback_port();
-        let oauth = oauth_spec(
-            &fixture.token_url,
-            redirect_port,
-            ManifestOAuthPkceMode::Disabled,
-            confidential_client(ManifestOAuthClientSecretTransport::BasicAuth),
-        );
-        let service = OAuthCredentialService::new();
+        let oauth = confidential_basic_spec(&fixture.token_url, free_loopback_port());
 
-        let (authorization_tx, authorization_rx) = oneshot::channel();
-        let authorize = service.authorize(
-            StartOAuthCredentialRequest {
-                input_key: "API_TOKEN",
-                oauth: &oauth,
-                source_inputs: &EMPTY_SOURCE_INPUTS,
-                credential_inputs: vec![
-                    ("OAUTH_CLIENT_ID".to_string(), "client".to_string()),
-                    ("OAUTH_CLIENT_SECRET".to_string(), "secret".to_string()),
-                ],
+        let (completed, captured) = run_authorization_code_session(
+            fixture,
+            &oauth,
+            &[
+                ("OAUTH_CLIENT_ID", "client"),
+                ("OAUTH_CLIENT_SECRET", "secret"),
+            ],
+            |authorization_url| {
+                assert!(!query_pairs(authorization_url).contains_key("client_secret"));
             },
-            move |authorization| async move {
-                authorization_tx
-                    .send(authorization.authorization_url)
-                    .map_err(|_authorization_url| {
-                        crate::bootstrap::AppError::FailedPrecondition(
-                            "authorization receiver closed".to_string(),
-                        )
-                    })
-            },
-        );
-        let callback = async {
-            let authorization_url = authorization_rx.await.expect("authorization url");
-            let parsed = Url::parse(&authorization_url).expect("authorization url");
-            assert!(!query_pairs(&parsed).contains_key("client_secret"));
-            callback(&authorization_url).await;
-        };
+        )
+        .await;
 
-        let (completed, ()) = tokio::join!(authorize, callback);
-        let completed = completed.expect("authorize oauth");
-        let captured = fixture.token_server.await.expect("token server");
         assert_eq!(
             captured.authorization.as_deref(),
             Some("Basic Y2xpZW50OnNlY3JldA==")
         );
         assert!(!captured.form.contains_key("client_secret"));
-        assert_eq!(
-            completed
-                .internal_metadata
-                .get(&format!(
-                    "{}client_secret",
-                    oauth_metadata_prefix("API_TOKEN")
-                ))
-                .map(String::as_str),
-            Some("secret")
+        assert_oauth_meta(
+            &completed.internal_metadata,
+            "API_TOKEN",
+            &[("client_secret", Some("secret"))],
         );
         assert!(!completed.safe_metadata.contains_key("client_secret"));
     }
@@ -2125,39 +1954,7 @@ mod tests {
     #[tokio::test]
     async fn oauth_callback_accepts_request_split_across_reads() {
         let redirect_port = free_loopback_port();
-        let listener = tokio::net::TcpListener::bind(("127.0.0.1", redirect_port))
-            .await
-            .expect("bind callback listener");
-        let oauth = oauth_spec(
-            "https://provider.example.com/oauth/token",
-            redirect_port,
-            ManifestOAuthPkceMode::Disabled,
-            ManifestOAuthClientSpec {
-                id: ManifestOAuthClientIdSpec {
-                    default: Some("client".to_string()),
-                    input: None,
-                },
-                secret: None,
-            },
-        );
-        let endpoints = oauth
-            .endpoint_urls(&EMPTY_SOURCE_INPUTS)
-            .expect("render endpoints");
-        let session = AuthorizationCodeSessionConfig {
-            common: OAuthSessionCommon {
-                input_key: "API_TOKEN".to_string(),
-                oauth,
-                endpoints,
-                client_id: "client".to_string(),
-                client_secret: None,
-            },
-            state: "expected-state".to_string(),
-            code_verifier: None,
-            callback_path: "/oauth/callback".to_string(),
-            provider_redirect_uri: format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
-            listener,
-            expires_at: std::time::Instant::now() + std::time::Duration::from_mins(1),
-        };
+        let session = callback_session(redirect_port).await;
 
         let receive = receive_callback(&session);
         let send = async move {
@@ -2173,16 +1970,7 @@ mod tests {
                 .write_all(b"te=expected-state&code=test-code HTTP/1.1\r\nhost: 127.0.0.1\r\n\r\n")
                 .await
                 .expect("write rest of callback");
-            let mut response = Vec::new();
-            stream
-                .read_to_end(&mut response)
-                .await
-                .expect("read callback response");
-            assert!(
-                String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200 OK"),
-                "unexpected callback response: {}",
-                String::from_utf8_lossy(&response)
-            );
+            assert_callback_response_ok(&mut stream).await;
         };
 
         let (callback, ()) = tokio::join!(receive, send);
@@ -2192,39 +1980,7 @@ mod tests {
     #[tokio::test]
     async fn oauth_callback_accepts_real_callback_after_idle_preconnection() {
         let redirect_port = free_loopback_port();
-        let listener = tokio::net::TcpListener::bind(("127.0.0.1", redirect_port))
-            .await
-            .expect("bind callback listener");
-        let oauth = oauth_spec(
-            "https://provider.example.com/oauth/token",
-            redirect_port,
-            ManifestOAuthPkceMode::Disabled,
-            ManifestOAuthClientSpec {
-                id: ManifestOAuthClientIdSpec {
-                    default: Some("client".to_string()),
-                    input: None,
-                },
-                secret: None,
-            },
-        );
-        let endpoints = oauth
-            .endpoint_urls(&EMPTY_SOURCE_INPUTS)
-            .expect("render endpoints");
-        let session = AuthorizationCodeSessionConfig {
-            common: OAuthSessionCommon {
-                input_key: "API_TOKEN".to_string(),
-                oauth,
-                endpoints,
-                client_id: "client".to_string(),
-                client_secret: None,
-            },
-            state: "expected-state".to_string(),
-            code_verifier: None,
-            callback_path: "/oauth/callback".to_string(),
-            provider_redirect_uri: format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
-            listener,
-            expires_at: std::time::Instant::now() + std::time::Duration::from_mins(1),
-        };
+        let session = callback_session(redirect_port).await;
 
         let receive = receive_callback(&session);
         let send = async move {
@@ -2240,16 +1996,7 @@ mod tests {
                 )
                 .await
                 .expect("write callback");
-            let mut response = Vec::new();
-            stream
-                .read_to_end(&mut response)
-                .await
-                .expect("read callback response");
-            assert!(
-                String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200 OK"),
-                "unexpected callback response: {}",
-                String::from_utf8_lossy(&response)
-            );
+            assert_callback_response_ok(&mut stream).await;
         };
 
         let (callback, ()) = tokio::join!(receive, send);
@@ -2259,49 +2006,26 @@ mod tests {
     #[tokio::test]
     async fn confidential_oauth_session_uses_request_body_secret_transport() {
         let fixture = OAuthFixture::new(None);
-        let redirect_port = free_loopback_port();
         let oauth = oauth_spec(
             &fixture.token_url,
-            redirect_port,
+            free_loopback_port(),
             ManifestOAuthPkceMode::Disabled,
             confidential_client(ManifestOAuthClientSecretTransport::RequestBody),
         );
-        let service = OAuthCredentialService::new();
 
-        let (authorization_tx, authorization_rx) = oneshot::channel();
-        let authorize = service.authorize(
-            StartOAuthCredentialRequest {
-                input_key: "API_TOKEN",
-                oauth: &oauth,
-                source_inputs: &EMPTY_SOURCE_INPUTS,
-                credential_inputs: vec![
-                    ("OAUTH_CLIENT_ID".to_string(), "client".to_string()),
-                    ("OAUTH_CLIENT_SECRET".to_string(), "secret".to_string()),
-                ],
-            },
-            move |authorization| async move {
-                authorization_tx
-                    .send(authorization.authorization_url)
-                    .map_err(|_authorization_url| {
-                        crate::bootstrap::AppError::FailedPrecondition(
-                            "authorization receiver closed".to_string(),
-                        )
-                    })
-            },
-        );
-        let callback = async {
-            let authorization_url = authorization_rx.await.expect("authorization url");
-            callback(&authorization_url).await;
-        };
+        let (_completed, captured) = run_authorization_code_session(
+            fixture,
+            &oauth,
+            &[
+                ("OAUTH_CLIENT_ID", "client"),
+                ("OAUTH_CLIENT_SECRET", "secret"),
+            ],
+            |_authorization_url| {},
+        )
+        .await;
 
-        let (completed, ()) = tokio::join!(authorize, callback);
-        completed.expect("authorize oauth");
-        let captured = fixture.token_server.await.expect("token server");
         assert!(captured.authorization.is_none());
-        assert_eq!(
-            captured.form.get("client_secret").map(String::as_str),
-            Some("secret")
-        );
+        assert_entry(&captured.form, "client_secret", Some("secret"));
     }
 
     #[tokio::test]
@@ -2312,54 +2036,23 @@ mod tests {
             "http://127.0.0.1/oauth/callback",
             ManifestOAuthRedirectUriPortMode::Random,
             ManifestOAuthPkceMode::Required,
-            ManifestOAuthClientSpec {
-                id: ManifestOAuthClientIdSpec {
-                    default: Some("default-client".to_string()),
-                    input: None,
-                },
-                secret: None,
-            },
+            default_public_client("default-client"),
         );
-        let service = OAuthCredentialService::new();
 
-        let (authorization_tx, authorization_rx) = oneshot::channel();
-        let authorize = service.authorize(
-            StartOAuthCredentialRequest {
-                input_key: "API_TOKEN",
-                oauth: &oauth,
-                source_inputs: &EMPTY_SOURCE_INPUTS,
-                credential_inputs: Vec::new(),
-            },
-            move |authorization| async move {
-                authorization_tx
-                    .send(authorization.authorization_url)
-                    .map_err(|_authorization_url| {
-                        crate::bootstrap::AppError::FailedPrecondition(
-                            "authorization receiver closed".to_string(),
-                        )
-                    })
-            },
-        );
-        let callback = async {
-            let authorization_url = authorization_rx.await.expect("authorization url");
-            let authorization_url = Url::parse(&authorization_url).expect("authorization url");
-            let query = query_pairs(&authorization_url);
-            let redirect_uri =
-                Url::parse(query.get("redirect_uri").expect("redirect uri")).expect("redirect uri");
-            let redirect_port = redirect_uri.port().expect("assigned redirect port");
-            assert_ne!(redirect_port, 0);
+        let mut redirect_uri = None;
+        let (_completed, captured) =
+            run_authorization_code_session(fixture, &oauth, &[], |authorization_url| {
+                let query = query_pairs(authorization_url);
+                let assigned = Url::parse(query.get("redirect_uri").expect("redirect uri"))
+                    .expect("redirect uri");
+                let redirect_port = assigned.port().expect("assigned redirect port");
+                assert_ne!(redirect_port, 0);
+                redirect_uri = Some(assigned);
+            })
+            .await;
 
-            callback(authorization_url.as_str()).await;
-            redirect_uri
-        };
-        let (completed, redirect_uri) = tokio::join!(authorize, callback);
-        completed.expect("authorize oauth");
-
-        let captured = fixture.token_server.await.expect("token server");
-        assert_eq!(
-            captured.form.get("redirect_uri").map(String::as_str),
-            Some(redirect_uri.as_str())
-        );
+        let redirect_uri = redirect_uri.expect("redirect uri");
+        assert_entry(&captured.form, "redirect_uri", Some(redirect_uri.as_str()));
     }
 
     #[tokio::test]
@@ -2372,53 +2065,17 @@ mod tests {
             &redirect_uri,
             ManifestOAuthRedirectUriPortMode::Fixed,
             ManifestOAuthPkceMode::Required,
-            ManifestOAuthClientSpec {
-                id: ManifestOAuthClientIdSpec {
-                    default: Some("default-client".to_string()),
-                    input: None,
-                },
-                secret: None,
-            },
+            default_public_client("default-client"),
         );
-        let service = OAuthCredentialService::new();
 
-        let (authorization_tx, authorization_rx) = oneshot::channel();
-        let authorize = service.authorize(
-            StartOAuthCredentialRequest {
-                input_key: "API_TOKEN",
-                oauth: &oauth,
-                source_inputs: &EMPTY_SOURCE_INPUTS,
-                credential_inputs: Vec::new(),
-            },
-            move |authorization| async move {
-                authorization_tx
-                    .send(authorization.authorization_url)
-                    .map_err(|_authorization_url| {
-                        crate::bootstrap::AppError::FailedPrecondition(
-                            "authorization receiver closed".to_string(),
-                        )
-                    })
-            },
-        );
-        let callback = async {
-            let authorization_url = authorization_rx.await.expect("authorization url");
-            let authorization_url = Url::parse(&authorization_url).expect("authorization url");
-            let query = query_pairs(&authorization_url);
-            assert_eq!(
-                query.get("redirect_uri").map(String::as_str),
-                Some(redirect_uri.as_str())
-            );
+        let (_completed, captured) =
+            run_authorization_code_session(fixture, &oauth, &[], |authorization_url| {
+                let query = query_pairs(authorization_url);
+                assert_entry(&query, "redirect_uri", Some(redirect_uri.as_str()));
+            })
+            .await;
 
-            callback(authorization_url.as_str()).await;
-        };
-        let (completed, ()) = tokio::join!(authorize, callback);
-        completed.expect("authorize oauth");
-
-        let captured = fixture.token_server.await.expect("token server");
-        assert_eq!(
-            captured.form.get("redirect_uri").map(String::as_str),
-            Some(redirect_uri.as_str())
-        );
+        assert_entry(&captured.form, "redirect_uri", Some(redirect_uri.as_str()));
     }
 
     async fn callback(authorization_url: &str) {
@@ -2436,6 +2093,213 @@ mod tests {
             .expect("callback response")
             .error_for_status()
             .expect("callback success");
+    }
+
+    /// Starts an authorize flow for input key "`API_TOKEN`" on a fresh service,
+    /// with a callback that forwards the authorization through the returned
+    /// receiver. Keep the receiver alive until the authorize future resolves.
+    fn start_authorize<'a>(
+        oauth: &'a ManifestOAuthCredentialSpec,
+        source_inputs: &'a BTreeMap<String, String>,
+        credential_inputs: &[(&str, &str)],
+    ) -> (
+        impl Future<Output = Result<OAuthCredentialMaterial, AppError>> + 'a,
+        oneshot::Receiver<OAuthAuthorization>,
+    ) {
+        let credential_inputs = credential_inputs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect();
+        let (authorization_tx, authorization_rx) = oneshot::channel();
+        let authorize = async move {
+            OAuthCredentialService::new()
+                .authorize(
+                    StartOAuthCredentialRequest {
+                        input_key: "API_TOKEN",
+                        oauth,
+                        source_inputs,
+                        credential_inputs,
+                    },
+                    move |authorization| async move {
+                        authorization_tx
+                            .send(authorization)
+                            .map_err(|_authorization| {
+                                AppError::FailedPrecondition(
+                                    "authorization receiver closed".to_string(),
+                                )
+                            })
+                    },
+                )
+                .await
+        };
+        (authorize, authorization_rx)
+    }
+
+    /// Drives an authorization-code session end to end: starts authorize for
+    /// "`API_TOKEN`", lets `inspect` assert on the authorization URL, completes
+    /// the loopback callback with code "test-code", and returns the completed
+    /// material plus the captured token request.
+    async fn run_authorization_code_session(
+        fixture: OAuthFixture,
+        oauth: &ManifestOAuthCredentialSpec,
+        credential_inputs: &[(&str, &str)],
+        inspect: impl FnOnce(&Url),
+    ) -> (OAuthCredentialMaterial, CapturedTokenRequest) {
+        let (authorize, authorization_rx) =
+            start_authorize(oauth, &EMPTY_SOURCE_INPUTS, credential_inputs);
+        let callback_flow = async {
+            let authorization_url = authorization_rx
+                .await
+                .expect("authorization url")
+                .authorization_url;
+            inspect(&Url::parse(&authorization_url).expect("authorization url"));
+            callback(&authorization_url).await;
+        };
+        let (completed, ()) = tokio::join!(authorize, callback_flow);
+        let completed = completed.expect("authorize oauth");
+        let captured = fixture.token_server.await.expect("token server");
+        (completed, captured)
+    }
+
+    /// Runs a source-input refresh of `input_key` on a default-configured
+    /// service.
+    async fn refresh_source_input(
+        input_key: &str,
+        oauth: &ManifestOAuthCredentialSpec,
+        material: &mut BTreeMap<String, String>,
+    ) -> Result<bool, AppError> {
+        OAuthCredentialService::new()
+            .refresh_if_needed(
+                RefreshOAuthCredentialRequest::for_source_input(input_key, oauth),
+                material,
+            )
+            .await
+    }
+
+    /// Persisted OAuth material for `input_key`: access token, `method=oauth`
+    /// marker, and an expiry offset from now, plus `extra` metadata entries
+    /// (stored under the input's OAuth metadata prefix).
+    fn stored_oauth_material(
+        input_key: &str,
+        access_token: &str,
+        expires_in: chrono::Duration,
+        extra: &[(&str, &str)],
+    ) -> BTreeMap<String, String> {
+        let prefix = oauth_metadata_prefix(input_key);
+        let mut material = BTreeMap::from([
+            (input_key.to_string(), access_token.to_string()),
+            (format!("{prefix}method"), "oauth".to_string()),
+            (
+                format!("{prefix}access_token_expires_at"),
+                (chrono::Utc::now() + expires_in).to_rfc3339(),
+            ),
+        ]);
+        for (key, value) in extra {
+            material.insert(format!("{prefix}{key}"), (*value).to_string());
+        }
+        material
+    }
+
+    /// Authorization-code callback session listening on `redirect_port` for
+    /// state "expected-state" at path /oauth/callback.
+    async fn callback_session(redirect_port: u16) -> AuthorizationCodeSessionConfig {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", redirect_port))
+            .await
+            .expect("bind callback listener");
+        let oauth = oauth_spec(
+            "https://provider.example.com/oauth/token",
+            redirect_port,
+            ManifestOAuthPkceMode::Disabled,
+            default_public_client("client"),
+        );
+        let endpoints = oauth
+            .endpoint_urls(&EMPTY_SOURCE_INPUTS)
+            .expect("render endpoints");
+        AuthorizationCodeSessionConfig {
+            common: OAuthSessionCommon {
+                input_key: "API_TOKEN".to_string(),
+                oauth,
+                endpoints,
+                client_id: "client".to_string(),
+                client_secret: None,
+            },
+            state: "expected-state".to_string(),
+            code_verifier: None,
+            callback_path: "/oauth/callback".to_string(),
+            provider_redirect_uri: format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
+            listener,
+            expires_at: std::time::Instant::now() + std::time::Duration::from_mins(1),
+        }
+    }
+
+    async fn assert_callback_response_ok(stream: &mut tokio::net::TcpStream) {
+        let mut response = Vec::new();
+        stream
+            .read_to_end(&mut response)
+            .await
+            .expect("read callback response");
+        assert!(
+            String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200 OK"),
+            "unexpected callback response: {}",
+            String::from_utf8_lossy(&response)
+        );
+    }
+
+    #[track_caller]
+    fn assert_entry(map: &BTreeMap<String, String>, key: &str, expected: Option<&str>) {
+        assert_eq!(
+            map.get(key).map(String::as_str),
+            expected,
+            "unexpected value for key {key:?}"
+        );
+    }
+
+    /// Asserts the value (or absence, for `None`) of each `(suffix, value)`
+    /// entry under the input's OAuth metadata prefix.
+    #[track_caller]
+    fn assert_oauth_meta(
+        map: &BTreeMap<String, String>,
+        input_key: &str,
+        expected: &[(&str, Option<&str>)],
+    ) {
+        for (suffix, value) in expected {
+            assert_entry(
+                map,
+                &format!("{}{suffix}", oauth_metadata_prefix(input_key)),
+                *value,
+            );
+        }
+    }
+
+    #[track_caller]
+    fn assert_basic_auth(captured: &CapturedTokenRequest, client_id: &str, client_secret: &str) {
+        let expected_authorization = basic_client_authorization(client_id, client_secret);
+        assert_eq!(
+            captured.authorization.as_deref(),
+            Some(expected_authorization.as_str())
+        );
+    }
+
+    /// Authorization-code spec (PKCE disabled) for a public client with
+    /// spec-default id "default-client".
+    fn public_spec(token_url: &str, redirect_port: u16) -> ManifestOAuthCredentialSpec {
+        oauth_spec(
+            token_url,
+            redirect_port,
+            ManifestOAuthPkceMode::Disabled,
+            default_public_client("default-client"),
+        )
+    }
+
+    /// Authorization-code spec (PKCE disabled) for a confidential client with
+    /// basic-auth secret transport.
+    fn confidential_basic_spec(token_url: &str, redirect_port: u16) -> ManifestOAuthCredentialSpec {
+        oauth_spec(
+            token_url,
+            redirect_port,
+            ManifestOAuthPkceMode::Disabled,
+            confidential_client(ManifestOAuthClientSecretTransport::BasicAuth),
+        )
     }
 
     fn oauth_spec(
@@ -2471,12 +2335,7 @@ mod tests {
             device_authorization_url: None,
             token_url: token_url.to_string(),
             client,
-            scopes: Some(ManifestOAuthScopesSpec {
-                scope: ManifestOAuthScopeSpec {
-                    delimiter: ManifestOAuthScopeDelimiter::Space,
-                    values: vec!["repo".to_string(), "read:org".to_string()],
-                },
-            }),
+            scopes: default_scopes(),
         }
     }
 
@@ -2492,29 +2351,47 @@ mod tests {
             device_authorization_url: Some(device_url.to_string()),
             token_url: token_url.to_string(),
             client: ManifestOAuthClientSpec {
-                id: ManifestOAuthClientIdSpec {
-                    default: None,
-                    input: Some("OAUTH_CLIENT_ID".to_string()),
-                },
+                id: client_id_spec(None, Some("OAUTH_CLIENT_ID")),
                 secret: None,
             },
-            scopes: Some(ManifestOAuthScopesSpec {
-                scope: ManifestOAuthScopeSpec {
-                    delimiter: ManifestOAuthScopeDelimiter::Space,
-                    values: vec!["repo".to_string(), "read:org".to_string()],
-                },
-            }),
+            scopes: default_scopes(),
         }
     }
 
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "test fixture: returns Option to slot directly into the spec field"
+    )]
+    fn default_scopes() -> Option<ManifestOAuthScopesSpec> {
+        Some(ManifestOAuthScopesSpec {
+            scope: ManifestOAuthScopeSpec {
+                delimiter: ManifestOAuthScopeDelimiter::Space,
+                values: vec!["repo".to_string(), "read:org".to_string()],
+            },
+        })
+    }
+
+    fn client_id_spec(default: Option<&str>, input: Option<&str>) -> ManifestOAuthClientIdSpec {
+        ManifestOAuthClientIdSpec {
+            default: default.map(str::to_string),
+            input: input.map(str::to_string),
+        }
+    }
+
+    /// Public client with only a spec-default client id.
+    fn default_public_client(client_id: &str) -> ManifestOAuthClientSpec {
+        ManifestOAuthClientSpec {
+            id: client_id_spec(Some(client_id), None),
+            secret: None,
+        }
+    }
+
+    /// Confidential client whose id and secret both come from credential inputs.
     fn confidential_client(
         transport: ManifestOAuthClientSecretTransport,
     ) -> ManifestOAuthClientSpec {
         ManifestOAuthClientSpec {
-            id: ManifestOAuthClientIdSpec {
-                default: None,
-                input: Some("OAUTH_CLIENT_ID".to_string()),
-            },
+            id: client_id_spec(None, Some("OAUTH_CLIENT_ID")),
             secret: Some(ManifestOAuthClientSecretSpec {
                 input: "OAUTH_CLIENT_SECRET".to_string(),
                 transport,
@@ -2552,13 +2429,7 @@ mod tests {
                 let response_body = response_body.unwrap_or(
                     r#"{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","scope":"repo read:org","expires_in":3600}"#,
                 );
-                let response = format!(
-                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
-                    response_body.len()
-                );
-                stream
-                    .write_all(response.as_bytes())
-                    .expect("write token response");
+                write_json_response(&mut stream, response_body);
                 request
             });
             Self {
@@ -2620,20 +2491,14 @@ mod tests {
                 break;
             }
             buffer.extend_from_slice(&temp[..read]);
-            if buffer.windows(4).any(|window| window == b"\r\n\r\n") {
-                let header_end = buffer
-                    .windows(4)
-                    .position(|window| window == b"\r\n\r\n")
-                    .expect("header end")
-                    + 4;
+            if let Some(header_break) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+                let header_end = header_break + 4;
                 let headers = String::from_utf8_lossy(&buffer[..header_end]);
                 let content_length = headers
                     .lines()
-                    .find_map(|line| line.strip_prefix("content-length: "))
-                    .or_else(|| {
-                        headers
-                            .lines()
-                            .find_map(|line| line.strip_prefix("Content-Length: "))
+                    .find_map(|line| {
+                        line.strip_prefix("content-length: ")
+                            .or_else(|| line.strip_prefix("Content-Length: "))
                     })
                     .and_then(|value| value.parse::<usize>().ok())
                     .unwrap_or(0);

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -1061,104 +1061,19 @@ fn encode_env_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
-    use std::sync::{Arc, Mutex};
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
 
-    use super::{CredentialMaterialBackend, CredentialSetRef, EncodedCredentialMaterial};
-    use super::{CredentialStore, decode_env_value, encode_env_value, load_file, save_file};
-    use crate::credentials::{
-        CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind,
-        CredentialStoragePreference,
+    use super::{
+        CredentialSetRef, CredentialStore, TestKeychainBackend, decode_env_value, encode_env_value,
+        load_file, save_file,
     };
+    use crate::bootstrap::AppError;
+    use crate::credentials::{CredentialSetId, CredentialStorageKind, CredentialStoragePreference};
     use crate::sources::SourceName;
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
     use tempfile::TempDir;
-
-    struct FakeKeychainBackend {
-        probe_ok: bool,
-        material: Mutex<Option<Vec<u8>>>,
-    }
-
-    impl FakeKeychainBackend {
-        fn available() -> Arc<Self> {
-            Arc::new(Self {
-                probe_ok: true,
-                material: Mutex::new(None),
-            })
-        }
-
-        fn unavailable() -> Arc<Self> {
-            Arc::new(Self {
-                probe_ok: false,
-                material: Mutex::new(None),
-            })
-        }
-
-        fn material_bytes(&self) -> Option<Vec<u8>> {
-            self.material.lock().expect("material lock").clone()
-        }
-
-        fn lock_material(
-            &self,
-        ) -> Result<std::sync::MutexGuard<'_, Option<Vec<u8>>>, super::CredentialsError> {
-            self.material.lock().map_err(|error| {
-                super::CredentialsError::Unavailable(format!(
-                    "fake keychain lock poisoned: {error}"
-                ))
-            })
-        }
-    }
-
-    impl CredentialMaterialBackend for FakeKeychainBackend {
-        fn probe(&self) -> Result<(), super::CredentialsError> {
-            if self.probe_ok {
-                Ok(())
-            } else {
-                Err(super::CredentialsError::Unavailable(
-                    "fake keychain unavailable".to_string(),
-                ))
-            }
-        }
-
-        fn read(
-            &self,
-            _set: &CredentialSetRef<'_>,
-        ) -> Result<Option<EncodedCredentialMaterial>, super::CredentialsError> {
-            self.probe()?;
-            Ok(self.lock_material()?.clone().map(EncodedCredentialMaterial))
-        }
-
-        fn write(
-            &self,
-            _set: &CredentialSetRef<'_>,
-            material: Option<&EncodedCredentialMaterial>,
-        ) -> Result<(), super::CredentialsError> {
-            self.probe()?;
-            *self.lock_material()? = material.map(|material| material.bytes().to_vec());
-            Ok(())
-        }
-
-        fn snapshot(
-            &self,
-            _set: &CredentialSetRef<'_>,
-        ) -> Result<CredentialMaterialSnapshot, super::CredentialsError> {
-            self.probe()?;
-            Ok(CredentialMaterialSnapshot::new(
-                CredentialStorageKind::Keychain,
-                self.lock_material()?.clone(),
-            ))
-        }
-
-        fn restore(
-            &self,
-            _set: &CredentialSetRef<'_>,
-            snapshot: &CredentialMaterialSnapshot,
-        ) -> Result<(), super::CredentialsError> {
-            self.probe()?;
-            *self.lock_material()? = snapshot.material().map(ToOwned::to_owned);
-            Ok(())
-        }
-    }
 
     #[test]
     fn keychain_address_namespaces_by_config_workspace_and_credential_set() {
@@ -1257,185 +1172,120 @@ mod tests {
 
     #[test]
     fn replace_material_does_not_parse_existing_file() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::new(layout.clone());
-        let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        let path = layout.secret_file(&workspace_name, &source_name);
-        std::fs::create_dir_all(path.parent().expect("secret parent")).expect("secret parent dir");
-        std::fs::write(&path, "BROKEN\n").expect("write malformed existing env file");
+        let fixture = StoreFixture::file();
+        let path = &fixture.path;
+        write_malformed_material(path);
 
         let values = BTreeMap::from([("API_TOKEN".to_string(), "secret-token".to_string())]);
-        store
-            .replace_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-                &values,
-            )
+        fixture
+            .replace(CredentialStorageKind::File, &values)
             .expect("replace malformed material");
-        assert_eq!(load_file(&path).expect("load replaced material"), values);
+        assert_eq!(load_file(path).expect("load replaced material"), values);
 
-        std::fs::write(&path, "BROKEN\n").expect("write malformed existing env file");
-        store
-            .replace_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-                &BTreeMap::new(),
-            )
+        write_malformed_material(path);
+        fixture
+            .replace(CredentialStorageKind::File, &BTreeMap::new())
             .expect("remove malformed material");
         assert!(!path.exists(), "empty replacement should remove material");
     }
 
     #[test]
     fn remove_material_treats_missing_files_as_success() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::new(layout.clone());
-        let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        let path = layout.secret_file(&workspace_name, &source_name);
+        let fixture = StoreFixture::file();
+        let path = &fixture.path;
 
-        store
-            .remove_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-            )
+        fixture
+            .remove(CredentialStorageKind::File)
             .expect("missing material should be removable");
 
-        std::fs::create_dir_all(path.parent().expect("secret parent")).expect("secret parent dir");
-        std::fs::write(&path, "BROKEN\n").expect("write malformed existing env file");
-        store
-            .remove_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-            )
+        write_malformed_material(path);
+        fixture
+            .remove(CredentialStorageKind::File)
             .expect("malformed material should be removable");
         assert!(!path.exists(), "remove should delete material");
 
-        store
-            .remove_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-            )
+        fixture
+            .remove(CredentialStorageKind::File)
             .expect("second remove should still be successful");
     }
 
     #[test]
     fn restore_material_snapshot_preserves_raw_bytes() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::new(layout.clone());
-        let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        let path = layout.secret_file(&workspace_name, &source_name);
-        std::fs::create_dir_all(path.parent().expect("secret parent")).expect("secret parent dir");
-        std::fs::write(&path, "BROKEN\n").expect("write malformed existing env file");
+        let fixture = StoreFixture::file();
+        write_malformed_material(&fixture.path);
 
-        let snapshot = store
+        let snapshot = fixture
+            .store
             .snapshot_material(
-                &workspace_name,
-                &credential_set_id,
+                &fixture.workspace_name,
+                &fixture.credential_set_id,
                 CredentialStorageKind::File,
             )
             .expect("snapshot malformed material");
         let values = BTreeMap::from([("API_TOKEN".to_string(), "secret-token".to_string())]);
-        store
-            .replace_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-                &values,
-            )
+        fixture
+            .replace(CredentialStorageKind::File, &values)
             .expect("replace material");
 
-        store
-            .restore_material(&workspace_name, &credential_set_id, &snapshot)
+        fixture
+            .store
+            .restore_material(
+                &fixture.workspace_name,
+                &fixture.credential_set_id,
+                &snapshot,
+            )
             .expect("restore malformed material");
         assert_eq!(
-            std::fs::read(&path).expect("restored bytes"),
+            std::fs::read(&fixture.path).expect("restored bytes"),
             b"BROKEN\n".to_vec()
         );
     }
 
+    /// Merges `auto_prefers_keychain_when_probe_succeeds`,
+    /// `auto_falls_back_to_file_when_keychain_probe_fails`, and
+    /// `explicit_file_uses_file_even_when_keychain_probe_fails`, whose bodies
+    /// were identical apart from the preference, the keychain probe result,
+    /// and the expected storage kind.
     #[test]
-    fn auto_prefers_keychain_when_probe_succeeds() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let keychain = FakeKeychainBackend::available();
-        let store = CredentialStore::with_keychain_backend(
-            layout,
-            CredentialStoragePreference::Auto,
-            keychain.clone(),
-        );
-        assert_eq!(
-            store.default_write_storage().expect("storage"),
-            CredentialStorageKind::Keychain
-        );
-    }
-
-    #[test]
-    fn auto_falls_back_to_file_when_keychain_probe_fails() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::with_keychain_backend(
-            layout,
-            CredentialStoragePreference::Auto,
-            FakeKeychainBackend::unavailable(),
-        );
-        assert_eq!(
-            store.default_write_storage().expect("storage"),
-            CredentialStorageKind::File
-        );
-    }
-
-    #[test]
-    fn explicit_file_uses_file_even_when_keychain_probe_fails() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::with_keychain_backend(
-            layout,
-            CredentialStoragePreference::File,
-            FakeKeychainBackend::unavailable(),
-        );
-        assert_eq!(
-            store.default_write_storage().expect("storage"),
-            CredentialStorageKind::File
-        );
+    fn default_write_storage_follows_preference_and_keychain_probe() {
+        let cases = [
+            (
+                "auto prefers keychain when probe succeeds",
+                CredentialStoragePreference::Auto,
+                TestKeychainBackend::available(),
+                CredentialStorageKind::Keychain,
+            ),
+            (
+                "auto falls back to file when keychain probe fails",
+                CredentialStoragePreference::Auto,
+                TestKeychainBackend::unavailable(),
+                CredentialStorageKind::File,
+            ),
+            (
+                "explicit file uses file even when keychain probe fails",
+                CredentialStoragePreference::File,
+                TestKeychainBackend::unavailable(),
+                CredentialStorageKind::File,
+            ),
+        ];
+        for (label, preference, keychain, expected) in cases {
+            let fixture = StoreFixture::with_keychain(preference, Arc::new(keychain));
+            assert_eq!(
+                fixture.store.default_write_storage().expect("storage"),
+                expected,
+                "{label}"
+            );
+        }
     }
 
     #[test]
     fn explicit_keychain_fails_when_probe_fails() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::with_keychain_backend(
-            layout,
+        let fixture = StoreFixture::with_keychain(
             CredentialStoragePreference::Keychain,
-            FakeKeychainBackend::unavailable(),
+            Arc::new(TestKeychainBackend::unavailable()),
         );
-        let error = store
+        let error = fixture
+            .store
             .default_write_storage()
             .expect_err("explicit keychain should fail");
         assert!(
@@ -1450,19 +1300,9 @@ mod tests {
 
     #[test]
     fn keychain_backend_stores_one_versioned_document() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let keychain = FakeKeychainBackend::available();
-        let store = CredentialStore::with_keychain_backend(
-            layout,
-            CredentialStoragePreference::Keychain,
-            keychain.clone(),
-        );
-        let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let keychain = Arc::new(TestKeychainBackend::available());
+        let fixture =
+            StoreFixture::with_keychain(CredentialStoragePreference::Keychain, keychain.clone());
         let values = BTreeMap::from([
             ("API_TOKEN".to_string(), "secret-token".to_string()),
             (
@@ -1471,16 +1311,15 @@ mod tests {
             ),
         ]);
 
-        store
-            .replace_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::Keychain,
-                &values,
-            )
+        fixture
+            .replace(CredentialStorageKind::Keychain, &values)
             .expect("write keychain material");
 
-        let raw = keychain.material_bytes().expect("keychain blob");
+        let raw = keychain
+            .lock_material()
+            .expect("keychain lock")
+            .clone()
+            .expect("keychain blob");
         let document: serde_json::Value = serde_json::from_slice(&raw).expect("json");
         assert_eq!(document.get("version"), Some(&serde_json::json!(1)));
         assert_eq!(
@@ -1490,26 +1329,87 @@ mod tests {
             Some(&serde_json::json!("secret-token"))
         );
         assert_eq!(
-            store
+            fixture
+                .store
                 .read_material(
-                    &workspace_name,
-                    &credential_set_id,
+                    &fixture.workspace_name,
+                    &fixture.credential_set_id,
                     CredentialStorageKind::Keychain,
                 )
                 .expect("read keychain material"),
             values
         );
 
-        store
-            .remove_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::Keychain,
-            )
+        fixture
+            .remove(CredentialStorageKind::Keychain)
             .expect("remove keychain material");
         assert!(
-            keychain.material_bytes().is_none(),
+            keychain.lock_material().expect("keychain lock").is_none(),
             "remove should delete the stored keychain document"
         );
+    }
+
+    /// Store under test plus the ids of its exercised credential set:
+    /// workspace "default" and source "`secured_messages`", whose file-backend
+    /// secret file lives at `path`.
+    struct StoreFixture {
+        _temp: TempDir,
+        store: CredentialStore,
+        workspace_name: WorkspaceName,
+        credential_set_id: CredentialSetId,
+        path: PathBuf,
+    }
+
+    impl StoreFixture {
+        fn new(store: impl FnOnce(AppStateLayout) -> CredentialStore) -> Self {
+            let temp = TempDir::new().expect("temp dir");
+            let layout =
+                AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+            layout.ensure().expect("ensure layout");
+            let workspace_name = WorkspaceName::default();
+            let source_name = SourceName::parse("secured_messages").expect("source");
+            let path = layout.secret_file(&workspace_name, &source_name);
+            Self {
+                _temp: temp,
+                store: store(layout),
+                workspace_name,
+                credential_set_id: CredentialSetId::for_source(&source_name),
+                path,
+            }
+        }
+
+        fn file() -> Self {
+            Self::new(CredentialStore::new)
+        }
+
+        fn with_keychain(
+            preference: CredentialStoragePreference,
+            keychain: Arc<TestKeychainBackend>,
+        ) -> Self {
+            Self::new(|layout| CredentialStore::with_keychain_backend(layout, preference, keychain))
+        }
+
+        fn replace(
+            &self,
+            storage: CredentialStorageKind,
+            values: &BTreeMap<String, String>,
+        ) -> Result<(), AppError> {
+            self.store.replace_material(
+                &self.workspace_name,
+                &self.credential_set_id,
+                storage,
+                values,
+            )
+        }
+
+        fn remove(&self, storage: CredentialStorageKind) -> Result<(), AppError> {
+            self.store
+                .remove_material(&self.workspace_name, &self.credential_set_id, storage)
+        }
+    }
+
+    fn write_malformed_material(path: &Path) {
+        std::fs::create_dir_all(path.parent().expect("secret parent")).expect("secret parent dir");
+        std::fs::write(path, "BROKEN\n").expect("write malformed existing env file");
     }
 }

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -8,8 +8,8 @@ use serde_yaml::Value as YamlValue;
 
 use crate::bootstrap::AppError;
 use crate::credentials::oauth::{
-    OAuthCredentialMaterial, OAuthCredentialService, StartOAuthCredentialRequest,
-    material_key_belongs_to_input,
+    OAuthCredentialMaterial, OAuthCredentialService, OAuthProgressEventSender,
+    StartOAuthCredentialRequest, material_key_belongs_to_input,
 };
 use crate::credentials::{
     CORAL_INTERNAL_KEY_PREFIX, CredentialManager, CredentialMaterialGuard,
@@ -30,7 +30,6 @@ use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
-use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 use uuid::Uuid;
 
@@ -81,55 +80,6 @@ pub(crate) struct SourceOAuthCredentialRetrieval {
     pub(crate) credential_inputs: Vec<SourceBinding>,
 }
 
-pub(crate) enum ImportSourceWithCredentialsEvent {
-    OAuthAuthorization {
-        input_key: String,
-        authorization_url: String,
-        expires_in_seconds: u64,
-        user_code: Option<String>,
-        verification_uri: Option<String>,
-        verification_uri_complete: Option<String>,
-    },
-    OAuthCompleted {
-        input_key: String,
-        metadata: BTreeMap<String, String>,
-    },
-}
-
-#[derive(Clone)]
-pub(crate) struct ImportSourceEventSender {
-    tx: mpsc::Sender<PendingImportSourceWithCredentialsEvent>,
-}
-
-pub(crate) struct PendingImportSourceWithCredentialsEvent {
-    event: ImportSourceWithCredentialsEvent,
-    delivered: oneshot::Sender<()>,
-}
-
-impl ImportSourceEventSender {
-    pub(crate) fn new(tx: mpsc::Sender<PendingImportSourceWithCredentialsEvent>) -> Self {
-        Self { tx }
-    }
-
-    async fn send(&self, event: ImportSourceWithCredentialsEvent) -> Result<(), AppError> {
-        let (delivered, delivered_rx) = oneshot::channel();
-        self.tx
-            .send(PendingImportSourceWithCredentialsEvent { event, delivered })
-            .await
-            .map_err(|_closed| AppError::FailedPrecondition(import_stream_closed_message()))?;
-        delivered_rx
-            .await
-            .map_err(|_closed| AppError::FailedPrecondition(import_stream_closed_message()))
-    }
-}
-
-impl PendingImportSourceWithCredentialsEvent {
-    pub(crate) fn into_event(self) -> ImportSourceWithCredentialsEvent {
-        let _delivery = self.delivered.send(());
-        self.event
-    }
-}
-
 struct SourceCredentialOAuthConfig<'a> {
     input_key: &'a str,
     oauth: &'a ManifestOAuthCredentialSpec,
@@ -139,6 +89,15 @@ struct ValidatedBindings {
     variables: BTreeMap<String, String>,
     secrets: BTreeMap<String, String>,
     replaced_oauth_inputs: BTreeSet<String>,
+}
+
+#[derive(Clone, Copy)]
+struct InstallSourceRequest<'a> {
+    candidate: &'a CandidateSource,
+    bindings: &'a SourceBindings,
+    manifest_yaml: Option<&'a str>,
+    materialization_manifest_yaml: &'a str,
+    origin: SourceOrigin,
 }
 
 struct PersistSourceRequest<'a> {
@@ -265,11 +224,13 @@ impl SourceManager {
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
         self.install_validated_source(
             workspace_name,
-            &candidate,
-            &command.bindings,
-            None,
-            &bundled.manifest_yaml,
-            SourceOrigin::Bundled,
+            InstallSourceRequest {
+                candidate: &candidate,
+                bindings: &command.bindings,
+                manifest_yaml: None,
+                materialization_manifest_yaml: &bundled.manifest_yaml,
+                origin: SourceOrigin::Bundled,
+            },
         )
     }
 
@@ -277,19 +238,21 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         command: CreateBundledSourceWithOAuthCommand,
-        events: ImportSourceEventSender,
+        events: OAuthProgressEventSender,
     ) -> Result<InstalledSource, AppError> {
         let bundled = load_bundled_source(&command.name)?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
         self.install_source_with_oauth(
             workspace_name,
-            &candidate,
-            &command.bindings,
+            InstallSourceRequest {
+                candidate: &candidate,
+                bindings: &command.bindings,
+                manifest_yaml: None,
+                materialization_manifest_yaml: &bundled.manifest_yaml,
+                origin: SourceOrigin::Bundled,
+            },
             command.oauth_credential_retrievals,
             events,
-            None,
-            &bundled.manifest_yaml,
-            SourceOrigin::Bundled,
         )
         .await
     }
@@ -306,11 +269,13 @@ impl SourceManager {
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         self.install_validated_source(
             workspace_name,
-            &candidate,
-            &command.bindings,
-            Some(&manifest_yaml),
-            &manifest_yaml,
-            SourceOrigin::Imported,
+            InstallSourceRequest {
+                candidate: &candidate,
+                bindings: &command.bindings,
+                manifest_yaml: Some(&manifest_yaml),
+                materialization_manifest_yaml: &manifest_yaml,
+                origin: SourceOrigin::Imported,
+            },
         )
     }
 
@@ -318,7 +283,7 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         command: ImportSourceWithCredentialsCommand,
-        events: ImportSourceEventSender,
+        events: OAuthProgressEventSender,
     ) -> Result<InstalledSource, AppError> {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
@@ -327,13 +292,15 @@ impl SourceManager {
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         self.install_source_with_oauth(
             workspace_name,
-            &candidate,
-            &command.bindings,
+            InstallSourceRequest {
+                candidate: &candidate,
+                bindings: &command.bindings,
+                manifest_yaml: Some(&manifest_yaml),
+                materialization_manifest_yaml: &manifest_yaml,
+                origin: SourceOrigin::Imported,
+            },
             command.oauth_credential_retrievals,
             events,
-            Some(&manifest_yaml),
-            &manifest_yaml,
-            SourceOrigin::Imported,
         )
         .await
     }
@@ -345,47 +312,46 @@ impl SourceManager {
     fn install_validated_source(
         &self,
         workspace_name: &WorkspaceName,
-        candidate: &CandidateSource,
-        bindings: &SourceBindings,
-        manifest_yaml: Option<&str>,
-        materialization_manifest_yaml: &str,
-        origin: SourceOrigin,
+        request: InstallSourceRequest<'_>,
     ) -> Result<InstalledSource, AppError> {
+        let manifest = parse_source_manifest_yaml(request.materialization_manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         self.validate_runtime_schema_names_available(
             workspace_name,
-            &candidate.name,
-            materialization_manifest_yaml,
+            &request.candidate.name,
+            &manifest,
         )?;
         let stored_material = self.source_stored_material_for_validation(
             workspace_name,
-            candidate,
-            bindings,
+            request.candidate,
+            request.bindings,
             &BTreeSet::new(),
         )?;
-        let bindings = validate_bindings(candidate, bindings, &stored_material)?;
+        let bindings = validate_bindings(request.candidate, request.bindings, &stored_material)?;
         let materialization_inputs =
             materialization_inputs_from_bindings(&bindings, &stored_material);
         let credential_storage = self.source_persist_storage(
             workspace_name,
-            &candidate.name,
+            &request.candidate.name,
             &bindings,
             !stored_material.is_empty(),
         )?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
-                candidate,
-                manifest_yaml,
+                candidate: request.candidate,
+                manifest_yaml: request.manifest_yaml,
                 bindings,
-                origin,
+                origin: request.origin,
                 credential_storage,
                 materialization_tmp: self
                     .prepare_v4_materialization(
                         workspace_name,
-                        candidate,
-                        materialization_manifest_yaml,
+                        request.candidate,
+                        &manifest,
+                        request.materialization_manifest_yaml,
                         &materialization_inputs,
-                        origin,
+                        request.origin,
                         "tmp",
                     )?
                     .map(|build| build.temp_dir),
@@ -397,25 +363,19 @@ impl SourceManager {
     /// `events`), then validates and persists the source. Shared tail of the
     /// OAuth install entry points; the caller supplies the resolved `candidate`
     /// plus the per-origin `manifest_yaml`/`origin`.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "Shared OAuth install tail for the source-lifecycle entry points; the parameters are the irreducible per-call inputs and a grouping struct would only relocate the list."
-    )]
     async fn install_source_with_oauth(
         &self,
         workspace_name: &WorkspaceName,
-        candidate: &CandidateSource,
-        bindings: &SourceBindings,
+        request: InstallSourceRequest<'_>,
         oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
-        events: ImportSourceEventSender,
-        manifest_yaml: Option<&str>,
-        materialization_manifest_yaml: &str,
-        origin: SourceOrigin,
+        events: OAuthProgressEventSender,
     ) -> Result<InstalledSource, AppError> {
+        let manifest = parse_source_manifest_yaml(request.materialization_manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         self.validate_runtime_schema_names_available(
             workspace_name,
-            &candidate.name,
-            materialization_manifest_yaml,
+            &request.candidate.name,
+            &manifest,
         )?;
         let oauth_input_keys = oauth_credential_retrievals
             .iter()
@@ -423,16 +383,16 @@ impl SourceManager {
             .collect::<BTreeSet<_>>();
         let stored_material = self.source_stored_material_for_validation(
             workspace_name,
-            candidate,
-            bindings,
+            request.candidate,
+            request.bindings,
             &oauth_input_keys,
         )?;
         let has_stored_material = !stored_material.is_empty();
         let stored_material_for_materialization = stored_material.clone();
         let bindings = self
             .bindings_with_oauth_material(
-                candidate,
-                bindings,
+                request.candidate,
+                request.bindings,
                 stored_material,
                 oauth_credential_retrievals,
                 events,
@@ -442,25 +402,26 @@ impl SourceManager {
             materialization_inputs_from_bindings(&bindings, &stored_material_for_materialization);
         let credential_storage = self.source_persist_storage(
             workspace_name,
-            &candidate.name,
+            &request.candidate.name,
             &bindings,
             has_stored_material,
         )?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
-                candidate,
-                manifest_yaml,
+                candidate: request.candidate,
+                manifest_yaml: request.manifest_yaml,
                 bindings,
-                origin,
+                origin: request.origin,
                 credential_storage,
                 materialization_tmp: self
                     .prepare_v4_materialization(
                         workspace_name,
-                        candidate,
-                        materialization_manifest_yaml,
+                        request.candidate,
+                        &manifest,
+                        request.materialization_manifest_yaml,
                         &materialization_inputs,
-                        origin,
+                        request.origin,
                         "tmp",
                     )?
                     .map(|build| build.temp_dir),
@@ -716,13 +677,12 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         candidate: &CandidateSource,
+        manifest: &ValidatedSourceManifest,
         manifest_yaml: &str,
         inputs: &MaterializationInputs,
         origin: SourceOrigin,
         suffix_prefix: &str,
     ) -> Result<Option<MaterializationBuild>, AppError> {
-        let manifest = parse_source_manifest_yaml(manifest_yaml)
-            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let Some(v4) = manifest.as_v4() else {
             return Ok(None);
         };
@@ -755,11 +715,9 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         candidate_name: &SourceName,
-        manifest_yaml: &str,
+        candidate_manifest: &ValidatedSourceManifest,
     ) -> Result<(), AppError> {
-        let candidate_manifest = parse_source_manifest_yaml(manifest_yaml)
-            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
-        let candidate_schema_names = runtime_schema_names(&candidate_manifest);
+        let candidate_schema_names = runtime_schema_names(candidate_manifest);
         for installed in self.config_store.list_workspace_sources(workspace_name)? {
             if installed.name == *candidate_name {
                 continue;
@@ -930,7 +888,7 @@ impl SourceManager {
         candidate: &CandidateSource,
         source_inputs: &BTreeMap<String, String>,
         oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
-        events: ImportSourceEventSender,
+        events: OAuthProgressEventSender,
     ) -> Result<Vec<OAuthCredentialMaterial>, AppError> {
         let mut seen = BTreeSet::new();
         let mut materials = Vec::new();
@@ -949,40 +907,18 @@ impl SourceManager {
                 .into_iter()
                 .map(|input| (input.key, input.value))
                 .collect();
-            let authorization_input_key = input_key.clone();
-            let authorization_events = events.clone();
             let material = self
                 .oauth_credential_service
-                .authorize(
+                .authorize_with_progress(
                     StartOAuthCredentialRequest {
                         input_key: &input_key,
                         oauth: config.oauth,
                         source_inputs,
                         credential_inputs,
                     },
-                    move |authorization| {
-                        let events = authorization_events;
-                        async move {
-                            events
-                                .send(ImportSourceWithCredentialsEvent::OAuthAuthorization {
-                                    input_key: authorization_input_key,
-                                    authorization_url: authorization.authorization_url,
-                                    expires_in_seconds: authorization.expires_in_seconds,
-                                    user_code: authorization.user_code,
-                                    verification_uri: authorization.verification_uri,
-                                    verification_uri_complete: authorization
-                                        .verification_uri_complete,
-                                })
-                                .await
-                        }
-                    },
+                    input_key.clone(),
+                    &events,
                 )
-                .await?;
-            events
-                .send(ImportSourceWithCredentialsEvent::OAuthCompleted {
-                    input_key: material.input_key.clone(),
-                    metadata: material.safe_metadata.clone(),
-                })
                 .await?;
             materials.push(material);
         }
@@ -995,7 +931,7 @@ impl SourceManager {
         bindings: &SourceBindings,
         stored_material: BTreeMap<String, String>,
         oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
-        events: ImportSourceEventSender,
+        events: OAuthProgressEventSender,
     ) -> Result<ValidatedBindings, AppError> {
         let preflight_bindings = Self::validate_oauth_import_preflight(
             candidate,
@@ -1330,10 +1266,6 @@ fn merge_oauth_material_into_bindings(
     Ok(())
 }
 
-fn import_stream_closed_message() -> String {
-    "source import stream closed".to_string()
-}
-
 fn collect_unique_variables(
     variables: &[SourceBinding],
 ) -> Result<BTreeMap<String, String>, AppError> {
@@ -1410,7 +1342,7 @@ fn durable_import_manifest_yaml(
     };
     let mut replacement_files = BTreeMap::new();
     for surface in &v4.surfaces {
-        let SurfaceDescriptor::File { file } = &surface.descriptor else {
+        let SurfaceDescriptor::File { file, .. } = &surface.descriptor else {
             continue;
         };
         let canonical = canonicalize_file_descriptor(file)?;
@@ -1471,28 +1403,30 @@ fn cleanup_empty_parent(root: &std::path::Path, path: Option<&std::path::Path>) 
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
-    use std::io::{Read as _, Write as _};
     use std::net::TcpListener as StdTcpListener;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::sync::mpsc as std_mpsc;
     use std::thread;
     use std::time::Duration;
 
     use tempfile::TempDir;
     use tokio::sync::mpsc;
-    use tokio::task::JoinHandle;
     use url::Url;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::{
-        ImportSourceCommand, ImportSourceEventSender, ImportSourceWithCredentialsCommand,
-        ImportSourceWithCredentialsEvent, PendingImportSourceWithCredentialsEvent, SourceBinding,
+        AppError, ImportSourceCommand, ImportSourceWithCredentialsCommand, SourceBinding,
         SourceBindings, SourceManager, SourceOAuthCredentialRetrieval, ValidatedBindings,
         materialization_inputs_from_bindings, normalize_binding_key,
         source_needs_stored_material_for_validation,
     };
+    use crate::credentials::oauth::{
+        OAuthProgressEvent, OAuthProgressEventSender, PendingOAuthProgressEvent,
+    };
     use crate::credentials::{
         CredentialManager, CredentialSetId, CredentialStorageKind, CredentialStoragePreference,
-        CredentialStore,
+        CredentialStore, CredentialsError,
     };
     use crate::sources::SourceName;
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
@@ -1504,8 +1438,39 @@ mod tests {
         WorkspaceName::default()
     }
 
+    /// dsl_version-3 HTTP manifest exposing a single `messages` table;
+    /// `head_yaml` supplies the `name/version/inputs/base_url/auth` prefix.
+    fn http_manifest(head_yaml: &str, table_description: &str) -> String {
+        format!(
+            r"{head_yaml}tables:
+  - name: messages
+    description: {table_description}
+    request:
+      method: GET
+      path: /messages
+    response: {{}}
+    columns:
+      - name: id
+        type: Utf8
+"
+        )
+    }
+
+    /// Templated `base_url` plus bearer-token auth shared by the secret-bearing
+    /// v3 manifests.
+    const V3_BEARER_AUTH_YAML: &str = r#"base_url: "{{input.API_BASE}}"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.API_TOKEN}}
+"#;
+
     fn manifest_with_secret() -> String {
-        r#"
+        http_manifest(
+            &format!(
+                r"
 name: secured_messages
 version: 0.1.0
 dsl_version: 3
@@ -1516,217 +1481,29 @@ inputs:
     default: https://example.com
   API_TOKEN:
     kind: secret
-base_url: "{{input.API_BASE}}"
-auth:
-  type: HeaderAuth
-  headers:
-    - name: Authorization
-      from: template
-      template: Bearer {{input.API_TOKEN}}
-tables:
-  - name: messages
-    description: Secured messages
-    request:
-      method: GET
-      path: /messages
-    response: {}
-    columns:
-      - name: id
-        type: Utf8
-"#
-        .to_string()
-    }
-
-    fn v4_openapi_fixture() -> &'static str {
-        r"
-openapi: 3.0.3
-paths:
-  /repos/{owner}/{repo}/issues:
-    get:
-      operationId: issues/list-for-repo
-      parameters:
-        - {name: owner, in: path, required: true, schema: {type: string}}
-        - {name: repo, in: path, required: true, schema: {type: string}}
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items: {$ref: '#/components/schemas/issue'}
-components:
-  schemas:
-    issue:
-      type: object
-      properties:
-        id: {type: integer}
-        title: {type: string}
-"
-    }
-
-    fn v4_openapi_fixture_with_metadata() -> &'static str {
-        r"
-openapi: 3.0.3
-info:
-  title: GitHub
-  description: Query GitHub issues.
-servers:
-  - url: https://api.github.test
-paths:
-  /repos/{owner}/{repo}/issues:
-    get:
-      operationId: issues/list-for-repo
-      parameters:
-        - {name: owner, in: path, required: true, schema: {type: string}}
-        - {name: repo, in: path, required: true, schema: {type: string}}
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items: {$ref: '#/components/schemas/issue'}
-components:
-  schemas:
-    issue:
-      type: object
-      properties:
-        id: {type: integer}
-        title: {type: string}
-"
-    }
-
-    fn v4_openapi_fixture_with_defaulted_input_server_url() -> &'static str {
-        r#"
-openapi: 3.0.3
-servers:
-  - url: "{apiBase}"
-    variables:
-      apiBase:
-        default: "{{input.API_BASE|https://fallback.example.com}}"
-paths:
-  /repos/{owner}/{repo}/issues:
-    get:
-      operationId: issues/list-for-repo
-      parameters:
-        - {name: owner, in: path, required: true, schema: {type: string}}
-        - {name: repo, in: path, required: true, schema: {type: string}}
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items: {$ref: '#/components/schemas/issue'}
-components:
-  schemas:
-    issue:
-      type: object
-      properties:
-        id: {type: integer}
-        title: {type: string}
-"#
-    }
-
-    fn manifest_v4_with_file_descriptor(openapi_file: &std::path::Path) -> String {
-        format!(
-            r#"
-name: github_v4_test
-dsl_version: 4
-surfaces:
-  - id: rest
-    type: openapi
-    file: {}
-    inputs:
-      API_BASE:
-        kind: variable
-        default: http://127.0.0.1:1
-    base_url: "{{{{input.API_BASE}}}}"
-"#,
-            openapi_file.display()
-        )
-    }
-
-    fn manifest_v4_with_surface_namespace(
-        openapi_file: &std::path::Path,
-        source_name: &str,
-        namespace_suffix: &str,
-    ) -> String {
-        format!(
-            r#"
-name: {source_name}
-dsl_version: 4
-surfaces:
-  - id: rest
-    namespace_suffix: {namespace_suffix}
-    type: openapi
-    file: {}
-    inputs:
-      API_BASE:
-        kind: variable
-        default: http://127.0.0.1:1
-    base_url: "{{{{input.API_BASE}}}}"
-"#,
-            openapi_file.display()
-        )
-    }
-
-    fn manifest_v4_with_input_and_derived_base_url(openapi_file: &std::path::Path) -> String {
-        format!(
-            r"
-name: github_v4_test
-dsl_version: 4
-surfaces:
-  - id: rest
-    type: openapi
-    file: {}
-    inputs:
-      API_BASE:
-        kind: variable
-        default: https://api.example.com
-",
-            openapi_file.display()
-        )
-    }
-
-    fn manifest_v4_without_description_or_base_url(openapi_file: &std::path::Path) -> String {
-        format!(
-            r"
-name: github_v4_test
-dsl_version: 4
-surfaces:
-  - id: rest
-    type: openapi
-    file: {}
-",
-            openapi_file.display()
+{V3_BEARER_AUTH_YAML}"
+            ),
+            "Secured messages",
         )
     }
 
     fn manifest_without_secrets() -> String {
-        r#"
+        http_manifest(
+            r#"
 name: public_messages
 version: 0.1.0
 dsl_version: 3
 backend: http
 base_url: "https://example.com"
-tables:
-  - name: messages
-    description: Public messages
-    request:
-      method: GET
-      path: /messages
-    response: {}
-    columns:
-      - name: id
-        type: Utf8
-"#
-        .to_string()
+"#,
+            "Public messages",
+        )
     }
 
     fn manifest_with_oauth_secret(token_url: &str, redirect_port: u16) -> String {
-        format!(
-            r#"
+        http_manifest(
+            &format!(
+                r"
 name: secured_messages
 version: 0.2.0
 dsl_version: 3
@@ -1752,25 +1529,360 @@ inputs:
             client:
               id:
                 default: default-client
-base_url: "{{{{input.API_BASE}}}}"
-auth:
-  type: HeaderAuth
-  headers:
-    - name: Authorization
-      from: template
-      template: Bearer {{{{input.API_TOKEN}}}}
-tables:
-  - name: messages
-    description: Secured messages
-    request:
-      method: GET
-      path: /messages
-    response: {{}}
-    columns:
-      - name: id
-        type: Utf8
-"#
+{V3_BEARER_AUTH_YAML}"
+            ),
+            "Secured messages",
         )
+    }
+
+    /// Shared `OpenAPI` operations document body for the v4 import fixtures.
+    const V4_OPENAPI_OPERATIONS: &str = r"paths:
+  /repos/{owner}/{repo}/issues:
+    get:
+      operationId: issues/list-for-repo
+      parameters:
+        - {name: owner, in: path, required: true, schema: {type: string}}
+        - {name: repo, in: path, required: true, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: '#/components/schemas/issue'}
+components:
+  schemas:
+    issue:
+      type: object
+      properties:
+        id: {type: integer}
+        title: {type: string}
+";
+
+    fn v4_openapi_fixture() -> String {
+        format!("\nopenapi: 3.0.3\n{V4_OPENAPI_OPERATIONS}")
+    }
+
+    fn v4_openapi_fixture_with_metadata() -> String {
+        format!(
+            r"
+openapi: 3.0.3
+info:
+  title: GitHub
+  description: Query GitHub issues.
+servers:
+  - url: https://api.github.test
+{V4_OPENAPI_OPERATIONS}"
+        )
+    }
+
+    fn v4_openapi_fixture_with_defaulted_input_server_url() -> String {
+        format!(
+            r#"
+openapi: 3.0.3
+servers:
+  - url: "{{apiBase}}"
+    variables:
+      apiBase:
+        default: "{{{{input.API_BASE|https://fallback.example.com}}}}"
+{V4_OPENAPI_OPERATIONS}"#
+        )
+    }
+
+    /// Renders a v4 manifest whose `rest` surface points at the authored
+    /// descriptor, with `extra_surface_yaml` appended to the surface entry.
+    fn manifest_v4(openapi_file: &Path, extra_surface_yaml: &str) -> String {
+        format!(
+            r"
+name: github_v4_test
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+{extra_surface_yaml}",
+            openapi_file.display(),
+        )
+    }
+
+    const V4_LOCAL_BASE_URL_YAML: &str = r#"    inputs:
+      API_BASE:
+        kind: variable
+        default: http://127.0.0.1:1
+    base_url: "{{input.API_BASE}}"
+"#;
+
+    fn manifest_v4_with_file_descriptor(openapi_file: &Path) -> String {
+        manifest_v4(openapi_file, V4_LOCAL_BASE_URL_YAML)
+    }
+
+    fn manifest_v4_with_surface_namespace(
+        openapi_file: &Path,
+        source_name: &str,
+        namespace_suffix: &str,
+    ) -> String {
+        format!(
+            r"
+name: {source_name}
+dsl_version: 4
+surfaces:
+  - id: rest
+    namespace_suffix: {namespace_suffix}
+    type: openapi
+    file: {}
+{V4_LOCAL_BASE_URL_YAML}",
+            openapi_file.display(),
+        )
+    }
+
+    fn manifest_v4_with_input_and_derived_base_url(openapi_file: &Path) -> String {
+        manifest_v4(
+            openapi_file,
+            r"    inputs:
+      API_BASE:
+        kind: variable
+        default: https://api.example.com
+",
+        )
+    }
+
+    fn manifest_v4_without_description_or_base_url(openapi_file: &Path) -> String {
+        manifest_v4(openapi_file, "")
+    }
+
+    /// Authored-descriptor state plus a source manager over a fresh app
+    /// layout.
+    struct V4ImportFixture {
+        _temp: TempDir,
+        _descriptor_temp: TempDir,
+        layout: AppStateLayout,
+        openapi_file: PathBuf,
+        manager: SourceManager,
+    }
+
+    impl V4ImportFixture {
+        /// Renders `manifest` against the fixture descriptor.
+        fn manifest(&self, manifest: fn(&Path) -> String) -> String {
+            manifest(&self.openapi_file)
+        }
+
+        /// Imports the rendered `manifest` with no bindings into the default
+        /// workspace.
+        fn import(&self, manifest: fn(&Path) -> String) -> Result<InstalledSource, AppError> {
+            import_manifest(
+                &self.manager,
+                self.manifest(manifest),
+                SourceBindings::default(),
+            )
+        }
+    }
+
+    fn v4_import_fixture(openapi_yaml: &str) -> V4ImportFixture {
+        let temp = TempDir::new().expect("temp dir");
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
+        std::fs::write(&openapi_file, openapi_yaml).expect("write fixture");
+        let manager = SourceManager::new(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout.clone(),
+        );
+        V4ImportFixture {
+            _temp: temp,
+            _descriptor_temp: descriptor_temp,
+            layout,
+            openapi_file,
+            manager,
+        }
+    }
+
+    /// An [`ImportSourceCommand`] for `manifest_yaml` with `bindings`.
+    fn import_command(manifest_yaml: String, bindings: SourceBindings) -> ImportSourceCommand {
+        ImportSourceCommand {
+            manifest_yaml,
+            bindings,
+        }
+    }
+
+    /// An [`ImportSourceWithCredentialsCommand`] for `manifest_yaml` with
+    /// `bindings`.
+    fn credentials_import_command(
+        manifest_yaml: String,
+        bindings: SourceBindings,
+        oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
+    ) -> ImportSourceWithCredentialsCommand {
+        ImportSourceWithCredentialsCommand {
+            manifest_yaml,
+            bindings,
+            oauth_credential_retrievals,
+        }
+    }
+
+    /// A credentials-import command for `manifest_with_oauth_secret` whose
+    /// token endpoint is unreachable; for tests that must fail preflight
+    /// before OAuth retrieval starts.
+    fn unreachable_oauth_import_command(
+        bindings: SourceBindings,
+    ) -> ImportSourceWithCredentialsCommand {
+        credentials_import_command(
+            manifest_with_oauth_secret("http://127.0.0.1:1/token", free_loopback_port()),
+            bindings,
+            api_token_oauth_retrieval(),
+        )
+    }
+
+    fn api_token_oauth_retrieval() -> Vec<SourceOAuthCredentialRetrieval> {
+        vec![SourceOAuthCredentialRetrieval {
+            input_key: "API_TOKEN".to_string(),
+            method_index: 0,
+            credential_inputs: Vec::new(),
+        }]
+    }
+
+    fn binding(key: &str, value: &str) -> SourceBinding {
+        SourceBinding {
+            key: key.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    /// [`SourceBindings`] built from `(key, value)` variable and secret pairs.
+    fn bindings(variables: &[(&str, &str)], secrets: &[(&str, &str)]) -> SourceBindings {
+        SourceBindings {
+            variables: variables
+                .iter()
+                .map(|(key, value)| binding(key, value))
+                .collect(),
+            secrets: secrets
+                .iter()
+                .map(|(key, value)| binding(key, value))
+                .collect(),
+        }
+    }
+
+    fn api_token_bindings(value: &str) -> SourceBindings {
+        bindings(&[], &[("API_TOKEN", value)])
+    }
+
+    /// Imports `manifest_yaml` with `bindings` into the default workspace.
+    fn import_manifest(
+        manager: &SourceManager,
+        manifest_yaml: String,
+        bindings: SourceBindings,
+    ) -> Result<InstalledSource, AppError> {
+        manager.import_source(
+            &default_workspace(),
+            &import_command(manifest_yaml, bindings),
+        )
+    }
+
+    /// Imports [`manifest_with_secret`] into the default workspace.
+    fn import_secured(
+        manager: &SourceManager,
+        bindings: SourceBindings,
+    ) -> Result<InstalledSource, AppError> {
+        import_manifest(manager, manifest_with_secret(), bindings)
+    }
+
+    /// The source name shared by the secret-bearing v3 manifests, with its
+    /// credential set id.
+    fn secured_messages_ids() -> (SourceName, CredentialSetId) {
+        let source_name = SourceName::parse("secured_messages").expect("source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        (source_name, credential_set_id)
+    }
+
+    /// Asserts `map[key] == expected`, labeling failures with the key.
+    #[track_caller]
+    fn assert_map_entry(map: &BTreeMap<String, String>, key: &str, expected: &str) {
+        assert_eq!(
+            map.get(key).map(String::as_str),
+            Some(expected),
+            "entry '{key}'"
+        );
+    }
+
+    /// Asserts the error's message contains `expected`.
+    #[track_caller]
+    fn assert_error_contains(error: &AppError, expected: &str) {
+        let message = error.to_string();
+        assert!(message.contains(expected), "unexpected error: {message}");
+    }
+
+    /// A plain (no v4 features) source manager over a fresh app layout.
+    struct ManagerFixture {
+        _temp: TempDir,
+        layout: AppStateLayout,
+        credential_store: CredentialStore,
+        credential_manager: CredentialManager,
+        manager: SourceManager,
+    }
+
+    impl ManagerFixture {
+        /// Path of `source_name`'s file-backed secret material.
+        fn secret_path(&self, source_name: &SourceName) -> PathBuf {
+            self.layout.secret_file(&default_workspace(), source_name)
+        }
+
+        /// Reads stored credential material of `kind` for `credential_set_id`.
+        fn material(
+            &self,
+            credential_set_id: &CredentialSetId,
+            kind: CredentialStorageKind,
+        ) -> BTreeMap<String, String> {
+            self.credential_manager
+                .read_material(&default_workspace(), credential_set_id, kind)
+                .expect("read material")
+        }
+
+        /// Seeds file-backed credential material for `credential_set_id`.
+        fn seed_file_material(
+            &self,
+            credential_set_id: &CredentialSetId,
+            entries: &[(&str, &str)],
+        ) {
+            self.credential_manager
+                .replace_material(
+                    &default_workspace(),
+                    credential_set_id,
+                    CredentialStorageKind::File,
+                    &entries
+                        .iter()
+                        .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+                        .collect::<BTreeMap<_, _>>(),
+                )
+                .expect("seed credential material");
+        }
+    }
+
+    fn manager_fixture() -> ManagerFixture {
+        manager_fixture_with_store(|layout| CredentialStore::new(layout.clone()))
+    }
+
+    fn manager_fixture_with_store(
+        credential_store: impl FnOnce(&AppStateLayout) -> CredentialStore,
+    ) -> ManagerFixture {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let credential_store = credential_store(&layout);
+        let credential_manager = CredentialManager::new(credential_store.clone());
+        let manager = SourceManager::new(
+            ConfigStore::new(layout.clone()),
+            credential_manager.clone(),
+            layout.clone(),
+        );
+        ManagerFixture {
+            _temp: temp,
+            layout,
+            credential_store,
+            credential_manager,
+            manager,
+        }
     }
 
     fn manifest_with_templated_oauth_endpoints(
@@ -1792,19 +1904,13 @@ tables:
     }
 
     fn oauth_import_bindings_with_tenant() -> SourceBindings {
-        SourceBindings {
-            variables: vec![
-                SourceBinding {
-                    key: "API_BASE".to_string(),
-                    value: "https://api.example.test".to_string(),
-                },
-                SourceBinding {
-                    key: "OUTLOOK_TENANT_ID".to_string(),
-                    value: "organizations".to_string(),
-                },
+        bindings(
+            &[
+                ("API_BASE", "https://api.example.test"),
+                ("OUTLOOK_TENANT_ID", "organizations"),
             ],
-            secrets: Vec::new(),
-        }
+            &[],
+        )
     }
 
     fn candidate_with_secret(key: &str, required: bool) -> CandidateSource {
@@ -1915,14 +2021,7 @@ tables:
 
     #[test]
     fn discover_sources_omits_core_v4_preview_sources() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let ManagerFixture { _temp, manager, .. } = manager_fixture();
 
         let disabled = manager
             .discover_sources(&default_workspace())
@@ -1936,31 +2035,17 @@ tables:
 
     #[test]
     fn import_v4_source_writes_materialized_artifacts() {
-        let temp = TempDir::new().expect("temp dir");
-        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
-        std::fs::write(&openapi_file, v4_openapi_fixture()).expect("write fixture");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let fixture = v4_import_fixture(&v4_openapi_fixture());
 
-        let installed = manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_v4_with_file_descriptor(&openapi_file),
-                    bindings: SourceBindings::default(),
-                },
-            )
+        let installed = fixture
+            .import(manifest_v4_with_file_descriptor)
             .expect("import v4 source");
 
         assert_eq!(installed.name.as_str(), "github_v4_test");
         let source_name = SourceName::parse("github_v4_test").expect("source");
-        let materialized = layout.v4_materialized_dir(&default_workspace(), &source_name);
+        let materialized = fixture
+            .layout
+            .v4_materialized_dir(&default_workspace(), &source_name);
         assert!(materialized.join("fingerprint.yaml").exists());
         assert!(materialized.join("projections.yaml").exists());
         assert!(
@@ -1971,7 +2056,8 @@ tables:
                 .exists()
         );
 
-        let info = manager
+        let info = fixture
+            .manager
             .get_source_info(&default_workspace(), &source_name)
             .expect("installed v4 source should be usable");
         assert_eq!(info.name.as_str(), "github_v4_test");
@@ -2037,40 +2123,16 @@ tables:
 
     #[test]
     fn import_v4_source_rejects_derived_base_url_input_token_defaults() {
-        let temp = TempDir::new().expect("temp dir");
-        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
-        std::fs::write(
-            &openapi_file,
-            v4_openapi_fixture_with_defaulted_input_server_url(),
-        )
-        .expect("write fixture");
-        let manager = SourceManager::new(
-            ConfigStore::new(layout.clone()),
-            CredentialManager::new(CredentialStore::new(layout.clone())),
-            layout.clone(),
-        );
+        let fixture = v4_import_fixture(&v4_openapi_fixture_with_defaulted_input_server_url());
 
-        let error = manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_v4_with_input_and_derived_base_url(&openapi_file),
-                    bindings: SourceBindings::default(),
-                },
-            )
+        let error = fixture
+            .import(manifest_v4_with_input_and_derived_base_url)
             .expect_err("source add should reject derived base_url input token defaults");
 
-        let message = error.to_string();
+        assert_error_contains(&error, "derived OpenAPI server base_url input token");
         assert!(
-            message.contains("derived OpenAPI server base_url input token"),
-            "unexpected error: {message}"
-        );
-        assert!(
-            !layout
+            !fixture
+                .layout
                 .v4_materialized_dir(
                     &default_workspace(),
                     &SourceName::parse("github_v4_test").expect("source")
@@ -2082,63 +2144,36 @@ tables:
 
     #[test]
     fn import_v4_source_rejects_unresolved_relative_descriptor() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let manager = SourceManager::new(
-            ConfigStore::new(layout.clone()),
-            CredentialManager::new(CredentialStore::new(layout.clone())),
-            layout,
-        );
+        let fixture = v4_import_fixture(&v4_openapi_fixture());
 
-        let error = manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_v4_with_file_descriptor(Path::new("openapi.yaml")),
-                    bindings: SourceBindings::default(),
-                },
-            )
-            .expect_err("raw relative descriptors should fail in app import");
+        let error = import_manifest(
+            &fixture.manager,
+            manifest_v4_with_file_descriptor(Path::new("openapi.yaml")),
+            SourceBindings::default(),
+        )
+        .expect_err("raw relative descriptors should fail in app import");
 
-        assert!(
-            error
-                .to_string()
-                .contains("imported DSL v4 manifests must use absolute file descriptors"),
-            "unexpected error: {error}"
+        assert_error_contains(
+            &error,
+            "imported DSL v4 manifests must use absolute file descriptors",
         );
     }
 
     #[test]
     fn import_v4_source_preserves_intent_yaml_without_openapi_metadata() {
-        let temp = TempDir::new().expect("temp dir");
-        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
-        std::fs::write(&openapi_file, v4_openapi_fixture_with_metadata()).expect("write fixture");
-        let manager = SourceManager::new(
-            ConfigStore::new(layout.clone()),
-            CredentialManager::new(CredentialStore::new(layout.clone())),
-            layout.clone(),
-        );
+        let fixture = v4_import_fixture(&v4_openapi_fixture_with_metadata());
 
-        manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_v4_without_description_or_base_url(&openapi_file),
-                    bindings: SourceBindings::default(),
-                },
-            )
+        fixture
+            .import(manifest_v4_without_description_or_base_url)
             .expect("import v4 source");
 
         let source_name = SourceName::parse("github_v4_test").expect("source");
-        let stored_manifest =
-            std::fs::read_to_string(layout.manifest_file(&default_workspace(), &source_name))
-                .expect("stored manifest");
+        let stored_manifest = std::fs::read_to_string(
+            fixture
+                .layout
+                .manifest_file(&default_workspace(), &source_name),
+        )
+        .expect("stored manifest");
         assert!(
             !stored_manifest.contains("description: Query GitHub issues."),
             "expected stored manifest not to contain OpenAPI description: {stored_manifest}"
@@ -2151,57 +2186,38 @@ tables:
 
     #[test]
     fn import_restores_prior_state_when_secret_persistence_fails() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
-
+        let fixture = manager_fixture();
         let source_name = SourceName::parse("secured_messages").expect("source");
-        let source_dir = layout.source_dir(&default_workspace(), &source_name);
+        let source_dir = fixture
+            .layout
+            .source_dir(&default_workspace(), &source_name);
         std::fs::create_dir_all(&source_dir).expect("create source dir");
         std::fs::create_dir(source_dir.join("secrets.env"))
             .expect("create blocking secrets directory");
 
-        let error = manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings {
-                        variables: vec![SourceBinding {
-                            key: "API_BASE".to_string(),
-                            value: "https://example.com".to_string(),
-                        }],
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "secret-token".to_string(),
-                        }],
-                    },
-                },
-            )
-            .expect_err("secret persistence should fail");
+        let error = import_secured(
+            &fixture.manager,
+            bindings(
+                &[("API_BASE", "https://example.com")],
+                &[("API_TOKEN", "secret-token")],
+            ),
+        )
+        .expect_err("secret persistence should fail");
 
         assert!(
-            matches!(
-                error,
-                crate::bootstrap::AppError::Credentials(crate::credentials::CredentialsError::Io(
-                    _
-                ))
-            ),
+            matches!(error, AppError::Credentials(CredentialsError::Io(_))),
             "unexpected error: {error:#}"
         );
         assert!(
-            !layout
+            !fixture
+                .layout
                 .source_dir(&default_workspace(), &source_name)
                 .exists(),
             "source dir should be cleaned up after secret persistence failure"
         );
         assert!(
-            manager
+            fixture
+                .manager
                 .list_workspace_sources(&default_workspace())
                 .expect("list sources")
                 .is_empty(),
@@ -2217,103 +2233,61 @@ tables:
         );
     }
 
+    /// Labeled reject cases for [`normalize_binding_key`]: env-file breaking
+    /// characters, comment markers, and reserved internal prefixes.
     #[test]
-    fn rejects_env_file_breaking_binding_keys() {
-        let error = normalize_binding_key("source secret key", "API=TOKEN")
-            .expect_err("'=' should be rejected");
-        assert!(
-            error
-                .to_string()
-                .contains("must not contain '=', '\\n', or '\\r'")
-        );
-
-        let error = normalize_binding_key("source secret key", "API\nTOKEN")
-            .expect_err("newlines should be rejected");
-        assert!(
-            error
-                .to_string()
-                .contains("must not contain '=', '\\n', or '\\r'")
-        );
-
-        let error = normalize_binding_key("source secret key", " #comment")
-            .expect_err("leading comment markers should be rejected");
-        assert!(error.to_string().contains("must not start with '#'"));
-    }
-
-    #[test]
-    fn rejects_reserved_internal_binding_keys() {
-        let error = normalize_binding_key("source secret key", "__coral.API_TOKEN")
-            .expect_err("reserved prefix should be rejected");
-        assert!(
-            error
-                .to_string()
-                .contains("must not start with reserved prefix '__coral'")
-        );
+    fn rejects_invalid_binding_keys() {
+        for (label, key, expected) in [
+            (
+                "'=' should be rejected",
+                "API=TOKEN",
+                "must not contain '=', '\\n', or '\\r'",
+            ),
+            (
+                "newlines should be rejected",
+                "API\nTOKEN",
+                "must not contain '=', '\\n', or '\\r'",
+            ),
+            (
+                "leading comment markers should be rejected",
+                " #comment",
+                "must not start with '#'",
+            ),
+            (
+                "reserved prefix should be rejected",
+                "__coral.API_TOKEN",
+                "must not start with reserved prefix '__coral'",
+            ),
+        ] {
+            let error = normalize_binding_key("source secret key", key).expect_err(label);
+            assert!(
+                error.to_string().contains(expected),
+                "{label}: unexpected error: {error}"
+            );
+        }
     }
 
     #[test]
     fn import_materializes_variable_defaults_server_side() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout);
+        let ManagerFixture { _temp, manager, .. } = manager_fixture();
 
-        let source = manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings {
-                        variables: vec![],
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "secret-token".to_string(),
-                        }],
-                    },
-                },
-            )
-            .expect("import source");
+        let source =
+            import_secured(&manager, api_token_bindings("secret-token")).expect("import source");
 
-        assert_eq!(
-            source.variables.get("API_BASE").map(String::as_str),
-            Some("https://example.com")
-        );
+        assert_map_entry(&source.variables, "API_BASE", "https://example.com");
     }
 
     #[test]
     fn import_new_source_uses_keychain_when_auto_probe_succeeds() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::with_available_keychain_for_test(
-            layout.clone(),
-            CredentialStoragePreference::Auto,
-        );
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout.clone());
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-
-        let source = manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings {
-                        variables: vec![],
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "secret-token".to_string(),
-                        }],
-                    },
-                },
+        let fixture = manager_fixture_with_store(|layout| {
+            CredentialStore::with_available_keychain_for_test(
+                layout.clone(),
+                CredentialStoragePreference::Auto,
             )
+        });
+        let (source_name, credential_set_id) = secured_messages_ids();
+
+        let source = import_secured(&fixture.manager, api_token_bindings("secret-token"))
             .expect("import source");
 
         assert_eq!(
@@ -2321,34 +2295,19 @@ tables:
             Some(CredentialStorageKind::Keychain)
         );
         assert!(
-            !layout
-                .secret_file(&default_workspace(), &source_name)
-                .exists(),
+            !fixture.secret_path(&source_name).exists(),
             "keychain-routed install should not create plaintext material"
         );
-        let stored = credential_manager
-            .read_material(
-                &default_workspace(),
-                &credential_set_id,
-                CredentialStorageKind::Keychain,
-            )
-            .expect("read keychain material");
-        assert_eq!(
-            stored.get("API_TOKEN").map(String::as_str),
-            Some("secret-token")
-        );
+        let stored = fixture.material(&credential_set_id, CredentialStorageKind::Keychain);
+        assert_map_entry(&stored, "API_TOKEN", "secret-token");
 
-        manager
+        fixture
+            .manager
             .delete_source(&default_workspace(), &source_name)
             .expect("delete source");
         assert!(
-            credential_manager
-                .read_material(
-                    &default_workspace(),
-                    &credential_set_id,
-                    CredentialStorageKind::Keychain,
-                )
-                .expect("read removed keychain material")
+            fixture
+                .material(&credential_set_id, CredentialStorageKind::Keychain)
                 .is_empty(),
             "delete should remove keychain-routed material"
         );
@@ -2356,39 +2315,29 @@ tables:
 
     #[test]
     fn import_source_without_secret_material_does_not_probe_keychain() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::with_unavailable_keychain_for_test(
-            layout.clone(),
-            CredentialStoragePreference::Keychain,
-        );
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let fixture = manager_fixture_with_store(|layout| {
+            CredentialStore::with_unavailable_keychain_for_test(
+                layout.clone(),
+                CredentialStoragePreference::Keychain,
+            )
+        });
         let source_name = SourceName::parse("public_messages").expect("source");
 
-        let source = manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_without_secrets(),
-                    bindings: SourceBindings::default(),
-                },
-            )
-            .expect("import source");
+        let source = import_manifest(
+            &fixture.manager,
+            manifest_without_secrets(),
+            SourceBindings::default(),
+        )
+        .expect("import source");
 
         assert!(source.secrets.is_empty());
         assert_eq!(source.credential_storage, None);
         assert!(
-            !layout
-                .secret_file(&default_workspace(), &source_name)
-                .exists(),
+            !fixture.secret_path(&source_name).exists(),
             "credential material should not be created for a source without secrets"
         );
         let config_raw =
-            std::fs::read_to_string(layout.config_file()).expect("read rendered config");
+            std::fs::read_to_string(fixture.layout.config_file()).expect("read rendered config");
         assert!(
             !config_raw.contains("credential_storage"),
             "source without credential material should not persist a storage route"
@@ -2397,26 +2346,14 @@ tables:
 
     #[test]
     fn import_missing_secret_does_not_probe_keychain_for_new_source() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::with_unavailable_keychain_for_test(
-            layout.clone(),
-            CredentialStoragePreference::Keychain,
-        );
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout);
-
-        let error = manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings::default(),
-                },
+        let ManagerFixture { _temp, manager, .. } = manager_fixture_with_store(|layout| {
+            CredentialStore::with_unavailable_keychain_for_test(
+                layout.clone(),
+                CredentialStoragePreference::Keychain,
             )
+        });
+
+        let error = import_secured(&manager, SourceBindings::default())
             .expect_err("missing required secret should fail validation");
 
         assert!(
@@ -2429,49 +2366,14 @@ tables:
 
     #[test]
     fn import_replaces_malformed_existing_credential_material() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
-
+        let fixture = manager_fixture();
         let source_name = SourceName::parse("secured_messages").expect("source");
-        manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings {
-                        variables: vec![],
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "old-token".to_string(),
-                        }],
-                    },
-                },
-            )
-            .expect("initial import");
+        import_secured(&fixture.manager, api_token_bindings("old-token")).expect("initial import");
 
-        let secret_path = layout.secret_file(&default_workspace(), &source_name);
+        let secret_path = fixture.secret_path(&source_name);
         std::fs::write(&secret_path, "BROKEN\n").expect("write malformed credential material");
 
-        manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings {
-                        variables: vec![],
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "new-token".to_string(),
-                        }],
-                    },
-                },
-            )
+        import_secured(&fixture.manager, api_token_bindings("new-token"))
             .expect("replace malformed credential material");
 
         assert_eq!(
@@ -2482,36 +2384,16 @@ tables:
 
     #[test]
     fn delete_removes_source_with_malformed_credential_material() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
-
+        let fixture = manager_fixture();
         let source_name = SourceName::parse("secured_messages").expect("source");
-        manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings {
-                        variables: vec![],
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "secret-token".to_string(),
-                        }],
-                    },
-                },
-            )
+        import_secured(&fixture.manager, api_token_bindings("secret-token"))
             .expect("initial import");
 
-        let secret_path = layout.secret_file(&default_workspace(), &source_name);
+        let secret_path = fixture.secret_path(&source_name);
         std::fs::write(&secret_path, "BROKEN\n").expect("write malformed credential material");
 
-        manager
+        fixture
+            .manager
             .delete_source(&default_workspace(), &source_name)
             .expect("delete source with malformed credential material");
 
@@ -2520,7 +2402,8 @@ tables:
             "delete should remove malformed credential material"
         );
         assert!(
-            manager
+            fixture
+                .manager
                 .list_workspace_sources(&default_workspace())
                 .expect("list sources")
                 .is_empty(),
@@ -2530,154 +2413,59 @@ tables:
 
     #[test]
     fn import_accepts_secret_already_populated_in_credential_material() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout);
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        credential_manager
-            .replace_material(
-                &default_workspace(),
-                &credential_set_id,
-                CredentialStorageKind::File,
-                &BTreeMap::from([
-                    ("API_TOKEN".to_string(), "oauth-token".to_string()),
-                    (
-                        "__coral_oauth.QVBJX1RPS0VO.method".to_string(),
-                        "oauth".to_string(),
-                    ),
-                ]),
-            )
-            .expect("seed credential material");
+        let fixture = manager_fixture();
+        let (_, credential_set_id) = secured_messages_ids();
+        fixture.seed_file_material(
+            &credential_set_id,
+            &[
+                ("API_TOKEN", "oauth-token"),
+                ("__coral_oauth.QVBJX1RPS0VO.method", "oauth"),
+            ],
+        );
 
-        let source = manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings::default(),
-                },
-            )
-            .expect("import source");
+        let source =
+            import_secured(&fixture.manager, SourceBindings::default()).expect("import source");
 
         assert_eq!(source.secrets, vec!["API_TOKEN"]);
-        let material = credential_manager
-            .read_material(
-                &default_workspace(),
-                &credential_set_id,
-                CredentialStorageKind::File,
-            )
-            .expect("read material");
-        assert_eq!(
-            material.get("API_TOKEN").map(String::as_str),
-            Some("oauth-token")
-        );
-        assert_eq!(
-            material
-                .get("__coral_oauth.QVBJX1RPS0VO.method")
-                .map(String::as_str),
-            Some("oauth")
-        );
+        let material = fixture.material(&credential_set_id, CredentialStorageKind::File);
+        assert_map_entry(&material, "API_TOKEN", "oauth-token");
+        assert_map_entry(&material, "__coral_oauth.QVBJX1RPS0VO.method", "oauth");
     }
 
     #[test]
     fn import_preserves_credential_store_io_errors_when_material_is_needed() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let fixture = manager_fixture();
         let source_name = SourceName::parse("secured_messages").expect("source");
-        let secret_path = layout.secret_file(&default_workspace(), &source_name);
+        let secret_path = fixture.secret_path(&source_name);
         std::fs::create_dir_all(&secret_path).expect("create blocking secret directory");
 
-        let error = manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings::default(),
-                },
-            )
+        let error = import_secured(&fixture.manager, SourceBindings::default())
             .expect_err("stored material I/O error should fail import");
 
         assert!(
-            matches!(
-                error,
-                crate::bootstrap::AppError::Credentials(crate::credentials::CredentialsError::Io(
-                    _
-                ))
-            ),
+            matches!(error, AppError::Credentials(CredentialsError::Io(_))),
             "unexpected error: {error:#}"
         );
     }
 
     #[test]
     fn manual_secret_reimport_clears_prior_oauth_material() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout);
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        credential_manager
-            .replace_material(
-                &default_workspace(),
-                &credential_set_id,
-                CredentialStorageKind::File,
-                &BTreeMap::from([
-                    ("API_TOKEN".to_string(), "oauth-token".to_string()),
-                    (
-                        "__coral_oauth.QVBJX1RPS0VO.refresh_token".to_string(),
-                        "refresh-token".to_string(),
-                    ),
-                    (
-                        "__coral_oauth.QVBJX1RPS0VO.method".to_string(),
-                        "oauth".to_string(),
-                    ),
-                ]),
-            )
-            .expect("seed credential material");
+        let fixture = manager_fixture();
+        let (_, credential_set_id) = secured_messages_ids();
+        fixture.seed_file_material(
+            &credential_set_id,
+            &[
+                ("API_TOKEN", "oauth-token"),
+                ("__coral_oauth.QVBJX1RPS0VO.refresh_token", "refresh-token"),
+                ("__coral_oauth.QVBJX1RPS0VO.method", "oauth"),
+            ],
+        );
 
-        manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings {
-                        variables: Vec::new(),
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "manual-token".to_string(),
-                        }],
-                    },
-                },
-            )
+        import_secured(&fixture.manager, api_token_bindings("manual-token"))
             .expect("import source");
 
-        let material = credential_manager
-            .read_material(
-                &default_workspace(),
-                &credential_set_id,
-                CredentialStorageKind::File,
-            )
-            .expect("read material");
-        assert_eq!(
-            material.get("API_TOKEN").map(String::as_str),
-            Some("manual-token")
-        );
+        let material = fixture.material(&credential_set_id, CredentialStorageKind::File);
+        assert_map_entry(&material, "API_TOKEN", "manual-token");
         assert!(
             !material
                 .keys()
@@ -2688,61 +2476,29 @@ tables:
 
     #[test]
     fn source_rollback_snapshots_credentials_after_refresh_lock() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store.clone());
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout.clone());
+        let fixture = manager_fixture();
         let workspace_name = default_workspace();
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        manager
-            .import_source(
-                &workspace_name,
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings {
-                        variables: Vec::new(),
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "old-token".to_string(),
-                        }],
-                    },
-                },
-            )
-            .expect("install source");
-        let refresh_lock = credential_store
+        let (_, credential_set_id) = secured_messages_ids();
+        import_secured(&fixture.manager, api_token_bindings("old-token")).expect("install source");
+        let refresh_lock = fixture
+            .credential_store
             .credential_refresh_lock(&workspace_name, &credential_set_id)
             .expect("hold refresh lock");
-        let config_temp_path = layout
+        let config_temp_path = fixture
+            .layout
             .config_file()
             .with_file_name(format!("config.toml.tmp.{}", std::process::id()));
         std::fs::create_dir_all(&config_temp_path).expect("block config save temp path");
         let (started_tx, started_rx) = std_mpsc::channel();
-        let import_manager = manager.clone();
-        let import_workspace = workspace_name.clone();
+        let import_manager = fixture.manager.clone();
         let import_handle = thread::spawn(move || {
             started_tx.send(()).expect("signal import start");
-            import_manager.import_source(
-                &import_workspace,
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings {
-                        variables: Vec::new(),
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "manual-token".to_string(),
-                        }],
-                    },
-                },
-            )
+            import_secured(&import_manager, api_token_bindings("manual-token"))
         });
         started_rx.recv().expect("wait for import thread");
         thread::sleep(Duration::from_millis(50));
-        credential_store
+        fixture
+            .credential_store
             .replace_material(
                 &workspace_name,
                 &credential_set_id,
@@ -2763,41 +2519,32 @@ tables:
             .expect_err("blocked config save should fail import");
         drop(std::fs::remove_dir_all(&config_temp_path));
 
-        let material = credential_manager
-            .read_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-            )
-            .expect("read material");
-        assert_eq!(
-            material.get("API_TOKEN").map(String::as_str),
-            Some("refreshed-token")
-        );
-        assert_eq!(
-            material
-                .get("__coral_oauth.QVBJX1RPS0VO.refresh_token")
-                .map(String::as_str),
-            Some("refreshed-refresh-token")
+        let material = fixture.material(&credential_set_id, CredentialStorageKind::File);
+        assert_map_entry(&material, "API_TOKEN", "refreshed-token");
+        assert_map_entry(
+            &material,
+            "__coral_oauth.QVBJX1RPS0VO.refresh_token",
+            "refreshed-refresh-token",
         );
     }
 
     #[tokio::test]
     async fn import_with_oauth_persists_retrieved_material() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout);
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        let fixture = OAuthFixture::new();
+        let fixture = manager_fixture();
+        let (_, credential_set_id) = secured_messages_ids();
+        let token_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"{"access_token":"access-token","token_type":"Bearer"}"#,
+                "application/json",
+            ))
+            .mount(&token_server)
+            .await;
         let redirect_port = free_loopback_port();
-        let (manifest_yaml, rendered_token_url) =
-            manifest_with_templated_oauth_endpoints(&fixture.token_url, redirect_port);
+        let (manifest_yaml, rendered_token_url) = manifest_with_templated_oauth_endpoints(
+            &format!("{}/token", token_server.uri()),
+            redirect_port,
+        );
         assert!(
             manifest_yaml.find("  API_TOKEN:").expect("API_TOKEN input")
                 < manifest_yaml
@@ -2807,17 +2554,13 @@ tables:
         );
         let (event_tx, mut event_rx) = import_event_channel();
         let workspace_name = default_workspace();
-        let import = manager.import_source_with_credentials(
+        let import = fixture.manager.import_source_with_credentials(
             &workspace_name,
-            ImportSourceWithCredentialsCommand {
+            credentials_import_command(
                 manifest_yaml,
-                bindings: oauth_import_bindings_with_tenant(),
-                oauth_credential_retrievals: vec![SourceOAuthCredentialRetrieval {
-                    input_key: "API_TOKEN".to_string(),
-                    method_index: 0,
-                    credential_inputs: Vec::new(),
-                }],
-            },
+                oauth_import_bindings_with_tenant(),
+                api_token_oauth_retrieval(),
+            ),
             event_tx,
         );
         let callback = async {
@@ -2826,7 +2569,7 @@ tables:
                 .await
                 .expect("authorization event")
                 .into_event();
-            let ImportSourceWithCredentialsEvent::OAuthAuthorization {
+            let OAuthProgressEvent::OAuthAuthorization {
                 input_key,
                 authorization_url,
                 ..
@@ -2843,7 +2586,7 @@ tables:
                 .await
                 .expect("completion event")
                 .into_event();
-            let ImportSourceWithCredentialsEvent::OAuthCompleted { input_key, .. } = event else {
+            let OAuthProgressEvent::OAuthCompleted { input_key, .. } = event else {
                 panic!("unexpected import event");
             };
             assert_eq!(input_key, "API_TOKEN");
@@ -2852,106 +2595,50 @@ tables:
         let (source, ()) = tokio::join!(import, callback);
         let source = source.expect("import source with OAuth");
         assert_eq!(source.secrets, vec!["API_TOKEN"]);
-        let captured = fixture.token_server.await.expect("token server");
-        assert_eq!(
-            captured.form.get("code").map(String::as_str),
-            Some("test-code")
-        );
-        let material = credential_manager
-            .read_material(
-                &default_workspace(),
-                &credential_set_id,
-                CredentialStorageKind::File,
-            )
-            .expect("read material");
-        assert_eq!(
-            material.get("API_TOKEN").map(String::as_str),
-            Some("access-token")
-        );
-        assert_eq!(
-            material
-                .get("__coral_oauth.QVBJX1RPS0VO.method")
-                .map(String::as_str),
-            Some("oauth")
-        );
-        assert_eq!(
-            material
-                .get("__coral_oauth.QVBJX1RPS0VO.token_url")
-                .map(String::as_str),
-            Some(rendered_token_url.as_str())
+        let token_request = token_server
+            .received_requests()
+            .await
+            .expect("recorded token requests")
+            .into_iter()
+            .next()
+            .expect("token request");
+        let form: BTreeMap<String, String> = url::form_urlencoded::parse(&token_request.body)
+            .into_owned()
+            .collect();
+        assert_eq!(form.get("code").map(String::as_str), Some("test-code"));
+        let material = fixture.material(&credential_set_id, CredentialStorageKind::File);
+        assert_map_entry(&material, "API_TOKEN", "access-token");
+        assert_map_entry(&material, "__coral_oauth.QVBJX1RPS0VO.method", "oauth");
+        assert_map_entry(
+            &material,
+            "__coral_oauth.QVBJX1RPS0VO.token_url",
+            &rendered_token_url,
         );
     }
 
     #[tokio::test]
     async fn import_with_oauth_does_not_overwrite_installed_credentials_when_validation_fails() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout);
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        manager
-            .import_source(
-                &default_workspace(),
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings {
-                        variables: vec![],
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "old-token".to_string(),
-                        }],
-                    },
-                },
-            )
-            .expect("install source");
+        let fixture = manager_fixture();
+        let (_, credential_set_id) = secured_messages_ids();
+        import_secured(&fixture.manager, api_token_bindings("old-token")).expect("install source");
 
-        let redirect_port = free_loopback_port();
         let (event_tx, mut event_rx) = import_event_channel();
-        let workspace_name = default_workspace();
-        let error = manager
+        let error = fixture
+            .manager
             .import_source_with_credentials(
-                &workspace_name,
-                ImportSourceWithCredentialsCommand {
-                    manifest_yaml: manifest_with_oauth_secret(
-                        "http://127.0.0.1:1/token",
-                        redirect_port,
-                    ),
-                    bindings: SourceBindings::default(),
-                    oauth_credential_retrievals: vec![SourceOAuthCredentialRetrieval {
-                        input_key: "API_TOKEN".to_string(),
-                        method_index: 0,
-                        credential_inputs: Vec::new(),
-                    }],
-                },
+                &default_workspace(),
+                unreachable_oauth_import_command(SourceBindings::default()),
                 event_tx,
             )
             .await
             .expect_err("missing API_BASE should fail validation");
-        assert!(
-            error
-                .to_string()
-                .contains("missing required source variable 'API_BASE'")
-        );
+        assert_error_contains(&error, "missing required source variable 'API_BASE'");
         assert!(
             event_rx.try_recv().is_err(),
             "preflight validation should fail before OAuth retrieval starts"
         );
-        let material = credential_manager
-            .read_material(
-                &default_workspace(),
-                &credential_set_id,
-                CredentialStorageKind::File,
-            )
-            .expect("read material");
-        assert_eq!(
-            material.get("API_TOKEN").map(String::as_str),
-            Some("old-token")
-        );
+        let material = fixture.material(&credential_set_id, CredentialStorageKind::File);
+        assert_map_entry(&material, "API_TOKEN", "old-token");
         assert!(
             !material.values().any(|value| value == "access-token"),
             "candidate OAuth material should not be persisted on validation failure"
@@ -2960,49 +2647,23 @@ tables:
 
     #[tokio::test]
     async fn import_with_oauth_rejects_source_config_conflict_before_authorization() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout);
-        let redirect_port = free_loopback_port();
+        let ManagerFixture { _temp, manager, .. } = manager_fixture();
         let (event_tx, mut event_rx) = import_event_channel();
 
         let error = manager
             .import_source_with_credentials(
                 &default_workspace(),
-                ImportSourceWithCredentialsCommand {
-                    manifest_yaml: manifest_with_oauth_secret(
-                        "http://127.0.0.1:1/token",
-                        redirect_port,
-                    ),
-                    bindings: SourceBindings {
-                        variables: vec![SourceBinding {
-                            key: "API_BASE".to_string(),
-                            value: "https://api.example.test".to_string(),
-                        }],
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "manual-token".to_string(),
-                        }],
-                    },
-                    oauth_credential_retrievals: vec![SourceOAuthCredentialRetrieval {
-                        input_key: "API_TOKEN".to_string(),
-                        method_index: 0,
-                        credential_inputs: Vec::new(),
-                    }],
-                },
+                unreachable_oauth_import_command(bindings(
+                    &[("API_BASE", "https://api.example.test")],
+                    &[("API_TOKEN", "manual-token")],
+                )),
                 event_tx,
             )
             .await
             .expect_err("source config and OAuth should conflict");
-        assert!(
-            error
-                .to_string()
-                .contains("source secret 'API_TOKEN' was provided by both source config and OAuth")
+        assert_error_contains(
+            &error,
+            "source secret 'API_TOKEN' was provided by both source config and OAuth",
         );
         assert!(
             event_rx.try_recv().is_err(),
@@ -3026,11 +2687,14 @@ tables:
     }
 
     fn import_event_channel() -> (
-        ImportSourceEventSender,
-        mpsc::Receiver<PendingImportSourceWithCredentialsEvent>,
+        OAuthProgressEventSender,
+        mpsc::Receiver<PendingOAuthProgressEvent>,
     ) {
         let (tx, rx) = mpsc::channel(4);
-        (ImportSourceEventSender::new(tx), rx)
+        (
+            OAuthProgressEventSender::new(tx, "source import stream closed"),
+            rx,
+        )
     }
 
     fn free_loopback_port() -> u16 {
@@ -3039,89 +2703,5 @@ tables:
             .local_addr()
             .expect("addr")
             .port()
-    }
-
-    struct OAuthFixture {
-        token_url: String,
-        token_server: JoinHandle<CapturedTokenRequest>,
-    }
-
-    impl OAuthFixture {
-        fn new() -> Self {
-            let token_listener = StdTcpListener::bind("127.0.0.1:0").expect("token listener");
-            let token_url = format!(
-                "http://{}/token",
-                token_listener.local_addr().expect("addr")
-            );
-            let token_server = tokio::task::spawn_blocking(move || {
-                let (mut stream, _) = token_listener.accept().expect("accept token request");
-                let request = read_http_request(&mut stream);
-                let response_body = r#"{"access_token":"access-token","token_type":"Bearer"}"#;
-                let response = format!(
-                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
-                    response_body.len()
-                );
-                stream
-                    .write_all(response.as_bytes())
-                    .expect("write token response");
-                request
-            });
-            Self {
-                token_url,
-                token_server,
-            }
-        }
-    }
-
-    struct CapturedTokenRequest {
-        form: BTreeMap<String, String>,
-    }
-
-    fn read_http_request(stream: &mut std::net::TcpStream) -> CapturedTokenRequest {
-        let mut buffer = Vec::new();
-        let mut temp = [0_u8; 1024];
-        loop {
-            let read = stream.read(&mut temp).expect("read token request");
-            if read == 0 {
-                break;
-            }
-            buffer.extend_from_slice(temp.get(..read).expect("read length is in buffer bounds"));
-            if buffer.windows(4).any(|window| window == b"\r\n\r\n") {
-                let header_end = buffer
-                    .windows(4)
-                    .position(|window| window == b"\r\n\r\n")
-                    .expect("header end")
-                    + 4;
-                let headers = String::from_utf8_lossy(
-                    buffer
-                        .get(..header_end)
-                        .expect("header end is in buffer bounds"),
-                );
-                let content_length = headers
-                    .lines()
-                    .find_map(|line| line.strip_prefix("content-length: "))
-                    .or_else(|| {
-                        headers
-                            .lines()
-                            .find_map(|line| line.strip_prefix("Content-Length: "))
-                    })
-                    .and_then(|value| value.parse::<usize>().ok())
-                    .unwrap_or(0);
-                while buffer.len() < header_end + content_length {
-                    let read = stream.read(&mut temp).expect("read token body");
-                    if read == 0 {
-                        break;
-                    }
-                    buffer.extend_from_slice(temp.get(..read).expect("read length is in bounds"));
-                }
-                break;
-            }
-        }
-        let raw = String::from_utf8_lossy(&buffer);
-        let (_headers, body) = raw.split_once("\r\n\r\n").expect("split request");
-        let form = url::form_urlencoded::parse(body.as_bytes())
-            .into_owned()
-            .collect();
-        CapturedTokenRequest { form }
     }
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -3,17 +3,15 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use coral_api::v1::source_service_server::SourceService as SourceServiceApi;
 use coral_api::v1::{
     CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
-    CreateBundledSourceWithOAuthResponse, CredentialMetadata, DeleteSourceRequest,
-    DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
-    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
-    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, OAuthCredentialAuthorization,
-    OAuthCredentialClient, OAuthCredentialClientId, OAuthCredentialClientSecret,
-    OAuthCredentialCompleted, OAuthCredentialEndpoints, OAuthCredentialInput,
+    CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DeleteSourceResponse,
+    DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest, GetSourceInfoResponse,
+    GetSourceRequest, GetSourceResponse, ImportSourceRequest, ImportSourceResponse,
+    ListSourcesRequest, ListSourcesResponse, OAuthCredentialClient, OAuthCredentialClientId,
+    OAuthCredentialClientSecret, OAuthCredentialEndpoints, OAuthCredentialInput,
     OAuthCredentialMethod, OAuthCredentialRetrieval, OAuthCredentialScope, OAuthCredentialScopes,
     OauthCredentialClientSecretTransport, OauthCredentialFlowType, OauthCredentialPkceMode,
     OauthCredentialRedirectUriPortMode, OauthCredentialScopeDelimiter, Source,
@@ -34,23 +32,22 @@ use tonic::{Request, Response, Status};
 
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
+use crate::credentials::oauth::{OAuthProgressEvent, OAuthProgressEventSender};
 use crate::identity::UserPrincipalProvider;
 use crate::query::manager::QueryManager;
 use crate::sources::SourceName;
 use crate::sources::manager::{
     CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
-    ImportSourceEventSender, ImportSourceWithCredentialsCommand, ImportSourceWithCredentialsEvent,
-    PendingImportSourceWithCredentialsEvent, SourceBinding, SourceBindings, SourceManager,
+    ImportSourceWithCredentialsCommand, SourceBinding, SourceBindings, SourceManager,
     SourceOAuthCredentialRetrieval,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::transport::{
-    instrument_authenticated_grpc, instrument_grpc, query_status,
+    OAuthProgressProto, instrument_authenticated_grpc, instrument_grpc,
+    oauth_operation_response_stream, query_status, run_blocking_operation,
     validate_source_response_to_proto, workspace_name_from_proto, workspace_to_proto,
 };
 use crate::workspaces::WorkspaceName;
-use tokio::sync::mpsc;
-use tokio::task;
 use tokio_stream::Stream;
 use tokio_stream::StreamExt as _;
 
@@ -184,7 +181,7 @@ impl SourceServiceApi for SourceService {
                     bindings: source_bindings_from_proto(request.variables, request.secrets),
                 };
                 let response_workspace_name = workspace_name.clone();
-                let installed = run_blocking_source_operation(move || {
+                let installed = run_blocking_operation("source operation", move || {
                     sources.create_bundled_source(&workspace_name, &command)
                 })
                 .await?;
@@ -260,17 +257,13 @@ impl SourceServiceApi for SourceService {
                         manifest_yaml: request.manifest_yaml,
                         bindings: source_bindings_from_proto(request.variables, request.secrets),
                     };
-                    let installed = run_blocking_source_operation(move || {
+                    let installed = run_blocking_operation("source operation", move || {
                         sources.import_source(&workspace_name, &command)
                     })
                     .await?;
-                    let response = ImportSourceResponse {
-                        event: Some(import_source_response::Event::Source(
-                            installed_source_to_proto(&response_workspace_name, installed),
-                        )),
-                    };
-                    return Ok(Response::new(
-                        Box::pin(tokio_stream::once(Ok(response))) as Self::ImportSourceStream
+                    return Ok(single_import_source_response(
+                        &response_workspace_name,
+                        installed,
                     ));
                 }
                 let command = ImportSourceWithCredentialsCommand {
@@ -313,7 +306,7 @@ impl SourceServiceApi for SourceService {
             |_principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
                 let source_name = SourceName::parse(&request.name).map_err(app_status)?;
-                run_blocking_source_operation(move || {
+                run_blocking_operation("source operation", move || {
                     sources.delete_source(&workspace_name, &source_name)
                 })
                 .await?;
@@ -355,97 +348,27 @@ type CreateBundledSourceWithOAuthResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithOAuthResponse, Status>> + Send>>;
 type ImportSourceResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
-type ImportSourceFuture = Pin<Box<dyn Future<Output = Result<InstalledSource, Status>> + Send>>;
 
-async fn run_blocking_source_operation<T, F>(operation: F) -> Result<T, Status>
-where
-    T: Send + 'static,
-    F: FnOnce() -> Result<T, AppError> + Send + 'static,
-{
-    let span = tracing::Span::current();
-    task::spawn_blocking(move || span.in_scope(operation))
-        .await
-        .map_err(|error| Status::internal(format!("source operation task failed: {error}")))?
-        .map_err(app_status)
-}
-
+/// Builds the import-source response stream: OAuth progress events while
+/// `import` runs, then the installed source.
 fn import_source_response_stream<F, Fut>(
     response_workspace_name: WorkspaceName,
     import: F,
 ) -> ImportSourceResponseStreamBox
 where
-    F: FnOnce(ImportSourceEventSender) -> Fut,
+    F: FnOnce(OAuthProgressEventSender) -> Fut,
     Fut: Future<Output = Result<InstalledSource, Status>> + Send + 'static,
 {
-    let (event_tx, event_rx) = mpsc::channel(8);
-    Box::pin(ImportSourceResponseStream::new(
-        event_rx,
-        Box::pin(import(ImportSourceEventSender::new(event_tx))),
-        response_workspace_name,
-    ))
-}
-
-struct ImportSourceResponseStream {
-    events: mpsc::Receiver<PendingImportSourceWithCredentialsEvent>,
-    import: Option<ImportSourceFuture>,
-    response_workspace_name: WorkspaceName,
-    completion: Option<Result<ImportSourceResponse, Status>>,
-}
-
-impl ImportSourceResponseStream {
-    fn new(
-        events: mpsc::Receiver<PendingImportSourceWithCredentialsEvent>,
-        import: ImportSourceFuture,
-        response_workspace_name: WorkspaceName,
-    ) -> Self {
-        Self {
-            events,
-            import: Some(import),
-            response_workspace_name,
-            completion: None,
-        }
-    }
-
-    fn poll_event(&mut self, cx: &mut Context<'_>) -> Poll<Option<ImportSourceResponse>> {
-        Pin::new(&mut self.events)
-            .poll_recv(cx)
-            .map(|event| event.map(|event| import_source_event_to_proto(event.into_event())))
-    }
-}
-
-impl Stream for ImportSourceResponseStream {
-    type Item = Result<ImportSourceResponse, Status>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        loop {
-            if let Poll::Ready(Some(event)) = this.poll_event(cx) {
-                return Poll::Ready(Some(Ok(event)));
-            }
-            if let Some(completion) = this.completion.take() {
-                return Poll::Ready(Some(completion));
-            }
-            let Some(import) = this.import.as_mut() else {
-                return Poll::Ready(None);
-            };
-            match import.as_mut().poll(cx) {
-                Poll::Ready(result) => {
-                    this.import = None;
-                    this.completion = Some(result.map(|installed| ImportSourceResponse {
-                        event: Some(import_source_response::Event::Source(
-                            installed_source_to_proto(&this.response_workspace_name, installed),
-                        )),
-                    }));
-                }
-                Poll::Pending => {
-                    return match this.poll_event(cx) {
-                        Poll::Ready(Some(event)) => Poll::Ready(Some(Ok(event))),
-                        Poll::Ready(None) | Poll::Pending => Poll::Pending,
-                    };
-                }
-            }
-        }
-    }
+    oauth_operation_response_stream(
+        "source import stream closed",
+        import,
+        import_source_event_to_proto,
+        move |installed| ImportSourceResponse {
+            event: Some(import_source_response::Event::Source(
+                installed_source_to_proto(&response_workspace_name, installed),
+            )),
+        },
+    )
 }
 
 fn source_bindings_from_proto(
@@ -459,6 +382,18 @@ fn source_bindings_from_proto(
             .collect(),
         secrets: secrets.into_iter().map(source_secret_from_proto).collect(),
     }
+}
+
+fn single_import_source_response(
+    workspace_name: &WorkspaceName,
+    installed: InstalledSource,
+) -> Response<ImportSourceResponseStreamBox> {
+    let response = ImportSourceResponse {
+        event: Some(import_source_response::Event::Source(
+            installed_source_to_proto(workspace_name, installed),
+        )),
+    };
+    Response::new(Box::pin(tokio_stream::once(Ok(response))) as ImportSourceResponseStreamBox)
 }
 
 fn source_variable_from_proto(variable: SourceVariable) -> SourceBinding {
@@ -502,33 +437,14 @@ fn source_secret_from_proto(secret: SourceSecret) -> SourceBinding {
     }
 }
 
-fn import_source_event_to_proto(event: ImportSourceWithCredentialsEvent) -> ImportSourceResponse {
-    let event = match event {
-        ImportSourceWithCredentialsEvent::OAuthAuthorization {
-            input_key,
-            authorization_url,
-            expires_in_seconds,
-            user_code,
-            verification_uri,
-            verification_uri_complete,
-        } => import_source_response::Event::OauthAuthorization(OAuthCredentialAuthorization {
-            input_key,
-            authorization_url,
-            expires_in_seconds,
-            user_code: user_code.unwrap_or_default(),
-            verification_uri: verification_uri.unwrap_or_default(),
-            verification_uri_complete: verification_uri_complete.unwrap_or_default(),
-        }),
-        ImportSourceWithCredentialsEvent::OAuthCompleted {
-            input_key,
-            metadata,
-        } => import_source_response::Event::OauthCompleted(OAuthCredentialCompleted {
-            input_key,
-            metadata: metadata
-                .into_iter()
-                .map(|(key, value)| CredentialMetadata { key, value })
-                .collect(),
-        }),
+fn import_source_event_to_proto(event: OAuthProgressEvent) -> ImportSourceResponse {
+    let event = match OAuthProgressProto::from(event) {
+        OAuthProgressProto::Authorization(authorization) => {
+            import_source_response::Event::OauthAuthorization(authorization)
+        }
+        OAuthProgressProto::Completed(completed) => {
+            import_source_response::Event::OauthCompleted(completed)
+        }
     };
     ImportSourceResponse { event: Some(event) }
 }
@@ -746,60 +662,69 @@ mod tests {
         ManifestOAuthRedirectUriPortMode,
     };
 
-    #[test]
-    fn converts_credential_methods_to_source_input_spec() {
-        let input = ManifestInputSpec {
+    /// A required `API_TOKEN` secret input with the given credential spec.
+    fn api_token_input(credential: Option<ManifestCredentialSpec>) -> ManifestInputSpec {
+        ManifestInputSpec {
             key: "API_TOKEN".to_string(),
             kind: ManifestInputKind::Secret,
             required: true,
             default_value: String::new(),
             hint: None,
-            credential: Some(ManifestCredentialSpec {
-                methods: vec![
-                    ManifestCredentialMethod {
-                        kind: ManifestCredentialMethodKind::OAuth,
-                        label: Some("Connect".to_string()),
-                        description: None,
-                        hint: Some("Authorize in your browser.".to_string()),
-                        oauth: Some(ManifestOAuthCredentialSpec {
-                            flow: ManifestOAuthFlowSpec {
-                                kind: ManifestOAuthFlowKind::AuthorizationCode,
-                                pkce: ManifestOAuthPkceMode::Required,
-                            },
-                            redirect_uri: Some("http://127.0.0.1:53682/oauth/callback".to_string()),
-                            redirect_uri_port_mode: ManifestOAuthRedirectUriPortMode::Fixed,
-                            authorization_url: Some(
-                                "https://provider.example.com/oauth/authorize".to_string(),
-                            ),
-                            device_authorization_url: None,
-                            token_url: "https://provider.example.com/oauth/token".to_string(),
-                            client: ManifestOAuthClientSpec {
-                                id: ManifestOAuthClientIdSpec {
-                                    default: Some("default-client".to_string()),
-                                    input: None,
-                                },
-                                secret: None,
-                            },
-                            scopes: None,
-                        }),
-                    },
-                    ManifestCredentialMethod {
-                        kind: ManifestCredentialMethodKind::SourceConfig,
-                        label: Some("Paste token".to_string()),
-                        description: None,
-                        hint: None,
-                        oauth: None,
-                    },
-                ],
-            }),
-        };
+            credential,
+        }
+    }
 
-        let proto = candidate_source_input_to_proto(input);
-
-        let secret = match proto.input.expect("input") {
+    /// Converts `input` to proto and unwraps the secret variant.
+    fn secret_proto(input: ManifestInputSpec) -> SourceSecretInput {
+        match candidate_source_input_to_proto(input).input.expect("input") {
             ProtoSourceInput::Secret(secret) => secret,
             ProtoSourceInput::Variable(_) => panic!("expected secret input"),
-        };
+        }
+    }
+
+    #[test]
+    fn converts_credential_methods_to_source_input_spec() {
+        let input = api_token_input(Some(ManifestCredentialSpec {
+            methods: vec![
+                ManifestCredentialMethod {
+                    kind: ManifestCredentialMethodKind::OAuth,
+                    label: Some("Connect".to_string()),
+                    description: None,
+                    hint: Some("Authorize in your browser.".to_string()),
+                    oauth: Some(ManifestOAuthCredentialSpec {
+                        flow: ManifestOAuthFlowSpec {
+                            kind: ManifestOAuthFlowKind::AuthorizationCode,
+                            pkce: ManifestOAuthPkceMode::Required,
+                        },
+                        redirect_uri: Some("http://127.0.0.1:53682/oauth/callback".to_string()),
+                        redirect_uri_port_mode: ManifestOAuthRedirectUriPortMode::Fixed,
+                        authorization_url: Some(
+                            "https://provider.example.com/oauth/authorize".to_string(),
+                        ),
+                        device_authorization_url: None,
+                        token_url: "https://provider.example.com/oauth/token".to_string(),
+                        client: ManifestOAuthClientSpec {
+                            id: ManifestOAuthClientIdSpec {
+                                default: Some("default-client".to_string()),
+                                input: None,
+                            },
+                            secret: None,
+                        },
+                        scopes: None,
+                    }),
+                },
+                ManifestCredentialMethod {
+                    kind: ManifestCredentialMethodKind::SourceConfig,
+                    label: Some("Paste token".to_string()),
+                    description: None,
+                    hint: None,
+                    oauth: None,
+                },
+            ],
+        }));
+
+        let secret = secret_proto(input);
+
         let credential = secret.credential.expect("credential");
         assert_eq!(credential.methods.len(), 2);
         assert_eq!(
@@ -833,22 +758,7 @@ mod tests {
 
     #[test]
     fn missing_credential_metadata_remains_absent() {
-        let input = ManifestInputSpec {
-            key: "API_TOKEN".to_string(),
-            kind: ManifestInputKind::Secret,
-            required: true,
-            default_value: String::new(),
-            hint: None,
-            credential: None,
-        };
-
-        let proto = candidate_source_input_to_proto(input);
-        let secret = match proto.input.expect("input") {
-            ProtoSourceInput::Secret(secret) => secret,
-            ProtoSourceInput::Variable(_) => panic!("expected secret input"),
-        };
-
-        assert!(secret.credential.is_none());
+        assert!(secret_proto(api_token_input(None)).credential.is_none());
     }
 
     #[test]

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -1,7 +1,13 @@
 //! Shared gRPC transport helpers for app-owned services.
 
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tokio::sync::mpsc;
+use tokio::task;
+use tokio_stream::Stream;
 
 use coral_api::{
     CORAL_EPISODE_ID_METADATA_KEY, CORAL_ERROR_DOMAIN, grpc_response_status_code,
@@ -26,6 +32,9 @@ use crate::bootstrap::{AppError, app_status, core_status};
 use crate::catalog::discovery::{
     CatalogItem, CatalogMetadataField, CatalogSearchResult, ColumnMetadataField,
     ColumnSearchResult, DescribeTableResult,
+};
+use crate::credentials::oauth::{
+    OAuthProgressEvent, OAuthProgressEventSender, PendingOAuthProgressEvent,
 };
 use crate::episode::EpisodeId;
 use crate::identity::{UserPrincipal, UserPrincipalError, UserPrincipalProvider};
@@ -187,12 +196,27 @@ where
     result
 }
 
+/// Runs a blocking `operation` on the blocking thread pool while preserving the
+/// current tracing span, mapping a join failure or [`AppError`] to a [`Status`].
+/// `label` names the operation in the join-failure message.
+pub(crate) async fn run_blocking_operation<T, F>(label: &str, operation: F) -> Result<T, Status>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, AppError> + Send + 'static,
+{
+    let span = tracing::Span::current();
+    task::spawn_blocking(move || span.in_scope(operation))
+        .await
+        .map_err(|error| Status::internal(format!("{label} task failed: {error}")))?
+        .map_err(app_status)
+}
+
 /// Creates the request span, authenticates the caller through the provider,
 /// and runs `handler` with the authenticated principal and decoded message,
 /// recording the gRPC status on the span.
 ///
-/// Handlers that need the request span can read it with
-/// `tracing::Span::current()`.
+/// Handlers that need the request span (for example to instrument a response
+/// stream) can read it with `tracing::Span::current()`.
 pub(crate) async fn instrument_authenticated_grpc<Req, Res, F, Fut>(
     user_principal_provider: &Arc<dyn UserPrincipalProvider>,
     request: Request<Req>,
@@ -267,6 +291,129 @@ fn decode_grpc_error(status: &Status) -> GrpcErrorTelemetry {
     GrpcErrorTelemetry {
         error_type: grpc_response_status_code(status.code()).to_string(),
         message: status.message().to_string(),
+    }
+}
+
+/// One OAuth progress event mapped onto the shared credential proto pair.
+#[expect(unreachable_pub, reason = "re-exported from lib.rs in a later PR")]
+pub enum OAuthProgressProto {
+    /// Authorization URL or device-code details.
+    Authorization(coral_api::v1::OAuthCredentialAuthorization),
+    /// OAuth credential retrieval completion metadata.
+    Completed(coral_api::v1::OAuthCredentialCompleted),
+}
+
+impl From<OAuthProgressEvent> for OAuthProgressProto {
+    fn from(event: OAuthProgressEvent) -> Self {
+        match event {
+            OAuthProgressEvent::OAuthAuthorization {
+                input_key,
+                authorization_url,
+                expires_in_seconds,
+                user_code,
+                verification_uri,
+                verification_uri_complete,
+            } => Self::Authorization(coral_api::v1::OAuthCredentialAuthorization {
+                input_key,
+                authorization_url,
+                expires_in_seconds,
+                user_code: user_code.unwrap_or_default(),
+                verification_uri: verification_uri.unwrap_or_default(),
+                verification_uri_complete: verification_uri_complete.unwrap_or_default(),
+            }),
+            OAuthProgressEvent::OAuthCompleted {
+                input_key,
+                metadata,
+            } => Self::Completed(coral_api::v1::OAuthCredentialCompleted {
+                input_key,
+                metadata: metadata
+                    .into_iter()
+                    .map(|(key, value)| coral_api::v1::CredentialMetadata { key, value })
+                    .collect(),
+            }),
+        }
+    }
+}
+
+/// Builds a gRPC response stream that forwards acknowledged OAuth progress
+/// events while `operation` runs, then yields the operation's mapped result.
+///
+/// `closed_message` is the error reported to the operation when it emits an
+/// event after the stream consumer went away.
+#[expect(unreachable_pub, reason = "re-exported from lib.rs in a later PR")]
+pub fn oauth_operation_response_stream<T, R, F, Fut>(
+    closed_message: &'static str,
+    operation: F,
+    event_to_response: fn(OAuthProgressEvent) -> R,
+    operation_to_response: impl FnOnce(T) -> R + Send + 'static,
+) -> Pin<Box<dyn Stream<Item = Result<R, Status>> + Send>>
+where
+    T: 'static,
+    R: Send + Unpin + 'static,
+    F: FnOnce(OAuthProgressEventSender) -> Fut,
+    Fut: Future<Output = Result<T, Status>> + Send + 'static,
+{
+    let (event_tx, event_rx) = mpsc::channel(8);
+    let sender = OAuthProgressEventSender::new(event_tx, closed_message);
+    Box::pin(OAuthOperationResponseStream {
+        events: event_rx,
+        operation: Some((
+            Box::pin(operation(sender)) as Pin<Box<dyn Future<Output = _> + Send>>,
+            Box::new(operation_to_response),
+        )),
+        completion: None,
+        event_to_response,
+    })
+}
+
+struct OAuthOperationResponseStream<T, R> {
+    events: mpsc::Receiver<PendingOAuthProgressEvent>,
+    #[expect(clippy::type_complexity, reason = "private one-shot operation slot")]
+    operation: Option<(
+        Pin<Box<dyn Future<Output = Result<T, Status>> + Send>>,
+        Box<dyn FnOnce(T) -> R + Send>,
+    )>,
+    completion: Option<Result<R, Status>>,
+    event_to_response: fn(OAuthProgressEvent) -> R,
+}
+
+impl<T, R> OAuthOperationResponseStream<T, R> {
+    fn poll_event(&mut self, cx: &mut Context<'_>) -> Poll<Option<R>> {
+        Pin::new(&mut self.events)
+            .poll_recv(cx)
+            .map(|event| event.map(|event| (self.event_to_response)(event.into_event())))
+    }
+}
+
+impl<T, R: Unpin> Stream for OAuthOperationResponseStream<T, R> {
+    type Item = Result<R, Status>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            if let Poll::Ready(Some(event)) = this.poll_event(cx) {
+                return Poll::Ready(Some(Ok(event)));
+            }
+            if let Some(completion) = this.completion.take() {
+                return Poll::Ready(Some(completion));
+            }
+            let Some((operation, _)) = this.operation.as_mut() else {
+                return Poll::Ready(None);
+            };
+            match operation.as_mut().poll(cx) {
+                Poll::Ready(result) => {
+                    if let Some((_, operation_to_response)) = this.operation.take() {
+                        this.completion = Some(result.map(operation_to_response));
+                    }
+                }
+                Poll::Pending => {
+                    return match this.poll_event(cx) {
+                        Poll::Ready(Some(event)) => Poll::Ready(Some(Ok(event))),
+                        Poll::Ready(None) | Poll::Pending => Poll::Pending,
+                    };
+                }
+            }
+        }
     }
 }
 
@@ -562,12 +709,13 @@ mod tests {
 
     #[test]
     fn grpc_response_status_codes_use_otel_names() {
-        assert_eq!(grpc_response_status_code(Code::Ok), "OK");
-        assert_eq!(
-            grpc_response_status_code(Code::InvalidArgument),
-            "INVALID_ARGUMENT"
-        );
-        assert_eq!(grpc_response_status_code(Code::Unavailable), "UNAVAILABLE");
+        for (code, name) in [
+            (Code::Ok, "OK"),
+            (Code::InvalidArgument, "INVALID_ARGUMENT"),
+            (Code::Unavailable, "UNAVAILABLE"),
+        ] {
+            assert_eq!(grpc_response_status_code(code), name, "{name}");
+        }
     }
 
     #[test]
@@ -648,10 +796,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn table_to_proto_preserves_table_metadata() {
-        let workspace_name = WorkspaceName::parse("default").expect("workspace");
-        let table = TableInfo {
+    /// The `TableInfo` fixture shared by the table proto-mapping tests.
+    fn demo_users_table() -> TableInfo {
+        TableInfo {
             schema_name: "demo".to_string(),
             table_name: "users".to_string(),
             description: "User records".to_string(),
@@ -666,9 +813,14 @@ mod tests {
                 ordinal_position: 0,
             }],
             required_filters: vec!["org_id".to_string()],
-        };
+        }
+    }
 
-        let proto = table_to_proto(&workspace_name, table);
+    #[test]
+    fn table_to_proto_preserves_table_metadata() {
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+
+        let proto = table_to_proto(&workspace_name, demo_users_table());
 
         assert_eq!(proto.workspace, Some(workspace_to_proto(&workspace_name)));
         assert_eq!(proto.schema_name, "demo");
@@ -689,24 +841,8 @@ mod tests {
     #[test]
     fn table_summary_to_proto_preserves_table_metadata_without_columns() {
         let workspace_name = WorkspaceName::parse("default").expect("workspace");
-        let table = TableInfo {
-            schema_name: "demo".to_string(),
-            table_name: "users".to_string(),
-            description: "User records".to_string(),
-            guide: "Filter by org_id.".to_string(),
-            columns: vec![ColumnInfo {
-                name: "id".to_string(),
-                data_type: "Int64".to_string(),
-                nullable: false,
-                is_virtual: false,
-                is_required_filter: true,
-                description: "User id".to_string(),
-                ordinal_position: 0,
-            }],
-            required_filters: vec!["org_id".to_string()],
-        };
 
-        let proto = table_summary_to_proto(&workspace_name, table);
+        let proto = table_summary_to_proto(&workspace_name, demo_users_table());
 
         assert_eq!(proto.workspace, Some(workspace_to_proto(&workspace_name)));
         assert_eq!(proto.schema_name, "demo");

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -2,9 +2,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use coral_api::v1::{
-    ExecuteSqlRequest, ImportSourceRequest, ListCatalogRequest, ListSourcesRequest,
-    PaginationRequest, Source, SourceSecret, SourceVariable, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, catalog_item, import_source_response,
+    ExecuteSqlRequest, ExecuteSqlResponse, ImportSourceRequest, ListCatalogRequest,
+    ListSourcesRequest, PaginationRequest, Source, SourceSecret, SourceVariable, TableSummary,
+    ValidateSourceRequest, ValidateSourceResponse, catalog_item, import_source_response,
 };
 use coral_client::{
     AppClient, CatalogClient, QueryClient, SourceClient, batches_to_json_rows,
@@ -83,19 +83,27 @@ impl GrpcHarness {
         variables: Vec<SourceVariable>,
         secrets: Vec<SourceSecret>,
     ) -> Source {
+        self.try_import_source(ImportSourceRequest {
+            variables,
+            secrets,
+            ..import_request(manifest_yaml)
+        })
+        .await
+        .expect("import source")
+    }
+
+    /// Sends `request` and returns the first `Source` event, or the status when
+    /// opening the import stream fails.
+    pub(crate) async fn try_import_source(
+        &self,
+        request: ImportSourceRequest,
+    ) -> Result<Source, tonic::Status> {
         let mut stream = self
             .source_client()
-            .import_source(Request::new(ImportSourceRequest {
-                workspace: Some(default_workspace()),
-                manifest_yaml,
-                variables,
-                secrets,
-                oauth_credential_retrievals: Vec::new(),
-            }))
-            .await
-            .expect("import source")
+            .import_source(Request::new(request))
+            .await?
             .into_inner();
-        stream
+        Ok(stream
             .message()
             .await
             .expect("import source stream")
@@ -103,7 +111,7 @@ impl GrpcHarness {
                 Some(import_source_response::Event::Source(source)) => Some(source),
                 _ => None,
             })
-            .expect("import source response")
+            .expect("import source response"))
     }
 
     pub(crate) async fn list_sources(&self) -> Vec<Source> {
@@ -141,32 +149,71 @@ impl GrpcHarness {
     }
 
     pub(crate) async fn validate_source(&self, source_name: &str) -> ValidateSourceResponse {
-        self.source_client()
+        self.try_validate_source(source_name)
+            .await
+            .expect("validate source")
+    }
+
+    pub(crate) async fn try_validate_source(
+        &self,
+        source_name: &str,
+    ) -> Result<ValidateSourceResponse, tonic::Status> {
+        Ok(self
+            .source_client()
             .validate_source(Request::new(ValidateSourceRequest {
                 workspace: Some(default_workspace()),
                 name: source_name.to_string(),
             }))
-            .await
-            .expect("validate source")
-            .into_inner()
+            .await?
+            .into_inner())
     }
 
     pub(crate) async fn execute_sql_rows(&self, sql: &str) -> Vec<Value> {
-        let response = self
-            .query_client()
-            .execute_sql(Request::new(ExecuteSqlRequest {
-                workspace: Some(default_workspace()),
-                sql: sql.to_string(),
-            }))
-            .await
-            .expect("execute sql")
-            .into_inner();
+        let response = self.try_execute_sql(sql).await.expect("execute sql");
         batches_to_json_rows(
             decode_execute_sql_response(&response)
                 .expect("decode query response")
                 .batches(),
         )
         .expect("query rows")
+    }
+
+    pub(crate) async fn try_execute_sql(
+        &self,
+        sql: &str,
+    ) -> Result<ExecuteSqlResponse, tonic::Status> {
+        Ok(self
+            .query_client()
+            .execute_sql(Request::new(ExecuteSqlRequest {
+                workspace: Some(default_workspace()),
+                sql: sql.to_string(),
+            }))
+            .await?
+            .into_inner())
+    }
+}
+
+/// Builds an `ImportSourceRequest` for the default workspace with every other
+/// field left at its default; tests override fields with struct-update syntax.
+pub(crate) fn import_request(manifest_yaml: String) -> ImportSourceRequest {
+    ImportSourceRequest {
+        workspace: Some(default_workspace()),
+        manifest_yaml,
+        ..Default::default()
+    }
+}
+
+pub(crate) fn variable(key: &str, value: &str) -> SourceVariable {
+    SourceVariable {
+        key: key.to_string(),
+        value: value.to_string(),
+    }
+}
+
+pub(crate) fn secret(key: &str, value: &str) -> SourceSecret {
+    SourceSecret {
+        key: key.to_string(),
+        value: value.to_string(),
     }
 }
 
@@ -244,6 +291,23 @@ pub(crate) fn fixture_manifest_yaml(root: &Path) -> String {
 }
 
 pub(crate) fn fixture_manifest_with_multiple_tables_yaml(root: &Path) -> String {
+    let data_dir = fixture_data_dir(root);
+    manifest_yaml(&json!({
+        "name": "local_messages",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "file",
+        "tables": [
+            jsonl_table("events", "Fixture events", &data_dir),
+            jsonl_table("messages", "Fixture messages", &data_dir),
+            jsonl_table("sessions", "Fixture sessions", &data_dir),
+        ],
+    }))
+}
+
+/// Writes the shared `messages.jsonl` fixture under `root` and returns its
+/// data directory.
+fn fixture_data_dir(root: &Path) -> PathBuf {
     let data_dir = root.join("fixture-data");
     fs::create_dir_all(&data_dir).expect("create data dir");
     fs::write(
@@ -253,44 +317,24 @@ pub(crate) fn fixture_manifest_with_multiple_tables_yaml(root: &Path) -> String 
 "#,
     )
     .expect("write jsonl");
-    let table_source = json!({
-        "location": format!("file://{}/", data_dir.display()),
-        "glob": "**/*.jsonl",
-    });
-    let table_columns = json!([
-        {"name": "type", "type": "Utf8"},
-        {"name": "sessionId", "type": "Utf8"},
-        {"name": "text", "type": "Utf8"},
-    ]);
-    manifest_yaml(&json!({
-        "name": "local_messages",
-        "version": "0.1.0",
-        "dsl_version": 3,
-        "backend": "file",
-        "tables": [
-            {
-                "name": "events",
-                "description": "Fixture events",
-                "format": "jsonl",
-                "source": table_source.clone(),
-                "columns": table_columns.clone(),
-            },
-            {
-                "name": "messages",
-                "description": "Fixture messages",
-                "format": "jsonl",
-                "source": table_source.clone(),
-                "columns": table_columns.clone(),
-            },
-            {
-                "name": "sessions",
-                "description": "Fixture sessions",
-                "format": "jsonl",
-                "source": table_source,
-                "columns": table_columns,
-            },
+    data_dir
+}
+
+fn jsonl_table(name: &str, description: &str, data_dir: &Path) -> Value {
+    json!({
+        "name": name,
+        "description": description,
+        "format": "jsonl",
+        "source": {
+            "location": format!("file://{}/", data_dir.display()),
+            "glob": "**/*.jsonl",
+        },
+        "columns": [
+            {"name": "type", "type": "Utf8"},
+            {"name": "sessionId", "type": "Utf8"},
+            {"name": "text", "type": "Utf8"},
         ],
-    }))
+    })
 }
 
 pub(crate) fn fixture_manifest_with_required_filter_yaml() -> String {
@@ -431,80 +475,43 @@ pub(crate) fn fixture_manifest_with_test_queries_yaml(
     root: &Path,
     test_queries: &[&str],
 ) -> String {
-    let data_dir = root.join("fixture-data");
-    fs::create_dir_all(&data_dir).expect("create data dir");
-    fs::write(
-        data_dir.join("messages.jsonl"),
-        r#"{"type":"user","sessionId":"s1","text":"hello"}
-{"type":"assistant","sessionId":"s1","text":"world"}
-"#,
-    )
-    .expect("write jsonl");
+    let data_dir = fixture_data_dir(root);
     manifest_yaml(&json!({
         "name": "local_messages",
         "version": "0.1.0",
         "dsl_version": 3,
         "backend": "file",
         "test_queries": test_queries,
-        "tables": [{
-            "name": "messages",
-            "description": "Fixture messages",
-            "format": "jsonl",
-            "source": {
-                "location": format!("file://{}/", data_dir.display()),
-                "glob": "**/*.jsonl",
-            },
-            "columns": [
-                {"name": "type", "type": "Utf8"},
-                {"name": "sessionId", "type": "Utf8"},
-                {"name": "text", "type": "Utf8"},
-            ],
-        }],
+        "tables": [jsonl_table("messages", "Fixture messages", &data_dir)],
     }))
 }
 
 pub(crate) fn fixture_manifest_with_inputs_yaml() -> String {
-    manifest_yaml(&json!({
-        "name": "secured_messages",
-        "version": "0.1.0",
-        "dsl_version": 3,
-        "backend": "http",
-        "inputs": {
-            "API_BASE": { "kind": "variable", "default": "https://example.com" },
-            "API_TOKEN": { "kind": "secret" },
-        },
-        "base_url": "{{input.API_BASE}}",
-        "auth": {
-            "type": "HeaderAuth",
-            "headers": [{
-                "name": "Authorization",
-                "from": "template",
-                "template": "Bearer {{input.API_TOKEN}}",
-            }],
-        },
-        "tables": [{
-            "name": "messages",
-            "description": "Secured messages",
-            "request": {
-                "method": "GET",
-                "path": "/messages",
-            },
-            "response": {},
-            "columns": [
-                {"name": "id", "type": "Utf8"},
-            ],
-        }],
-    }))
+    inputs_manifest_yaml(
+        "secured_messages",
+        &json!({ "kind": "variable", "default": "https://example.com" }),
+        "Secured messages",
+    )
 }
 
 pub(crate) fn fixture_manifest_with_required_inputs_yaml() -> String {
+    inputs_manifest_yaml(
+        "required_messages",
+        &json!({ "kind": "variable" }),
+        "Required-input messages",
+    )
+}
+
+/// Single-table HTTP manifest with an `API_BASE` variable (declared as
+/// `api_base_input`) and a required `API_TOKEN` secret used for auth.
+fn inputs_manifest_yaml(name: &str, api_base_input: &Value, table_description: &str) -> String {
     manifest_yaml(&json!({
-        "name": "required_messages",
+        "name": name,
         "version": "0.1.0",
         "dsl_version": 3,
         "backend": "http",
         "inputs": {
-            "API_BASE": { "kind": "variable" },
+            "API_BASE": api_base_input,
             "API_TOKEN": { "kind": "secret" },
         },
         "base_url": "{{input.API_BASE}}",
@@ -518,7 +525,7 @@ pub(crate) fn fixture_manifest_with_required_inputs_yaml() -> String {
         },
         "tables": [{
             "name": "messages",
-            "description": "Required-input messages",
+            "description": table_description,
             "request": {
                 "method": "GET",
                 "path": "/messages",

--- a/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
+++ b/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
@@ -21,7 +21,7 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::sync::Notify;
 use tonic::{Code, Request};
 
-use crate::harness::{GrpcHarness, fixture_manifest_yaml, source_dir};
+use crate::harness::{GrpcHarness, fixture_manifest_yaml, import_request, source_dir};
 
 #[tokio::test]
 async fn query_refreshes_expired_oauth_access_token_at_request_time() {
@@ -398,8 +398,6 @@ async fn manual_credential_replacement_waits_for_in_flight_refresh() {
     let import = tokio::spawn(async move {
         let mut stream = source_client
             .import_source(Request::new(ImportSourceRequest {
-                workspace: Some(default_workspace()),
-                manifest_yaml: import_manifest_yaml,
                 variables: vec![SourceVariable {
                     key: "API_BASE".to_string(),
                     value: import_base_url,
@@ -408,7 +406,7 @@ async fn manual_credential_replacement_waits_for_in_flight_refresh() {
                     key: "API_TOKEN".to_string(),
                     value: "manual-token".to_string(),
                 }],
-                oauth_credential_retrievals: Vec::new(),
+                ..import_request(import_manifest_yaml)
             }))
             .await
             .expect("import source")

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -4,15 +4,15 @@
     reason = "test code: assertion-style indexing is idiomatic in tests"
 )]
 
-use std::fs;
+use std::{fs, path::PathBuf};
 
 use coral_api::v1::{
-    CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
-    ExplainSqlRequest, GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest,
-    ListCatalogRequest, OauthCredentialFlowType, OauthCredentialScopeDelimiter, PaginationRequest,
-    QueryTestFailure, QueryTestSuccess, SourceCredentialStorage, SourceOrigin, SourceSecret,
-    SourceVariable, ValidateSourceRequest, Workspace, catalog_item, import_source_response,
-    query_test_result, source_credential_method::Method as ProtoCredentialMethod,
+    CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExplainSqlRequest,
+    GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest, ListCatalogRequest,
+    ListCatalogResponse, OauthCredentialFlowType, OauthCredentialScopeDelimiter, PaginationRequest,
+    QueryTestFailure, QueryTestSuccess, Source, SourceCredentialStorage, SourceInfo, SourceOrigin,
+    SourceSecret, SourceVariable, Workspace, catalog_item, query_test_result,
+    source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::default_workspace;
@@ -23,7 +23,7 @@ use crate::harness::{
     FailingHttpFixture, GrpcHarness, fixture_function_only_manifest_yaml,
     fixture_manifest_with_inputs_yaml, fixture_manifest_with_multiple_tables_yaml,
     fixture_manifest_with_required_inputs_yaml, fixture_manifest_with_test_queries_yaml,
-    fixture_manifest_yaml, invalid_manifest_yaml, source_dir,
+    fixture_manifest_yaml, import_request, invalid_manifest_yaml, secret, source_dir, variable,
 };
 
 #[tokio::test]
@@ -45,8 +45,7 @@ async fn import_source_persists_and_lists() {
     assert!(added.variables.is_empty());
     assert!(added.secrets.is_empty());
 
-    let config_raw =
-        fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    let config_raw = read_config(&harness);
     assert!(config_raw.contains("[workspaces.default.sources.local_messages]"));
     assert!(config_raw.contains("secrets = []"));
     assert!(!config_raw.contains("credential_storage"));
@@ -71,6 +70,10 @@ async fn import_source_persists_and_lists() {
     );
 }
 
+fn read_config(harness: &GrpcHarness) -> String {
+    fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config")
+}
+
 #[tokio::test]
 async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     let harness = GrpcHarness::new().await;
@@ -78,14 +81,8 @@ async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     let imported = harness
         .import_source(
             fixture_manifest_with_inputs_yaml(),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: "https://example.com".to_string(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "secret-token".to_string(),
-            }],
+            vec![variable("API_BASE", "https://example.com")],
+            vec![secret("API_TOKEN", "secret-token")],
         )
         .await;
     assert_eq!(imported.variables.len(), 1);
@@ -95,17 +92,9 @@ async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     assert_eq!(imported.secrets[0].key, "API_TOKEN");
     assert!(imported.secrets[0].value.is_empty());
 
-    let fetched = harness
-        .source_client()
-        .get_source(Request::new(GetSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "secured_messages".to_string(),
-        }))
+    let fetched = try_get_source(&harness, "secured_messages")
         .await
-        .expect("get source")
-        .into_inner()
-        .source
-        .expect("get source response");
+        .expect("get source");
     assert_eq!(fetched.name, "secured_messages");
     assert_eq!(fetched.version, "0.1.0");
     assert_eq!(fetched.origin, SourceOrigin::Imported as i32);
@@ -125,40 +114,15 @@ async fn import_duplicate_source_overwrites_existing_source() {
         .import_source(manifest_yaml.clone(), Vec::new(), Vec::new())
         .await;
 
-    let mut import_stream = harness
-        .source_client()
-        .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
-            manifest_yaml: manifest_yaml.replace("0.1.0", "0.2.0"),
-            variables: Vec::new(),
-            secrets: Vec::new(),
-            oauth_credential_retrievals: Vec::new(),
-        }))
+    let reimported = harness
+        .try_import_source(import_request(manifest_yaml.replace("0.1.0", "0.2.0")))
         .await
-        .expect("duplicate import should overwrite")
-        .into_inner();
-    let reimported = import_stream
-        .message()
-        .await
-        .expect("duplicate import stream")
-        .and_then(|response| match response.event {
-            Some(import_source_response::Event::Source(source)) => Some(source),
-            _ => None,
-        })
-        .expect("import source response");
+        .expect("duplicate import should overwrite");
     assert_eq!(reimported.version, "0.2.0");
 
-    let fetched = harness
-        .source_client()
-        .get_source(Request::new(GetSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "local_messages".to_string(),
-        }))
+    let fetched = try_get_source(&harness, "local_messages")
         .await
-        .expect("get overwritten source")
-        .into_inner()
-        .source
-        .expect("get source response");
+        .expect("get overwritten source");
     assert_eq!(fetched.version, "0.2.0");
 }
 
@@ -167,14 +131,7 @@ async fn import_invalid_manifest_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
 
     let error = harness
-        .source_client()
-        .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
-            manifest_yaml: invalid_manifest_yaml(),
-            variables: Vec::new(),
-            secrets: Vec::new(),
-            oauth_credential_retrievals: Vec::new(),
-        }))
+        .try_import_source(import_request(invalid_manifest_yaml()))
         .await
         .expect_err("invalid manifest should fail");
     assert_eq!(error.code(), tonic::Code::InvalidArgument);
@@ -188,12 +145,7 @@ async fn delete_source_removes_from_list_and_disk() {
         .import_source(manifest_yaml, Vec::new(), Vec::new())
         .await;
 
-    harness
-        .source_client()
-        .delete_source(Request::new(DeleteSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "local_messages".to_string(),
-        }))
+    try_delete_source(&harness, "local_messages")
         .await
         .expect("delete source");
 
@@ -201,11 +153,7 @@ async fn delete_source_removes_from_list_and_disk() {
     assert!(!source_dir(harness.config_dir(), "local_messages").exists());
 
     let query_error = harness
-        .query_client()
-        .execute_sql(Request::new(ExecuteSqlRequest {
-            workspace: Some(default_workspace()),
-            sql: "SELECT * FROM local_messages.messages".to_string(),
-        }))
+        .try_execute_sql("SELECT * FROM local_messages.messages")
         .await
         .expect_err("query should fail after delete");
     assert!(!query_error.message().is_empty());
@@ -215,12 +163,7 @@ async fn delete_source_removes_from_list_and_disk() {
 async fn delete_nonexistent_source_returns_not_found() {
     let harness = GrpcHarness::new().await;
 
-    let error = harness
-        .source_client()
-        .delete_source(Request::new(DeleteSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "missing".to_string(),
-        }))
+    let error = try_delete_source(&harness, "missing")
         .await
         .expect_err("missing delete should fail");
     assert_eq!(error.code(), tonic::Code::NotFound);
@@ -284,20 +227,7 @@ async fn list_catalog_supports_table_kind_and_pagination() {
         )
         .await;
 
-    let page = harness
-        .catalog_client()
-        .list_catalog(Request::new(ListCatalogRequest {
-            workspace: Some(default_workspace()),
-            schema_name: "local_messages".to_string(),
-            kind: 1,
-            pagination: Some(PaginationRequest {
-                limit: 2,
-                offset: 0,
-            }),
-        }))
-        .await
-        .expect("paginated list catalog")
-        .into_inner();
+    let page = list_catalog_page(&harness, "local_messages", "paginated list catalog").await;
     let page_pagination = page.pagination.as_ref().expect("page pagination");
     assert_eq!(page_pagination.total_count, 3);
     assert_eq!(page_pagination.limit, 2);
@@ -318,20 +248,8 @@ async fn list_catalog_supports_table_kind_and_pagination() {
         vec!["events", "messages"]
     );
 
-    let unknown_schema = harness
-        .catalog_client()
-        .list_catalog(Request::new(ListCatalogRequest {
-            workspace: Some(default_workspace()),
-            schema_name: "missing".to_string(),
-            kind: 1,
-            pagination: Some(PaginationRequest {
-                limit: 2,
-                offset: 0,
-            }),
-        }))
-        .await
-        .expect("unknown schema list catalog")
-        .into_inner();
+    let unknown_schema =
+        list_catalog_page(&harness, "missing", "unknown schema list catalog").await;
     let unknown_schema_pagination = unknown_schema
         .pagination
         .as_ref()
@@ -415,36 +333,24 @@ async fn query_execution_rejects_non_read_only_sql() {
 
     let copy_target = harness.temp_path().join("copied.arrow");
     let copy_error = harness
-        .query_client()
-        .execute_sql(Request::new(ExecuteSqlRequest {
-            workspace: Some(default_workspace()),
-            sql: format!(
-                "COPY local_messages.messages TO '{}' STORED AS ARROW",
-                copy_target.display()
-            ),
-        }))
+        .try_execute_sql(&format!(
+            "COPY local_messages.messages TO '{}' STORED AS ARROW",
+            copy_target.display()
+        ))
         .await
         .expect_err("COPY TO should be rejected");
     assert_eq!(copy_error.code(), tonic::Code::InvalidArgument);
     assert!(copy_error.message().contains("DML not supported: COPY"));
 
     let create_error = harness
-        .query_client()
-        .execute_sql(Request::new(ExecuteSqlRequest {
-            workspace: Some(default_workspace()),
-            sql: "CREATE TABLE copied AS SELECT * FROM local_messages.messages".to_string(),
-        }))
+        .try_execute_sql("CREATE TABLE copied AS SELECT * FROM local_messages.messages")
         .await
         .expect_err("CREATE TABLE should be rejected");
     assert_eq!(create_error.code(), tonic::Code::InvalidArgument);
     assert!(create_error.message().contains("DDL not supported"));
 
     let set_error = harness
-        .query_client()
-        .execute_sql(Request::new(ExecuteSqlRequest {
-            workspace: Some(default_workspace()),
-            sql: "SET datafusion.execution.batch_size = 1".to_string(),
-        }))
+        .try_execute_sql("SET datafusion.execution.batch_size = 1")
         .await
         .expect_err("SET should be rejected");
     assert_eq!(set_error.code(), tonic::Code::InvalidArgument);
@@ -460,14 +366,9 @@ async fn validate_source_with_unreachable_api_returns_declared_tables() {
         .await;
 
     let validated = harness
-        .source_client()
-        .validate_source(Request::new(ValidateSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "unreachable_messages".to_string(),
-        }))
+        .try_validate_source("unreachable_messages")
         .await
-        .expect("unreachable source validation should still enumerate tables")
-        .into_inner();
+        .expect("unreachable source validation should still enumerate tables");
     assert_eq!(validated.tables.len(), 1);
     assert_eq!(validated.tables[0].schema_name, "unreachable_messages");
     assert_eq!(validated.tables[0].name, "messages");
@@ -545,11 +446,7 @@ async fn validate_source_skipped_registration_returns_unary_failed_precondition(
         .await;
 
     let error = harness
-        .source_client()
-        .validate_source(Request::new(ValidateSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "missing_messages".to_string(),
-        }))
+        .try_validate_source("missing_messages")
         .await
         .expect_err("validation should fail when the source never registers");
     assert_eq!(error.code(), tonic::Code::FailedPrecondition);
@@ -565,211 +462,105 @@ async fn execute_sql_with_unreachable_api_returns_unavailable_error() {
         .await;
 
     let error = harness
-        .query_client()
-        .execute_sql(Request::new(ExecuteSqlRequest {
-            workspace: Some(default_workspace()),
-            sql: "SELECT * FROM unreachable_messages.messages".to_string(),
-        }))
+        .try_execute_sql("SELECT * FROM unreachable_messages.messages")
         .await
         .expect_err("unreachable source query should fail");
     assert_eq!(error.code(), tonic::Code::Unavailable);
 }
 
+/// Merged input-validation cases for `ImportSource`; each case is the same
+/// scenario with one invalid inputs combination and asserts `InvalidArgument`
+/// with the case-specific message. Covers the former tests:
+/// `import_source_missing_required_secret_returns_invalid_argument`,
+/// `import_source_missing_required_variable_returns_invalid_argument`,
+/// `import_source_unknown_variable_returns_invalid_argument`,
+/// `import_source_unknown_secret_returns_invalid_argument`,
+/// `import_source_repeated_variable_returns_invalid_argument` and
+/// `import_source_repeated_secret_returns_invalid_argument`.
 #[tokio::test]
-async fn import_source_missing_required_secret_returns_invalid_argument() {
+async fn import_source_invalid_inputs_return_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    let api_base = || variable("API_BASE", "https://example.com");
+    let api_token = || secret("API_TOKEN", "secret-token");
 
-    let error = harness
-        .source_client()
-        .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
-            manifest_yaml: fixture_manifest_with_inputs_yaml(),
-            variables: vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: "https://example.com".to_string(),
-            }],
-            secrets: Vec::new(),
-            oauth_credential_retrievals: Vec::new(),
-        }))
-        .await
-        .expect_err("missing required secret should fail");
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(
-        error
-            .message()
-            .contains("missing required source secret 'API_TOKEN'")
-    );
-}
+    let cases = [
+        (
+            "missing required secret should fail",
+            ImportSourceRequest {
+                variables: vec![api_base()],
+                ..import_request(fixture_manifest_with_inputs_yaml())
+            },
+            "missing required source secret 'API_TOKEN'",
+        ),
+        (
+            "missing required variable should fail",
+            ImportSourceRequest {
+                secrets: vec![api_token()],
+                ..import_request(fixture_manifest_with_required_inputs_yaml())
+            },
+            "missing required source variable 'API_BASE'",
+        ),
+        (
+            "unknown variable should fail",
+            ImportSourceRequest {
+                variables: vec![variable("UNUSED", "value")],
+                secrets: vec![api_token()],
+                ..import_request(fixture_manifest_with_inputs_yaml())
+            },
+            "unknown source variable 'UNUSED'",
+        ),
+        (
+            "unknown secret should fail",
+            ImportSourceRequest {
+                variables: vec![api_base()],
+                secrets: vec![api_token(), secret("EXTRA_SECRET", "unused")],
+                ..import_request(fixture_manifest_with_inputs_yaml())
+            },
+            "unknown source secret 'EXTRA_SECRET'",
+        ),
+        (
+            "repeated variable should fail",
+            ImportSourceRequest {
+                variables: vec![
+                    api_base(),
+                    variable("API_BASE", "https://override.example.com"),
+                ],
+                secrets: vec![api_token()],
+                ..import_request(fixture_manifest_with_inputs_yaml())
+            },
+            "source variable 'API_BASE' is repeated",
+        ),
+        (
+            "repeated secret should fail",
+            ImportSourceRequest {
+                variables: vec![api_base()],
+                secrets: vec![api_token(), secret("API_TOKEN", "shadow-token")],
+                ..import_request(fixture_manifest_with_inputs_yaml())
+            },
+            "source secret 'API_TOKEN' is repeated",
+        ),
+    ];
 
-#[tokio::test]
-async fn import_source_missing_required_variable_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-
-    let error = harness
-        .source_client()
-        .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
-            manifest_yaml: fixture_manifest_with_required_inputs_yaml(),
-            variables: Vec::new(),
-            secrets: vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "secret-token".to_string(),
-            }],
-            oauth_credential_retrievals: Vec::new(),
-        }))
-        .await
-        .expect_err("missing required variable should fail");
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(
-        error
-            .message()
-            .contains("missing required source variable 'API_BASE'")
-    );
-}
-
-#[tokio::test]
-async fn import_source_unknown_variable_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-
-    let error = harness
-        .source_client()
-        .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
-            manifest_yaml: fixture_manifest_with_inputs_yaml(),
-            variables: vec![SourceVariable {
-                key: "UNUSED".to_string(),
-                value: "value".to_string(),
-            }],
-            secrets: vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "secret-token".to_string(),
-            }],
-            oauth_credential_retrievals: Vec::new(),
-        }))
-        .await
-        .expect_err("unknown variable should fail");
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(error.message().contains("unknown source variable 'UNUSED'"));
-}
-
-#[tokio::test]
-async fn import_source_unknown_secret_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-
-    let error = harness
-        .source_client()
-        .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
-            manifest_yaml: fixture_manifest_with_inputs_yaml(),
-            variables: vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: "https://example.com".to_string(),
-            }],
-            secrets: vec![
-                SourceSecret {
-                    key: "API_TOKEN".to_string(),
-                    value: "secret-token".to_string(),
-                },
-                SourceSecret {
-                    key: "EXTRA_SECRET".to_string(),
-                    value: "unused".to_string(),
-                },
-            ],
-            oauth_credential_retrievals: Vec::new(),
-        }))
-        .await
-        .expect_err("unknown secret should fail");
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(
-        error
-            .message()
-            .contains("unknown source secret 'EXTRA_SECRET'")
-    );
-}
-
-#[tokio::test]
-async fn import_source_repeated_variable_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-
-    let error = harness
-        .source_client()
-        .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
-            manifest_yaml: fixture_manifest_with_inputs_yaml(),
-            variables: vec![
-                SourceVariable {
-                    key: "API_BASE".to_string(),
-                    value: "https://example.com".to_string(),
-                },
-                SourceVariable {
-                    key: "API_BASE".to_string(),
-                    value: "https://override.example.com".to_string(),
-                },
-            ],
-            secrets: vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "secret-token".to_string(),
-            }],
-            oauth_credential_retrievals: Vec::new(),
-        }))
-        .await
-        .expect_err("repeated variable should fail");
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(
-        error
-            .message()
-            .contains("source variable 'API_BASE' is repeated")
-    );
-}
-
-#[tokio::test]
-async fn import_source_repeated_secret_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-
-    let error = harness
-        .source_client()
-        .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
-            manifest_yaml: fixture_manifest_with_inputs_yaml(),
-            variables: vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: "https://example.com".to_string(),
-            }],
-            secrets: vec![
-                SourceSecret {
-                    key: "API_TOKEN".to_string(),
-                    value: "secret-token".to_string(),
-                },
-                SourceSecret {
-                    key: "API_TOKEN".to_string(),
-                    value: "shadow-token".to_string(),
-                },
-            ],
-            oauth_credential_retrievals: Vec::new(),
-        }))
-        .await
-        .expect_err("repeated secret should fail");
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(
-        error
-            .message()
-            .contains("source secret 'API_TOKEN' is repeated")
-    );
+    for (label, request, expected_message) in cases {
+        let error = harness.try_import_source(request).await.expect_err(label);
+        assert_eq!(
+            error.code(),
+            tonic::Code::InvalidArgument,
+            "case {label}: unexpected code"
+        );
+        assert!(
+            error.message().contains(expected_message),
+            "case {label}: unexpected error: {}",
+            error.message()
+        );
+    }
 }
 
 #[tokio::test]
 async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() {
     let harness = GrpcHarness::new().await;
 
-    let discovered = harness
-        .source_client()
-        .discover_sources(Request::new(DiscoverSourcesRequest {
-            workspace: Some(default_workspace()),
-        }))
-        .await
-        .expect("discover sources")
-        .into_inner()
-        .sources;
+    let discovered = discover_sources(&harness, "discover sources").await;
     assert!(!discovered.is_empty());
     let github = discovered
         .iter()
@@ -777,32 +568,9 @@ async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() 
         .expect("github bundled source");
     assert!(!github.installed);
 
-    harness
-        .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "github".to_string(),
-            variables: vec![SourceVariable {
-                key: "GITHUB_API_BASE".to_string(),
-                value: "https://api.github.com".to_string(),
-            }],
-            secrets: vec![SourceSecret {
-                key: "GITHUB_TOKEN".to_string(),
-                value: "fake-token".to_string(),
-            }],
-        }))
-        .await
-        .expect("create bundled github source");
+    create_bundled_github_source(&harness).await;
 
-    let rediscovered = harness
-        .source_client()
-        .discover_sources(Request::new(DiscoverSourcesRequest {
-            workspace: Some(default_workspace()),
-        }))
-        .await
-        .expect("rediscover sources")
-        .into_inner()
-        .sources;
+    let rediscovered = discover_sources(&harness, "rediscover sources").await;
     let github = rediscovered
         .iter()
         .find(|source| source.name == "github")
@@ -814,17 +582,7 @@ async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() 
 async fn get_source_info_returns_available_bundled_metadata() {
     let harness = GrpcHarness::new().await;
 
-    let info = harness
-        .source_client()
-        .get_source_info(Request::new(GetSourceInfoRequest {
-            workspace: Some(default_workspace()),
-            name: "github".to_string(),
-        }))
-        .await
-        .expect("get source info")
-        .into_inner()
-        .source_info
-        .expect("get source info response");
+    let info = get_source_info(&harness, "github").await;
 
     assert_eq!(info.name, "github");
     assert_eq!(info.origin, SourceOrigin::Bundled as i32);
@@ -845,17 +603,7 @@ async fn get_source_info_returns_available_bundled_metadata() {
 async fn get_source_info_returns_sentry_oauth_credential_metadata() {
     let harness = GrpcHarness::new().await;
 
-    let info = harness
-        .source_client()
-        .get_source_info(Request::new(GetSourceInfoRequest {
-            workspace: Some(default_workspace()),
-            name: "sentry".to_string(),
-        }))
-        .await
-        .expect("get source info")
-        .into_inner()
-        .source_info
-        .expect("get source info response");
+    let info = get_source_info(&harness, "sentry").await;
 
     let token = info
         .inputs
@@ -922,28 +670,12 @@ async fn get_source_info_uses_effective_installed_imported_manifest() {
     harness
         .import_source(
             fixture_manifest_with_inputs_yaml(),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: "https://example.com".to_string(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "secret-token".to_string(),
-            }],
+            vec![variable("API_BASE", "https://example.com")],
+            vec![secret("API_TOKEN", "secret-token")],
         )
         .await;
 
-    let info = harness
-        .source_client()
-        .get_source_info(Request::new(GetSourceInfoRequest {
-            workspace: Some(default_workspace()),
-            name: "secured_messages".to_string(),
-        }))
-        .await
-        .expect("get source info")
-        .into_inner()
-        .source_info
-        .expect("get source info response");
+    let info = get_source_info(&harness, "secured_messages").await;
 
     assert_eq!(info.name, "secured_messages");
     assert_eq!(info.version, "0.1.0");
@@ -968,22 +700,7 @@ async fn get_source_info_uses_effective_installed_imported_manifest() {
 async fn create_bundled_source_registers_tables() {
     let harness = GrpcHarness::new().await;
 
-    harness
-        .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "github".to_string(),
-            variables: vec![SourceVariable {
-                key: "GITHUB_API_BASE".to_string(),
-                value: "https://api.github.com".to_string(),
-            }],
-            secrets: vec![SourceSecret {
-                key: "GITHUB_TOKEN".to_string(),
-                value: "fake-token".to_string(),
-            }],
-        }))
-        .await
-        .expect("create bundled github source");
+    create_bundled_github_source(&harness).await;
 
     let tables = harness.list_tables().await;
     assert!(
@@ -992,143 +709,68 @@ async fn create_bundled_source_registers_tables() {
     );
 }
 
+/// Merged input-validation cases for `CreateBundledSource`; each case creates
+/// the bundled `sentry` source with one invalid inputs combination and asserts
+/// `InvalidArgument` with the case-specific message. Covers the former tests:
+/// `create_bundled_source_missing_required_secret_returns_invalid_argument`,
+/// `create_bundled_source_missing_required_variable_returns_invalid_argument`,
+/// `create_bundled_source_unknown_input_returns_invalid_argument` and
+/// `create_bundled_source_repeated_secret_returns_invalid_argument`.
 #[tokio::test]
-async fn create_bundled_source_missing_required_secret_returns_invalid_argument() {
+async fn create_bundled_source_invalid_inputs_return_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    let sentry_org = || variable("SENTRY_ORG", "phoebe");
+    let sentry_token = || secret("SENTRY_TOKEN", "secret-token");
 
-    let error = harness
-        .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "sentry".to_string(),
-            variables: vec![SourceVariable {
-                key: "SENTRY_ORG".to_string(),
-                value: "phoebe".to_string(),
-            }],
-            secrets: Vec::new(),
-        }))
-        .await
-        .expect_err("missing bundled secret should fail");
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(
-        error
-            .message()
-            .contains("missing required source secret 'SENTRY_TOKEN'")
-    );
-}
+    let cases = [
+        (
+            "missing bundled secret should fail",
+            vec![sentry_org()],
+            Vec::new(),
+            "missing required source secret 'SENTRY_TOKEN'",
+        ),
+        (
+            "missing bundled variable should fail",
+            Vec::new(),
+            vec![sentry_token()],
+            "missing required source variable 'SENTRY_ORG'",
+        ),
+        (
+            "unknown bundled input should fail",
+            vec![sentry_org(), variable("EXTRA", "value")],
+            vec![sentry_token()],
+            "unknown source variable 'EXTRA'",
+        ),
+        (
+            "repeated bundled secret should fail",
+            vec![sentry_org()],
+            vec![sentry_token(), secret("SENTRY_TOKEN", "shadow-token")],
+            "source secret 'SENTRY_TOKEN' is repeated",
+        ),
+    ];
 
-#[tokio::test]
-async fn create_bundled_source_missing_required_variable_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-
-    let error = harness
-        .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "sentry".to_string(),
-            variables: Vec::new(),
-            secrets: vec![SourceSecret {
-                key: "SENTRY_TOKEN".to_string(),
-                value: "secret-token".to_string(),
-            }],
-        }))
-        .await
-        .expect_err("missing bundled variable should fail");
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(
-        error
-            .message()
-            .contains("missing required source variable 'SENTRY_ORG'")
-    );
-}
-
-#[tokio::test]
-async fn create_bundled_source_unknown_input_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-
-    let error = harness
-        .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "sentry".to_string(),
-            variables: vec![
-                SourceVariable {
-                    key: "SENTRY_ORG".to_string(),
-                    value: "phoebe".to_string(),
-                },
-                SourceVariable {
-                    key: "EXTRA".to_string(),
-                    value: "value".to_string(),
-                },
-            ],
-            secrets: vec![SourceSecret {
-                key: "SENTRY_TOKEN".to_string(),
-                value: "secret-token".to_string(),
-            }],
-        }))
-        .await
-        .expect_err("unknown bundled input should fail");
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(error.message().contains("unknown source variable 'EXTRA'"));
-}
-
-#[tokio::test]
-async fn create_bundled_source_repeated_secret_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-
-    let error = harness
-        .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "sentry".to_string(),
-            variables: vec![SourceVariable {
-                key: "SENTRY_ORG".to_string(),
-                value: "phoebe".to_string(),
-            }],
-            secrets: vec![
-                SourceSecret {
-                    key: "SENTRY_TOKEN".to_string(),
-                    value: "secret-token".to_string(),
-                },
-                SourceSecret {
-                    key: "SENTRY_TOKEN".to_string(),
-                    value: "shadow-token".to_string(),
-                },
-            ],
-        }))
-        .await
-        .expect_err("repeated bundled secret should fail");
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(
-        error
-            .message()
-            .contains("source secret 'SENTRY_TOKEN' is repeated")
-    );
+    for (label, variables, secrets, expected_message) in cases {
+        let error = try_create_bundled_source(&harness, "sentry", variables, secrets)
+            .await
+            .expect_err(label);
+        assert_eq!(
+            error.code(),
+            tonic::Code::InvalidArgument,
+            "case {label}: unexpected code"
+        );
+        assert!(
+            error.message().contains(expected_message),
+            "case {label}: unexpected error: {}",
+            error.message()
+        );
+    }
 }
 
 #[tokio::test]
 async fn create_bundled_source_does_not_persist_manifest_to_config_dir() {
     let harness = GrpcHarness::new().await;
 
-    let created = harness
-        .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "github".to_string(),
-            variables: vec![SourceVariable {
-                key: "GITHUB_API_BASE".to_string(),
-                value: "https://api.github.com".to_string(),
-            }],
-            secrets: vec![SourceSecret {
-                key: "GITHUB_TOKEN".to_string(),
-                value: "fake-token".to_string(),
-            }],
-        }))
-        .await
-        .expect("create bundled github source")
-        .into_inner()
-        .source
-        .expect("create bundled source response");
+    let created = create_bundled_github_source(&harness).await;
 
     assert_eq!(created.name, "github");
     assert_eq!(created.origin, SourceOrigin::Bundled as i32);
@@ -1152,26 +794,26 @@ async fn create_bundled_source_does_not_persist_manifest_to_config_dir() {
         "bundled source should register tables resolved from the binary"
     );
 
-    let config_raw =
-        fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    let config_raw = read_config(&harness);
     assert!(
         !config_raw.contains("version = \""),
         "bundled source config should not persist a version field"
     );
 }
 
+/// Merged missing-input cases for validating a bundled source whose installed
+/// config lacks a required input; each case pre-writes a sentry config that
+/// models a binary update requiring an input the original installation never
+/// provided, then asserts `FailedPrecondition` with the case-specific message.
+/// Covers the former tests:
+/// `validate_bundled_source_missing_required_variable_returns_failed_precondition` and
+/// `validate_bundled_source_missing_required_secret_returns_failed_precondition`.
 #[tokio::test]
-async fn validate_bundled_source_missing_required_variable_returns_failed_precondition() {
-    let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    fs::create_dir_all(&config_dir).expect("create config dir");
-
-    // Simulate a bundled source installed without the required SENTRY_ORG variable.
-    // This models the case where the binary is updated to require a new variable
-    // that was not provided during the original installation.
-    fs::write(
-        config_dir.join("config.toml"),
-        r#"
+async fn validate_bundled_source_missing_required_inputs_return_failed_precondition() {
+    let cases = [
+        (
+            "validation should fail when a required variable is missing",
+            r#"
 version = 1
 
 [workspaces.default.sources.sentry]
@@ -1179,45 +821,14 @@ variables = {}
 secrets = ["SENTRY_TOKEN"]
 origin = "bundled"
 "#,
-    )
-    .expect("write config");
-
-    // Write the source secret file so validation can reach variable checks.
-    let secret_dir = config_dir
-        .join("workspaces")
-        .join("default")
-        .join("sources")
-        .join("sentry");
-    fs::create_dir_all(&secret_dir).expect("create secret dir");
-    fs::write(secret_dir.join("secrets.env"), "SENTRY_TOKEN=fake-token\n").expect("write secrets");
-
-    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
-    let error = harness
-        .source_client()
-        .validate_source(Request::new(ValidateSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "sentry".to_string(),
-        }))
-        .await
-        .expect_err("validation should fail when a required variable is missing");
-    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
-    assert!(
-        error.message().contains("missing variable 'SENTRY_ORG'"),
-        "error should identify the missing variable, got: {}",
-        error.message()
-    );
-}
-
-#[tokio::test]
-async fn validate_bundled_source_missing_required_secret_returns_failed_precondition() {
-    let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    fs::create_dir_all(&config_dir).expect("create config dir");
-
-    // Simulate a bundled source installed without the required SENTRY_TOKEN secret.
-    fs::write(
-        config_dir.join("config.toml"),
-        r#"
+            // Write the source secret file so validation can reach variable checks.
+            Some("SENTRY_TOKEN=fake-token\n"),
+            "missing variable 'SENTRY_ORG'",
+            "error should identify the missing variable",
+        ),
+        (
+            "validation should fail when a required secret is missing",
+            r#"
 version = 1
 
 [workspaces.default.sources.sentry]
@@ -1225,36 +836,43 @@ variables = { SENTRY_ORG = "test-org" }
 secrets = []
 origin = "bundled"
 "#,
-    )
-    .expect("write config");
+            None,
+            "missing secret 'SENTRY_TOKEN'",
+            "error should identify the missing secret",
+        ),
+    ];
 
-    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
-    let error = harness
-        .source_client()
-        .validate_source(Request::new(ValidateSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "sentry".to_string(),
-        }))
-        .await
-        .expect_err("validation should fail when a required secret is missing");
-    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
-    assert!(
-        error.message().contains("missing secret 'SENTRY_TOKEN'"),
-        "error should identify the missing secret, got: {}",
-        error.message()
-    );
+    for (label, config_toml, secrets_env, expected_message, assert_label) in cases {
+        let (_temp, config_dir) = config_dir_with(config_toml);
+        if let Some(secrets_env) = secrets_env {
+            let secret_dir = source_dir(&config_dir, "sentry");
+            fs::create_dir_all(&secret_dir).expect("create secret dir");
+            fs::write(secret_dir.join("secrets.env"), secrets_env).expect("write secrets");
+        }
+
+        let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+        let error = harness
+            .try_validate_source("sentry")
+            .await
+            .expect_err(label);
+        assert_eq!(
+            error.code(),
+            tonic::Code::FailedPrecondition,
+            "case {label}: unexpected code"
+        );
+        assert!(
+            error.message().contains(expected_message),
+            "{assert_label}, got: {}",
+            error.message()
+        );
+    }
 }
 
 #[tokio::test]
 async fn get_nonexistent_source_returns_not_found() {
     let harness = GrpcHarness::new().await;
 
-    let error = harness
-        .source_client()
-        .get_source(Request::new(GetSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "missing".to_string(),
-        }))
+    let error = try_get_source(&harness, "missing")
         .await
         .expect_err("missing source should fail");
     assert_eq!(error.code(), tonic::Code::NotFound);
@@ -1262,11 +880,7 @@ async fn get_nonexistent_source_returns_not_found() {
 
 #[tokio::test]
 async fn missing_source_manifest_file_returns_not_found() {
-    let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    fs::create_dir_all(&config_dir).expect("create config dir");
-    fs::write(
-        config_dir.join("config.toml"),
+    let (_temp, config_dir) = config_dir_with(
         r#"
 version = 1
 
@@ -1274,16 +888,11 @@ version = 1
 version = "0.1.0"
 origin = "imported"
 "#,
-    )
-    .expect("write config");
+    );
 
     let harness = GrpcHarness::start_with_config_dir(config_dir).await;
     let error = harness
-        .source_client()
-        .validate_source(Request::new(ValidateSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "demo".to_string(),
-        }))
+        .try_validate_source("demo")
         .await
         .expect_err("missing manifest file should fail");
     assert_eq!(error.code(), tonic::Code::NotFound);
@@ -1291,20 +900,15 @@ origin = "imported"
 
 #[tokio::test]
 async fn config_persists_across_rebuilds_without_trace_history_state() {
-    let temp = TempDir::new().expect("temp dir");
-    let manifest_yaml = fixture_manifest_yaml(temp.path());
-    let config_dir = temp.path().join("coral-config");
-    fs::create_dir_all(&config_dir).expect("create config dir");
-    fs::write(
-        config_dir.join("config.toml"),
+    let (temp, config_dir) = config_dir_with(
         r"
 version = 1
 
 [trace_history]
 enabled = false
 ",
-    )
-    .expect("write config");
+    );
+    let manifest_yaml = fixture_manifest_yaml(temp.path());
 
     {
         let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
@@ -1334,10 +938,7 @@ enabled = false
 async fn corrupted_config_fails_at_startup() {
     use coral_client::local::ServerBuilder;
 
-    let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    fs::create_dir_all(&config_dir).expect("create config dir");
-    fs::write(config_dir.join("config.toml"), "[[sources]\n").expect("write invalid config");
+    let (_temp, config_dir) = config_dir_with("[[sources]\n");
 
     assert!(
         ServerBuilder::new()
@@ -1354,10 +955,7 @@ async fn corrupted_config_fails_at_startup() {
 async fn import_rolls_back_on_config_write_failure() {
     use std::os::unix::fs::PermissionsExt;
 
-    let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    fs::create_dir_all(&config_dir).expect("create config dir");
-    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    let harness = GrpcHarness::new().await;
     let sources_root = harness
         .config_dir()
         .join("workspaces")
@@ -1368,20 +966,11 @@ async fn import_rolls_back_on_config_write_failure() {
         .expect("make config dir read-only");
 
     let error = harness
-        .source_client()
-        .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
-            manifest_yaml: fixture_manifest_with_inputs_yaml(),
-            variables: vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: "https://example.com".to_string(),
-            }],
-            secrets: vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "secret-token".to_string(),
-            }],
-            oauth_credential_retrievals: Vec::new(),
-        }))
+        .try_import_source(ImportSourceRequest {
+            variables: vec![variable("API_BASE", "https://example.com")],
+            secrets: vec![secret("API_TOKEN", "secret-token")],
+            ..import_request(fixture_manifest_with_inputs_yaml())
+        })
         .await
         .expect_err("config write should fail");
 
@@ -1402,14 +991,8 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
     harness
         .import_source(
             fixture_manifest_with_inputs_yaml(),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: "https://example.com".to_string(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "secret-token".to_string(),
-            }],
+            vec![variable("API_BASE", "https://example.com")],
+            vec![secret("API_TOKEN", "secret-token")],
         )
         .await;
 
@@ -1423,12 +1006,7 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
     fs::set_permissions(&sources_root, fs::Permissions::from_mode(0o500))
         .expect("make sources dir read-only");
 
-    let error = harness
-        .source_client()
-        .delete_source(Request::new(DeleteSourceRequest {
-            workspace: Some(default_workspace()),
-            name: "secured_messages".to_string(),
-        }))
+    let error = try_delete_source(&harness, "secured_messages")
         .await
         .expect_err("manifest cleanup should fail");
 
@@ -1463,11 +1041,7 @@ async fn rejects_invalid_workspace_and_source_names() {
     assert_eq!(invalid_workspace.code(), tonic::Code::InvalidArgument);
 
     let invalid_source_name = harness
-        .source_client()
-        .validate_source(Request::new(ValidateSourceRequest {
-            workspace: Some(default_workspace()),
-            name: r"bad\source".to_string(),
-        }))
+        .try_validate_source(r"bad\source")
         .await
         .expect_err("source name with backslash should fail");
     assert_eq!(invalid_source_name.code(), tonic::Code::InvalidArgument);
@@ -1475,13 +1049,8 @@ async fn rejects_invalid_workspace_and_source_names() {
 
 #[tokio::test]
 async fn adding_source_preserves_otel_config_and_existing_sources() {
-    let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    fs::create_dir_all(&config_dir).expect("create config dir");
-
     // Pre-populate the config with an [otel] section and an existing source.
-    fs::write(
-        config_dir.join("config.toml"),
+    let (temp, config_dir) = config_dir_with(
         r#"version = 1
 
 [otel]
@@ -1498,8 +1067,7 @@ variables = {}
 secrets = []
 origin = "imported"
 "#,
-    )
-    .expect("write initial config");
+    );
     let demo_manifest = fixture_manifest_yaml(temp.path()).replace("local_messages", "demo");
     let demo_manifest_path = source_dir(&config_dir, "demo").join("manifest.yaml");
     fs::create_dir_all(demo_manifest_path.parent().expect("manifest parent"))
@@ -1553,4 +1121,115 @@ origin = "imported"
         config_raw.contains("[workspaces.default.sources.local_messages]"),
         "newly added source should be in config"
     );
+}
+
+/// Creates a config dir pre-populated with `config_toml`, returning it with
+/// the temp dir that keeps it alive.
+fn config_dir_with(config_toml: &str) -> (TempDir, PathBuf) {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(config_dir.join("config.toml"), config_toml).expect("write config");
+    (temp, config_dir)
+}
+
+async fn try_get_source(harness: &GrpcHarness, name: &str) -> Result<Source, tonic::Status> {
+    let response = harness
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(default_workspace()),
+            name: name.to_string(),
+        }))
+        .await?
+        .into_inner();
+    Ok(response.source.expect("get source response"))
+}
+
+async fn try_delete_source(harness: &GrpcHarness, name: &str) -> Result<(), tonic::Status> {
+    harness
+        .source_client()
+        .delete_source(Request::new(DeleteSourceRequest {
+            workspace: Some(default_workspace()),
+            name: name.to_string(),
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn discover_sources(harness: &GrpcHarness, label: &str) -> Vec<SourceInfo> {
+    harness
+        .source_client()
+        .discover_sources(Request::new(DiscoverSourcesRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect(label)
+        .into_inner()
+        .sources
+}
+
+async fn try_create_bundled_source(
+    harness: &GrpcHarness,
+    name: &str,
+    variables: Vec<SourceVariable>,
+    secrets: Vec<SourceSecret>,
+) -> Result<Source, tonic::Status> {
+    Ok(harness
+        .source_client()
+        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+            workspace: Some(default_workspace()),
+            name: name.to_string(),
+            variables,
+            secrets,
+        }))
+        .await?
+        .into_inner()
+        .source
+        .expect("create bundled source response"))
+}
+
+async fn create_bundled_github_source(harness: &GrpcHarness) -> Source {
+    try_create_bundled_source(
+        harness,
+        "github",
+        vec![variable("GITHUB_API_BASE", "https://api.github.com")],
+        vec![secret("GITHUB_TOKEN", "fake-token")],
+    )
+    .await
+    .expect("create bundled github source")
+}
+
+async fn get_source_info(harness: &GrpcHarness, name: &str) -> SourceInfo {
+    harness
+        .source_client()
+        .get_source_info(Request::new(GetSourceInfoRequest {
+            workspace: Some(default_workspace()),
+            name: name.to_string(),
+        }))
+        .await
+        .expect("get source info")
+        .into_inner()
+        .source_info
+        .expect("get source info response")
+}
+
+async fn list_catalog_page(
+    harness: &GrpcHarness,
+    schema_name: &str,
+    label: &str,
+) -> ListCatalogResponse {
+    harness
+        .catalog_client()
+        .list_catalog(Request::new(ListCatalogRequest {
+            workspace: Some(default_workspace()),
+            schema_name: schema_name.to_string(),
+            kind: 1,
+            pagination: Some(PaginationRequest {
+                limit: 2,
+                offset: 0,
+            }),
+        }))
+        .await
+        .expect(label)
+        .into_inner()
 }

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -11,9 +11,8 @@ use std::time::Duration;
 use anyhow::{Context as _, bail};
 use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
-    CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
-    CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DiscoverSourcesRequest,
-    GetSourceInfoRequest, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
+    CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest, DeleteSourceRequest,
+    DiscoverSourcesRequest, GetSourceInfoRequest, ImportSourceRequest, ListSourcesRequest,
     OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source,
     SourceCredentialStorage, SourceInfo, SourceOrigin, SourceSecret, SourceVariable,
     ValidateSourceRequest, ValidateSourceResponse, create_bundled_source_with_o_auth_response,
@@ -191,7 +190,18 @@ pub(crate) async fn add_bundled_source_with_credentials(
             oauth_credential_retrievals: inputs.oauth_credential_retrievals,
         }))
         .await?;
-    source_from_bundled_credential_stream(response.into_inner(), &inputs.oauth_labels).await
+    completion_from_oauth_stream(
+        response.into_inner(),
+        &inputs.oauth_labels,
+        OAuthStreamContext {
+            ended_message:
+                "source credential retrieval stream ended before source installation completed",
+            error_action: "retrieve",
+            retry_command: "coral source add",
+        },
+        |response| response.event.map(CredentialStreamEvent::from),
+    )
+    .await
 }
 
 pub(crate) async fn import_source_with_credentials(
@@ -212,69 +222,62 @@ pub(crate) async fn import_source_with_credentials(
             oauth_credential_retrievals: inputs.oauth_credential_retrievals,
         }))
         .await?;
-    source_from_import_credential_stream(response.into_inner(), &inputs.oauth_labels).await
+    completion_from_oauth_stream(
+        response.into_inner(),
+        &inputs.oauth_labels,
+        OAuthStreamContext {
+            ended_message:
+                "source credential retrieval stream ended before source import completed",
+            error_action: "retrieve",
+            retry_command: "coral source add",
+        },
+        |response| response.event.map(CredentialStreamEvent::from),
+    )
+    .await
 }
 
-async fn source_from_bundled_credential_stream(
-    mut stream: tonic::Streaming<CreateBundledSourceWithOAuthResponse>,
+struct OAuthStreamContext {
+    ended_message: &'static str,
+    error_action: &'static str,
+    retry_command: &'static str,
+}
+
+/// Drives one OAuth-progress response stream to completion, rendering
+/// authorization prompts along the way, and returns the completion payload.
+async fn completion_from_oauth_stream<M, T>(
+    mut stream: tonic::Streaming<M>,
     oauth_labels: &BTreeMap<String, String>,
-) -> Result<Source, anyhow::Error> {
+    context: OAuthStreamContext,
+    event_from: impl Fn(M) -> Option<CredentialStreamEvent<T>>,
+) -> Result<T, anyhow::Error> {
     let mut redirect_prompt = OAuthRedirectPastePrompt::default();
     loop {
         let response = match stream.message().await {
             Ok(Some(response)) => response,
             Ok(None) => {
                 redirect_prompt.cancel_and_join();
-                return Err(anyhow::anyhow!(
-                    "source credential retrieval stream ended before source installation completed"
-                ));
+                return Err(anyhow::anyhow!(context.ended_message));
             }
             Err(error) => {
                 redirect_prompt.cancel_and_join();
-                return Err(oauth_error("retrieve", &error));
+                return Err(oauth_error(
+                    context.error_action,
+                    &error,
+                    context.retry_command,
+                ));
             }
         };
-        let event = response.event.map(CredentialStreamEvent::from);
-        if let Some(source) =
-            handle_credential_stream_event(event, oauth_labels, &mut redirect_prompt)
+        if let Some(completed) =
+            handle_credential_stream_event(event_from(response), oauth_labels, &mut redirect_prompt)
         {
             redirect_prompt.cancel_and_join();
-            return Ok(source);
+            return Ok(completed);
         }
     }
 }
 
-async fn source_from_import_credential_stream(
-    mut stream: tonic::Streaming<ImportSourceResponse>,
-    oauth_labels: &BTreeMap<String, String>,
-) -> Result<Source, anyhow::Error> {
-    let mut redirect_prompt = OAuthRedirectPastePrompt::default();
-    loop {
-        let response = match stream.message().await {
-            Ok(Some(response)) => response,
-            Ok(None) => {
-                redirect_prompt.cancel_and_join();
-                return Err(anyhow::anyhow!(
-                    "source credential retrieval stream ended before source import completed"
-                ));
-            }
-            Err(error) => {
-                redirect_prompt.cancel_and_join();
-                return Err(oauth_error("retrieve", &error));
-            }
-        };
-        let event = response.event.map(CredentialStreamEvent::from);
-        if let Some(source) =
-            handle_credential_stream_event(event, oauth_labels, &mut redirect_prompt)
-        {
-            redirect_prompt.cancel_and_join();
-            return Ok(source);
-        }
-    }
-}
-
-enum CredentialStreamEvent {
-    Source(Source),
+enum CredentialStreamEvent<T> {
+    Completed(T),
     OAuthAuthorization {
         input_key: String,
         authorization_url: String,
@@ -283,11 +286,11 @@ enum CredentialStreamEvent {
     OAuthCompleted,
 }
 
-impl From<create_bundled_source_with_o_auth_response::Event> for CredentialStreamEvent {
+impl From<create_bundled_source_with_o_auth_response::Event> for CredentialStreamEvent<Source> {
     fn from(event: create_bundled_source_with_o_auth_response::Event) -> Self {
         match event {
             create_bundled_source_with_o_auth_response::Event::Source(source) => {
-                Self::Source(source)
+                Self::Completed(source)
             }
             create_bundled_source_with_o_auth_response::Event::OauthAuthorization(
                 authorization,
@@ -303,10 +306,10 @@ impl From<create_bundled_source_with_o_auth_response::Event> for CredentialStrea
     }
 }
 
-impl From<import_source_response::Event> for CredentialStreamEvent {
+impl From<import_source_response::Event> for CredentialStreamEvent<Source> {
     fn from(event: import_source_response::Event) -> Self {
         match event {
-            import_source_response::Event::Source(source) => Self::Source(source),
+            import_source_response::Event::Source(source) => Self::Completed(source),
             import_source_response::Event::OauthAuthorization(authorization) => {
                 Self::OAuthAuthorization {
                     input_key: authorization.input_key,
@@ -319,43 +322,58 @@ impl From<import_source_response::Event> for CredentialStreamEvent {
     }
 }
 
-fn handle_credential_stream_event(
-    event: Option<CredentialStreamEvent>,
+fn handle_credential_stream_event<T>(
+    event: Option<CredentialStreamEvent<T>>,
     oauth_labels: &BTreeMap<String, String>,
     redirect_prompt: &mut OAuthRedirectPastePrompt,
-) -> Option<Source> {
+) -> Option<T> {
     match event {
         Some(CredentialStreamEvent::OAuthAuthorization {
             input_key,
             authorization_url,
             user_code,
         }) => {
-            let label = oauth_labels
-                .get(&input_key)
-                .map_or(input_key.as_str(), String::as_str);
-            println!("Open this URL to connect {label}:");
-            println!("{authorization_url}");
-            redirect_prompt.cancel_and_join();
-            if user_code.is_empty() {
-                redirect_prompt
-                    .replace(spawn_oauth_redirect_paste_prompt(&authorization_url, label));
-            } else {
-                println!("Enter this code when prompted: {user_code}");
-            }
-            if let Err(err) = crate::browser::open_url(&authorization_url) {
-                println!("{}", style(format!("Could not open browser: {err}")).dim());
-            }
+            handle_oauth_authorization_event(
+                &input_key,
+                &authorization_url,
+                &user_code,
+                oauth_labels,
+                redirect_prompt,
+            );
             None
         }
-        Some(CredentialStreamEvent::Source(source)) => {
+        Some(CredentialStreamEvent::Completed(completed)) => {
             redirect_prompt.cancel_and_join();
-            Some(source)
+            Some(completed)
         }
         Some(CredentialStreamEvent::OAuthCompleted) => {
             redirect_prompt.cancel_and_join();
             None
         }
         None => None,
+    }
+}
+
+fn handle_oauth_authorization_event(
+    input_key: &str,
+    authorization_url: &str,
+    user_code: &str,
+    oauth_labels: &BTreeMap<String, String>,
+    redirect_prompt: &mut OAuthRedirectPastePrompt,
+) {
+    let label = oauth_labels
+        .get(input_key)
+        .map_or(input_key, String::as_str);
+    println!("Open this URL to connect {label}:");
+    println!("{authorization_url}");
+    redirect_prompt.cancel_and_join();
+    if user_code.is_empty() {
+        redirect_prompt.replace(spawn_oauth_redirect_paste_prompt(authorization_url, label));
+    } else {
+        println!("Enter this code when prompted: {user_code}");
+    }
+    if let Err(err) = crate::browser::open_url(authorization_url) {
+        println!("{}", style(format!("Could not open browser: {err}")).dim());
     }
 }
 
@@ -415,7 +433,7 @@ fn durable_manifest_file_yaml(
     };
     let mut replacement_files = BTreeMap::new();
     for surface in &v4.surfaces {
-        let SurfaceDescriptor::File { file } = &surface.descriptor else {
+        let SurfaceDescriptor::File { file, .. } = &surface.descriptor else {
             continue;
         };
         let canonical = canonicalize_manifest_descriptor(file, manifest_dir)?;
@@ -1202,9 +1220,9 @@ fn collect_oauth_credential_method(
     })
 }
 
-fn oauth_error(action: &str, error: &tonic::Status) -> anyhow::Error {
+fn oauth_error(action: &str, error: &tonic::Status, retry_command: &str) -> anyhow::Error {
     anyhow::anyhow!(
-        "OAuth credential retrieval failed during {action}: {error}. Rerun `coral source add` to try again."
+        "OAuth credential retrieval failed during {action}: {error}. Rerun `{retry_command}` to try again."
     )
 }
 

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -9,18 +9,19 @@
 
 mod harness;
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-#[cfg(feature = "embedded-ui")]
 use assert_cmd::Command;
+use assert_cmd::assert::Assert;
 use coral_api::v1::{
     DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, Source,
     SourceCredentialStorage, SourceInfo, SourceOrigin,
 };
-use tempfile::tempdir;
+use tempfile::{TempDir, tempdir};
 use tonic::Code;
 
 use harness::{MockServer, MockServerConfig, encode_arrow_ipc_stream};
@@ -34,7 +35,7 @@ fn ui_help_does_not_require_app_bootstrap() {
         .assert()
         .success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert!(
         stdout.contains("embedded Coral UI"),
         "expected ui help text: {stdout}"
@@ -65,17 +66,44 @@ fn assert_default_workspace(workspace: Option<&coral_api::v1::Workspace>) {
     );
 }
 
+/// Runs `coral <args>` against the mock server and returns the assertion.
+fn run_cli(server: &MockServer, args: &[&str]) -> Assert {
+    server.cmd().args(args).assert()
+}
+
+fn stdout_text(assert: &Assert) -> String {
+    String::from_utf8_lossy(&assert.get_output().stdout).into_owned()
+}
+
+fn stderr_text(assert: &Assert) -> String {
+    String::from_utf8_lossy(&assert.get_output().stderr).into_owned()
+}
+
+fn write_yaml(dir: &TempDir, file_name: &str, yaml: &str) -> PathBuf {
+    let path = dir.path().join(file_name);
+    std::fs::write(&path, yaml).expect("write yaml fixture");
+    path
+}
+
+/// Prepares `coral <subcommand> add --file <file>` against the mock server.
+fn add_file_cmd(server: &MockServer, subcommand: &str, file: &Path) -> Command {
+    let mut cmd = server.cmd();
+    cmd.args([
+        subcommand,
+        "add",
+        "--file",
+        file.to_str().expect("fixture path utf8"),
+    ]);
+    cmd
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn sql_command_renders_table_output() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["sql", "select 1 as value"])
-        .assert()
-        .success();
+    let assert = run_cli(&server, &["sql", "select 1 as value"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert!(stdout.contains("value"), "expected column header: {stdout}");
     assert!(stdout.contains('1'), "expected row value: {stdout}");
 
@@ -91,9 +119,9 @@ async fn sql_command_renders_table_output() {
 async fn source_list_renders_configured_sources() {
     let server = MockServer::start().await;
 
-    let assert = server.cmd().args(["source", "list"]).assert().success();
+    let assert = run_cli(&server, &["source", "list"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert_eq!(
         nonempty_lines(&stdout),
         vec![
@@ -129,9 +157,9 @@ async fn source_list_renders_dash_for_missing_authored_version() {
     ))
     .await;
 
-    let assert = server.cmd().args(["source", "list"]).assert().success();
+    let assert = run_cli(&server, &["source", "list"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert_eq!(
         nonempty_lines(&stdout),
         vec![
@@ -149,13 +177,9 @@ async fn source_list_renders_dash_for_missing_authored_version() {
 async fn sql_command_renders_json_output() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["sql", "--format", "json", "select 1 as value"])
-        .assert()
-        .success();
+    let assert = run_cli(&server, &["sql", "--format", "json", "select 1 as value"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert_eq!(stdout.trim(), "[{\"value\":1}]", "expected JSON rows");
 
     let requests = server.execute_sql_requests();
@@ -170,9 +194,9 @@ async fn sql_command_renders_json_output() {
 async fn source_discover_renders_available_sources() {
     let server = MockServer::start().await;
 
-    let assert = server.cmd().args(["source", "discover"]).assert().success();
+    let assert = run_cli(&server, &["source", "discover"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert_eq!(
         nonempty_lines(&stdout),
         vec![
@@ -200,9 +224,9 @@ async fn source_discover_renders_empty_state() {
     ))
     .await;
 
-    let assert = server.cmd().args(["source", "discover"]).assert().success();
+    let assert = run_cli(&server, &["source", "discover"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert_eq!(
         stdout.trim(),
         "No bundled sources available.",
@@ -220,13 +244,9 @@ async fn source_discover_renders_empty_state() {
 async fn source_info_renders_metadata_for_installed_source() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "info", "github"])
-        .assert()
-        .success();
+    let assert = run_cli(&server, &["source", "info", "github"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert!(stdout.contains("github"), "expected source name: {stdout}");
     assert!(
         stdout.contains("installed"),
@@ -263,13 +283,9 @@ async fn source_info_renders_metadata_for_installed_source() {
 async fn source_info_verbose_includes_input_hints() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "info", "github", "--verbose"])
-        .assert()
-        .success();
+    let assert = run_cli(&server, &["source", "info", "github", "--verbose"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert!(
         stdout.contains("github.com/settings/tokens"),
         "expected hint with --verbose: {stdout}"
@@ -282,13 +298,9 @@ async fn source_info_verbose_includes_input_hints() {
 async fn source_info_renders_metadata_for_available_source() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "info", "slack"])
-        .assert()
-        .success();
+    let assert = run_cli(&server, &["source", "info", "slack"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert!(
         stdout.contains("not installed"),
         "expected not-installed status: {stdout}"
@@ -306,13 +318,9 @@ async fn source_info_renders_metadata_for_available_source() {
 async fn source_info_renders_installed_imported_source() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "info", "jira"])
-        .assert()
-        .success();
+    let assert = run_cli(&server, &["source", "info", "jira"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert!(stdout.contains("jira"), "expected source name: {stdout}");
     assert!(
         stdout.contains("installed"),
@@ -336,13 +344,9 @@ async fn source_info_renders_installed_imported_source() {
 async fn source_info_omits_missing_authored_version() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "info", "versionless"])
-        .assert()
-        .success();
+    let assert = run_cli(&server, &["source", "info", "versionless"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert!(
         stdout.contains("versionless"),
         "expected source name: {stdout}"
@@ -359,13 +363,9 @@ async fn source_info_omits_missing_authored_version() {
 async fn source_info_errors_for_unknown_source() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "info", "nope"])
-        .assert()
-        .failure();
+    let assert = run_cli(&server, &["source", "info", "nope"]).failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("unknown source 'nope'"),
         "expected unknown source error: {stderr}"
@@ -383,9 +383,9 @@ async fn source_list_renders_empty_state() {
     ))
     .await;
 
-    let assert = server.cmd().args(["source", "list"]).assert().success();
+    let assert = run_cli(&server, &["source", "list"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert_eq!(
         stdout.trim(),
         "No sources configured.",
@@ -403,13 +403,9 @@ async fn source_list_renders_empty_state() {
 async fn source_test_renders_validation_summary() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "test", "github"])
-        .assert()
-        .success();
+    let assert = run_cli(&server, &["source", "test", "github"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert!(
         stdout.contains("github connected successfully"),
         "expected success summary: {stdout}"
@@ -436,13 +432,9 @@ async fn source_test_renders_validation_summary() {
 async fn source_remove_reports_removed_source() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "remove", "github"])
-        .assert()
-        .success();
+    let assert = run_cli(&server, &["source", "remove", "github"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert_eq!(
         stdout.trim(),
         "Removed source github",
@@ -464,13 +456,9 @@ async fn sql_command_surfaces_server_errors() {
     )
     .await;
 
-    let assert = server
-        .cmd()
-        .args(["sql", "select 1 as value"])
-        .assert()
-        .failure();
+    let assert = run_cli(&server, &["sql", "select 1 as value"]).failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("mock SQL failure"),
         "expected server error in stderr: {stderr}"
@@ -491,13 +479,9 @@ async fn source_test_surfaces_validation_errors() {
     )
     .await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "test", "github"])
-        .assert()
-        .failure();
+    let assert = run_cli(&server, &["source", "test", "github"]).failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("mock validate failure"),
         "expected validation error in stderr: {stderr}"
@@ -541,13 +525,9 @@ async fn sql_table_output_renders_multiple_columns_and_rows() {
     )
     .await;
 
-    let assert = server
-        .cmd()
-        .args(["sql", "select id, name from users"])
-        .assert()
-        .success();
+    let assert = run_cli(&server, &["sql", "select id, name from users"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     let lines = nonempty_lines(&stdout);
 
     // Arrow pretty table: border, header, border, data rows, border.
@@ -600,13 +580,13 @@ async fn sql_json_output_renders_multiple_rows() {
     )
     .await;
 
-    let assert = server
-        .cmd()
-        .args(["sql", "--format", "json", "select id, name from users"])
-        .assert()
-        .success();
+    let assert = run_cli(
+        &server,
+        &["sql", "--format", "json", "select id, name from users"],
+    )
+    .success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     let rows: Vec<serde_json::Map<String, serde_json::Value>> =
         serde_json::from_str(stdout.trim()).expect("sql --format json should emit a JSON array");
 
@@ -642,13 +622,9 @@ async fn sql_table_output_renders_empty_result() {
     )
     .await;
 
-    let assert = server
-        .cmd()
-        .args(["sql", "select id, name from empty_table"])
-        .assert()
-        .success();
+    let assert = run_cli(&server, &["sql", "select id, name from empty_table"]).success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     let lines = nonempty_lines(&stdout);
 
     // Empty result: border, header, border, border (no data rows).
@@ -684,13 +660,13 @@ async fn sql_json_output_renders_empty_result() {
     )
     .await;
 
-    let assert = server
-        .cmd()
-        .args(["sql", "--format", "json", "select id from empty_table"])
-        .assert()
-        .success();
+    let assert = run_cli(
+        &server,
+        &["sql", "--format", "json", "select id from empty_table"],
+    )
+    .success();
 
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout = stdout_text(&assert);
     assert_eq!(stdout.trim(), "[]", "expected empty JSON array");
 
     let requests = server.execute_sql_requests();
@@ -709,9 +685,9 @@ async fn sql_json_output_renders_empty_result() {
 async fn source_add_requires_name_or_file() {
     let server = MockServer::start().await;
 
-    let assert = server.cmd().args(["source", "add"]).assert().failure();
+    let assert = run_cli(&server, &["source", "add"]).failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("required") || stderr.contains("must be provided"),
         "expected clap error about required arguments: {stderr}"
@@ -724,13 +700,13 @@ async fn source_add_requires_name_or_file() {
 async fn source_add_rejects_name_and_file_together() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "add", "github", "--file", "manifest.yaml"])
-        .assert()
-        .failure();
+    let assert = run_cli(
+        &server,
+        &["source", "add", "github", "--file", "manifest.yaml"],
+    )
+    .failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("cannot be used with"),
         "expected clap conflict error: {stderr}"
@@ -739,48 +715,47 @@ async fn source_add_rejects_name_and_file_together() {
     server.shutdown().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn source_add_file_resolves_v4_relative_descriptor_from_manifest_dir() {
-    let server = MockServer::start().await;
-    let source_dir = tempdir().expect("source dir");
-    let openapi_file = source_dir.path().join("openapi.yaml");
-    std::fs::write(
-        &openapi_file,
-        r"
-openapi: 3.0.3
-paths: {}
-",
-    )
-    .expect("write descriptor");
-    let manifest_file = source_dir.path().join("manifest.yaml");
-    std::fs::write(
-        &manifest_file,
-        r"
+/// DSL v4 github manifest whose single surface references a relative
+/// `openapi.yaml` descriptor.
+const V4_GITHUB_MANIFEST: &str = r"
 name: github
 dsl_version: 4
 surfaces:
   - id: rest
     type: openapi
     file: openapi.yaml
-",
-    )
-    .expect("write manifest");
+";
 
-    server
-        .cmd()
-        .args([
-            "source",
-            "add",
-            "--file",
-            manifest_file.to_str().expect("manifest path utf8"),
-        ])
+/// Writes the v4 github manifest plus its `openapi.yaml` descriptor into a
+/// fresh temp dir; `manifest_suffix` extends the single surface entry.
+fn v4_github_source_dir(manifest_suffix: &str) -> (TempDir, PathBuf) {
+    let source_dir = tempdir().expect("source dir");
+    write_yaml(&source_dir, "openapi.yaml", "\nopenapi: 3.0.3\npaths: {}\n");
+    let manifest_file = write_yaml(
+        &source_dir,
+        "manifest.yaml",
+        &format!("{V4_GITHUB_MANIFEST}{manifest_suffix}"),
+    );
+    (source_dir, manifest_file)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_file_resolves_v4_relative_descriptor_from_manifest_dir() {
+    let server = MockServer::start().await;
+    let (source_dir, manifest_file) = v4_github_source_dir("");
+
+    add_file_cmd(&server, "source", &manifest_file)
         .assert()
         .success();
 
     let requests = server.import_source_requests();
     assert_eq!(requests.len(), 1, "expected one import_source call");
     let manifest_yaml = &requests[0].manifest_yaml;
-    let canonical = openapi_file.canonicalize().expect("canonical descriptor");
+    let canonical = source_dir
+        .path()
+        .join("openapi.yaml")
+        .canonicalize()
+        .expect("canonical descriptor");
     let canonical = canonical.to_string_lossy();
     assert!(
         manifest_yaml.contains(canonical.as_ref()),
@@ -802,13 +777,9 @@ surfaces:
 async fn source_test_rejects_invalid_name() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "test", "a/b"])
-        .assert()
-        .failure();
+    let assert = run_cli(&server, &["source", "test", "a/b"]).failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("must not contain"),
         "expected name validation error: {stderr}"
@@ -821,13 +792,9 @@ async fn source_test_rejects_invalid_name() {
 async fn source_remove_rejects_invalid_name() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "remove", "a/b"])
-        .assert()
-        .failure();
+    let assert = run_cli(&server, &["source", "remove", "a/b"]).failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("must not contain"),
         "expected name validation error: {stderr}"
@@ -851,7 +818,7 @@ async fn source_add_reports_missing_env_vars_without_interactive() {
         .assert()
         .failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("missing required environment variable"),
         "expected missing env var error: {stderr}"
@@ -872,13 +839,9 @@ async fn source_add_reports_missing_env_vars_without_interactive() {
 async fn source_add_interactive_requires_tty() {
     let server = MockServer::start().await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "add", "--interactive", "github"])
-        .assert()
-        .failure();
+    let assert = run_cli(&server, &["source", "add", "--interactive", "github"]).failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("requires a TTY"),
         "expected TTY requirement error: {stderr}"
@@ -906,13 +869,9 @@ async fn source_test_suggests_add_for_uninstalled_bundled_source() {
     )
     .await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "test", "demo_bundled"])
-        .assert()
-        .failure();
+    let assert = run_cli(&server, &["source", "test", "demo_bundled"]).failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("source 'demo_bundled' is not installed"),
         "expected not-installed error in stderr: {stderr}"
@@ -940,13 +899,9 @@ async fn source_test_normalizes_error_for_unknown_source() {
     )
     .await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "test", "totally_unknown"])
-        .assert()
-        .failure();
+    let assert = run_cli(&server, &["source", "test", "totally_unknown"]).failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("source 'totally_unknown' was not found"),
         "expected normalized not-found error in stderr: {stderr}"
@@ -970,13 +925,9 @@ async fn source_remove_normalizes_error_for_unknown_source() {
     )
     .await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "remove", "unknown_source"])
-        .assert()
-        .failure();
+    let assert = run_cli(&server, &["source", "remove", "unknown_source"]).failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains("source 'unknown_source' was not found"),
         "expected normalized not-found error in stderr: {stderr}"
@@ -1005,13 +956,9 @@ async fn source_remove_preserves_unrelated_not_found_errors() {
     )
     .await;
 
-    let assert = server
-        .cmd()
-        .args(["source", "remove", "broken_source"])
-        .assert()
-        .failure();
+    let assert = run_cli(&server, &["source", "remove", "broken_source"]).failure();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stderr = stderr_text(&assert);
     assert!(
         stderr.contains(raw_message),
         "expected raw server error to surface unchanged: {stderr}"

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -37,7 +37,7 @@ use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_stream::Stream;
-use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
+use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::Server;
 use tonic::{Code, Request, Response, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
@@ -572,22 +572,61 @@ fn list_catalog_response(request: &ListCatalogRequest) -> ListCatalogResponse {
     }
 }
 
-#[derive(Default)]
-struct Captured {
-    execute_sql: Mutex<Vec<ExecuteSqlRequest>>,
-    list_catalog: Mutex<Vec<ListCatalogRequest>>,
-    search_catalog: Mutex<Vec<SearchCatalogRequest>>,
-    describe_table: Mutex<Vec<DescribeTableRequest>>,
-    list_columns: Mutex<Vec<ListColumnsRequest>>,
-    discover_sources: Mutex<Vec<DiscoverSourcesRequest>>,
-    list_sources: Mutex<Vec<ListSourcesRequest>>,
-    get_source: Mutex<Vec<GetSourceRequest>>,
-    get_source_info: Mutex<Vec<GetSourceInfoRequest>>,
-    create_bundled_source: Mutex<Vec<CreateBundledSourceRequest>>,
-    create_bundled_source_with_oauth: Mutex<Vec<CreateBundledSourceWithOAuthRequest>>,
-    import_source: Mutex<Vec<ImportSourceRequest>>,
-    delete_source: Mutex<Vec<DeleteSourceRequest>>,
-    validate_source: Mutex<Vec<ValidateSourceRequest>>,
+/// Declares one capture slot per mocked RPC together with the `MockServer`
+/// getter that exposes the recorded requests to tests.
+macro_rules! captured_requests {
+    ($($field:ident as $getter:ident: $request:ty),* $(,)?) => {
+        #[derive(Default)]
+        struct Captured {
+            $($field: Mutex<Vec<$request>>,)*
+        }
+
+        impl MockServer {
+            $(pub(crate) fn $getter(&self) -> Vec<$request> {
+                self.captured
+                    .$field
+                    .lock()
+                    .expect("captured requests lock")
+                    .clone()
+            })*
+        }
+    };
+}
+
+captured_requests! {
+    execute_sql as execute_sql_requests: ExecuteSqlRequest,
+    list_catalog as list_catalog_requests: ListCatalogRequest,
+    search_catalog as search_catalog_requests: SearchCatalogRequest,
+    describe_table as describe_table_requests: DescribeTableRequest,
+    list_columns as list_columns_requests: ListColumnsRequest,
+    discover_sources as discover_sources_requests: DiscoverSourcesRequest,
+    list_sources as list_sources_requests: ListSourcesRequest,
+    get_source as get_source_requests: GetSourceRequest,
+    get_source_info as get_source_info_requests: GetSourceInfoRequest,
+    create_bundled_source as create_bundled_source_requests: CreateBundledSourceRequest,
+    create_bundled_source_with_oauth as create_bundled_source_with_oauth_requests:
+        CreateBundledSourceWithOAuthRequest,
+    import_source as import_source_requests: ImportSourceRequest,
+    delete_source as delete_source_requests: DeleteSourceRequest,
+    validate_source as validate_source_requests: ValidateSourceRequest,
+}
+
+/// Records the unwrapped `request` in its capture slot and returns it for
+/// handlers that also inspect the request.
+fn capture<T: Clone>(slot: &Mutex<Vec<T>>, request: Request<T>) -> T {
+    let request = request.into_inner();
+    slot.lock()
+        .expect("captured requests lock")
+        .push(request.clone());
+    request
+}
+
+/// Server-streaming response type used by the mocks: one event, then end of
+/// stream.
+type EventStream<T> = Pin<Box<dyn Stream<Item = Result<T, Status>> + Send>>;
+
+fn single_event_stream<T: Send + 'static>(event: T) -> EventStream<T> {
+    Box::pin(tokio_stream::once(Ok(event)))
 }
 
 pub(crate) fn encode_arrow_ipc_stream(
@@ -617,13 +656,7 @@ impl QueryService for MockQueryService {
         &self,
         request: Request<ExecuteSqlRequest>,
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
-        let request = request.into_inner();
-        self.captured
-            .execute_sql
-            .lock()
-            .expect("execute_sql capture")
-            .push(request.clone());
-        let sql = request.sql;
+        let sql = capture(&self.captured.execute_sql, request).sql;
         if sql
             .trim_start()
             .to_ascii_uppercase()
@@ -665,12 +698,7 @@ impl CatalogService for MockCatalogService {
         &self,
         request: Request<ListCatalogRequest>,
     ) -> Result<Response<ListCatalogResponse>, Status> {
-        let request = request.into_inner();
-        self.captured
-            .list_catalog
-            .lock()
-            .expect("list_catalog capture")
-            .push(request.clone());
+        let request = capture(&self.captured.list_catalog, request);
         Ok(Response::new(list_catalog_response(&request)))
     }
 
@@ -678,12 +706,7 @@ impl CatalogService for MockCatalogService {
         &self,
         request: Request<SearchCatalogRequest>,
     ) -> Result<Response<SearchCatalogResponse>, Status> {
-        let request = request.into_inner();
-        self.captured
-            .search_catalog
-            .lock()
-            .expect("search_catalog capture")
-            .push(request.clone());
+        let request = capture(&self.captured.search_catalog, request);
         let pattern = regex::RegexBuilder::new(&request.pattern)
             .case_insensitive(request.ignore_case)
             .build()
@@ -721,12 +744,7 @@ impl CatalogService for MockCatalogService {
         &self,
         request: Request<DescribeTableRequest>,
     ) -> Result<Response<DescribeTableResponse>, Status> {
-        let request = request.into_inner();
-        self.captured
-            .describe_table
-            .lock()
-            .expect("describe_table capture")
-            .push(request.clone());
+        let request = capture(&self.captured.describe_table, request);
         let table = mock_visible_tables().into_iter().find(|table| {
             table.schema_name == request.schema_name && table.name == request.table_name
         });
@@ -756,12 +774,7 @@ impl CatalogService for MockCatalogService {
         &self,
         request: Request<ListColumnsRequest>,
     ) -> Result<Response<ListColumnsResponse>, Status> {
-        let request = request.into_inner();
-        self.captured
-            .list_columns
-            .lock()
-            .expect("list_columns capture")
-            .push(request.clone());
+        let request = capture(&self.captured.list_columns, request);
         let table = mock_visible_tables()
             .into_iter()
             .find(|table| {
@@ -810,163 +823,80 @@ impl CatalogService for MockCatalogService {
     }
 }
 
+/// Generates one mock service impl. Every method records the request in its
+/// `captured` slot, then evaluates `$body` (with the captured request and the
+/// server config in scope) to produce the response. Generating the whole
+/// `impl` keeps `#[tonic::async_trait]` running after macro expansion.
+macro_rules! mock_service {
+    (
+        impl $service:ident for $mock:ident {
+            $(type $stream:ident = $stream_ty:ty;)*
+            $(fn $rpc:ident($slot:ident, $req:ty) -> $resp:ty = |$cfg:ident, $request:ident| $body:expr;)*
+        }
+    ) => {
+        #[tonic::async_trait]
+        impl $service for $mock {
+            $(type $stream = $stream_ty;)*
+            $(
+                async fn $rpc(&self, request: Request<$req>) -> Result<Response<$resp>, Status> {
+                    let $request = capture(&self.captured.$slot, request);
+                    let $cfg = &self.config;
+                    Ok(Response::new($body))
+                }
+            )*
+        }
+    };
+}
+
 #[derive(Clone)]
 struct MockSourceService {
     config: Arc<MockServerConfig>,
     captured: Arc<Captured>,
 }
 
-type MockBundledSourceStream =
-    Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithOAuthResponse, Status>> + Send>>;
-type MockImportSourceStream =
-    Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
-
-fn mock_bundled_source_stream() -> MockBundledSourceStream {
-    let (tx, rx) =
-        tokio::sync::mpsc::channel::<Result<CreateBundledSourceWithOAuthResponse, Status>>(1);
-    tx.try_send(Ok(CreateBundledSourceWithOAuthResponse {
-        event: Some(create_bundled_source_with_o_auth_response::Event::Source(
-            mock_source(),
-        )),
-    }))
-    .expect("send mock bundled source credential event");
-    Box::pin(ReceiverStream::new(rx))
-}
-
-fn mock_import_source_stream() -> MockImportSourceStream {
-    let (tx, rx) = tokio::sync::mpsc::channel::<Result<ImportSourceResponse, Status>>(1);
-    tx.try_send(Ok(ImportSourceResponse {
-        event: Some(import_source_response::Event::Source(mock_source())),
-    }))
-    .expect("send mock import source credential event");
-    Box::pin(ReceiverStream::new(rx))
-}
-
-#[tonic::async_trait]
-impl SourceService for MockSourceService {
-    type CreateBundledSourceWithOAuthStream = MockBundledSourceStream;
-    type ImportSourceStream = MockImportSourceStream;
-
-    async fn discover_sources(
-        &self,
-        request: Request<DiscoverSourcesRequest>,
-    ) -> Result<Response<DiscoverSourcesResponse>, Status> {
-        self.captured
-            .discover_sources
-            .lock()
-            .expect("discover_sources capture")
-            .push(request.into_inner());
-        Ok(Response::new(
-            self.config.discover_sources.clone().into_tonic_result()?,
-        ))
-    }
-
-    async fn list_sources(
-        &self,
-        request: Request<ListSourcesRequest>,
-    ) -> Result<Response<ListSourcesResponse>, Status> {
-        self.captured
-            .list_sources
-            .lock()
-            .expect("list_sources capture")
-            .push(request.into_inner());
-        Ok(Response::new(
-            self.config.list_sources.clone().into_tonic_result()?,
-        ))
-    }
-
-    async fn get_source(
-        &self,
-        request: Request<GetSourceRequest>,
-    ) -> Result<Response<GetSourceResponse>, Status> {
-        self.captured
-            .get_source
-            .lock()
-            .expect("get_source capture")
-            .push(request.into_inner());
-        Ok(Response::new(GetSourceResponse {
-            source: Some(mock_source()),
-        }))
-    }
-
-    async fn get_source_info(
-        &self,
-        request: Request<GetSourceInfoRequest>,
-    ) -> Result<Response<GetSourceInfoResponse>, Status> {
-        let request = request.into_inner();
-        self.captured
-            .get_source_info
-            .lock()
-            .expect("get_source_info capture")
-            .push(request.clone());
-        Ok(Response::new(GetSourceInfoResponse {
-            source_info: Some(mock_source_info(&request.name)?),
-        }))
-    }
-
-    async fn create_bundled_source(
-        &self,
-        request: Request<CreateBundledSourceRequest>,
-    ) -> Result<Response<CreateBundledSourceResponse>, Status> {
-        self.captured
-            .create_bundled_source
-            .lock()
-            .expect("create_bundled_source capture")
-            .push(request.into_inner());
-        Ok(Response::new(CreateBundledSourceResponse {
-            source: Some(mock_source()),
-        }))
-    }
-
-    async fn create_bundled_source_with_o_auth(
-        &self,
-        request: Request<CreateBundledSourceWithOAuthRequest>,
-    ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
-        self.captured
-            .create_bundled_source_with_oauth
-            .lock()
-            .expect("create_bundled_source_with_oauth capture")
-            .push(request.into_inner());
-        Ok(Response::new(mock_bundled_source_stream()))
-    }
-
-    async fn import_source(
-        &self,
-        request: Request<ImportSourceRequest>,
-    ) -> Result<Response<Self::ImportSourceStream>, Status> {
-        self.captured
-            .import_source
-            .lock()
-            .expect("import_source capture")
-            .push(request.into_inner());
-        Ok(Response::new(mock_import_source_stream()))
-    }
-
-    async fn delete_source(
-        &self,
-        request: Request<DeleteSourceRequest>,
-    ) -> Result<Response<DeleteSourceResponse>, Status> {
-        self.captured
-            .delete_source
-            .lock()
-            .expect("delete_source capture")
-            .push(request.into_inner());
-        self.config.delete_source.clone().into_tonic_result()?;
-        Ok(Response::new(DeleteSourceResponse {}))
-    }
-
-    async fn validate_source(
-        &self,
-        request: Request<ValidateSourceRequest>,
-    ) -> Result<Response<ValidateSourceResponse>, Status> {
-        self.captured
-            .validate_source
-            .lock()
-            .expect("validate_source capture")
-            .push(request.into_inner());
-        Ok(Response::new(
-            self.config.validate_source.clone().into_tonic_result()?,
-        ))
+mock_service! {
+    impl SourceService for MockSourceService {
+        type CreateBundledSourceWithOAuthStream =
+            EventStream<CreateBundledSourceWithOAuthResponse>;
+        type ImportSourceStream = EventStream<ImportSourceResponse>;
+        fn discover_sources(discover_sources, DiscoverSourcesRequest) -> DiscoverSourcesResponse =
+            |cfg, _request| cfg.discover_sources.clone().into_tonic_result()?;
+        fn list_sources(list_sources, ListSourcesRequest) -> ListSourcesResponse =
+            |cfg, _request| cfg.list_sources.clone().into_tonic_result()?;
+        fn get_source(get_source, GetSourceRequest) -> GetSourceResponse =
+            |_cfg, _request| GetSourceResponse {
+                source: Some(mock_source()),
+            };
+        fn get_source_info(get_source_info, GetSourceInfoRequest) -> GetSourceInfoResponse =
+            |_cfg, request| GetSourceInfoResponse {
+                source_info: Some(mock_source_info(&request.name)?),
+            };
+        fn create_bundled_source(create_bundled_source, CreateBundledSourceRequest)
+            -> CreateBundledSourceResponse =
+            |_cfg, _request| CreateBundledSourceResponse {
+                source: Some(mock_source()),
+            };
+        fn create_bundled_source_with_o_auth(
+            create_bundled_source_with_oauth,
+            CreateBundledSourceWithOAuthRequest
+        ) -> EventStream<CreateBundledSourceWithOAuthResponse> =
+            |_cfg, _request| single_event_stream(CreateBundledSourceWithOAuthResponse {
+                event: Some(create_bundled_source_with_o_auth_response::Event::Source(
+                    mock_source(),
+                )),
+            });
+        fn import_source(import_source, ImportSourceRequest)
+            -> EventStream<ImportSourceResponse> =
+            |_cfg, _request| single_event_stream(ImportSourceResponse {
+                event: Some(import_source_response::Event::Source(mock_source())),
+            });
+        fn delete_source(delete_source, DeleteSourceRequest) -> DeleteSourceResponse =
+            |cfg, _request| {
+                cfg.delete_source.clone().into_tonic_result()?;
+                DeleteSourceResponse {}
+            };
+        fn validate_source(validate_source, ValidateSourceRequest) -> ValidateSourceResponse =
+            |cfg, _request| cfg.validate_source.clone().into_tonic_result()?;
     }
 }
 
@@ -991,22 +921,20 @@ impl MockServer {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let config = Arc::new(config);
         let captured = Arc::new(Captured::default());
-        let query_captured = Arc::clone(&captured);
-        let catalog_captured = Arc::clone(&captured);
-        let source_captured = Arc::clone(&captured);
-        let query_config = Arc::clone(&config);
+        let task_captured = Arc::clone(&captured);
         let task = tokio::spawn(async move {
+            let captured = task_captured;
             Server::builder()
                 .add_service(CatalogServiceServer::new(MockCatalogService {
-                    captured: catalog_captured,
+                    captured: Arc::clone(&captured),
                 }))
                 .add_service(QueryServiceServer::new(MockQueryService {
-                    config: query_config,
-                    captured: query_captured,
+                    config: Arc::clone(&config),
+                    captured: Arc::clone(&captured),
                 }))
                 .add_service(SourceServiceServer::new(MockSourceService {
                     config,
-                    captured: source_captured,
+                    captured,
                 }))
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                     drop(shutdown_rx.await);
@@ -1040,94 +968,6 @@ impl MockServer {
 
     pub(crate) fn config_dir(&self) -> &Path {
         self.config_dir.path()
-    }
-
-    pub(crate) fn execute_sql_requests(&self) -> Vec<ExecuteSqlRequest> {
-        self.captured
-            .execute_sql
-            .lock()
-            .expect("execute_sql capture")
-            .clone()
-    }
-
-    pub(crate) fn discover_sources_requests(&self) -> Vec<DiscoverSourcesRequest> {
-        self.captured
-            .discover_sources
-            .lock()
-            .expect("discover_sources capture")
-            .clone()
-    }
-
-    pub(crate) fn list_sources_requests(&self) -> Vec<ListSourcesRequest> {
-        self.captured
-            .list_sources
-            .lock()
-            .expect("list_sources capture")
-            .clone()
-    }
-
-    pub(crate) fn list_catalog_requests(&self) -> Vec<ListCatalogRequest> {
-        self.captured
-            .list_catalog
-            .lock()
-            .expect("list_catalog capture")
-            .clone()
-    }
-
-    pub(crate) fn search_catalog_requests(&self) -> Vec<SearchCatalogRequest> {
-        self.captured
-            .search_catalog
-            .lock()
-            .expect("search_catalog capture")
-            .clone()
-    }
-
-    pub(crate) fn describe_table_requests(&self) -> Vec<DescribeTableRequest> {
-        self.captured
-            .describe_table
-            .lock()
-            .expect("describe_table capture")
-            .clone()
-    }
-
-    pub(crate) fn list_columns_requests(&self) -> Vec<ListColumnsRequest> {
-        self.captured
-            .list_columns
-            .lock()
-            .expect("list_columns capture")
-            .clone()
-    }
-
-    pub(crate) fn get_source_info_requests(&self) -> Vec<GetSourceInfoRequest> {
-        self.captured
-            .get_source_info
-            .lock()
-            .expect("get_source_info capture")
-            .clone()
-    }
-
-    pub(crate) fn validate_source_requests(&self) -> Vec<ValidateSourceRequest> {
-        self.captured
-            .validate_source
-            .lock()
-            .expect("validate_source capture")
-            .clone()
-    }
-
-    pub(crate) fn delete_source_requests(&self) -> Vec<DeleteSourceRequest> {
-        self.captured
-            .delete_source
-            .lock()
-            .expect("delete_source capture")
-            .clone()
-    }
-
-    pub(crate) fn import_source_requests(&self) -> Vec<ImportSourceRequest> {
-        self.captured
-            .import_source
-            .lock()
-            .expect("import_source capture")
-            .clone()
     }
 
     pub(crate) fn endpoint_uri(&self) -> &str {

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -38,105 +38,59 @@ pub enum SourceFailurePolicy {
     Abort,
 }
 
-/// Neutral error type for source-decoration failures.
-#[derive(Debug, thiserror::Error)]
-pub enum SourceDecoratorError {
-    /// The decorator was configured with invalid input.
-    #[error("{0}")]
-    InvalidInput(String),
-    /// The decorator could not proceed because a precondition was unmet.
-    #[error("{0}")]
-    FailedPrecondition(String),
+/// Defines one neutral two-variant error type for an engine extension point.
+///
+/// Every extension seam reports failures the same way, so the error shape is
+/// kept uniform on purpose: callers map `InvalidInput` to invalid-argument
+/// handling and `FailedPrecondition` to precondition handling.
+macro_rules! extension_error {
+    ($(#[$doc:meta])* $name:ident) => {
+        $(#[$doc])*
+        #[derive(Debug, thiserror::Error)]
+        pub enum $name {
+            /// The extension was configured with invalid input.
+            #[error("{0}")]
+            InvalidInput(String),
+            /// The extension could not proceed because a precondition was unmet.
+            #[error("{0}")]
+            FailedPrecondition(String),
+        }
+
+        impl $name {
+            #[must_use]
+            /// Builds an invalid-input error.
+            pub fn invalid_input(detail: impl Into<String>) -> Self {
+                Self::InvalidInput(detail.into())
+            }
+
+            #[must_use]
+            /// Builds a failed-precondition error.
+            pub fn failed_precondition(detail: impl Into<String>) -> Self {
+                Self::FailedPrecondition(detail.into())
+            }
+        }
+    };
 }
 
-impl SourceDecoratorError {
-    #[must_use]
-    /// Builds an invalid-input error.
-    pub fn invalid_input(detail: impl Into<String>) -> Self {
-        Self::InvalidInput(detail.into())
-    }
+extension_error!(
+    /// Neutral error type for source-decoration failures.
+    SourceDecoratorError
+);
 
-    #[must_use]
-    /// Builds a failed-precondition error.
-    pub fn failed_precondition(detail: impl Into<String>) -> Self {
-        Self::FailedPrecondition(detail.into())
-    }
-}
+extension_error!(
+    /// Neutral error type for query-result observer failures.
+    QueryResultObserverError
+);
 
-/// Neutral error type for query-result observer failures.
-#[derive(Debug, thiserror::Error)]
-pub enum QueryResultObserverError {
-    /// The observer was configured with invalid input.
-    #[error("{0}")]
-    InvalidInput(String),
-    /// The observer could not proceed because a precondition was unmet.
-    #[error("{0}")]
-    FailedPrecondition(String),
-}
+extension_error!(
+    /// Neutral error type for request-authenticator failures.
+    RequestAuthenticatorError
+);
 
-impl QueryResultObserverError {
-    #[must_use]
-    /// Builds an invalid-input error.
-    pub fn invalid_input(detail: impl Into<String>) -> Self {
-        Self::InvalidInput(detail.into())
-    }
-
-    #[must_use]
-    /// Builds a failed-precondition error.
-    pub fn failed_precondition(detail: impl Into<String>) -> Self {
-        Self::FailedPrecondition(detail.into())
-    }
-}
-
-/// Neutral error type for request-authenticator failures.
-#[derive(Debug, thiserror::Error)]
-pub enum RequestAuthenticatorError {
-    /// The authenticator was configured with invalid input.
-    #[error("{0}")]
-    InvalidInput(String),
-    /// The authenticator could not proceed because a precondition was unmet.
-    #[error("{0}")]
-    FailedPrecondition(String),
-}
-
-impl RequestAuthenticatorError {
-    #[must_use]
-    /// Builds an invalid-input error.
-    pub fn invalid_input(detail: impl Into<String>) -> Self {
-        Self::InvalidInput(detail.into())
-    }
-
-    #[must_use]
-    /// Builds a failed-precondition error.
-    pub fn failed_precondition(detail: impl Into<String>) -> Self {
-        Self::FailedPrecondition(detail.into())
-    }
-}
-
-/// Neutral error type for request-time source input resolution failures.
-#[derive(Debug, thiserror::Error)]
-pub enum SourceInputResolverError {
-    /// The resolver was configured with invalid input.
-    #[error("{0}")]
-    InvalidInput(String),
-    /// The resolver could not proceed because a precondition was unmet.
-    #[error("{0}")]
-    FailedPrecondition(String),
-}
-
-impl SourceInputResolverError {
-    #[must_use]
-    /// Builds an invalid-input error.
-    pub fn invalid_input(detail: impl Into<String>) -> Self {
-        Self::InvalidInput(detail.into())
-    }
-
-    #[must_use]
-    /// Builds a failed-precondition error.
-    pub fn failed_precondition(detail: impl Into<String>) -> Self {
-        Self::FailedPrecondition(detail.into())
-    }
-}
+extension_error!(
+    /// Neutral error type for request-time source input resolution failures.
+    SourceInputResolverError
+);
 
 /// Request-time source input-resolution context exposed to source input resolvers.
 ///


### PR DESCRIPTION
No-behavior-change refactors extracted from the DSL v4 identity work so
the feature PRs stay small and reviewable:

- hoist OAuth import progress plumbing from sources/manager.rs into
  credentials/oauth.rs (OAuthProgressEvent/OAuthProgressEventSender/
  authorize_with_progress) and add transport-level run_blocking_operation
  + oauth_operation_response_stream consumed by sources/service.rs
- dissolve ServerConfig into ServerBuilder fields and bundle
  start_server params into ServerServices
- bundle install params into InstallSourceRequest and OAuth session
  params into OAuthSessionCommon
- extract extension_error! macro for coral-engine composition error enums
- test-only refactors: fixture builders (ManagerFixture/V4ImportFixture/
  StoreFixture/import_request with struct-update syntax), 12->3
  table-driven input-validation consolidation in source_lifecycle_tests,
  OAuth test-session helpers, CLI mock-harness macros and e2e helpers