### PR TITLE
feat(api): identity and identity-spec protos with thin clients

### DIFF
--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -1,6 +1,22 @@
 //! Build script for the generated `coral-api` `protobuf` and `tonic` bindings.
 
 fn main() {
+    const PROTOS: &[&str] = &[
+        "proto/coral/v1/catalog.proto",
+        "proto/coral/v1/resources.proto",
+        "proto/coral/v1/feedback.proto",
+        "proto/coral/v1/identities.proto",
+        "proto/coral/v1/identity_specs.proto",
+        "proto/coral/v1/sources.proto",
+        "proto/coral/v1/query.proto",
+        "proto/coral/v1/traces.proto",
+        "proto/coral/v1/episode.proto",
+    ];
+    for proto in PROTOS {
+        println!("cargo:rerun-if-changed={proto}");
+    }
+    println!("cargo:rerun-if-changed=proto");
+
     let protoc = protoc_bin_vendored::protoc_bin_path().expect("vendored protoc");
     let mut config = tonic_prost_build::Config::new();
     config.protoc_executable(protoc);
@@ -11,18 +27,6 @@ fn main() {
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
-        .compile_with_config(
-            config,
-            &[
-                "proto/coral/v1/catalog.proto",
-                "proto/coral/v1/resources.proto",
-                "proto/coral/v1/feedback.proto",
-                "proto/coral/v1/sources.proto",
-                "proto/coral/v1/query.proto",
-                "proto/coral/v1/traces.proto",
-                "proto/coral/v1/episode.proto",
-            ],
-            &["proto"],
-        )
+        .compile_with_config(config, PROTOS, &["proto"])
         .expect("compile coral v1 protobuf");
 }

--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -1,0 +1,97 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/sources.proto";
+
+// Scope that owns stored provider-facing identity material.
+enum IdentityOwner {
+  reserved 2;
+  reserved "IDENTITY_OWNER_WORKSPACE";
+
+  // Identity owner was not specified.
+  IDENTITY_OWNER_UNSPECIFIED = 0;
+  // Identity material is owned by the current Coral user principal.
+  IDENTITY_OWNER_USER = 1;
+}
+
+// Stored provider-facing identity instance backed by an installed identity spec.
+message Identity {
+  // Stable identity name used by source identity bindings.
+  string name = 1;
+  // Installed identity spec name used to instantiate this identity.
+  string identity_spec = 2;
+  // Provider or issuer name copied from the identity spec.
+  string issuer = 3;
+  // Identity type, such as `oauth`, `fixed_token`, or `username_password`.
+  string identity_type = 4;
+  // Stored identity owner.
+  IdentityOwner owner = 5;
+  // Safe provider metadata, never token material.
+  repeated CredentialMetadata metadata = 6;
+}
+
+// Creates or replaces one OAuth identity owned by the request Coral user principal.
+message CreateUserOwnedIdentityWithOAuthRequest {
+  reserved 3;
+
+  // Stable identity name used by source identity bindings.
+  string name = 1;
+  // Installed OAuth identity spec name.
+  string identity_spec = 2;
+  // Legacy method-specific OAuth client values such as client ID or client
+  // secret. Inputs declared by the identity spec are owned by the installed
+  // identity spec and are supplied through AddIdentitySpecRequest instead.
+  repeated OAuthCredentialInput credential_inputs = 4;
+}
+
+// Creates or replaces one fixed-token identity owned by the request Coral user principal.
+message CreateUserOwnedIdentityWithFixedTokenRequest {
+  // Stable identity name used by source identity bindings.
+  string name = 1;
+  // Installed fixed-token identity spec name.
+  string identity_spec = 2;
+  // Bearer token to store for this identity.
+  string token = 3;
+}
+
+// Returns the created fixed-token identity.
+message CreateUserOwnedIdentityWithFixedTokenResponse {
+  // Stored identity.
+  Identity identity = 1;
+}
+
+// Streaming event emitted while creating an OAuth identity owned by a Coral user principal.
+message CreateUserOwnedIdentityWithOAuthResponse {
+  // Creation progress or completion event.
+  oneof event {
+    // Identity creation completed.
+    Identity identity = 1;
+    // OAuth authorization URL is ready.
+    OAuthCredentialAuthorization oauth_authorization = 2;
+    // OAuth credential retrieval completed.
+    OAuthCredentialCompleted oauth_completed = 3;
+  }
+}
+
+// Lists user-owned identities for the request Coral user principal.
+message ListUserOwnedIdentitiesRequest {}
+
+// Returns user-owned identities sorted by name.
+message ListUserOwnedIdentitiesResponse {
+  // Stored user-owned identities.
+  repeated Identity identities = 1;
+}
+
+// Stored identity APIs.
+service IdentityService {
+  // Creates or replaces one OAuth identity owned by the request Coral user principal.
+  rpc CreateUserOwnedIdentityWithOAuth(CreateUserOwnedIdentityWithOAuthRequest)
+      returns (stream CreateUserOwnedIdentityWithOAuthResponse);
+  // Creates or replaces one fixed-token identity owned by the request Coral user principal.
+  rpc CreateUserOwnedIdentityWithFixedToken(CreateUserOwnedIdentityWithFixedTokenRequest)
+      returns (CreateUserOwnedIdentityWithFixedTokenResponse);
+  // Lists user-owned identities.
+  rpc ListUserOwnedIdentities(ListUserOwnedIdentitiesRequest)
+      returns (ListUserOwnedIdentitiesResponse);
+}

--- a/crates/coral-api/proto/coral/v1/identity_specs.proto
+++ b/crates/coral-api/proto/coral/v1/identity_specs.proto
@@ -1,0 +1,97 @@
+syntax = "proto3";
+
+package coral.v1;
+
+// A global identity spec installed for all Coral workspaces.
+message IdentitySpec {
+  // Stable identity spec name.
+  string name = 1;
+  // Authored identity spec version string.
+  string version = 2;
+  // Human-readable description.
+  string description = 3;
+  // Provider or issuer name, such as `github`.
+  string issuer = 4;
+  // Identity type, such as `oauth`, `fixed_token`, or `username_password`.
+  string identity_type = 5;
+  // Canonical identity spec manifest YAML.
+  string manifest_yaml = 7;
+  reserved 6;
+}
+
+// Installs one global identity spec, or replaces an unused existing spec.
+// Existing specs referenced by stored identities may only be re-added with an
+// equivalent manifest.
+message AddIdentitySpecRequest {
+  // Raw identity spec manifest YAML to validate and install.
+  string manifest_yaml = 1;
+  // Setup input values owned by the installed identity spec. Secret values are
+  // persisted in Coral credential storage for later identity materialization.
+  repeated IdentitySpecInput inputs = 2;
+}
+
+// One setup input value for an installed identity spec.
+message IdentitySpecInput {
+  // Declared identity spec input key.
+  string key = 1;
+  // Input value. Secret values are only accepted on write requests and are not
+  // returned by identity spec read APIs.
+  string value = 2;
+}
+
+// Returns the installed identity spec.
+message AddIdentitySpecResponse {
+  // The installed identity spec.
+  IdentitySpec identity_spec = 1;
+  // Whether an existing spec with the same name was replaced.
+  bool replaced = 2;
+}
+
+// Lists all globally installed identity specs.
+message ListIdentitySpecsRequest {}
+
+// Returns global identity specs.
+message ListIdentitySpecsResponse {
+  // Installed identity specs sorted by name.
+  repeated IdentitySpec identity_specs = 1;
+}
+
+// Fetches one globally installed identity spec.
+message GetIdentitySpecRequest {
+  // Identity spec name.
+  string name = 1;
+}
+
+// Returns one globally installed identity spec.
+message GetIdentitySpecResponse {
+  // The installed identity spec.
+  IdentitySpec identity_spec = 1;
+}
+
+// Deletes one globally installed identity spec.
+message DeleteIdentitySpecRequest {
+  // Identity spec name.
+  string name = 1;
+  // Required when deleting the spec would orphan stored identity instances of
+  // any owner or identity type.
+  bool force = 2;
+}
+
+// Confirms identity spec deletion.
+message DeleteIdentitySpecResponse {
+  // Number of stored identities orphaned by deletion, across identity owners
+  // and identity types visible to the app.
+  uint32 orphaned_identities = 1;
+}
+
+// Global identity spec APIs.
+service IdentitySpecService {
+  // Installs one global identity spec, or replaces an unused existing spec.
+  rpc AddIdentitySpec(AddIdentitySpecRequest) returns (AddIdentitySpecResponse);
+  // Lists globally installed identity specs.
+  rpc ListIdentitySpecs(ListIdentitySpecsRequest) returns (ListIdentitySpecsResponse);
+  // Fetches one globally installed identity spec.
+  rpc GetIdentitySpec(GetIdentitySpecRequest) returns (GetIdentitySpecResponse);
+  // Deletes one globally installed identity spec.
+  rpc DeleteIdentitySpec(DeleteIdentitySpecRequest) returns (DeleteIdentitySpecResponse);
+}

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package coral.v1;
 
 import "coral/v1/catalog.proto";
+import "coral/v1/identity_specs.proto";
 import "coral/v1/resources.proto";
 
 // How one installed source entered Coral ownership.
@@ -24,6 +25,45 @@ enum SourceCredentialStorage {
   SOURCE_CREDENTIAL_STORAGE_FILE = 1;
   // Credential material is stored in the operating-system credential store.
   SOURCE_CREDENTIAL_STORAGE_KEYCHAIN = 2;
+}
+
+// Scope that owns provider-facing identity material for a source binding.
+enum SourceIdentityOwner {
+  // Source identity owner was not specified.
+  SOURCE_IDENTITY_OWNER_UNSPECIFIED = 0;
+  // Identity material is owned by the current Coral user principal.
+  SOURCE_IDENTITY_OWNER_USER = 1;
+  // Identity material is owned by the workspace and independent of a user principal.
+  SOURCE_IDENTITY_OWNER_WORKSPACE = 2;
+}
+
+// One workspace source-surface identity slot.
+message SourceIdentityBinding {
+  // DSL v4 surface id being configured.
+  string surface_id = 1;
+  // Stable identity name used by workspace-owned bindings.
+  //
+  // User-owned bindings leave this empty because the concrete identity is
+  // selected independently by each Coral user principal.
+  string identity = 2;
+  // Scope that owns the identity material.
+  SourceIdentityOwner owner = 3;
+  // Optional accepted identity id from the surface's identity_requirements for
+  // workspace-owned bindings.
+  //
+  // User-owned bindings leave this empty because the accepted branch is
+  // selected independently by each Coral user principal.
+  string accepted_identity = 4;
+}
+
+// One source-surface identity selection owned by the request user.
+message UserSourceIdentityBinding {
+  // DSL v4 surface id being configured.
+  string surface_id = 1;
+  // Stable user-owned identity name.
+  string identity = 2;
+  // Optional accepted identity id from the surface's identity_requirements.
+  string accepted_identity = 3;
 }
 
 // One configured non-secret source variable.
@@ -327,6 +367,34 @@ message ImportSourceRequest {
   repeated SourceSecret secrets = 4;
   // OAuth credential retrievals the app should run before validation and import.
   repeated OAuthCredentialRetrieval oauth_credential_retrievals = 5;
+  // Global identity specs authored in the same import bundle as this source.
+  // The app installs these specs for all workspaces before importing the
+  // source manifest. They do not create identity instances or source bindings.
+  repeated string identity_spec_manifest_yamls = 6;
+  // Workspace source-surface identity bindings to persist with the imported
+  // source. Omitted bindings preserve any existing bindings for the source.
+  repeated SourceIdentityBinding identity_bindings = 7;
+  // Source-surface identity selections to persist for the request user.
+  repeated UserSourceIdentityBinding user_identity_bindings = 8;
+  // When true, replace stored source identity bindings with identity_bindings
+  // exactly, including clearing them when identity_bindings is empty.
+  //
+  // When false, an empty identity_bindings list preserves existing bindings for
+  // compatibility with callers that cannot distinguish omitted and empty
+  // repeated fields.
+  bool replace_identity_bindings = 9;
+  // Setup input values for identity specs imported with this source. Values are
+  // grouped by identity spec name and stored as identity-spec-owned material,
+  // not as source or identity instance material.
+  repeated IdentitySpecImportInputs identity_spec_inputs = 10;
+}
+
+// Setup inputs for one identity spec imported with a source bundle.
+message IdentitySpecImportInputs {
+  // Identity spec name matching one identity_spec_manifest_yamls entry.
+  string identity_spec_name = 1;
+  // Setup input values owned by the installed identity spec.
+  repeated IdentitySpecInput inputs = 2;
 }
 
 // Streaming event emitted while importing a source.

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -252,6 +252,7 @@ impl SourceServiceApi for SourceService {
                 let span = tracing::Span::current();
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
                 let response_workspace_name = workspace_name.clone();
+                reject_unsupported_import_identity_fields(&request).map_err(app_status)?;
                 if request.oauth_credential_retrievals.is_empty() {
                     let command = ImportSourceCommand {
                         manifest_yaml: request.manifest_yaml,
@@ -342,6 +343,22 @@ impl SourceServiceApi for SourceService {
         )
         .await
     }
+}
+
+fn reject_unsupported_import_identity_fields(
+    request: &ImportSourceRequest,
+) -> Result<(), AppError> {
+    if request.identity_spec_manifest_yamls.is_empty()
+        && request.identity_bindings.is_empty()
+        && request.user_identity_bindings.is_empty()
+        && !request.replace_identity_bindings
+        && request.identity_spec_inputs.is_empty()
+    {
+        return Ok(());
+    }
+    Err(AppError::InvalidInput(
+        "ImportSourceRequest identity import fields are not supported by this build".to_string(),
+    ))
 }
 
 type CreateBundledSourceWithOAuthResponseStreamBox =

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -539,6 +539,14 @@ async fn import_source_invalid_inputs_return_invalid_argument() {
             },
             "source secret 'API_TOKEN' is repeated",
         ),
+        (
+            "unsupported identity import fields should fail",
+            ImportSourceRequest {
+                identity_spec_manifest_yamls: vec!["kind: identity".to_string()],
+                ..import_request(fixture_manifest_yaml(harness.temp_path()))
+            },
+            "identity import fields are not supported",
+        ),
     ];
 
     for (label, request, expected_message) in cases {

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -126,6 +126,7 @@ pub(crate) async fn import_source(
             variables,
             secrets,
             oauth_credential_retrievals: Vec::new(),
+            ..Default::default()
         }))
         .await?
         .into_inner();
@@ -220,6 +221,7 @@ pub(crate) async fn import_source_with_credentials(
             variables: inputs.variables,
             secrets: inputs.secrets,
             oauth_credential_retrievals: inputs.oauth_credential_retrievals,
+            ..Default::default()
         }))
         .await?;
     completion_from_oauth_stream(

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -3,6 +3,8 @@
 use coral_api::v1::Workspace;
 use coral_api::v1::catalog_service_client::CatalogServiceClient;
 use coral_api::v1::feedback_service_client::FeedbackServiceClient;
+use coral_api::v1::identity_service_client::IdentityServiceClient;
+use coral_api::v1::identity_spec_service_client::IdentitySpecServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
 use coral_api::{
@@ -32,6 +34,12 @@ type GrpcService = InstrumentedGrpcService<RawGrpcService>;
 /// Public source-management gRPC client.
 pub type SourceClient = SourceServiceClient<GrpcService>;
 
+/// Public global identity-spec gRPC client.
+pub type IdentitySpecClient = IdentitySpecServiceClient<GrpcService>;
+
+/// Public stored-identity gRPC client.
+pub type IdentityClient = IdentityServiceClient<GrpcService>;
+
 /// Public catalog-discovery gRPC client.
 pub type CatalogClient = CatalogServiceClient<GrpcService>;
 
@@ -47,6 +55,8 @@ pub type FeedbackClient = FeedbackServiceClient<GrpcService>;
 #[derive(Clone)]
 pub struct AppClient {
     source: SourceClient,
+    identity_spec: IdentitySpecClient,
+    identity: IdentityClient,
     catalog: CatalogClient,
     query: QueryClient,
     feedback: FeedbackClient,
@@ -96,6 +106,16 @@ impl AppClient {
             &grpc_endpoint,
             static_metadata.clone(),
         ));
+        let identity_spec_client = IdentitySpecClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ));
+        let identity_client = IdentityClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ));
         let catalog_client = CatalogClient::new(grpc_service(
             channel.clone(),
             &grpc_endpoint,
@@ -112,6 +132,8 @@ impl AppClient {
             FeedbackClient::new(grpc_service(channel, &grpc_endpoint, static_metadata));
         Ok(Self {
             source: source_client,
+            identity_spec: identity_spec_client,
+            identity: identity_client,
             catalog: catalog_client,
             query: query_client,
             feedback: feedback_client,
@@ -122,6 +144,18 @@ impl AppClient {
     /// Returns a cloned source-management client.
     pub fn source_client(&self) -> SourceClient {
         self.source.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned global identity-spec client.
+    pub fn identity_spec_client(&self) -> IdentitySpecClient {
+        self.identity_spec.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned stored-identity client.
+    pub fn identity_client(&self) -> IdentityClient {
+        self.identity.clone()
     }
 
     #[must_use]

--- a/crates/coral-client/src/error.rs
+++ b/crates/coral-client/src/error.rs
@@ -6,7 +6,7 @@ pub enum ClientError {
     /// Connecting the generated gRPC client failed.
     #[error(transparent)]
     Transport(#[from] tonic::transport::Error),
-    /// Caller-supplied static gRPC metadata was invalid.
+    /// Caller-supplied request metadata was invalid.
     #[error("invalid client metadata: {0}")]
     InvalidMetadata(String),
 }

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -40,8 +40,8 @@ use coral_api::v1::ExecuteSqlResponse;
 use serde_json::Value;
 
 pub use client::{
-    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, QueryClient, SourceClient,
-    default_workspace,
+    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, IdentityClient,
+    IdentitySpecClient, QueryClient, SourceClient, default_workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use sources::{SourceInputDecodeError, manifest_input_from_proto};

--- a/crates/coral-client/src/propagation.rs
+++ b/crates/coral-client/src/propagation.rs
@@ -14,7 +14,7 @@ static PROPAGATOR_INIT: OnceLock<()> = OnceLock::new();
 /// Installs `TraceContextPropagator` as the process-global text-map
 /// propagator the first time this is called.
 ///
-/// `ClientMetadataInterceptor` injects via the global propagator on every
+/// `TraceContextInterceptor` injects via the global propagator on every
 /// outgoing request. Without this, a client-only process (talking to a
 /// remote endpoint or a separate test server, with no local
 /// `ServerBuilder::start` to install one) would fall back to the default
@@ -119,18 +119,18 @@ mod tests {
 
     #[test]
     fn interceptor_injects_static_metadata() {
-        let metadata =
-            StaticClientMetadata::try_from_pairs([("x-coral-user-id", "saul")]).expect("metadata");
+        let metadata = StaticClientMetadata::try_from_pairs([("x-coral-cloud-member-id", "saul")])
+            .expect("metadata");
         let mut interceptor = ClientMetadataInterceptor::new(metadata);
 
         let request = interceptor
             .call(tonic::Request::new(()))
-            .expect("interceptor");
+            .expect("intercept request");
 
         assert_eq!(
             request
                 .metadata()
-                .get("x-coral-user-id")
+                .get("x-coral-cloud-member-id")
                 .and_then(|value| value.to_str().ok()),
             Some("saul")
         );

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -172,6 +172,11 @@ async fn add_demo_source(source_client: &mut SourceClient, manifest_yaml: String
             variables: Vec::new(),
             secrets: Vec::new(),
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
+            identity_bindings: Vec::new(),
+            user_identity_bindings: Vec::new(),
+            replace_identity_bindings: false,
         }))
         .await
         .expect("add source")

--- a/ui/buf.gen.yaml
+++ b/ui/buf.gen.yaml
@@ -11,5 +11,6 @@ inputs:
       - ../crates/coral-api/proto/coral/v1/resources.proto
       - ../crates/coral-api/proto/coral/v1/catalog.proto
       - ../crates/coral-api/proto/coral/v1/query.proto
+      - ../crates/coral-api/proto/coral/v1/identity_specs.proto
       - ../crates/coral-api/proto/coral/v1/sources.proto
       - ../crates/coral-api/proto/coral/v1/traces.proto


### PR DESCRIPTION
Wire contract for DSL v4 identities, with no server implementation yet
(services return UNIMPLEMENTED until the corresponding managers land):

- identity_specs.proto: IdentitySpecService CRUD over installed
  identity specs (manifest-yaml payloads, spec input material)
- identities.proto: IdentityService for user-owned identities —
  streaming OAuth creation, fixed-token creation, list
- sources.proto: ImportSourceRequest gains identity_spec_manifest_yamls,
  identity_spec_inputs, identity_bindings, user_identity_bindings,
  replace_identity_bindings so imports can carry identity setup
- coral-client: thin IdentitySpecClient/IdentityClient wrappers plus
  propagation/error module renames riding the client surface change
- coral-mcp test literals and coral-cli import call sites updated via
  struct-update syntax (no behavior change; fields default to empty)

buf lint clean.