### PR TITLE
feat(engine): request identity resolution seam with fail-closed header injection

### DIFF
--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use coral_engine::RuntimeSourceComponent;
+use coral_engine::{RuntimeHttpSourceComponent, RuntimeSourceComponent};
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::backends::mcp::{
     McpSourceManifest, McpTableFilterBinding, McpTableFunctionSpec, McpTableSpec,
@@ -31,11 +31,10 @@ pub(crate) fn runtime_components_for_v4_source(
         }
         match surface.surface_type {
             SurfaceType::OpenApi => {
-                components.push(RuntimeSourceComponent::Http(http_manifest_for_surface(
-                    manifest,
-                    materialized,
-                    &surface.id,
-                )?));
+                let http_manifest = http_manifest_for_surface(manifest, materialized, &surface.id)?;
+                components.push(RuntimeSourceComponent::Http(
+                    RuntimeHttpSourceComponent::new(http_manifest),
+                ));
             }
             SurfaceType::Mcp => {
                 components.push(RuntimeSourceComponent::Mcp(mcp_manifest_for_surface(

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -3,7 +3,10 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, OnceLock};
 
-use crate::{QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceInputResolver};
+use crate::{
+    QueryRuntimeContext, QuerySource, RequestAuthenticator, RequestIdentityResolver,
+    SourceInputResolver,
+};
 use async_trait::async_trait;
 use coral_spec::{
     ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
@@ -127,6 +130,7 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) source_variables: BTreeMap<String, String>,
     pub(crate) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
     pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    pub(crate) request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
 }
 
 /// Shared resources available while registering one batch of compiled sources.

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -15,8 +15,8 @@ use crate::backends::http::registration_checks::validate_source_scoped_http_conf
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::http::trace::HttpBodyCapture;
 use crate::{
-    RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver,
-    SourceInputResolverError,
+    RequestAuthenticator, RequestIdentityResolutionContext, RequestIdentityResolver,
+    SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
 };
 use coral_spec::backends::http::{HttpSourceManifest, RateLimitSpec};
 use coral_spec::{AuthSpec, HeaderSpec, ParsedTemplate, RequestSpec as ManifestRequestSpec};
@@ -35,6 +35,8 @@ pub(crate) struct HttpSourceClient {
     pub(super) request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolution_context: Option<SourceInputResolutionContext>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    pub(super) identity_context: Option<RequestIdentityResolutionContext>,
+    pub(super) request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
     pub(super) rate_limit: RateLimitSpec,
     pub(super) resolved_inputs: Arc<BTreeMap<String, String>>,
     pub(super) body_capture: HttpBodyCapture,
@@ -44,6 +46,8 @@ pub(crate) struct HttpSourceClient {
 pub(crate) struct HttpSourceClientRuntime {
     source_input_resolution_context: Option<SourceInputResolutionContext>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    identity_context: Option<RequestIdentityResolutionContext>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<OtelContext>,
     http: reqwest::Client,
@@ -53,6 +57,8 @@ impl HttpSourceClientRuntime {
     pub(crate) fn new(
         source_input_resolution_context: SourceInputResolutionContext,
         source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+        identity_context: Option<RequestIdentityResolutionContext>,
+        request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
         body_capture_max_bytes: Option<usize>,
         trace_context: Option<OtelContext>,
         http: reqwest::Client,
@@ -60,6 +66,8 @@ impl HttpSourceClientRuntime {
         Self {
             source_input_resolution_context: Some(source_input_resolution_context),
             source_input_resolver,
+            identity_context,
+            request_identity_resolver,
             body_capture_max_bytes,
             trace_context,
             http,
@@ -71,6 +79,8 @@ impl HttpSourceClientRuntime {
         Self {
             source_input_resolution_context: None,
             source_input_resolver: None,
+            identity_context: None,
+            request_identity_resolver: None,
             body_capture_max_bytes,
             trace_context: None,
             http,
@@ -182,6 +192,8 @@ impl HttpSourceClient {
             request_authenticators: request_authenticators.clone(),
             source_input_resolution_context: runtime.source_input_resolution_context,
             source_input_resolver: runtime.source_input_resolver,
+            identity_context: runtime.identity_context,
+            request_identity_resolver: runtime.request_identity_resolver,
             rate_limit: manifest.rate_limit.clone(),
             resolved_inputs: Arc::new(resolved_inputs),
             body_capture: HttpBodyCapture::new(runtime.body_capture_max_bytes),

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -160,6 +160,8 @@ pub(super) async fn fetch_rows(
                 auth: &client.auth,
                 request_headers: &client.request_headers,
                 request_authenticators: &client.request_authenticators,
+                identity_context: client.identity_context.as_ref(),
+                request_identity_resolver: client.request_identity_resolver.as_deref(),
                 trace_context: client.trace_context.as_ref(),
                 table_headers: &active_request.headers,
                 table_name: target.name(),

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -9,14 +9,19 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 use datafusion::prelude::SessionContext;
 
+#[cfg(test)]
+use crate::backends::BackendCompileRequest;
 use crate::backends::{
-    BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
-    BackendSchemaRegistration, CompiledBackendSource, RegisteredSource, RegisteredTable,
-    SourceFunctionProviderFactory, build_registered_inputs, build_registered_table,
-    build_registered_table_function, registered_columns_from_specs, required_filter_names,
+    BackendRegistration, BackendRegistrationContext, BackendSchemaRegistration,
+    CompiledBackendSource, RegisteredSource, RegisteredTable, SourceFunctionProviderFactory,
+    build_registered_inputs, build_registered_table, build_registered_table_function,
+    registered_columns_from_specs, required_filter_names,
     validate_lookup_key_filter_backend_support,
 };
-use crate::{RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver};
+use crate::{
+    RequestAuthenticator, RequestIdentityResolutionContext, RequestIdentityResolver,
+    SourceInputResolutionContext, SourceInputResolver,
+};
 use coral_spec::SourceBackend;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod auth;
@@ -50,26 +55,38 @@ struct HttpCompiledSource {
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<opentelemetry::Context>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    identity_context: Option<RequestIdentityResolutionContext>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct HttpCompileRuntime {
+    pub(crate) body_capture_max_bytes: Option<usize>,
+    pub(crate) trace_context: Option<opentelemetry::Context>,
+    pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    pub(crate) identity_context: Option<RequestIdentityResolutionContext>,
+    pub(crate) request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
 }
 
 pub(crate) fn compile_source(
     manifest: HttpSourceManifest,
     source_input_resolution: SourceInputResolutionContext,
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
-    body_capture_max_bytes: Option<usize>,
-    trace_context: Option<opentelemetry::Context>,
-    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    runtime: HttpCompileRuntime,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(HttpCompiledSource {
         manifest,
         source_input_resolution,
         request_authenticators,
-        body_capture_max_bytes,
-        trace_context,
-        source_input_resolver,
+        body_capture_max_bytes: runtime.body_capture_max_bytes,
+        trace_context: runtime.trace_context,
+        source_input_resolver: runtime.source_input_resolver,
+        identity_context: runtime.identity_context,
+        request_identity_resolver: runtime.request_identity_resolver,
     })
 }
 
+#[cfg(test)]
 pub(crate) fn compile_manifest(
     manifest: &HttpSourceManifest,
     request: &BackendCompileRequest<'_>,
@@ -78,9 +95,13 @@ pub(crate) fn compile_manifest(
         manifest.clone(),
         SourceInputResolutionContext::from_query_source(request.source),
         request.request_authenticators.clone(),
-        request.runtime_context.body_capture_max_bytes,
-        request.runtime_context.trace_context.clone(),
-        request.source_input_resolver.clone(),
+        HttpCompileRuntime {
+            body_capture_max_bytes: request.runtime_context.body_capture_max_bytes,
+            trace_context: request.runtime_context.trace_context.clone(),
+            source_input_resolver: request.source_input_resolver.clone(),
+            identity_context: None,
+            request_identity_resolver: request.request_identity_resolver.clone(),
+        },
     )
 }
 
@@ -115,6 +136,8 @@ impl CompiledBackendSource for HttpCompiledSource {
         let runtime = HttpSourceClientRuntime::new(
             self.source_input_resolution.clone(),
             self.source_input_resolver.clone(),
+            self.identity_context.clone(),
+            self.request_identity_resolver.clone(),
             self.body_capture_max_bytes,
             self.trace_context.clone(),
             http,

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -13,7 +13,6 @@ use tracing::Instrument as _;
 use tracing::field;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
-use crate::RequestAuthenticator;
 use crate::backends::http::ProviderQueryError;
 use crate::backends::http::auth::resolve_auth_headers;
 use crate::backends::http::error::{pagination_error, provider_error};
@@ -27,6 +26,10 @@ use crate::backends::http::trace::{
     trace_reqwest_error, trace_reqwest_error_type,
 };
 use crate::backends::shared::template::{RenderContext, resolve_value_source, value_to_string};
+use crate::{
+    RequestAuthenticator, RequestIdentityResolutionContext, RequestIdentityResolver,
+    RequestIdentityResolverError,
+};
 use coral_spec::backends::http::RateLimitSpec;
 use coral_spec::{AuthSpec, HeaderSpec, HttpMethod, ResponseBodyFormat};
 
@@ -36,6 +39,8 @@ pub(super) struct OutgoingHttpRequest<'a> {
     pub(super) auth: &'a AuthSpec,
     pub(super) request_headers: &'a [HeaderSpec],
     pub(super) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
+    pub(super) identity_context: Option<&'a RequestIdentityResolutionContext>,
+    pub(super) request_identity_resolver: Option<&'a dyn RequestIdentityResolver>,
     pub(super) trace_context: Option<&'a OtelContext>,
     pub(super) table_headers: &'a [HeaderSpec],
     pub(super) table_name: &'a str,
@@ -71,6 +76,8 @@ pub(super) async fn execute_request(
         auth,
         request_headers,
         request_authenticators,
+        identity_context,
+        request_identity_resolver,
         trace_context,
         table_headers,
         table_name,
@@ -189,7 +196,12 @@ pub(super) async fn execute_request(
         }
 
         body_capture.record_request(&request_span, request_id, body);
-        let built = match resolve_auth_headers(
+        if let (Some(identity_context), None) = (identity_context, request_identity_resolver) {
+            let error = missing_identity_resolver_error(identity_context);
+            record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
+            return Err(error);
+        }
+        let mut built = match resolve_auth_headers(
             auth,
             request,
             request_authenticators,
@@ -201,6 +213,29 @@ pub(super) async fn execute_request(
                 return Err(error);
             }
         };
+        if let (Some(identity_context), Some(resolver)) =
+            (identity_context, request_identity_resolver)
+        {
+            let identity_headers = match resolver
+                .resolve_identity_headers(identity_context, &built, render_context.resolved_inputs)
+                .await
+            {
+                Ok(headers) => headers,
+                Err(error) => {
+                    let error = identity_resolver_error(identity_context, &error);
+                    record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
+                    return Err(error);
+                }
+            };
+            for (name, value) in identity_headers {
+                if built.headers().contains_key(&name) {
+                    let error = identity_header_conflict_error(identity_context, &name);
+                    record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
+                    return Err(error);
+                }
+                built.headers_mut().insert(name, value);
+            }
+        }
         let response = match http.execute(built).instrument(request_span.clone()).await {
             Ok(response) => response,
             Err(error) => {
@@ -376,6 +411,39 @@ pub(super) async fn execute_request(
     }
 }
 
+fn identity_resolver_error(
+    identity_context: &RequestIdentityResolutionContext,
+    error: &RequestIdentityResolverError,
+) -> DataFusionError {
+    DataFusionError::Execution(format!(
+        "request identity resolver failed for source '{}' surface '{}': {error}",
+        identity_context.source_name(),
+        identity_context.surface_id()
+    ))
+}
+
+fn missing_identity_resolver_error(
+    identity_context: &RequestIdentityResolutionContext,
+) -> DataFusionError {
+    DataFusionError::Execution(format!(
+        "source '{}' surface '{}' declares identity_requirements but no request identity resolver is installed",
+        identity_context.source_name(),
+        identity_context.surface_id()
+    ))
+}
+
+fn identity_header_conflict_error(
+    identity_context: &RequestIdentityResolutionContext,
+    name: &HeaderName,
+) -> DataFusionError {
+    DataFusionError::Execution(format!(
+        "request identity resolver attempted to overwrite header '{}' for source '{}' surface '{}'",
+        name.as_str(),
+        identity_context.source_name(),
+        identity_context.surface_id()
+    ))
+}
+
 fn request_error(
     source_schema: &str,
     table_name: &str,
@@ -498,6 +566,8 @@ mod tests {
                 auth: &AuthSpec::default(),
                 request_headers: &[],
                 request_authenticators: &HashMap::new(),
+                identity_context: None,
+                request_identity_resolver: None,
                 trace_context: None,
                 table_headers: &[],
                 table_name: "items",

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -415,33 +415,45 @@ fn identity_resolver_error(
     identity_context: &RequestIdentityResolutionContext,
     error: &RequestIdentityResolverError,
 ) -> DataFusionError {
-    DataFusionError::Execution(format!(
+    let detail = format!(
         "request identity resolver failed for source '{}' surface '{}': {error}",
         identity_context.source_name(),
         identity_context.surface_id()
-    ))
+    );
+    match error {
+        RequestIdentityResolverError::InvalidInput(_) => DataFusionError::External(Box::new(
+            RequestIdentityResolverError::invalid_input(detail),
+        )),
+        RequestIdentityResolverError::FailedPrecondition(_) => DataFusionError::External(Box::new(
+            RequestIdentityResolverError::failed_precondition(detail),
+        )),
+    }
 }
 
 fn missing_identity_resolver_error(
     identity_context: &RequestIdentityResolutionContext,
 ) -> DataFusionError {
-    DataFusionError::Execution(format!(
-        "source '{}' surface '{}' declares identity_requirements but no request identity resolver is installed",
-        identity_context.source_name(),
-        identity_context.surface_id()
-    ))
+    DataFusionError::External(Box::new(RequestIdentityResolverError::failed_precondition(
+        format!(
+            "source '{}' surface '{}' declares identity_requirements but no request identity resolver is installed",
+            identity_context.source_name(),
+            identity_context.surface_id()
+        ),
+    )))
 }
 
 fn identity_header_conflict_error(
     identity_context: &RequestIdentityResolutionContext,
     name: &HeaderName,
 ) -> DataFusionError {
-    DataFusionError::Execution(format!(
-        "request identity resolver attempted to overwrite header '{}' for source '{}' surface '{}'",
-        name.as_str(),
-        identity_context.source_name(),
-        identity_context.surface_id()
-    ))
+    DataFusionError::External(Box::new(RequestIdentityResolverError::invalid_input(
+        format!(
+            "request identity resolver attempted to overwrite header '{}' for source '{}' surface '{}'",
+            name.as_str(),
+            identity_context.source_name(),
+            identity_context.surface_id()
+        ),
+    )))
 }
 
 fn request_error(

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -71,7 +71,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::{
-    CoreError, QuerySource, RequestAuthenticator, RuntimeSourceComponent, SourceInputResolver,
+    CoreError, QuerySource, RequestAuthenticator, RequestIdentityResolver, RuntimeSourceComponent,
+    SourceInputResolutionContext, SourceInputResolver,
 };
 #[cfg(test)]
 use coral_spec::ValidatedSourceManifest;
@@ -97,6 +98,7 @@ pub(crate) fn compile_query_source(
     runtime_context: &crate::QueryRuntimeContext,
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     if source.components().is_empty() {
         return Err(CoreError::FailedPrecondition(format!(
@@ -111,6 +113,7 @@ pub(crate) fn compile_query_source(
         source_variables: source.variables().clone(),
         request_authenticators,
         source_input_resolver,
+        request_identity_resolver,
     };
     let compiled_components = source
         .components()
@@ -128,7 +131,25 @@ fn compile_component(
     request: &BackendCompileRequest<'_>,
 ) -> Box<dyn CompiledBackendSource> {
     match component {
-        RuntimeSourceComponent::Http(manifest) => http::compile_manifest(manifest, request),
+        RuntimeSourceComponent::Http(component) => {
+            let identity_context =
+                component.identity_resolution_context(request.source.source_name());
+            http::compile_source(
+                component.manifest.clone(),
+                SourceInputResolutionContext::from_query_source_with_declared_inputs(
+                    request.source,
+                    &component.manifest.declared_inputs,
+                ),
+                request.request_authenticators.clone(),
+                http::HttpCompileRuntime {
+                    body_capture_max_bytes: request.runtime_context.body_capture_max_bytes,
+                    trace_context: request.runtime_context.trace_context.clone(),
+                    source_input_resolver: request.source_input_resolver.clone(),
+                    identity_context,
+                    request_identity_resolver: request.request_identity_resolver.clone(),
+                },
+            )
+        }
         RuntimeSourceComponent::File(manifest) => file::compile_manifest(manifest, request),
         RuntimeSourceComponent::Mcp(manifest) => mcp::compile_manifest(manifest, request),
     }
@@ -156,6 +177,7 @@ pub(crate) fn compile_source_manifest(
             source_variables,
             request_authenticators: &request_authenticators,
             source_input_resolver: None,
+            request_identity_resolver: None,
         },
     )
 }

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -8,9 +8,11 @@ use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use reqwest::header::{HeaderName, HeaderValue};
+use serde_json::Value;
 
 use crate::CoreError;
 use crate::contracts::QuerySource;
+use coral_spec::v4::IdentityRequirements;
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
 /// One source's table providers keyed by manifest table name.
@@ -110,9 +112,22 @@ impl SourceInputResolutionContext {
     #[must_use]
     /// Builds request input-resolution context from one selected query source.
     pub fn from_query_source(source: &QuerySource) -> Self {
+        Self::from_query_source_with_declared_inputs(source, source.declared_inputs())
+    }
+
+    #[must_use]
+    /// Builds request input-resolution context with a narrowed input contract.
+    ///
+    /// DSL v4 compiles each surface into its own executable HTTP source, so each
+    /// synthesized surface should expose only the inputs declared by that
+    /// surface rather than the union of every surface in the manifest.
+    pub fn from_query_source_with_declared_inputs(
+        source: &QuerySource,
+        declared_inputs: &[ManifestInputSpec],
+    ) -> Self {
         Self {
             source_name: Arc::from(source.source_name()),
-            declared_inputs: Arc::from(source.declared_inputs().to_vec()),
+            declared_inputs: Arc::from(declared_inputs.to_vec()),
             variables: Arc::new(source.variables().clone()),
             secrets: Arc::new(source.secrets().clone()),
         }
@@ -164,6 +179,81 @@ impl SourceInputResolutionContext {
     }
 }
 
+/// Request-time identity-resolution context exposed to request identity resolvers.
+#[derive(Debug, Clone)]
+pub struct RequestIdentityResolutionContext {
+    source_name: Arc<str>,
+    surface_id: Arc<str>,
+    identity_requirements: Arc<IdentityRequirements>,
+}
+
+impl RequestIdentityResolutionContext {
+    #[must_use]
+    /// Builds identity-resolution context for one executable source surface.
+    pub fn new(
+        source_name: impl Into<Arc<str>>,
+        surface_id: impl Into<Arc<str>>,
+        identity_requirements: IdentityRequirements,
+    ) -> Self {
+        Self {
+            source_name: source_name.into(),
+            surface_id: surface_id.into(),
+            identity_requirements: Arc::new(identity_requirements),
+        }
+    }
+
+    #[must_use]
+    /// Returns the canonical source name. This is also the SQL schema name.
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    #[must_use]
+    /// Returns the DSL v4 surface id whose request is being executed.
+    pub fn surface_id(&self) -> &str {
+        &self.surface_id
+    }
+
+    #[must_use]
+    /// Returns the identity requirements declared by the selected surface.
+    pub fn identity_requirements(&self) -> &IdentityRequirements {
+        &self.identity_requirements
+    }
+
+    #[must_use]
+    /// Returns whether a candidate identity satisfies the selected surface's
+    /// declared requirements.
+    ///
+    /// Accepted identity entries have OR semantics: the candidate is accepted if
+    /// it satisfies any single accepted entry. Within one accepted entry, the
+    /// candidate identity's spec id must be listed in `identity_specs`, and the
+    /// declared `audience` must be a *subset* of the candidate `audience`: every
+    /// required key/value must appear in the candidate, but the candidate may
+    /// carry additional audience entries. An accepted entry with an empty
+    /// `audience` therefore imposes no audience constraint.
+    ///
+    /// Audience values are compared by exact JSON equality, type included: a
+    /// required `443` (integer) does not match a candidate `443.0` (float) or
+    /// `"443"` (string). Resolvers must construct candidate audience values
+    /// with the same JSON types the manifest declares.
+    pub fn accepts_identity(
+        &self,
+        identity_spec_id: &str,
+        audience: &BTreeMap<String, Value>,
+    ) -> bool {
+        self.identity_requirements.accepts.iter().any(|accepted| {
+            accepted
+                .identity_specs
+                .iter()
+                .any(|accepted_spec_id| accepted_spec_id == identity_spec_id)
+                && accepted
+                    .audience
+                    .iter()
+                    .all(|(key, required_value)| audience.get(key) == Some(required_value))
+        })
+    }
+}
+
 /// Request-time HTTP authenticator registered through engine extensions.
 pub trait RequestAuthenticator: Send + Sync + std::fmt::Debug {
     /// Stable authenticator name used in diagnostics and manifest dispatch.
@@ -195,6 +285,31 @@ pub trait RequestAuthenticator: Send + Sync + std::fmt::Debug {
     ) -> Result<(), RequestAuthenticatorError> {
         Ok(())
     }
+}
+
+extension_error!(
+    /// Neutral error type for request identity-resolution failures.
+    RequestIdentityResolverError
+);
+
+/// Request-time resolver for app-managed identities.
+///
+/// The engine calls this only when a DSL v4 surface declares identity
+/// requirements and an outbound request is about to be sent.
+#[async_trait]
+pub trait RequestIdentityResolver: Send + Sync + std::fmt::Debug {
+    /// Returns identity headers to append to the outbound request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RequestIdentityResolverError`] when no suitable identity is
+    /// bound, the identity is unhealthy, or identity material cannot be minted.
+    async fn resolve_identity_headers(
+        &self,
+        identity: &RequestIdentityResolutionContext,
+        request: &reqwest::Request,
+        resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError>;
 }
 
 /// Request-time resolver for source inputs owned by the app layer.
@@ -308,9 +423,29 @@ mod tests {
     use std::collections::BTreeMap;
 
     use coral_spec::parse_source_manifest_value;
-    use serde_json::json;
+    use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
+    use serde_json::{Value, json};
 
-    use crate::{QuerySource, SourceInputResolutionContext};
+    use crate::{QuerySource, RequestIdentityResolutionContext, SourceInputResolutionContext};
+
+    /// One-requirement identity context accepting `identity_specs` for the
+    /// `github-rest-read` requirement with the given audience constraints.
+    fn identity_context(
+        identity_specs: &[&str],
+        audience: BTreeMap<String, Value>,
+    ) -> RequestIdentityResolutionContext {
+        RequestIdentityResolutionContext::new(
+            "github",
+            "github_rest",
+            IdentityRequirements {
+                accepts: vec![AcceptedIdentityRequirement {
+                    id: "github-rest-read".to_string(),
+                    identity_specs: identity_specs.iter().map(ToString::to_string).collect(),
+                    audience,
+                }],
+            },
+        )
+    }
 
     #[test]
     fn source_input_resolution_context_keeps_only_request_input_contract() {
@@ -397,5 +532,56 @@ mod tests {
             Some("fresh-token")
         );
         assert!(!refreshed.secrets().contains_key("OPTIONAL_TOKEN"));
+    }
+
+    #[test]
+    fn request_identity_context_matches_candidate_by_spec_id_and_audience() {
+        let audience = BTreeMap::from([("host".to_string(), json!("github.com"))]);
+        let context = identity_context(&["github_oauth", "github_pat"], audience.clone());
+
+        assert!(context.accepts_identity("github_oauth", &audience));
+        assert!(context.accepts_identity("github_pat", &audience));
+        assert!(!context.accepts_identity("gitlab_oauth", &audience));
+    }
+
+    #[test]
+    fn request_identity_context_audience_is_subset_and_json_type_exact() {
+        let context = identity_context(
+            &["github_oauth"],
+            BTreeMap::from([("port".to_string(), json!(443))]),
+        );
+        let accepts =
+            |audience: &BTreeMap<String, Value>| context.accepts_identity("github_oauth", audience);
+
+        // Required entry present plus an extra candidate entry still matches
+        // (declared audience is a subset of the candidate audience).
+        assert!(accepts(&BTreeMap::from([
+            ("port".to_string(), json!(443)),
+            ("tenant".to_string(), json!("acme")),
+        ])));
+        // Exact JSON-type equality: float and string do not match the integer.
+        assert!(!accepts(&BTreeMap::from([(
+            "port".to_string(),
+            json!(443.0)
+        )])));
+        assert!(!accepts(&BTreeMap::from([(
+            "port".to_string(),
+            json!("443")
+        )])));
+        // Missing required key does not match.
+        assert!(!accepts(&BTreeMap::new()));
+    }
+
+    #[test]
+    fn request_identity_context_empty_audience_imposes_no_constraint() {
+        let context = identity_context(&["github_oauth"], BTreeMap::new());
+
+        // An accepted shape with no declared audience matches any candidate
+        // audience, but identity spec id still must match exactly.
+        assert!(context.accepts_identity(
+            "github_oauth",
+            &BTreeMap::from([("host".to_string(), json!("github.com"))])
+        ));
+        assert!(!context.accepts_identity("gitlab_oauth", &BTreeMap::new()));
     }
 }

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -13,8 +13,8 @@ pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
     DependentJoinConfig, DependentJoinSourceConfig, EffectiveDependentJoinConfig, QueryExecution,
     QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTestFailure,
-    QueryTestResult, QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage,
-    SourceValidationReport,
+    QueryTestResult, QueryTestSuccess, RuntimeHttpSourceComponent, RuntimeIdentityRequirements,
+    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -10,11 +10,12 @@ use arrow::record_batch::RecordBatch;
 use coral_spec::backends::file::FileSourceManifest;
 use coral_spec::backends::http::HttpSourceManifest;
 use coral_spec::backends::mcp::McpSourceManifest;
+use coral_spec::v4::IdentityRequirements;
 use coral_spec::{ManifestInputSpec, ValidatedSourceManifest};
 use opentelemetry::Context as OtelContext;
 
 use super::ColumnInfo;
-use crate::EngineExtensions;
+use crate::{EngineExtensions, RequestIdentityResolutionContext, RequestIdentityResolver};
 
 /// One managed source selected into the current query runtime.
 #[derive(Debug, Clone)]
@@ -50,11 +51,72 @@ pub struct RuntimeSourcePackage {
 #[derive(Debug, Clone)]
 pub enum RuntimeSourceComponent {
     /// HTTP-backed runtime component.
-    Http(HttpSourceManifest),
+    Http(RuntimeHttpSourceComponent),
     /// File-backed runtime component.
     File(FileSourceManifest),
     /// MCP-backed runtime component.
     Mcp(McpSourceManifest),
+}
+
+/// Backend-ready HTTP component plus optional app-owned runtime metadata.
+#[derive(Debug, Clone)]
+pub struct RuntimeHttpSourceComponent {
+    /// HTTP runtime manifest executed by the engine.
+    pub manifest: HttpSourceManifest,
+    /// Request identity requirements associated with this component.
+    pub identity_requirements: Option<RuntimeIdentityRequirements>,
+}
+
+/// Identity requirements attached to one app-assembled runtime component.
+#[derive(Debug, Clone)]
+pub struct RuntimeIdentityRequirements {
+    /// Authored DSL v4 surface id that produced this runtime component.
+    pub surface_id: String,
+    /// Accepted request identities for this runtime component.
+    pub requirements: IdentityRequirements,
+}
+
+impl RuntimeHttpSourceComponent {
+    #[must_use]
+    /// Builds an HTTP runtime component without request identity requirements.
+    pub fn new(manifest: HttpSourceManifest) -> Self {
+        Self {
+            manifest,
+            identity_requirements: None,
+        }
+    }
+
+    #[must_use]
+    /// Builds an HTTP runtime component with request identity requirements.
+    pub fn with_identity_requirements(
+        manifest: HttpSourceManifest,
+        surface_id: impl Into<String>,
+        requirements: IdentityRequirements,
+    ) -> Self {
+        Self {
+            manifest,
+            identity_requirements: Some(RuntimeIdentityRequirements {
+                surface_id: surface_id.into(),
+                requirements,
+            }),
+        }
+    }
+
+    /// Builds the request-time identity-resolution context for this component,
+    /// or `None` when the component declares no identity requirements.
+    #[must_use]
+    pub fn identity_resolution_context(
+        &self,
+        source_name: impl Into<Arc<str>>,
+    ) -> Option<RequestIdentityResolutionContext> {
+        self.identity_requirements.as_ref().map(|identity| {
+            RequestIdentityResolutionContext::new(
+                source_name,
+                identity.surface_id.clone(),
+                identity.requirements.clone(),
+            )
+        })
+    }
 }
 
 impl QuerySource {
@@ -199,7 +261,7 @@ impl RuntimeSourceComponent {
     /// Returns the runtime schema name declared by this component.
     pub fn source_name(&self) -> &str {
         match self {
-            Self::Http(manifest) => &manifest.common.name,
+            Self::Http(component) => &component.manifest.common.name,
             Self::File(manifest) => &manifest.common.name,
             Self::Mcp(manifest) => &manifest.common.name,
         }
@@ -208,7 +270,9 @@ impl RuntimeSourceComponent {
 
 fn components_from_manifest(source_spec: &ValidatedSourceManifest) -> Vec<RuntimeSourceComponent> {
     if let Some(http) = source_spec.as_http() {
-        return vec![RuntimeSourceComponent::Http(http.clone())];
+        return vec![RuntimeSourceComponent::Http(
+            RuntimeHttpSourceComponent::new(http.clone()),
+        )];
     }
     if let Some(file) = source_spec.as_file() {
         return vec![RuntimeSourceComponent::File(file.clone())];
@@ -375,6 +439,8 @@ pub struct QueryRuntimeConfig {
     pub context: QueryRuntimeContext,
     /// Optional engine extensions for this runtime build.
     pub extensions: EngineExtensions,
+    /// Request-time resolver for app-selected source identities.
+    pub request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
     /// Runtime policy for dependent predicate pushdown.
     pub dependent_join: DependentJoinConfig,
 }
@@ -386,8 +452,19 @@ impl QueryRuntimeConfig {
         Self {
             context,
             extensions,
+            request_identity_resolver: None,
             dependent_join: DependentJoinConfig::default(),
         }
+    }
+
+    /// Installs an app-selected request identity resolver for this runtime.
+    #[must_use]
+    pub fn with_request_identity_resolver(
+        mut self,
+        resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    ) -> Self {
+        self.request_identity_resolver = resolver;
+        self
     }
 }
 

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -63,16 +63,17 @@ mod runtime;
 pub use backends::mcp::discover_tool_catalog as discover_mcp_tool_catalog;
 pub use composition::{
     EngineExtensions, QueryResultObserver, QueryResultObserverError, RequestAuthenticator,
-    RequestAuthenticatorError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
+    RequestAuthenticatorError, RequestIdentityResolutionContext, RequestIdentityResolver,
+    RequestIdentityResolverError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
     SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError, SourceTables,
 };
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
     DescribeTableInfo, EffectiveDependentJoinConfig, QueryExecution, QueryPlan, QueryRuntimeConfig,
     QueryRuntimeContext, QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess,
-    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport, StatusCode,
-    StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
-    TableFunctionResultColumnInfo, TableInfo,
+    RuntimeHttpSourceComponent, RuntimeIdentityRequirements, RuntimeSourceComponent,
+    RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
+    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// High-level query operations for the local query engine.

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -12,7 +12,8 @@ use crate::backends::mcp::McpProviderQueryError;
 use crate::contracts::{ColumnParts, StructuredQueryError, TableRefParts};
 use crate::runtime::dependent_join::error::DependentJoinError;
 use crate::{
-    CoreError, QueryResultObserverError, SourceDecoratorError, SourceInputResolverError, TableInfo,
+    CoreError, QueryResultObserverError, RequestIdentityResolverError, SourceDecoratorError,
+    SourceInputResolverError, TableInfo,
 };
 
 const DATAFUSION_DEFAULT_CATALOG: &str = "datafusion";
@@ -61,6 +62,9 @@ pub(crate) fn datafusion_to_core_with_sql_and_table_functions(
             if let Some(source_input_error) = inner.downcast_ref::<SourceInputResolverError>() {
                 return source_input_resolver_error_to_core(source_input_error);
             }
+            if let Some(identity_error) = inner.downcast_ref::<RequestIdentityResolverError>() {
+                return request_identity_resolver_error_to_core(identity_error);
+            }
             if let Some(dependent_join_error) = inner.downcast_ref::<DependentJoinError>() {
                 return dependent_join_error.to_core_error();
             }
@@ -94,6 +98,17 @@ fn source_input_resolver_error_to_core(error: &SourceInputResolverError) -> Core
     match error {
         SourceInputResolverError::InvalidInput(detail) => CoreError::InvalidInput(detail.clone()),
         SourceInputResolverError::FailedPrecondition(detail) => {
+            CoreError::FailedPrecondition(detail.clone())
+        }
+    }
+}
+
+fn request_identity_resolver_error_to_core(error: &RequestIdentityResolverError) -> CoreError {
+    match error {
+        RequestIdentityResolverError::InvalidInput(detail) => {
+            CoreError::InvalidInput(detail.clone())
+        }
+        RequestIdentityResolverError::FailedPrecondition(detail) => {
             CoreError::FailedPrecondition(detail.clone())
         }
     }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -33,8 +33,8 @@ use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
     CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, QueryExecution, QueryPlan,
     QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext,
-    QuerySource, RequestAuthenticator, SourceDecorator, SourceInputResolver, TableFunctionInfo,
-    TableInfo,
+    QuerySource, RequestAuthenticator, RequestIdentityResolver, SourceDecorator,
+    SourceInputResolver, TableFunctionInfo, TableInfo,
 };
 
 pub(crate) struct QueryRuntimeAdapter {
@@ -58,6 +58,7 @@ struct FallbackRuntimeConfig {
     dependent_join: DependentJoinConfig,
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
 }
 
 struct RegisteredRuntime {
@@ -89,6 +90,7 @@ async fn build_runtime_inner(
         context: runtime_context,
         dependent_join,
         mut extensions,
+        request_identity_resolver,
     } = runtime;
     let request_authenticators = extensions.request_authenticators.clone();
     let source_input_resolver = extensions.source_input_resolver.clone();
@@ -106,6 +108,7 @@ async fn build_runtime_inner(
             dependent_join: dependent_join.clone(),
             request_authenticators: request_authenticators.clone(),
             source_input_resolver: source_input_resolver.clone(),
+            request_identity_resolver: request_identity_resolver.clone(),
         })
     });
 
@@ -114,6 +117,7 @@ async fn build_runtime_inner(
         &runtime_context,
         &request_authenticators,
         source_input_resolver,
+        request_identity_resolver,
         extensions.source_decorators.as_mut_slice(),
         &dependent_join,
     )
@@ -134,6 +138,7 @@ async fn build_registered_runtime(
     runtime_context: &QueryRuntimeContext,
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
     source_decorators: &mut [Box<dyn SourceDecorator>],
     dependent_join: &DependentJoinConfig,
 ) -> Result<RegisteredRuntime, CoreError> {
@@ -144,6 +149,7 @@ async fn build_registered_runtime(
         runtime_context,
         request_authenticators,
         source_input_resolver,
+        request_identity_resolver,
         source_decorators,
     )
     .await?;
@@ -228,6 +234,7 @@ async fn register_runtime_sources(
     runtime_context: &QueryRuntimeContext,
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
     source_decorators: &mut [Box<dyn SourceDecorator>],
 ) -> Result<crate::runtime::registry::SourceRegistrationResult, CoreError> {
     let mut source_candidates = Vec::new();
@@ -237,6 +244,7 @@ async fn register_runtime_sources(
             runtime_context,
             request_authenticators,
             source_input_resolver.clone(),
+            request_identity_resolver.clone(),
         ) {
             Ok(compiled) => {
                 source_candidates.push(SourceRegistrationCandidate::Compiled(
@@ -502,6 +510,7 @@ impl FallbackRuntimeConfig {
             &self.runtime_context,
             &self.request_authenticators,
             self.source_input_resolver.clone(),
+            self.request_identity_resolver.clone(),
             source_decorators.as_mut_slice(),
             &self.dependent_join.without_rewrites(),
         )

--- a/crates/coral-engine/tests/engine.rs
+++ b/crates/coral-engine/tests/engine.rs
@@ -33,3 +33,5 @@ mod query_result_observer_tests;
 mod structured_error_tests;
 #[path = "engine/test_source_tests.rs"]
 mod test_source_tests;
+#[path = "engine/v4_tests.rs"]
+mod v4_tests;

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 
-use coral_engine::{CoralQuery, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage};
+use coral_engine::{
+    CoralQuery, QuerySource, RuntimeHttpSourceComponent, RuntimeSourceComponent,
+    RuntimeSourcePackage,
+};
 use coral_spec::backends::http::HttpSourceManifest;
 use coral_spec::parse_source_manifest_yaml;
 use coral_spec::{FilterMode, FilterSpec};
@@ -38,8 +41,8 @@ async fn multi_component_source_executes_across_component_tables() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             components: vec![
-                RuntimeSourceComponent::Http(issues),
-                RuntimeSourceComponent::Http(pulls),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(issues)),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(pulls)),
             ],
         },
         BTreeMap::new(),
@@ -124,8 +127,8 @@ async fn multi_component_source_can_register_multiple_schemas() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             components: vec![
-                RuntimeSourceComponent::Http(issues),
-                RuntimeSourceComponent::Http(pulls),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(issues)),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(pulls)),
             ],
         },
         BTreeMap::new(),
@@ -162,12 +165,14 @@ async fn selected_sources_reject_runtime_schema_collisions() {
             description: "Composite GitHub runtime package".to_string(),
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
-            components: vec![RuntimeSourceComponent::Http(http_component(
-                &server.uri(),
-                "github_v4_rest",
-                "issues",
-                "/issues",
-            ))],
+            components: vec![RuntimeSourceComponent::Http(
+                RuntimeHttpSourceComponent::new(http_component(
+                    &server.uri(),
+                    "github_v4_rest",
+                    "issues",
+                    "/issues",
+                )),
+            )],
         },
         BTreeMap::new(),
         BTreeMap::new(),
@@ -180,12 +185,14 @@ async fn selected_sources_reject_runtime_schema_collisions() {
             description: "Conflicting runtime package".to_string(),
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
-            components: vec![RuntimeSourceComponent::Http(http_component(
-                &server.uri(),
-                "github_v4_rest",
-                "pulls",
-                "/pulls",
-            ))],
+            components: vec![RuntimeSourceComponent::Http(
+                RuntimeHttpSourceComponent::new(http_component(
+                    &server.uri(),
+                    "github_v4_rest",
+                    "pulls",
+                    "/pulls",
+                )),
+            )],
         },
         BTreeMap::new(),
         BTreeMap::new(),
@@ -217,8 +224,8 @@ async fn validate_source_reports_only_component_schemas_for_multi_schema_source(
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             components: vec![
-                RuntimeSourceComponent::Http(issues),
-                RuntimeSourceComponent::Http(pulls),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(issues)),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(pulls)),
             ],
         },
         BTreeMap::new(),

--- a/crates/coral-engine/tests/engine/v4_tests.rs
+++ b/crates/coral-engine/tests/engine/v4_tests.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use coral_engine::{
-    CoralQuery, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    CoralQuery, CoreError, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
     RequestIdentityResolutionContext, RequestIdentityResolver, RequestIdentityResolverError,
     RuntimeHttpSourceComponent, RuntimeSourceComponent, RuntimeSourcePackage,
 };
@@ -120,6 +120,23 @@ impl RequestIdentityResolver for RecordingIdentityResolver {
     }
 }
 
+#[derive(Debug)]
+struct FailingIdentityResolver;
+
+#[async_trait::async_trait]
+impl RequestIdentityResolver for FailingIdentityResolver {
+    async fn resolve_identity_headers(
+        &self,
+        _identity: &RequestIdentityResolutionContext,
+        _request: &reqwest::Request,
+        _resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
+        Err(RequestIdentityResolverError::failed_precondition(
+            "no healthy identity is bound",
+        ))
+    }
+}
+
 /// Engine runtime with a [`RecordingIdentityResolver`] writing into `observed`.
 fn recording_identity_runtime(observed: &ObservedCell) -> QueryRuntimeConfig {
     QueryRuntimeConfig::new(QueryRuntimeContext::default(), EngineExtensions::default())
@@ -173,12 +190,35 @@ async fn v4_identity_requirements_fail_closed_without_resolver() {
         .await
         .expect_err("identity-backed query without resolver should fail");
 
-    assert!(
-        error.to_string().contains(
-            "declares identity_requirements but no request identity resolver is installed"
+    match error {
+        CoreError::FailedPrecondition(detail) => assert!(
+            detail.contains(
+                "declares identity_requirements but no request identity resolver is installed"
+            ),
+            "unexpected error: {detail}"
         ),
-        "unexpected error: {error}"
-    );
+        other => panic!("expected CoreError::FailedPrecondition, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn v4_identity_resolver_failure_preserves_failed_precondition() {
+    let runtime =
+        QueryRuntimeConfig::new(QueryRuntimeContext::default(), EngineExtensions::default())
+            .with_request_identity_resolver(Some(Arc::new(FailingIdentityResolver)));
+    let source = github_v4_source("http://127.0.0.1:1", identity_requirements_yaml());
+
+    let error = CoralQuery::execute_sql(&[source], runtime, github_issues_sql())
+        .await
+        .expect_err("identity resolver should fail");
+
+    match error {
+        CoreError::FailedPrecondition(detail) => assert!(
+            detail.contains("no healthy identity is bound"),
+            "unexpected error: {detail}"
+        ),
+        other => panic!("expected CoreError::FailedPrecondition, got {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -196,12 +236,15 @@ async fn v4_identity_resolver_cannot_overwrite_existing_headers() {
         .await
         .expect_err("identity resolver should not overwrite existing header");
 
-    assert!(
-        error
-            .to_string()
-            .contains("request identity resolver attempted to overwrite header 'x-coral-identity'"),
-        "unexpected error: {error}"
-    );
+    match error {
+        CoreError::InvalidInput(detail) => assert!(
+            detail.contains(
+                "request identity resolver attempted to overwrite header 'x-coral-identity'"
+            ),
+            "unexpected error: {detail}"
+        ),
+        other => panic!("expected CoreError::InvalidInput, got {other:?}"),
+    }
 }
 
 /// Builds an app-style v4 runtime source for the GitHub openapi fixture;

--- a/crates/coral-engine/tests/engine/v4_tests.rs
+++ b/crates/coral-engine/tests/engine/v4_tests.rs
@@ -1,0 +1,356 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use coral_engine::{
+    CoralQuery, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    RequestIdentityResolutionContext, RequestIdentityResolver, RequestIdentityResolverError,
+    RuntimeHttpSourceComponent, RuntimeSourceComponent, RuntimeSourcePackage,
+};
+use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
+use coral_spec::parse_source_manifest_yaml;
+use coral_spec::v4::{
+    IrExecutionAttachment, ProjectionKind, ProjectionVisibility, V4SourceManifest, V4Surface,
+    generate_projection_catalog, import_openapi_surface, projection_arg_specs,
+    projection_column_specs, projection_filter_specs, request_spec_for_projection,
+};
+use coral_spec::{SourceManifestCommon, SourceTableFunctionSpec, TableCommon};
+use reqwest::header::{HeaderName, HeaderValue};
+use serde_json::{Value, json};
+use wiremock::matchers::{header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::harness::{execution_to_rows, test_runtime};
+
+/// Mounts the GitHub issues endpoint returning one issue, optionally requiring
+/// an identity header on the request.
+async fn mount_issues_endpoint(
+    server: &MockServer,
+    identity_header: Option<(&str, &str)>,
+    issue: Value,
+) {
+    let mut mock = Mock::given(method("GET"))
+        .and(path("/repos/octocat/Hello-World/issues"))
+        .and(query_param("state", "open"));
+    if let Some((name, value)) = identity_header {
+        mock = mock.and(header(name, value));
+    }
+    mock.respond_with(ResponseTemplate::new(200).set_body_json(json!([issue])))
+        .mount(server)
+        .await;
+}
+
+fn issue_json(id: u64, number: u64, title: &str) -> Value {
+    json!({
+        "id": id,
+        "number": number,
+        "title": title,
+        "state": "open",
+        "html_url": format!("https://github.com/octocat/Hello-World/issues/{number}")
+    })
+}
+
+#[tokio::test]
+async fn v4_openapi_projection_executes_generated_table() {
+    let server = MockServer::start().await;
+    mount_issues_endpoint(&server, None, issue_json(1, 42, "Found it")).await;
+    let source = github_v4_source(&server.uri(), "");
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(&[source], test_runtime(), github_issues_sql())
+            .await
+            .expect("query should execute"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({"id": 1, "number": 42, "title": "Found it"})]
+    );
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ObservedIdentityResolution {
+    source_name: String,
+    surface_id: String,
+    requirement_id: String,
+    api_base: String,
+    request_path: String,
+    accepts_candidate: bool,
+}
+
+type ObservedCell = Arc<Mutex<Option<ObservedIdentityResolution>>>;
+
+#[derive(Debug)]
+struct RecordingIdentityResolver {
+    observed: ObservedCell,
+    header_name: HeaderName,
+}
+
+#[async_trait::async_trait]
+impl RequestIdentityResolver for RecordingIdentityResolver {
+    async fn resolve_identity_headers(
+        &self,
+        identity: &RequestIdentityResolutionContext,
+        request: &reqwest::Request,
+        resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
+        let audience = BTreeMap::from([("host".to_string(), json!("github.com"))]);
+        let accepts_candidate = identity.accepts_identity("github_oauth", &audience);
+        let requirement_id = identity
+            .identity_requirements()
+            .accepts
+            .first()
+            .expect("accepted identity requirement")
+            .id
+            .clone();
+        *self.observed.lock().expect("observed identity lock") = Some(ObservedIdentityResolution {
+            source_name: identity.source_name().to_string(),
+            surface_id: identity.surface_id().to_string(),
+            requirement_id,
+            api_base: resolved_inputs
+                .get("API_BASE")
+                .expect("resolved API_BASE")
+                .clone(),
+            request_path: request.url().path().to_string(),
+            accepts_candidate,
+        });
+        Ok(vec![(
+            self.header_name.clone(),
+            HeaderValue::from_static("member-token"),
+        )])
+    }
+}
+
+/// Engine runtime with a [`RecordingIdentityResolver`] writing into `observed`.
+fn recording_identity_runtime(observed: &ObservedCell) -> QueryRuntimeConfig {
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), EngineExtensions::default())
+        .with_request_identity_resolver(Some(Arc::new(RecordingIdentityResolver {
+            observed: Arc::clone(observed),
+            header_name: HeaderName::from_static("x-coral-identity"),
+        })))
+}
+
+#[tokio::test]
+async fn v4_identity_requirements_call_resolver_and_inject_headers() {
+    let server = MockServer::start().await;
+    mount_issues_endpoint(
+        &server,
+        Some(("x-coral-identity", "member-token")),
+        issue_json(7, 99, "Identity routed"),
+    )
+    .await;
+    let observed: ObservedCell = Arc::new(Mutex::new(None));
+    let runtime = recording_identity_runtime(&observed);
+    let source = github_v4_source(&server.uri(), identity_requirements_yaml());
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(&[source], runtime, github_issues_sql())
+            .await
+            .expect("identity-backed query should execute"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({"id": 7, "number": 99, "title": "Identity routed"})]
+    );
+    assert_eq!(
+        *observed.lock().expect("observed identity lock"),
+        Some(ObservedIdentityResolution {
+            source_name: "github_v4".to_string(),
+            surface_id: "rest".to_string(),
+            requirement_id: "github-rest-read".to_string(),
+            api_base: server.uri(),
+            request_path: "/repos/octocat/Hello-World/issues".to_string(),
+            accepts_candidate: true,
+        })
+    );
+}
+
+#[tokio::test]
+async fn v4_identity_requirements_fail_closed_without_resolver() {
+    let source = github_v4_source("http://127.0.0.1:1", identity_requirements_yaml());
+
+    let error = CoralQuery::execute_sql(&[source], test_runtime(), github_issues_sql())
+        .await
+        .expect_err("identity-backed query without resolver should fail");
+
+    assert!(
+        error.to_string().contains(
+            "declares identity_requirements but no request identity resolver is installed"
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn v4_identity_resolver_cannot_overwrite_existing_headers() {
+    let runtime = recording_identity_runtime(&Arc::new(Mutex::new(None)));
+    let source = github_v4_source(
+        "http://127.0.0.1:1",
+        &format!(
+            "{}    request_headers:\n      - {{name: x-coral-identity, from: literal, value: existing-token}}\n",
+            identity_requirements_yaml()
+        ),
+    );
+
+    let error = CoralQuery::execute_sql(&[source], runtime, github_issues_sql())
+        .await
+        .expect_err("identity resolver should not overwrite existing header");
+
+    assert!(
+        error
+            .to_string()
+            .contains("request identity resolver attempted to overwrite header 'x-coral-identity'"),
+        "unexpected error: {error}"
+    );
+}
+
+/// Builds an app-style v4 runtime source for the GitHub openapi fixture;
+/// `surface_extra` lines are appended under the openapi surface entry.
+fn github_v4_source(base_url: &str, surface_extra: &str) -> QuerySource {
+    let manifest = parse_source_manifest_yaml(&format!(
+        "name: github_v4\ndsl_version: 4\nsurfaces:\n  - id: rest\n    type: openapi\n    file: /tmp/github-openapi.yaml\n    sha256: 0000000000000000000000000000000000000000000000000000000000000000\n    inputs:\n      API_BASE: {{kind: variable, default: '{base_url}'}}\n    base_url: \"{{{{input.API_BASE}}}}\"\n{surface_extra}\n"
+    ))
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let openapi_runtime = surface.openapi_runtime().expect("openapi runtime");
+    let (tables, functions) = published_projection_specs(v4, surface);
+
+    let http_manifest = HttpSourceManifest {
+        common: SourceManifestCommon {
+            dsl_version: v4.common.dsl_version,
+            name: v4.common.name.clone(),
+            version: String::new(),
+            description: v4.common.description.clone(),
+            test_queries: Vec::new(),
+        },
+        base_url: openapi_runtime.base_url.clone(),
+        auth: openapi_runtime.auth.clone(),
+        request_headers: openapi_runtime.request_headers.clone(),
+        rate_limit: openapi_runtime.rate_limit.clone(),
+        tables,
+        functions,
+        declared_inputs: surface.inputs.clone(),
+    };
+
+    let http_component = if let Some(identity_requirements) = surface.identity_requirements.clone()
+    {
+        RuntimeHttpSourceComponent::with_identity_requirements(
+            http_manifest,
+            surface.id.clone(),
+            identity_requirements,
+        )
+    } else {
+        RuntimeHttpSourceComponent::new(http_manifest)
+    };
+    QuerySource::from_runtime_components(
+        RuntimeSourcePackage {
+            source_name: v4.common.name.clone(),
+            authored_version: None,
+            description: v4.common.description.clone(),
+            declared_inputs: v4.declared_inputs.clone(),
+            test_queries: v4.common.test_queries.clone(),
+            components: vec![RuntimeSourceComponent::Http(http_component)],
+        },
+        BTreeMap::new(),
+        BTreeMap::new(),
+    )
+    .expect("runtime source")
+}
+
+/// Imports the GitHub openapi fixture and generates the published table and
+/// table-function specs for `surface`, mirroring app-style v4 assembly.
+fn published_projection_specs(
+    v4: &V4SourceManifest,
+    surface: &V4Surface,
+) -> (Vec<HttpTableSpec>, Vec<SourceTableFunctionSpec>) {
+    let semantic_ir = import_openapi_surface(v4, surface, github_openapi().as_bytes()).expect("ir");
+    let projections =
+        generate_projection_catalog(v4, std::slice::from_ref(&semantic_ir)).expect("projections");
+    let operations = semantic_ir
+        .operations
+        .iter()
+        .map(|operation| (operation.id.as_str(), operation))
+        .collect::<BTreeMap<_, _>>();
+    let mut tables = Vec::new();
+    let mut functions = Vec::new();
+    for projection in projections.projections.iter().filter(|projection| {
+        projection.surface_id == surface.id
+            && projection.visibility == ProjectionVisibility::Published
+    }) {
+        let operation = operations
+            .get(projection.operation_id.as_str())
+            .expect("projection operation");
+        let request = request_spec_for_projection(projection, operation).expect("request spec");
+        let columns = projection_column_specs(projection);
+        let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+            panic!("OpenAPI projection should be backed by REST execution");
+        };
+        match &projection.kind {
+            ProjectionKind::Table => tables.push(HttpTableSpec {
+                common: TableCommon {
+                    name: projection.name.clone(),
+                    description: projection.description.clone(),
+                    guide: projection.guide.clone(),
+                    filters: projection_filter_specs(projection),
+                    fetch_limit_default: None,
+                    search_limits: projection.search_limits.clone(),
+                    detail_hints: projection.detail_hints.clone(),
+                    columns,
+                },
+                request,
+                requests: Vec::new(),
+                response: rest.response.response.clone(),
+                pagination: projection.pagination.clone(),
+            }),
+            ProjectionKind::TableFunction { function_kind } => {
+                functions.push(SourceTableFunctionSpec {
+                    name: projection.name.clone(),
+                    kind: *function_kind,
+                    description: projection.description.clone(),
+                    fetch_limit_default: None,
+                    search_limits: projection.search_limits.clone(),
+                    detail_hints: projection.detail_hints.clone(),
+                    args: projection_arg_specs(projection),
+                    request,
+                    response: rest.response.response.clone(),
+                    pagination: projection.pagination.clone(),
+                    columns,
+                });
+            }
+        }
+    }
+    (tables, functions)
+}
+
+fn identity_requirements_yaml() -> &'static str {
+    "\n    identity_requirements:\n      accepts:\n        - id: github-rest-read\n          identity_specs: [github_oauth, github_pat]\n          audience: {host: github.com}\n"
+}
+
+fn github_issues_sql() -> &'static str {
+    "SELECT id, number, title FROM github_v4.issues WHERE owner = 'octocat' AND repo = 'Hello-World' AND state = 'open'"
+}
+
+fn github_openapi() -> &'static str {
+    r"
+openapi: 3.0.3
+paths:
+  /repos/{owner}/{repo}/issues:
+    get:
+      operationId: issues/list-for-repo
+      parameters:
+        - {name: owner, in: path, required: true, schema: {type: string}}
+        - {name: repo, in: path, required: true, schema: {type: string}}
+        - {name: state, in: query, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {type: array, items: {$ref: '#/components/schemas/issue'}}
+components:
+  schemas:
+    issue:
+      type: object
+      properties: {id: {type: integer}, number: {type: integer}, title: {type: string}, state: {type: string}, html_url: {type: string}}
+"
+}


### PR DESCRIPTION
Engine-side primitives for DSL v4 identity resolution. Everything
defaults to None — no behavior changes unless a runtime component
carries identity requirements, and none does yet:

- composition.rs: RequestIdentityResolver trait with
  RequestIdentityResolutionContext (source/surface/audience) and
  accepts_identity audience matching; extension_error!-generated
  RequestIdentityResolverError
- contracts: RuntimeHttpSourceComponent (manifest + surface id +
  optional RuntimeIdentityRequirements) replaces the bare
  HttpSourceManifest payload in RuntimeSourceComponent::Http;
  per-surface declared-inputs narrowing
- QueryRuntimeConfig grows a request_identity_resolver builder seam
  threaded through backend compilation into HTTP transport
  execute_request, which injects resolved headers fail-closed (a
  resolver error aborts the request rather than sending it bare)
- v4_tests.rs: end-to-end engine suite exercising the seam with an
  in-test resolver, including off-audience rejection
- coral-app runtime_package.rs: mechanical RuntimeHttpSourceComponent::new
  wrap (no identity requirements passed yet)