### PR TITLE
feat(app): identity-spec registry and admin service behind dsl_v4 flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,16 @@
   `<name>_v4`. Do not bundle `sources/core-v4` into the binary; install preview
   v4 sources with `coral source add --file`. Do not replace or migrate an
   existing v3 source merely because a preview v4 spec exists.
+- Keep maintained identity specs under `identities/core/**`. Identity specs
+  describe how app-owned identities are instantiated and how their credential
+  material is injected into HTTP requests; they do not install sources or store
+  identity material by themselves.
+- OAuth identity specs may declare setup `inputs`. Client IDs should use
+  variable inputs or spec-authored defaults, client secrets must use secret
+  inputs, and OAuth endpoint templates may reference only variable inputs.
+  Secret identity inputs are owned by the installed identity spec, not by
+  identities instantiated from it; they are stored as identity-spec input
+  material so identity materialization and token refresh can retrieve them.
 - Changes to `scripts/install.sh` must keep the `Validate` workflow's
   install-script matrix in sync with every OS/architecture target that the
   installer supports.

--- a/crates/coral-app/src/authorization.rs
+++ b/crates/coral-app/src/authorization.rs
@@ -1,0 +1,106 @@
+//! Product authorization seam for management-plane mutations.
+
+use std::fmt;
+
+use crate::identity::UserPrincipal;
+
+/// Error returned when a product runtime rejects a management-plane mutation.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthorizationError {
+    /// The authenticated principal is not allowed to perform the operation.
+    #[error("{0}")]
+    Forbidden(String),
+    /// Authorization failed unexpectedly.
+    #[error("{0}")]
+    Internal(String),
+}
+
+impl AuthorizationError {
+    /// Builds a permission-denied authorization error.
+    #[must_use]
+    pub fn forbidden(message: impl Into<String>) -> Self {
+        Self::Forbidden(message.into())
+    }
+
+    /// Builds an internal authorization error.
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+/// Source mutation operation being authorized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceMutationKind {
+    /// Install a source from Coral's bundled source catalog.
+    CreateBundled,
+    /// Install a bundled source while retrieving OAuth credentials.
+    CreateBundledWithOAuth,
+    /// Import a source spec.
+    Import,
+    /// Remove an installed source from a workspace.
+    Delete,
+}
+
+/// Product-provided authorization policy for management-plane mutations.
+///
+/// OSS Coral installs [`AllowAllManagementAuthorizer`] by default to preserve
+/// local single-user behavior. Product runtimes can replace it to gate source
+/// and identity-spec mutations while reusing the shared gRPC service surface.
+#[tonic::async_trait]
+pub trait ManagementAuthorizer: fmt::Debug + Send + Sync + 'static {
+    /// Authorizes creating or deleting global identity specs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthorizationError`] when the principal is not allowed to
+    /// mutate identity specs.
+    async fn authorize_identity_spec_mutation(
+        &self,
+        principal: &UserPrincipal,
+    ) -> Result<(), AuthorizationError>;
+
+    /// Authorizes creating, importing, or deleting a workspace source through
+    /// the shared OSS source mutation APIs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthorizationError`] when the principal is not allowed to
+    /// mutate sources in the workspace.
+    async fn authorize_source_mutation(
+        &self,
+        principal: &UserPrincipal,
+        workspace_id: &str,
+        kind: SourceMutationKind,
+    ) -> Result<(), AuthorizationError>;
+}
+
+/// Default OSS authorizer for local single-user usage.
+#[derive(Debug, Default)]
+pub struct AllowAllManagementAuthorizer;
+
+#[tonic::async_trait]
+impl ManagementAuthorizer for AllowAllManagementAuthorizer {
+    async fn authorize_identity_spec_mutation(
+        &self,
+        _principal: &UserPrincipal,
+    ) -> Result<(), AuthorizationError> {
+        Ok(())
+    }
+
+    async fn authorize_source_mutation(
+        &self,
+        _principal: &UserPrincipal,
+        _workspace_id: &str,
+        _kind: SourceMutationKind,
+    ) -> Result<(), AuthorizationError> {
+        Ok(())
+    }
+}
+
+pub(crate) fn authorization_status(error: AuthorizationError) -> tonic::Status {
+    match error {
+        AuthorizationError::Forbidden(message) => tonic::Status::permission_denied(message),
+        AuthorizationError::Internal(message) => tonic::Status::internal(message),
+    }
+}

--- a/crates/coral-app/src/authorization.rs
+++ b/crates/coral-app/src/authorization.rs
@@ -38,6 +38,8 @@ pub enum SourceMutationKind {
     CreateBundledWithOAuth,
     /// Import a source spec.
     Import,
+    /// Import a source spec while retrieving OAuth credentials.
+    ImportWithOAuth,
     /// Remove an installed source from a workspace.
     Delete,
 }

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -16,6 +16,12 @@ pub enum AppError {
     /// A requested source was not found in config.
     #[error("source '{0}' not found")]
     SourceNotFound(String),
+    /// A requested identity spec was not found in global app state.
+    #[error("identity spec '{0}' not found")]
+    IdentitySpecNotFound(String),
+    /// A requested stored identity was not found in app state.
+    #[error("identity '{0}' not found")]
+    IdentityNotFound(String),
     /// Caller-supplied input was invalid.
     #[error("invalid input: {0}")]
     InvalidInput(String),
@@ -32,6 +38,12 @@ pub enum AppError {
         /// Specific materialization mismatch or missing-artifact detail.
         detail: String,
     },
+    /// A known, installed source cannot be served until the user takes an
+    /// explicit action (enabling the required runtime feature or re-adding the
+    /// source to regenerate materialized artifacts). Surfaced loudly during
+    /// best-effort query-source loading instead of being silently skipped.
+    #[error("failed precondition: {0}")]
+    SourceUnservable(String),
     /// Provider-managed credential refresh failed during active source use.
     #[error("credential refresh failed: {0}")]
     CredentialRefresh(String),
@@ -194,10 +206,13 @@ fn grpc_code(status: StatusCode) -> Code {
 
 fn app_code(error: &AppError) -> Code {
     match error {
-        AppError::SourceNotFound(_) => Code::NotFound,
+        AppError::SourceNotFound(_)
+        | AppError::IdentitySpecNotFound(_)
+        | AppError::IdentityNotFound(_) => Code::NotFound,
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
         | AppError::MissingOrIncompatibleV4Materialization { .. }
+        | AppError::SourceUnservable(_)
         | AppError::CredentialRefresh(_)
         | AppError::MissingConfigDir
         | AppError::Credentials(CredentialsError::Parse(_) | CredentialsError::Unavailable(_)) => {

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -50,7 +50,7 @@ use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
-use crate::identity_specs::{IdentitySpecManager, IdentitySpecService};
+use crate::identity_specs::{IdentitySpecManager, IdentitySpecService, IdentitySpecUsageProvider};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
@@ -112,8 +112,11 @@ pub struct ServerBuilder {
     // Defaults preserve single-user local-first behavior; see `Self::new`.
     config_dir: Option<PathBuf>,
     mode: ServerMode,
+    feature_overrides: FeatureOverrides,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    management_authorizer: Arc<dyn ManagementAuthorizer>,
+    identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
     enable_stderr_logs: bool,
 }
@@ -131,8 +134,11 @@ impl ServerBuilder {
         Self {
             config_dir: None,
             mode: ServerMode::NativeGrpc,
+            feature_overrides: FeatureOverrides::default(),
             engine_extensions_providers: Vec::new(),
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
+            management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+            identity_spec_usage_providers: Vec::new(),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
             enable_stderr_logs: false,
         }
@@ -171,6 +177,13 @@ impl ServerBuilder {
     }
 
     #[must_use]
+    /// Applies process-local runtime feature overrides to the local server.
+    pub fn with_feature_overrides(mut self, feature_overrides: FeatureOverrides) -> Self {
+        self.feature_overrides = feature_overrides;
+        self
+    }
+
+    #[must_use]
     /// Adds an engine extensions provider used for query runtime builds.
     ///
     /// Providers are evaluated in call order, so later providers can add or
@@ -196,6 +209,31 @@ impl ServerBuilder {
         user_principal_provider: Arc<dyn UserPrincipalProvider>,
     ) -> Self {
         self.user_principal_provider = user_principal_provider;
+        self
+    }
+
+    #[must_use]
+    /// Sets the product-specific management-plane authorizer.
+    ///
+    /// The default authorizer allows all source and identity-spec mutations to
+    /// preserve OSS single-user behavior. Product runtimes can install a
+    /// stricter policy for multi-user control planes.
+    pub fn with_management_authorizer(
+        mut self,
+        management_authorizer: Arc<dyn ManagementAuthorizer>,
+    ) -> Self {
+        self.management_authorizer = management_authorizer;
+        self
+    }
+
+    #[must_use]
+    /// Adds a provider that reports product-owned stored identities for
+    /// identity-spec replacement and deletion checks.
+    pub fn add_identity_spec_usage_provider(
+        mut self,
+        usage_provider: Arc<dyn IdentitySpecUsageProvider>,
+    ) -> Self {
+        self.identity_spec_usage_providers.push(usage_provider);
         self
     }
 
@@ -244,7 +282,7 @@ impl ServerBuilder {
         )?;
         let config_store = ConfigStore::new(layout.clone());
         let features =
-            FeatureStore::new(layout.clone()).load_with_overrides(&FeatureOverrides::default())?;
+            FeatureStore::new(layout.clone()).load_with_overrides(&self.feature_overrides)?;
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
@@ -267,8 +305,8 @@ impl ServerBuilder {
         let identity_spec_manager = IdentitySpecManager::new_with_credential_store(
             layout.clone(),
             credential_store,
-            features,
-            Vec::new(),
+            features.clone(),
+            self.identity_spec_usage_providers,
         );
 
         let query_manager = QueryManager::new(
@@ -276,6 +314,7 @@ impl ServerBuilder {
             credential_manager,
             query_runtime_context,
             layout,
+            features,
             self.engine_extensions_providers,
         );
         let trace_service = if telemetry_config.trace_history.enabled {
@@ -288,7 +327,7 @@ impl ServerBuilder {
             query_manager,
             identity_spec_manager,
             user_principal_provider: self.user_principal_provider,
-            management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+            management_authorizer: self.management_authorizer,
             feedback_manager,
             episode_store,
             trace_service,
@@ -396,6 +435,7 @@ async fn start_server(services: ServerServices) -> Result<RunningServer, AppErro
         source_manager,
         query_manager.clone(),
         Arc::clone(&user_principal_provider),
+        Arc::clone(&management_authorizer),
     );
     let catalog_service =
         CatalogService::new(query_manager.clone(), Arc::clone(&user_principal_provider));
@@ -666,13 +706,16 @@ mod tests {
     use coral_api::v1::catalog_service_client::CatalogServiceClient;
     use coral_api::v1::episode_service_client::EpisodeServiceClient;
     use coral_api::v1::feedback_service_client::FeedbackServiceClient;
+    use coral_api::v1::identity_spec_service_client::IdentitySpecServiceClient;
     use coral_api::v1::query_service_client::QueryServiceClient;
     use coral_api::v1::source_service_client::SourceServiceClient;
     use coral_api::v1::trace_service_client::TraceServiceClient;
     use coral_api::v1::{
+        AddIdentitySpecRequest, CreateBundledSourceRequest, DeleteIdentitySpecRequest,
         ExecuteSqlRequest, ExecuteSqlResponse, ImportSourceRequest, ImportSourceResponse,
         ListCatalogRequest, ListSourcesRequest, ListTracesRequest, ListTracesResponse,
-        OpenEpisodeRequest, SubmitFeedbackRequest, Workspace, import_source_response,
+        OAuthCredentialRetrieval, OpenEpisodeRequest, SubmitFeedbackRequest, Workspace,
+        import_source_response,
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
@@ -685,11 +728,15 @@ mod tests {
         RunningServer, ServerBuilder, ServerMode, ServerServices, StaticAsset,
         StaticAssetsProvider, is_grpc_web_content_type, is_native_grpc_content_type, start_server,
     };
-    use crate::authorization::AllowAllManagementAuthorizer;
+    use crate::authorization::{
+        AllowAllManagementAuthorizer, AuthorizationError, ManagementAuthorizer, SourceMutationKind,
+    };
+    use crate::bootstrap::AppError;
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::episode::store::EpisodeStore;
+    use crate::features::{Feature, FeatureOverrides};
     use crate::feedback::manager::FeedbackManager;
-    use crate::identity_specs::IdentitySpecManager;
+    use crate::identity_specs::{IdentitySpecManager, IdentitySpecUsageProvider};
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
     use crate::state::{AppStateLayout, ConfigStore};
@@ -718,6 +765,85 @@ mod tests {
                 "rejected user principal",
             ))
         }
+    }
+
+    #[derive(Debug)]
+    struct DenyingManagementAuthorizer;
+
+    #[tonic::async_trait]
+    impl ManagementAuthorizer for DenyingManagementAuthorizer {
+        async fn authorize_identity_spec_mutation(
+            &self,
+            _principal: &UserPrincipal,
+        ) -> Result<(), AuthorizationError> {
+            Err(AuthorizationError::forbidden("identity specs are blocked"))
+        }
+
+        async fn authorize_source_mutation(
+            &self,
+            _principal: &UserPrincipal,
+            _workspace_id: &str,
+            _kind: SourceMutationKind,
+        ) -> Result<(), AuthorizationError> {
+            Err(AuthorizationError::forbidden("sources are blocked"))
+        }
+    }
+
+    #[derive(Debug)]
+    struct DenyImportWithOAuthAuthorizer;
+
+    #[tonic::async_trait]
+    impl ManagementAuthorizer for DenyImportWithOAuthAuthorizer {
+        async fn authorize_identity_spec_mutation(
+            &self,
+            _principal: &UserPrincipal,
+        ) -> Result<(), AuthorizationError> {
+            Ok(())
+        }
+
+        async fn authorize_source_mutation(
+            &self,
+            _principal: &UserPrincipal,
+            _workspace_id: &str,
+            kind: SourceMutationKind,
+        ) -> Result<(), AuthorizationError> {
+            if kind == SourceMutationKind::ImportWithOAuth {
+                return Err(AuthorizationError::forbidden("OAuth imports are blocked"));
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct StaticIdentitySpecUsageProvider {
+        identity_spec_name: String,
+        count: u32,
+    }
+
+    impl IdentitySpecUsageProvider for StaticIdentitySpecUsageProvider {
+        fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError> {
+            if identity_spec_name == self.identity_spec_name {
+                Ok(self.count)
+            } else {
+                Ok(0)
+            }
+        }
+    }
+
+    fn fixed_token_identity_spec_yaml(name: &str) -> String {
+        format!(
+            r"
+kind: identity
+spec_version: 1
+name: {name}
+version: 0.1.0
+description: Demo identity.
+issuer: github
+type: fixed_token
+audience:
+  host: github.com
+"
+        )
     }
 
     fn disable_internal_tracing(config_dir: &Path) {
@@ -758,6 +884,7 @@ enabled = false
                 credential_manager,
                 runtime_context,
                 layout.clone(),
+                crate::features::dsl_v4_features(),
                 vec![Arc::new(NoopEngineExtensionsProvider)],
             ),
             identity_spec_manager,
@@ -939,6 +1066,131 @@ enabled = false
 
         assert!(response.traces.is_empty());
         assert!(response.next_page_token.is_empty());
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn server_builder_installs_identity_spec_management_authorizer() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_management_authorizer(Arc::new(DenyingManagementAuthorizer))
+            .start()
+            .await
+            .expect("start server");
+        let mut client = IdentitySpecServiceClient::new(connect(&server).await);
+
+        let status = client
+            .add_identity_spec(Request::new(AddIdentitySpecRequest {
+                manifest_yaml: String::new(),
+                inputs: Vec::new(),
+            }))
+            .await
+            .expect_err("identity spec mutation should be denied");
+
+        assert_eq!(status.code(), Code::PermissionDenied);
+        assert!(status.message().contains("identity specs are blocked"));
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn server_builder_installs_source_management_authorizer() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_management_authorizer(Arc::new(DenyingManagementAuthorizer))
+            .start()
+            .await
+            .expect("start server");
+        let mut client = SourceServiceClient::new(connect(&server).await);
+
+        let status = client
+            .create_bundled_source(Request::new(CreateBundledSourceRequest {
+                workspace: Some(default_workspace()),
+                name: "github".to_string(),
+                variables: Vec::new(),
+                secrets: Vec::new(),
+            }))
+            .await
+            .expect_err("source mutation should be denied");
+
+        assert_eq!(status.code(), Code::PermissionDenied);
+        assert!(status.message().contains("sources are blocked"));
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn source_import_with_oauth_uses_distinct_authorization_kind() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_management_authorizer(Arc::new(DenyImportWithOAuthAuthorizer))
+            .start()
+            .await
+            .expect("start server");
+        let mut client = SourceServiceClient::new(connect(&server).await);
+        let mut request = import_source_request("not valid yaml".to_string());
+        request
+            .oauth_credential_retrievals
+            .push(OAuthCredentialRetrieval {
+                input_key: "API_TOKEN".to_string(),
+                method_index: Some(0),
+                credential_inputs: Vec::new(),
+            });
+
+        let status = client
+            .import_source(Request::new(request))
+            .await
+            .expect_err("OAuth import should be denied before import starts");
+
+        assert_eq!(status.code(), Code::PermissionDenied);
+        assert!(status.message().contains("OAuth imports are blocked"));
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn server_builder_installs_identity_spec_usage_provider() {
+        let temp = TempDir::new().expect("temp dir");
+        let mut feature_overrides = FeatureOverrides::default();
+        feature_overrides.set(Feature::DslV4, true);
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_feature_overrides(feature_overrides)
+            .add_identity_spec_usage_provider(Arc::new(StaticIdentitySpecUsageProvider {
+                identity_spec_name: "github_oauth".to_string(),
+                count: 4,
+            }))
+            .start()
+            .await
+            .expect("start server");
+        let mut client = IdentitySpecServiceClient::new(connect(&server).await);
+        client
+            .add_identity_spec(Request::new(AddIdentitySpecRequest {
+                manifest_yaml: fixed_token_identity_spec_yaml("github_oauth"),
+                inputs: Vec::new(),
+            }))
+            .await
+            .expect("add identity spec");
+
+        let status = client
+            .delete_identity_spec(Request::new(DeleteIdentitySpecRequest {
+                name: "github_oauth".to_string(),
+                force: false,
+            }))
+            .await
+            .expect_err("usage provider should block non-forced deletion");
+
+        assert_eq!(status.code(), Code::FailedPrecondition);
+        assert!(status.message().contains("4 stored identities"));
+        let deleted = client
+            .delete_identity_spec(Request::new(DeleteIdentitySpecRequest {
+                name: "github_oauth".to_string(),
+                force: true,
+            }))
+            .await
+            .expect("force delete identity spec")
+            .into_inner();
+        assert_eq!(deleted.orphaned_identities, 4);
         server.shutdown().await.expect("shutdown");
     }
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -17,6 +17,7 @@ use axum::response::Response as AxumResponse;
 use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::episode_service_server::EpisodeServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
+use coral_api::v1::identity_spec_service_server::IdentitySpecServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
 use coral_api::v1::trace_service_server::TraceServiceServer;
@@ -37,16 +38,19 @@ use tower::{Layer, Service};
 
 use super::env::AppEnvironment;
 use super::error::AppError;
+use crate::authorization::{AllowAllManagementAuthorizer, ManagementAuthorizer};
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
 use crate::credentials::{CredentialManager, CredentialStore};
 use crate::episode::service::EpisodeService;
 use crate::episode::store::EpisodeStore;
+use crate::features::{FeatureOverrides, FeatureStore};
 use crate::feedback::manager::FeedbackManager;
 use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
+use crate::identity_specs::{IdentitySpecManager, IdentitySpecService};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
@@ -239,14 +243,17 @@ impl ServerBuilder {
             internal_trace_store_dir.clone(),
         )?;
         let config_store = ConfigStore::new(layout.clone());
+        let features =
+            FeatureStore::new(layout.clone()).load_with_overrides(&FeatureOverrides::default())?;
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
-        let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
+        let credential_manager = CredentialManager::new(credential_store.clone());
+        let source_manager = SourceManager::new_with_features(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            features.clone(),
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.feedback_publisher);
@@ -257,6 +264,12 @@ impl ServerBuilder {
         let query_runtime_context = env
             .query_runtime_context()
             .with_body_capture_max_bytes(body_capture_max_bytes);
+        let identity_spec_manager = IdentitySpecManager::new_with_credential_store(
+            layout.clone(),
+            credential_store,
+            features,
+            Vec::new(),
+        );
 
         let query_manager = QueryManager::new(
             config_store,
@@ -273,7 +286,9 @@ impl ServerBuilder {
         start_server(ServerServices {
             source_manager,
             query_manager,
+            identity_spec_manager,
             user_principal_provider: self.user_principal_provider,
+            management_authorizer: Arc::new(AllowAllManagementAuthorizer),
             feedback_manager,
             episode_store,
             trace_service,
@@ -356,7 +371,9 @@ impl Drop for RunningServer {
 struct ServerServices {
     source_manager: SourceManager,
     query_manager: QueryManager,
+    identity_spec_manager: IdentitySpecManager,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    management_authorizer: Arc<dyn ManagementAuthorizer>,
     feedback_manager: FeedbackManager,
     episode_store: EpisodeStore,
     trace_service: Option<TraceService>,
@@ -367,7 +384,9 @@ async fn start_server(services: ServerServices) -> Result<RunningServer, AppErro
     let ServerServices {
         source_manager,
         query_manager,
+        identity_spec_manager,
         user_principal_provider,
+        management_authorizer,
         feedback_manager,
         episode_store,
         trace_service,
@@ -381,6 +400,11 @@ async fn start_server(services: ServerServices) -> Result<RunningServer, AppErro
     let catalog_service =
         CatalogService::new(query_manager.clone(), Arc::clone(&user_principal_provider));
     let query_service = QueryService::new(query_manager, Arc::clone(&user_principal_provider));
+    let identity_spec_service = IdentitySpecService::new(
+        identity_spec_manager,
+        Arc::clone(&user_principal_provider),
+        Arc::clone(&management_authorizer),
+    );
     let feedback_service =
         FeedbackService::new(feedback_manager, Arc::clone(&user_principal_provider));
     let episode_service = EpisodeService::new(episode_store);
@@ -388,6 +412,9 @@ async fn start_server(services: ServerServices) -> Result<RunningServer, AppErro
         .add_service(GrpcMethodAnnotatedService::new(SourceServiceServer::new(
             source_service,
         )))
+        .add_service(GrpcMethodAnnotatedService::new(
+            IdentitySpecServiceServer::new(identity_spec_service),
+        ))
         .add_service(GrpcMethodAnnotatedService::new(
             CatalogServiceServer::new(catalog_service)
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
@@ -658,9 +685,11 @@ mod tests {
         RunningServer, ServerBuilder, ServerMode, ServerServices, StaticAsset,
         StaticAssetsProvider, is_grpc_web_content_type, is_native_grpc_content_type, start_server,
     };
+    use crate::authorization::AllowAllManagementAuthorizer;
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::episode::store::EpisodeStore;
     use crate::feedback::manager::FeedbackManager;
+    use crate::identity_specs::IdentitySpecManager;
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
     use crate::state::{AppStateLayout, ConfigStore};
@@ -717,6 +746,7 @@ enabled = false
         layout.ensure().expect("layout dirs");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let identity_spec_manager = IdentitySpecManager::new(layout.clone());
         let server = start_server(ServerServices {
             source_manager: SourceManager::new(
                 config_store.clone(),
@@ -730,7 +760,9 @@ enabled = false
                 layout.clone(),
                 vec![Arc::new(NoopEngineExtensionsProvider)],
             ),
+            identity_spec_manager,
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
+            management_authorizer: Arc::new(AllowAllManagementAuthorizer),
             feedback_manager: FeedbackManager::new(layout.clone()),
             episode_store: EpisodeStore::new(layout.clone()),
             trace_service,

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -106,10 +106,6 @@ impl CredentialSetId {
 
     /// Build the identity-spec-backed credential-set id used for spec-owned
     /// input material.
-    #[expect(
-        dead_code,
-        reason = "consumed by the identity-spec manager in a later PR"
-    )]
     pub(crate) fn for_identity_spec(identity_spec_name: &str) -> Self {
         Self(format!("identity-spec.{identity_spec_name}"))
     }

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -71,7 +71,6 @@ pub(crate) enum OAuthClientMaterialPersistence {
 
 /// Progress event emitted while an OAuth credential authorization runs.
 #[derive(Debug, Clone)]
-#[expect(unreachable_pub, reason = "re-exported from lib.rs in a later PR")]
 pub enum OAuthProgressEvent {
     /// OAuth authorization URL or device-code details are ready for the user.
     OAuthAuthorization {
@@ -101,7 +100,6 @@ pub enum OAuthProgressEvent {
 /// operation to its gRPC response stream. `send` resolves only once the
 /// consumer dequeued the event, so progress cannot outrun the stream.
 #[derive(Clone)]
-#[expect(unreachable_pub, reason = "re-exported from lib.rs in a later PR")]
 pub struct OAuthProgressEventSender {
     tx: mpsc::Sender<PendingOAuthProgressEvent>,
     closed_message: &'static str,

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -118,7 +118,17 @@ impl OAuthProgressEventSender {
         Self { tx, closed_message }
     }
 
-    pub(crate) async fn send(&self, event: OAuthProgressEvent) -> Result<(), AppError> {
+    /// Sends an OAuth progress event to the response stream.
+    ///
+    /// The returned future resolves only after the stream consumer has dequeued
+    /// the event, preserving backpressure between the OAuth operation and the
+    /// response stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError::FailedPrecondition`] when the response stream closes
+    /// before the event can be delivered.
+    pub async fn send(&self, event: OAuthProgressEvent) -> Result<(), AppError> {
         let (delivered, delivered_rx) = oneshot::channel();
         self.tx
             .send(PendingOAuthProgressEvent { event, delivered })

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -222,10 +222,6 @@ impl CredentialStore {
         Ok(())
     }
 
-    #[expect(
-        dead_code,
-        reason = "consumed by the identity-spec manager in a later PR"
-    )]
     pub(crate) fn replace_material_unlocked(
         &self,
         workspace_name: &WorkspaceName,
@@ -367,10 +363,6 @@ impl CredentialStore {
         Ok(())
     }
 
-    #[expect(
-        dead_code,
-        reason = "consumed by the identity-spec manager in a later PR"
-    )]
     pub(crate) fn remove_material_unlocked(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -123,11 +123,26 @@ trait CredentialMaterialBackend: Send + Sync {
         set: &CredentialSetRef<'_>,
     ) -> Result<CredentialMaterialSnapshot, CredentialsError>;
 
+    fn snapshot_unlocked(
+        &self,
+        set: &CredentialSetRef<'_>,
+    ) -> Result<CredentialMaterialSnapshot, CredentialsError> {
+        self.snapshot(set)
+    }
+
     fn restore(
         &self,
         set: &CredentialSetRef<'_>,
         snapshot: &CredentialMaterialSnapshot,
     ) -> Result<(), CredentialsError>;
+
+    fn restore_unlocked(
+        &self,
+        set: &CredentialSetRef<'_>,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), CredentialsError> {
+        self.restore(set, snapshot)
+    }
 }
 
 #[derive(Clone)]
@@ -322,6 +337,26 @@ impl CredentialStore {
         .map_err(Into::into)
     }
 
+    pub(crate) fn snapshot_material_unlocked(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
+    ) -> Result<CredentialMaterialSnapshot, AppError> {
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        tracing::trace!(%credential_set_id, %storage, "snapshotting credential material without taking a state lock");
+        contextualize_storage_error(
+            self.backend(storage).snapshot_unlocked(&set),
+            "snapshotting",
+            credential_set_id,
+            storage,
+        )
+        .map_err(Into::into)
+    }
+
     pub(crate) fn restore_material(
         &self,
         workspace_name: &WorkspaceName,
@@ -336,6 +371,27 @@ impl CredentialStore {
         tracing::trace!(%credential_set_id, %storage, "restoring credential material");
         contextualize_storage_error(
             self.backend(storage).restore(&set, snapshot),
+            "restoring",
+            credential_set_id,
+            storage,
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn restore_material_unlocked(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), AppError> {
+        let storage = snapshot.storage();
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        tracing::trace!(%credential_set_id, %storage, "restoring credential material without taking a state lock");
+        contextualize_storage_error(
+            self.backend(storage).restore_unlocked(&set, snapshot),
             "restoring",
             credential_set_id,
             storage,
@@ -594,8 +650,15 @@ impl CredentialMaterialBackend for FileCredentialBackend {
         &self,
         set: &CredentialSetRef<'_>,
     ) -> Result<CredentialMaterialSnapshot, CredentialsError> {
-        let path = self.material_file(set)?;
         let _lock = FileLock::shared(self.layout.state_lock())?;
+        self.snapshot_unlocked(set)
+    }
+
+    fn snapshot_unlocked(
+        &self,
+        set: &CredentialSetRef<'_>,
+    ) -> Result<CredentialMaterialSnapshot, CredentialsError> {
+        let path = self.material_file(set)?;
         match std::fs::read(path) {
             Ok(bytes) => Ok(CredentialMaterialSnapshot::new(
                 CredentialStorageKind::File,
@@ -619,8 +682,22 @@ impl CredentialMaterialBackend for FileCredentialBackend {
                 requested: CredentialStorageKind::File.as_config_value(),
             });
         }
-        let path = self.material_file(set)?;
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        self.restore_unlocked(set, snapshot)
+    }
+
+    fn restore_unlocked(
+        &self,
+        set: &CredentialSetRef<'_>,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), CredentialsError> {
+        if snapshot.storage() != CredentialStorageKind::File {
+            return Err(CredentialsError::SnapshotStorageMismatch {
+                snapshot: snapshot.storage().as_config_value(),
+                requested: CredentialStorageKind::File.as_config_value(),
+            });
+        }
+        let path = self.material_file(set)?;
         match snapshot.material() {
             Some(bytes) => write_file_unlocked(&path, bytes),
             None => remove_file_if_exists_unlocked(&path).map_err(Into::into),

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -173,7 +173,11 @@ impl Features {
     /// while `dsl_v4` is off, so the source-install, identity-spec-install, and
     /// query-load paths share this single gate and its canonical remediation
     /// message.
-    pub(crate) fn ensure_dsl_v4_enabled(&self) -> Result<(), AppError> {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError::SourceUnservable`] when `dsl_v4` is disabled.
+    pub fn ensure_dsl_v4_enabled(&self) -> Result<(), AppError> {
         if self.enabled(Feature::DslV4) {
             return Ok(());
         }

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -13,6 +13,8 @@ use crate::state::{
 /// Runtime feature keys recognized by Coral.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Feature {
+    /// Enables preview DSL v4 source manifests.
+    DslV4,
     /// Expose the optional MCP `feedback` tool.
     Feedback,
     /// Experimental trajectory-memory episodes (in progress): will associate each
@@ -70,6 +72,14 @@ struct FeatureSpec {
 }
 
 const FEATURE_SPECS: &[FeatureSpec] = &[
+    FeatureSpec {
+        feature: Feature::DslV4,
+        key: "dsl_v4",
+        default_enabled: false,
+        description: "Enables preview DSL v4 source manifests.",
+        enable_flag: "enable-dsl-v4",
+        disable_flag: "disable-dsl-v4",
+    },
     FeatureSpec {
         feature: Feature::Feedback,
         key: "feedback",
@@ -157,6 +167,22 @@ impl Features {
         self.enabled.get(&feature).copied().unwrap_or(false)
     }
 
+    /// Errors unless the preview DSL v4 runtime feature is enabled.
+    ///
+    /// DSL v4 sources and their identity specs cannot be installed or served
+    /// while `dsl_v4` is off, so the source-install, identity-spec-install, and
+    /// query-load paths share this single gate and its canonical remediation
+    /// message.
+    pub(crate) fn ensure_dsl_v4_enabled(&self) -> Result<(), AppError> {
+        if self.enabled(Feature::DslV4) {
+            return Ok(());
+        }
+        Err(AppError::SourceUnservable(
+            "DSL v4 sources require the 'dsl_v4' runtime feature. Run `coral features enable dsl_v4` or pass `--enable-dsl-v4` and retry."
+                .to_string(),
+        ))
+    }
+
     fn from_raw_overrides(raw: &RawFeatureOverrides) -> Self {
         let mut features = Self::default();
         for (key, value) in raw.iter() {
@@ -180,7 +206,7 @@ impl Features {
         features
     }
 
-    fn apply_overrides(&mut self, overrides: &FeatureOverrides) {
+    pub(crate) fn apply_overrides(&mut self, overrides: &FeatureOverrides) {
         for (feature, enabled) in overrides.iter() {
             self.enabled.insert(feature, enabled);
         }
@@ -199,6 +225,21 @@ impl FeatureOverrides {
         self.enabled.insert(feature, enabled);
     }
 
+    /// Returns the process-local override for a known feature, when present.
+    #[must_use]
+    pub fn get(&self, feature: Feature) -> Option<bool> {
+        self.enabled.get(&feature).copied()
+    }
+
+    /// Adds every override from `defaults` that is not already explicitly set.
+    pub fn apply_defaults_from(&mut self, defaults: &Self) {
+        for (feature, enabled) in defaults.iter() {
+            if self.get(feature).is_none() {
+                self.set(feature, enabled);
+            }
+        }
+    }
+
     fn iter(&self) -> impl Iterator<Item = (Feature, bool)> + '_ {
         self.enabled
             .iter()
@@ -213,6 +254,12 @@ pub struct FeatureStore {
 }
 
 impl FeatureStore {
+    /// Builds a feature store for an already-discovered app state layout.
+    #[must_use]
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
     /// Discovers the Coral app state layout used for runtime feature config.
     ///
     /// # Errors
@@ -329,6 +376,17 @@ fn spec_for_key(key: &str) -> Option<&'static FeatureSpec> {
     FEATURE_SPECS.iter().find(|spec| spec.key == key)
 }
 
+/// Builds a [`Features`] with the preview DSL v4 feature enabled, shared by the
+/// crate's source-install and query tests that exercise v4 sources.
+#[cfg(test)]
+pub(crate) fn dsl_v4_features() -> Features {
+    let mut overrides = FeatureOverrides::default();
+    overrides.set(Feature::DslV4, true);
+    let mut features = Features::default();
+    features.apply_overrides(&overrides);
+    features
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -340,10 +398,12 @@ mod tests {
     }
 
     #[test]
-    fn defaults_disable_feedback() {
+    fn defaults_disable_features() {
         let features = Features::default();
 
-        assert!(!features.enabled(Feature::Feedback));
+        for (label, feature) in [("feedback", Feature::Feedback), ("dsl_v4", Feature::DslV4)] {
+            assert!(!features.enabled(feature), "{label} should default off");
+        }
     }
 
     #[test]
@@ -358,19 +418,44 @@ mod tests {
     }
 
     #[test]
-    fn known_boolean_override_enables_feedback() {
-        let raw = raw([("feedback", RawFeatureValue::Bool(true))]);
-        let features = Features::from_raw_overrides(&raw);
+    fn process_override_get_reports_only_explicit_overrides() {
+        let mut overrides = FeatureOverrides::default();
 
-        assert!(features.enabled(Feature::Feedback));
+        assert_eq!(overrides.get(Feature::DslV4), None);
+
+        overrides.set(Feature::DslV4, false);
+
+        assert_eq!(overrides.get(Feature::DslV4), Some(false));
     }
 
     #[test]
-    fn known_boolean_override_disables_feedback() {
-        let raw = raw([("feedback", RawFeatureValue::Bool(false))]);
-        let features = Features::from_raw_overrides(&raw);
+    fn process_override_defaults_fill_missing_features_only() {
+        let mut overrides = FeatureOverrides::default();
+        overrides.set(Feature::DslV4, false);
+        let mut defaults = FeatureOverrides::default();
+        defaults.set(Feature::DslV4, true);
+        defaults.set(Feature::Feedback, true);
 
-        assert!(!features.enabled(Feature::Feedback));
+        overrides.apply_defaults_from(&defaults);
+
+        assert_eq!(overrides.get(Feature::DslV4), Some(false));
+        assert_eq!(overrides.get(Feature::Feedback), Some(true));
+    }
+
+    #[test]
+    fn raw_overrides_toggle_only_known_boolean_entries() {
+        use RawFeatureValue::{Bool, UnsupportedType};
+
+        for (label, key, value, on) in [
+            ("enables feedback", "feedback", Bool(true), true),
+            ("disables feedback", "feedback", Bool(false), false),
+            ("unknown key ignored", "future_flag", Bool(true), false),
+            ("unsupported type", "feedback", UnsupportedType, false),
+        ] {
+            let features = Features::from_raw_overrides(&raw([(key, value)]));
+
+            assert_eq!(features.enabled(Feature::Feedback), on, "{label}");
+        }
     }
 
     #[test]
@@ -386,31 +471,15 @@ mod tests {
     }
 
     #[test]
-    fn unknown_override_is_ignored() {
-        let raw = raw([("future_flag", RawFeatureValue::Bool(true))]);
-        let features = Features::from_raw_overrides(&raw);
-
-        assert!(!features.enabled(Feature::Feedback));
-    }
-
-    #[test]
-    fn unsupported_known_override_is_ignored() {
-        let raw = raw([("feedback", RawFeatureValue::UnsupportedType)]);
-        let features = Features::from_raw_overrides(&raw);
-
-        assert!(!features.enabled(Feature::Feedback));
-    }
-
-    #[test]
     fn statuses_report_invalid_known_value_without_enabling_feature() {
         let raw = raw([("feedback", RawFeatureValue::UnsupportedType)]);
         let features = Features::from_raw_overrides(&raw);
 
-        let statuses = FEATURE_SPECS
+        let status = FEATURE_SPECS
             .iter()
             .map(|spec| status_from_raw(spec, &raw, &features))
-            .collect::<Vec<_>>();
-        let status = statuses.first().expect("feedback status");
+            .find(|status| status.key == "feedback")
+            .expect("feedback status");
 
         assert_eq!(status.key, "feedback");
         assert_eq!(status.configured, FeatureConfiguredState::InvalidValue);

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -1,6 +1,52 @@
-//! Shared validation helpers for app-owned identifiers.
+//! App-owned identity context, binding, and runtime identity helpers.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use coral_engine::{RequestIdentityResolutionContext, RequestIdentityResolverError};
+use coral_spec::v4::IdentityRequirements;
+use reqwest::header::{HeaderName, HeaderValue};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::bootstrap::AppError;
+
+/// Collects `(key, value)` inputs into a map, validating each key as a path
+/// segment and rejecting duplicates. `label` names the input kind in errors.
+pub(crate) fn unique_input_map(
+    inputs: impl IntoIterator<Item = (String, String)>,
+    label: &str,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let mut values = BTreeMap::new();
+    for (key, value) in inputs {
+        let key = parse_path_segment(label, &key)?;
+        if values.insert(key.clone(), value).is_some() {
+            return Err(AppError::InvalidInput(format!(
+                "{label} '{key}' is repeated"
+            )));
+        }
+    }
+    Ok(values)
+}
+
+pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::InvalidInput(format!("missing {kind} name")));
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(AppError::InvalidInput(format!(
+            "{kind} name must not contain '/' or '\\\\'"
+        )));
+    }
+    if trimmed == "." || trimmed == ".." {
+        return Err(AppError::InvalidInput(format!(
+            "{kind} name must not be '.' or '..'"
+        )));
+    }
+    Ok(trimmed.to_string())
+}
 
 /// Stable local user used by single-user local mode.
 pub(crate) const LOCAL_MEMBER_ID: &str = "local";
@@ -116,27 +162,412 @@ impl UserPrincipalProvider for SingleUserPrincipalProvider {
     }
 }
 
-pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppError> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(AppError::InvalidInput(format!("missing {kind} name")));
+/// Scope that owns configured provider-facing source identity material.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[expect(
+    unreachable_pub,
+    reason = "source identity vocabulary re-exported from lib.rs in a later PR"
+)]
+pub enum SourceIdentityOwner {
+    /// Identity material is owned by the current Coral user principal.
+    User,
+    /// Identity material is owned by the workspace and independent of a user principal.
+    Workspace,
+}
+
+#[expect(
+    dead_code,
+    reason = "source identity vocabulary consumed by source lifecycle and query resolution in later PRs"
+)]
+impl SourceIdentityOwner {
+    pub(crate) fn as_config_value(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Workspace => "workspace",
+        }
     }
-    if trimmed.contains('/') || trimmed.contains('\\') {
-        return Err(AppError::InvalidInput(format!(
-            "{kind} name must not contain '/' or '\\\\'"
-        )));
+}
+
+/// Subject used to select provider-facing source identity material.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[expect(
+    unreachable_pub,
+    reason = "source identity vocabulary re-exported from lib.rs in a later PR"
+)]
+pub enum SourceIdentitySubject {
+    /// Identity material is owned by the request user principal.
+    User(String),
+    /// Identity material is owned by the workspace, not a user principal.
+    Workspace,
+}
+
+#[expect(
+    dead_code,
+    unreachable_pub,
+    reason = "source identity vocabulary consumed and re-exported in later PRs"
+)]
+impl SourceIdentitySubject {
+    pub(crate) fn for_binding_owner(
+        owner: SourceIdentityOwner,
+        user_principal: &UserPrincipal,
+    ) -> Self {
+        match owner {
+            SourceIdentityOwner::User => Self::User(user_principal.user_id().to_string()),
+            SourceIdentityOwner::Workspace => Self::Workspace,
+        }
     }
-    if trimmed == "." || trimmed == ".." {
-        return Err(AppError::InvalidInput(format!(
-            "{kind} name must not be '.' or '..'"
-        )));
+
+    /// Returns the selected user id for user-owned identity material.
+    #[must_use]
+    pub fn user_id(&self) -> Option<&str> {
+        match self {
+            Self::User(user_id) => Some(user_id),
+            Self::Workspace => None,
+        }
     }
-    Ok(trimmed.to_string())
+
+    /// Returns whether identity material is workspace-owned.
+    #[must_use]
+    pub const fn is_workspace(&self) -> bool {
+        matches!(self, Self::Workspace)
+    }
+}
+
+/// Workspace config binding from one source-local surface to an identity slot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[expect(
+    unreachable_pub,
+    reason = "source identity vocabulary re-exported from lib.rs in a later PR"
+)]
+pub struct SourceIdentityBinding {
+    /// Whether the identity is user-specific or workspace-owned.
+    pub owner: SourceIdentityOwner,
+    /// Workspace-owned identity reference understood by installed identity
+    /// providers.
+    ///
+    /// User-owned bindings intentionally leave this empty because the concrete
+    /// identity selection is per Coral user principal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<String>,
+    /// Workspace-owned accepted identity id from the surface's
+    /// `identity_requirements`.
+    ///
+    /// User-owned bindings intentionally leave this empty because the concrete
+    /// accepted branch is per Coral user principal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_identity: Option<String>,
+}
+
+#[expect(
+    dead_code,
+    unreachable_pub,
+    reason = "source identity vocabulary consumed and re-exported in later PRs"
+)]
+impl SourceIdentityBinding {
+    /// Builds one validated user-owned source identity slot.
+    #[must_use]
+    pub const fn user_owned() -> Self {
+        Self {
+            owner: SourceIdentityOwner::User,
+            identity: None,
+            accepted_identity: None,
+        }
+    }
+
+    /// Builds one validated workspace-owned source identity binding.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the identity reference or accepted identity id is
+    /// empty or contains a path separator.
+    pub fn workspace_owned(
+        identity: impl Into<String>,
+        accepted_identity: Option<String>,
+    ) -> Result<Self, AppError> {
+        let identity = parse_path_segment("identity", &identity.into())?;
+        let accepted_identity = accepted_identity
+            .map(|accepted_identity| parse_path_segment("accepted identity", &accepted_identity))
+            .transpose()?;
+        Ok(Self {
+            owner: SourceIdentityOwner::Workspace,
+            identity: Some(identity),
+            accepted_identity,
+        })
+    }
+
+    /// Validates a binding loaded from config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the identity reference or accepted identity id is
+    /// empty or contains a path separator.
+    pub fn validate(&self) -> Result<(), AppError> {
+        match self.owner {
+            SourceIdentityOwner::User => {
+                if self.identity.is_some() || self.accepted_identity.is_some() {
+                    return Err(AppError::InvalidInput(
+                        "user-owned source identity bindings store only owner; identity and accepted_identity are selected per user".to_string(),
+                    ));
+                }
+            }
+            SourceIdentityOwner::Workspace => {
+                let Some(identity) = &self.identity else {
+                    return Err(AppError::InvalidInput(
+                        "workspace-owned source identity binding is missing identity".to_string(),
+                    ));
+                };
+                parse_path_segment("identity", identity)?;
+                if let Some(accepted_identity) = &self.accepted_identity {
+                    parse_path_segment("accepted identity", accepted_identity)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn workspace_selection(&self) -> Result<SourceIdentitySelection, AppError> {
+        if self.owner != SourceIdentityOwner::Workspace {
+            return Err(AppError::InvalidInput(
+                "user-owned source identity selection must be resolved per user".to_string(),
+            ));
+        }
+        SourceIdentitySelection::new(
+            self.identity.clone().ok_or_else(|| {
+                AppError::InvalidInput(
+                    "workspace-owned source identity binding is missing identity".to_string(),
+                )
+            })?,
+            self.accepted_identity.clone(),
+        )
+    }
+}
+
+/// Concrete identity selected for one source-local surface.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[expect(
+    unreachable_pub,
+    reason = "source identity vocabulary re-exported from lib.rs in a later PR"
+)]
+pub struct SourceIdentitySelection {
+    /// Stable identity reference understood by installed identity providers.
+    pub identity: String,
+    /// Optional accepted identity id from the surface's `identity_requirements`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_identity: Option<String>,
+}
+
+#[expect(
+    dead_code,
+    unreachable_pub,
+    reason = "source identity vocabulary consumed and re-exported in later PRs"
+)]
+impl SourceIdentitySelection {
+    /// Builds one validated source identity selection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the identity reference or accepted identity id is
+    /// empty or contains a path separator.
+    pub fn new(
+        identity: impl Into<String>,
+        accepted_identity: Option<String>,
+    ) -> Result<Self, AppError> {
+        let identity = parse_path_segment("identity", &identity.into())?;
+        let accepted_identity = accepted_identity
+            .map(|accepted_identity| parse_path_segment("accepted identity", &accepted_identity))
+            .transpose()?;
+        Ok(Self {
+            identity,
+            accepted_identity,
+        })
+    }
+
+    /// Validates a selection loaded from storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the identity reference or accepted identity id is
+    /// empty or contains a path separator.
+    pub fn validate(&self) -> Result<(), AppError> {
+        parse_path_segment("identity", &self.identity)?;
+        if let Some(accepted_identity) = &self.accepted_identity {
+            parse_path_segment("accepted identity", accepted_identity)?;
+        }
+        Ok(())
+    }
+}
+
+/// Request to resolve a user-specific source identity selection.
+#[derive(Debug, Clone)]
+#[expect(
+    dead_code,
+    unreachable_pub,
+    reason = "source identity vocabulary consumed and re-exported in later PRs"
+)]
+pub struct SourceIdentitySelectionRequest {
+    /// Workspace selected by the request.
+    pub workspace_name: String,
+    /// Subject selected by Coral for this binding; user-owned bindings carry
+    /// the request user id (`subject.user_id()`).
+    pub subject: SourceIdentitySubject,
+    /// Source/schema name whose surface needs identity material.
+    pub source_name: String,
+    /// DSL v4 surface id.
+    pub surface_id: String,
+    /// Workspace source-surface identity binding.
+    pub binding: SourceIdentityBinding,
+}
+
+/// Request to resolve one configured source identity binding into runtime material.
+#[derive(Debug, Clone)]
+#[expect(
+    dead_code,
+    unreachable_pub,
+    reason = "source identity vocabulary consumed and re-exported in later PRs"
+)]
+pub struct SourceIdentityResolutionRequest {
+    /// Workspace selected by the request.
+    pub workspace_name: String,
+    /// Subject selected by Coral for this binding.
+    ///
+    /// User-owned bindings carry the request user id. Workspace-owned bindings
+    /// intentionally carry no request user id, so providers cannot accidentally
+    /// select user-scoped material for a workspace identity.
+    pub subject: SourceIdentitySubject,
+    /// Source/schema name whose surface needs identity material.
+    pub source_name: String,
+    /// DSL v4 surface id.
+    pub surface_id: String,
+    /// Configured source-surface identity binding.
+    pub binding: SourceIdentityBinding,
+    /// Concrete source-surface identity selection.
+    pub selection: SourceIdentitySelection,
+    /// The workspace binding's selected identity requirements.
+    pub identity_requirements: IdentityRequirements,
+}
+
+/// Provider that resolves configured Coral identity bindings into runtime material.
+#[tonic::async_trait]
+#[expect(
+    unreachable_pub,
+    reason = "source identity provider seam re-exported from lib.rs in a later PR"
+)]
+pub trait SourceIdentityProvider: Send + Sync + fmt::Debug {
+    /// Resolves one user-owned source identity selection.
+    ///
+    /// Providers return `Ok(None)` when they do not own the requested
+    /// selection scope. Workspace-owned bindings are resolved directly from the
+    /// workspace binding and do not call providers for selection.
+    async fn resolve_source_identity_selection(
+        &self,
+        _request: &SourceIdentitySelectionRequest,
+    ) -> Result<Option<SourceIdentitySelection>, AppError> {
+        Ok(None)
+    }
+
+    /// Resolves one source identity binding.
+    ///
+    /// Providers return `Ok(None)` when they do not own the requested identity
+    /// reference. Coral tries providers in registration order and fails if none
+    /// can resolve a required binding.
+    async fn resolve_source_identity(
+        &self,
+        request: &SourceIdentityResolutionRequest,
+    ) -> Result<Option<Arc<dyn RuntimeSourceIdentity>>, AppError>;
+}
+
+/// Runtime identity selected by Coral for one source surface.
+#[tonic::async_trait]
+#[expect(
+    dead_code,
+    unreachable_pub,
+    reason = "runtime source identity seam consumed and re-exported in later PRs"
+)]
+pub trait RuntimeSourceIdentity: Send + Sync + fmt::Debug {
+    /// Installed identity spec id that describes this identity.
+    fn identity_spec_id(&self) -> &str;
+
+    /// Candidate audience claims for requirement matching.
+    fn audience(&self) -> &BTreeMap<String, Value>;
+
+    /// Returns headers to append to the outbound HTTP request.
+    async fn resolve_headers(
+        &self,
+        identity: &RequestIdentityResolutionContext,
+        request: &reqwest::Request,
+        resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError>;
+}
+
+/// App-owned identity manager. It owns binding resolution policy; providers
+/// only supply material for an already-selected binding.
+#[derive(Clone, Default)]
+pub(crate) struct IdentityManager {
+    providers: Arc<Vec<Arc<dyn SourceIdentityProvider>>>,
+}
+
+#[expect(
+    dead_code,
+    reason = "identity manager consumed by query-time identity resolution in a later PR"
+)]
+impl IdentityManager {
+    pub(crate) fn new(providers: Vec<Arc<dyn SourceIdentityProvider>>) -> Self {
+        Self {
+            providers: Arc::new(providers),
+        }
+    }
+
+    pub(crate) async fn resolve_source_identity(
+        &self,
+        request: SourceIdentityResolutionRequest,
+    ) -> Result<Arc<dyn RuntimeSourceIdentity>, AppError> {
+        for provider in self.providers.iter() {
+            if let Some(identity) = provider.resolve_source_identity(&request).await? {
+                return Ok(identity);
+            }
+        }
+        Err(AppError::FailedPrecondition(format!(
+            "no source identity provider resolved identity '{}' for source '{}' surface '{}'",
+            request.selection.identity, request.source_name, request.surface_id
+        )))
+    }
+
+    pub(crate) async fn resolve_source_identity_selection(
+        &self,
+        request: SourceIdentitySelectionRequest,
+    ) -> Result<SourceIdentitySelection, AppError> {
+        if request.binding.owner == SourceIdentityOwner::Workspace {
+            return request.binding.workspace_selection();
+        }
+        for provider in self.providers.iter() {
+            if let Some(selection) = provider.resolve_source_identity_selection(&request).await? {
+                return Ok(selection);
+            }
+        }
+        Err(AppError::FailedPrecondition(format!(
+            "no source identity provider resolved user-owned selection for source '{}' surface '{}' and user '{}'",
+            request.source_name,
+            request.surface_id,
+            request.subject.user_id().unwrap_or("<unresolved>")
+        )))
+    }
+}
+
+impl fmt::Debug for IdentityManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IdentityManager")
+            .field("provider_count", &self.providers.len())
+            .finish()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::parse_path_segment;
+    use super::{
+        LOCAL_MEMBER_ID, SourceIdentityOwner, SourceIdentitySubject, UserPrincipal,
+        parse_path_segment,
+    };
 
     #[test]
     fn rejects_empty_names() {
@@ -161,6 +592,37 @@ mod tests {
             error
                 .to_string()
                 .contains("source name must not be '.' or '..'")
+        );
+    }
+
+    #[test]
+    fn user_principal_rejects_reserved_local_sentinel() {
+        let principal = UserPrincipal::for_user("saul").expect("named user");
+        assert_eq!(principal.user_id(), "saul");
+
+        let error = UserPrincipal::for_user(LOCAL_MEMBER_ID).expect_err("local id is reserved");
+        assert!(
+            error
+                .to_string()
+                .contains("reserved for single-user local mode"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn source_identity_subject_carries_user_only_for_user_owned_bindings() {
+        let user_principal = UserPrincipal::for_user("saul").expect("named user");
+
+        assert_eq!(
+            SourceIdentitySubject::for_binding_owner(SourceIdentityOwner::User, &user_principal),
+            SourceIdentitySubject::User("saul".to_string())
+        );
+        assert_eq!(
+            SourceIdentitySubject::for_binding_owner(
+                SourceIdentityOwner::Workspace,
+                &user_principal,
+            ),
+            SourceIdentitySubject::Workspace
         );
     }
 }

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -1,0 +1,1354 @@
+//! Filesystem-backed global identity-spec registry.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::sync::Arc;
+
+use coral_spec::{IdentityManifest, ManifestInputKind, parse_identity_manifest_yaml};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest as _, Sha256};
+use tracing::info_span;
+
+use crate::bootstrap::AppError;
+use crate::credentials::{CredentialSetId, CredentialStorageKind, CredentialStore};
+use crate::features::Features;
+use crate::identity::{parse_path_segment, unique_input_map};
+use crate::state::{AppStateLayout, INSTALLED_IDENTITY_FILE_NAME};
+use crate::storage::fs::{self as storage_fs, FileLock};
+use crate::workspaces::WorkspaceName;
+
+const IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME: &str = "inputs.yaml";
+const IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION: u32 = 1;
+
+/// One installed global identity spec.
+#[derive(Debug, Clone)]
+pub(crate) struct IdentitySpecRecord {
+    pub(crate) manifest_yaml: String,
+    pub(crate) manifest: IdentityManifest,
+}
+
+/// One setup input value for a globally installed identity spec.
+#[derive(Debug, Clone)]
+pub(crate) struct IdentitySpecInputValue {
+    pub(crate) key: String,
+    pub(crate) value: String,
+}
+
+/// Validated identity of one identity-spec manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentitySpecManifestMetadata {
+    /// Stable identity-spec id declared by the manifest.
+    pub identity_spec_id: String,
+    /// Authored identity-spec version.
+    pub version: String,
+}
+
+/// Validates one identity-spec manifest and returns its registry identity.
+///
+/// # Errors
+///
+/// Returns [`AppError`] when the manifest is invalid.
+pub fn identity_spec_manifest_metadata(
+    manifest_yaml: &str,
+) -> Result<IdentitySpecManifestMetadata, AppError> {
+    let manifest = parse_identity_manifest_yaml(manifest_yaml)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    Ok(IdentitySpecManifestMetadata {
+        identity_spec_id: manifest.name,
+        version: manifest.version,
+    })
+}
+
+/// Validates identity-spec setup inputs for one manifest.
+///
+/// # Errors
+///
+/// Returns [`AppError`] when the manifest or inputs are invalid.
+pub fn identity_spec_input_material_from_manifest(
+    manifest_yaml: &str,
+    inputs: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let existing = BTreeMap::new();
+    identity_spec_input_material_from_manifest_with_existing(manifest_yaml, &existing, inputs)
+}
+
+/// Validates identity-spec setup inputs and merges them over existing material.
+///
+/// # Errors
+///
+/// Returns [`AppError`] when the manifest or inputs are invalid.
+pub fn identity_spec_input_material_from_manifest_with_existing(
+    manifest_yaml: &str,
+    existing_input_material: &BTreeMap<String, String>,
+    inputs: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let record = parse_identity_spec_record(manifest_yaml)?;
+    merge_identity_spec_input_material(&record.manifest, existing_input_material, inputs)
+}
+
+/// Durable record for one installed global identity spec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentitySpecRegistryRecord {
+    /// Raw identity-spec manifest YAML.
+    pub manifest_yaml: String,
+    /// Stored setup input material for later identity materialization.
+    pub input_material: BTreeMap<String, String>,
+}
+
+/// Durable storage backend for global identity specs.
+pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
+    /// Lists all installed identity specs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the registry cannot be read.
+    fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRegistryRecord>, AppError>;
+
+    /// Fetches one identity spec by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the registry cannot be read.
+    fn get_identity_spec(&self, name: &str)
+    -> Result<Option<IdentitySpecRegistryRecord>, AppError>;
+
+    /// Inserts or replaces one identity spec.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the record cannot be persisted.
+    fn upsert_identity_spec(
+        &self,
+        name: &str,
+        record: IdentitySpecRegistryRecord,
+    ) -> Result<(), AppError>;
+
+    /// Removes one identity spec.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the record cannot be removed.
+    fn remove_identity_spec(&self, name: &str) -> Result<(), AppError>;
+}
+
+/// Complete rollback snapshot for one installed global identity spec.
+#[derive(Debug, Clone)]
+pub(crate) struct IdentitySpecSnapshot {
+    record: IdentitySpecRecord,
+    input_material: BTreeMap<String, String>,
+}
+
+impl IdentitySpecSnapshot {
+    pub(crate) fn name(&self) -> &str {
+        &self.record.manifest.name
+    }
+}
+
+/// Reports stored identities that reference an installed identity spec.
+///
+/// Identity ownership is orthogonal to identity type. Product runtimes that
+/// persist workspace-owned identities should install a provider so identity-spec
+/// deletion can reject or report orphaning for those identities too.
+pub trait IdentitySpecUsageProvider: Send + Sync + std::fmt::Debug + 'static {
+    /// Returns how many stored identities currently depend on `identity_spec_name`.
+    ///
+    /// The count should include every relevant identity owner and type managed
+    /// by the provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the provider cannot inspect its identity store.
+    fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError>;
+}
+
+/// Manages identity specs installed for all workspaces.
+#[derive(Clone)]
+pub(crate) struct IdentitySpecManager {
+    layout: AppStateLayout,
+    registry: Arc<dyn IdentitySpecRegistry>,
+    features: Features,
+    usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+}
+
+impl std::fmt::Debug for IdentitySpecManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IdentitySpecManager")
+            .field("layout", &self.layout)
+            .field("registry", &self.registry)
+            .field("features", &self.features)
+            .field("usage_providers", &self.usage_providers)
+            .finish_non_exhaustive()
+    }
+}
+
+impl IdentitySpecManager {
+    #[cfg(test)]
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self::new_with_usage_providers(layout, crate::features::dsl_v4_features(), Vec::new())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_usage_providers(
+        layout: AppStateLayout,
+        features: Features,
+        usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+    ) -> Self {
+        let credential_store = CredentialStore::with_preference(
+            layout.clone(),
+            crate::credentials::CredentialStoragePreference::File,
+        );
+        Self::new_with_credential_store(layout, credential_store, features, usage_providers)
+    }
+
+    pub(crate) fn new_with_credential_store(
+        layout: AppStateLayout,
+        credential_store: CredentialStore,
+        features: Features,
+        usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+    ) -> Self {
+        let registry = Arc::new(FileIdentitySpecRegistry::new(
+            layout.clone(),
+            credential_store,
+        ));
+        Self::new_with_registry(layout, registry, features, usage_providers)
+    }
+
+    pub(crate) fn new_with_registry(
+        layout: AppStateLayout,
+        registry: Arc<dyn IdentitySpecRegistry>,
+        features: Features,
+        usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+    ) -> Self {
+        Self {
+            layout,
+            registry,
+            features,
+            usage_providers,
+        }
+    }
+
+    /// Errors unless the preview DSL v4 runtime feature is enabled.
+    ///
+    /// Identity specs back DSL v4 source identities, so the whole `identity-spec`
+    /// surface is gated behind `dsl_v4`. The mutating manager methods enforce the
+    /// gate directly (and so cover the source-import bundle path); the read-only
+    /// `get_identity_spec` is also used by query-time identity resolution, so its
+    /// RPC enforces the gate from the service layer instead of the method.
+    pub(crate) fn ensure_dsl_v4_enabled(&self) -> Result<(), AppError> {
+        self.features.ensure_dsl_v4_enabled()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn add_identity_spec(
+        &self,
+        manifest_yaml: &str,
+    ) -> Result<(IdentitySpecRecord, bool), AppError> {
+        self.add_identity_spec_with_inputs(manifest_yaml, Vec::new())
+    }
+
+    pub(crate) fn add_identity_spec_with_inputs(
+        &self,
+        manifest_yaml: &str,
+        inputs: Vec<IdentitySpecInputValue>,
+    ) -> Result<(IdentitySpecRecord, bool), AppError> {
+        let span = info_span!("coral.app.identity_specs.add");
+        let _guard = span.enter();
+        self.features.ensure_dsl_v4_enabled()?;
+        let record = parse_identity_spec_record(manifest_yaml)?;
+        let name = record.manifest.name.clone();
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        let existing = self.registry.get_identity_spec(&name)?;
+        let replaced = existing.is_some();
+        let existing_input_material = existing
+            .as_ref()
+            .map(|record| record.input_material.clone())
+            .unwrap_or_default();
+        if let Some(existing) = &existing {
+            let existing = parse_identity_spec_record(&existing.manifest_yaml)?;
+            if existing.manifest != record.manifest {
+                let referencing_identities = self.count_identities_for_spec_unlocked(&name)?;
+                if referencing_identities > 0 {
+                    return Err(AppError::FailedPrecondition(format!(
+                        "identity spec '{name}' is used by {referencing_identities} stored {} and cannot be replaced with a different manifest; remove it with --force only if you intend to recreate {} against a new spec",
+                        plural_identity(referencing_identities),
+                        plural_pronoun(referencing_identities)
+                    )));
+                }
+            }
+        }
+        let provided_inputs = unique_input_map(
+            inputs.into_iter().map(|input| (input.key, input.value)),
+            "identity spec input",
+        )?;
+        let input_material = merge_identity_spec_input_material(
+            &record.manifest,
+            &existing_input_material,
+            &provided_inputs,
+        )?;
+        self.registry.upsert_identity_spec(
+            &record.manifest.name,
+            IdentitySpecRegistryRecord {
+                manifest_yaml: record.manifest_yaml.clone(),
+                input_material,
+            },
+        )?;
+        Ok((record, replaced))
+    }
+
+    pub(crate) fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRecord>, AppError> {
+        let span = info_span!("coral.app.identity_specs.list");
+        let _guard = span.enter();
+        self.features.ensure_dsl_v4_enabled()?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        let mut records = self
+            .registry
+            .list_identity_specs()?
+            .into_iter()
+            .map(|record| parse_identity_spec_record(&record.manifest_yaml))
+            .collect::<Result<Vec<_>, _>>()?;
+        records.sort_by(|left, right| left.manifest.name.cmp(&right.manifest.name));
+        Ok(records)
+    }
+
+    pub(crate) fn get_identity_spec(&self, name: &str) -> Result<IdentitySpecRecord, AppError> {
+        let span = info_span!("coral.app.identity_specs.get");
+        let _guard = span.enter();
+        let name = validate_identity_spec_name(name)?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        self.load_identity_spec_unlocked(&name)
+    }
+
+    #[expect(
+        dead_code,
+        reason = "identity-spec rollback snapshot consumed by the source import flow in a later PR"
+    )]
+    pub(crate) fn snapshot_identity_spec(
+        &self,
+        name: &str,
+    ) -> Result<Option<IdentitySpecSnapshot>, AppError> {
+        let span = info_span!("coral.app.identity_specs.snapshot");
+        let _guard = span.enter();
+        let name = validate_identity_spec_name(name)?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        let Some(stored) = self.registry.get_identity_spec(&name)? else {
+            return Ok(None);
+        };
+        let record = parse_identity_spec_record(&stored.manifest_yaml)?;
+        Ok(Some(IdentitySpecSnapshot {
+            record,
+            input_material: stored.input_material,
+        }))
+    }
+
+    #[expect(
+        dead_code,
+        reason = "identity-spec rollback snapshot consumed by the source import flow in a later PR"
+    )]
+    pub(crate) fn restore_identity_spec_snapshot(
+        &self,
+        snapshot: &IdentitySpecSnapshot,
+    ) -> Result<(), AppError> {
+        let span = info_span!("coral.app.identity_specs.restore_snapshot");
+        let _guard = span.enter();
+        let name = validate_identity_spec_name(snapshot.name())?;
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        self.registry.upsert_identity_spec(
+            &name,
+            IdentitySpecRegistryRecord {
+                manifest_yaml: snapshot.record.manifest_yaml.clone(),
+                input_material: snapshot.input_material.clone(),
+            },
+        )?;
+        Ok(())
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by user-owned identity materialization and query-time identity resolution in later PRs"
+        )
+    )]
+    pub(crate) fn resolve_identity_spec_inputs(
+        &self,
+        manifest: &IdentityManifest,
+    ) -> Result<BTreeMap<String, String>, AppError> {
+        let span = info_span!("coral.app.identity_specs.resolve_inputs");
+        let _guard = span.enter();
+        let name = validate_identity_spec_name(&manifest.name)?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        let stored = self
+            .registry
+            .get_identity_spec(&name)?
+            .map(|record| record.input_material)
+            .unwrap_or_default();
+        resolve_identity_spec_inputs_for_use(manifest, &stored)
+    }
+
+    pub(crate) fn remove_identity_spec(&self, name: &str, force: bool) -> Result<u32, AppError> {
+        let span = info_span!("coral.app.identity_specs.remove");
+        let _guard = span.enter();
+        self.features.ensure_dsl_v4_enabled()?;
+        let name = validate_identity_spec_name(name)?;
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        if self.registry.get_identity_spec(&name)?.is_none() {
+            return Err(AppError::IdentitySpecNotFound(name));
+        }
+        let orphaned_identities = self.count_identities_for_spec_unlocked(&name)?;
+        if orphaned_identities > 0 && !force {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity spec '{name}' is used by {orphaned_identities} stored {}; rerun with --force to orphan {}",
+                plural_identity(orphaned_identities),
+                plural_pronoun(orphaned_identities)
+            )));
+        }
+        self.registry.remove_identity_spec(&name)?;
+        Ok(orphaned_identities)
+    }
+
+    fn load_identity_spec_unlocked(&self, name: &str) -> Result<IdentitySpecRecord, AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let Some(stored) = self.registry.get_identity_spec(&name)? else {
+            return Err(AppError::IdentitySpecNotFound(name));
+        };
+        let record = parse_identity_spec_record(&stored.manifest_yaml)?;
+        if record.manifest.name != name {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity spec registry record '{name}' contains identity spec '{}'",
+                record.manifest.name
+            )));
+        }
+        Ok(record)
+    }
+
+    fn count_identities_for_spec_unlocked(
+        &self,
+        identity_spec_name: &str,
+    ) -> Result<u32, AppError> {
+        let mut count = self.count_user_owned_identities_for_spec_unlocked(identity_spec_name)?;
+        for provider in &self.usage_providers {
+            count = checked_add_identity_count(
+                count,
+                provider.count_identities_for_spec(identity_spec_name)?,
+                identity_spec_name,
+            )?;
+        }
+        Ok(count)
+    }
+
+    fn count_user_owned_identities_for_spec_unlocked(
+        &self,
+        identity_spec_name: &str,
+    ) -> Result<u32, AppError> {
+        let users_root = self.layout.identities_root().join("users");
+        if !users_root.exists() {
+            return Ok(0);
+        }
+        let mut count = 0u32;
+        for user_entry in fs::read_dir(users_root)? {
+            let user_entry = user_entry?;
+            if !user_entry.file_type()?.is_dir() {
+                continue;
+            }
+            for identity_entry in fs::read_dir(user_entry.path())? {
+                let identity_entry = identity_entry?;
+                if !identity_entry.file_type()?.is_dir() {
+                    continue;
+                }
+                let manifest_path = identity_entry.path().join(INSTALLED_IDENTITY_FILE_NAME);
+                if !manifest_path.exists() {
+                    continue;
+                }
+                let raw = fs::read_to_string(&manifest_path)?;
+                let reference: UserOwnedIdentitySpecReference = serde_yaml::from_str(&raw)?;
+                if reference.identity_spec == identity_spec_name {
+                    count = checked_add_identity_count(count, 1, identity_spec_name)?;
+                }
+            }
+        }
+        Ok(count)
+    }
+}
+
+struct FileIdentitySpecRegistry {
+    layout: AppStateLayout,
+    credential_store: CredentialStore,
+}
+
+impl std::fmt::Debug for FileIdentitySpecRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileIdentitySpecRegistry")
+            .field("layout", &self.layout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FileIdentitySpecRegistry {
+    fn new(layout: AppStateLayout, credential_store: CredentialStore) -> Self {
+        Self {
+            layout,
+            credential_store,
+        }
+    }
+
+    fn input_material_state_file(&self, name: &str) -> std::path::PathBuf {
+        self.layout
+            .identity_spec_dir(name)
+            .join(IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME)
+    }
+
+    fn credential_set_id(name: &str) -> CredentialSetId {
+        CredentialSetId::for_identity_spec(name)
+    }
+
+    fn input_material_workspace() -> WorkspaceName {
+        WorkspaceName::default()
+    }
+
+    fn load_input_material_state(
+        &self,
+        name: &str,
+    ) -> Result<IdentitySpecInputMaterialState, AppError> {
+        let path = self.input_material_state_file(name);
+        if !path.exists() {
+            return Ok(IdentitySpecInputMaterialState::default());
+        }
+        let raw = fs::read_to_string(&path)?;
+        let state: IdentitySpecInputMaterialState = serde_yaml::from_str(&raw)?;
+        if state.version != IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity spec '{name}' input material state has unsupported version {}",
+                state.version
+            )));
+        }
+        Ok(state)
+    }
+
+    fn write_input_material_state(
+        &self,
+        name: &str,
+        state: &IdentitySpecInputMaterialState,
+    ) -> Result<(), AppError> {
+        let path = self.input_material_state_file(name);
+        if state.credential_storage.is_none() {
+            remove_file_if_exists(&path)?;
+            return Ok(());
+        }
+        let raw = serde_yaml::to_string(state)?;
+        storage_fs::write_atomic(&path, raw.as_bytes())?;
+        Ok(())
+    }
+
+    fn read_input_material(
+        &self,
+        name: &str,
+        storage: CredentialStorageKind,
+    ) -> Result<BTreeMap<String, String>, AppError> {
+        self.credential_store.read_material(
+            &Self::input_material_workspace(),
+            &Self::credential_set_id(name),
+            storage,
+        )
+    }
+
+    fn replace_input_material(
+        &self,
+        name: &str,
+        existing_storage: Option<CredentialStorageKind>,
+        next_storage: Option<CredentialStorageKind>,
+        material: &BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
+        if let Some(existing_storage) = existing_storage
+            && Some(existing_storage) != next_storage
+        {
+            self.credential_store.remove_material_unlocked(
+                &Self::input_material_workspace(),
+                &Self::credential_set_id(name),
+                existing_storage,
+            )?;
+        }
+        let Some(storage) = next_storage else {
+            remove_file_if_exists(&self.layout.identity_spec_material_file(name))?;
+            return Ok(());
+        };
+        self.credential_store.replace_material_unlocked(
+            &Self::input_material_workspace(),
+            &Self::credential_set_id(name),
+            storage,
+            material,
+        )
+    }
+
+    fn remove_input_material(&self, name: &str) -> Result<(), AppError> {
+        let state = self.load_input_material_state(name)?;
+        if let Some(storage) = state.credential_storage {
+            self.credential_store.remove_material_unlocked(
+                &Self::input_material_workspace(),
+                &Self::credential_set_id(name),
+                storage,
+            )?;
+        }
+        remove_file_if_exists(&self.input_material_state_file(name))?;
+        remove_file_if_exists(&self.layout.identity_spec_material_file(name))?;
+        Ok(())
+    }
+}
+
+impl IdentitySpecRegistry for FileIdentitySpecRegistry {
+    fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRegistryRecord>, AppError> {
+        let root = self.layout.identity_specs_root();
+        if !root.exists() {
+            return Ok(Vec::new());
+        }
+        let mut records = Vec::new();
+        for entry in fs::read_dir(root)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(ToString::to_string) else {
+                continue;
+            };
+            if let Some(record) = self.get_identity_spec(&name)? {
+                records.push(record);
+            }
+        }
+        Ok(records)
+    }
+
+    fn get_identity_spec(
+        &self,
+        name: &str,
+    ) -> Result<Option<IdentitySpecRegistryRecord>, AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let path = self.layout.identity_spec_manifest_file(&name);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let manifest_yaml = fs::read_to_string(&path)?;
+        let state = self.load_input_material_state(&name)?;
+        let input_material = match state.credential_storage {
+            Some(storage) => self.read_input_material(&name, storage)?,
+            None => BTreeMap::new(),
+        };
+        Ok(Some(IdentitySpecRegistryRecord {
+            manifest_yaml,
+            input_material,
+        }))
+    }
+
+    fn upsert_identity_spec(
+        &self,
+        name: &str,
+        record: IdentitySpecRegistryRecord,
+    ) -> Result<(), AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let path = self.layout.identity_spec_manifest_file(&name);
+        let previous_material_state = if path.exists() {
+            Some(self.load_input_material_state(&name)?)
+        } else {
+            None
+        };
+        let existing_storage = previous_material_state
+            .as_ref()
+            .and_then(|state| state.credential_storage);
+        let credential_storage = if record.input_material.is_empty() {
+            None
+        } else {
+            existing_storage.or(Some(self.credential_store.default_write_storage()?))
+        };
+        if let Some(parent) = path.parent() {
+            storage_fs::ensure_private_dir(parent)?;
+        }
+        self.replace_input_material(
+            &name,
+            existing_storage,
+            credential_storage,
+            &record.input_material,
+        )?;
+        storage_fs::write_atomic(&path, record.manifest_yaml.as_bytes())?;
+        self.write_input_material_state(
+            &name,
+            &IdentitySpecInputMaterialState {
+                credential_storage,
+                version: IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION,
+            },
+        )
+    }
+
+    fn remove_identity_spec(&self, name: &str) -> Result<(), AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let path = self.layout.identity_spec_manifest_file(&name);
+        if !path.exists() {
+            return Ok(());
+        }
+        fs::remove_file(&path)?;
+        self.remove_input_material(&name)?;
+        if let Some(parent) = path.parent() {
+            drop(fs::remove_dir(parent));
+        }
+        Ok(())
+    }
+}
+
+fn checked_add_identity_count(
+    left: u32,
+    right: u32,
+    identity_spec_name: &str,
+) -> Result<u32, AppError> {
+    left.checked_add(right).ok_or_else(|| {
+        AppError::FailedPrecondition(format!(
+            "too many stored identities reference identity spec '{identity_spec_name}'"
+        ))
+    })
+}
+
+/// Hashes the parsed identity manifest so stored identities can detect when
+/// the spec they were created from has changed.
+///
+/// The manifest serializes with `serde` (struct fields in declaration order)
+/// and `canonical_json_value` sorts any free-form JSON objects (such as
+/// `audience` values), so semantically equal manifests fingerprint equally.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by user-owned identity creation in a later PR"
+    )
+)]
+pub(crate) fn identity_spec_fingerprint(manifest: &IdentityManifest) -> Result<String, AppError> {
+    let encode_error = |error: &dyn std::fmt::Display| {
+        AppError::FailedPrecondition(format!(
+            "failed to encode identity spec '{}' fingerprint: {error}",
+            manifest.name
+        ))
+    };
+    let value = canonical_json_value(serde_json::to_value(manifest).map_err(|e| encode_error(&e))?);
+    let bytes = serde_json::to_vec(&value).map_err(|e| encode_error(&e))?;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn canonical_json_value(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut entries = map.into_iter().collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            Value::Object(
+                entries
+                    .into_iter()
+                    .map(|(key, value)| (key, canonical_json_value(value)))
+                    .collect(),
+            )
+        }
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .map(canonical_json_value)
+                .collect::<Vec<_>>(),
+        ),
+        scalar => scalar,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct UserOwnedIdentitySpecReference {
+    identity_spec: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IdentitySpecInputMaterialState {
+    version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    credential_storage: Option<CredentialStorageKind>,
+}
+
+impl Default for IdentitySpecInputMaterialState {
+    fn default() -> Self {
+        Self {
+            version: IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION,
+            credential_storage: None,
+        }
+    }
+}
+
+fn merge_identity_spec_input_material(
+    manifest: &IdentityManifest,
+    stored: &BTreeMap<String, String>,
+    provided: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let declared = manifest
+        .inputs
+        .iter()
+        .map(|input| input.key.as_str())
+        .collect::<BTreeSet<_>>();
+    for key in provided.keys() {
+        if !declared.contains(key.as_str()) {
+            return Err(AppError::InvalidInput(format!(
+                "unknown identity spec input '{key}' for identity spec '{}'",
+                manifest.name
+            )));
+        }
+    }
+
+    let mut material = BTreeMap::new();
+    for input in &manifest.inputs {
+        if let Some(value) = provided
+            .get(&input.key)
+            .filter(|value| !value.is_empty())
+            .or_else(|| stored.get(&input.key).filter(|value| !value.is_empty()))
+        {
+            material.insert(input.key.clone(), value.clone());
+        }
+    }
+    resolve_identity_spec_inputs_for_use(manifest, &material)?;
+    Ok(material)
+}
+
+fn resolve_identity_spec_inputs_for_use(
+    manifest: &IdentityManifest,
+    material: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let mut resolved = BTreeMap::new();
+    for input in &manifest.inputs {
+        let value = material
+            .get(&input.key)
+            .filter(|value| !value.is_empty())
+            .cloned()
+            .or_else(|| {
+                (input.kind == ManifestInputKind::Variable && !input.default_value.is_empty())
+                    .then(|| input.default_value.clone())
+            });
+        if let Some(value) = value {
+            resolved.insert(input.key.clone(), value);
+        } else if input.required {
+            return Err(AppError::FailedPrecondition(format!(
+                "missing identity spec input '{}' for identity spec '{}'",
+                input.key, manifest.name
+            )));
+        }
+    }
+    Ok(resolved)
+}
+
+fn remove_file_if_exists(path: &std::path::Path) -> Result<(), AppError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn plural_identity(count: u32) -> &'static str {
+    if count == 1 { "identity" } else { "identities" }
+}
+
+fn plural_pronoun(count: u32) -> &'static str {
+    if count == 1 { "it" } else { "them" }
+}
+
+fn parse_identity_spec_record(manifest_yaml: &str) -> Result<IdentitySpecRecord, AppError> {
+    let manifest = parse_identity_manifest_yaml(manifest_yaml)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    Ok(IdentitySpecRecord {
+        manifest_yaml: normalized_manifest_yaml(manifest_yaml),
+        manifest,
+    })
+}
+
+fn normalized_manifest_yaml(manifest_yaml: &str) -> String {
+    if manifest_yaml.ends_with('\n') {
+        manifest_yaml.to_string()
+    } else {
+        format!("{manifest_yaml}\n")
+    }
+}
+
+pub(crate) fn validate_identity_spec_name(name: &str) -> Result<String, AppError> {
+    parse_path_segment("identity spec", name)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+
+    use super::{
+        IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord, IdentitySpecUsageProvider,
+        identity_spec_fingerprint,
+    };
+    use crate::bootstrap::AppError;
+    use crate::credentials::parse_env_file;
+    use crate::features::{Features, dsl_v4_features};
+    use crate::state::AppStateLayout;
+
+    fn manager() -> (TempDir, IdentitySpecManager, AppStateLayout) {
+        manager_with(dsl_v4_features(), Vec::new())
+    }
+
+    fn manager_with(
+        features: Features,
+        usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+    ) -> (TempDir, IdentitySpecManager, AppStateLayout) {
+        let temp = TempDir::new().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout directories");
+        let manager = IdentitySpecManager::new_with_usage_providers(
+            layout.clone(),
+            features,
+            usage_providers,
+        );
+        (temp, manager, layout)
+    }
+
+    #[track_caller]
+    fn add_spec(manager: &IdentitySpecManager, yaml: &str) -> (IdentitySpecRecord, bool) {
+        manager.add_identity_spec(yaml).expect("add identity spec")
+    }
+
+    #[track_caller]
+    fn add_spec_with_secret(
+        manager: &IdentitySpecManager,
+        yaml: &str,
+    ) -> (IdentitySpecRecord, bool) {
+        manager
+            .add_identity_spec_with_inputs(
+                yaml,
+                vec![IdentitySpecInputValue {
+                    key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                    value: "client-secret".to_string(),
+                }],
+            )
+            .expect("add identity spec with inputs")
+    }
+
+    #[track_caller]
+    fn remove_spec(manager: &IdentitySpecManager, name: &str, force: bool) -> u32 {
+        manager
+            .remove_identity_spec(name, force)
+            .expect("remove identity spec")
+    }
+
+    #[track_caller]
+    fn stored_spec(manager: &IdentitySpecManager, name: &str) -> IdentitySpecRecord {
+        manager.get_identity_spec(name).expect("stored spec")
+    }
+
+    #[track_caller]
+    fn resolved_inputs(
+        manager: &IdentitySpecManager,
+        record: &IdentitySpecRecord,
+    ) -> BTreeMap<String, String> {
+        manager
+            .resolve_identity_spec_inputs(&record.manifest)
+            .expect("resolve stored inputs")
+    }
+
+    #[track_caller]
+    fn assert_input(resolved: &BTreeMap<String, String>, key: &str, expected: &str) {
+        assert_eq!(resolved.get(key).map(String::as_str), Some(expected));
+    }
+
+    #[track_caller]
+    fn assert_failed_precondition(error: &AppError, fragments: [&str; 2]) {
+        match error {
+            AppError::FailedPrecondition(message) => {
+                for fragment in fragments {
+                    assert!(
+                        message.contains(fragment),
+                        "missing {fragment:?} in: {message}"
+                    );
+                }
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn identity_spec_operations_require_dsl_v4_feature() {
+        let (_temp, manager, _layout) = manager_with(Features::default(), Vec::new());
+
+        let errors = [
+            manager
+                .add_identity_spec(&identity_yaml("github_oauth", "0.1.0"))
+                .expect_err("add requires the dsl_v4 feature"),
+            manager
+                .list_identity_specs()
+                .expect_err("list requires the dsl_v4 feature"),
+            manager
+                .remove_identity_spec("github_oauth", true)
+                .expect_err("remove requires the dsl_v4 feature"),
+        ];
+
+        for error in errors {
+            assert!(
+                matches!(&error, AppError::SourceUnservable(message) if message.contains("dsl_v4")),
+                "unexpected error: {error:?}"
+            );
+        }
+    }
+
+    #[derive(Debug)]
+    struct StaticUsageProvider {
+        identity_spec_name: String,
+        count: u32,
+    }
+
+    impl IdentitySpecUsageProvider for StaticUsageProvider {
+        fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError> {
+            if identity_spec_name == self.identity_spec_name {
+                Ok(self.count)
+            } else {
+                Ok(0)
+            }
+        }
+    }
+
+    fn identity_yaml(name: &str, version: &str) -> String {
+        identity_yaml_with_audience(name, version, "github.com")
+    }
+
+    fn identity_yaml_with_audience(name: &str, version: &str, audience_host: &str) -> String {
+        identity_yaml_with_audience_block(name, version, &format!("  host: {audience_host}\n"))
+    }
+
+    fn identity_yaml_with_audience_block(name: &str, version: &str, audience: &str) -> String {
+        format!(
+            r"
+kind: identity
+spec_version: 1
+name: {name}
+version: {version}
+description: Demo identity.
+issuer: github
+type: fixed_token
+audience:
+{audience}"
+        )
+    }
+
+    fn oauth_identity_yaml_with_inputs() -> String {
+        oauth_identity_yaml_with_inputs_default("tenant-a")
+    }
+
+    fn oauth_identity_yaml_with_inputs_default(default_tenant: &str) -> String {
+        r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+description: Demo OAuth identity.
+issuer: demo
+type: oauth
+audience:
+  host: api.example.test
+inputs:
+  DEMO_TENANT:
+    kind: variable
+    required: false
+    default: {{default_tenant}}
+  DEMO_OAUTH_CLIENT_SECRET:
+    kind: secret
+    required: true
+oauth:
+  method:
+    label: Demo OAuth
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/callback
+    endpoints:
+      authorization_url: https://auth.example.test/{{input.DEMO_TENANT}}/authorize
+      token_url: https://auth.example.test/{{input.DEMO_TENANT}}/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+        transport: request_body
+"
+        .replace("{{default_tenant}}", default_tenant)
+    }
+
+    /// Merges the previous standalone replace test into the CRUD round-trip:
+    /// the version 0.2.0 re-add runs over the same stored spec.
+    #[test]
+    fn add_lists_gets_replaces_and_removes_identity_specs() {
+        let (_temp, manager, _layout) = manager();
+
+        let (record, replaced) = add_spec(&manager, &identity_yaml("github_oauth", "0.1.0"));
+        assert!(!replaced);
+        assert_eq!(record.manifest.name, "github_oauth");
+
+        let list = manager.list_identity_specs().expect("list identity specs");
+        assert_eq!(list.len(), 1);
+        assert_eq!(
+            list.first().expect("one identity spec").manifest.version,
+            "0.1.0"
+        );
+        assert_eq!(
+            stored_spec(&manager, "github_oauth").manifest.description,
+            "Demo identity."
+        );
+
+        let (record, replaced) = add_spec(&manager, &identity_yaml("github_oauth", "0.2.0"));
+        assert!(replaced);
+        assert_eq!(record.manifest.version, "0.2.0");
+        assert_eq!(
+            stored_spec(&manager, "github_oauth").manifest.version,
+            "0.2.0"
+        );
+
+        let orphaned = remove_spec(&manager, "github_oauth", false);
+        assert_eq!(orphaned, 0);
+        assert!(
+            manager
+                .list_identity_specs()
+                .expect("list again")
+                .is_empty()
+        );
+    }
+
+    /// Merges the previous missing-input rejection, declared-input storage,
+    /// and removal tests into one spec-owned input material lifecycle: the
+    /// add fails without the required secret, succeeds with it (storing the
+    /// material under the spec), and removal deletes the material with it.
+    #[test]
+    fn spec_owned_input_material_is_required_stored_on_spec_and_removed_with_it() {
+        let (_temp, manager, layout) = manager();
+
+        let error = manager
+            .add_identity_spec(&oauth_identity_yaml_with_inputs())
+            .expect_err("missing required input should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("missing identity spec input 'DEMO_OAUTH_CLIENT_SECRET'"),
+            "unexpected error: {error}"
+        );
+
+        let (record, replaced) = add_spec_with_secret(&manager, &oauth_identity_yaml_with_inputs());
+        assert!(!replaced);
+        let resolved = resolved_inputs(&manager, &record);
+        assert_input(&resolved, "DEMO_TENANT", "tenant-a");
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "client-secret");
+        assert!(
+            layout.identity_spec_material_file("demo_oauth").exists(),
+            "input material belongs under the installed identity spec"
+        );
+        let stored = parse_env_file(
+            &fs::read_to_string(layout.identity_spec_material_file("demo_oauth"))
+                .expect("identity spec material file"),
+        )
+        .expect("parse material");
+        assert!(
+            !stored.contains_key("DEMO_TENANT"),
+            "manifest defaults must not be persisted as identity-spec input material"
+        );
+
+        remove_spec(&manager, "demo_oauth", false);
+
+        assert!(!layout.identity_spec_material_file("demo_oauth").exists());
+        assert!(!layout.identity_spec_dir("demo_oauth").exists());
+    }
+
+    /// Merges the previous `readding_identity_spec_preserves_existing_input_material`
+    /// coverage with the changed-default re-add: both re-adds run against the same
+    /// stored material.
+    #[test]
+    fn readding_identity_spec_preserves_material_and_uses_new_manifest_default() {
+        let (_temp, manager, _layout) = manager();
+        let (record, _replaced) = add_spec_with_secret(
+            &manager,
+            &oauth_identity_yaml_with_inputs_default("tenant-a"),
+        );
+
+        // Re-adding the identical manifest keeps the stored input material.
+        add_spec(
+            &manager,
+            &oauth_identity_yaml_with_inputs_default("tenant-a"),
+        );
+        let resolved = resolved_inputs(&manager, &record);
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "client-secret");
+
+        // Re-adding with a changed manifest default uses the new default without
+        // persisting the old one.
+        let (record, replaced) = add_spec(
+            &manager,
+            &oauth_identity_yaml_with_inputs_default("tenant-b"),
+        );
+        assert!(replaced);
+        let resolved = resolved_inputs(&manager, &record);
+        assert_input(&resolved, "DEMO_TENANT", "tenant-b");
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "client-secret");
+    }
+
+    /// Merges the identical-manifest and changed-manifest re-add tests over
+    /// one spec referenced by a stored identity: re-adding the identical
+    /// manifest is allowed, while a different manifest is rejected and
+    /// leaves the stored spec untouched.
+    #[test]
+    fn add_over_used_identity_spec_allows_identical_manifest_and_rejects_changes() {
+        let (_temp, manager, layout) = manager();
+        let manifest_yaml = identity_yaml_with_audience("github_oauth", "0.1.0", "github.com");
+        add_spec(&manager, &manifest_yaml);
+        write_user_owned_identity_manifest(&layout, "local", "github_local", "github_oauth");
+
+        let (record, replaced) = add_spec(&manager, &manifest_yaml);
+        assert!(replaced);
+        assert_eq!(record.manifest.version, "0.1.0");
+
+        let error = manager
+            .add_identity_spec(&identity_yaml_with_audience(
+                "github_oauth",
+                "0.1.0",
+                "attacker.test",
+            ))
+            .expect_err("used identity spec replacement should fail");
+        assert_failed_precondition(&error, ["1 stored identity", "cannot be replaced"]);
+        assert_eq!(
+            stored_spec(&manager, "github_oauth")
+                .manifest
+                .audience
+                .get("host")
+                .and_then(serde_json::Value::as_str),
+            Some("github.com")
+        );
+    }
+
+    #[test]
+    fn identity_spec_fingerprint_canonicalizes_nested_json_object_order() {
+        let left = coral_spec::parse_identity_manifest_yaml(&identity_yaml_with_audience_block(
+            "github_oauth",
+            "0.1.0",
+            "  host: github.com\n  tenant: acme\n",
+        ))
+        .expect("left manifest");
+        let right = coral_spec::parse_identity_manifest_yaml(&identity_yaml_with_audience_block(
+            "github_oauth",
+            "0.1.0",
+            "  tenant: acme\n  host: github.com\n",
+        ))
+        .expect("right manifest");
+
+        assert_eq!(left, right);
+        assert_eq!(
+            identity_spec_fingerprint(&left).expect("left fingerprint"),
+            identity_spec_fingerprint(&right).expect("right fingerprint")
+        );
+    }
+
+    #[test]
+    fn remove_missing_identity_spec_reports_not_found() {
+        let (_temp, manager, _layout) = manager();
+
+        let error = manager
+            .remove_identity_spec("missing", false)
+            .expect_err("missing identity spec");
+
+        assert!(matches!(error, AppError::IdentitySpecNotFound(_)));
+    }
+
+    #[test]
+    fn rejects_invalid_identity_manifest() {
+        let (_temp, manager, _layout) = manager();
+
+        let error = manager
+            .add_identity_spec(
+                r"
+kind: identity
+spec_version: 1
+name: github_oauth
+version: 0.1.0
+issuer: github
+type: oauth
+",
+            )
+            .expect_err("invalid identity spec");
+
+        assert!(
+            error.to_string().contains("type oauth is missing oauth"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// Merges the previous without-force rejection test and the force-removal
+    /// orphan report test into one flow over the same stored identities.
+    #[test]
+    fn remove_identity_spec_requires_force_and_reports_orphaned_user_owned_identities() {
+        let (_temp, manager, layout) = manager();
+        add_spec(&manager, &identity_yaml("github_oauth", "0.1.0"));
+        write_user_owned_identity_manifest(&layout, "local", "github_local", "github_oauth");
+
+        let error = manager
+            .remove_identity_spec("github_oauth", false)
+            .expect_err("remove should require force");
+
+        assert_failed_precondition(&error, ["1 stored identity", "--force"]);
+        manager
+            .get_identity_spec("github_oauth")
+            .expect("spec remains installed");
+
+        write_user_owned_identity_manifest(&layout, "local", "github_alt", "github_oauth");
+        write_user_owned_identity_manifest(&layout, "local", "stripe_local", "stripe_oauth");
+
+        let orphaned = remove_spec(&manager, "github_oauth", true);
+
+        assert_eq!(orphaned, 2);
+        assert!(matches!(
+            manager
+                .get_identity_spec("github_oauth")
+                .expect_err("spec removed"),
+            AppError::IdentitySpecNotFound(_)
+        ));
+    }
+
+    #[test]
+    fn remove_identity_spec_counts_external_identity_usage_provider() {
+        let (_temp, manager, _layout) = manager_with(
+            dsl_v4_features(),
+            vec![Arc::new(StaticUsageProvider {
+                identity_spec_name: "github_oauth".to_string(),
+                count: 3,
+            })],
+        );
+        add_spec(&manager, &identity_yaml("github_oauth", "0.1.0"));
+
+        let error = manager
+            .remove_identity_spec("github_oauth", false)
+            .expect_err("remove should require force");
+        assert_failed_precondition(&error, ["3 stored identities", "--force"]);
+
+        let orphaned = remove_spec(&manager, "github_oauth", true);
+        assert_eq!(orphaned, 3);
+    }
+
+    fn write_user_owned_identity_manifest(
+        layout: &AppStateLayout,
+        user_id: &str,
+        identity_name: &str,
+        identity_spec: &str,
+    ) {
+        let path = layout.user_owned_identity_manifest_file(user_id, identity_name);
+        fs::create_dir_all(path.parent().expect("identity dir")).expect("identity dir");
+        fs::write(
+            path,
+            format!(
+                r"version: 1
+name: {identity_name}
+identity_spec: {identity_spec}
+issuer: github
+identity_type: oauth
+metadata: {{}}
+"
+            ),
+        )
+        .expect("write identity manifest");
+    }
+}

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use coral_spec::{IdentityManifest, ManifestInputKind, parse_identity_manifest_yaml};
@@ -11,7 +12,9 @@ use sha2::{Digest as _, Sha256};
 use tracing::info_span;
 
 use crate::bootstrap::AppError;
-use crate::credentials::{CredentialSetId, CredentialStorageKind, CredentialStore};
+use crate::credentials::{
+    CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialStore,
+};
 use crate::features::Features;
 use crate::identity::{parse_path_segment, unique_input_map};
 use crate::state::{AppStateLayout, INSTALLED_IDENTITY_FILE_NAME};
@@ -105,6 +108,21 @@ pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
     /// Returns [`AppError`] when the registry cannot be read.
     fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRegistryRecord>, AppError>;
 
+    /// Lists raw manifests for all installed identity specs without loading
+    /// stored setup input material.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the registry cannot be read.
+    fn list_identity_spec_manifests(&self) -> Result<Vec<String>, AppError> {
+        self.list_identity_specs().map(|records| {
+            records
+                .into_iter()
+                .map(|record| record.manifest_yaml)
+                .collect()
+        })
+    }
+
     /// Fetches one identity spec by name.
     ///
     /// # Errors
@@ -112,6 +130,18 @@ pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
     /// Returns [`AppError`] when the registry cannot be read.
     fn get_identity_spec(&self, name: &str)
     -> Result<Option<IdentitySpecRegistryRecord>, AppError>;
+
+    /// Fetches one raw identity-spec manifest by name without loading stored
+    /// setup input material.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the registry cannot be read.
+    fn get_identity_spec_manifest(&self, name: &str) -> Result<Option<String>, AppError> {
+        Ok(self
+            .get_identity_spec(name)?
+            .map(|record| record.manifest_yaml))
+    }
 
     /// Inserts or replaces one identity spec.
     ///
@@ -266,6 +296,7 @@ impl IdentitySpecManager {
             .unwrap_or_default();
         if let Some(existing) = &existing {
             let existing = parse_identity_spec_record(&existing.manifest_yaml)?;
+            ensure_identity_spec_record_name(&name, &existing)?;
             if existing.manifest != record.manifest {
                 let referencing_identities = self.count_identities_for_spec_unlocked(&name)?;
                 if referencing_identities > 0 {
@@ -303,9 +334,9 @@ impl IdentitySpecManager {
         let _lock = FileLock::shared(self.layout.state_lock())?;
         let mut records = self
             .registry
-            .list_identity_specs()?
+            .list_identity_spec_manifests()?
             .into_iter()
-            .map(|record| parse_identity_spec_record(&record.manifest_yaml))
+            .map(|manifest_yaml| parse_identity_spec_record(&manifest_yaml))
             .collect::<Result<Vec<_>, _>>()?;
         records.sort_by(|left, right| left.manifest.name.cmp(&right.manifest.name));
         Ok(records)
@@ -392,33 +423,27 @@ impl IdentitySpecManager {
         self.features.ensure_dsl_v4_enabled()?;
         let name = validate_identity_spec_name(name)?;
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        if self.registry.get_identity_spec(&name)?.is_none() {
-            return Err(AppError::IdentitySpecNotFound(name));
-        }
-        let orphaned_identities = self.count_identities_for_spec_unlocked(&name)?;
+        let record = self.load_identity_spec_unlocked(&name)?;
+        let identity_spec_name = record.manifest.name;
+        let orphaned_identities = self.count_identities_for_spec_unlocked(&identity_spec_name)?;
         if orphaned_identities > 0 && !force {
             return Err(AppError::FailedPrecondition(format!(
-                "identity spec '{name}' is used by {orphaned_identities} stored {}; rerun with --force to orphan {}",
+                "identity spec '{identity_spec_name}' is used by {orphaned_identities} stored {}; rerun with --force to orphan {}",
                 plural_identity(orphaned_identities),
                 plural_pronoun(orphaned_identities)
             )));
         }
-        self.registry.remove_identity_spec(&name)?;
+        self.registry.remove_identity_spec(&identity_spec_name)?;
         Ok(orphaned_identities)
     }
 
     fn load_identity_spec_unlocked(&self, name: &str) -> Result<IdentitySpecRecord, AppError> {
         let name = validate_identity_spec_name(name)?;
-        let Some(stored) = self.registry.get_identity_spec(&name)? else {
+        let Some(manifest_yaml) = self.registry.get_identity_spec_manifest(&name)? else {
             return Err(AppError::IdentitySpecNotFound(name));
         };
-        let record = parse_identity_spec_record(&stored.manifest_yaml)?;
-        if record.manifest.name != name {
-            return Err(AppError::FailedPrecondition(format!(
-                "identity spec registry record '{name}' contains identity spec '{}'",
-                record.manifest.name
-            )));
-        }
+        let record = parse_identity_spec_record(&manifest_yaml)?;
+        ensure_identity_spec_record_name(&name, &record)?;
         Ok(record)
     }
 
@@ -474,6 +499,24 @@ impl IdentitySpecManager {
 struct FileIdentitySpecRegistry {
     layout: AppStateLayout,
     credential_store: CredentialStore,
+    #[cfg(test)]
+    fail_manifest_remove_for_test: bool,
+}
+
+struct IdentitySpecUpsertRollback {
+    manifest_path: PathBuf,
+    previous_manifest: Option<Vec<u8>>,
+    input_material_state_path: PathBuf,
+    previous_input_material_state: Option<Vec<u8>>,
+    previous_credential_storage: Option<CredentialStorageKind>,
+    previous_credential_material: Option<CredentialMaterialSnapshot>,
+}
+
+struct IdentitySpecRemoveRollback {
+    input_material_state_path: PathBuf,
+    previous_input_material_state: Option<Vec<u8>>,
+    previous_credential_storage: Option<CredentialStorageKind>,
+    previous_credential_material: Option<CredentialMaterialSnapshot>,
 }
 
 impl std::fmt::Debug for FileIdentitySpecRegistry {
@@ -489,6 +532,20 @@ impl FileIdentitySpecRegistry {
         Self {
             layout,
             credential_store,
+            #[cfg(test)]
+            fail_manifest_remove_for_test: false,
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_manifest_remove_failure_for_test(
+        layout: AppStateLayout,
+        credential_store: CredentialStore,
+    ) -> Self {
+        Self {
+            layout,
+            credential_store,
+            fail_manifest_remove_for_test: true,
         }
     }
 
@@ -552,6 +609,22 @@ impl FileIdentitySpecRegistry {
         )
     }
 
+    fn snapshot_input_material(
+        &self,
+        name: &str,
+        storage: Option<CredentialStorageKind>,
+    ) -> Result<Option<CredentialMaterialSnapshot>, AppError> {
+        storage
+            .map(|storage| {
+                self.credential_store.snapshot_material_unlocked(
+                    &Self::input_material_workspace(),
+                    &Self::credential_set_id(name),
+                    storage,
+                )
+            })
+            .transpose()
+    }
+
     fn replace_input_material(
         &self,
         name: &str,
@@ -580,8 +653,94 @@ impl FileIdentitySpecRegistry {
         )
     }
 
-    fn remove_input_material(&self, name: &str) -> Result<(), AppError> {
-        let state = self.load_input_material_state(name)?;
+    fn restore_input_material(
+        &self,
+        name: &str,
+        previous_storage: Option<CredentialStorageKind>,
+        previous_material: Option<&CredentialMaterialSnapshot>,
+        next_storage: Option<CredentialStorageKind>,
+    ) -> Result<(), AppError> {
+        if let Some(next_storage) = next_storage
+            && Some(next_storage) != previous_storage
+        {
+            self.credential_store.remove_material_unlocked(
+                &Self::input_material_workspace(),
+                &Self::credential_set_id(name),
+                next_storage,
+            )?;
+        }
+        if let Some(previous_material) = previous_material {
+            self.credential_store.restore_material_unlocked(
+                &Self::input_material_workspace(),
+                &Self::credential_set_id(name),
+                previous_material,
+            )?;
+        } else if let Some(next_storage) = next_storage {
+            self.credential_store.remove_material_unlocked(
+                &Self::input_material_workspace(),
+                &Self::credential_set_id(name),
+                next_storage,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn restore_upsert_rollback(
+        &self,
+        name: &str,
+        rollback: &IdentitySpecUpsertRollback,
+        next_storage: Option<CredentialStorageKind>,
+    ) {
+        if let Err(error) = self.restore_input_material(
+            name,
+            rollback.previous_credential_storage,
+            rollback.previous_credential_material.as_ref(),
+            next_storage,
+        ) {
+            tracing::warn!("rollback: failed to restore identity-spec input material: {error}");
+        }
+        if let Err(error) = restore_optional_file(
+            &rollback.manifest_path,
+            rollback.previous_manifest.as_deref(),
+        ) {
+            tracing::warn!("rollback: failed to restore identity-spec manifest: {error}");
+        }
+        if let Err(error) = restore_optional_file(
+            &rollback.input_material_state_path,
+            rollback.previous_input_material_state.as_deref(),
+        ) {
+            tracing::warn!("rollback: failed to restore identity-spec input state: {error}");
+        }
+        if rollback.previous_manifest.is_none()
+            && rollback.previous_input_material_state.is_none()
+            && let Some(parent) = rollback.manifest_path.parent()
+        {
+            drop(fs::remove_dir(parent));
+        }
+    }
+
+    fn restore_remove_rollback(&self, name: &str, rollback: &IdentitySpecRemoveRollback) {
+        if let Err(error) = self.restore_input_material(
+            name,
+            rollback.previous_credential_storage,
+            rollback.previous_credential_material.as_ref(),
+            None,
+        ) {
+            tracing::warn!("rollback: failed to restore identity-spec input material: {error}");
+        }
+        if let Err(error) = restore_optional_file(
+            &rollback.input_material_state_path,
+            rollback.previous_input_material_state.as_deref(),
+        ) {
+            tracing::warn!("rollback: failed to restore identity-spec input state: {error}");
+        }
+    }
+
+    fn remove_input_material_with_state(
+        &self,
+        name: &str,
+        state: &IdentitySpecInputMaterialState,
+    ) -> Result<(), AppError> {
         if let Some(storage) = state.credential_storage {
             self.credential_store.remove_material_unlocked(
                 &Self::input_material_workspace(),
@@ -591,6 +750,22 @@ impl FileIdentitySpecRegistry {
         }
         remove_file_if_exists(&self.input_material_state_file(name))?;
         remove_file_if_exists(&self.layout.identity_spec_material_file(name))?;
+        Ok(())
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            clippy::unused_self,
+            reason = "test builds use a registry-local manifest removal failure hook"
+        )
+    )]
+    fn remove_manifest_file(&self, path: &Path) -> Result<(), AppError> {
+        #[cfg(test)]
+        if self.fail_manifest_remove_for_test {
+            return Err(std::io::Error::other("test manifest remove failure").into());
+        }
+        fs::remove_file(path)?;
         Ok(())
     }
 }
@@ -617,16 +792,35 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
         Ok(records)
     }
 
+    fn list_identity_spec_manifests(&self) -> Result<Vec<String>, AppError> {
+        let root = self.layout.identity_specs_root();
+        if !root.exists() {
+            return Ok(Vec::new());
+        }
+        let mut manifests = Vec::new();
+        for entry in fs::read_dir(root)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(ToString::to_string) else {
+                continue;
+            };
+            if let Some(manifest_yaml) = self.get_identity_spec_manifest(&name)? {
+                manifests.push(manifest_yaml);
+            }
+        }
+        Ok(manifests)
+    }
+
     fn get_identity_spec(
         &self,
         name: &str,
     ) -> Result<Option<IdentitySpecRegistryRecord>, AppError> {
         let name = validate_identity_spec_name(name)?;
-        let path = self.layout.identity_spec_manifest_file(&name);
-        if !path.exists() {
+        let Some(manifest_yaml) = self.get_identity_spec_manifest(&name)? else {
             return Ok(None);
-        }
-        let manifest_yaml = fs::read_to_string(&path)?;
+        };
         let state = self.load_input_material_state(&name)?;
         let input_material = match state.credential_storage {
             Some(storage) => self.read_input_material(&name, storage)?,
@@ -638,6 +832,15 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
         }))
     }
 
+    fn get_identity_spec_manifest(&self, name: &str) -> Result<Option<String>, AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let path = self.layout.identity_spec_manifest_file(&name);
+        if !path.exists() {
+            return Ok(None);
+        }
+        Ok(Some(fs::read_to_string(&path)?))
+    }
+
     fn upsert_identity_spec(
         &self,
         name: &str,
@@ -645,7 +848,10 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
     ) -> Result<(), AppError> {
         let name = validate_identity_spec_name(name)?;
         let path = self.layout.identity_spec_manifest_file(&name);
-        let previous_material_state = if path.exists() {
+        let previous_manifest = read_optional_file(&path)?;
+        let input_material_state_path = self.input_material_state_file(&name);
+        let previous_input_material_state = read_optional_file(&input_material_state_path)?;
+        let previous_material_state = if previous_manifest.is_some() {
             Some(self.load_input_material_state(&name)?)
         } else {
             None
@@ -653,6 +859,15 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
         let existing_storage = previous_material_state
             .as_ref()
             .and_then(|state| state.credential_storage);
+        let previous_credential_material = self.snapshot_input_material(&name, existing_storage)?;
+        let rollback = IdentitySpecUpsertRollback {
+            manifest_path: path.clone(),
+            previous_manifest,
+            input_material_state_path,
+            previous_input_material_state,
+            previous_credential_storage: existing_storage,
+            previous_credential_material,
+        };
         let credential_storage = if record.input_material.is_empty() {
             None
         } else {
@@ -661,20 +876,27 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
         if let Some(parent) = path.parent() {
             storage_fs::ensure_private_dir(parent)?;
         }
-        self.replace_input_material(
-            &name,
-            existing_storage,
-            credential_storage,
-            &record.input_material,
-        )?;
-        storage_fs::write_atomic(&path, record.manifest_yaml.as_bytes())?;
-        self.write_input_material_state(
-            &name,
-            &IdentitySpecInputMaterialState {
+        let result = (|| {
+            self.replace_input_material(
+                &name,
+                existing_storage,
                 credential_storage,
-                version: IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION,
-            },
-        )
+                &record.input_material,
+            )?;
+            storage_fs::write_atomic(&path, record.manifest_yaml.as_bytes())?;
+            self.write_input_material_state(
+                &name,
+                &IdentitySpecInputMaterialState {
+                    credential_storage,
+                    version: IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION,
+                },
+            )
+        })();
+        if let Err(error) = result {
+            self.restore_upsert_rollback(&name, &rollback, credential_storage);
+            return Err(error);
+        }
+        Ok(())
     }
 
     fn remove_identity_spec(&self, name: &str) -> Result<(), AppError> {
@@ -683,8 +905,27 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
         if !path.exists() {
             return Ok(());
         }
-        fs::remove_file(&path)?;
-        self.remove_input_material(&name)?;
+        let input_material_state_path = self.input_material_state_file(&name);
+        let previous_input_material_state = read_optional_file(&input_material_state_path)?;
+        let input_material_state = self.load_input_material_state(&name)?;
+        let previous_credential_storage = input_material_state.credential_storage;
+        let previous_credential_material =
+            self.snapshot_input_material(&name, previous_credential_storage)?;
+        let rollback = IdentitySpecRemoveRollback {
+            input_material_state_path,
+            previous_input_material_state,
+            previous_credential_storage,
+            previous_credential_material,
+        };
+        let result = (|| {
+            self.remove_input_material_with_state(&name, &input_material_state)?;
+            self.remove_manifest_file(&path)?;
+            Ok(())
+        })();
+        if let Err(error) = result {
+            self.restore_remove_rollback(&name, &rollback);
+            return Err(error);
+        }
         if let Some(parent) = path.parent() {
             drop(fs::remove_dir(parent));
         }
@@ -841,6 +1082,28 @@ fn remove_file_if_exists(path: &std::path::Path) -> Result<(), AppError> {
     }
 }
 
+fn read_optional_file(path: &Path) -> Result<Option<Vec<u8>>, AppError> {
+    match fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn restore_optional_file(path: &Path, previous: Option<&[u8]>) -> Result<(), AppError> {
+    let Some(previous) = previous else {
+        return remove_file_if_exists(path);
+    };
+    if matches!(fs::read(path), Ok(current) if current == previous) {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        storage_fs::ensure_private_dir(parent)?;
+    }
+    storage_fs::write_atomic(path, previous)?;
+    Ok(())
+}
+
 fn plural_identity(count: u32) -> &'static str {
     if count == 1 { "identity" } else { "identities" }
 }
@@ -856,6 +1119,19 @@ fn parse_identity_spec_record(manifest_yaml: &str) -> Result<IdentitySpecRecord,
         manifest_yaml: normalized_manifest_yaml(manifest_yaml),
         manifest,
     })
+}
+
+fn ensure_identity_spec_record_name(
+    requested_name: &str,
+    record: &IdentitySpecRecord,
+) -> Result<(), AppError> {
+    if record.manifest.name == requested_name {
+        return Ok(());
+    }
+    Err(AppError::FailedPrecondition(format!(
+        "identity spec registry record '{requested_name}' contains identity spec '{}'",
+        record.manifest.name
+    )))
 }
 
 fn normalized_manifest_yaml(manifest_yaml: &str) -> String {
@@ -875,15 +1151,17 @@ mod tests {
     use std::collections::BTreeMap;
     use std::fs;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use tempfile::TempDir;
 
     use super::{
-        IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord, IdentitySpecUsageProvider,
+        FileIdentitySpecRegistry, IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord,
+        IdentitySpecRegistry, IdentitySpecRegistryRecord, IdentitySpecUsageProvider,
         identity_spec_fingerprint,
     };
     use crate::bootstrap::AppError;
-    use crate::credentials::parse_env_file;
+    use crate::credentials::{CredentialStoragePreference, CredentialStore, parse_env_file};
     use crate::features::{Features, dsl_v4_features};
     use crate::state::AppStateLayout;
 
@@ -1007,6 +1285,48 @@ mod tests {
             } else {
                 Ok(0)
             }
+        }
+    }
+
+    #[derive(Debug)]
+    struct CaseCollidingRegistry {
+        record: IdentitySpecRegistryRecord,
+        removed: Arc<AtomicBool>,
+        upserted: Arc<AtomicBool>,
+    }
+
+    impl IdentitySpecRegistry for CaseCollidingRegistry {
+        fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRegistryRecord>, AppError> {
+            Ok(vec![self.record.clone()])
+        }
+
+        fn list_identity_spec_manifests(&self) -> Result<Vec<String>, AppError> {
+            Ok(vec![self.record.manifest_yaml.clone()])
+        }
+
+        fn get_identity_spec(
+            &self,
+            _name: &str,
+        ) -> Result<Option<IdentitySpecRegistryRecord>, AppError> {
+            Ok(Some(self.record.clone()))
+        }
+
+        fn get_identity_spec_manifest(&self, _name: &str) -> Result<Option<String>, AppError> {
+            Ok(Some(self.record.manifest_yaml.clone()))
+        }
+
+        fn upsert_identity_spec(
+            &self,
+            _name: &str,
+            _record: IdentitySpecRegistryRecord,
+        ) -> Result<(), AppError> {
+            self.upserted.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn remove_identity_spec(&self, _name: &str) -> Result<(), AppError> {
+            self.removed.store(true, Ordering::SeqCst);
+            Ok(())
         }
     }
 
@@ -1158,6 +1478,162 @@ oauth:
         assert!(!layout.identity_spec_dir("demo_oauth").exists());
     }
 
+    #[test]
+    fn list_and_get_identity_specs_do_not_load_input_material() {
+        let (_temp, manager, layout) = manager();
+        add_spec_with_secret(&manager, &oauth_identity_yaml_with_inputs());
+        let state_file = layout.identity_spec_dir("demo_oauth").join("inputs.yaml");
+        fs::write(
+            &state_file,
+            r"
+version: 1
+credential_storage: keychain
+",
+        )
+        .expect("route input material to keychain");
+        let unavailable_keychain = CredentialStore::with_unavailable_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Keychain,
+        );
+        let manager = IdentitySpecManager::new_with_credential_store(
+            layout,
+            unavailable_keychain,
+            dsl_v4_features(),
+            Vec::new(),
+        );
+
+        let listed = manager
+            .list_identity_specs()
+            .expect("list should read manifests only");
+        let fetched = manager
+            .get_identity_spec("demo_oauth")
+            .expect("get should read manifest only");
+
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed.first().expect("listed identity spec").manifest.name,
+            "demo_oauth"
+        );
+        assert_eq!(fetched.manifest.name, "demo_oauth");
+    }
+
+    #[test]
+    fn remove_identity_spec_keeps_manifest_when_material_cleanup_fails() {
+        let (_temp, manager, layout) = manager();
+        add_spec_with_secret(&manager, &oauth_identity_yaml_with_inputs());
+        let state_file = layout.identity_spec_dir("demo_oauth").join("inputs.yaml");
+        fs::write(
+            &state_file,
+            r"
+version: 1
+credential_storage: keychain
+",
+        )
+        .expect("route input material to keychain for removal");
+        let unavailable_keychain = CredentialStore::with_unavailable_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Keychain,
+        );
+        let registry = FileIdentitySpecRegistry::new(layout.clone(), unavailable_keychain);
+
+        let error = IdentitySpecRegistry::remove_identity_spec(&registry, "demo_oauth")
+            .expect_err("keychain cleanup should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("keychain is unavailable while snapshotting"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            layout.identity_spec_manifest_file("demo_oauth").exists(),
+            "manifest should remain so deletion can be retried"
+        );
+        assert!(state_file.exists(), "input material state should remain");
+    }
+
+    #[test]
+    fn remove_identity_spec_restores_input_material_when_manifest_delete_fails() {
+        let temp = TempDir::new().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout directories");
+        let credential_store = CredentialStore::with_available_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Keychain,
+        );
+        let manager = IdentitySpecManager::new_with_credential_store(
+            layout.clone(),
+            credential_store.clone(),
+            dsl_v4_features(),
+            Vec::new(),
+        );
+        add_spec_with_secret(&manager, &oauth_identity_yaml_with_inputs());
+        let registry = FileIdentitySpecRegistry::new_with_manifest_remove_failure_for_test(
+            layout.clone(),
+            credential_store,
+        );
+
+        let error = IdentitySpecRegistry::remove_identity_spec(&registry, "demo_oauth")
+            .expect_err("manifest removal failure should reject deletion");
+
+        assert!(
+            error.to_string().contains("test manifest remove failure"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            layout.identity_spec_manifest_file("demo_oauth").exists(),
+            "manifest should remain so deletion can be retried"
+        );
+        assert!(
+            layout
+                .identity_spec_dir("demo_oauth")
+                .join("inputs.yaml")
+                .exists(),
+            "input material state should be restored"
+        );
+        let stored = stored_spec(&manager, "demo_oauth");
+        let resolved = resolved_inputs(&manager, &stored);
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "client-secret");
+    }
+
+    #[test]
+    fn upsert_identity_spec_rolls_back_material_after_state_write_failure() {
+        let (_temp, manager, layout) = manager();
+        add_spec_with_secret(
+            &manager,
+            &oauth_identity_yaml_with_inputs_default("tenant-a"),
+        );
+        let state_file = layout.identity_spec_dir("demo_oauth").join("inputs.yaml");
+        let blocked_temp_path =
+            state_file.with_file_name(format!("inputs.yaml.tmp.{}", std::process::id()));
+        fs::create_dir(&blocked_temp_path).expect("block atomic state write temp path");
+
+        manager
+            .add_identity_spec_with_inputs(
+                &oauth_identity_yaml_with_inputs_default("tenant-b"),
+                vec![IdentitySpecInputValue {
+                    key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                    value: "rotated-secret".to_string(),
+                }],
+            )
+            .expect_err("state write failure should reject replacement");
+
+        let stored = stored_spec(&manager, "demo_oauth");
+        let resolved = resolved_inputs(&manager, &stored);
+        assert_input(&resolved, "DEMO_TENANT", "tenant-a");
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "client-secret");
+        let material = parse_env_file(
+            &fs::read_to_string(layout.identity_spec_material_file("demo_oauth"))
+                .expect("identity spec material file"),
+        )
+        .expect("parse material");
+        assert_eq!(
+            material.get("DEMO_OAUTH_CLIENT_SECRET").map(String::as_str),
+            Some("client-secret")
+        );
+    }
+
     /// Merges the previous `readding_identity_spec_preserves_existing_input_material`
     /// coverage with the changed-default re-add: both re-adds run against the same
     /// stored material.
@@ -1220,6 +1696,51 @@ oauth:
                 .and_then(serde_json::Value::as_str),
             Some("github.com")
         );
+    }
+
+    #[test]
+    fn rejects_case_colliding_registry_records_before_replacement_or_deletion() {
+        let temp = TempDir::new().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout directories");
+        let removed = Arc::new(AtomicBool::new(false));
+        let upserted = Arc::new(AtomicBool::new(false));
+        let registry = Arc::new(CaseCollidingRegistry {
+            record: IdentitySpecRegistryRecord {
+                manifest_yaml: identity_yaml("GitHub_OAuth", "0.1.0"),
+                input_material: BTreeMap::new(),
+            },
+            removed: Arc::clone(&removed),
+            upserted: Arc::clone(&upserted),
+        });
+        let manager = IdentitySpecManager::new_with_registry(
+            layout,
+            registry,
+            dsl_v4_features(),
+            vec![Arc::new(StaticUsageProvider {
+                identity_spec_name: "GitHub_OAuth".to_string(),
+                count: 1,
+            })],
+        );
+
+        let replace_error = manager
+            .add_identity_spec(&identity_yaml("github_oauth", "0.1.0"))
+            .expect_err("replacement should reject case-colliding record");
+        assert_failed_precondition(
+            &replace_error,
+            ["registry record 'github_oauth'", "GitHub_OAuth"],
+        );
+        assert!(!upserted.load(Ordering::SeqCst));
+
+        let remove_error = manager
+            .remove_identity_spec("github_oauth", true)
+            .expect_err("deletion should reject case-colliding record");
+        assert_failed_precondition(
+            &remove_error,
+            ["registry record 'github_oauth'", "GitHub_OAuth"],
+        );
+        assert!(!removed.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/crates/coral-app/src/identity_specs/mod.rs
+++ b/crates/coral-app/src/identity_specs/mod.rs
@@ -1,0 +1,19 @@
+//! Global identity-spec registry.
+
+mod manager;
+mod service;
+
+#[expect(
+    unused_imports,
+    reason = "re-exports consumed by the identity and source managers in later PRs"
+)]
+pub(crate) use manager::{
+    IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord, IdentitySpecSnapshot,
+    identity_spec_fingerprint, validate_identity_spec_name,
+};
+pub use manager::{
+    IdentitySpecManifestMetadata, IdentitySpecRegistry, IdentitySpecRegistryRecord,
+    IdentitySpecUsageProvider, identity_spec_input_material_from_manifest,
+    identity_spec_input_material_from_manifest_with_existing, identity_spec_manifest_metadata,
+};
+pub(crate) use service::IdentitySpecService;

--- a/crates/coral-app/src/identity_specs/service.rs
+++ b/crates/coral-app/src/identity_specs/service.rs
@@ -1,0 +1,166 @@
+//! Implements the gRPC `IdentitySpecService`.
+
+use std::sync::Arc;
+
+use coral_api::v1::identity_spec_service_server::IdentitySpecService as IdentitySpecServiceApi;
+use coral_api::v1::{
+    AddIdentitySpecRequest, AddIdentitySpecResponse, DeleteIdentitySpecRequest,
+    DeleteIdentitySpecResponse, GetIdentitySpecRequest, GetIdentitySpecResponse, IdentitySpec,
+    ListIdentitySpecsRequest, ListIdentitySpecsResponse,
+};
+use tonic::{Request, Response, Status};
+
+use crate::authorization::{ManagementAuthorizer, authorization_status};
+use crate::identity::UserPrincipalProvider;
+use crate::identity_specs::manager::{
+    IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord,
+};
+use crate::transport::{instrument_authenticated_grpc, run_blocking_operation};
+
+#[derive(Clone)]
+pub(crate) struct IdentitySpecService {
+    identity_specs: IdentitySpecManager,
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    management_authorizer: Arc<dyn ManagementAuthorizer>,
+}
+
+impl IdentitySpecService {
+    pub(crate) fn new(
+        identity_specs: IdentitySpecManager,
+        user_principal_provider: Arc<dyn UserPrincipalProvider>,
+        management_authorizer: Arc<dyn ManagementAuthorizer>,
+    ) -> Self {
+        Self {
+            identity_specs,
+            user_principal_provider,
+            management_authorizer,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl IdentitySpecServiceApi for IdentitySpecService {
+    async fn add_identity_spec(
+        &self,
+        request: Request<AddIdentitySpecRequest>,
+    ) -> Result<Response<AddIdentitySpecResponse>, Status> {
+        let identity_specs = self.identity_specs.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |principal, request| async move {
+                management_authorizer
+                    .authorize_identity_spec_mutation(&principal)
+                    .await
+                    .map_err(authorization_status)?;
+                let inputs = request
+                    .inputs
+                    .into_iter()
+                    .map(|input| IdentitySpecInputValue {
+                        key: input.key,
+                        value: input.value,
+                    })
+                    .collect::<Vec<_>>();
+                let (record, replaced) =
+                    run_blocking_operation("identity spec operation", move || {
+                        identity_specs.add_identity_spec_with_inputs(&request.manifest_yaml, inputs)
+                    })
+                    .await?;
+                Ok(Response::new(AddIdentitySpecResponse {
+                    identity_spec: Some(identity_spec_record_to_proto(record)),
+                    replaced,
+                }))
+            },
+        )
+        .await
+    }
+
+    async fn list_identity_specs(
+        &self,
+        request: Request<ListIdentitySpecsRequest>,
+    ) -> Result<Response<ListIdentitySpecsResponse>, Status> {
+        let identity_specs = self.identity_specs.clone();
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |_principal, _request| async move {
+                let records = run_blocking_operation("identity spec operation", move || {
+                    identity_specs.list_identity_specs()
+                })
+                .await?;
+                Ok(Response::new(ListIdentitySpecsResponse {
+                    identity_specs: records
+                        .into_iter()
+                        .map(identity_spec_record_to_proto)
+                        .collect(),
+                }))
+            },
+        )
+        .await
+    }
+
+    async fn get_identity_spec(
+        &self,
+        request: Request<GetIdentitySpecRequest>,
+    ) -> Result<Response<GetIdentitySpecResponse>, Status> {
+        let identity_specs = self.identity_specs.clone();
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |_principal, request| async move {
+                let record = run_blocking_operation("identity spec operation", move || {
+                    // The other identity-spec RPCs gate `dsl_v4` inside the manager
+                    // method, but `get_identity_spec` is shared with query-time
+                    // identity resolution (which must stay ungated), so the gate is
+                    // enforced here at the read RPC instead.
+                    identity_specs.ensure_dsl_v4_enabled()?;
+                    identity_specs.get_identity_spec(&request.name)
+                })
+                .await?;
+                Ok(Response::new(GetIdentitySpecResponse {
+                    identity_spec: Some(identity_spec_record_to_proto(record)),
+                }))
+            },
+        )
+        .await
+    }
+
+    async fn delete_identity_spec(
+        &self,
+        request: Request<DeleteIdentitySpecRequest>,
+    ) -> Result<Response<DeleteIdentitySpecResponse>, Status> {
+        let identity_specs = self.identity_specs.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |principal, request| async move {
+                management_authorizer
+                    .authorize_identity_spec_mutation(&principal)
+                    .await
+                    .map_err(authorization_status)?;
+                let orphaned_identities =
+                    run_blocking_operation("identity spec operation", move || {
+                        identity_specs.remove_identity_spec(&request.name, request.force)
+                    })
+                    .await?;
+                Ok(Response::new(DeleteIdentitySpecResponse {
+                    orphaned_identities,
+                }))
+            },
+        )
+        .await
+    }
+}
+
+fn identity_spec_record_to_proto(record: IdentitySpecRecord) -> IdentitySpec {
+    IdentitySpec {
+        name: record.manifest.name,
+        version: record.manifest.version,
+        description: record.manifest.description,
+        issuer: record.manifest.issuer,
+        identity_type: record.manifest.identity_type.label().to_string(),
+        manifest_yaml: record.manifest_yaml,
+    }
+}

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -33,6 +33,7 @@
 //! - `coral-engine` owns the data plane: backend registration, `DataFusion`
 //!   runtime assembly, and `SQL` execution over validated specs.
 //!
+mod authorization;
 /// Bootstrap entrypoints and local server assembly.
 pub mod bootstrap;
 mod catalog;
@@ -42,6 +43,7 @@ pub mod features;
 mod feedback;
 mod identities;
 mod identity;
+mod identity_specs;
 mod query;
 mod sources;
 mod state;
@@ -50,10 +52,14 @@ pub mod telemetry;
 mod transport;
 mod workspaces;
 
+pub use authorization::{
+    AllowAllManagementAuthorizer, AuthorizationError, ManagementAuthorizer, SourceMutationKind,
+};
 pub use bootstrap::{
     AppError, RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider,
 };
 pub use coral_engine::{EngineExtensions, QuerySource};
+pub use credentials::oauth::{OAuthProgressEvent, OAuthProgressEventSender};
 pub use identities::{
     IdentityOwnerKey, UserOwnedIdentityMaterialGuard, UserOwnedIdentityRecord,
     UserOwnedIdentityStore,
@@ -61,8 +67,14 @@ pub use identities::{
 pub use identity::{
     SingleUserPrincipalProvider, UserPrincipal, UserPrincipalError, UserPrincipalProvider,
 };
+pub use identity_specs::{
+    IdentitySpecManifestMetadata, IdentitySpecRegistry, IdentitySpecRegistryRecord,
+    IdentitySpecUsageProvider, identity_spec_input_material_from_manifest,
+    identity_spec_input_material_from_manifest_with_existing, identity_spec_manifest_metadata,
+};
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };
 pub use telemetry::{RunContext, RunErrorTelemetry, run_with_context, shutdown_tracing};
+pub use transport::{OAuthProgressProto, oauth_operation_response_stream};
 pub use workspaces::DEFAULT_WORKSPACE_ID;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -529,8 +529,10 @@ fn query_error_message(error: &QueryManagerError) -> String {
 fn app_error_type(error: &AppError) -> &'static str {
     match error {
         AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
+        AppError::IdentitySpecNotFound(_) => "IDENTITY_SPEC_NOT_FOUND",
+        AppError::IdentityNotFound(_) => "IDENTITY_NOT_FOUND",
         AppError::InvalidInput(_) => "INVALID_INPUT",
-        AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
+        AppError::FailedPrecondition(_) | AppError::SourceUnservable(_) => "FAILED_PRECONDITION",
         AppError::MissingOrIncompatibleV4Materialization { .. } => {
             "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION"
         }
@@ -611,6 +613,7 @@ mod tests {
 
     use super::*;
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
+    use crate::features::dsl_v4_features;
     use crate::identity::SingleUserPrincipalProvider;
     use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
     use crate::sources::materialization::sha256_hex;
@@ -825,10 +828,11 @@ tables:
 
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
         fixture.manager.layout.ensure().expect("ensure layout");
-        let source_manager = SourceManager::new(
+        let source_manager = SourceManager::new_with_features(
             fixture.manager.config_store.clone(),
             fixture.manager.credential_manager.clone(),
             fixture.manager.layout.clone(),
+            dsl_v4_features(),
         );
         let workspace_name = WorkspaceName::default();
         let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -18,6 +18,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::episode::EpisodeId;
+use crate::features::Features;
 use crate::identity::UserPrincipal;
 use crate::query::QueryAttribution;
 use crate::query::extensions::{
@@ -50,6 +51,7 @@ pub(crate) struct QueryManager {
     credential_manager: CredentialManager,
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
+    features: Features,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
 }
 
@@ -59,6 +61,7 @@ impl QueryManager {
         credential_manager: CredentialManager,
         runtime_context: QueryRuntimeContext,
         layout: AppStateLayout,
+        features: Features,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
         Self {
@@ -66,6 +69,7 @@ impl QueryManager {
             credential_manager,
             runtime_context,
             layout,
+            features,
             engine_extensions_providers,
         }
     }
@@ -291,6 +295,7 @@ impl QueryManager {
                 Ok((query_source, _version)) => query_sources.push(query_source),
                 Err(
                     error @ (AppError::Credentials(CredentialsError::Unavailable(_))
+                    | AppError::SourceUnservable(_)
                     | AppError::MissingOrIncompatibleV4Materialization { .. }),
                 ) => {
                     return Err(error);
@@ -316,6 +321,7 @@ impl QueryManager {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = installed.source_spec;
         let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
+            self.features.ensure_dsl_v4_enabled()?;
             let materialized = load_v4_materialization(
                 &self.layout,
                 workspace_name,
@@ -628,6 +634,14 @@ mod tests {
         runtime_context: QueryRuntimeContext,
         providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> QueryManagerFixture {
+        query_manager_with_features(runtime_context, providers, dsl_v4_features())
+    }
+
+    fn query_manager_with_features(
+        runtime_context: QueryRuntimeContext,
+        providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        features: Features,
+    ) -> QueryManagerFixture {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -636,6 +650,7 @@ mod tests {
             CredentialManager::new(CredentialStore::new(layout.clone())),
             runtime_context,
             layout,
+            features,
             providers,
         );
         QueryManagerFixture {
@@ -964,6 +979,67 @@ surfaces:
     }
 
     #[test]
+    fn load_query_sources_fails_closed_when_dsl_v4_is_disabled() {
+        let fixture = query_manager_with_features(
+            QueryRuntimeContext::default(),
+            Vec::new(),
+            Features::default(),
+        );
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("github_v4_disabled").expect("source name");
+        let manifest_path = fixture
+            .manager
+            .layout
+            .manifest_file(&workspace_name, &source_name);
+        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create source dir");
+        std::fs::write(
+            &manifest_path,
+            r"
+name: github_v4_disabled
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+",
+        )
+        .expect("write manifest");
+        fixture
+            .manager
+            .config_store
+            .upsert_source(
+                &workspace_name,
+                InstalledSource {
+                    name: source_name.clone(),
+                    version: None,
+                    variables: BTreeMap::new(),
+                    secrets: Vec::new(),
+                    credential_storage: None,
+                    origin: SourceOrigin::Imported,
+                },
+            )
+            .expect("persist source");
+
+        let config = fixture
+            .manager
+            .config_store
+            .load_config()
+            .expect("load config");
+        let error = fixture
+            .manager
+            .load_query_sources(&workspace_name, &config)
+            .expect_err("disabled dsl_v4 feature should fail closed");
+
+        assert!(
+            matches!(error, AppError::SourceUnservable(ref message) if message.contains("dsl_v4")),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
     fn load_query_sources_fails_closed_for_unavailable_keychain_source() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
@@ -994,6 +1070,7 @@ surfaces:
             CredentialManager::new(credential_store),
             QueryRuntimeContext::default(),
             layout,
+            dsl_v4_features(),
             Vec::new(),
         );
         let config = manager.config_store.load_config().expect("load config");

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -282,6 +282,7 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_feature_enabled(&manifest)?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
@@ -305,6 +306,7 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_feature_enabled(&manifest)?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -15,6 +15,7 @@ use crate::credentials::{
     CORAL_INTERNAL_KEY_PREFIX, CredentialManager, CredentialMaterialGuard,
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialsError,
 };
+use crate::features::Features;
 use crate::sources::SourceName;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
@@ -39,6 +40,7 @@ pub(crate) struct SourceManager {
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
     layout: AppStateLayout,
+    features: Features,
 }
 
 pub(crate) struct CreateBundledSourceCommand {
@@ -128,16 +130,32 @@ fn materialization_inputs_from_bindings(
 }
 
 impl SourceManager {
+    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
         layout: AppStateLayout,
+    ) -> Self {
+        Self::new_with_features(
+            config_store,
+            credential_manager,
+            layout,
+            Features::default(),
+        )
+    }
+
+    pub(crate) fn new_with_features(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+        features: Features,
     ) -> Self {
         Self {
             config_store,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
             layout,
+            features,
         }
     }
 
@@ -316,6 +334,7 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let manifest = parse_source_manifest_yaml(request.materialization_manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_feature_enabled(&manifest)?;
         self.validate_runtime_schema_names_available(
             workspace_name,
             &request.candidate.name,
@@ -372,6 +391,7 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let manifest = parse_source_manifest_yaml(request.materialization_manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_feature_enabled(&manifest)?;
         self.validate_runtime_schema_names_available(
             workspace_name,
             &request.candidate.name,
@@ -686,6 +706,7 @@ impl SourceManager {
         let Some(v4) = manifest.as_v4() else {
             return Ok(None);
         };
+        self.features.ensure_dsl_v4_enabled()?;
         if matches!(origin, SourceOrigin::Bundled)
             && v4.surfaces.iter().any(|surface| {
                 matches!(
@@ -734,6 +755,16 @@ impl SourceManager {
                     installed.name
                 )));
             }
+        }
+        Ok(())
+    }
+
+    fn ensure_dsl_v4_feature_enabled(
+        &self,
+        manifest: &ValidatedSourceManifest,
+    ) -> Result<(), AppError> {
+        if manifest.as_v4().is_some() {
+            self.features.ensure_dsl_v4_enabled()?;
         }
         Ok(())
     }
@@ -1429,6 +1460,7 @@ mod tests {
         CredentialManager, CredentialSetId, CredentialStorageKind, CredentialStoragePreference,
         CredentialStore, CredentialsError,
     };
+    use crate::features::{Features, dsl_v4_features};
     use crate::sources::SourceName;
     use crate::sources::materialization::sha256_hex;
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
@@ -1658,6 +1690,23 @@ surfaces:
         manifest_v4(openapi_file, sha256, "")
     }
 
+    fn manifest_v4_with_variable_input() -> String {
+        r#"
+name: secured_messages_v4
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    inputs:
+      API_BASE:
+        kind: variable
+    base_url: "{{input.API_BASE}}"
+"#
+        .to_string()
+    }
+
     /// Authored-descriptor state plus a source manager over a fresh app
     /// layout.
     struct V4ImportFixture {
@@ -1687,6 +1736,12 @@ surfaces:
     }
 
     fn v4_import_fixture(openapi_yaml: &str) -> V4ImportFixture {
+        v4_import_fixture_with_features(openapi_yaml, dsl_v4_features())
+    }
+
+    /// As [`v4_import_fixture`], but with the given feature set (so tests can
+    /// exercise the `dsl_v4` feature gate).
+    fn v4_import_fixture_with_features(openapi_yaml: &str, features: Features) -> V4ImportFixture {
         let temp = TempDir::new().expect("temp dir");
         let descriptor_temp = TempDir::new().expect("descriptor temp dir");
         let layout =
@@ -1694,10 +1749,11 @@ surfaces:
         layout.ensure().expect("ensure layout");
         let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
         std::fs::write(&openapi_file, openapi_yaml).expect("write fixture");
-        let manager = SourceManager::new(
+        let manager = SourceManager::new_with_features(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout.clone(),
+            features,
         );
         V4ImportFixture {
             _temp: temp,
@@ -2083,10 +2139,11 @@ surfaces:
         let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
         let openapi_yaml = v4_openapi_fixture();
         std::fs::write(&openapi_file, &openapi_yaml).expect("write fixture");
-        let manager = SourceManager::new(
+        let manager = SourceManager::new_with_features(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout.clone(),
+            dsl_v4_features(),
         );
 
         manager
@@ -2130,6 +2187,42 @@ surfaces:
                 .v4_materialized_dir(&default_workspace(), &rejected_source)
                 .exists(),
             "rejected source should not materialize artifacts"
+        );
+    }
+
+    #[test]
+    fn import_v4_source_requires_dsl_v4_feature() {
+        let fixture = v4_import_fixture_with_features(&v4_openapi_fixture(), Features::default());
+
+        let error = fixture
+            .import(manifest_v4_with_file_descriptor)
+            .expect_err("disabled v4 feature should reject import");
+
+        assert_error_contains(&error, "dsl_v4");
+    }
+
+    #[tokio::test]
+    async fn import_v4_with_credentials_requires_feature_before_import() {
+        let ManagerFixture { _temp, manager, .. } = manager_fixture();
+        let (event_tx, mut event_rx) = import_event_channel();
+
+        let error = manager
+            .import_source_with_credentials(
+                &default_workspace(),
+                credentials_import_command(
+                    manifest_v4_with_variable_input(),
+                    bindings(&[("API_BASE", "https://api.example.test")], &[]),
+                    Vec::new(),
+                ),
+                event_tx,
+            )
+            .await
+            .expect_err("disabled v4 feature should reject before import");
+
+        assert_error_contains(&error, "dsl_v4");
+        assert!(
+            event_rx.try_recv().is_err(),
+            "feature gate should fail before import events"
         );
     }
 

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -30,6 +30,7 @@ use coral_spec::{
 };
 use tonic::{Request, Response, Status};
 
+use crate::authorization::{ManagementAuthorizer, SourceMutationKind, authorization_status};
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
 use crate::credentials::oauth::{OAuthProgressEvent, OAuthProgressEventSender};
@@ -56,6 +57,7 @@ pub(crate) struct SourceService {
     sources: SourceManager,
     queries: QueryManager,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    management_authorizer: Arc<dyn ManagementAuthorizer>,
 }
 
 impl SourceService {
@@ -63,11 +65,13 @@ impl SourceService {
         source_manager: SourceManager,
         query_manager: QueryManager,
         user_principal_provider: Arc<dyn UserPrincipalProvider>,
+        management_authorizer: Arc<dyn ManagementAuthorizer>,
     ) -> Self {
         Self {
             sources: source_manager,
             queries: query_manager,
             user_principal_provider,
+            management_authorizer,
         }
     }
 }
@@ -170,11 +174,20 @@ impl SourceServiceApi for SourceService {
         request: Request<CreateBundledSourceRequest>,
     ) -> Result<Response<CreateBundledSourceResponse>, Status> {
         let sources = self.sources.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
-            |_principal, request| async move {
+            |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                management_authorizer
+                    .authorize_source_mutation(
+                        &principal,
+                        workspace_name.as_str(),
+                        SourceMutationKind::CreateBundled,
+                    )
+                    .await
+                    .map_err(authorization_status)?;
                 let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
                 let command = CreateBundledSourceCommand {
                     name: bundled_name,
@@ -201,12 +214,21 @@ impl SourceServiceApi for SourceService {
         request: Request<CreateBundledSourceWithOAuthRequest>,
     ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
         let sources = self.sources.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
-            |_principal, request| async move {
+            |principal, request| async move {
                 let span = tracing::Span::current();
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                management_authorizer
+                    .authorize_source_mutation(
+                        &principal,
+                        workspace_name.as_str(),
+                        SourceMutationKind::CreateBundledWithOAuth,
+                    )
+                    .await
+                    .map_err(authorization_status)?;
                 let response_workspace_name = workspace_name.clone();
                 let command = CreateBundledSourceWithOAuthCommand {
                     name: SourceName::parse(&request.name).map_err(app_status)?,
@@ -245,12 +267,22 @@ impl SourceServiceApi for SourceService {
         request: Request<ImportSourceRequest>,
     ) -> Result<Response<Self::ImportSourceStream>, Status> {
         let sources = self.sources.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
-            |_principal, request| async move {
+            |principal, request| async move {
                 let span = tracing::Span::current();
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                let mutation_kind = if request.oauth_credential_retrievals.is_empty() {
+                    SourceMutationKind::Import
+                } else {
+                    SourceMutationKind::ImportWithOAuth
+                };
+                management_authorizer
+                    .authorize_source_mutation(&principal, workspace_name.as_str(), mutation_kind)
+                    .await
+                    .map_err(authorization_status)?;
                 let response_workspace_name = workspace_name.clone();
                 reject_unsupported_import_identity_fields(&request).map_err(app_status)?;
                 if request.oauth_credential_retrievals.is_empty() {
@@ -301,11 +333,20 @@ impl SourceServiceApi for SourceService {
         request: Request<DeleteSourceRequest>,
     ) -> Result<Response<DeleteSourceResponse>, Status> {
         let sources = self.sources.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
-            |_principal, request| async move {
+            |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                management_authorizer
+                    .authorize_source_mutation(
+                        &principal,
+                        workspace_name.as_str(),
+                        SourceMutationKind::Delete,
+                    )
+                    .await
+                    .map_err(authorization_status)?;
                 let source_name = SourceName::parse(&request.name).map_err(app_status)?;
                 run_blocking_operation("source operation", move || {
                     sources.delete_source(&workspace_name, &source_name)

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -105,10 +105,6 @@ impl AppStateLayout {
         self.identity_specs_root().join(identity_spec_name)
     }
 
-    #[expect(
-        dead_code,
-        reason = "consumed by the identity-spec manager in a later PR"
-    )]
     pub(crate) fn identity_spec_manifest_file(&self, identity_spec_name: &str) -> PathBuf {
         self.identity_spec_dir(identity_spec_name)
             .join(INSTALLED_MANIFEST_FILE_NAME)
@@ -152,7 +148,10 @@ impl AppStateLayout {
         self.user_owned_identities_root(user_id).join(identity_name)
     }
 
-    #[expect(dead_code, reason = "consumed by the identity manager in a later PR")]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "consumed by the identity manager in a later PR")
+    )]
     pub(crate) fn user_owned_identity_manifest_file(
         &self,
         user_id: &str,

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -8,9 +8,4 @@ pub(crate) use config::{
     RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue, load_raw_feature_overrides,
     set_raw_feature_override,
 };
-pub(crate) use layout::AppStateLayout;
-#[expect(
-    unused_imports,
-    reason = "re-export consumed by the identity-spec manager in a later PR"
-)]
-pub(crate) use layout::INSTALLED_IDENTITY_FILE_NAME;
+pub(crate) use layout::{AppStateLayout, INSTALLED_IDENTITY_FILE_NAME};

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -295,7 +295,6 @@ fn decode_grpc_error(status: &Status) -> GrpcErrorTelemetry {
 }
 
 /// One OAuth progress event mapped onto the shared credential proto pair.
-#[expect(unreachable_pub, reason = "re-exported from lib.rs in a later PR")]
 pub enum OAuthProgressProto {
     /// Authorization URL or device-code details.
     Authorization(coral_api::v1::OAuthCredentialAuthorization),
@@ -340,7 +339,6 @@ impl From<OAuthProgressEvent> for OAuthProgressProto {
 ///
 /// `closed_message` is the error reported to the operation when it emits an
 /// event after the stream consumer went away.
-#[expect(unreachable_pub, reason = "re-exported from lib.rs in a later PR")]
 pub fn oauth_operation_response_stream<T, R, F, Fut>(
     closed_message: &'static str,
     operation: F,

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -9,6 +9,8 @@
 mod catalog_discovery_tests;
 #[path = "grpc/harness.rs"]
 mod harness;
+#[path = "grpc/identity_spec_tests.rs"]
+mod identity_spec_tests;
 #[path = "grpc/oauth_refresh_tests.rs"]
 mod oauth_refresh_tests;
 #[path = "grpc/resilience_tests.rs"]

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -2,12 +2,14 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use coral_api::v1::{
-    ExecuteSqlRequest, ExecuteSqlResponse, ImportSourceRequest, ListCatalogRequest,
+    AddIdentitySpecRequest, AddIdentitySpecResponse, DeleteIdentitySpecRequest,
+    DeleteIdentitySpecResponse, ExecuteSqlRequest, ExecuteSqlResponse, IdentitySpec,
+    IdentitySpecInput, ImportSourceRequest, ListCatalogRequest, ListIdentitySpecsRequest,
     ListSourcesRequest, PaginationRequest, Source, SourceSecret, SourceVariable, TableSummary,
     ValidateSourceRequest, ValidateSourceResponse, catalog_item, import_source_response,
 };
 use coral_client::{
-    AppClient, CatalogClient, QueryClient, SourceClient, batches_to_json_rows,
+    AppClient, CatalogClient, IdentitySpecClient, QueryClient, SourceClient, batches_to_json_rows,
     decode_execute_sql_response, default_workspace,
     local::{RunningServer, ServerBuilder},
 };
@@ -39,8 +41,25 @@ impl GrpcHarness {
         Self::start_with_parts(temp_dir, config_dir).await
     }
 
+    /// Starts a server with the `dsl_v4` feature explicitly disabled.
+    ///
+    /// Pre-writing the config (with the credentials block present) makes
+    /// `ensure_default_test_config` leave it untouched, so the default
+    /// `dsl_v4 = true` is not applied.
+    pub(crate) async fn new_without_dsl_v4() -> Self {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let config_dir = temp_dir.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[features]\ndsl_v4 = false\n\n[credentials]\nstorage = \"file\"\n",
+        )
+        .expect("write config without dsl_v4");
+        Self::start_with_parts(temp_dir, config_dir).await
+    }
+
     async fn start_with_parts(temp_dir: TempDir, config_dir: PathBuf) -> Self {
-        ensure_file_credentials_config(&config_dir);
+        ensure_default_test_config(&config_dir);
         let server = ServerBuilder::new()
             .with_config_dir(&config_dir)
             .start()
@@ -67,6 +86,10 @@ impl GrpcHarness {
 
     pub(crate) fn source_client(&self) -> SourceClient {
         self.app.source_client()
+    }
+
+    pub(crate) fn identity_spec_client(&self) -> IdentitySpecClient {
+        self.app.identity_spec_client()
     }
 
     pub(crate) fn catalog_client(&self) -> CatalogClient {
@@ -191,6 +214,44 @@ impl GrpcHarness {
             .await?
             .into_inner())
     }
+
+    pub(crate) async fn try_add_identity_spec(
+        &self,
+        manifest_yaml: String,
+        inputs: Vec<IdentitySpecInput>,
+    ) -> Result<AddIdentitySpecResponse, tonic::Status> {
+        Ok(self
+            .identity_spec_client()
+            .add_identity_spec(Request::new(AddIdentitySpecRequest {
+                manifest_yaml,
+                inputs,
+            }))
+            .await?
+            .into_inner())
+    }
+
+    pub(crate) async fn list_identity_specs(&self) -> Vec<IdentitySpec> {
+        self.identity_spec_client()
+            .list_identity_specs(Request::new(ListIdentitySpecsRequest {}))
+            .await
+            .expect("list identity specs")
+            .into_inner()
+            .identity_specs
+    }
+
+    pub(crate) async fn force_delete_identity_spec(
+        &self,
+        name: &str,
+    ) -> DeleteIdentitySpecResponse {
+        self.identity_spec_client()
+            .delete_identity_spec(Request::new(DeleteIdentitySpecRequest {
+                name: name.to_string(),
+                force: true,
+            }))
+            .await
+            .expect("force remove identity spec")
+            .into_inner()
+    }
 }
 
 /// Builds an `ImportSourceRequest` for the default workspace with every other
@@ -217,7 +278,23 @@ pub(crate) fn secret(key: &str, value: &str) -> SourceSecret {
     }
 }
 
-fn ensure_file_credentials_config(config_dir: &Path) {
+pub(crate) fn fixed_token_identity_spec_yaml(spec_name: &str, audience_host: &str) -> String {
+    format!(
+        r"
+kind: identity
+spec_version: 1
+name: {spec_name}
+version: 0.1.0
+description: Test token identity.
+issuer: github
+type: fixed_token
+audience:
+  host: {audience_host}
+"
+    )
+}
+
+fn ensure_default_test_config(config_dir: &Path) {
     std::fs::create_dir_all(config_dir).expect("create config dir");
     let config_file = config_dir.join("config.toml");
     let raw = std::fs::read_to_string(&config_file).unwrap_or_default();
@@ -229,8 +306,13 @@ fn ensure_file_credentials_config(config_dir: &Path) {
     } else {
         "\n"
     };
-    let updated = format!("{raw}{separator}\n[credentials]\nstorage = \"file\"\n");
-    std::fs::write(config_file, updated).expect("write test credential config");
+    // DSL v4 (and its identity specs) are gated behind the `dsl_v4` feature, so
+    // enable it in the baseline test config; tests that need it off install
+    // their own config via `start_with_config_dir`.
+    let updated = format!(
+        "{raw}{separator}\n[features]\ndsl_v4 = true\n\n[credentials]\nstorage = \"file\"\n"
+    );
+    std::fs::write(config_file, updated).expect("write default test config");
 }
 
 impl FailingHttpFixture {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -8,6 +8,7 @@ use coral_api::v1::{
     ListSourcesRequest, PaginationRequest, Source, SourceSecret, SourceVariable, TableSummary,
     ValidateSourceRequest, ValidateSourceResponse, catalog_item, import_source_response,
 };
+use coral_app::features::FeatureOverrides;
 use coral_client::{
     AppClient, CatalogClient, IdentitySpecClient, QueryClient, SourceClient, batches_to_json_rows,
     decode_execute_sql_response, default_workspace,
@@ -49,19 +50,37 @@ impl GrpcHarness {
     pub(crate) async fn new_without_dsl_v4() -> Self {
         let temp_dir = TempDir::new().expect("temp dir");
         let config_dir = temp_dir.path().join("coral-config");
-        std::fs::create_dir_all(&config_dir).expect("create config dir");
-        std::fs::write(
-            config_dir.join("config.toml"),
-            "[features]\ndsl_v4 = false\n\n[credentials]\nstorage = \"file\"\n",
-        )
-        .expect("write config without dsl_v4");
+        write_config_without_dsl_v4(&config_dir);
         Self::start_with_parts(temp_dir, config_dir).await
     }
 
+    pub(crate) async fn new_without_dsl_v4_with_feature_overrides(
+        feature_overrides: FeatureOverrides,
+    ) -> Self {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let config_dir = temp_dir.path().join("coral-config");
+        write_config_without_dsl_v4(&config_dir);
+        Self::start_with_parts_with_feature_overrides(temp_dir, config_dir, feature_overrides).await
+    }
+
     async fn start_with_parts(temp_dir: TempDir, config_dir: PathBuf) -> Self {
+        Self::start_with_parts_with_feature_overrides(
+            temp_dir,
+            config_dir,
+            FeatureOverrides::default(),
+        )
+        .await
+    }
+
+    async fn start_with_parts_with_feature_overrides(
+        temp_dir: TempDir,
+        config_dir: PathBuf,
+        feature_overrides: FeatureOverrides,
+    ) -> Self {
         ensure_default_test_config(&config_dir);
         let server = ServerBuilder::new()
             .with_config_dir(&config_dir)
+            .with_feature_overrides(feature_overrides)
             .start()
             .await
             .expect("start server");
@@ -313,6 +332,15 @@ fn ensure_default_test_config(config_dir: &Path) {
         "{raw}{separator}\n[features]\ndsl_v4 = true\n\n[credentials]\nstorage = \"file\"\n"
     );
     std::fs::write(config_file, updated).expect("write default test config");
+}
+
+fn write_config_without_dsl_v4(config_dir: &Path) {
+    std::fs::create_dir_all(config_dir).expect("create config dir");
+    std::fs::write(
+        config_dir.join("config.toml"),
+        "[features]\ndsl_v4 = false\n\n[credentials]\nstorage = \"file\"\n",
+    )
+    .expect("write config without dsl_v4");
 }
 
 impl FailingHttpFixture {

--- a/crates/coral-app/tests/grpc/identity_spec_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_spec_tests.rs
@@ -1,0 +1,169 @@
+use coral_api::v1::{
+    AddIdentitySpecRequest, DeleteIdentitySpecRequest, GetIdentitySpecRequest, IdentitySpecInput,
+    ListIdentitySpecsRequest,
+};
+use tonic::{Code, Request};
+
+use crate::harness::{GrpcHarness, fixed_token_identity_spec_yaml};
+
+fn oauth_identity_yaml_with_required_secret() -> String {
+    r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+description: Demo OAuth identity.
+issuer: demo
+type: oauth
+audience:
+  host: api.example.test
+inputs:
+  DEMO_OAUTH_CLIENT_SECRET:
+    kind: secret
+    required: true
+oauth:
+  method:
+    label: Demo OAuth
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/callback
+    endpoints:
+      authorization_url: https://auth.example.test/authorize
+      token_url: https://auth.example.test/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+        transport: request_body
+"
+    .to_string()
+}
+
+fn client_secret_input() -> IdentitySpecInput {
+    IdentitySpecInput {
+        key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+        value: "client-secret".to_string(),
+    }
+}
+
+async fn get_identity_spec_manifest(harness: &GrpcHarness, name: &str) -> String {
+    harness
+        .identity_spec_client()
+        .get_identity_spec(Request::new(GetIdentitySpecRequest {
+            name: name.to_string(),
+        }))
+        .await
+        .expect("get identity spec")
+        .into_inner()
+        .identity_spec
+        .expect("fetched identity spec")
+        .manifest_yaml
+}
+
+#[tokio::test]
+async fn identity_spec_subcommand_requires_dsl_v4_feature() {
+    let harness = GrpcHarness::new_without_dsl_v4().await;
+    let mut client = harness.identity_spec_client();
+
+    let add = client
+        .add_identity_spec(Request::new(AddIdentitySpecRequest {
+            manifest_yaml: fixed_token_identity_spec_yaml("github_oauth", "github.com"),
+            inputs: Vec::new(),
+        }))
+        .await
+        .expect_err("add requires the dsl_v4 feature");
+    let list = client
+        .list_identity_specs(Request::new(ListIdentitySpecsRequest {}))
+        .await
+        .expect_err("list requires the dsl_v4 feature");
+    let get = client
+        .get_identity_spec(Request::new(GetIdentitySpecRequest {
+            name: "github_oauth".to_string(),
+        }))
+        .await
+        .expect_err("info requires the dsl_v4 feature");
+    let delete = client
+        .delete_identity_spec(Request::new(DeleteIdentitySpecRequest {
+            name: "github_oauth".to_string(),
+            force: true,
+        }))
+        .await
+        .expect_err("remove requires the dsl_v4 feature");
+
+    for status in [add, list, get, delete] {
+        assert_eq!(
+            status.code(),
+            Code::FailedPrecondition,
+            "unexpected status: {status:?}"
+        );
+        assert!(
+            status.message().contains("dsl_v4"),
+            "unexpected message: {}",
+            status.message()
+        );
+    }
+}
+
+#[tokio::test]
+async fn identity_spec_service_adds_lists_gets_and_deletes_global_specs() {
+    let harness = GrpcHarness::new().await;
+
+    let added = harness
+        .try_add_identity_spec(
+            fixed_token_identity_spec_yaml("github_oauth", "github.com"),
+            Vec::new(),
+        )
+        .await
+        .expect("add identity spec");
+    assert!(!added.replaced);
+    assert_eq!(
+        added.identity_spec.expect("added identity spec").name,
+        "github_oauth"
+    );
+
+    let listed = harness.list_identity_specs().await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(
+        listed.first().expect("listed identity spec").name,
+        "github_oauth"
+    );
+
+    let fetched = get_identity_spec_manifest(&harness, "github_oauth").await;
+    assert!(fetched.contains("name: github_oauth"));
+
+    let deleted = harness.force_delete_identity_spec("github_oauth").await;
+    assert_eq!(deleted.orphaned_identities, 0);
+
+    assert!(harness.list_identity_specs().await.is_empty());
+}
+
+#[tokio::test]
+async fn identity_spec_service_stores_request_inputs_on_identity_spec() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = oauth_identity_yaml_with_required_secret();
+
+    let error = harness
+        .try_add_identity_spec(manifest_yaml.clone(), Vec::new())
+        .await
+        .expect_err("missing required identity spec input should fail");
+
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error
+            .message()
+            .contains("missing identity spec input 'DEMO_OAUTH_CLIENT_SECRET'"),
+        "unexpected error: {error}"
+    );
+
+    let added = harness
+        .try_add_identity_spec(manifest_yaml, vec![client_secret_input()])
+        .await
+        .expect("add identity spec with request input");
+
+    assert_eq!(
+        added.identity_spec.expect("added identity spec").name,
+        "demo_oauth"
+    );
+}

--- a/crates/coral-app/tests/grpc/identity_spec_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_spec_tests.rs
@@ -2,6 +2,7 @@ use coral_api::v1::{
     AddIdentitySpecRequest, DeleteIdentitySpecRequest, GetIdentitySpecRequest, IdentitySpecInput,
     ListIdentitySpecsRequest,
 };
+use coral_app::features::{Feature, FeatureOverrides};
 use tonic::{Code, Request};
 
 use crate::harness::{GrpcHarness, fixed_token_identity_spec_yaml};
@@ -104,6 +105,26 @@ async fn identity_spec_subcommand_requires_dsl_v4_feature() {
             status.message()
         );
     }
+}
+
+#[tokio::test]
+async fn identity_spec_service_honors_process_feature_override() {
+    let mut overrides = FeatureOverrides::default();
+    overrides.set(Feature::DslV4, true);
+    let harness = GrpcHarness::new_without_dsl_v4_with_feature_overrides(overrides).await;
+
+    let added = harness
+        .try_add_identity_spec(
+            fixed_token_identity_spec_yaml("github_oauth", "github.com"),
+            Vec::new(),
+        )
+        .await
+        .expect("process override should enable identity specs");
+
+    assert_eq!(
+        added.identity_spec.expect("added identity spec").name,
+        "github_oauth"
+    );
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -138,6 +138,41 @@ async fn import_invalid_manifest_returns_invalid_argument() {
 }
 
 #[tokio::test]
+async fn disabled_dsl_v4_import_fails_before_file_descriptor_canonicalization() {
+    let harness = GrpcHarness::new_without_dsl_v4().await;
+    let missing_descriptor = harness.temp_path().join("missing-openapi.yaml");
+    let manifest_yaml = format!(
+        r"
+name: disabled_v4
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+",
+        missing_descriptor.display()
+    );
+
+    let error = harness
+        .try_import_source(import_request(manifest_yaml))
+        .await
+        .expect_err("disabled dsl_v4 import should fail before canonicalizing descriptor files");
+
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error.message().contains("dsl_v4"),
+        "unexpected error: {}",
+        error.message()
+    );
+    assert!(
+        !error.message().contains("missing-openapi"),
+        "disabled feature should fail before probing descriptor path: {}",
+        error.message()
+    );
+}
+
+#[tokio::test]
 async fn delete_source_removes_from_list_and_disk() {
     let harness = GrpcHarness::new().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use coral_app::AwsEngineExtensionsProvider;
+use coral_app::{AwsEngineExtensionsProvider, features::FeatureOverrides};
 use coral_client::{
     AppClient, ClientError,
     local::{LocalServerError, RunningServer, ServerBuilder},
@@ -11,9 +11,10 @@ pub(crate) struct Bootstrap {
     server: Option<RunningServer>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct BootstrapOptions {
     pub(crate) enable_stderr_logs: bool,
+    pub(crate) feature_overrides: FeatureOverrides,
 }
 
 impl Bootstrap {
@@ -51,10 +52,16 @@ pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, Bo
 }
 
 #[cfg(feature = "embedded-ui")]
-pub(crate) async fn start_ui_server(port: u16) -> Result<RunningServer, BootstrapError> {
+pub(crate) async fn start_ui_server(
+    port: u16,
+    feature_overrides: FeatureOverrides,
+) -> Result<RunningServer, BootstrapError> {
     let server = configure_server_builder(
         ServerBuilder::embedded_ui_loopback(port, crate::embedded_ui_assets()),
-        BootstrapOptions::default(),
+        BootstrapOptions {
+            feature_overrides,
+            ..BootstrapOptions::default()
+        },
     )
     .start()
     .await?;
@@ -64,6 +71,7 @@ pub(crate) async fn start_ui_server(port: u16) -> Result<RunningServer, Bootstra
 fn configure_server_builder(builder: ServerBuilder, options: BootstrapOptions) -> ServerBuilder {
     builder
         .with_stderr_logs(options.enable_stderr_logs)
+        .with_feature_overrides(options.feature_overrides)
         .add_engine_extensions_provider(Arc::new(AwsEngineExtensionsProvider))
 }
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -437,6 +437,7 @@ pub async fn run_from_env() -> Result<(), CliError> {
             let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
             let bootstrap = bootstrap::bootstrap(bootstrap::BootstrapOptions {
                 enable_stderr_logs: command.enables_stderr_logs(),
+                feature_overrides: feature_overrides.clone(),
             })
             .await
             .map_err(anyhow::Error::from)?;
@@ -481,8 +482,11 @@ pub fn open_url(url: &str) -> Result<(), std::io::Error> {
 }
 
 #[cfg(feature = "embedded-ui")]
-async fn run_ui(args: UiArgs) -> Result<(), anyhow::Error> {
-    let server = bootstrap::start_ui_server(args.port).await?;
+async fn run_ui(
+    args: UiArgs,
+    feature_overrides: &coral_app::features::FeatureOverrides,
+) -> Result<(), anyhow::Error> {
+    let server = bootstrap::start_ui_server(args.port, feature_overrides.clone()).await?;
     let endpoint = server.endpoint_uri().to_string();
 
     println!("Coral UI listening on {endpoint}");
@@ -519,7 +523,7 @@ async fn run_no_runtime_command(
         }
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
-        Command::Ui(args) => run_ui(args).await.map_err(Into::into),
+        Command::Ui(args) => run_ui(args, feature_overrides).await.map_err(Into::into),
         Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
         }
@@ -554,7 +558,7 @@ async fn run_app_command(
             let result = decode_execute_sql_response(&response).map_err(anyhow::Error::from)?;
             print_batches(result.batches(), args.format)?;
         }
-        Command::Source(args) => run_source(&app, args).await?,
+        Command::Source(args) => run_source(&app, args, feature_overrides).await?,
         Command::Onboard => {
             onboard::run(&app).await?;
         }
@@ -619,7 +623,11 @@ fn run_features(
     Ok(())
 }
 
-async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
+async fn run_source(
+    app: &AppClient,
+    args: SourceArgs,
+    feature_overrides: &coral_app::features::FeatureOverrides,
+) -> Result<(), CliError> {
     match args.command {
         SourceCommand::Discover => {
             let sources = source_ops::discover_sources(app).await?;
@@ -661,7 +669,7 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
         SourceCommand::Info { name, verbose } => {
             source_ops::print_source_info(app, &name, verbose).await?;
         }
-        SourceCommand::Add(args) => run_source_add(app, args).await?,
+        SourceCommand::Add(args) => run_source_add(app, args, feature_overrides).await?,
         SourceCommand::Lint { file } => {
             source_ops::load_validated_manifest_file(&file)?;
             println!("Manifest is valid");
@@ -769,7 +777,11 @@ fn pad_cell(value: &str, width: usize, pad: bool) -> String {
     format!("{value}{}", " ".repeat(padding))
 }
 
-async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliError> {
+async fn run_source_add(
+    app: &AppClient,
+    args: SourceAddArgs,
+    feature_overrides: &coral_app::features::FeatureOverrides,
+) -> Result<(), CliError> {
     let SourceAddArgs {
         name,
         file,
@@ -805,7 +817,11 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
             }
         }
         (None, Some(file)) => {
-            let (manifest_yaml, manifest) = source_ops::load_validated_manifest_file(&file)?;
+            let raw_manifest_yaml = std::fs::read_to_string(&file).map_err(anyhow::Error::from)?;
+            ensure_source_add_manifest_yaml_features(&raw_manifest_yaml, feature_overrides)?;
+            let (manifest_yaml, manifest) =
+                source_ops::load_validated_manifest_file_yaml(&file, &raw_manifest_yaml)?;
+            ensure_source_add_manifest_features(&manifest, feature_overrides)?;
             if interactive {
                 let inputs = source_ops::prompt_for_inputs_with_credential_methods(
                     manifest.declared_inputs(),
@@ -834,11 +850,73 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
         .map_err(Into::into)
 }
 
+fn ensure_source_add_manifest_features(
+    manifest: &coral_spec::ValidatedSourceManifest,
+    feature_overrides: &coral_app::features::FeatureOverrides,
+) -> Result<(), anyhow::Error> {
+    if manifest.as_v4().is_none() {
+        return Ok(());
+    }
+    ensure_dsl_v4_source_add_enabled(feature_overrides)
+}
+
+fn ensure_source_add_manifest_yaml_features(
+    manifest_yaml: &str,
+    feature_overrides: &coral_app::features::FeatureOverrides,
+) -> Result<(), anyhow::Error> {
+    let manifest_value: serde_yaml::Value = serde_yaml::from_str(manifest_yaml)?;
+    if manifest_value
+        .as_mapping()
+        .and_then(|mapping| mapping.get(serde_yaml::Value::String("dsl_version".to_string())))
+        .and_then(serde_yaml::Value::as_u64)
+        .is_none_or(|dsl_version| dsl_version != 4)
+    {
+        return Ok(());
+    }
+    ensure_dsl_v4_source_add_enabled(feature_overrides)
+}
+
+fn ensure_dsl_v4_source_add_enabled(
+    feature_overrides: &coral_app::features::FeatureOverrides,
+) -> Result<(), anyhow::Error> {
+    match feature_overrides.get(coral_app::features::Feature::DslV4) {
+        Some(true) => Ok(()),
+        Some(false) => coral_app::features::Features::default()
+            .ensure_dsl_v4_enabled()
+            .map_err(Into::into),
+        None => coral_app::features::FeatureStore::discover(None)?
+            .load_with_overrides(feature_overrides)?
+            .ensure_dsl_v4_enabled()
+            .map_err(Into::into),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use clap::{CommandFactory, Parser};
 
-    use super::{Cli, RequiredRuntime, command_enables_stderr_logs};
+    use super::{
+        Cli, RequiredRuntime, command_enables_stderr_logs, ensure_source_add_manifest_features,
+        ensure_source_add_manifest_yaml_features,
+    };
+
+    fn v4_manifest_with_required_input() -> coral_spec::ValidatedSourceManifest {
+        coral_spec::parse_source_manifest_yaml(
+            r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    inputs:
+      DEMO_TENANT:
+        kind: variable
+",
+        )
+        .expect("v4 manifest")
+    }
 
     #[test]
     fn server_command_is_not_available() {
@@ -908,6 +986,56 @@ mod tests {
             .expect("global feature override should parse before subcommand");
 
         assert!(matches!(cli.command, super::Command::McpStdio(_)));
+    }
+
+    #[test]
+    fn source_add_file_rejects_v4_before_input_collection_when_feature_disabled() {
+        let manifest = v4_manifest_with_required_input();
+        let mut overrides = coral_app::features::FeatureOverrides::default();
+        overrides.set(coral_app::features::Feature::DslV4, false);
+
+        let error = ensure_source_add_manifest_features(&manifest, &overrides)
+            .expect_err("v4 source add should require feature");
+
+        assert!(
+            error.to_string().contains("DSL v4 sources require"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn source_add_file_rejects_raw_v4_before_descriptor_validation_when_feature_disabled() {
+        let mut overrides = coral_app::features::FeatureOverrides::default();
+        overrides.set(coral_app::features::Feature::DslV4, false);
+
+        let error = ensure_source_add_manifest_yaml_features(
+            r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /definitely/missing/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+",
+            &overrides,
+        )
+        .expect_err("disabled v4 feature should reject before descriptor validation");
+
+        assert!(
+            error.to_string().contains("DSL v4 sources require"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn source_add_file_accepts_v4_when_feature_enabled() {
+        let manifest = v4_manifest_with_required_input();
+        let mut overrides = coral_app::features::FeatureOverrides::default();
+        overrides.set(coral_app::features::Feature::DslV4, true);
+
+        ensure_source_add_manifest_features(&manifest, &overrides)
+            .expect("explicit feature override should allow v4 source add");
     }
 
     #[test]

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -404,10 +404,17 @@ pub(crate) fn load_validated_manifest_file(
     file: &Path,
 ) -> Result<(String, ValidatedSourceManifest), anyhow::Error> {
     let manifest_yaml = std::fs::read_to_string(file)?;
-    let manifest = parse_source_manifest_yaml(manifest_yaml.as_str())?;
+    load_validated_manifest_file_yaml(file, &manifest_yaml)
+}
+
+pub(crate) fn load_validated_manifest_file_yaml(
+    file: &Path,
+    manifest_yaml: &str,
+) -> Result<(String, ValidatedSourceManifest), anyhow::Error> {
+    let manifest = parse_source_manifest_yaml(manifest_yaml)?;
     let manifest_dir = manifest_file_parent_dir(file)?;
     let manifest_yaml =
-        durable_manifest_file_yaml(&manifest_yaml, &manifest, manifest_dir.as_path())?;
+        durable_manifest_file_yaml(manifest_yaml, &manifest, manifest_dir.as_path())?;
     let manifest = parse_source_manifest_yaml(manifest_yaml.as_str())?;
     Ok((manifest_yaml, manifest))
 }

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -9,7 +9,7 @@
 
 mod harness;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use arrow::array::{Int64Array, StringArray};
@@ -83,18 +83,6 @@ fn write_yaml(dir: &TempDir, file_name: &str, yaml: &str) -> PathBuf {
     let path = dir.path().join(file_name);
     std::fs::write(&path, yaml).expect("write yaml fixture");
     path
-}
-
-/// Prepares `coral <subcommand> add --file <file>` against the mock server.
-fn add_file_cmd(server: &MockServer, subcommand: &str, file: &Path) -> Command {
-    let mut cmd = server.cmd();
-    cmd.args([
-        subcommand,
-        "add",
-        "--file",
-        file.to_str().expect("fixture path utf8"),
-    ]);
-    cmd
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -745,7 +733,15 @@ async fn source_add_file_resolves_v4_relative_descriptor_from_manifest_dir() {
     let server = MockServer::start().await;
     let (source_dir, manifest_file) = v4_github_source_dir("");
 
-    add_file_cmd(&server, "source", &manifest_file)
+    server
+        .cmd()
+        .args([
+            "--enable-dsl-v4",
+            "source",
+            "add",
+            "--file",
+            manifest_file.to_str().expect("fixture path utf8"),
+        ])
         .assert()
         .success();
 


### PR DESCRIPTION
Introduces installed identity specs and their admin surface, gated by
the default-off dsl_v4 feature:

- identity_specs module: IdentitySpecManager installs/lists/gets/deletes
  identity specs, persists spec-owned input material via the
  identity-spec credential routing from the previous PR, computes spec
  fingerprints, and snapshots specs for rollback
- IdentitySpecService gRPC admin API, registered in the server behind a
  ManagementAuthorizer seam (default AllowAllManagementAuthorizer)
- identity vocabulary (SourceIdentity* types, provider traits,
  IdentityManager) lands in identity.rs; items consumed only by later
  PRs carry #[expect(dead_code)]
- authorization.rs ManagementAuthorizer trait; features.rs dsl_v4 flag
  + FeatureOverrides; AppError::IdentitySpecNotFound/IdentityNotFound
- SourceManager gains a Features field and gates v4 install/serve on
  dsl_v4 (ensure_dsl_v4_feature_enabled)
- grpc harness dsl_v4 config + identity_spec_client; identity_spec_tests
  covering CRUD, feature gating, and replace protection (import-flow
  and identity-usage tests deferred to PRs 7-8)

The IdentityService proto stays UNIMPLEMENTED and the new
ImportSourceRequest identity fields remain wire-compatible no-ops until
the user-owned identity and source-lifecycle PRs land.