### PR TITLE
feat(app): user-owned identity creation, storage, refresh, and bearer injection

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -17,6 +17,7 @@ use axum::response::Response as AxumResponse;
 use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::episode_service_server::EpisodeServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
+use coral_api::v1::identity_service_server::IdentityServiceServer;
 use coral_api::v1::identity_spec_service_server::IdentitySpecServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
@@ -50,6 +51,7 @@ use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
+use crate::identities::{IdentityService, UserOwnedIdentityManager};
 use crate::identity_specs::{IdentitySpecManager, IdentitySpecService, IdentitySpecUsageProvider};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
@@ -304,9 +306,14 @@ impl ServerBuilder {
             .with_body_capture_max_bytes(body_capture_max_bytes);
         let identity_spec_manager = IdentitySpecManager::new_with_credential_store(
             layout.clone(),
-            credential_store,
+            credential_store.clone(),
             features.clone(),
             self.identity_spec_usage_providers,
+        );
+        let user_owned_identity_manager = UserOwnedIdentityManager::new(
+            layout.clone(),
+            identity_spec_manager.clone(),
+            credential_store,
         );
 
         let query_manager = QueryManager::new(
@@ -326,6 +333,7 @@ impl ServerBuilder {
             source_manager,
             query_manager,
             identity_spec_manager,
+            user_owned_identity_manager,
             user_principal_provider: self.user_principal_provider,
             management_authorizer: self.management_authorizer,
             feedback_manager,
@@ -411,6 +419,7 @@ struct ServerServices {
     source_manager: SourceManager,
     query_manager: QueryManager,
     identity_spec_manager: IdentitySpecManager,
+    user_owned_identity_manager: UserOwnedIdentityManager,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
     feedback_manager: FeedbackManager,
@@ -424,6 +433,7 @@ async fn start_server(services: ServerServices) -> Result<RunningServer, AppErro
         source_manager,
         query_manager,
         identity_spec_manager,
+        user_owned_identity_manager,
         user_principal_provider,
         management_authorizer,
         feedback_manager,
@@ -439,6 +449,10 @@ async fn start_server(services: ServerServices) -> Result<RunningServer, AppErro
     );
     let catalog_service =
         CatalogService::new(query_manager.clone(), Arc::clone(&user_principal_provider));
+    let identity_service = IdentityService::new(
+        user_owned_identity_manager,
+        Arc::clone(&user_principal_provider),
+    );
     let query_service = QueryService::new(query_manager, Arc::clone(&user_principal_provider));
     let identity_spec_service = IdentitySpecService::new(
         identity_spec_manager,
@@ -455,6 +469,9 @@ async fn start_server(services: ServerServices) -> Result<RunningServer, AppErro
         .add_service(GrpcMethodAnnotatedService::new(
             IdentitySpecServiceServer::new(identity_spec_service),
         ))
+        .add_service(GrpcMethodAnnotatedService::new(IdentityServiceServer::new(
+            identity_service,
+        )))
         .add_service(GrpcMethodAnnotatedService::new(
             CatalogServiceServer::new(catalog_service)
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
@@ -736,6 +753,7 @@ mod tests {
     use crate::episode::store::EpisodeStore;
     use crate::features::{Feature, FeatureOverrides};
     use crate::feedback::manager::FeedbackManager;
+    use crate::identities::UserOwnedIdentityManager;
     use crate::identity_specs::{IdentitySpecManager, IdentitySpecUsageProvider};
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
@@ -871,8 +889,14 @@ enabled = false
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         layout.ensure().expect("layout dirs");
         let config_store = ConfigStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store.clone());
         let identity_spec_manager = IdentitySpecManager::new(layout.clone());
+        let user_owned_identity_manager = UserOwnedIdentityManager::new(
+            layout.clone(),
+            identity_spec_manager.clone(),
+            credential_store,
+        );
         let server = start_server(ServerServices {
             source_manager: SourceManager::new(
                 config_store.clone(),
@@ -888,6 +912,7 @@ enabled = false
                 vec![Arc::new(NoopEngineExtensionsProvider)],
             ),
             identity_spec_manager,
+            user_owned_identity_manager,
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             management_authorizer: Arc::new(AllowAllManagementAuthorizer),
             feedback_manager: FeedbackManager::new(layout.clone()),

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -10,19 +10,17 @@ use std::fmt;
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
 use crate::bootstrap::AppError;
+use crate::identity::parse_path_segment;
 use crate::sources::SourceName;
 use crate::storage::fs::FileLock;
 use crate::workspaces::WorkspaceName;
 
 use self::oauth::{OAuthCredentialService, RefreshOAuthCredentialRequest};
 
-pub(crate) use store::{CredentialStore, CredentialsError};
-#[expect(
-    unused_imports,
-    reason = "re-exports consumed by the identity managers in later PRs"
-)]
+#[cfg(test)]
+pub(crate) use store::parse_env_file;
 pub(crate) use store::{
-    parse_env_file, remove_file_if_exists_unlocked, render_env_file, write_file_unlocked,
+    CredentialStore, CredentialsError, remove_file_if_exists_unlocked, write_file_unlocked,
 };
 
 /// Opaque credential material captured for best-effort rollback.
@@ -110,6 +108,12 @@ impl CredentialSetId {
         Self(format!("identity-spec.{identity_spec_name}"))
     }
 
+    /// Build the user-owned identity credential-set id used for provider token
+    /// material.
+    pub(crate) fn for_user_owned_identity(owner_key: &str, identity_name: &str) -> Self {
+        Self(format!("user-owned-identity/{owner_key}/{identity_name}"))
+    }
+
     pub(crate) fn source_name(&self) -> Result<SourceName, AppError> {
         let Some(source_name) = self.0.strip_prefix("source.") else {
             return Err(AppError::FailedPrecondition(format!(
@@ -127,6 +131,22 @@ impl CredentialSetId {
                 self.0
             ))
         })
+    }
+
+    pub(crate) fn user_owned_identity_key(&self) -> Result<Option<(String, String)>, AppError> {
+        let Some(rest) = self.0.strip_prefix("user-owned-identity/") else {
+            return Ok(None);
+        };
+        let Some((owner_key, identity_name)) = rest.split_once('/') else {
+            return Err(AppError::FailedPrecondition(format!(
+                "credential set '{}' is not a valid user-owned identity credential set",
+                self.0
+            )));
+        };
+        Ok(Some((
+            parse_path_segment("identity owner", owner_key)?,
+            parse_path_segment("identity", identity_name)?,
+        )))
     }
 
     pub(crate) fn is_identity_spec_backed(&self) -> bool {

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -50,22 +50,7 @@ pub(crate) struct StartOAuthCredentialRequest<'a> {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum OAuthClientMaterialPersistence {
-    #[expect(
-        dead_code,
-        reason = "constructed by the identity manager in a later PR"
-    )]
-    None,
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "constructed by the identity manager in a later PR"
-        )
-    )]
-    ClientCredentials {
-        client_id: bool,
-        client_secret: bool,
-    },
+    PinnedEndpoint { client_secret: bool },
     All,
 }
 
@@ -149,25 +134,23 @@ impl PendingOAuthProgressEvent {
 
 impl OAuthClientMaterialPersistence {
     fn stores_client_id(self) -> bool {
-        matches!(
-            self,
-            Self::All
-                | Self::ClientCredentials {
-                    client_id: true,
-                    ..
-                }
-        )
+        match self {
+            Self::PinnedEndpoint { .. } | Self::All => true,
+        }
     }
 
     fn stores_client_secret(self) -> bool {
         matches!(
             self,
             Self::All
-                | Self::ClientCredentials {
+                | Self::PinnedEndpoint {
                     client_secret: true,
-                    ..
                 }
         )
+    }
+
+    fn stores_token_url(self) -> bool {
+        matches!(self, Self::All | Self::PinnedEndpoint { .. })
     }
 }
 
@@ -195,10 +178,6 @@ impl<'a> RefreshOAuthCredentialRequest<'a> {
         }
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "consumed by the identity runtime in a later PR")
-    )]
     pub(crate) fn for_identity(
         identity_name: &str,
         access_token_material_key: &'a str,
@@ -1411,7 +1390,7 @@ fn oauth_credential_material(
     if session.client_material_persistence.stores_client_id() {
         internal_metadata.insert(format!("{prefix}client_id"), session.client_id.clone());
     }
-    if session.client_material_persistence == OAuthClientMaterialPersistence::All {
+    if session.client_material_persistence.stores_token_url() {
         internal_metadata.insert(
             format!("{prefix}token_url"),
             session.endpoints.token_url.clone(),
@@ -1754,7 +1733,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_identity_client_credentials_persistence_omits_token_url() {
+    fn identity_pinned_endpoint_persistence_stores_token_url() {
         let oauth = oauth_spec(
             "https://auth.example.test/token",
             53682,
@@ -1777,7 +1756,7 @@ mod tests {
             &[
                 ("client_id", Some("legacy-client")),
                 ("client_secret", Some("legacy-secret")),
-                ("token_url", None),
+                ("token_url", Some("https://auth.example.test/token")),
             ],
         );
     }
@@ -1810,6 +1789,7 @@ mod tests {
                 ("client_id", Some("legacy-client")),
                 ("client_secret", None),
                 ("client_secret_transport", None),
+                ("token_url", Some(fixture.token_url.as_str())),
             ],
         );
 
@@ -2535,8 +2515,7 @@ mod tests {
                 endpoints,
                 client_id: "legacy-client".to_string(),
                 client_secret: Some(client_secret.to_string()),
-                client_material_persistence: OAuthClientMaterialPersistence::ClientCredentials {
-                    client_id: true,
+                client_material_persistence: OAuthClientMaterialPersistence::PinnedEndpoint {
                     client_secret: store_client_secret,
                 },
             },

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -599,6 +599,15 @@ impl FileCredentialBackend {
         &self,
         set: &CredentialSetRef<'_>,
     ) -> Result<std::path::PathBuf, CredentialsError> {
+        if let Some((owner_key, identity_name)) = set
+            .credential_set_id
+            .user_owned_identity_key()
+            .map_err(|error| CredentialsError::Parse(error.to_string()))?
+        {
+            return Ok(self
+                .layout
+                .user_owned_identity_material_file(&owner_key, &identity_name));
+        }
         if set.credential_set_id.is_identity_spec_backed() {
             let identity_spec_name = set
                 .credential_set_id

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1,11 +1,48 @@
 //! Filesystem-backed user-owned provider identity registry and runtime provider.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
+use std::fs;
 use std::str::FromStr;
+use std::sync::Arc;
+
+use coral_engine::RequestIdentityResolutionContext;
+use coral_spec::parse_identity_manifest_yaml;
+use coral_spec::v4::IdentityRequirements;
+use coral_spec::{
+    IdentityManifest, IdentitySpecConfig, IdentitySpecType, ManifestOAuthCredentialSpec,
+};
+use serde::{Deserialize, Serialize};
+use tracing::info_span;
 
 use crate::bootstrap::AppError;
-use crate::identity::parse_path_segment;
+use crate::credentials::oauth::{
+    OAuthClientMaterialPersistence, OAuthCredentialMaterial, OAuthCredentialService,
+    OAuthProgressEventSender, StartOAuthCredentialRequest,
+};
+use crate::credentials::{
+    CredentialSetId, CredentialStorageKind, CredentialStore, remove_file_if_exists_unlocked,
+    write_file_unlocked,
+};
+use crate::identities::runtime::{
+    FIXED_TOKEN_MATERIAL_KEY, IdentityRuntimeServices, OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
+    StoredIdentityRuntimeData,
+};
+use crate::identity::{
+    RuntimeSourceIdentity, SourceIdentityProvider, SourceIdentityResolutionRequest,
+    SourceIdentitySelection, SourceIdentitySelectionRequest, UserPrincipal, parse_path_segment,
+    unique_input_map,
+};
+use crate::identity_specs::{
+    IdentitySpecManager, IdentitySpecRecord, identity_spec_fingerprint, validate_identity_spec_name,
+};
+use crate::sources::SourceName;
+use crate::state::AppStateLayout;
+use crate::storage::fs::{self as storage_fs, FileLock};
+use crate::workspaces::WorkspaceName;
+
+const USER_OWNED_IDENTITY_DOCUMENT_VERSION: u32 = 1;
+const USER_SOURCE_IDENTITY_BINDING_DOCUMENT_VERSION: u32 = 1;
 
 /// One stored user-owned identity.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,6 +79,10 @@ impl IdentityOwnerKey {
         parse_path_segment("identity owner", &value.into()).map(Self)
     }
 
+    pub(crate) fn for_user_principal(principal: &UserPrincipal) -> Result<Self, AppError> {
+        Self::new(principal.user_id())
+    }
+
     /// Returns the storage key string.
     #[must_use]
     pub fn as_str(&self) -> &str {
@@ -71,6 +112,71 @@ impl TryFrom<String> for IdentityOwnerKey {
     }
 }
 
+/// Request to create or replace an OAuth identity.
+#[derive(Clone)]
+pub struct CreateOAuthIdentityCommand {
+    /// Stable identity name used by source identity bindings.
+    pub name: String,
+    /// Installed OAuth identity spec name.
+    pub identity_spec: String,
+    /// Method-specific OAuth credential inputs.
+    pub credential_inputs: Vec<IdentityCredentialInput>,
+}
+
+impl fmt::Debug for CreateOAuthIdentityCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let credential_input_keys = self
+            .credential_inputs
+            .iter()
+            .map(|input| input.key.as_str())
+            .collect::<Vec<_>>();
+        f.debug_struct("CreateOAuthIdentityCommand")
+            .field("name", &self.name)
+            .field("identity_spec", &self.identity_spec)
+            .field("credential_input_keys", &credential_input_keys)
+            .finish()
+    }
+}
+
+/// Request to create or replace a fixed-token identity.
+#[derive(Clone)]
+pub struct CreateFixedTokenIdentityCommand {
+    /// Stable identity name used by source identity bindings.
+    pub name: String,
+    /// Installed fixed-token identity spec name.
+    pub identity_spec: String,
+    /// Bearer token to store.
+    pub token: String,
+}
+
+impl fmt::Debug for CreateFixedTokenIdentityCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CreateFixedTokenIdentityCommand")
+            .field("name", &self.name)
+            .field("identity_spec", &self.identity_spec)
+            .field("token", &"<redacted>")
+            .finish()
+    }
+}
+
+/// OAuth method input supplied while creating an identity.
+#[derive(Clone)]
+pub struct IdentityCredentialInput {
+    /// Input key.
+    pub key: String,
+    /// Input value.
+    pub value: String,
+}
+
+impl fmt::Debug for IdentityCredentialInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IdentityCredentialInput")
+            .field("key", &self.key)
+            .field("value", &"<redacted>")
+            .finish()
+    }
+}
+
 /// Locked access to credential material for one user-owned identity.
 #[tonic::async_trait]
 pub trait UserOwnedIdentityMaterialGuard: Send {
@@ -89,7 +195,7 @@ pub trait UserOwnedIdentityMaterialGuard: Send {
     async fn write_material(&self, material: &BTreeMap<String, String>) -> Result<(), AppError>;
 }
 
-/// Durable storage backend for user-owned identities.
+/// Durable storage backend for user-owned identities and their source bindings.
 #[tonic::async_trait]
 pub trait UserOwnedIdentityStore: Send + Sync + std::fmt::Debug + 'static {
     /// Lists identities owned by one opaque owner key.
@@ -146,11 +252,1217 @@ pub trait UserOwnedIdentityStore: Send + Sync + std::fmt::Debug + 'static {
         owner: &IdentityOwnerKey,
         identity_name: &str,
     ) -> Result<Box<dyn UserOwnedIdentityMaterialGuard>, AppError>;
+
+    /// Replaces one per-user source identity selection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot be written.
+    async fn replace_source_identity_binding(
+        &self,
+        _user_id: &str,
+        _workspace_name: &str,
+        _source_name: &str,
+        _surface_id: &str,
+        _selection: &SourceIdentitySelection,
+    ) -> Result<(), AppError> {
+        Err(AppError::FailedPrecondition(
+            "user-owned source identity binding storage is not supported by this identity store"
+                .to_string(),
+        ))
+    }
+
+    /// Loads one per-user source identity selection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot be read.
+    async fn load_source_identity_binding(
+        &self,
+        _user_id: &str,
+        _workspace_name: &str,
+        _source_name: &str,
+        _surface_id: &str,
+    ) -> Result<SourceIdentitySelection, AppError> {
+        Err(AppError::FailedPrecondition(
+            "user-owned source identity binding storage is not supported by this identity store"
+                .to_string(),
+        ))
+    }
+}
+
+/// Manages provider-facing identities owned by Coral user principals.
+#[derive(Debug, Clone)]
+pub(crate) struct UserOwnedIdentityManager {
+    identity_specs: IdentitySpecManager,
+    oauth_credential_service: OAuthCredentialService,
+    store: Arc<dyn UserOwnedIdentityStore>,
+}
+
+/// Product-facing handle for stored provider identity management.
+///
+/// The handle intentionally deals only in opaque owner keys. OSS callers keep
+/// using user-owned gRPC methods, while product runtimes can map their own
+/// owner metadata into stable keys.
+#[derive(Debug, Clone)]
+pub struct IdentityManagementHandle {
+    manager: UserOwnedIdentityManager,
+}
+
+impl IdentityManagementHandle {
+    /// Creates or replaces an OAuth identity under `owner`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the identity spec is invalid, OAuth
+    /// authorization fails, or credential material cannot be stored.
+    pub async fn create_oauth_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        command: CreateOAuthIdentityCommand,
+        events: OAuthProgressEventSender,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        self.manager
+            .create_oauth_identity(owner, command, events)
+            .await
+    }
+
+    /// Creates or replaces a fixed-token identity under `owner`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when validation or storage fails.
+    pub async fn create_fixed_token_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        command: CreateFixedTokenIdentityCommand,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        self.manager
+            .create_fixed_token_identity(owner, command)
+            .await
+    }
+
+    /// Lists identities stored under `owner`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot be read.
+    pub async fn list_identities(
+        &self,
+        owner: &IdentityOwnerKey,
+    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+        self.manager.list_identities(owner).await
+    }
+
+    /// Deletes an identity stored under `owner`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot be written.
+    pub async fn delete_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<bool, AppError> {
+        self.manager.delete_identity(owner, identity_name).await
+    }
+
+    /// Resolves an identity under `owner` into runtime credential material,
+    /// refreshing OAuth material if necessary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the stored identity is invalid or refresh
+    /// fails.
+    pub async fn resolve_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<Option<Arc<dyn RuntimeSourceIdentity>>, AppError> {
+        self.manager.resolve_identity(owner, identity_name).await
+    }
+}
+
+impl UserOwnedIdentityManager {
+    pub(crate) fn new(
+        layout: AppStateLayout,
+        identity_specs: IdentitySpecManager,
+        credential_store: CredentialStore,
+    ) -> Self {
+        Self::new_with_store(
+            identity_specs,
+            Arc::new(FileUserOwnedIdentityStore::new(layout, credential_store)),
+        )
+    }
+
+    pub(crate) fn new_with_store(
+        identity_specs: IdentitySpecManager,
+        store: Arc<dyn UserOwnedIdentityStore>,
+    ) -> Self {
+        Self {
+            identity_specs,
+            oauth_credential_service: OAuthCredentialService::new(),
+            store,
+        }
+    }
+
+    #[expect(
+        dead_code,
+        reason = "consumed by the server extension context (ServerExtensionContext) in a later PR"
+    )]
+    pub(crate) fn handle(&self) -> IdentityManagementHandle {
+        IdentityManagementHandle {
+            manager: self.clone(),
+        }
+    }
+
+    /// Gates, validates, and loads the identity spec shared by both identity
+    /// creation paths, erroring when the spec's type is not `expected`.
+    fn prepare_identity_creation(
+        &self,
+        owner: &IdentityOwnerKey,
+        name: &str,
+        identity_spec: &str,
+        expected: IdentitySpecType,
+    ) -> Result<(IdentityOwnerKey, String, IdentitySpecRecord), AppError> {
+        self.identity_specs.ensure_dsl_v4_enabled()?;
+        let name = validate_identity_name(name)?;
+        let identity_spec_name = validate_identity_spec_name(identity_spec)?;
+        let spec = self.identity_specs.get_identity_spec(&identity_spec_name)?;
+        if spec.manifest.identity_type != expected {
+            return Err(AppError::InvalidInput(format!(
+                "identity spec '{identity_spec_name}' has type '{}'; expected {}",
+                spec.manifest.identity_type.label(),
+                expected.label()
+            )));
+        }
+        Ok((owner.clone(), name, spec))
+    }
+
+    async fn create_oauth_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        command: CreateOAuthIdentityCommand,
+        events: OAuthProgressEventSender,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        let span = info_span!("coral.app.identities.create_oauth");
+        let _guard = span.enter();
+        let (owner, name, spec) = self.prepare_identity_creation(
+            owner,
+            &command.name,
+            &command.identity_spec,
+            IdentitySpecType::OAuth,
+        )?;
+        let identity_spec_name = spec.manifest.name.clone();
+        let oauth = oauth_method(&identity_spec_name, &spec.manifest.config)?;
+        let provided_inputs = unique_input_map(
+            command
+                .credential_inputs
+                .into_iter()
+                .map(|input| (input.key, input.value)),
+            "credential input",
+        )?;
+        reject_identity_owned_inputs(
+            &name,
+            &identity_spec_name,
+            &spec.manifest,
+            oauth,
+            &provided_inputs,
+        )?;
+        let identity_inputs = self
+            .identity_specs
+            .resolve_identity_spec_inputs(&spec.manifest)?;
+        let credential_inputs =
+            oauth_credential_inputs_from_identity_inputs(oauth, &identity_inputs, &provided_inputs);
+        OAuthCredentialService::validate_credential_inputs(
+            oauth,
+            &identity_inputs,
+            credential_inputs.clone(),
+        )?;
+
+        let client_material_persistence =
+            oauth_client_material_persistence_for_identity(oauth, &provided_inputs);
+        let material = self
+            .oauth_credential_service
+            .authorize_with_progress(
+                StartOAuthCredentialRequest {
+                    input_key: OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
+                    oauth,
+                    source_inputs: &identity_inputs,
+                    credential_inputs,
+                    client_material_persistence,
+                },
+                name.clone(),
+                &events,
+            )
+            .await?;
+
+        let record = UserOwnedIdentityRecord {
+            name,
+            identity_spec: identity_spec_name,
+            identity_spec_fingerprint: Some(identity_spec_fingerprint(&spec.manifest)?),
+            issuer: spec.manifest.issuer,
+            identity_type: spec.manifest.identity_type.label().to_string(),
+            metadata: material.safe_metadata.clone(),
+        };
+        let material = material_values(material);
+        self.store
+            .replace_identity(&owner, &record, &material)
+            .await?;
+        Ok(record)
+    }
+
+    async fn create_fixed_token_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        command: CreateFixedTokenIdentityCommand,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        let span = info_span!("coral.app.identities.create_fixed_token");
+        let _guard = span.enter();
+        let (owner, name, spec) = self.prepare_identity_creation(
+            owner,
+            &command.name,
+            &command.identity_spec,
+            IdentitySpecType::FixedToken,
+        )?;
+        if command.token.is_empty() {
+            return Err(AppError::InvalidInput(
+                "fixed token identity token must not be empty".to_string(),
+            ));
+        }
+        let record = UserOwnedIdentityRecord {
+            name,
+            identity_spec: spec.manifest.name.clone(),
+            identity_spec_fingerprint: Some(identity_spec_fingerprint(&spec.manifest)?),
+            issuer: spec.manifest.issuer,
+            identity_type: spec.manifest.identity_type.label().to_string(),
+            metadata: BTreeMap::new(),
+        };
+        let material = BTreeMap::from([(FIXED_TOKEN_MATERIAL_KEY.to_string(), command.token)]);
+        self.store
+            .replace_identity(&owner, &record, &material)
+            .await?;
+        Ok(record)
+    }
+
+    pub(crate) async fn create_user_owned_oauth_identity(
+        &self,
+        principal: &UserPrincipal,
+        command: CreateOAuthIdentityCommand,
+        events: OAuthProgressEventSender,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+        self.create_oauth_identity(&owner, command, events).await
+    }
+
+    pub(crate) async fn create_user_owned_fixed_token_identity(
+        &self,
+        principal: &UserPrincipal,
+        command: CreateFixedTokenIdentityCommand,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+        self.create_fixed_token_identity(&owner, command).await
+    }
+
+    async fn list_identities(
+        &self,
+        owner: &IdentityOwnerKey,
+    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+        self.identity_specs.ensure_dsl_v4_enabled()?;
+        self.store.list_identities(owner).await
+    }
+
+    pub(crate) async fn list_user_owned_identities(
+        &self,
+        principal: &UserPrincipal,
+    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+        let span = info_span!("coral.app.identities.list_user_owned");
+        let _guard = span.enter();
+        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+        self.list_identities(&owner).await
+    }
+
+    async fn delete_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<bool, AppError> {
+        let identity_name = validate_identity_name(identity_name)?;
+        self.store.delete_identity(owner, &identity_name).await
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by the v4 source lifecycle (sources/service.rs) in a later PR"
+        )
+    )]
+    pub(crate) async fn replace_user_owned_source_identity_binding(
+        &self,
+        principal: &UserPrincipal,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        surface_id: &str,
+        selection: &SourceIdentitySelection,
+    ) -> Result<(), AppError> {
+        let span = info_span!("coral.app.identities.replace_user_owned_source_binding");
+        let _guard = span.enter();
+        let user_id = validate_user_id(principal.user_id())?;
+        let surface_id = validate_source_surface_id(surface_id)?;
+        selection.validate()?;
+        self.store
+            .replace_source_identity_binding(
+                &user_id,
+                workspace_name.as_str(),
+                source_name.as_str(),
+                &surface_id,
+                selection,
+            )
+            .await
+    }
+
+    #[expect(
+        dead_code,
+        reason = "consumed by the v4 source lifecycle (sources/service.rs) in a later PR"
+    )]
+    pub(crate) async fn validate_user_owned_source_identity_selection(
+        &self,
+        principal: &UserPrincipal,
+        source_name: &SourceName,
+        surface_id: &str,
+        selection: &SourceIdentitySelection,
+        requirements: &IdentityRequirements,
+    ) -> Result<(), AppError> {
+        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+        let identity_name = validate_identity_name(&selection.identity)?;
+        let record = self
+            .store
+            .load_identity(&owner, &identity_name)
+            .await?
+            .ok_or_else(|| AppError::IdentityNotFound(identity_name.clone()))?;
+        let spec = self.load_spec_for_record(&record)?;
+        let context = RequestIdentityResolutionContext::new(
+            source_name.as_str().to_string(),
+            surface_id.to_string(),
+            requirements.clone(),
+        );
+        if !context.accepts_identity(&record.identity_spec, &spec.manifest.audience) {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity '{}' does not satisfy selected identity requirements for source '{}' surface '{}'",
+                selection.identity,
+                source_name.as_str(),
+                surface_id
+            )));
+        }
+        Ok(())
+    }
+
+    /// Loads the installed identity spec backing `record`, reporting orphaned
+    /// identities and rejecting records that no longer match the spec.
+    fn load_spec_for_record(
+        &self,
+        record: &UserOwnedIdentityRecord,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        let spec = match self.identity_specs.get_identity_spec(&record.identity_spec) {
+            Ok(spec) => spec,
+            Err(AppError::IdentitySpecNotFound(_)) => {
+                return Err(AppError::FailedPrecondition(format!(
+                    "identity '{}' is orphaned because identity spec '{}' is not installed",
+                    record.name, record.identity_spec
+                )));
+            }
+            Err(error) => return Err(error),
+        };
+        validate_record_identity_type(record, spec.manifest.identity_type)?;
+        validate_record_identity_spec_fingerprint(record, &spec.manifest)?;
+        Ok(spec)
+    }
+
+    async fn resolve_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<Option<Arc<dyn RuntimeSourceIdentity>>, AppError> {
+        let identity_name = validate_identity_name(identity_name)?;
+        let material_guard = match self.store.material_guard(owner, &identity_name).await {
+            Ok(material_guard) => material_guard,
+            Err(AppError::IdentityNotFound(_)) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let record = self.store.load_identity(owner, &identity_name).await?;
+        let Some(record) = record else {
+            return Ok(None);
+        };
+        let spec = self.load_spec_for_record(&record)?;
+        let identity_inputs = self
+            .identity_specs
+            .resolve_identity_spec_inputs(&spec.manifest)?;
+        let material = material_guard.read_material().await?;
+        let prepared = StoredIdentityRuntimeData::new(
+            record.name.clone(),
+            spec.manifest,
+            identity_inputs,
+            material,
+        )
+        .prepare(IdentityRuntimeServices {
+            oauth_credential_service: &self.oauth_credential_service,
+        })
+        .await?;
+        if let Some(updated_material) = prepared.updated_material {
+            material_guard.write_material(&updated_material).await?;
+        }
+        Ok(Some(prepared.identity))
+    }
+}
+
+#[derive(Clone)]
+struct FileUserOwnedIdentityStore {
+    layout: AppStateLayout,
+    credential_store: CredentialStore,
+}
+
+impl fmt::Debug for FileUserOwnedIdentityStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FileUserOwnedIdentityStore")
+            .field("layout", &self.layout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FileUserOwnedIdentityStore {
+    fn new(layout: AppStateLayout, credential_store: CredentialStore) -> Self {
+        Self {
+            layout,
+            credential_store,
+        }
+    }
+
+    fn load_identity_unlocked(
+        &self,
+        owner_key: &str,
+        name: &str,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        let document = self.load_identity_document_unlocked(owner_key, name)?;
+        document.into_record(name)
+    }
+
+    fn load_identity_document_unlocked(
+        &self,
+        owner_key: &str,
+        name: &str,
+    ) -> Result<UserOwnedIdentityDocument, AppError> {
+        let owner_key = validate_identity_owner_key(owner_key)?;
+        let name = validate_identity_name(name)?;
+        let path = self
+            .layout
+            .user_owned_identity_manifest_file(&owner_key, &name);
+        if !path.exists() {
+            return Err(AppError::IdentityNotFound(name));
+        }
+        let raw = fs::read_to_string(&path)?;
+        serde_yaml::from_str(&raw).map_err(Into::into)
+    }
+
+    fn material_lock_for_layout(
+        layout: &AppStateLayout,
+        owner_key: &str,
+        identity_name: &str,
+    ) -> Result<FileLock, AppError> {
+        FileLock::exclusive(&layout.user_owned_identity_refresh_lock_file(owner_key, identity_name))
+            .map_err(Into::into)
+    }
+
+    fn validate_identity_spec_write_precondition_unlocked(
+        layout: &AppStateLayout,
+        record: &UserOwnedIdentityRecord,
+    ) -> Result<(), AppError> {
+        let Some(expected_fingerprint) = record.identity_spec_fingerprint.as_deref() else {
+            return Ok(());
+        };
+        let identity_spec_name = validate_identity_spec_name(&record.identity_spec)?;
+        let manifest_path = layout.identity_spec_manifest_file(&identity_spec_name);
+        let manifest_yaml = match fs::read_to_string(&manifest_path) {
+            Ok(manifest_yaml) => manifest_yaml,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(AppError::FailedPrecondition(format!(
+                    "identity '{}' cannot be written because identity spec '{}' is not installed; retry identity creation",
+                    record.name, identity_spec_name
+                )));
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let manifest = parse_identity_manifest_yaml(&manifest_yaml).map_err(|error| {
+            AppError::FailedPrecondition(format!(
+                "identity '{}' cannot be written because identity spec '{}' could not be parsed: {error}",
+                record.name, identity_spec_name
+            ))
+        })?;
+        if manifest.name != identity_spec_name {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity '{}' cannot be written because identity spec '{}' was replaced by manifest '{}'; retry identity creation",
+                record.name, identity_spec_name, manifest.name
+            )));
+        }
+        let observed_fingerprint = identity_spec_fingerprint(&manifest)?;
+        if observed_fingerprint == expected_fingerprint {
+            return Ok(());
+        }
+        Err(AppError::FailedPrecondition(format!(
+            "identity '{}' cannot be written because identity spec '{}' changed while creating it; retry identity creation",
+            record.name, identity_spec_name
+        )))
+    }
+}
+
+#[tonic::async_trait]
+impl UserOwnedIdentityStore for FileUserOwnedIdentityStore {
+    async fn list_identities(
+        &self,
+        owner: &IdentityOwnerKey,
+    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+        let store = self.clone();
+        let owner_key = owner.as_str().to_string();
+        tokio::task::spawn_blocking(move || {
+            let owner_key = validate_identity_owner_key(&owner_key)?;
+            let _lock = FileLock::shared(store.layout.state_lock())?;
+            let root = store.layout.user_owned_identities_root(&owner_key);
+            if !root.exists() {
+                return Ok(Vec::new());
+            }
+            let mut records = Vec::new();
+            for entry in fs::read_dir(root)? {
+                let entry = entry?;
+                if !entry.file_type()?.is_dir() {
+                    continue;
+                }
+                let Some(name) = entry.file_name().to_str().map(ToString::to_string) else {
+                    continue;
+                };
+                match store.load_identity_unlocked(&owner_key, &name) {
+                    Ok(record) => records.push(record),
+                    Err(AppError::IdentityNotFound(_)) => {}
+                    Err(error) => return Err(error),
+                }
+            }
+            records.sort_by(|left, right| left.name.cmp(&right.name));
+            Ok(records)
+        })
+        .await?
+    }
+
+    async fn load_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<Option<UserOwnedIdentityRecord>, AppError> {
+        let store = self.clone();
+        let owner_key = owner.as_str().to_string();
+        let identity_name = identity_name.to_string();
+        tokio::task::spawn_blocking(move || {
+            let _lock = FileLock::shared(store.layout.state_lock())?;
+            match store.load_identity_unlocked(&owner_key, &identity_name) {
+                Ok(record) => Ok(Some(record)),
+                Err(AppError::IdentityNotFound(_)) => Ok(None),
+                Err(error) => Err(error),
+            }
+        })
+        .await?
+    }
+
+    async fn replace_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        record: &UserOwnedIdentityRecord,
+        material: &BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
+        let store = self.clone();
+        let owner_key = owner.as_str().to_string();
+        let record = record.clone();
+        let material = material.clone();
+        tokio::task::spawn_blocking(move || {
+            let owner_key = validate_identity_owner_key(&owner_key)?;
+            let _material_lock =
+                Self::material_lock_for_layout(&store.layout, &owner_key, record.name.as_str())?;
+            let _state_lock = FileLock::exclusive(store.layout.state_lock())?;
+            Self::validate_identity_spec_write_precondition_unlocked(&store.layout, &record)?;
+            let credential_storage =
+                match store.load_identity_document_unlocked(&owner_key, record.name.as_str()) {
+                    Ok(document) => document.credential_storage,
+                    Err(AppError::IdentityNotFound(_)) => store
+                        .credential_store
+                        .default_write_storage()
+                        .map_err(AppError::from)?,
+                    Err(error) => return Err(error),
+                };
+            let credential_set_id =
+                CredentialSetId::for_user_owned_identity(&owner_key, record.name.as_str());
+            let material_snapshot = store.credential_store.snapshot_material_unlocked(
+                &WorkspaceName::default(),
+                &credential_set_id,
+                credential_storage,
+            )?;
+            let manifest_path = store
+                .layout
+                .user_owned_identity_manifest_file(&owner_key, record.name.as_str());
+            if let Some(parent) = manifest_path.parent() {
+                storage_fs::ensure_private_dir(parent)?;
+            }
+            let manifest_snapshot = snapshot_file_unlocked(&manifest_path)?;
+            let result = (|| {
+                let document = UserOwnedIdentityDocument::from_record(&record, credential_storage);
+                write_file_unlocked(&manifest_path, serde_yaml::to_string(&document)?.as_bytes())?;
+                store.credential_store.replace_material_unlocked(
+                    &WorkspaceName::default(),
+                    &credential_set_id,
+                    credential_storage,
+                    &material,
+                )?;
+                Ok(())
+            })();
+            if result.is_err() {
+                restore_file_unlocked(&manifest_path, manifest_snapshot)?;
+                store.credential_store.restore_material_unlocked(
+                    &WorkspaceName::default(),
+                    &credential_set_id,
+                    &material_snapshot,
+                )?;
+            }
+            result
+        })
+        .await?
+    }
+
+    async fn delete_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<bool, AppError> {
+        let store = self.clone();
+        let owner_key = owner.as_str().to_string();
+        let identity_name = identity_name.to_string();
+        tokio::task::spawn_blocking(move || {
+            let owner_key = validate_identity_owner_key(&owner_key)?;
+            let identity_name = validate_identity_name(&identity_name)?;
+            let _material_lock =
+                Self::material_lock_for_layout(&store.layout, &owner_key, &identity_name)?;
+            let _state_lock = FileLock::exclusive(store.layout.state_lock())?;
+            let document = match store.load_identity_document_unlocked(&owner_key, &identity_name) {
+                Ok(document) => document,
+                Err(AppError::IdentityNotFound(_)) => return Ok(false),
+                Err(error) => return Err(error),
+            };
+            let credential_set_id =
+                CredentialSetId::for_user_owned_identity(&owner_key, &identity_name);
+            let manifest_path = store
+                .layout
+                .user_owned_identity_manifest_file(&owner_key, &identity_name);
+            store.credential_store.remove_material_unlocked(
+                &WorkspaceName::default(),
+                &credential_set_id,
+                document.credential_storage,
+            )?;
+            remove_file_if_exists_unlocked(&manifest_path)?;
+            let identity_dir = store
+                .layout
+                .user_owned_identity_dir(&owner_key, &identity_name);
+            if identity_dir.exists() {
+                match fs::remove_dir(&identity_dir) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => {}
+                    Err(error) => return Err(error.into()),
+                }
+            }
+            Ok(true)
+        })
+        .await?
+    }
+
+    async fn material_guard(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<Box<dyn UserOwnedIdentityMaterialGuard>, AppError> {
+        let layout = self.layout.clone();
+        let store = self.clone();
+        let owner_key = owner.as_str().to_string();
+        let identity_name = identity_name.to_string();
+        tokio::task::spawn_blocking(move || {
+            let owner_key = validate_identity_owner_key(&owner_key)?;
+            let identity_name = validate_identity_name(&identity_name)?;
+            let lock = Self::material_lock_for_layout(&layout, &owner_key, &identity_name)?;
+            let _state_lock = FileLock::shared(layout.state_lock())?;
+            let document = store.load_identity_document_unlocked(&owner_key, &identity_name)?;
+            Ok(Box::new(FileUserOwnedIdentityMaterialGuard {
+                layout,
+                credential_store: store.credential_store.clone(),
+                owner_key,
+                identity_name,
+                credential_storage: document.credential_storage,
+                _lock: lock,
+            }) as Box<dyn UserOwnedIdentityMaterialGuard>)
+        })
+        .await?
+    }
+
+    async fn replace_source_identity_binding(
+        &self,
+        user_id: &str,
+        workspace_name: &str,
+        source_name: &str,
+        surface_id: &str,
+        selection: &SourceIdentitySelection,
+    ) -> Result<(), AppError> {
+        let store = self.clone();
+        let user_id = user_id.to_string();
+        let workspace_name = workspace_name.to_string();
+        let source_name = source_name.to_string();
+        let surface_id = surface_id.to_string();
+        let selection = selection.clone();
+        tokio::task::spawn_blocking(move || {
+            let user_id = validate_user_id(&user_id)?;
+            let workspace_name = WorkspaceName::parse(&workspace_name)?;
+            let source_name = SourceName::parse(&source_name)?;
+            let surface_id = validate_source_surface_id(&surface_id)?;
+            selection.validate()?;
+            let _lock = FileLock::exclusive(store.layout.state_lock())?;
+            let path = store.layout.user_owned_source_identity_binding_file(
+                &user_id,
+                &workspace_name,
+                &source_name,
+                &surface_id,
+            );
+            if let Some(parent) = path.parent() {
+                storage_fs::ensure_private_dir(parent)?;
+            }
+            write_files_transactionally(&[&path], || {
+                let document = UserSourceIdentityBindingDocument::from_selection(&selection);
+                write_file_unlocked(&path, serde_yaml::to_string(&document)?.as_bytes())?;
+                Ok(())
+            })
+        })
+        .await?
+    }
+
+    async fn load_source_identity_binding(
+        &self,
+        user_id: &str,
+        workspace_name: &str,
+        source_name: &str,
+        surface_id: &str,
+    ) -> Result<SourceIdentitySelection, AppError> {
+        let store = self.clone();
+        let user_id = user_id.to_string();
+        let workspace_name = workspace_name.to_string();
+        let source_name = source_name.to_string();
+        let surface_id = surface_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let user_id = validate_user_id(&user_id)?;
+            let workspace_name = WorkspaceName::parse(&workspace_name)?;
+            let source_name = SourceName::parse(&source_name)?;
+            let surface_id = validate_source_surface_id(&surface_id)?;
+            let _lock = FileLock::shared(store.layout.state_lock())?;
+            let path = store.layout.user_owned_source_identity_binding_file(
+                &user_id,
+                &workspace_name,
+                &source_name,
+                &surface_id,
+            );
+            if !path.exists() {
+                return Err(AppError::FailedPrecondition(format!(
+                    "user '{user_id}' has no selected identity for source '{}' surface '{surface_id}'",
+                    source_name.as_str()
+                )));
+            }
+            let raw = fs::read_to_string(&path)?;
+            let document: UserSourceIdentityBindingDocument = serde_yaml::from_str(&raw)?;
+            document.into_selection()
+        })
+        .await?
+    }
+}
+
+struct FileUserOwnedIdentityMaterialGuard {
+    layout: AppStateLayout,
+    credential_store: CredentialStore,
+    owner_key: String,
+    identity_name: String,
+    credential_storage: CredentialStorageKind,
+    _lock: FileLock,
+}
+
+#[tonic::async_trait]
+impl UserOwnedIdentityMaterialGuard for FileUserOwnedIdentityMaterialGuard {
+    async fn read_material(&self) -> Result<BTreeMap<String, String>, AppError> {
+        let credential_store = self.credential_store.clone();
+        let credential_set_id =
+            CredentialSetId::for_user_owned_identity(&self.owner_key, &self.identity_name);
+        let credential_storage = self.credential_storage;
+        let identity_name = self.identity_name.clone();
+        tokio::task::spawn_blocking(move || {
+            let material = credential_store.read_material(
+                &WorkspaceName::default(),
+                &credential_set_id,
+                credential_storage,
+            )?;
+            if material.is_empty() {
+                return Err(AppError::FailedPrecondition(format!(
+                    "identity '{identity_name}' is missing credential material"
+                )));
+            }
+            Ok(material)
+        })
+        .await?
+    }
+
+    async fn write_material(&self, material: &BTreeMap<String, String>) -> Result<(), AppError> {
+        let layout = self.layout.clone();
+        let credential_store = self.credential_store.clone();
+        let owner_key = self.owner_key.clone();
+        let identity_name = self.identity_name.clone();
+        let credential_storage = self.credential_storage;
+        let material = material.clone();
+        tokio::task::spawn_blocking(move || {
+            let credential_set_id =
+                CredentialSetId::for_user_owned_identity(&owner_key, &identity_name);
+            let _state_lock = FileLock::exclusive(layout.state_lock())?;
+            let manifest_path =
+                layout.user_owned_identity_manifest_file(&owner_key, &identity_name);
+            if !manifest_path.exists() {
+                return Err(AppError::IdentityNotFound(identity_name));
+            }
+            credential_store.replace_material_unlocked(
+                &WorkspaceName::default(),
+                &credential_set_id,
+                credential_storage,
+                &material,
+            )
+        })
+        .await?
+    }
+}
+
+#[tonic::async_trait]
+impl SourceIdentityProvider for UserOwnedIdentityManager {
+    async fn resolve_source_identity_selection(
+        &self,
+        request: &SourceIdentitySelectionRequest,
+    ) -> Result<Option<SourceIdentitySelection>, AppError> {
+        let Some(user_id) = request.subject.user_id() else {
+            return Ok(None);
+        };
+        let user_id = validate_user_id(user_id)?;
+        let workspace_name = WorkspaceName::parse(&request.workspace_name)?;
+        let source_name = SourceName::parse(&request.source_name)?;
+        let selection = self
+            .store
+            .load_source_identity_binding(
+                &user_id,
+                workspace_name.as_str(),
+                source_name.as_str(),
+                &request.surface_id,
+            )
+            .await?;
+        Ok(Some(selection))
+    }
+
+    async fn resolve_source_identity(
+        &self,
+        request: &SourceIdentityResolutionRequest,
+    ) -> Result<Option<Arc<dyn RuntimeSourceIdentity>>, AppError> {
+        let Some(user_id) = request.subject.user_id() else {
+            return Ok(None);
+        };
+        let owner = IdentityOwnerKey::new(user_id)?;
+        let identity_name = validate_identity_name(&request.selection.identity)?;
+        self.resolve_identity(&owner, &identity_name).await
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UserOwnedIdentityDocument {
+    version: u32,
+    name: String,
+    identity_spec: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    identity_spec_fingerprint: Option<String>,
+    #[serde(default = "default_user_owned_identity_credential_storage")]
+    credential_storage: CredentialStorageKind,
+    issuer: String,
+    identity_type: String,
+    #[serde(default)]
+    metadata: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UserSourceIdentityBindingDocument {
+    version: u32,
+    identity: String,
+    #[serde(default)]
+    accepted_identity: Option<String>,
+}
+
+impl UserSourceIdentityBindingDocument {
+    fn from_selection(selection: &SourceIdentitySelection) -> Self {
+        Self {
+            version: USER_SOURCE_IDENTITY_BINDING_DOCUMENT_VERSION,
+            identity: selection.identity.clone(),
+            accepted_identity: selection.accepted_identity.clone(),
+        }
+    }
+
+    fn into_selection(self) -> Result<SourceIdentitySelection, AppError> {
+        if self.version != USER_SOURCE_IDENTITY_BINDING_DOCUMENT_VERSION {
+            return Err(AppError::FailedPrecondition(format!(
+                "source identity binding for identity '{}' has unsupported document version {}; expected {}",
+                self.identity, self.version, USER_SOURCE_IDENTITY_BINDING_DOCUMENT_VERSION
+            )));
+        }
+        SourceIdentitySelection::new(self.identity, self.accepted_identity)
+    }
+}
+
+impl UserOwnedIdentityDocument {
+    fn from_record(
+        record: &UserOwnedIdentityRecord,
+        credential_storage: CredentialStorageKind,
+    ) -> Self {
+        Self {
+            version: USER_OWNED_IDENTITY_DOCUMENT_VERSION,
+            name: record.name.clone(),
+            identity_spec: record.identity_spec.clone(),
+            identity_spec_fingerprint: record.identity_spec_fingerprint.clone(),
+            credential_storage,
+            issuer: record.issuer.clone(),
+            identity_type: record.identity_type.clone(),
+            metadata: record.metadata.clone(),
+        }
+    }
+
+    fn into_record(self, expected_name: &str) -> Result<UserOwnedIdentityRecord, AppError> {
+        if self.version != USER_OWNED_IDENTITY_DOCUMENT_VERSION {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity '{}' has unsupported document version {}; expected {}",
+                self.name, self.version, USER_OWNED_IDENTITY_DOCUMENT_VERSION
+            )));
+        }
+        let name = validate_identity_name(&self.name)?;
+        if name != expected_name {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity file for '{expected_name}' contains identity '{name}'"
+            )));
+        }
+        Ok(UserOwnedIdentityRecord {
+            name,
+            identity_spec: validate_identity_spec_name(&self.identity_spec)?,
+            identity_spec_fingerprint: self.identity_spec_fingerprint,
+            issuer: self.issuer,
+            identity_type: self.identity_type,
+            metadata: self.metadata,
+        })
+    }
+}
+
+fn default_user_owned_identity_credential_storage() -> CredentialStorageKind {
+    CredentialStorageKind::File
+}
+
+fn oauth_method<'a>(
+    identity_spec_name: &str,
+    config: &'a IdentitySpecConfig,
+) -> Result<&'a ManifestOAuthCredentialSpec, AppError> {
+    let IdentitySpecConfig::OAuth(oauth) = config else {
+        return Err(AppError::InvalidInput(format!(
+            "identity spec '{identity_spec_name}' is not oauth"
+        )));
+    };
+    Ok(&oauth.method.oauth)
+}
+
+fn material_values(material: OAuthCredentialMaterial) -> BTreeMap<String, String> {
+    let mut values = material.internal_metadata;
+    values.insert(
+        OAUTH_ACCESS_TOKEN_MATERIAL_KEY.to_string(),
+        material.access_token,
+    );
+    values
+}
+
+fn validate_record_identity_type(
+    record: &UserOwnedIdentityRecord,
+    identity_spec_type: IdentitySpecType,
+) -> Result<(), AppError> {
+    let expected = identity_spec_type.label();
+    if record.identity_type == expected {
+        return Ok(());
+    }
+    Err(AppError::FailedPrecondition(format!(
+        "identity '{}' is orphaned because identity spec '{}' has type '{}', but the stored identity has type '{}'",
+        record.name, record.identity_spec, expected, record.identity_type
+    )))
+}
+
+fn validate_record_identity_spec_fingerprint(
+    record: &UserOwnedIdentityRecord,
+    identity_spec: &IdentityManifest,
+) -> Result<(), AppError> {
+    let Some(stored_fingerprint) = record.identity_spec_fingerprint.as_deref() else {
+        return Err(AppError::FailedPrecondition(format!(
+            "identity '{}' is orphaned because it was created before identity spec fingerprinting; recreate it from identity spec '{}'",
+            record.name, record.identity_spec
+        )));
+    };
+    let current_fingerprint = identity_spec_fingerprint(identity_spec)?;
+    if stored_fingerprint == current_fingerprint {
+        return Ok(());
+    }
+    Err(AppError::FailedPrecondition(format!(
+        "identity '{}' is orphaned because identity spec '{}' has changed since the identity was created; recreate the identity from the current spec",
+        record.name, record.identity_spec
+    )))
+}
+
+fn reject_identity_owned_inputs(
+    identity_name: &str,
+    identity_spec_name: &str,
+    manifest: &IdentityManifest,
+    oauth: &ManifestOAuthCredentialSpec,
+    provided: &BTreeMap<String, String>,
+) -> Result<(), AppError> {
+    let declared = manifest
+        .inputs
+        .iter()
+        .map(|input| input.key.as_str())
+        .collect::<BTreeSet<_>>();
+    for key in provided.keys() {
+        if declared.contains(key.as_str()) {
+            return Err(AppError::InvalidInput(format!(
+                "identity input '{key}' belongs to identity spec '{identity_spec_name}', not identity '{identity_name}'; provide it when installing the identity spec"
+            )));
+        }
+        if legacy_oauth_client_input(oauth, key) {
+            continue;
+        }
+        return Err(AppError::InvalidInput(format!(
+            "unknown OAuth credential input '{key}' for identity '{identity_name}'"
+        )));
+    }
+    Ok(())
+}
+
+fn legacy_oauth_client_input(oauth: &ManifestOAuthCredentialSpec, key: &str) -> bool {
+    oauth.client.id.input.as_deref() == Some(key)
+        || oauth
+            .client
+            .secret
+            .as_ref()
+            .is_some_and(|secret| secret.input == key)
+}
+
+fn oauth_credential_inputs_from_identity_inputs(
+    oauth: &ManifestOAuthCredentialSpec,
+    identity_inputs: &BTreeMap<String, String>,
+    provided: &BTreeMap<String, String>,
+) -> Vec<(String, String)> {
+    let mut values = Vec::new();
+    if let Some(input_key) = oauth.client.id.input.as_deref()
+        && let Some(value) = identity_inputs
+            .get(input_key)
+            .or_else(|| provided.get(input_key))
+            .filter(|value| !value.is_empty())
+    {
+        values.push((input_key.to_string(), value.clone()));
+    }
+    if let Some(secret) = oauth.client.secret.as_ref()
+        && let Some(value) = identity_inputs
+            .get(&secret.input)
+            .or_else(|| provided.get(&secret.input))
+            .filter(|value| !value.is_empty())
+    {
+        values.push((secret.input.clone(), value.clone()));
+    }
+    values
+}
+
+fn oauth_client_material_persistence_for_identity(
+    oauth: &ManifestOAuthCredentialSpec,
+    provided: &BTreeMap<String, String>,
+) -> OAuthClientMaterialPersistence {
+    let client_secret = oauth
+        .client
+        .secret
+        .as_ref()
+        .is_some_and(|secret| provided.contains_key(&secret.input));
+    OAuthClientMaterialPersistence::PinnedEndpoint { client_secret }
+}
+
+fn validate_user_id(user_id: &str) -> Result<String, AppError> {
+    parse_path_segment("user", user_id)
+}
+
+fn validate_identity_owner_key(owner: &str) -> Result<String, AppError> {
+    parse_path_segment("identity owner", owner)
+}
+
+fn validate_identity_name(name: &str) -> Result<String, AppError> {
+    parse_path_segment("identity", name)
+}
+
+fn validate_source_surface_id(surface_id: &str) -> Result<String, AppError> {
+    parse_path_segment("source surface", surface_id)
+}
+
+/// Snapshots `paths`, runs `write`, and restores every file to its prior
+/// contents if `write` fails, so a partial write never leaves files mutated.
+fn write_files_transactionally(
+    paths: &[&std::path::Path],
+    write: impl FnOnce() -> Result<(), AppError>,
+) -> Result<(), AppError> {
+    let snapshots = paths
+        .iter()
+        .map(|&path| snapshot_file_unlocked(path))
+        .collect::<Result<Vec<_>, _>>()?;
+    let result = write();
+    if result.is_err() {
+        for (&path, snapshot) in paths.iter().zip(snapshots) {
+            restore_file_unlocked(path, snapshot)?;
+        }
+    }
+    result
+}
+
+fn snapshot_file_unlocked(path: &std::path::Path) -> Result<Option<Vec<u8>>, AppError> {
+    match fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn restore_file_unlocked(
+    path: &std::path::Path,
+    snapshot: Option<Vec<u8>>,
+) -> Result<(), AppError> {
+    match snapshot {
+        Some(bytes) => write_file_unlocked(path, &bytes).map_err(Into::into),
+        None => remove_file_if_exists_unlocked(path).map_err(Into::into),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::IdentityOwnerKey;
+    use super::*;
+    use crate::credentials::CredentialStoragePreference;
+    use crate::features::{Features, dsl_v4_features};
+    use crate::identities::runtime::FIXED_TOKEN_MATERIAL_KEY;
+    use crate::identity::{
+        SourceIdentityBinding, SourceIdentitySelection, SourceIdentitySelectionRequest,
+        SourceIdentitySubject,
+    };
+    use tempfile::TempDir;
 
     #[test]
     fn owner_key_rejects_storage_unsafe_values() {
@@ -160,15 +1472,655 @@ mod tests {
         IdentityOwnerKey::new("..").unwrap_err();
     }
 
-    #[test]
-    fn owner_key_round_trips_storage_key() {
-        let owner = IdentityOwnerKey::new("member-123").expect("owner key");
+    fn test_layout(temp: &TempDir) -> AppStateLayout {
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout directories");
+        layout
+    }
 
-        assert_eq!(owner.as_str(), "member-123");
-        assert_eq!(owner.to_string(), "member-123");
+    fn manager() -> (TempDir, UserOwnedIdentityManager, IdentitySpecManager) {
+        manager_with_features(dsl_v4_features())
+    }
+
+    fn manager_with_features(
+        features: Features,
+    ) -> (TempDir, UserOwnedIdentityManager, IdentitySpecManager) {
+        let temp = TempDir::new().expect("tempdir");
+        let layout = test_layout(&temp);
+        let identity_specs =
+            IdentitySpecManager::new_with_usage_providers(layout.clone(), features, Vec::new());
+        (
+            temp,
+            UserOwnedIdentityManager::new(
+                layout.clone(),
+                identity_specs.clone(),
+                CredentialStore::new(layout),
+            ),
+            identity_specs,
+        )
+    }
+
+    fn manager_with_github_pat_spec() -> (TempDir, UserOwnedIdentityManager, IdentitySpecManager) {
+        let (temp, manager, identity_specs) = manager();
+        identity_specs
+            .add_identity_spec(&fixed_identity_spec_yaml())
+            .expect("add identity spec");
+        (temp, manager, identity_specs)
+    }
+
+    fn github_local_command(token: &str) -> CreateFixedTokenIdentityCommand {
+        CreateFixedTokenIdentityCommand {
+            name: "github_local".to_string(),
+            identity_spec: "github_pat".to_string(),
+            token: token.to_string(),
+        }
+    }
+
+    fn local_owner() -> IdentityOwnerKey {
+        IdentityOwnerKey::new("local").expect("local owner")
+    }
+
+    async fn create_github_local(manager: &UserOwnedIdentityManager, token: &str) {
+        manager
+            .create_user_owned_fixed_token_identity(
+                &UserPrincipal::local(),
+                github_local_command(token),
+            )
+            .await
+            .expect("create identity");
+    }
+
+    fn github_local_record(identity_spec: &str, identity_type: &str) -> UserOwnedIdentityRecord {
+        UserOwnedIdentityRecord {
+            name: "github_local".to_string(),
+            identity_spec: identity_spec.to_string(),
+            identity_spec_fingerprint: None,
+            issuer: "github".to_string(),
+            identity_type: identity_type.to_string(),
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    fn fingerprinted_github_local_record(manifest_yaml: &str) -> UserOwnedIdentityRecord {
+        let manifest = parse_identity_manifest_yaml(manifest_yaml).expect("identity spec");
+        UserOwnedIdentityRecord {
+            identity_spec_fingerprint: Some(
+                identity_spec_fingerprint(&manifest).expect("identity spec fingerprint"),
+            ),
+            ..github_local_record(&manifest.name, manifest.identity_type.label())
+        }
+    }
+
+    fn material(key: &str, value: &str) -> BTreeMap<String, String> {
+        BTreeMap::from([(key.to_string(), value.to_string())])
+    }
+
+    fn fixed_identity_spec_yaml() -> String {
+        fixed_identity_spec_yaml_for_host("github.com")
+    }
+
+    fn fixed_identity_spec_yaml_for_host(host: &str) -> String {
+        format!(
+            r"
+kind: identity
+spec_version: 1
+name: github_pat
+version: 0.1.0
+issuer: github
+type: fixed_token
+audience:
+  host: {host}
+"
+        )
+    }
+
+    /// Declares spec-owned inputs (`DEMO_TENANT`, `DEMO_OAUTH_CLIENT_SECRET`);
+    /// `client_id` selects between a spec default and a legacy identity-owned input.
+    fn demo_oauth_identity_spec(client_id: &str) -> IdentityManifest {
+        coral_spec::parse_identity_manifest_yaml(&format!(
+            r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+issuer: demo
+type: oauth
+audience:
+  host: example.test
+inputs:
+  DEMO_TENANT:
+    kind: variable
+    default: tenant-a
+  DEMO_OAUTH_CLIENT_SECRET:
+    kind: secret
+oauth:
+  method:
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    endpoints:
+      authorization_url: https://{{{{input.DEMO_TENANT}}}}.example.test/oauth/authorize
+      token_url: https://{{{{input.DEMO_TENANT}}}}.example.test/oauth/token
+    client:
+      id:
+        {client_id}
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+        transport: request_body
+"
+        ))
+        .expect("identity spec")
+    }
+
+    fn resolution_request(identity_name: &str) -> SourceIdentityResolutionRequest {
+        SourceIdentityResolutionRequest {
+            workspace_name: "default".to_string(),
+            subject: SourceIdentitySubject::User("local".to_string()),
+            source_name: "github".to_string(),
+            surface_id: "rest".to_string(),
+            binding: SourceIdentityBinding::user_owned(),
+            selection: SourceIdentitySelection::new(identity_name, None).expect("selection"),
+            identity_requirements: coral_spec::v4::IdentityRequirements {
+                accepts: Vec::new(),
+            },
+        }
+    }
+
+    async fn resolve_github_local_err(
+        manager: &UserOwnedIdentityManager,
+        expect_message: &str,
+    ) -> String {
+        manager
+            .resolve_source_identity(&resolution_request("github_local"))
+            .await
+            .expect_err(expect_message)
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn create_user_owned_identity_requires_dsl_v4_feature() {
+        let (_temp, manager, _identity_specs) = manager_with_features(Features::default());
+
+        let error = manager
+            .create_user_owned_fixed_token_identity(
+                &UserPrincipal::local(),
+                github_local_command("token"),
+            )
+            .await
+            .expect_err("identity creation requires the dsl_v4 feature");
+
+        assert!(
+            matches!(&error, AppError::SourceUnservable(message) if message.contains("dsl_v4")),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_user_owned_identities_requires_dsl_v4_feature() {
+        let (_temp, manager, _identity_specs) = manager_with_features(Features::default());
+
+        let error = manager
+            .list_user_owned_identities(&UserPrincipal::local())
+            .await
+            .expect_err("identity listing requires the dsl_v4 feature");
+
+        assert!(
+            matches!(&error, AppError::SourceUnservable(message) if message.contains("dsl_v4")),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn refreshed_material_write_rejects_deleted_identity() {
+        let (temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        create_github_local(&manager, "old-token").await;
+        let layout = test_layout(&temp);
+        let refresh_guard = manager
+            .store
+            .material_guard(&local_owner(), "github_local")
+            .await
+            .expect("open material guard");
+        fs::remove_dir_all(layout.user_owned_identity_dir("local", "github_local"))
+            .expect("delete identity");
+
+        let error = refresh_guard
+            .write_material(&material(FIXED_TOKEN_MATERIAL_KEY, "new-token"))
+            .await
+            .expect_err("deleted identity material must not be recreated");
+
+        assert!(matches!(error, AppError::IdentityNotFound(name) if name == "github_local"));
+        assert!(
+            !layout
+                .user_owned_identity_material_file("local", "github_local")
+                .exists(),
+            "deleted identity material should stay deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_material_uses_configured_keychain_storage_for_create_refresh_and_delete() {
+        let temp = TempDir::new().expect("tempdir");
+        let layout = test_layout(&temp);
+        let credential_store = CredentialStore::with_available_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Keychain,
+        );
+        let identity_specs = IdentitySpecManager::new_with_usage_providers(
+            layout.clone(),
+            dsl_v4_features(),
+            Vec::new(),
+        );
+        let manager = UserOwnedIdentityManager::new(
+            layout.clone(),
+            identity_specs.clone(),
+            credential_store.clone(),
+        );
+        identity_specs
+            .add_identity_spec(&fixed_identity_spec_yaml())
+            .expect("add identity spec");
+        let credential_set_id = CredentialSetId::for_user_owned_identity("local", "github_local");
+
+        create_github_local(&manager, "identity-token").await;
+
+        assert!(
+            !layout
+                .user_owned_identity_material_file("local", "github_local")
+                .exists(),
+            "keychain-backed identity material must not be written as a plaintext file"
+        );
+        let stored = credential_store
+            .read_material(
+                &WorkspaceName::default(),
+                &credential_set_id,
+                CredentialStorageKind::Keychain,
+            )
+            .expect("read keychain material");
         assert_eq!(
-            "member-123".parse::<IdentityOwnerKey>().expect("parse"),
-            owner
+            stored.get(FIXED_TOKEN_MATERIAL_KEY).map(String::as_str),
+            Some("identity-token")
+        );
+        let manifest =
+            fs::read_to_string(layout.user_owned_identity_manifest_file("local", "github_local"))
+                .expect("read identity manifest");
+        assert!(
+            manifest.contains("credential_storage: keychain"),
+            "identity manifest should record material storage route: {manifest}"
+        );
+
+        manager
+            .store
+            .material_guard(&local_owner(), "github_local")
+            .await
+            .expect("open keychain material guard")
+            .write_material(&material(FIXED_TOKEN_MATERIAL_KEY, "refreshed-token"))
+            .await
+            .expect("write refreshed keychain material");
+        let refreshed = credential_store
+            .read_material(
+                &WorkspaceName::default(),
+                &credential_set_id,
+                CredentialStorageKind::Keychain,
+            )
+            .expect("read refreshed keychain material");
+        assert_eq!(
+            refreshed.get(FIXED_TOKEN_MATERIAL_KEY).map(String::as_str),
+            Some("refreshed-token")
+        );
+        assert!(
+            !layout
+                .user_owned_identity_material_file("local", "github_local")
+                .exists(),
+            "keychain-backed refresh must not create a plaintext material file"
+        );
+
+        assert!(
+            manager
+                .delete_identity(&local_owner(), "github_local")
+                .await
+                .expect("delete keychain identity"),
+            "identity delete should report removal"
+        );
+        let deleted = credential_store
+            .read_material(
+                &WorkspaceName::default(),
+                &credential_set_id,
+                CredentialStorageKind::Keychain,
+            )
+            .expect("read deleted keychain material");
+        assert!(
+            deleted.is_empty(),
+            "keychain material should be removed with the identity"
+        );
+    }
+
+    #[test]
+    fn create_identity_command_debug_redacts_secret_values() {
+        let credential_input = IdentityCredentialInput {
+            key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+            value: "client-secret".to_string(),
+        };
+        let oauth_command = CreateOAuthIdentityCommand {
+            name: "demo_local".to_string(),
+            identity_spec: "demo_oauth".to_string(),
+            credential_inputs: vec![credential_input.clone()],
+        };
+        let fixed_command = CreateFixedTokenIdentityCommand {
+            name: "github_pat_local".to_string(),
+            identity_spec: "github_pat".to_string(),
+            token: "pat-token".to_string(),
+        };
+
+        let input_debug = format!("{credential_input:?}");
+        let oauth_debug = format!("{oauth_command:?}");
+        let fixed_debug = format!("{fixed_command:?}");
+
+        assert!(input_debug.contains("DEMO_OAUTH_CLIENT_SECRET"));
+        assert!(oauth_debug.contains("DEMO_OAUTH_CLIENT_SECRET"));
+        assert!(fixed_debug.contains("github_pat_local"));
+        assert!(!input_debug.contains("client-secret"));
+        assert!(!oauth_debug.contains("client-secret"));
+        assert!(!fixed_debug.contains("pat-token"));
+    }
+
+    #[test]
+    fn identity_creation_rejects_declared_spec_inputs() {
+        let manifest = demo_oauth_identity_spec("default: demo-client");
+        let oauth = oauth_method(&manifest.name, &manifest.config).expect("oauth method");
+        let provided = material("DEMO_OAUTH_CLIENT_SECRET", "client-secret");
+
+        let error =
+            reject_identity_owned_inputs("demo_local", &manifest.name, &manifest, oauth, &provided)
+                .expect_err("declared input belongs to the identity spec");
+
+        assert!(
+            error
+                .to_string()
+                .contains("belongs to identity spec 'demo_oauth'"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn identity_oauth_persistence_pins_endpoint_without_spec_owned_secret() {
+        let manifest = demo_oauth_identity_spec("default: demo-client");
+        let oauth = oauth_method(&manifest.name, &manifest.config).expect("oauth method");
+        let provided = BTreeMap::new();
+
+        assert_eq!(
+            oauth_client_material_persistence_for_identity(oauth, &provided),
+            OAuthClientMaterialPersistence::PinnedEndpoint {
+                client_secret: false,
+            }
+        );
+    }
+
+    #[test]
+    fn identity_material_values_store_only_token_material() {
+        let material = OAuthCredentialMaterial {
+            input_key: OAUTH_ACCESS_TOKEN_MATERIAL_KEY.to_string(),
+            access_token: "access-token".to_string(),
+            internal_metadata: BTreeMap::new(),
+            safe_metadata: BTreeMap::new(),
+        };
+        let values = material_values(material);
+
+        assert_eq!(
+            values
+                .get(OAUTH_ACCESS_TOKEN_MATERIAL_KEY)
+                .map(String::as_str),
+            Some("access-token")
+        );
+        assert_eq!(values.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn identity_replacement_waits_for_in_flight_material_refresh() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        create_github_local(&manager, "old-token").await;
+
+        let refresh_guard = manager
+            .store
+            .material_guard(&local_owner(), "github_local")
+            .await
+            .expect("hold refresh lock");
+        let replacement_manager = manager.clone();
+        let mut replacement = tokio::spawn(async move {
+            replacement_manager
+                .create_user_owned_fixed_token_identity(
+                    &UserPrincipal::local(),
+                    github_local_command("replacement-token"),
+                )
+                .await
+        });
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(200), &mut replacement,)
+                .await
+                .is_err(),
+            "identity replacement must wait behind an in-flight material refresh"
+        );
+        refresh_guard
+            .write_material(&material(FIXED_TOKEN_MATERIAL_KEY, "stale-refreshed-token"))
+            .await
+            .expect("write stale refreshed material while refresh lock is held");
+        drop(refresh_guard);
+        replacement
+            .await
+            .expect("replacement task")
+            .expect("replacement should succeed");
+
+        let final_material = manager
+            .store
+            .material_guard(&local_owner(), "github_local")
+            .await
+            .expect("open final material guard")
+            .read_material()
+            .await
+            .expect("read final material");
+        assert_eq!(
+            final_material
+                .get(FIXED_TOKEN_MATERIAL_KEY)
+                .map(String::as_str),
+            Some("replacement-token"),
+            "replacement material should win over stale in-flight refresh material"
+        );
+    }
+
+    #[tokio::test]
+    async fn lists_user_owned_identity_records() {
+        let (temp, manager, _identity_specs) = manager();
+        let principal = UserPrincipal::local();
+        let record = UserOwnedIdentityRecord {
+            metadata: BTreeMap::from([("scope".to_string(), "repo".to_string())]),
+            ..github_local_record("github_oauth", "oauth")
+        };
+
+        manager
+            .store
+            .replace_identity(
+                &local_owner(),
+                &record,
+                &material(OAUTH_ACCESS_TOKEN_MATERIAL_KEY, "gho_token"),
+            )
+            .await
+            .expect("write identity");
+        let layout = test_layout(&temp);
+        fs::create_dir_all(layout.user_owned_identity_dir("local", "partial_identity"))
+            .expect("partial identity dir");
+
+        let listed = manager
+            .list_user_owned_identities(&principal)
+            .await
+            .expect("list identities");
+        assert_eq!(listed, vec![record]);
+    }
+
+    #[tokio::test]
+    async fn identity_write_revalidates_fingerprinted_spec_under_state_lock() {
+        let (_temp, manager, identity_specs) = manager_with_github_pat_spec();
+        let record = fingerprinted_github_local_record(&fixed_identity_spec_yaml());
+        identity_specs
+            .remove_identity_spec("github_pat", true)
+            .expect("remove identity spec");
+
+        let error = manager
+            .store
+            .replace_identity(
+                &local_owner(),
+                &record,
+                &material(FIXED_TOKEN_MATERIAL_KEY, "identity-token"),
+            )
+            .await
+            .expect_err("missing identity spec should reject identity write");
+
+        assert!(
+            error.to_string().contains("is not installed"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            manager
+                .store
+                .load_identity(&local_owner(), "github_local")
+                .await
+                .expect("load identity")
+                .is_none(),
+            "failed write must not leave an orphaned identity"
+        );
+    }
+
+    #[tokio::test]
+    async fn built_in_provider_ignores_workspace_owned_bindings() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        let request = SourceIdentityResolutionRequest {
+            subject: SourceIdentitySubject::Workspace,
+            binding: SourceIdentityBinding::workspace_owned("github_local", None).expect("binding"),
+            ..resolution_request("github_local")
+        };
+
+        let resolved = manager
+            .resolve_source_identity(&request)
+            .await
+            .expect("workspace binding ignored");
+        assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn provider_returns_none_for_missing_user_owned_identity() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+
+        let resolved = manager
+            .resolve_source_identity(&resolution_request("github_local"))
+            .await
+            .expect("missing identity should not fail provider resolution");
+
+        assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolves_user_owned_source_identity_selection_per_user() {
+        let (_temp, manager, _identity_specs) = manager();
+        let principal = UserPrincipal::for_user("saul").expect("principal");
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github_v4").expect("source");
+        let selection =
+            SourceIdentitySelection::new("github_saul", Some("github-rest-read".to_string()))
+                .expect("selection");
+        manager
+            .replace_user_owned_source_identity_binding(
+                &principal,
+                &workspace_name,
+                &source_name,
+                "rest",
+                &selection,
+            )
+            .await
+            .expect("write source identity binding");
+
+        let request = SourceIdentitySelectionRequest {
+            workspace_name: "default".to_string(),
+            subject: SourceIdentitySubject::User("saul".to_string()),
+            source_name: "github_v4".to_string(),
+            surface_id: "rest".to_string(),
+            binding: SourceIdentityBinding::user_owned(),
+        };
+
+        let resolved = manager
+            .resolve_source_identity_selection(&request)
+            .await
+            .expect("resolve source identity binding")
+            .expect("selection");
+        assert_eq!(resolved, selection);
+
+        let missing_user = SourceIdentitySelectionRequest {
+            subject: SourceIdentitySubject::User("tina".to_string()),
+            ..request
+        };
+        let error = manager
+            .resolve_source_identity_selection(&missing_user)
+            .await
+            .expect_err("selection should be per user");
+        assert!(
+            error
+                .to_string()
+                .contains("user 'tina' has no selected identity")
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_reports_orphaned_user_owned_identity() {
+        let (_temp, manager, _identity_specs) = manager();
+        manager
+            .store
+            .replace_identity(
+                &local_owner(),
+                &github_local_record("missing_oauth", "oauth"),
+                &material(OAUTH_ACCESS_TOKEN_MATERIAL_KEY, "gho_token"),
+            )
+            .await
+            .expect("write identity");
+
+        let error = resolve_github_local_err(&manager, "orphaned identity should fail").await;
+        assert!(error.contains("is orphaned"));
+    }
+
+    #[tokio::test]
+    async fn provider_rejects_identity_without_stored_spec_fingerprint() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        manager
+            .store
+            .replace_identity(
+                &local_owner(),
+                &github_local_record("github_pat", "fixed_token"),
+                &material(FIXED_TOKEN_MATERIAL_KEY, "identity-token"),
+            )
+            .await
+            .expect("write legacy identity");
+
+        let error = resolve_github_local_err(&manager, "legacy identity should fail closed").await;
+        assert!(
+            error.contains("created before identity spec fingerprinting"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_rejects_identity_when_spec_fingerprint_changes_after_force_readd() {
+        let (_temp, manager, identity_specs) = manager_with_github_pat_spec();
+        create_github_local(&manager, "identity-token").await;
+        identity_specs
+            .remove_identity_spec("github_pat", true)
+            .expect("force remove spec");
+        identity_specs
+            .add_identity_spec(&fixed_identity_spec_yaml_for_host("attacker.test"))
+            .expect("add different spec with same name");
+
+        let error =
+            resolve_github_local_err(&manager, "changed identity spec should fail closed").await;
+        assert!(
+            error.contains("has changed since the identity was created"),
+            "unexpected error: {error}"
         );
     }
 }

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -1,8 +1,13 @@
-//! Stored user-owned provider identity storage seams.
+//! Stored user-owned provider identity registry and APIs.
 
 mod manager;
+mod runtime;
+mod service;
 
+pub(crate) use manager::UserOwnedIdentityManager;
 pub use manager::{
-    IdentityOwnerKey, UserOwnedIdentityMaterialGuard, UserOwnedIdentityRecord,
-    UserOwnedIdentityStore,
+    CreateFixedTokenIdentityCommand, CreateOAuthIdentityCommand, IdentityCredentialInput,
+    IdentityManagementHandle, IdentityOwnerKey, UserOwnedIdentityMaterialGuard,
+    UserOwnedIdentityRecord, UserOwnedIdentityStore,
 };
+pub(crate) use service::IdentityService;

--- a/crates/coral-app/src/identities/runtime.rs
+++ b/crates/coral-app/src/identities/runtime.rs
@@ -1,0 +1,714 @@
+//! Runtime HTTP injection for stored provider identities.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use coral_engine::{RequestIdentityResolutionContext, RequestIdentityResolverError};
+use coral_spec::{
+    IdentityManifest, IdentitySpecConfig, IdentitySpecType, ManifestOAuthCredentialSpec,
+};
+use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
+use serde_json::Value;
+
+use crate::bootstrap::AppError;
+use crate::credentials::oauth::{OAuthCredentialService, RefreshOAuthCredentialRequest};
+use crate::identity::RuntimeSourceIdentity;
+
+pub(super) const OAUTH_ACCESS_TOKEN_MATERIAL_KEY: &str = "ACCESS_TOKEN";
+pub(super) const FIXED_TOKEN_MATERIAL_KEY: &str = "TOKEN";
+
+/// Services type-specific identity runtimes may need while preparing material.
+pub(super) struct IdentityRuntimeServices<'a> {
+    pub(super) oauth_credential_service: &'a OAuthCredentialService,
+}
+
+/// Parsed identity spec plus stored secret material for one concrete identity.
+pub(super) struct StoredIdentityRuntimeData {
+    identity_name: String,
+    identity_spec: IdentityManifest,
+    identity_inputs: BTreeMap<String, String>,
+    material: BTreeMap<String, String>,
+}
+
+impl fmt::Debug for StoredIdentityRuntimeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let identity_input_keys = self.identity_inputs.keys().collect::<Vec<_>>();
+        let material_keys = self.material.keys().collect::<Vec<_>>();
+        f.debug_struct("StoredIdentityRuntimeData")
+            .field("identity_name", &self.identity_name)
+            .field("identity_spec", &self.identity_spec.name)
+            .field("identity_type", &self.identity_spec.identity_type.label())
+            .field("identity_input_keys", &identity_input_keys)
+            .field("material_keys", &material_keys)
+            .finish()
+    }
+}
+
+impl StoredIdentityRuntimeData {
+    pub(super) fn new(
+        identity_name: String,
+        identity_spec: IdentityManifest,
+        identity_inputs: BTreeMap<String, String>,
+        material: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            identity_name,
+            identity_spec,
+            identity_inputs,
+            material,
+        }
+    }
+
+    /// Prepares the runtime identity for this stored identity's type:
+    /// OAuth identities refresh stored token material when needed before
+    /// injection; fixed-token identities inject their stored token as-is.
+    pub(super) async fn prepare(
+        mut self,
+        services: IdentityRuntimeServices<'_>,
+    ) -> Result<PreparedRuntimeIdentity, AppError> {
+        let (material_key, label, updated_material) = match self.identity_spec.identity_type {
+            IdentitySpecType::OAuth => {
+                let oauth = oauth_method(&self.identity_spec)?;
+                let refreshed = services
+                    .oauth_credential_service
+                    .refresh_if_needed(
+                        RefreshOAuthCredentialRequest::for_identity(
+                            &self.identity_name,
+                            OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
+                            oauth,
+                            &self.identity_inputs,
+                        ),
+                        &mut self.material,
+                    )
+                    .await?;
+                let updated_material = refreshed.then(|| self.material.clone());
+                (
+                    OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
+                    "OAuth access token",
+                    updated_material,
+                )
+            }
+            IdentitySpecType::FixedToken => (FIXED_TOKEN_MATERIAL_KEY, "fixed token", None),
+        };
+        Ok(PreparedRuntimeIdentity {
+            identity: Arc::new(BearerTokenRuntimeIdentity {
+                data: self,
+                material_key,
+                label,
+            }),
+            updated_material,
+        })
+    }
+
+    fn identity_spec_id(&self) -> &str {
+        &self.identity_spec.name
+    }
+
+    fn audience(&self) -> &BTreeMap<String, Value> {
+        &self.identity_spec.audience
+    }
+}
+
+pub(super) struct PreparedRuntimeIdentity {
+    pub(super) identity: Arc<dyn RuntimeSourceIdentity>,
+    pub(super) updated_material: Option<BTreeMap<String, String>>,
+}
+
+/// Runtime identity that injects `Authorization: Bearer <token>` from one
+/// stored material key, after enforcing the identity's audience host.
+struct BearerTokenRuntimeIdentity {
+    data: StoredIdentityRuntimeData,
+    material_key: &'static str,
+    label: &'static str,
+}
+
+impl fmt::Debug for BearerTokenRuntimeIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BearerTokenRuntimeIdentity")
+            .field("data", &self.data)
+            .field("material_key", &self.material_key)
+            .field("label", &self.label)
+            .finish()
+    }
+}
+
+#[tonic::async_trait]
+impl RuntimeSourceIdentity for BearerTokenRuntimeIdentity {
+    fn identity_spec_id(&self) -> &str {
+        self.data.identity_spec_id()
+    }
+
+    fn audience(&self) -> &BTreeMap<String, Value> {
+        self.data.audience()
+    }
+
+    async fn resolve_headers(
+        &self,
+        identity: &RequestIdentityResolutionContext,
+        request: &reqwest::Request,
+        _resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
+        ensure_identity_is_accepted(&self.data, identity)?;
+        ensure_request_matches_identity_audience(&self.data, request)?;
+        let token = required_material(&self.data, self.material_key, self.label)?;
+        bearer_authorization_header(&self.data, token, self.label)
+    }
+}
+
+fn oauth_method(spec: &IdentityManifest) -> Result<&ManifestOAuthCredentialSpec, AppError> {
+    let IdentitySpecConfig::OAuth(oauth) = &spec.config else {
+        return Err(AppError::FailedPrecondition(format!(
+            "identity spec '{}' has type oauth but no OAuth runtime config",
+            spec.name
+        )));
+    };
+    Ok(&oauth.method.oauth)
+}
+
+fn required_material<'a>(
+    data: &'a StoredIdentityRuntimeData,
+    key: &str,
+    label: &str,
+) -> Result<&'a str, RequestIdentityResolverError> {
+    data.material
+        .get(key)
+        .filter(|value| !value.is_empty())
+        .map(String::as_str)
+        .ok_or_else(|| {
+            RequestIdentityResolverError::failed_precondition(format!(
+                "identity '{}' is missing {label} material key '{key}'",
+                data.identity_name
+            ))
+        })
+}
+
+fn bearer_authorization_header(
+    data: &StoredIdentityRuntimeData,
+    token: &str,
+    label: &str,
+) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
+    authorization_header(data, "Bearer", token, label)
+}
+
+fn ensure_identity_is_accepted(
+    data: &StoredIdentityRuntimeData,
+    identity: &RequestIdentityResolutionContext,
+) -> Result<(), RequestIdentityResolverError> {
+    if identity.accepts_identity(data.identity_spec_id(), data.audience()) {
+        return Ok(());
+    }
+    Err(RequestIdentityResolverError::failed_precondition(format!(
+        "identity '{}' with spec '{}' is not accepted by source '{}' surface '{}'",
+        data.identity_name,
+        data.identity_spec_id(),
+        identity.source_name(),
+        identity.surface_id()
+    )))
+}
+
+fn authorization_header(
+    data: &StoredIdentityRuntimeData,
+    scheme: &str,
+    credential: &str,
+    label: &str,
+) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
+    let value = HeaderValue::from_str(&format!("{scheme} {credential}")).map_err(|error| {
+        RequestIdentityResolverError::failed_precondition(format!(
+            "identity '{}' {label} material could not be encoded as an Authorization header: {error}",
+            data.identity_name
+        ))
+    })?;
+    Ok(vec![(AUTHORIZATION, value)])
+}
+
+fn ensure_request_matches_identity_audience(
+    data: &StoredIdentityRuntimeData,
+    request: &reqwest::Request,
+) -> Result<(), RequestIdentityResolverError> {
+    let audience_host = required_audience_host(data)?;
+    let request_host = request.url().host_str().ok_or_else(|| {
+        RequestIdentityResolverError::failed_precondition(format!(
+            "identity '{}' cannot inject Authorization headers for URL without a host",
+            data.identity_name
+        ))
+    })?;
+    if !host_matches_audience(request_host, audience_host) {
+        return Err(RequestIdentityResolverError::failed_precondition(format!(
+            "identity '{}' audience host '{}' does not match request host '{}'",
+            data.identity_name, audience_host, request_host
+        )));
+    }
+    ensure_request_scheme_matches_identity_audience(data, request.url().scheme())?;
+    ensure_request_port_matches_identity_audience(data, request.url().port_or_known_default())?;
+    Ok(())
+}
+
+fn required_audience_host(
+    data: &StoredIdentityRuntimeData,
+) -> Result<&str, RequestIdentityResolverError> {
+    data.identity_spec
+        .audience
+        .get("host")
+        .and_then(Value::as_str)
+        .filter(|host| !host.trim().is_empty())
+        .ok_or_else(|| {
+            RequestIdentityResolverError::failed_precondition(format!(
+                "identity spec '{}' must declare string audience.host before identity '{}' can inject Authorization headers",
+                data.identity_spec.name, data.identity_name
+            ))
+        })
+}
+
+fn optional_audience_string_claim<'a>(
+    data: &'a StoredIdentityRuntimeData,
+    key: &str,
+) -> Result<Option<&'a str>, RequestIdentityResolverError> {
+    let Some(value) = data.identity_spec.audience.get(key) else {
+        return Ok(None);
+    };
+    value
+        .as_str()
+        .filter(|value| !value.trim().is_empty())
+        .map(Some)
+        .ok_or_else(|| {
+            RequestIdentityResolverError::failed_precondition(format!(
+                "identity spec '{}' audience.{key} must be a non-empty string before identity '{}' can inject Authorization headers",
+                data.identity_spec.name, data.identity_name
+            ))
+        })
+}
+
+fn optional_audience_port(
+    data: &StoredIdentityRuntimeData,
+) -> Result<Option<u16>, RequestIdentityResolverError> {
+    let Some(value) = data.identity_spec.audience.get("port") else {
+        return Ok(None);
+    };
+    let port = value.as_u64().and_then(|port| u16::try_from(port).ok());
+    port.map(Some).ok_or_else(|| {
+        RequestIdentityResolverError::failed_precondition(format!(
+            "identity spec '{}' audience.port must be an integer between 0 and 65535 before identity '{}' can inject Authorization headers",
+            data.identity_spec.name, data.identity_name
+        ))
+    })
+}
+
+fn ensure_request_scheme_matches_identity_audience(
+    data: &StoredIdentityRuntimeData,
+    request_scheme: &str,
+) -> Result<(), RequestIdentityResolverError> {
+    let audience_scheme = optional_audience_string_claim(data, "scheme")?.unwrap_or("https");
+    if request_scheme.eq_ignore_ascii_case(audience_scheme) {
+        return Ok(());
+    }
+    Err(RequestIdentityResolverError::failed_precondition(format!(
+        "identity '{}' audience scheme '{}' does not match request scheme '{}'",
+        data.identity_name, audience_scheme, request_scheme
+    )))
+}
+
+fn ensure_request_port_matches_identity_audience(
+    data: &StoredIdentityRuntimeData,
+    request_port: Option<u16>,
+) -> Result<(), RequestIdentityResolverError> {
+    let Some(audience_port) = optional_audience_port(data)? else {
+        return Ok(());
+    };
+    let Some(request_port) = request_port else {
+        return Err(RequestIdentityResolverError::failed_precondition(format!(
+            "identity '{}' cannot inject Authorization headers for URL without a known port while audience.port is {}",
+            data.identity_name, audience_port
+        )));
+    };
+    if request_port == audience_port {
+        return Ok(());
+    }
+    Err(RequestIdentityResolverError::failed_precondition(format!(
+        "identity '{}' audience port '{}' does not match request port '{}'",
+        data.identity_name, audience_port, request_port
+    )))
+}
+
+fn host_matches_audience(request_host: &str, audience_host: &str) -> bool {
+    let request_host = request_host
+        .trim()
+        .trim_end_matches('.')
+        .to_ascii_lowercase();
+    let audience_host = audience_host
+        .trim()
+        .trim_end_matches('.')
+        .to_ascii_lowercase();
+    !audience_host.is_empty() && request_host == audience_host
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coral_spec::parse_identity_manifest_yaml;
+    use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
+
+    async fn prepared_identity(
+        identity_spec: IdentityManifest,
+        material_key: &str,
+        token: &str,
+    ) -> PreparedRuntimeIdentity {
+        StoredIdentityRuntimeData::new(
+            "demo_local".to_string(),
+            identity_spec,
+            BTreeMap::new(),
+            BTreeMap::from([(material_key.to_string(), token.to_string())]),
+        )
+        .prepare(IdentityRuntimeServices {
+            oauth_credential_service: &OAuthCredentialService::new(),
+        })
+        .await
+        .expect("prepare identity")
+    }
+
+    async fn prepared_fixed_token_identity(
+        identity_spec: IdentityManifest,
+    ) -> PreparedRuntimeIdentity {
+        prepared_identity(identity_spec, FIXED_TOKEN_MATERIAL_KEY, "fixed-token").await
+    }
+
+    async fn resolve_headers(
+        prepared: &PreparedRuntimeIdentity,
+        host: &str,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
+        resolve_headers_for_url(prepared, &format!("https://{host}/user")).await
+    }
+
+    async fn resolve_headers_for_url(
+        prepared: &PreparedRuntimeIdentity,
+        url: &str,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
+        let requirements = IdentityRequirements {
+            accepts: vec![AcceptedIdentityRequirement {
+                id: "demo-runtime".to_string(),
+                identity_specs: vec![prepared.identity.identity_spec_id().to_string()],
+                audience: prepared.identity.audience().clone(),
+            }],
+        };
+        resolve_headers_for_url_with_requirements(prepared, url, requirements).await
+    }
+
+    async fn resolve_headers_with_requirements(
+        prepared: &PreparedRuntimeIdentity,
+        host: &str,
+        requirements: IdentityRequirements,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
+        resolve_headers_for_url_with_requirements(
+            prepared,
+            &format!("https://{host}/user"),
+            requirements,
+        )
+        .await
+    }
+
+    async fn resolve_headers_for_url_with_requirements(
+        prepared: &PreparedRuntimeIdentity,
+        url: &str,
+        requirements: IdentityRequirements,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
+        let context = RequestIdentityResolutionContext::new(
+            "demo".to_string(),
+            "rest".to_string(),
+            requirements,
+        );
+        let request = reqwest::Request::new(reqwest::Method::GET, url.parse().expect("url"));
+        prepared
+            .identity
+            .resolve_headers(&context, &request, &BTreeMap::new())
+            .await
+    }
+
+    async fn assert_identity_injects_bearer_token(
+        identity_spec: IdentityManifest,
+        material_key: &str,
+        token: &str,
+        expected_header: &'static str,
+    ) {
+        let prepared = prepared_identity(identity_spec, material_key, token).await;
+
+        let headers = resolve_headers(&prepared, "example.test")
+            .await
+            .expect("headers");
+
+        assert_eq!(
+            headers,
+            vec![(AUTHORIZATION, HeaderValue::from_static(expected_header))]
+        );
+        assert!(prepared.updated_material.is_none());
+    }
+
+    fn oauth_identity_spec() -> IdentityManifest {
+        parse_identity_manifest_yaml(
+            r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+issuer: demo
+type: oauth
+audience:
+  host: example.test
+oauth:
+  method:
+    flow:
+      type: device_code
+    endpoints:
+      device_authorization_url: https://example.test/device
+      token_url: https://example.test/token
+    client:
+      id:
+        default: demo-client
+",
+        )
+        .expect("identity spec")
+    }
+
+    fn fixed_token_identity_spec() -> IdentityManifest {
+        fixed_token_identity_spec_with_audience("host: example.test")
+    }
+
+    fn fixed_token_identity_spec_without_audience_host() -> IdentityManifest {
+        fixed_token_identity_spec_with_audience("tenant: demo")
+    }
+
+    fn fixed_token_identity_spec_with_origin_audience() -> IdentityManifest {
+        fixed_token_identity_spec_with_audience("host: example.test\n  scheme: https\n  port: 443")
+    }
+
+    fn fixed_token_identity_spec_with_audience(audience: &str) -> IdentityManifest {
+        parse_identity_manifest_yaml(&format!(
+            r"
+kind: identity
+spec_version: 1
+name: demo_token
+version: 0.1.0
+issuer: demo
+type: fixed_token
+audience:
+  {audience}
+"
+        ))
+        .expect("identity spec")
+    }
+
+    #[test]
+    fn runtime_identity_debug_redacts_inputs_and_material_values() {
+        let data = StoredIdentityRuntimeData::new(
+            "demo_local".to_string(),
+            oauth_identity_spec(),
+            BTreeMap::from([("CLIENT_SECRET".to_string(), "secret-input".to_string())]),
+            BTreeMap::from([
+                (
+                    OAUTH_ACCESS_TOKEN_MATERIAL_KEY.to_string(),
+                    "access-token".to_string(),
+                ),
+                (
+                    "__coral_oauth.ACCESS_TOKEN.refresh_token".to_string(),
+                    "refresh-token".to_string(),
+                ),
+            ]),
+        );
+
+        let data_debug = format!("{data:?}");
+        assert!(data_debug.contains("demo_local"));
+        assert!(data_debug.contains("CLIENT_SECRET"));
+        assert!(data_debug.contains(OAUTH_ACCESS_TOKEN_MATERIAL_KEY));
+        assert!(!data_debug.contains("secret-input"));
+        assert!(!data_debug.contains("access-token"));
+        assert!(!data_debug.contains("refresh-token"));
+
+        let identity = BearerTokenRuntimeIdentity {
+            data,
+            material_key: OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
+            label: "OAuth access token",
+        };
+        let identity_debug = format!("{identity:?}");
+        assert!(identity_debug.contains("BearerTokenRuntimeIdentity"));
+        assert!(!identity_debug.contains("secret-input"));
+        assert!(!identity_debug.contains("access-token"));
+        assert!(!identity_debug.contains("refresh-token"));
+    }
+
+    #[tokio::test]
+    async fn oauth_identity_injects_bearer_access_token_from_material() {
+        assert_identity_injects_bearer_token(
+            oauth_identity_spec(),
+            OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
+            "oauth-token",
+            "Bearer oauth-token",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn fixed_token_identity_injects_bearer_token_from_material() {
+        assert_identity_injects_bearer_token(
+            fixed_token_identity_spec(),
+            FIXED_TOKEN_MATERIAL_KEY,
+            "fixed-token",
+            "Bearer fixed-token",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn identity_headers_reject_identity_not_accepted_by_surface_requirements() {
+        let prepared = prepared_fixed_token_identity(fixed_token_identity_spec()).await;
+        let requirements = IdentityRequirements {
+            accepts: vec![AcceptedIdentityRequirement {
+                id: "other-runtime".to_string(),
+                identity_specs: vec!["other_identity_spec".to_string()],
+                audience: BTreeMap::new(),
+            }],
+        };
+
+        let error = resolve_headers_with_requirements(&prepared, "api.example.test", requirements)
+            .await
+            .expect_err("unaccepted identity should not receive identity headers");
+
+        assert!(
+            error.to_string().contains("is not accepted"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_headers_reject_subdomain_request_host_outside_audience() {
+        let prepared = prepared_fixed_token_identity(fixed_token_identity_spec()).await;
+
+        let error = resolve_headers(&prepared, "api.example.test")
+            .await
+            .expect_err("mismatched host should not receive identity headers");
+
+        assert!(
+            error.to_string().contains("does not match request host"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_headers_enforce_audience_scheme_and_port() {
+        let prepared =
+            prepared_fixed_token_identity(fixed_token_identity_spec_with_origin_audience()).await;
+
+        resolve_headers_for_url(&prepared, "https://example.test/user")
+            .await
+            .expect("default https port should satisfy audience.port");
+
+        let scheme_error = resolve_headers_for_url(&prepared, "http://example.test/user")
+            .await
+            .expect_err("mismatched scheme should not receive identity headers");
+        assert!(
+            scheme_error
+                .to_string()
+                .contains("audience scheme 'https' does not match request scheme 'http'"),
+            "unexpected error: {scheme_error}"
+        );
+
+        let port_error = resolve_headers_for_url(&prepared, "https://example.test:8443/user")
+            .await
+            .expect_err("mismatched port should not receive identity headers");
+        assert!(
+            port_error
+                .to_string()
+                .contains("audience port '443' does not match request port '8443'"),
+            "unexpected error: {port_error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_headers_require_https_for_host_only_audience() {
+        let prepared = prepared_fixed_token_identity(fixed_token_identity_spec()).await;
+
+        let error = resolve_headers_for_url(&prepared, "http://example.test/user")
+            .await
+            .expect_err("host-only audience should default to https");
+
+        assert!(
+            error
+                .to_string()
+                .contains("audience scheme 'https' does not match request scheme 'http'"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_headers_allow_explicit_http_audience_scheme() {
+        let prepared = prepared_fixed_token_identity(fixed_token_identity_spec_with_audience(
+            "host: example.test\n  scheme: http",
+        ))
+        .await;
+
+        resolve_headers_for_url(&prepared, "http://example.test/user")
+            .await
+            .expect("explicit http audience should allow http requests");
+    }
+
+    #[tokio::test]
+    async fn identity_headers_reject_invalid_audience_origin_claims() {
+        let invalid_scheme = prepared_fixed_token_identity(
+            fixed_token_identity_spec_with_audience("host: example.test\n  scheme: 42"),
+        )
+        .await;
+        let scheme_error = resolve_headers(&invalid_scheme, "example.test")
+            .await
+            .expect_err("non-string audience scheme should fail closed");
+        assert!(
+            scheme_error
+                .to_string()
+                .contains("audience.scheme must be a non-empty string"),
+            "unexpected error: {scheme_error}"
+        );
+
+        let invalid_port = prepared_fixed_token_identity(fixed_token_identity_spec_with_audience(
+            "host: example.test\n  port: bad",
+        ))
+        .await;
+        let port_error = resolve_headers(&invalid_port, "example.test")
+            .await
+            .expect_err("non-numeric audience port should fail closed");
+        assert!(
+            port_error
+                .to_string()
+                .contains("audience.port must be an integer between 0 and 65535"),
+            "unexpected error: {port_error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_headers_require_audience_host() {
+        let prepared =
+            prepared_fixed_token_identity(fixed_token_identity_spec_without_audience_host()).await;
+
+        let error = resolve_headers(&prepared, "api.example.test")
+            .await
+            .expect_err("missing audience host should fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("must declare string audience.host"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn audience_host_matching_allows_only_exact_hosts() {
+        assert!(host_matches_audience("example.test", "example.test"));
+        assert!(host_matches_audience("EXAMPLE.TEST", "example.test"));
+        assert!(host_matches_audience("example.test.", "example.test."));
+        assert!(!host_matches_audience("api.example.test", "example.test"));
+        assert!(!host_matches_audience("badexample.test", "example.test"));
+        assert!(!host_matches_audience(
+            "example.test.attacker.test",
+            "example.test"
+        ));
+        assert!(!host_matches_audience("github.com.evil.test", "github.com"));
+        assert!(!host_matches_audience("example.test", ""));
+    }
+}

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -1,0 +1,182 @@
+//! Implements the gRPC `IdentityService`.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use coral_api::v1::identity_service_server::IdentityService as IdentityServiceApi;
+use coral_api::v1::{
+    CreateUserOwnedIdentityWithFixedTokenRequest, CreateUserOwnedIdentityWithFixedTokenResponse,
+    CreateUserOwnedIdentityWithOAuthRequest, CreateUserOwnedIdentityWithOAuthResponse,
+    CredentialMetadata, Identity, IdentityOwner, ListUserOwnedIdentitiesRequest,
+    ListUserOwnedIdentitiesResponse, create_user_owned_identity_with_o_auth_response,
+};
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::app_status;
+use crate::credentials::oauth::OAuthProgressEvent;
+use crate::identities::{
+    CreateFixedTokenIdentityCommand, CreateOAuthIdentityCommand, IdentityCredentialInput,
+    UserOwnedIdentityManager, UserOwnedIdentityRecord,
+};
+use crate::identity::UserPrincipalProvider;
+use crate::transport::{
+    OAuthProgressProto, instrument_authenticated_grpc, instrument_grpc,
+    oauth_operation_response_stream,
+};
+
+#[derive(Clone)]
+pub(crate) struct IdentityService {
+    identities: UserOwnedIdentityManager,
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+}
+
+impl IdentityService {
+    pub(crate) fn new(
+        identities: UserOwnedIdentityManager,
+        user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    ) -> Self {
+        Self {
+            identities,
+            user_principal_provider,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl IdentityServiceApi for IdentityService {
+    type CreateUserOwnedIdentityWithOAuthStream = CreateUserOwnedIdentityResponseStreamBox;
+
+    async fn create_user_owned_identity_with_o_auth(
+        &self,
+        request: Request<CreateUserOwnedIdentityWithOAuthRequest>,
+    ) -> Result<Response<Self::CreateUserOwnedIdentityWithOAuthStream>, Status> {
+        let identities = self.identities.clone();
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |principal, request| async move {
+                let span = tracing::Span::current();
+                let command = create_user_owned_oauth_command_from_proto(request);
+                let stream = oauth_operation_response_stream(
+                    "identity OAuth stream closed before creation completed",
+                    move |event_sender| {
+                        instrument_grpc(span, async move {
+                            identities
+                                .create_user_owned_oauth_identity(&principal, command, event_sender)
+                                .await
+                                .map_err(app_status)
+                        })
+                    },
+                    identity_event_to_proto,
+                    |identity| CreateUserOwnedIdentityWithOAuthResponse {
+                        event: Some(
+                            create_user_owned_identity_with_o_auth_response::Event::Identity(
+                                identity_record_to_proto(identity),
+                            ),
+                        ),
+                    },
+                );
+                Ok(Response::new(stream))
+            },
+        )
+        .await
+    }
+
+    async fn create_user_owned_identity_with_fixed_token(
+        &self,
+        request: Request<CreateUserOwnedIdentityWithFixedTokenRequest>,
+    ) -> Result<Response<CreateUserOwnedIdentityWithFixedTokenResponse>, Status> {
+        let identities = self.identities.clone();
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |principal, request| async move {
+                let record = identities
+                    .create_user_owned_fixed_token_identity(
+                        &principal,
+                        CreateFixedTokenIdentityCommand {
+                            name: request.name,
+                            identity_spec: request.identity_spec,
+                            token: request.token,
+                        },
+                    )
+                    .await
+                    .map_err(app_status)?;
+                Ok(Response::new(
+                    CreateUserOwnedIdentityWithFixedTokenResponse {
+                        identity: Some(identity_record_to_proto(record)),
+                    },
+                ))
+            },
+        )
+        .await
+    }
+
+    async fn list_user_owned_identities(
+        &self,
+        request: Request<ListUserOwnedIdentitiesRequest>,
+    ) -> Result<Response<ListUserOwnedIdentitiesResponse>, Status> {
+        let identities = self.identities.clone();
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |principal, _request| async move {
+                let records = identities
+                    .list_user_owned_identities(&principal)
+                    .await
+                    .map_err(app_status)?;
+                Ok(Response::new(ListUserOwnedIdentitiesResponse {
+                    identities: records.into_iter().map(identity_record_to_proto).collect(),
+                }))
+            },
+        )
+        .await
+    }
+}
+
+type CreateUserOwnedIdentityResponseStreamBox =
+    Pin<Box<dyn Stream<Item = Result<CreateUserOwnedIdentityWithOAuthResponse, Status>> + Send>>;
+
+fn create_user_owned_oauth_command_from_proto(
+    request: CreateUserOwnedIdentityWithOAuthRequest,
+) -> CreateOAuthIdentityCommand {
+    CreateOAuthIdentityCommand {
+        name: request.name,
+        identity_spec: request.identity_spec,
+        credential_inputs: request
+            .credential_inputs
+            .into_iter()
+            .map(|input| IdentityCredentialInput {
+                key: input.key,
+                value: input.value,
+            })
+            .collect(),
+    }
+}
+
+fn identity_event_to_proto(event: OAuthProgressEvent) -> CreateUserOwnedIdentityWithOAuthResponse {
+    use create_user_owned_identity_with_o_auth_response::Event;
+    let event = match OAuthProgressProto::from(event) {
+        OAuthProgressProto::Authorization(authorization) => {
+            Event::OauthAuthorization(authorization)
+        }
+        OAuthProgressProto::Completed(completed) => Event::OauthCompleted(completed),
+    };
+    CreateUserOwnedIdentityWithOAuthResponse { event: Some(event) }
+}
+
+fn identity_record_to_proto(record: UserOwnedIdentityRecord) -> Identity {
+    Identity {
+        name: record.name,
+        identity_spec: record.identity_spec,
+        issuer: record.issuer,
+        identity_type: record.identity_type,
+        owner: IdentityOwner::User as i32,
+        metadata: record
+            .metadata
+            .into_iter()
+            .map(|(key, value)| CredentialMetadata { key, value })
+            .collect(),
+    }
+}

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -12,15 +12,15 @@ use serde_json::Value;
 
 use crate::bootstrap::AppError;
 
-/// Collects `(key, value)` inputs into a map, validating each key as a path
-/// segment and rejecting duplicates. `label` names the input kind in errors.
+/// Collects `(key, value)` inputs into a map, validating each key and rejecting
+/// duplicates. `label` names the input kind in errors.
 pub(crate) fn unique_input_map(
     inputs: impl IntoIterator<Item = (String, String)>,
     label: &str,
 ) -> Result<BTreeMap<String, String>, AppError> {
     let mut values = BTreeMap::new();
     for (key, value) in inputs {
-        let key = parse_path_segment(label, &key)?;
+        let key = normalize_input_key(label, &key)?;
         if values.insert(key.clone(), value).is_some() {
             return Err(AppError::InvalidInput(format!(
                 "{label} '{key}' is repeated"
@@ -30,14 +30,37 @@ pub(crate) fn unique_input_map(
     Ok(values)
 }
 
+fn normalize_input_key(label: &str, value: &str) -> Result<String, AppError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::InvalidInput(format!("missing {label} key")));
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(AppError::InvalidInput(format!(
+            "{label} key must not contain '/' or '\\\\'"
+        )));
+    }
+    if trimmed.contains('=') || trimmed.contains('\n') || trimmed.contains('\r') {
+        return Err(AppError::InvalidInput(format!(
+            "{label} key must not contain '=', '\\n', or '\\r'"
+        )));
+    }
+    if trimmed.starts_with('#') {
+        return Err(AppError::InvalidInput(format!(
+            "{label} key must not start with '#'"
+        )));
+    }
+    Ok(trimmed.to_string())
+}
+
 pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppError> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return Err(AppError::InvalidInput(format!("missing {kind} name")));
     }
-    if trimmed.contains('/') || trimmed.contains('\\') {
+    if trimmed.contains('/') || trimmed.contains('\\') || trimmed.contains(':') {
         return Err(AppError::InvalidInput(format!(
-            "{kind} name must not contain '/' or '\\\\'"
+            "{kind} name must not contain '/', '\\\\', or ':'"
         )));
     }
     if trimmed == "." || trimmed == ".." {
@@ -165,10 +188,6 @@ impl UserPrincipalProvider for SingleUserPrincipalProvider {
 /// Scope that owns configured provider-facing source identity material.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-#[expect(
-    unreachable_pub,
-    reason = "source identity vocabulary re-exported from lib.rs in a later PR"
-)]
 pub enum SourceIdentityOwner {
     /// Identity material is owned by the current Coral user principal.
     User,
@@ -191,10 +210,6 @@ impl SourceIdentityOwner {
 
 /// Subject used to select provider-facing source identity material.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[expect(
-    unreachable_pub,
-    reason = "source identity vocabulary re-exported from lib.rs in a later PR"
-)]
 pub enum SourceIdentitySubject {
     /// Identity material is owned by the request user principal.
     User(String),
@@ -202,10 +217,12 @@ pub enum SourceIdentitySubject {
     Workspace,
 }
 
-#[expect(
-    dead_code,
-    unreachable_pub,
-    reason = "source identity vocabulary consumed and re-exported in later PRs"
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "source identity vocabulary consumed and re-exported in later PRs"
+    )
 )]
 impl SourceIdentitySubject {
     pub(crate) fn for_binding_owner(
@@ -236,10 +253,6 @@ impl SourceIdentitySubject {
 
 /// Workspace config binding from one source-local surface to an identity slot.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[expect(
-    unreachable_pub,
-    reason = "source identity vocabulary re-exported from lib.rs in a later PR"
-)]
 pub struct SourceIdentityBinding {
     /// Whether the identity is user-specific or workspace-owned.
     pub owner: SourceIdentityOwner,
@@ -259,11 +272,6 @@ pub struct SourceIdentityBinding {
     pub accepted_identity: Option<String>,
 }
 
-#[expect(
-    dead_code,
-    unreachable_pub,
-    reason = "source identity vocabulary consumed and re-exported in later PRs"
-)]
 impl SourceIdentityBinding {
     /// Builds one validated user-owned source identity slot.
     #[must_use]
@@ -345,10 +353,6 @@ impl SourceIdentityBinding {
 
 /// Concrete identity selected for one source-local surface.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[expect(
-    unreachable_pub,
-    reason = "source identity vocabulary re-exported from lib.rs in a later PR"
-)]
 pub struct SourceIdentitySelection {
     /// Stable identity reference understood by installed identity providers.
     pub identity: String,
@@ -357,11 +361,6 @@ pub struct SourceIdentitySelection {
     pub accepted_identity: Option<String>,
 }
 
-#[expect(
-    dead_code,
-    unreachable_pub,
-    reason = "source identity vocabulary consumed and re-exported in later PRs"
-)]
 impl SourceIdentitySelection {
     /// Builds one validated source identity selection.
     ///
@@ -400,11 +399,6 @@ impl SourceIdentitySelection {
 
 /// Request to resolve a user-specific source identity selection.
 #[derive(Debug, Clone)]
-#[expect(
-    dead_code,
-    unreachable_pub,
-    reason = "source identity vocabulary consumed and re-exported in later PRs"
-)]
 pub struct SourceIdentitySelectionRequest {
     /// Workspace selected by the request.
     pub workspace_name: String,
@@ -421,11 +415,6 @@ pub struct SourceIdentitySelectionRequest {
 
 /// Request to resolve one configured source identity binding into runtime material.
 #[derive(Debug, Clone)]
-#[expect(
-    dead_code,
-    unreachable_pub,
-    reason = "source identity vocabulary consumed and re-exported in later PRs"
-)]
 pub struct SourceIdentityResolutionRequest {
     /// Workspace selected by the request.
     pub workspace_name: String,
@@ -449,10 +438,6 @@ pub struct SourceIdentityResolutionRequest {
 
 /// Provider that resolves configured Coral identity bindings into runtime material.
 #[tonic::async_trait]
-#[expect(
-    unreachable_pub,
-    reason = "source identity provider seam re-exported from lib.rs in a later PR"
-)]
 pub trait SourceIdentityProvider: Send + Sync + fmt::Debug {
     /// Resolves one user-owned source identity selection.
     ///
@@ -479,11 +464,6 @@ pub trait SourceIdentityProvider: Send + Sync + fmt::Debug {
 
 /// Runtime identity selected by Coral for one source surface.
 #[tonic::async_trait]
-#[expect(
-    dead_code,
-    unreachable_pub,
-    reason = "runtime source identity seam consumed and re-exported in later PRs"
-)]
 pub trait RuntimeSourceIdentity: Send + Sync + fmt::Debug {
     /// Installed identity spec id that describes this identity.
     fn identity_spec_id(&self) -> &str;
@@ -566,7 +546,7 @@ impl fmt::Debug for IdentityManager {
 mod tests {
     use super::{
         LOCAL_MEMBER_ID, SourceIdentityOwner, SourceIdentitySubject, UserPrincipal,
-        parse_path_segment,
+        parse_path_segment, unique_input_map,
     };
 
     #[test]
@@ -581,7 +561,45 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("workspace name must not contain '/' or '\\\\'")
+                .contains("workspace name must not contain '/', '\\\\', or ':'")
+        );
+    }
+
+    #[test]
+    fn rejects_windows_drive_prefixes() {
+        let error = parse_path_segment("identity", "C:foo")
+            .expect_err("windows drive-prefixed segment should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("identity name must not contain '/', '\\\\', or ':'")
+        );
+    }
+
+    #[test]
+    fn input_keys_allow_colons_but_reject_duplicates() {
+        let values = unique_input_map(
+            [("tenant:id".to_string(), "tenant-a".to_string())],
+            "credential input",
+        )
+        .expect("colon input key");
+        assert_eq!(
+            values.get("tenant:id").map(String::as_str),
+            Some("tenant-a")
+        );
+
+        let error = unique_input_map(
+            [
+                ("tenant:id".to_string(), "tenant-a".to_string()),
+                ("tenant:id".to_string(), "tenant-b".to_string()),
+            ],
+            "credential input",
+        )
+        .expect_err("duplicate input should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("credential input 'tenant:id' is repeated")
         );
     }
 

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -394,13 +394,6 @@ impl IdentitySpecManager {
         Ok(())
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by user-owned identity materialization and query-time identity resolution in later PRs"
-        )
-    )]
     pub(crate) fn resolve_identity_spec_inputs(
         &self,
         manifest: &IdentityManifest,
@@ -951,13 +944,6 @@ fn checked_add_identity_count(
 /// The manifest serializes with `serde` (struct fields in declaration order)
 /// and `canonical_json_value` sorts any free-form JSON objects (such as
 /// `audience` values), so semantically equal manifests fingerprint equally.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by user-owned identity creation in a later PR"
-    )
-)]
 pub(crate) fn identity_spec_fingerprint(manifest: &IdentityManifest) -> Result<String, AppError> {
     let encode_error = |error: &dyn std::fmt::Display| {
         AppError::FailedPrecondition(format!(

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -61,11 +61,15 @@ pub use bootstrap::{
 pub use coral_engine::{EngineExtensions, QuerySource};
 pub use credentials::oauth::{OAuthProgressEvent, OAuthProgressEventSender};
 pub use identities::{
-    IdentityOwnerKey, UserOwnedIdentityMaterialGuard, UserOwnedIdentityRecord,
-    UserOwnedIdentityStore,
+    CreateFixedTokenIdentityCommand, CreateOAuthIdentityCommand, IdentityCredentialInput,
+    IdentityManagementHandle, IdentityOwnerKey, UserOwnedIdentityMaterialGuard,
+    UserOwnedIdentityRecord, UserOwnedIdentityStore,
 };
+pub use identity::SingleUserPrincipalProvider;
 pub use identity::{
-    SingleUserPrincipalProvider, UserPrincipal, UserPrincipalError, UserPrincipalProvider,
+    RuntimeSourceIdentity, SourceIdentityBinding, SourceIdentityOwner, SourceIdentityProvider,
+    SourceIdentityResolutionRequest, SourceIdentitySelection, SourceIdentitySelectionRequest,
+    SourceIdentitySubject, UserPrincipal, UserPrincipalError, UserPrincipalProvider,
 };
 pub use identity_specs::{
     IdentitySpecManifestMetadata, IdentitySpecRegistry, IdentitySpecRegistryRecord,

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -127,7 +127,6 @@ impl AppStateLayout {
         self.identities_root().join("users").join(user_id)
     }
 
-    #[expect(dead_code, reason = "consumed by the identity manager in a later PR")]
     pub(crate) fn user_owned_source_identity_binding_file(
         &self,
         user_id: &str,
@@ -148,10 +147,6 @@ impl AppStateLayout {
         self.user_owned_identities_root(user_id).join(identity_name)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "consumed by the identity manager in a later PR")
-    )]
     pub(crate) fn user_owned_identity_manifest_file(
         &self,
         user_id: &str,
@@ -161,7 +156,6 @@ impl AppStateLayout {
             .join(INSTALLED_IDENTITY_FILE_NAME)
     }
 
-    #[expect(dead_code, reason = "consumed by the identity manager in a later PR")]
     pub(crate) fn user_owned_identity_material_file(
         &self,
         user_id: &str,
@@ -171,7 +165,6 @@ impl AppStateLayout {
             .join(INSTALLED_SECRETS_FILE_NAME)
     }
 
-    #[expect(dead_code, reason = "consumed by the identity manager in a later PR")]
     pub(crate) fn user_owned_identity_refresh_lock_file(
         &self,
         user_id: &str,

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -11,6 +11,8 @@ mod catalog_discovery_tests;
 mod harness;
 #[path = "grpc/identity_spec_tests.rs"]
 mod identity_spec_tests;
+#[path = "grpc/identity_tests.rs"]
+mod identity_tests;
 #[path = "grpc/oauth_refresh_tests.rs"]
 mod oauth_refresh_tests;
 #[path = "grpc/resilience_tests.rs"]

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -2,21 +2,25 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use coral_api::v1::{
-    AddIdentitySpecRequest, AddIdentitySpecResponse, DeleteIdentitySpecRequest,
-    DeleteIdentitySpecResponse, ExecuteSqlRequest, ExecuteSqlResponse, IdentitySpec,
-    IdentitySpecInput, ImportSourceRequest, ListCatalogRequest, ListIdentitySpecsRequest,
-    ListSourcesRequest, PaginationRequest, Source, SourceSecret, SourceVariable, TableSummary,
-    ValidateSourceRequest, ValidateSourceResponse, catalog_item, import_source_response,
+    AddIdentitySpecRequest, AddIdentitySpecResponse, CreateUserOwnedIdentityWithFixedTokenRequest,
+    CreateUserOwnedIdentityWithOAuthRequest, DeleteIdentitySpecRequest, DeleteIdentitySpecResponse,
+    ExecuteSqlRequest, ExecuteSqlResponse, Identity, IdentitySpec, IdentitySpecInput,
+    ImportSourceRequest, ListCatalogRequest, ListIdentitySpecsRequest, ListSourcesRequest,
+    PaginationRequest, Source, SourceSecret, SourceVariable, TableSummary, ValidateSourceRequest,
+    ValidateSourceResponse, catalog_item, create_user_owned_identity_with_o_auth_response,
+    import_source_response,
 };
 use coral_app::features::FeatureOverrides;
 use coral_client::{
-    AppClient, CatalogClient, IdentitySpecClient, QueryClient, SourceClient, batches_to_json_rows,
-    decode_execute_sql_response, default_workspace,
+    AppClient, CatalogClient, IdentityClient, IdentitySpecClient, QueryClient, SourceClient,
+    batches_to_json_rows, decode_execute_sql_response, default_workspace,
     local::{RunningServer, ServerBuilder},
 };
 use serde_json::{Value, json};
 use tempfile::TempDir;
 use tonic::Request;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 pub(crate) struct GrpcHarness {
     temp_dir: TempDir,
@@ -28,6 +32,10 @@ pub(crate) struct GrpcHarness {
 pub(crate) struct FailingHttpFixture {
     base_url: String,
     task: tokio::task::JoinHandle<()>,
+}
+
+pub(crate) struct OAuthFixture {
+    server: MockServer,
 }
 
 impl GrpcHarness {
@@ -109,6 +117,10 @@ impl GrpcHarness {
 
     pub(crate) fn identity_spec_client(&self) -> IdentitySpecClient {
         self.app.identity_spec_client()
+    }
+
+    pub(crate) fn identity_client(&self) -> IdentityClient {
+        self.app.identity_client()
     }
 
     pub(crate) fn catalog_client(&self) -> CatalogClient {
@@ -234,6 +246,12 @@ impl GrpcHarness {
             .into_inner())
     }
 
+    pub(crate) async fn add_identity_spec(&self, manifest_yaml: String) {
+        self.try_add_identity_spec(manifest_yaml, Vec::new())
+            .await
+            .expect("add identity spec");
+    }
+
     pub(crate) async fn try_add_identity_spec(
         &self,
         manifest_yaml: String,
@@ -270,6 +288,27 @@ impl GrpcHarness {
             .await
             .expect("force remove identity spec")
             .into_inner()
+    }
+
+    pub(crate) async fn create_fixed_token_identity(
+        &self,
+        name: &str,
+        identity_spec: &str,
+        token: &str,
+    ) -> Identity {
+        self.identity_client()
+            .create_user_owned_identity_with_fixed_token(Request::new(
+                CreateUserOwnedIdentityWithFixedTokenRequest {
+                    name: name.to_string(),
+                    identity_spec: identity_spec.to_string(),
+                    token: token.to_string(),
+                },
+            ))
+            .await
+            .expect("create fixed token identity")
+            .into_inner()
+            .identity
+            .expect("identity")
     }
 }
 
@@ -341,6 +380,132 @@ fn write_config_without_dsl_v4(config_dir: &Path) {
         "[features]\ndsl_v4 = false\n\n[credentials]\nstorage = \"file\"\n",
     )
     .expect("write config without dsl_v4");
+}
+
+impl OAuthFixture {
+    pub(crate) async fn start() -> Self {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/device"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "device_code": "device-code",
+                "user_code": "ABCD-EFGH",
+                "verification_uri": format!("{}/verify", server.uri()),
+                "expires_in": 600,
+                "interval": 1
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "identity-access-token",
+                "refresh_token": "identity-refresh-token",
+                "token_type": "Bearer",
+                "scope": "repo",
+                "expires_in": 3600
+            })))
+            .mount(&server)
+            .await;
+        Self { server }
+    }
+
+    pub(crate) fn verify_url(&self) -> String {
+        format!("{}/verify", self.server.uri())
+    }
+
+    pub(crate) fn identity_spec_yaml(&self, name: &str) -> String {
+        self.identity_spec_yaml_with_audience_host(name, "github.com")
+    }
+
+    pub(crate) fn identity_spec_yaml_with_audience_host(
+        &self,
+        name: &str,
+        audience_host: &str,
+    ) -> String {
+        format!(
+            r"
+kind: identity
+spec_version: 1
+name: {name}
+version: 0.1.0
+description: GitHub OAuth test identity.
+issuer: github
+type: oauth
+audience:
+  host: {audience_host}
+oauth:
+  method:
+    label: Test device flow
+    flow:
+      type: device_code
+    endpoints:
+      device_authorization_url: {}/device
+      token_url: {}/token
+    client:
+      id:
+        default: test-client
+    scopes:
+      scope:
+        delimiter: space
+        values:
+          - repo
+",
+            self.server.uri(),
+            self.server.uri()
+        )
+    }
+}
+
+pub(crate) async fn create_github_oauth_identity(
+    harness: &GrpcHarness,
+    oauth: &OAuthFixture,
+) -> Identity {
+    let mut stream = harness
+        .identity_client()
+        .create_user_owned_identity_with_o_auth(Request::new(
+            CreateUserOwnedIdentityWithOAuthRequest {
+                name: "github_local".to_string(),
+                identity_spec: "github_oauth".to_string(),
+                credential_inputs: Vec::new(),
+            },
+        ))
+        .await
+        .expect("create identity")
+        .into_inner();
+    let authorization = stream
+        .message()
+        .await
+        .expect("authorization response")
+        .expect("authorization event");
+    match authorization.event.expect("authorization event body") {
+        create_user_owned_identity_with_o_auth_response::Event::OauthAuthorization(
+            authorization,
+        ) => {
+            assert_eq!(authorization.input_key, "github_local");
+            assert_eq!(authorization.user_code, "ABCD-EFGH");
+            assert_eq!(authorization.authorization_url, oauth.verify_url());
+        }
+        other => panic!("unexpected first event: {other:?}"),
+    }
+    let completed = stream
+        .message()
+        .await
+        .expect("completed response")
+        .expect("completed event");
+    assert!(matches!(
+        completed.event,
+        Some(create_user_owned_identity_with_o_auth_response::Event::OauthCompleted(_))
+    ));
+    let created = stream
+        .message()
+        .await
+        .expect("created response")
+        .expect("created event");
+    match created.event.expect("created event body") {
+        create_user_owned_identity_with_o_auth_response::Event::Identity(identity) => identity,
+        other => panic!("unexpected created event: {other:?}"),
+    }
 }
 
 impl FailingHttpFixture {

--- a/crates/coral-app/tests/grpc/identity_spec_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_spec_tests.rs
@@ -188,3 +188,33 @@ async fn identity_spec_service_stores_request_inputs_on_identity_spec() {
         "demo_oauth"
     );
 }
+
+#[tokio::test]
+async fn identity_spec_service_rejects_replacing_spec_used_by_identity() {
+    let harness = GrpcHarness::new().await;
+
+    harness
+        .add_identity_spec(fixed_token_identity_spec_yaml("github_pat", "github.com"))
+        .await;
+    harness
+        .create_fixed_token_identity("github_local", "github_pat", "identity-token")
+        .await;
+
+    let error = harness
+        .try_add_identity_spec(
+            fixed_token_identity_spec_yaml("github_pat", "attacker.test"),
+            Vec::new(),
+        )
+        .await
+        .expect_err("used identity spec replacement should fail");
+
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error.message().contains("cannot be replaced"),
+        "unexpected error: {error}"
+    );
+
+    let fetched = get_identity_spec_manifest(&harness, "github_pat").await;
+    assert!(fetched.contains("host: github.com"));
+    assert!(!fetched.contains("attacker.test"));
+}

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -1,0 +1,78 @@
+use coral_api::v1::ListUserOwnedIdentitiesRequest;
+use tonic::Request;
+
+use crate::harness::{GrpcHarness, OAuthFixture, create_github_oauth_identity};
+
+async fn list_user_owned_identities(
+    harness: &GrpcHarness,
+    label: &str,
+) -> Vec<coral_api::v1::Identity> {
+    harness
+        .identity_client()
+        .list_user_owned_identities(Request::new(ListUserOwnedIdentitiesRequest {}))
+        .await
+        .expect(label)
+        .into_inner()
+        .identities
+}
+
+fn identity_material(harness: &GrpcHarness, identity_name: &str) -> String {
+    let material_path = harness.config_dir().join(format!(
+        "identities/users/local/{identity_name}/secrets.env"
+    ));
+    std::fs::read_to_string(material_path).expect("identity material")
+}
+
+#[tokio::test]
+async fn identity_service_creates_and_lists_user_oauth_identity() {
+    let harness = GrpcHarness::new().await;
+    let oauth = OAuthFixture::start().await;
+    harness
+        .add_identity_spec(oauth.identity_spec_yaml("github_oauth"))
+        .await;
+
+    let identity = create_github_oauth_identity(&harness, &oauth).await;
+    assert_eq!(identity.name, "github_local");
+    assert_eq!(identity.identity_spec, "github_oauth");
+    assert_eq!(identity.identity_type, "oauth");
+
+    let material = identity_material(&harness, "github_local");
+    assert!(material.contains("ACCESS_TOKEN=identity-access-token"));
+    assert!(material.contains("refresh_token=identity-refresh-token"));
+
+    let listed = list_user_owned_identities(&harness, "list identities").await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(
+        listed.first().expect("listed identity").name,
+        "github_local"
+    );
+}
+
+#[tokio::test]
+async fn identity_service_creates_user_fixed_token_identity() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .add_identity_spec(
+            r"
+kind: identity
+spec_version: 1
+name: github_pat
+version: 0.1.0
+issuer: github
+type: fixed_token
+"
+            .to_string(),
+        )
+        .await;
+
+    let identity = harness
+        .create_fixed_token_identity("github_pat_local", "github_pat", "pat-token")
+        .await;
+
+    assert_eq!(identity.name, "github_pat_local");
+    assert_eq!(identity.identity_spec, "github_pat");
+    assert_eq!(identity.identity_type, "fixed_token");
+
+    let material = identity_material(&harness, "github_pat_local");
+    assert!(material.contains("TOKEN=pat-token"));
+}


### PR DESCRIPTION
Adds end-user-owned identities instantiated from installed identity
specs, behind the default-off dsl_v4 flag:

- identities/manager.rs: UserOwnedIdentityManager creates identities via
  OAuth (streaming) and fixed token, stores them per user with
  per-source-surface bindings, detects spec-fingerprint orphans, and
  resolves with token refresh under a file lock; FileUserOwnedIdentityStore
  plus the replace/load_source_identity_binding trait extension
- identities/runtime.rs: BearerTokenRuntimeIdentity with fail-closed
  audience-host subdomain matching for header injection
- identities/service.rs: IdentityService streaming OAuth + fixed-token
  creation and listing
- server wiring: construct UserOwnedIdentityManager and register
  IdentityServiceServer (now implemented, no longer UNIMPLEMENTED)
- grpc harness OAuthFixture + create_github_oauth_identity/fixed-token
  helpers and identity_client; identity_tests end-to-end coverage
- retires the identity-vocabulary and OAuth-persistence #[expect(dead_code)]
  markers from the previous PRs now that identities consume them

Source-import identity binding and query-time resolution remain in the
following PRs; bindings are not yet consumed at query time here.