### PR TITLE
feat(app): v4 source lifecycle with identity bindings and artifact pinning

### DIFF
--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -28,22 +28,23 @@ pub enum AppError {
     /// The request requires additional setup before it can succeed.
     #[error("failed precondition: {0}")]
     FailedPrecondition(String),
-    /// A DSL v4 source has missing or stale generated runtime artifacts.
-    #[error(
-        "failed precondition: source '{source_name}' has missing or incompatible DSL v4 materialized artifacts: {detail}. Re-add the source to regenerate them."
-    )]
-    MissingOrIncompatibleV4Materialization {
-        /// Source name whose installed artifacts failed validation.
-        source_name: String,
-        /// Specific materialization mismatch or missing-artifact detail.
-        detail: String,
-    },
     /// A known, installed source cannot be served until the user takes an
     /// explicit action (enabling the required runtime feature or re-adding the
     /// source to regenerate materialized artifacts). Surfaced loudly during
     /// best-effort query-source loading instead of being silently skipped.
     #[error("failed precondition: {0}")]
     SourceUnservable(String),
+    /// Compatibility alias for callers that matched the pre-`SourceUnservable`
+    /// materialization failure shape. New code should use [`Self::SourceUnservable`].
+    #[error(
+        "failed precondition: source '{source_name}' has missing or incompatible DSL v4 materialization: {detail}"
+    )]
+    MissingOrIncompatibleV4Materialization {
+        /// Source whose materialized DSL v4 artifacts could not be served.
+        source_name: String,
+        /// Human-readable compatibility failure detail.
+        detail: String,
+    },
     /// Provider-managed credential refresh failed during active source use.
     #[error("credential refresh failed: {0}")]
     CredentialRefresh(String),
@@ -211,8 +212,8 @@ fn app_code(error: &AppError) -> Code {
         | AppError::IdentityNotFound(_) => Code::NotFound,
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
-        | AppError::MissingOrIncompatibleV4Materialization { .. }
         | AppError::SourceUnservable(_)
+        | AppError::MissingOrIncompatibleV4Materialization { .. }
         | AppError::CredentialRefresh(_)
         | AppError::MissingConfigDir
         | AppError::Credentials(CredentialsError::Parse(_) | CredentialsError::Unavailable(_)) => {

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -55,6 +55,7 @@ use crate::identities::{IdentityService, UserOwnedIdentityManager};
 use crate::identity_specs::{IdentitySpecManager, IdentitySpecService, IdentitySpecUsageProvider};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
+use crate::source_registry::SourceRegistry;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
@@ -289,8 +290,9 @@ impl ServerBuilder {
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store.clone());
-        let source_manager = SourceManager::new_with_features(
-            config_store.clone(),
+        let source_registry: Arc<dyn SourceRegistry> = Arc::new(config_store.clone());
+        let source_manager = SourceManager::new_with_features_and_source_registry(
+            source_registry.clone(),
             credential_manager.clone(),
             layout.clone(),
             features.clone(),
@@ -316,8 +318,9 @@ impl ServerBuilder {
             credential_store,
         );
 
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::new_with_source_registry(
             config_store,
+            source_registry,
             credential_manager,
             query_runtime_context,
             layout,
@@ -444,6 +447,8 @@ async fn start_server(services: ServerServices) -> Result<RunningServer, AppErro
     let source_service = SourceService::new(
         source_manager,
         query_manager.clone(),
+        identity_spec_manager.clone(),
+        user_owned_identity_manager.clone(),
         Arc::clone(&user_principal_provider),
         Arc::clone(&management_authorizer),
     );
@@ -808,6 +813,28 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct DenyIdentitySpecAllowSourcesAuthorizer;
+
+    #[tonic::async_trait]
+    impl ManagementAuthorizer for DenyIdentitySpecAllowSourcesAuthorizer {
+        async fn authorize_identity_spec_mutation(
+            &self,
+            _principal: &UserPrincipal,
+        ) -> Result<(), AuthorizationError> {
+            Err(AuthorizationError::forbidden("identity specs are blocked"))
+        }
+
+        async fn authorize_source_mutation(
+            &self,
+            _principal: &UserPrincipal,
+            _workspace_id: &str,
+            _kind: SourceMutationKind,
+        ) -> Result<(), AuthorizationError> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
     struct DenyImportWithOAuthAuthorizer;
 
     #[tonic::async_trait]
@@ -1141,6 +1168,31 @@ enabled = false
 
         assert_eq!(status.code(), Code::PermissionDenied);
         assert!(status.message().contains("sources are blocked"));
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn source_import_with_identity_specs_requires_identity_spec_authorization() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_management_authorizer(Arc::new(DenyIdentitySpecAllowSourcesAuthorizer))
+            .start()
+            .await
+            .expect("start server");
+        let mut client = SourceServiceClient::new(connect(&server).await);
+        let mut request = import_source_request("not valid yaml".to_string());
+        request
+            .identity_spec_manifest_yamls
+            .push(fixed_token_identity_spec_yaml("github_oauth"));
+
+        let status = client
+            .import_source(Request::new(request))
+            .await
+            .expect_err("identity spec mutation should be denied before import starts");
+
+        assert_eq!(status.code(), Code::PermissionDenied);
+        assert!(status.message().contains("identity specs are blocked"));
         server.shutdown().await.expect("shutdown");
     }
 

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -272,6 +272,44 @@ pub trait UserOwnedIdentityStore: Send + Sync + std::fmt::Debug + 'static {
         ))
     }
 
+    /// Snapshots one per-user source identity selection, returning `None` when
+    /// no selection has been stored.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot be read.
+    async fn snapshot_source_identity_binding(
+        &self,
+        _user_id: &str,
+        _workspace_name: &str,
+        _source_name: &str,
+        _surface_id: &str,
+    ) -> Result<Option<SourceIdentitySelection>, AppError> {
+        Err(AppError::FailedPrecondition(
+            "user-owned source identity binding storage is not supported by this identity store"
+                .to_string(),
+        ))
+    }
+
+    /// Restores one per-user source identity selection from a snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot be written.
+    async fn restore_source_identity_binding(
+        &self,
+        _user_id: &str,
+        _workspace_name: &str,
+        _source_name: &str,
+        _surface_id: &str,
+        _selection: Option<&SourceIdentitySelection>,
+    ) -> Result<(), AppError> {
+        Err(AppError::FailedPrecondition(
+            "user-owned source identity binding storage is not supported by this identity store"
+                .to_string(),
+        ))
+    }
+
     /// Loads one per-user source identity selection.
     ///
     /// # Errors
@@ -591,13 +629,6 @@ impl UserOwnedIdentityManager {
         self.store.delete_identity(owner, &identity_name).await
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by the v4 source lifecycle (sources/service.rs) in a later PR"
-        )
-    )]
     pub(crate) async fn replace_user_owned_source_identity_binding(
         &self,
         principal: &UserPrincipal,
@@ -622,10 +653,49 @@ impl UserOwnedIdentityManager {
             .await
     }
 
-    #[expect(
-        dead_code,
-        reason = "consumed by the v4 source lifecycle (sources/service.rs) in a later PR"
-    )]
+    pub(crate) async fn snapshot_user_owned_source_identity_binding(
+        &self,
+        principal: &UserPrincipal,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        surface_id: &str,
+    ) -> Result<Option<SourceIdentitySelection>, AppError> {
+        let user_id = validate_user_id(principal.user_id())?;
+        let surface_id = validate_source_surface_id(surface_id)?;
+        self.store
+            .snapshot_source_identity_binding(
+                &user_id,
+                workspace_name.as_str(),
+                source_name.as_str(),
+                &surface_id,
+            )
+            .await
+    }
+
+    pub(crate) async fn restore_user_owned_source_identity_binding(
+        &self,
+        principal: &UserPrincipal,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        surface_id: &str,
+        selection: Option<&SourceIdentitySelection>,
+    ) -> Result<(), AppError> {
+        let user_id = validate_user_id(principal.user_id())?;
+        let surface_id = validate_source_surface_id(surface_id)?;
+        if let Some(selection) = selection {
+            selection.validate()?;
+        }
+        self.store
+            .restore_source_identity_binding(
+                &user_id,
+                workspace_name.as_str(),
+                source_name.as_str(),
+                &surface_id,
+                selection,
+            )
+            .await
+    }
+
     pub(crate) async fn validate_user_owned_source_identity_selection(
         &self,
         principal: &UserPrincipal,
@@ -1039,6 +1109,89 @@ impl UserOwnedIdentityStore for FileUserOwnedIdentityStore {
             write_files_transactionally(&[&path], || {
                 let document = UserSourceIdentityBindingDocument::from_selection(&selection);
                 write_file_unlocked(&path, serde_yaml::to_string(&document)?.as_bytes())?;
+                Ok(())
+            })
+        })
+        .await?
+    }
+
+    async fn snapshot_source_identity_binding(
+        &self,
+        user_id: &str,
+        workspace_name: &str,
+        source_name: &str,
+        surface_id: &str,
+    ) -> Result<Option<SourceIdentitySelection>, AppError> {
+        let store = self.clone();
+        let user_id = user_id.to_string();
+        let workspace_name = workspace_name.to_string();
+        let source_name = source_name.to_string();
+        let surface_id = surface_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let user_id = validate_user_id(&user_id)?;
+            let workspace_name = WorkspaceName::parse(&workspace_name)?;
+            let source_name = SourceName::parse(&source_name)?;
+            let surface_id = validate_source_surface_id(&surface_id)?;
+            let _lock = FileLock::shared(store.layout.state_lock())?;
+            let path = store.layout.user_owned_source_identity_binding_file(
+                &user_id,
+                &workspace_name,
+                &source_name,
+                &surface_id,
+            );
+            if !path.exists() {
+                return Ok(None);
+            }
+            let raw = fs::read_to_string(&path)?;
+            let document: UserSourceIdentityBindingDocument = serde_yaml::from_str(&raw)?;
+            document.into_selection().map(Some)
+        })
+        .await?
+    }
+
+    async fn restore_source_identity_binding(
+        &self,
+        user_id: &str,
+        workspace_name: &str,
+        source_name: &str,
+        surface_id: &str,
+        selection: Option<&SourceIdentitySelection>,
+    ) -> Result<(), AppError> {
+        let store = self.clone();
+        let user_id = user_id.to_string();
+        let workspace_name = workspace_name.to_string();
+        let source_name = source_name.to_string();
+        let surface_id = surface_id.to_string();
+        let selection = selection.cloned();
+        tokio::task::spawn_blocking(move || {
+            let user_id = validate_user_id(&user_id)?;
+            let workspace_name = WorkspaceName::parse(&workspace_name)?;
+            let source_name = SourceName::parse(&source_name)?;
+            let surface_id = validate_source_surface_id(&surface_id)?;
+            if let Some(selection) = &selection {
+                selection.validate()?;
+            }
+            let _lock = FileLock::exclusive(store.layout.state_lock())?;
+            let path = store.layout.user_owned_source_identity_binding_file(
+                &user_id,
+                &workspace_name,
+                &source_name,
+                &surface_id,
+            );
+            write_files_transactionally(&[&path], || {
+                match selection {
+                    Some(selection) => {
+                        if let Some(parent) = path.parent() {
+                            storage_fs::ensure_private_dir(parent)?;
+                        }
+                        let document =
+                            UserSourceIdentityBindingDocument::from_selection(&selection);
+                        write_file_unlocked(&path, serde_yaml::to_string(&document)?.as_bytes())?;
+                    }
+                    None => {
+                        remove_file_if_exists_unlocked(&path)?;
+                    }
+                }
                 Ok(())
             })
         })
@@ -2052,10 +2205,50 @@ oauth:
             .expect("resolve source identity binding")
             .expect("selection");
         assert_eq!(resolved, selection);
+        let snapshot = manager
+            .snapshot_user_owned_source_identity_binding(
+                &principal,
+                &workspace_name,
+                &source_name,
+                "rest",
+            )
+            .await
+            .expect("snapshot source identity binding");
+        assert_eq!(snapshot, Some(selection.clone()));
+
+        let replacement =
+            SourceIdentitySelection::new("github_tina", Some("github-rest-read".to_string()))
+                .expect("replacement selection");
+        manager
+            .replace_user_owned_source_identity_binding(
+                &principal,
+                &workspace_name,
+                &source_name,
+                "rest",
+                &replacement,
+            )
+            .await
+            .expect("replace source identity binding");
+        manager
+            .restore_user_owned_source_identity_binding(
+                &principal,
+                &workspace_name,
+                &source_name,
+                "rest",
+                snapshot.as_ref(),
+            )
+            .await
+            .expect("restore source identity binding");
+        let restored = manager
+            .resolve_source_identity_selection(&request)
+            .await
+            .expect("resolve restored source identity binding")
+            .expect("selection");
+        assert_eq!(restored, selection);
 
         let missing_user = SourceIdentitySelectionRequest {
             subject: SourceIdentitySubject::User("tina".to_string()),
-            ..request
+            ..request.clone()
         };
         let error = manager
             .resolve_source_identity_selection(&missing_user)
@@ -2066,6 +2259,20 @@ oauth:
                 .to_string()
                 .contains("user 'tina' has no selected identity")
         );
+        manager
+            .restore_user_owned_source_identity_binding(
+                &principal,
+                &workspace_name,
+                &source_name,
+                "rest",
+                None,
+            )
+            .await
+            .expect("restore missing source identity binding");
+        manager
+            .resolve_source_identity_selection(&request)
+            .await
+            .expect_err("restored missing binding should not resolve");
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -195,10 +195,6 @@ pub enum SourceIdentityOwner {
     Workspace,
 }
 
-#[expect(
-    dead_code,
-    reason = "source identity vocabulary consumed by source lifecycle and query resolution in later PRs"
-)]
 impl SourceIdentityOwner {
     pub(crate) fn as_config_value(self) -> &'static str {
         match self {

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -99,6 +99,34 @@ pub struct IdentitySpecRegistryRecord {
     pub input_material: BTreeMap<String, String>,
 }
 
+/// Public storage hint for registry implementations that preserve where
+/// identity-spec setup input material is stored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentitySpecInputMaterialStorage {
+    /// Plaintext file-backed setup input material.
+    File,
+    /// Platform keychain-backed setup input material.
+    Keychain,
+}
+
+impl From<CredentialStorageKind> for IdentitySpecInputMaterialStorage {
+    fn from(value: CredentialStorageKind) -> Self {
+        match value {
+            CredentialStorageKind::File => Self::File,
+            CredentialStorageKind::Keychain => Self::Keychain,
+        }
+    }
+}
+
+impl From<IdentitySpecInputMaterialStorage> for CredentialStorageKind {
+    fn from(value: IdentitySpecInputMaterialStorage) -> Self {
+        match value {
+            IdentitySpecInputMaterialStorage::File => Self::File,
+            IdentitySpecInputMaterialStorage::Keychain => Self::Keychain,
+        }
+    }
+}
+
 /// Durable storage backend for global identity specs.
 pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
     /// Lists all installed identity specs.
@@ -131,6 +159,21 @@ pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
     fn get_identity_spec(&self, name: &str)
     -> Result<Option<IdentitySpecRegistryRecord>, AppError>;
 
+    /// Fetches the setup input material storage backend for one identity spec,
+    /// when the registry exposes that distinction.
+    ///
+    /// Registries that do not split material by backend can use the default.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the registry cannot be read.
+    fn get_identity_spec_input_material_storage(
+        &self,
+        _name: &str,
+    ) -> Result<Option<IdentitySpecInputMaterialStorage>, AppError> {
+        Ok(None)
+    }
+
     /// Fetches one raw identity-spec manifest by name without loading stored
     /// setup input material.
     ///
@@ -154,6 +197,24 @@ pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
         record: IdentitySpecRegistryRecord,
     ) -> Result<(), AppError>;
 
+    /// Inserts or replaces one identity spec using the provided material
+    /// storage backend when the registry supports backend-specific material.
+    ///
+    /// The default keeps existing [`Self::upsert_identity_spec`] implementations
+    /// source-compatible.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the record cannot be persisted.
+    fn upsert_identity_spec_with_input_material_storage(
+        &self,
+        name: &str,
+        record: IdentitySpecRegistryRecord,
+        _input_material_storage: Option<IdentitySpecInputMaterialStorage>,
+    ) -> Result<(), AppError> {
+        self.upsert_identity_spec(name, record)
+    }
+
     /// Removes one identity spec.
     ///
     /// # Errors
@@ -167,12 +228,27 @@ pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
 pub(crate) struct IdentitySpecSnapshot {
     record: IdentitySpecRecord,
     input_material: BTreeMap<String, String>,
+    input_material_storage: Option<CredentialStorageKind>,
 }
 
 impl IdentitySpecSnapshot {
     pub(crate) fn name(&self) -> &str {
         &self.record.manifest.name
     }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct IdentitySpecImportInstall {
+    pub(crate) name: String,
+    pub(crate) previous: Option<IdentitySpecSnapshot>,
+    pub(crate) installed: IdentitySpecSnapshot,
+    pub(crate) pre_import_usage_count: u32,
+}
+
+struct IdentitySpecAddOutcome {
+    record: IdentitySpecRecord,
+    replaced: bool,
+    import_install: IdentitySpecImportInstall,
 }
 
 /// Reports stored identities that reference an installed identity spec.
@@ -282,31 +358,47 @@ impl IdentitySpecManager {
         manifest_yaml: &str,
         inputs: Vec<IdentitySpecInputValue>,
     ) -> Result<(IdentitySpecRecord, bool), AppError> {
+        let outcome = self.add_identity_spec_with_inputs_inner(manifest_yaml, inputs)?;
+        Ok((outcome.record, outcome.replaced))
+    }
+
+    pub(crate) fn add_identity_spec_with_inputs_for_import(
+        &self,
+        manifest_yaml: &str,
+        inputs: Vec<IdentitySpecInputValue>,
+    ) -> Result<IdentitySpecImportInstall, AppError> {
+        Ok(self
+            .add_identity_spec_with_inputs_inner(manifest_yaml, inputs)?
+            .import_install)
+    }
+
+    fn add_identity_spec_with_inputs_inner(
+        &self,
+        manifest_yaml: &str,
+        inputs: Vec<IdentitySpecInputValue>,
+    ) -> Result<IdentitySpecAddOutcome, AppError> {
         let span = info_span!("coral.app.identity_specs.add");
         let _guard = span.enter();
         self.features.ensure_dsl_v4_enabled()?;
         let record = parse_identity_spec_record(manifest_yaml)?;
         let name = record.manifest.name.clone();
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        let existing = self.registry.get_identity_spec(&name)?;
-        let replaced = existing.is_some();
-        let existing_input_material = existing
+        let previous = self.snapshot_identity_spec_unlocked(&name)?;
+        let replaced = previous.is_some();
+        let existing_input_material = previous
             .as_ref()
-            .map(|record| record.input_material.clone())
+            .map(|snapshot| snapshot.input_material.clone())
             .unwrap_or_default();
-        if let Some(existing) = &existing {
-            let existing = parse_identity_spec_record(&existing.manifest_yaml)?;
-            ensure_identity_spec_record_name(&name, &existing)?;
-            if existing.manifest != record.manifest {
-                let referencing_identities = self.count_identities_for_spec_unlocked(&name)?;
-                if referencing_identities > 0 {
-                    return Err(AppError::FailedPrecondition(format!(
-                        "identity spec '{name}' is used by {referencing_identities} stored {} and cannot be replaced with a different manifest; remove it with --force only if you intend to recreate {} against a new spec",
-                        plural_identity(referencing_identities),
-                        plural_pronoun(referencing_identities)
-                    )));
-                }
-            }
+        let pre_import_usage_count = self.count_identities_for_spec_unlocked(&name)?;
+        if let Some(previous) = &previous
+            && previous.record.manifest != record.manifest
+            && pre_import_usage_count > 0
+        {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity spec '{name}' is used by {pre_import_usage_count} stored {} and cannot be replaced with a different manifest; remove it with --force only if you intend to recreate {} against a new spec",
+                plural_identity(pre_import_usage_count),
+                plural_pronoun(pre_import_usage_count)
+            )));
         }
         let provided_inputs = unique_input_map(
             inputs.into_iter().map(|input| (input.key, input.value)),
@@ -324,7 +416,36 @@ impl IdentitySpecManager {
                 input_material,
             },
         )?;
-        Ok((record, replaced))
+        let installed = match self.snapshot_identity_spec_unlocked(&name) {
+            Ok(Some(installed)) => installed,
+            Ok(None) => {
+                let error = AppError::FailedPrecondition(format!(
+                    "identity spec '{name}' was not available after import"
+                ));
+                return Err(self.restore_identity_spec_import_unlocked_or_error(
+                    &name,
+                    previous.as_ref(),
+                    error,
+                ));
+            }
+            Err(error) => {
+                return Err(self.restore_identity_spec_import_unlocked_or_error(
+                    &name,
+                    previous.as_ref(),
+                    error,
+                ));
+            }
+        };
+        Ok(IdentitySpecAddOutcome {
+            record,
+            replaced,
+            import_install: IdentitySpecImportInstall {
+                name,
+                previous,
+                installed,
+                pre_import_usage_count,
+            },
+        })
     }
 
     pub(crate) fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRecord>, AppError> {
@@ -350,9 +471,12 @@ impl IdentitySpecManager {
         self.load_identity_spec_unlocked(&name)
     }
 
-    #[expect(
-        dead_code,
-        reason = "identity-spec rollback snapshot consumed by the source import flow in a later PR"
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "rollback snapshot seam is exercised by unit tests; source import uses the atomic import-install method"
+        )
     )]
     pub(crate) fn snapshot_identity_spec(
         &self,
@@ -362,36 +486,123 @@ impl IdentitySpecManager {
         let _guard = span.enter();
         let name = validate_identity_spec_name(name)?;
         let _lock = FileLock::shared(self.layout.state_lock())?;
-        let Some(stored) = self.registry.get_identity_spec(&name)? else {
+        self.snapshot_identity_spec_unlocked(&name)
+    }
+
+    fn snapshot_identity_spec_unlocked(
+        &self,
+        name: &str,
+    ) -> Result<Option<IdentitySpecSnapshot>, AppError> {
+        let Some(stored) = self.registry.get_identity_spec(name)? else {
             return Ok(None);
         };
         let record = parse_identity_spec_record(&stored.manifest_yaml)?;
+        ensure_identity_spec_record_name(name, &record)?;
+        let input_material_storage = self
+            .registry
+            .get_identity_spec_input_material_storage(name)?
+            .map(Into::into);
         Ok(Some(IdentitySpecSnapshot {
             record,
             input_material: stored.input_material,
+            input_material_storage,
         }))
     }
 
-    #[expect(
-        dead_code,
-        reason = "identity-spec rollback snapshot consumed by the source import flow in a later PR"
-    )]
-    pub(crate) fn restore_identity_spec_snapshot(
+    fn restore_identity_spec_import_unlocked_or_error(
         &self,
-        snapshot: &IdentitySpecSnapshot,
+        name: &str,
+        previous: Option<&IdentitySpecSnapshot>,
+        error: AppError,
+    ) -> AppError {
+        if let Err(rollback_error) = self.restore_identity_spec_import_unlocked(name, previous) {
+            return AppError::FailedPrecondition(format!(
+                "failed to snapshot identity spec '{name}' after import: {error}; failed to restore previous identity spec state: {rollback_error}"
+            ));
+        }
+        error
+    }
+
+    fn restore_identity_spec_import_unlocked(
+        &self,
+        name: &str,
+        previous: Option<&IdentitySpecSnapshot>,
     ) -> Result<(), AppError> {
-        let span = info_span!("coral.app.identity_specs.restore_snapshot");
+        if let Some(previous) = previous {
+            self.registry
+                .upsert_identity_spec_with_input_material_storage(
+                    name,
+                    IdentitySpecRegistryRecord {
+                        manifest_yaml: previous.record.manifest_yaml.clone(),
+                        input_material: previous.input_material.clone(),
+                    },
+                    previous.input_material_storage.map(Into::into),
+                )
+        } else {
+            self.registry.remove_identity_spec(name)
+        }
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "usage-count seam is exercised by unit tests; source import captures usage under the add lock"
+        )
+    )]
+    pub(crate) fn identity_spec_usage_count(&self, name: &str) -> Result<u32, AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        self.count_identities_for_spec_unlocked(&name)
+    }
+
+    pub(crate) fn rollback_import_if_current(
+        &self,
+        installed: &IdentitySpecSnapshot,
+        previous: Option<&IdentitySpecSnapshot>,
+        pre_import_usage_count: u32,
+    ) -> Result<bool, AppError> {
+        let span = info_span!("coral.app.identity_specs.rollback_import");
         let _guard = span.enter();
-        let name = validate_identity_spec_name(snapshot.name())?;
+        let name = validate_identity_spec_name(installed.name())?;
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        self.registry.upsert_identity_spec(
-            &name,
-            IdentitySpecRegistryRecord {
-                manifest_yaml: snapshot.record.manifest_yaml.clone(),
-                input_material: snapshot.input_material.clone(),
-            },
-        )?;
-        Ok(())
+        let Some(stored) = self.registry.get_identity_spec(&name)? else {
+            return Ok(false);
+        };
+        let current = IdentitySpecSnapshot {
+            record: parse_identity_spec_record(&stored.manifest_yaml)?,
+            input_material: stored.input_material,
+            input_material_storage: self
+                .registry
+                .get_identity_spec_input_material_storage(&name)?
+                .map(Into::into),
+        };
+        if !identity_spec_snapshots_match(&current, installed) {
+            return Ok(false);
+        }
+        if let Some(previous) = previous {
+            let state_changed = !identity_spec_snapshots_match(previous, installed);
+            let current_usage_count = self.count_identities_for_spec_unlocked(&name)?;
+            if state_changed && (pre_import_usage_count > 0 || current_usage_count > 0) {
+                return Ok(false);
+            }
+            self.registry
+                .upsert_identity_spec_with_input_material_storage(
+                    &name,
+                    IdentitySpecRegistryRecord {
+                        manifest_yaml: previous.record.manifest_yaml.clone(),
+                        input_material: previous.input_material.clone(),
+                    },
+                    previous.input_material_storage.map(Into::into),
+                )?;
+        } else {
+            let current_usage_count = self.count_identities_for_spec_unlocked(&name)?;
+            if pre_import_usage_count > 0 || current_usage_count > 0 {
+                return Ok(false);
+            }
+            self.registry.remove_identity_spec(&name)?;
+        }
+        Ok(true)
     }
 
     pub(crate) fn resolve_identity_spec_inputs(
@@ -487,6 +698,15 @@ impl IdentitySpecManager {
         }
         Ok(count)
     }
+}
+
+fn identity_spec_snapshots_match(
+    left: &IdentitySpecSnapshot,
+    right: &IdentitySpecSnapshot,
+) -> bool {
+    left.record.manifest_yaml == right.record.manifest_yaml
+        && left.input_material == right.input_material
+        && left.input_material_storage == right.input_material_storage
 }
 
 struct FileIdentitySpecRegistry {
@@ -761,6 +981,67 @@ impl FileIdentitySpecRegistry {
         fs::remove_file(path)?;
         Ok(())
     }
+
+    fn upsert_identity_spec_with_storage(
+        &self,
+        name: &str,
+        record: &IdentitySpecRegistryRecord,
+        input_material_storage: Option<CredentialStorageKind>,
+    ) -> Result<(), AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let path = self.layout.identity_spec_manifest_file(&name);
+        let previous_manifest = read_optional_file(&path)?;
+        let input_material_state_path = self.input_material_state_file(&name);
+        let previous_input_material_state = read_optional_file(&input_material_state_path)?;
+        let previous_material_state = if previous_manifest.is_some() {
+            Some(self.load_input_material_state(&name)?)
+        } else {
+            None
+        };
+        let existing_storage = previous_material_state
+            .as_ref()
+            .and_then(|state| state.credential_storage);
+        let previous_credential_material = self.snapshot_input_material(&name, existing_storage)?;
+        let rollback = IdentitySpecUpsertRollback {
+            manifest_path: path.clone(),
+            previous_manifest,
+            input_material_state_path,
+            previous_input_material_state,
+            previous_credential_storage: existing_storage,
+            previous_credential_material,
+        };
+        let credential_storage = if record.input_material.is_empty() {
+            None
+        } else {
+            input_material_storage
+                .or(existing_storage)
+                .or(Some(self.credential_store.default_write_storage()?))
+        };
+        if let Some(parent) = path.parent() {
+            storage_fs::ensure_private_dir(parent)?;
+        }
+        let result = (|| {
+            self.replace_input_material(
+                &name,
+                existing_storage,
+                credential_storage,
+                &record.input_material,
+            )?;
+            storage_fs::write_atomic(&path, record.manifest_yaml.as_bytes())?;
+            self.write_input_material_state(
+                &name,
+                &IdentitySpecInputMaterialState {
+                    credential_storage,
+                    version: IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION,
+                },
+            )
+        })();
+        if let Err(error) = result {
+            self.restore_upsert_rollback(&name, &rollback, credential_storage);
+            return Err(error);
+        }
+        Ok(())
+    }
 }
 
 impl IdentitySpecRegistry for FileIdentitySpecRegistry {
@@ -825,6 +1106,17 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
         }))
     }
 
+    fn get_identity_spec_input_material_storage(
+        &self,
+        name: &str,
+    ) -> Result<Option<IdentitySpecInputMaterialStorage>, AppError> {
+        let name = validate_identity_spec_name(name)?;
+        Ok(self
+            .load_input_material_state(&name)?
+            .credential_storage
+            .map(Into::into))
+    }
+
     fn get_identity_spec_manifest(&self, name: &str) -> Result<Option<String>, AppError> {
         let name = validate_identity_spec_name(name)?;
         let path = self.layout.identity_spec_manifest_file(&name);
@@ -839,57 +1131,20 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
         name: &str,
         record: IdentitySpecRegistryRecord,
     ) -> Result<(), AppError> {
-        let name = validate_identity_spec_name(name)?;
-        let path = self.layout.identity_spec_manifest_file(&name);
-        let previous_manifest = read_optional_file(&path)?;
-        let input_material_state_path = self.input_material_state_file(&name);
-        let previous_input_material_state = read_optional_file(&input_material_state_path)?;
-        let previous_material_state = if previous_manifest.is_some() {
-            Some(self.load_input_material_state(&name)?)
-        } else {
-            None
-        };
-        let existing_storage = previous_material_state
-            .as_ref()
-            .and_then(|state| state.credential_storage);
-        let previous_credential_material = self.snapshot_input_material(&name, existing_storage)?;
-        let rollback = IdentitySpecUpsertRollback {
-            manifest_path: path.clone(),
-            previous_manifest,
-            input_material_state_path,
-            previous_input_material_state,
-            previous_credential_storage: existing_storage,
-            previous_credential_material,
-        };
-        let credential_storage = if record.input_material.is_empty() {
-            None
-        } else {
-            existing_storage.or(Some(self.credential_store.default_write_storage()?))
-        };
-        if let Some(parent) = path.parent() {
-            storage_fs::ensure_private_dir(parent)?;
-        }
-        let result = (|| {
-            self.replace_input_material(
-                &name,
-                existing_storage,
-                credential_storage,
-                &record.input_material,
-            )?;
-            storage_fs::write_atomic(&path, record.manifest_yaml.as_bytes())?;
-            self.write_input_material_state(
-                &name,
-                &IdentitySpecInputMaterialState {
-                    credential_storage,
-                    version: IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION,
-                },
-            )
-        })();
-        if let Err(error) = result {
-            self.restore_upsert_rollback(&name, &rollback, credential_storage);
-            return Err(error);
-        }
-        Ok(())
+        self.upsert_identity_spec_with_storage(name, &record, None)
+    }
+
+    fn upsert_identity_spec_with_input_material_storage(
+        &self,
+        name: &str,
+        record: IdentitySpecRegistryRecord,
+        input_material_storage: Option<IdentitySpecInputMaterialStorage>,
+    ) -> Result<(), AppError> {
+        self.upsert_identity_spec_with_storage(
+            name,
+            &record,
+            input_material_storage.map(Into::into),
+        )
     }
 
     fn remove_identity_spec(&self, name: &str) -> Result<(), AppError> {
@@ -1137,7 +1392,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::fs;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
     use tempfile::TempDir;
 
@@ -1147,9 +1402,13 @@ mod tests {
         identity_spec_fingerprint,
     };
     use crate::bootstrap::AppError;
-    use crate::credentials::{CredentialStoragePreference, CredentialStore, parse_env_file};
+    use crate::credentials::{
+        CredentialSetId, CredentialStorageKind, CredentialStoragePreference, CredentialStore,
+        parse_env_file,
+    };
     use crate::features::{Features, dsl_v4_features};
     use crate::state::AppStateLayout;
+    use crate::workspaces::WorkspaceName;
 
     fn manager() -> (TempDir, IdentitySpecManager, AppStateLayout) {
         manager_with(dsl_v4_features(), Vec::new())
@@ -1268,6 +1527,22 @@ mod tests {
         fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError> {
             if identity_spec_name == self.identity_spec_name {
                 Ok(self.count)
+            } else {
+                Ok(0)
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct DynamicUsageProvider {
+        identity_spec_name: String,
+        count: Arc<AtomicU32>,
+    }
+
+    impl IdentitySpecUsageProvider for DynamicUsageProvider {
+        fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError> {
+            if identity_spec_name == self.identity_spec_name {
+                Ok(self.count.load(Ordering::SeqCst))
             } else {
                 Ok(0)
             }
@@ -1618,6 +1893,247 @@ credential_storage: keychain
             material.get("DEMO_OAUTH_CLIENT_SECRET").map(String::as_str),
             Some("client-secret")
         );
+    }
+
+    #[test]
+    fn import_rollback_skips_input_material_restore_when_spec_is_used() {
+        let usage_provider = Arc::new(StaticUsageProvider {
+            identity_spec_name: "demo_oauth".to_string(),
+            count: 1,
+        });
+        let (_temp, manager, _layout) = manager_with(dsl_v4_features(), vec![usage_provider]);
+        let manifest_yaml = oauth_identity_yaml_with_inputs_default("tenant-a");
+        let (record, _replaced) = add_spec_with_secret(&manager, &manifest_yaml);
+        let previous = manager
+            .snapshot_identity_spec("demo_oauth")
+            .expect("snapshot previous")
+            .expect("previous spec");
+        let pre_import_usage_count = manager
+            .identity_spec_usage_count("demo_oauth")
+            .expect("usage count");
+
+        manager
+            .add_identity_spec_with_inputs(
+                &manifest_yaml,
+                vec![IdentitySpecInputValue {
+                    key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                    value: "rotated-secret".to_string(),
+                }],
+            )
+            .expect("replace input material");
+        let installed = manager
+            .snapshot_identity_spec("demo_oauth")
+            .expect("snapshot installed")
+            .expect("installed spec");
+        let resolved = resolved_inputs(&manager, &record);
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "rotated-secret");
+
+        assert!(
+            !manager
+                .rollback_import_if_current(&installed, Some(&previous), pre_import_usage_count)
+                .expect("rollback import")
+        );
+        let resolved = resolved_inputs(&manager, &record);
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "rotated-secret");
+    }
+
+    #[test]
+    fn import_rollback_skips_input_material_restore_when_usage_count_grows() {
+        let usage_count = Arc::new(AtomicU32::new(0));
+        let usage_provider = Arc::new(DynamicUsageProvider {
+            identity_spec_name: "demo_oauth".to_string(),
+            count: Arc::clone(&usage_count),
+        });
+        let (_temp, manager, _layout) = manager_with(dsl_v4_features(), vec![usage_provider]);
+        let manifest_yaml = oauth_identity_yaml_with_inputs_default("tenant-a");
+        let (record, _replaced) = add_spec_with_secret(&manager, &manifest_yaml);
+
+        let install = manager
+            .add_identity_spec_with_inputs_for_import(
+                &manifest_yaml,
+                vec![IdentitySpecInputValue {
+                    key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                    value: "rotated-secret".to_string(),
+                }],
+            )
+            .expect("replace input material for import");
+        usage_count.store(1, Ordering::SeqCst);
+
+        assert!(
+            !manager
+                .rollback_import_if_current(
+                    &install.installed,
+                    install.previous.as_ref(),
+                    install.pre_import_usage_count,
+                )
+                .expect("rollback import")
+        );
+        let resolved = resolved_inputs(&manager, &record);
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "rotated-secret");
+    }
+
+    #[test]
+    fn import_install_rollback_removes_new_spec() {
+        let (_temp, manager, _layout) = manager();
+        let manifest_yaml = identity_yaml("github_oauth", "0.1.0");
+        let install = manager
+            .add_identity_spec_with_inputs_for_import(&manifest_yaml, Vec::new())
+            .expect("import identity spec");
+
+        assert!(
+            manager
+                .rollback_import_if_current(
+                    &install.installed,
+                    install.previous.as_ref(),
+                    install.pre_import_usage_count,
+                )
+                .expect("rollback unverified import")
+        );
+
+        let error = manager
+            .get_identity_spec("github_oauth")
+            .expect_err("new spec should be removed");
+        assert!(matches!(error, AppError::IdentitySpecNotFound(_)));
+    }
+
+    #[test]
+    fn import_install_rollback_keeps_new_spec_when_name_was_already_used() {
+        let usage_provider = Arc::new(StaticUsageProvider {
+            identity_spec_name: "github_oauth".to_string(),
+            count: 1,
+        });
+        let (_temp, manager, _layout) = manager_with(dsl_v4_features(), vec![usage_provider]);
+        let manifest_yaml = identity_yaml("github_oauth", "0.1.0");
+        let install = manager
+            .add_identity_spec_with_inputs_for_import(&manifest_yaml, Vec::new())
+            .expect("import identity spec");
+
+        assert!(
+            !manager
+                .rollback_import_if_current(
+                    &install.installed,
+                    install.previous.as_ref(),
+                    install.pre_import_usage_count,
+                )
+                .expect("rollback import")
+        );
+
+        manager
+            .get_identity_spec("github_oauth")
+            .expect("used new spec should remain installed");
+    }
+
+    #[test]
+    fn import_install_rollback_restores_previous_spec() {
+        let (_temp, manager, _layout) = manager();
+        let original_manifest = identity_yaml_with_audience("github_oauth", "0.1.0", "github.com");
+        add_spec(&manager, &original_manifest);
+        let replacement_manifest =
+            identity_yaml_with_audience("github_oauth", "0.1.0", "api.github.com");
+        let install = manager
+            .add_identity_spec_with_inputs_for_import(&replacement_manifest, Vec::new())
+            .expect("import identity spec");
+
+        assert!(
+            manager
+                .rollback_import_if_current(
+                    &install.installed,
+                    install.previous.as_ref(),
+                    install.pre_import_usage_count,
+                )
+                .expect("rollback import")
+        );
+
+        let restored = stored_spec(&manager, "github_oauth");
+        assert!(restored.manifest_yaml.contains("host: github.com"));
+        assert!(!restored.manifest_yaml.contains("host: api.github.com"));
+    }
+
+    #[test]
+    fn import_rollback_restores_previous_input_material_storage_backend() {
+        let temp = TempDir::new().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout directories");
+        let credential_store = CredentialStore::with_available_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::File,
+        );
+        let manager = IdentitySpecManager::new_with_credential_store(
+            layout.clone(),
+            credential_store.clone(),
+            dsl_v4_features(),
+            Vec::new(),
+        );
+        let (record, _replaced) =
+            add_spec_with_secret(&manager, &oauth_identity_yaml_with_inputs());
+        let keychain_material = BTreeMap::from([(
+            "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+            "client-secret".to_string(),
+        )]);
+        credential_store
+            .replace_material(
+                &WorkspaceName::default(),
+                &CredentialSetId::for_identity_spec("demo_oauth"),
+                CredentialStorageKind::Keychain,
+                &keychain_material,
+            )
+            .expect("seed keychain material");
+        let state_file = layout.identity_spec_dir("demo_oauth").join("inputs.yaml");
+        fs::write(
+            &state_file,
+            r"
+version: 1
+credential_storage: keychain
+",
+        )
+        .expect("route input material to keychain");
+        fs::remove_file(layout.identity_spec_material_file("demo_oauth"))
+            .expect("remove file material");
+        let previous = manager
+            .snapshot_identity_spec("demo_oauth")
+            .expect("snapshot previous")
+            .expect("previous spec");
+        let pre_import_usage_count = manager
+            .identity_spec_usage_count("demo_oauth")
+            .expect("usage count");
+
+        add_spec(&manager, &identity_yaml("demo_oauth", "0.1.0"));
+        let installed = manager
+            .snapshot_identity_spec("demo_oauth")
+            .expect("snapshot installed")
+            .expect("installed spec");
+        assert_eq!(installed.input_material_storage, None);
+
+        assert!(
+            manager
+                .rollback_import_if_current(&installed, Some(&previous), pre_import_usage_count)
+                .expect("rollback import")
+        );
+
+        let restored_state = fs::read_to_string(&state_file).expect("restored input state");
+        assert!(
+            restored_state.contains("credential_storage: keychain"),
+            "rollback should restore keychain state: {restored_state}"
+        );
+        assert!(
+            !layout.identity_spec_material_file("demo_oauth").exists(),
+            "rollback must not copy keychain-only material into the file store"
+        );
+        let restored_keychain_material = credential_store
+            .read_material(
+                &WorkspaceName::default(),
+                &CredentialSetId::for_identity_spec("demo_oauth"),
+                CredentialStorageKind::Keychain,
+            )
+            .expect("read keychain material");
+        assert_input(
+            &restored_keychain_material,
+            "DEMO_OAUTH_CLIENT_SECRET",
+            "client-secret",
+        );
+        let resolved = resolved_inputs(&manager, &record);
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "client-secret");
     }
 
     /// Merges the previous `readding_identity_spec_preserves_existing_input_material`

--- a/crates/coral-app/src/identity_specs/mod.rs
+++ b/crates/coral-app/src/identity_specs/mod.rs
@@ -3,17 +3,14 @@
 mod manager;
 mod service;
 
-#[expect(
-    unused_imports,
-    reason = "re-exports consumed by the identity and source managers in later PRs"
-)]
+pub use manager::{
+    IdentitySpecInputMaterialStorage, IdentitySpecManifestMetadata, IdentitySpecRegistry,
+    IdentitySpecRegistryRecord, IdentitySpecUsageProvider,
+    identity_spec_input_material_from_manifest,
+    identity_spec_input_material_from_manifest_with_existing, identity_spec_manifest_metadata,
+};
 pub(crate) use manager::{
     IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord, IdentitySpecSnapshot,
     identity_spec_fingerprint, validate_identity_spec_name,
-};
-pub use manager::{
-    IdentitySpecManifestMetadata, IdentitySpecRegistry, IdentitySpecRegistryRecord,
-    IdentitySpecUsageProvider, identity_spec_input_material_from_manifest,
-    identity_spec_input_material_from_manifest_with_existing, identity_spec_manifest_metadata,
 };
 pub(crate) use service::IdentitySpecService;

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -45,6 +45,7 @@ mod identities;
 mod identity;
 mod identity_specs;
 mod query;
+mod source_registry;
 mod sources;
 mod state;
 mod storage;
@@ -72,12 +73,20 @@ pub use identity::{
     SourceIdentitySubject, UserPrincipal, UserPrincipalError, UserPrincipalProvider,
 };
 pub use identity_specs::{
-    IdentitySpecManifestMetadata, IdentitySpecRegistry, IdentitySpecRegistryRecord,
-    IdentitySpecUsageProvider, identity_spec_input_material_from_manifest,
+    IdentitySpecInputMaterialStorage, IdentitySpecManifestMetadata, IdentitySpecRegistry,
+    IdentitySpecRegistryRecord, IdentitySpecUsageProvider,
+    identity_spec_input_material_from_manifest,
     identity_spec_input_material_from_manifest_with_existing, identity_spec_manifest_metadata,
 };
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
+};
+pub use source_registry::{
+    BundleIdentityInputDiscoveryError, BundleIdentityInputKind, BundleIdentityInputSpec,
+    SourceRegistry, SourceRegistryCredentialStorage, SourceRegistryOrigin, SourceRegistryRecord,
+    SourceSpecManifestMetadata, SpecBundleIdentitySpec, SpecBundleManifest, SpecBundleSourceSpec,
+    bundle_identity_inputs_from_yaml, parse_spec_bundle_manifest_yaml,
+    source_spec_manifest_metadata,
 };
 pub use telemetry::{RunContext, RunErrorTelemetry, run_with_context, shutdown_tracing};
 pub use transport::{OAuthProgressProto, oauth_operation_response_stream};

--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -13,8 +13,8 @@ use coral_spec::ManifestInputKind;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
+use crate::source_registry::{SourceRegistry, installed_source_from_record};
 use crate::sources::SourceName;
-use crate::state::ConfigStore;
 use crate::workspaces::WorkspaceName;
 
 /// App-layer provider that selects engine extensions for one runtime build.
@@ -55,7 +55,7 @@ impl EngineExtensionsProvider for AwsEngineExtensionsProvider {
 #[derive(Clone)]
 pub(crate) struct CredentialRefreshingInputResolver {
     workspace_name: WorkspaceName,
-    config_store: ConfigStore,
+    source_registry: Arc<dyn SourceRegistry>,
     credential_manager: CredentialManager,
     delegate: Option<Arc<dyn SourceInputResolver>>,
 }
@@ -63,13 +63,13 @@ pub(crate) struct CredentialRefreshingInputResolver {
 impl CredentialRefreshingInputResolver {
     pub(crate) fn new(
         workspace_name: WorkspaceName,
-        config_store: ConfigStore,
+        source_registry: Arc<dyn SourceRegistry>,
         credential_manager: CredentialManager,
         delegate: Option<Arc<dyn SourceInputResolver>>,
     ) -> Self {
         Self {
             workspace_name,
-            config_store,
+            source_registry,
             credential_manager,
             delegate,
         }
@@ -94,9 +94,17 @@ impl SourceInputResolver for CredentialRefreshingInputResolver {
         let source_name = SourceName::parse(source.source_name())
             .map_err(|error| SourceInputResolverError::invalid_input(error.to_string()))?;
         let credential_set_id = CredentialSetId::for_source(&source_name);
-        let installed_source = self
-            .config_store
-            .get_source(&self.workspace_name, &source_name)
+        let record = self
+            .source_registry
+            .get_source(self.workspace_name.as_str(), source_name.as_str())
+            .map_err(source_input_error)?
+            .ok_or_else(|| {
+                source_input_error(AppError::SourceNotFound(format!(
+                    "{}:{}",
+                    self.workspace_name, source_name
+                )))
+            })?;
+        let installed_source = installed_source_from_record(&self.workspace_name, record)
             .map_err(source_input_error)?;
         let material =
             if let Some(credential_storage) = installed_source.credential_storage_for_material() {

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -24,8 +24,9 @@ use crate::query::QueryAttribution;
 use crate::query::extensions::{
     CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
 };
+use crate::source_registry::{SourceRegistry, installed_source_from_record};
 use crate::sources::SourceName;
-use crate::sources::catalog::resolve_installed_manifest;
+use crate::sources::catalog::resolve_installed_manifest_with_imported_yaml;
 use crate::sources::materialization::{
     incompatible_materialization_error, load_v4_materialization,
 };
@@ -45,9 +46,16 @@ pub(crate) struct ValidatedSource {
     pub(crate) report: SourceValidationReport,
 }
 
+#[derive(Debug)]
+struct RegistryQuerySource {
+    source: InstalledSource,
+    imported_manifest_yaml: Option<String>,
+}
+
 #[derive(Clone)]
 pub(crate) struct QueryManager {
     config_store: ConfigStore,
+    source_registry: Arc<dyn SourceRegistry>,
     credential_manager: CredentialManager,
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
@@ -56,6 +64,13 @@ pub(crate) struct QueryManager {
 }
 
 impl QueryManager {
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "tests use the default ConfigStore-backed constructor; server bootstrap injects the shared SourceRegistry"
+        )
+    )]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
@@ -64,8 +79,29 @@ impl QueryManager {
         features: Features,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
+        Self::new_with_source_registry(
+            config_store.clone(),
+            Arc::new(config_store),
+            credential_manager,
+            runtime_context,
+            layout,
+            features,
+            engine_extensions_providers,
+        )
+    }
+
+    pub(crate) fn new_with_source_registry(
+        config_store: ConfigStore,
+        source_registry: Arc<dyn SourceRegistry>,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        features: Features,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    ) -> Self {
         Self {
             config_store,
+            source_registry,
             credential_manager,
             runtime_context,
             layout,
@@ -85,7 +121,7 @@ impl QueryManager {
             .load_config()
             .map_err(QueryManagerError::App)?;
         let sources = self
-            .load_query_sources(workspace_name, &config)
+            .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
         let runtime = self
             .runtime_config(workspace_name, &sources, &config)
@@ -116,7 +152,7 @@ impl QueryManager {
             .load_config()
             .map_err(QueryManagerError::App)?;
         let sources = self
-            .load_query_sources(workspace_name, &config)
+            .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
         let runtime = self
             .runtime_config(workspace_name, &sources, &config)
@@ -146,7 +182,7 @@ impl QueryManager {
             .load_config()
             .map_err(QueryManagerError::App)?;
         let sources = self
-            .load_query_sources(workspace_name, &config)
+            .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
         let runtime = self
             .runtime_config(workspace_name, &sources, &config)
@@ -184,7 +220,7 @@ impl QueryManager {
                     .load_config()
                     .map_err(QueryManagerError::App)?;
                 let sources = self
-                    .load_query_sources(workspace_name, &config)
+                    .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &sources, &config)
@@ -225,7 +261,7 @@ impl QueryManager {
                     .load_config()
                     .map_err(QueryManagerError::App)?;
                 let sources = self
-                    .load_query_sources(workspace_name, &config)
+                    .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &sources, &config)
@@ -252,18 +288,20 @@ impl QueryManager {
     pub(crate) async fn validate_source(
         &self,
         workspace_name: &WorkspaceName,
+        // Threaded by `SourceService::validate_source` for HEAD's gRPC
+        // surface; query-time identity resolution consumes it in PR 9.
+        _request_principal: &UserPrincipal,
         source_name: &SourceName,
     ) -> Result<ValidatedSource, QueryManagerError> {
         let config = self
             .config_store
             .load_config()
             .map_err(QueryManagerError::App)?;
-        let source = config
-            .get_source(workspace_name, source_name)
-            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
+        let registry_source = self
+            .registry_source(workspace_name, source_name)
             .map_err(QueryManagerError::App)?;
         let (query_source, version) = self
-            .load_query_source(workspace_name, &source)
+            .load_registry_query_source(workspace_name, &registry_source)
             .map_err(QueryManagerError::App)?;
         let runtime = self
             .runtime_config(workspace_name, std::slice::from_ref(&query_source), &config)
@@ -272,7 +310,7 @@ impl QueryManager {
             CoralQuery::validate_source(&query_source, runtime, query_source.test_queries())
                 .await
                 .map_err(QueryManagerError::Core)?;
-        let mut source = source;
+        let mut source = registry_source.source;
         source.version = version;
 
         Ok(ValidatedSource { source, report })
@@ -281,7 +319,6 @@ impl QueryManager {
     fn load_query_sources(
         &self,
         workspace_name: &WorkspaceName,
-        config: &AppConfig,
     ) -> Result<Vec<QuerySource>, AppError> {
         let span = tracing::info_span!(
             "coral.app.query_sources.load",
@@ -290,19 +327,18 @@ impl QueryManager {
         );
         let _guard = span.enter();
         let mut query_sources = Vec::new();
-        for source in config.workspace_sources(workspace_name) {
-            match self.load_query_source(workspace_name, &source) {
+        for source in self.list_registry_sources(workspace_name)? {
+            match self.load_registry_query_source(workspace_name, &source) {
                 Ok((query_source, _version)) => query_sources.push(query_source),
                 Err(
                     error @ (AppError::Credentials(CredentialsError::Unavailable(_))
-                    | AppError::SourceUnservable(_)
-                    | AppError::MissingOrIncompatibleV4Materialization { .. }),
+                    | AppError::SourceUnservable(_)),
                 ) => {
                     return Err(error);
                 }
                 Err(error) => {
                     tracing::warn!(
-                        source = %source.name,
+                        source = %source.source.name,
                         detail = %error,
                         "skipping source during query-source load"
                     );
@@ -313,12 +349,80 @@ impl QueryManager {
         Ok(query_sources)
     }
 
+    fn list_registry_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<RegistryQuerySource>, AppError> {
+        self.source_registry
+            .list_workspace_sources(workspace_name.as_str())?
+            .into_iter()
+            .map(|record| {
+                let imported_manifest_yaml = record.manifest_yaml.clone();
+                installed_source_from_record(workspace_name, record).map(|source| {
+                    RegistryQuerySource {
+                        source,
+                        imported_manifest_yaml,
+                    }
+                })
+            })
+            .collect()
+    }
+
+    fn registry_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<RegistryQuerySource, AppError> {
+        let record = self
+            .source_registry
+            .get_source(workspace_name.as_str(), source_name.as_str())?
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))?;
+        let imported_manifest_yaml = record.manifest_yaml.clone();
+        installed_source_from_record(workspace_name, record).map(|source| RegistryQuerySource {
+            source,
+            imported_manifest_yaml,
+        })
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "direct source loading is retained for focused unit tests; runtime paths keep registry manifest context"
+        )
+    )]
     fn load_query_source(
         &self,
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
     ) -> Result<(QuerySource, Option<String>), AppError> {
-        let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
+        self.load_query_source_with_imported_manifest(workspace_name, source, None)
+    }
+
+    fn load_registry_query_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &RegistryQuerySource,
+    ) -> Result<(QuerySource, Option<String>), AppError> {
+        self.load_query_source_with_imported_manifest(
+            workspace_name,
+            &source.source,
+            source.imported_manifest_yaml.as_deref(),
+        )
+    }
+
+    fn load_query_source_with_imported_manifest(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        imported_manifest_yaml: Option<&str>,
+    ) -> Result<(QuerySource, Option<String>), AppError> {
+        let installed = resolve_installed_manifest_with_imported_yaml(
+            workspace_name,
+            source,
+            imported_manifest_yaml,
+            &self.layout,
+        )?;
         let source_spec = installed.source_spec;
         let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
             self.features.ensure_dsl_v4_enabled()?;
@@ -405,7 +509,7 @@ impl QueryManager {
         let provider_input_resolver = extensions.source_input_resolver.take();
         extensions.source_input_resolver = Some(Arc::new(CredentialRefreshingInputResolver::new(
             workspace_name.clone(),
-            self.config_store.clone(),
+            Arc::clone(&self.source_registry),
             self.credential_manager.clone(),
             provider_input_resolver,
         )));
@@ -538,10 +642,9 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::IdentitySpecNotFound(_) => "IDENTITY_SPEC_NOT_FOUND",
         AppError::IdentityNotFound(_) => "IDENTITY_NOT_FOUND",
         AppError::InvalidInput(_) => "INVALID_INPUT",
-        AppError::FailedPrecondition(_) | AppError::SourceUnservable(_) => "FAILED_PRECONDITION",
-        AppError::MissingOrIncompatibleV4Materialization { .. } => {
-            "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION"
-        }
+        AppError::FailedPrecondition(_)
+        | AppError::SourceUnservable(_)
+        | AppError::MissingOrIncompatibleV4Materialization { .. } => "FAILED_PRECONDITION",
         AppError::CredentialRefresh(_) => "CREDENTIAL_REFRESH",
         AppError::Unavailable(_) => "UNAVAILABLE",
         AppError::Io(_) => "IO",
@@ -621,6 +724,9 @@ mod tests {
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
     use crate::features::dsl_v4_features;
     use crate::identity::SingleUserPrincipalProvider;
+    use crate::source_registry::{
+        SourceRegistryCredentialStorage, SourceRegistryOrigin, SourceRegistryRecord,
+    };
     use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
     use crate::sources::materialization::sha256_hex;
     use crate::sources::model::SourceOrigin;
@@ -628,6 +734,51 @@ mod tests {
     struct QueryManagerFixture {
         _temp: TempDir,
         manager: QueryManager,
+    }
+
+    #[derive(Debug)]
+    struct StaticSourceRegistry {
+        records: Vec<SourceRegistryRecord>,
+    }
+
+    impl SourceRegistry for StaticSourceRegistry {
+        fn list_workspace_sources(
+            &self,
+            workspace_id: &str,
+        ) -> Result<Vec<SourceRegistryRecord>, AppError> {
+            Ok(self
+                .records
+                .iter()
+                .filter(|record| record.workspace_id == workspace_id)
+                .cloned()
+                .collect())
+        }
+
+        fn get_source(
+            &self,
+            workspace_id: &str,
+            source_name: &str,
+        ) -> Result<Option<SourceRegistryRecord>, AppError> {
+            Ok(self
+                .records
+                .iter()
+                .find(|record| {
+                    record.workspace_id == workspace_id && record.source_name == source_name
+                })
+                .cloned())
+        }
+
+        fn upsert_source(&self, _record: SourceRegistryRecord) -> Result<(), AppError> {
+            Err(AppError::FailedPrecondition(
+                "test registry is read-only".to_string(),
+            ))
+        }
+
+        fn remove_source(&self, _workspace_id: &str, _source_name: &str) -> Result<(), AppError> {
+            Err(AppError::FailedPrecondition(
+                "test registry is read-only".to_string(),
+            ))
+        }
     }
 
     fn query_manager_with(
@@ -716,6 +867,28 @@ mod tests {
         assert_eq!(episode_attr.value.as_str(), "ep_trace_1");
     }
 
+    fn query_manager_with_source_registry(
+        source_registry: Arc<dyn SourceRegistry>,
+    ) -> QueryManagerFixture {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let manager = QueryManager::new_with_source_registry(
+            config_store,
+            source_registry,
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            QueryRuntimeContext::default(),
+            layout,
+            dsl_v4_features(),
+            Vec::new(),
+        );
+        QueryManagerFixture {
+            _temp: temp,
+            manager,
+        }
+    }
+
     fn execution_to_rows(execution: &QueryExecution) -> Vec<Value> {
         let mut bytes = Vec::new();
         {
@@ -801,6 +974,7 @@ tables:
             variables: BTreeMap::new(),
             secrets: vec!["API_KEY".to_string(), "OAUTH_TOKEN".to_string()],
             credential_storage: Some(CredentialStorageKind::File),
+            identity_bindings: BTreeMap::new(),
             origin: SourceOrigin::Imported,
         };
         fixture
@@ -897,6 +1071,8 @@ surfaces:
                         openapi_sha256
                     ),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("import v4 source");
@@ -954,26 +1130,19 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: Vec::new(),
                     credential_storage: None,
+                    identity_bindings: BTreeMap::new(),
                     origin: SourceOrigin::Imported,
                 },
             )
             .expect("persist source");
 
-        let config = fixture
-            .manager
-            .config_store
-            .load_config()
-            .expect("load config");
         let error = fixture
             .manager
-            .load_query_sources(&workspace_name, &config)
+            .load_query_sources(&workspace_name)
             .expect_err("missing materialization should fail closed");
 
         assert!(
-            matches!(
-                error,
-                AppError::MissingOrIncompatibleV4Materialization { .. }
-            ),
+            matches!(error, AppError::SourceUnservable(_)),
             "unexpected error: {error:#}"
         );
     }
@@ -1018,19 +1187,15 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: Vec::new(),
                     credential_storage: None,
+                    identity_bindings: BTreeMap::new(),
                     origin: SourceOrigin::Imported,
                 },
             )
             .expect("persist source");
 
-        let config = fixture
-            .manager
-            .config_store
-            .load_config()
-            .expect("load config");
         let error = fixture
             .manager
-            .load_query_sources(&workspace_name, &config)
+            .load_query_sources(&workspace_name)
             .expect_err("disabled dsl_v4 feature should fail closed");
 
         assert!(
@@ -1057,6 +1222,7 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: vec!["GITHUB_TOKEN".to_string()],
                     credential_storage: Some(CredentialStorageKind::Keychain),
+                    identity_bindings: BTreeMap::new(),
                     origin: SourceOrigin::Bundled,
                 },
             )
@@ -1073,10 +1239,8 @@ surfaces:
             dsl_v4_features(),
             Vec::new(),
         );
-        let config = manager.config_store.load_config().expect("load config");
-
         let error = manager
-            .load_query_sources(&workspace_name, &config)
+            .load_query_sources(&workspace_name)
             .expect_err("unavailable keychain should fail closed");
 
         assert!(
@@ -1134,6 +1298,10 @@ surfaces:
     }
 
     #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "inlined source/credential setup; PR 9 extracts the shared test helpers that shorten this body"
+    )]
     async fn runtime_config_composes_provider_input_resolver_with_refreshed_inputs() {
         let calls = Arc::new(AtomicUsize::new(0));
         let observed_token = Arc::new(Mutex::new(None));
@@ -1158,6 +1326,7 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: vec!["API_TOKEN".to_string()],
                     credential_storage: Some(CredentialStorageKind::File),
+                    identity_bindings: BTreeMap::new(),
                     origin: SourceOrigin::Bundled,
                 },
             )
@@ -1237,5 +1406,130 @@ tables:
                 .as_deref(),
             Some("stored-token")
         );
+    }
+
+    #[tokio::test]
+    async fn runtime_input_resolver_uses_custom_source_registry() {
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("registry_secured_messages").expect("source name");
+        let manifest_yaml = r#"
+name: registry_secured_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+inputs:
+  API_BASE:
+    kind: variable
+    default: https://registry.example.com
+  API_TOKEN:
+    kind: secret
+base_url: "{{input.API_BASE}}"
+tables:
+  - name: messages
+    description: Secured messages
+    request:
+      method: GET
+      path: /messages
+    response: {}
+    columns:
+      - name: id
+        type: Utf8
+"#;
+        let fixture = query_manager_with_source_registry(Arc::new(StaticSourceRegistry {
+            records: vec![SourceRegistryRecord {
+                workspace_id: workspace_name.as_str().to_string(),
+                source_name: source_name.as_str().to_string(),
+                version: Some("0.1.0".to_string()),
+                manifest_yaml: Some(manifest_yaml.to_string()),
+                variables: BTreeMap::new(),
+                secrets: vec!["API_TOKEN".to_string()],
+                credential_storage: Some(SourceRegistryCredentialStorage::File),
+                identity_bindings: BTreeMap::new(),
+                origin: SourceRegistryOrigin::Imported,
+            }],
+        }));
+        fixture
+            .manager
+            .credential_manager
+            .replace_material(
+                &workspace_name,
+                &CredentialSetId::for_source(&source_name),
+                CredentialStorageKind::File,
+                &BTreeMap::from([("API_TOKEN".to_string(), "registry-token".to_string())]),
+            )
+            .expect("write credential material");
+        let source_spec = parse_source_manifest_yaml(manifest_yaml).expect("parse source manifest");
+        let source = QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new());
+        let runtime = fixture
+            .manager
+            .runtime_config(
+                &workspace_name,
+                std::slice::from_ref(&source),
+                &AppConfig::default(),
+            )
+            .expect("runtime config");
+        let input_resolver = runtime
+            .extensions
+            .source_input_resolver
+            .expect("runtime installs input resolver");
+
+        let resolved_inputs = input_resolver
+            .resolve_inputs(&SourceInputResolutionContext::from_query_source(&source))
+            .await
+            .expect("resolve source inputs");
+
+        assert_eq!(
+            resolved_inputs.get("API_TOKEN").map(String::as_str),
+            Some("registry-token")
+        );
+        assert_eq!(
+            resolved_inputs.get("API_BASE").map(String::as_str),
+            Some("https://registry.example.com")
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_source_registry_loads_imported_manifest_yaml_from_record() {
+        let workspace_name = WorkspaceName::default();
+        let fixture = query_manager_with_source_registry(Arc::new(StaticSourceRegistry {
+            records: vec![SourceRegistryRecord {
+                workspace_id: workspace_name.as_str().to_string(),
+                source_name: "registry_messages".to_string(),
+                version: Some("0.1.0".to_string()),
+                manifest_yaml: Some(
+                    r"
+name: registry_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Registry-backed messages
+    request:
+      path: /messages
+    columns:
+      - name: id
+        type: Utf8
+"
+                    .to_string(),
+                ),
+                variables: BTreeMap::new(),
+                secrets: Vec::new(),
+                credential_storage: None,
+                identity_bindings: BTreeMap::new(),
+                origin: SourceRegistryOrigin::Imported,
+            }],
+        }));
+
+        let tables = fixture
+            .manager
+            .list_tables(&workspace_name, None, None)
+            .await
+            .expect("registry manifest should load");
+
+        assert!(tables.iter().any(|table| {
+            table.schema_name == "registry_messages" && table.table_name == "messages"
+        }));
     }
 }

--- a/crates/coral-app/src/source_registry.rs
+++ b/crates/coral-app/src/source_registry.rs
@@ -1,0 +1,427 @@
+//! Public source registry extension seam.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::bootstrap::AppError;
+use crate::credentials::CredentialStorageKind;
+use crate::identity::SourceIdentityBinding;
+use crate::sources::SourceName;
+use crate::sources::model::{InstalledSource, SourceOrigin};
+use crate::workspaces::WorkspaceName;
+
+/// Validated identity of one source-spec manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceSpecManifestMetadata {
+    /// Stable source-spec id declared by the manifest.
+    pub source_spec_id: String,
+    /// Declared source-spec DSL version.
+    pub dsl_version: u32,
+    /// Authored source-spec version, when present.
+    pub version: Option<String>,
+}
+
+/// Validates one source-spec manifest and returns its registry identity.
+///
+/// # Errors
+///
+/// Returns [`AppError`] when the manifest is invalid.
+pub fn source_spec_manifest_metadata(
+    manifest_yaml: &str,
+) -> Result<SourceSpecManifestMetadata, AppError> {
+    let manifest = coral_spec::parse_source_manifest_yaml(manifest_yaml)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    Ok(SourceSpecManifestMetadata {
+        source_spec_id: manifest.schema_name().to_string(),
+        dsl_version: manifest.dsl_version(),
+        version: manifest.source_version().map(str::to_string),
+    })
+}
+
+/// Parsed source/identity spec bundle ready for global registry import.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpecBundleManifest {
+    /// Source spec document from the bundle.
+    pub source_spec: SpecBundleSourceSpec,
+    /// Identity spec documents from the bundle.
+    pub identity_specs: Vec<SpecBundleIdentitySpec>,
+}
+
+/// Source spec document in a parsed spec bundle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpecBundleSourceSpec {
+    /// Stable source-spec id declared by the manifest.
+    pub source_spec_id: String,
+    /// Declared source-spec DSL version.
+    pub dsl_version: u32,
+    /// Authored source-spec version, when present.
+    pub version: Option<String>,
+    /// Canonical source manifest YAML.
+    pub manifest_yaml: String,
+}
+
+/// Identity spec document in a parsed spec bundle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpecBundleIdentitySpec {
+    /// Stable identity-spec id declared by the manifest.
+    pub identity_spec_id: String,
+    /// Authored identity-spec version.
+    pub version: String,
+    /// Canonical identity manifest YAML.
+    pub manifest_yaml: String,
+}
+
+/// Kind of identity-spec setup input declared by an imported bundle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BundleIdentityInputKind {
+    /// Non-secret input material.
+    Variable,
+    /// Secret input material.
+    Secret,
+}
+
+/// Promptable identity-spec setup input declared by an imported bundle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BundleIdentityInputSpec {
+    /// Identity spec that owns the input.
+    pub identity_spec_id: String,
+    /// Input key declared by the identity spec.
+    pub key: String,
+    /// Input kind.
+    pub kind: BundleIdentityInputKind,
+    /// Whether this input must be present after defaults and existing material are resolved.
+    pub required: bool,
+    /// Authored default value for variable inputs, if any.
+    pub default_value: String,
+    /// Optional authored prompt hint.
+    pub hint: Option<String>,
+}
+
+/// Error returned while discovering identity-spec inputs from a bundle.
+#[derive(Debug, thiserror::Error)]
+pub enum BundleIdentityInputDiscoveryError {
+    /// Bundle YAML failed to parse or validate.
+    #[error("spec bundle is invalid: {0}")]
+    Invalid(String),
+}
+
+/// Parses a source/identity spec bundle and returns canonical documents.
+///
+/// # Errors
+///
+/// Returns [`AppError`] when the bundle is invalid.
+pub fn parse_spec_bundle_manifest_yaml(raw: &str) -> Result<SpecBundleManifest, AppError> {
+    let bundle = coral_spec::parse_manifest_bundle_yaml(raw)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    Ok(SpecBundleManifest {
+        source_spec: SpecBundleSourceSpec {
+            source_spec_id: bundle.source_manifest.schema_name().to_string(),
+            dsl_version: bundle.source_manifest.dsl_version(),
+            version: bundle.source_manifest.source_version().map(str::to_string),
+            manifest_yaml: bundle.source_manifest_yaml,
+        },
+        identity_specs: bundle
+            .identity_manifests
+            .into_iter()
+            .map(|identity| SpecBundleIdentitySpec {
+                identity_spec_id: identity.manifest.name,
+                version: identity.manifest.version,
+                manifest_yaml: identity.manifest_yaml,
+            })
+            .collect(),
+    })
+}
+
+/// Discover identity-spec setup inputs declared by a source/identity bundle.
+///
+/// # Errors
+///
+/// Returns [`BundleIdentityInputDiscoveryError`] when the bundle YAML is invalid.
+pub fn bundle_identity_inputs_from_yaml(
+    bundle_yaml: &str,
+) -> Result<Vec<BundleIdentityInputSpec>, BundleIdentityInputDiscoveryError> {
+    let bundle = coral_spec::parse_manifest_bundle_yaml(bundle_yaml)
+        .map_err(|error| BundleIdentityInputDiscoveryError::Invalid(error.to_string()))?;
+    Ok(bundle
+        .identity_manifests
+        .into_iter()
+        .flat_map(|identity| {
+            let identity_spec_id = identity.manifest.name;
+            identity.manifest.inputs.into_iter().map(move |input| {
+                let kind = match input.kind {
+                    coral_spec::ManifestInputKind::Variable => BundleIdentityInputKind::Variable,
+                    coral_spec::ManifestInputKind::Secret => BundleIdentityInputKind::Secret,
+                };
+                BundleIdentityInputSpec {
+                    identity_spec_id: identity_spec_id.clone(),
+                    key: input.key,
+                    kind,
+                    required: input.required,
+                    default_value: input.default_value,
+                    hint: input.hint,
+                }
+            })
+        })
+        .collect())
+}
+
+/// Durable storage backend for workspace-installed sources.
+///
+/// The default OSS implementation persists sources in local `config.toml`.
+/// Product runtimes can install an implementation backed by their own durable
+/// control-plane store.
+pub trait SourceRegistry: fmt::Debug + Send + Sync + 'static {
+    /// Lists all sources installed in one workspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the registry cannot be read or contains invalid
+    /// source records.
+    fn list_workspace_sources(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Vec<SourceRegistryRecord>, AppError>;
+
+    /// Fetches one installed source, returning `None` when it is absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the registry cannot be read or contains an
+    /// invalid source record.
+    fn get_source(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<SourceRegistryRecord>, AppError>;
+
+    /// Inserts or replaces one installed source.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the record is invalid or cannot be persisted.
+    fn upsert_source(&self, record: SourceRegistryRecord) -> Result<(), AppError>;
+
+    /// Removes one installed source if present.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the source cannot be removed.
+    fn remove_source(&self, workspace_id: &str, source_name: &str) -> Result<(), AppError>;
+}
+
+/// One source installed in a workspace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceRegistryRecord {
+    /// Workspace id that owns this source.
+    pub workspace_id: String,
+    /// Installed source name.
+    pub source_name: String,
+    /// Persisted source version, when applicable.
+    pub version: Option<String>,
+    /// Imported source manifest YAML.
+    ///
+    /// Bundled sources may leave this empty because their manifest is resolved
+    /// from Coral's bundled catalog. Imported DSL v4 manifests are not secret
+    /// material and product registries can persist them here.
+    pub manifest_yaml: Option<String>,
+    /// Configured non-secret variable values.
+    pub variables: BTreeMap<String, String>,
+    /// Source-owned secret keys for legacy source specs.
+    ///
+    /// DSL v4 sources should leave this empty and express credentials through
+    /// identity requirements.
+    pub secrets: Vec<String>,
+    /// Credential storage backend for legacy source-owned secrets.
+    pub credential_storage: Option<SourceRegistryCredentialStorage>,
+    /// Source-surface identity slot configuration.
+    pub identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+    /// How this source entered the registry.
+    pub origin: SourceRegistryOrigin,
+}
+
+/// Source origin stored by a source registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceRegistryOrigin {
+    /// Source was installed from Coral's bundled source catalog.
+    Bundled,
+    /// Source was imported from a user-provided manifest.
+    Imported,
+}
+
+/// Source-owned credential storage backend for legacy source specs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceRegistryCredentialStorage {
+    /// Credential material is stored in Coral's local file store.
+    File,
+    /// Credential material is stored in the operating-system keychain.
+    Keychain,
+}
+
+pub(crate) fn record_from_installed_source(
+    workspace_name: &WorkspaceName,
+    source: InstalledSource,
+) -> SourceRegistryRecord {
+    SourceRegistryRecord {
+        workspace_id: workspace_name.as_str().to_string(),
+        source_name: source.name.as_str().to_string(),
+        version: source.version,
+        manifest_yaml: None,
+        variables: source.variables,
+        secrets: source.secrets,
+        credential_storage: source.credential_storage.map(Into::into),
+        identity_bindings: source.identity_bindings,
+        origin: source.origin.into(),
+    }
+}
+
+pub(crate) fn installed_source_from_record(
+    expected_workspace: &WorkspaceName,
+    record: SourceRegistryRecord,
+) -> Result<InstalledSource, AppError> {
+    let workspace_name = WorkspaceName::parse(&record.workspace_id)?;
+    if &workspace_name != expected_workspace {
+        return Err(AppError::InvalidInput(format!(
+            "source registry returned workspace '{workspace_name}' while loading workspace '{expected_workspace}'"
+        )));
+    }
+    let source_name = SourceName::parse(&record.source_name)?;
+    validate_registry_identity_bindings(source_name.as_str(), &record.identity_bindings)?;
+    Ok(InstalledSource {
+        name: source_name,
+        version: record.version,
+        variables: record.variables,
+        secrets: record.secrets,
+        credential_storage: record.credential_storage.map(Into::into),
+        identity_bindings: record.identity_bindings,
+        origin: record.origin.into(),
+    })
+}
+
+fn validate_registry_identity_bindings(
+    source_name: &str,
+    bindings: &BTreeMap<String, SourceIdentityBinding>,
+) -> Result<(), AppError> {
+    for (surface_id, binding) in bindings {
+        let mut chars = surface_id.chars();
+        let valid = matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+            && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+        if !valid {
+            return Err(AppError::InvalidInput(format!(
+                "source '{source_name}' identity binding surface '{surface_id}' must match [a-z][a-z0-9_]*"
+            )));
+        }
+        binding.validate().map_err(|error| {
+            AppError::InvalidInput(format!(
+                "source '{source_name}' identity binding for surface '{surface_id}' is invalid: {error}"
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+impl From<SourceOrigin> for SourceRegistryOrigin {
+    fn from(value: SourceOrigin) -> Self {
+        match value {
+            SourceOrigin::Bundled => Self::Bundled,
+            SourceOrigin::Imported => Self::Imported,
+        }
+    }
+}
+
+impl From<SourceRegistryOrigin> for SourceOrigin {
+    fn from(value: SourceRegistryOrigin) -> Self {
+        match value {
+            SourceRegistryOrigin::Bundled => Self::Bundled,
+            SourceRegistryOrigin::Imported => Self::Imported,
+        }
+    }
+}
+
+impl From<CredentialStorageKind> for SourceRegistryCredentialStorage {
+    fn from(value: CredentialStorageKind) -> Self {
+        match value {
+            CredentialStorageKind::File => Self::File,
+            CredentialStorageKind::Keychain => Self::Keychain,
+        }
+    }
+}
+
+impl From<SourceRegistryCredentialStorage> for CredentialStorageKind {
+    fn from(value: SourceRegistryCredentialStorage) -> Self {
+        match value {
+            SourceRegistryCredentialStorage::File => Self::File,
+            SourceRegistryCredentialStorage::Keychain => Self::Keychain,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BundleIdentityInputKind, bundle_identity_inputs_from_yaml};
+
+    #[test]
+    fn bundle_identity_inputs_from_yaml_discovers_identity_inputs() {
+        let bundle_yaml = format!("---\n{}---\n{}", source_yaml("demo"), oauth_identity_yaml());
+
+        let inputs = bundle_identity_inputs_from_yaml(&bundle_yaml).expect("bundle inputs");
+
+        let [tenant, client_secret] = inputs.as_slice() else {
+            panic!("expected two inputs, got {inputs:?}");
+        };
+        assert_eq!(tenant.identity_spec_id, "demo_oauth");
+        assert_eq!(tenant.key, "DEMO_TENANT");
+        assert_eq!(tenant.kind, BundleIdentityInputKind::Variable);
+        assert_eq!(tenant.default_value, "oauth2");
+        assert_eq!(client_secret.identity_spec_id, "demo_oauth");
+        assert_eq!(client_secret.key, "DEMO_OAUTH_CLIENT_SECRET");
+        assert_eq!(client_secret.kind, BundleIdentityInputKind::Secret);
+        assert!(client_secret.required);
+    }
+
+    fn source_yaml(name: &str) -> String {
+        format!(
+            "name: {name}\nversion: 0.1.0\ndsl_version: 4\nsurfaces:\n  - id: rest\n    type: openapi\n    file: /tmp/openapi.yaml\n    sha256: 0000000000000000000000000000000000000000000000000000000000000000\n"
+        )
+    }
+
+    fn oauth_identity_yaml() -> &'static str {
+        r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+description: Demo OAuth identity.
+issuer: demo
+type: oauth
+audience:
+  host: api.example.test
+inputs:
+  DEMO_TENANT:
+    kind: variable
+    default: oauth2
+  DEMO_OAUTH_CLIENT_SECRET:
+    kind: secret
+    required: true
+oauth:
+  method:
+    label: Demo OAuth
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/callback
+    endpoints:
+      authorization_url: https://auth.example.test/authorize
+      token_url: https://auth.example.test/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+        transport: request_body
+"
+    }
+}

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -58,18 +58,18 @@ pub(crate) fn load_bundled_source(name: &SourceName) -> Result<BundledSourceMani
     })
 }
 
-/// Resolve the effective installed manifest and verify it still matches the
-/// installed source identity in app state.
-pub(crate) fn resolve_installed_manifest(
+pub(crate) fn resolve_installed_manifest_with_imported_yaml(
     workspace_name: &WorkspaceName,
     source: &InstalledSource,
+    imported_manifest_yaml: Option<&str>,
     layout: &AppStateLayout,
 ) -> Result<InstalledSourceManifest, AppError> {
     let manifest_yaml = match source.origin {
         SourceOrigin::Bundled => load_bundled_source(&source.name)?.manifest_yaml,
-        SourceOrigin::Imported => {
-            std::fs::read_to_string(layout.manifest_file(workspace_name, &source.name))?
-        }
+        SourceOrigin::Imported => match imported_manifest_yaml {
+            Some(manifest_yaml) => manifest_yaml.to_string(),
+            None => std::fs::read_to_string(layout.manifest_file(workspace_name, &source.name))?,
+        },
     };
     let source_spec = parse_source_manifest_yaml(&manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -2,8 +2,9 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
+use std::sync::Arc;
 
-use coral_spec::v4::SurfaceDescriptor;
+use coral_spec::v4::{IdentityRequirements, SurfaceDescriptor};
 use serde_yaml::Value as YamlValue;
 
 use crate::bootstrap::AppError;
@@ -15,10 +16,14 @@ use crate::credentials::{
     CORAL_INTERNAL_KEY_PREFIX, CredentialManager, CredentialMaterialGuard,
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialsError,
 };
-use crate::features::Features;
+use crate::source_registry::{
+    SourceRegistry, SourceRegistryOrigin, SourceRegistryRecord, installed_source_from_record,
+    record_from_installed_source,
+};
 use crate::sources::SourceName;
 use crate::sources::catalog::{
-    describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
+    describe_manifest, list_bundled_sources, load_bundled_source,
+    resolve_installed_manifest_with_imported_yaml,
 };
 use crate::sources::materialization::{
     MaterializationBuild, MaterializationInputs, build_v4_materialization_tmp,
@@ -26,7 +31,9 @@ use crate::sources::materialization::{
     new_materialization_suffix, replace_v4_materialization, restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
-use crate::state::{AppStateLayout, ConfigStore};
+use crate::state::AppStateLayout;
+#[cfg(test)]
+use crate::state::ConfigStore;
 use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
@@ -34,9 +41,12 @@ use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tracing::warn;
 use uuid::Uuid;
 
+use crate::features::Features;
+use crate::identity::{SourceIdentityBinding, SourceIdentityOwner};
+
 #[derive(Clone)]
 pub(crate) struct SourceManager {
-    config_store: ConfigStore,
+    source_registry: Arc<dyn SourceRegistry>,
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
     layout: AppStateLayout,
@@ -54,28 +64,36 @@ pub(crate) struct CreateBundledSourceWithOAuthCommand {
     pub(crate) oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
 }
 
+#[derive(Clone)]
 pub(crate) struct ImportSourceCommand {
     pub(crate) manifest_yaml: String,
     pub(crate) bindings: SourceBindings,
+    pub(crate) identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+    pub(crate) replace_identity_bindings: bool,
 }
 
+#[derive(Clone)]
 pub(crate) struct ImportSourceWithCredentialsCommand {
     pub(crate) manifest_yaml: String,
     pub(crate) bindings: SourceBindings,
     pub(crate) oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
+    pub(crate) identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+    pub(crate) replace_identity_bindings: bool,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct SourceBindings {
     pub(crate) variables: Vec<SourceBinding>,
     pub(crate) secrets: Vec<SourceBinding>,
 }
 
+#[derive(Clone)]
 pub(crate) struct SourceBinding {
     pub(crate) key: String,
     pub(crate) value: String,
 }
 
+#[derive(Clone)]
 pub(crate) struct SourceOAuthCredentialRetrieval {
     pub(crate) input_key: String,
     pub(crate) method_index: usize,
@@ -97,6 +115,8 @@ struct ValidatedBindings {
 struct InstallSourceRequest<'a> {
     candidate: &'a CandidateSource,
     bindings: &'a SourceBindings,
+    identity_bindings: &'a BTreeMap<String, SourceIdentityBinding>,
+    replace_identity_bindings: bool,
     manifest_yaml: Option<&'a str>,
     materialization_manifest_yaml: &'a str,
     origin: SourceOrigin,
@@ -104,11 +124,23 @@ struct InstallSourceRequest<'a> {
 
 struct PersistSourceRequest<'a> {
     candidate: &'a CandidateSource,
+    manifest: &'a ValidatedSourceManifest,
     manifest_yaml: Option<&'a str>,
     bindings: ValidatedBindings,
+    identity_bindings: &'a BTreeMap<String, SourceIdentityBinding>,
     origin: SourceOrigin,
     credential_storage: Option<CredentialStorageKind>,
     materialization_tmp: Option<PathBuf>,
+}
+
+struct PrepareV4MaterializationRequest<'a> {
+    workspace_name: &'a WorkspaceName,
+    candidate: &'a CandidateSource,
+    manifest: &'a ValidatedSourceManifest,
+    manifest_yaml: &'a str,
+    inputs: &'a MaterializationInputs,
+    origin: SourceOrigin,
+    suffix_prefix: &'a str,
 }
 
 struct SourceRollbackState {
@@ -129,6 +161,74 @@ fn materialization_inputs_from_bindings(
     }
 }
 
+pub(crate) struct SourceImportPreflight {
+    materialization_manifest_yaml: String,
+    materialization_tmp: Option<PathBuf>,
+}
+
+impl SourceImportPreflight {
+    fn new(materialization_manifest_yaml: &str, materialization_tmp: Option<PathBuf>) -> Self {
+        Self {
+            materialization_manifest_yaml: materialization_manifest_yaml.to_string(),
+            materialization_tmp,
+        }
+    }
+
+    fn materialization_manifest_yaml(&self) -> &str {
+        &self.materialization_manifest_yaml
+    }
+
+    fn take_materialization_tmp(&mut self) -> Option<PathBuf> {
+        self.materialization_tmp.take()
+    }
+}
+
+impl Drop for SourceImportPreflight {
+    fn drop(&mut self) {
+        cleanup_materialization_tmp(self.materialization_tmp.as_deref());
+    }
+}
+
+#[derive(Clone)]
+struct RegistrySource {
+    source: InstalledSource,
+    imported_manifest_yaml: Option<String>,
+}
+
+pub(crate) struct SourceImportRollbackState {
+    workspace_name: WorkspaceName,
+    source_name: SourceName,
+    installed_record: SourceRegistryRecord,
+    installed_manifest_yaml: Option<String>,
+    previous: Option<SourceRollbackState>,
+    materialization_rollback: SourceMaterializationRollbackState,
+    stale_user_binding_surfaces: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PreservedUserSourceIdentityBinding {
+    pub(crate) user_id: String,
+    pub(crate) surface_id: String,
+}
+
+struct PersistedSource {
+    source: InstalledSource,
+    rollback: SourceImportRollbackState,
+}
+
+enum SourceMaterializationRollbackState {
+    Unchanged,
+    Replaced { backup: Option<PathBuf> },
+}
+
+impl SourceMaterializationRollbackState {
+    fn cleanup(self) {
+        if let Self::Replaced { backup } = self {
+            cleanup_materialization_backup(backup);
+        }
+    }
+}
+
 impl SourceManager {
     #[cfg(test)]
     pub(crate) fn new(
@@ -144,14 +244,29 @@ impl SourceManager {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn new_with_features(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
         layout: AppStateLayout,
         features: Features,
     ) -> Self {
+        Self::new_with_features_and_source_registry(
+            Arc::new(config_store),
+            credential_manager,
+            layout,
+            features,
+        )
+    }
+
+    pub(crate) fn new_with_features_and_source_registry(
+        source_registry: Arc<dyn SourceRegistry>,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+        features: Features,
+    ) -> Self {
         Self {
-            config_store,
+            source_registry,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
             layout,
@@ -159,15 +274,74 @@ impl SourceManager {
         }
     }
 
+    fn list_registry_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        self.list_registry_source_records(workspace_name)
+            .map(|sources| sources.into_iter().map(|source| source.source).collect())
+    }
+
+    fn list_registry_source_records(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<RegistrySource>, AppError> {
+        self.source_registry
+            .list_workspace_sources(workspace_name.as_str())?
+            .into_iter()
+            .map(|record| {
+                let imported_manifest_yaml = record.manifest_yaml.clone();
+                installed_source_from_record(workspace_name, record).map(|source| RegistrySource {
+                    source,
+                    imported_manifest_yaml,
+                })
+            })
+            .collect()
+    }
+
+    fn get_registry_source_record(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<RegistrySource>, AppError> {
+        self.source_registry
+            .get_source(workspace_name.as_str(), source_name.as_str())?
+            .map(|record| {
+                let imported_manifest_yaml = record.manifest_yaml.clone();
+                installed_source_from_record(workspace_name, record).map(|source| RegistrySource {
+                    source,
+                    imported_manifest_yaml,
+                })
+            })
+            .transpose()
+    }
+
+    fn get_registry_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, AppError> {
+        self.get_registry_source_record(workspace_name, source_name)
+            .map(|source| source.map(|source| source.source))
+    }
+
+    fn require_registry_source_record(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<RegistrySource, AppError> {
+        self.get_registry_source_record(workspace_name, source_name)?
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
+    }
+
     pub(crate) fn list_workspace_sources(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<InstalledSource>, AppError> {
         Ok(self
-            .config_store
-            .list_workspace_sources(workspace_name)?
+            .list_registry_source_records(workspace_name)?
             .into_iter()
-            .map(|source| self.populate_source_version_or_keep(workspace_name, source))
+            .map(|source| self.populate_registry_source_version_or_keep(workspace_name, source))
             .collect())
     }
 
@@ -176,9 +350,9 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
-        Ok(self.populate_source_version_or_keep(
+        Ok(self.populate_registry_source_version_or_keep(
             workspace_name,
-            self.config_store.get_source(workspace_name, source_name)?,
+            self.require_registry_source_record(workspace_name, source_name)?,
         ))
     }
 
@@ -187,13 +361,9 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<CandidateSource, AppError> {
-        match self.config_store.get_source(workspace_name, source_name) {
-            Ok(source) => {
-                return Ok(
-                    resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
-                );
-            }
-            Err(AppError::SourceNotFound(_)) => {}
+        match self.get_registry_source_record(workspace_name, source_name) {
+            Ok(Some(source)) => return self.registry_source_info(workspace_name, &source),
+            Ok(None) => {}
             Err(error) => return Err(error),
         }
 
@@ -206,11 +376,25 @@ impl SourceManager {
         }
     }
 
+    fn registry_source_info(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &RegistrySource,
+    ) -> Result<CandidateSource, AppError> {
+        Ok(resolve_installed_manifest_with_imported_yaml(
+            workspace_name,
+            &source.source,
+            source.imported_manifest_yaml.as_deref(),
+            &self.layout,
+        )?
+        .candidate)
+    }
+
     pub(crate) fn discover_sources(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<CandidateSource>, AppError> {
-        let installed_sources = self.config_store.list_workspace_sources(workspace_name)?;
+        let installed_sources = self.list_registry_sources(workspace_name)?;
         let installed = installed_sources
             .iter()
             .map(|source| source.name.clone())
@@ -245,6 +429,8 @@ impl SourceManager {
             InstallSourceRequest {
                 candidate: &candidate,
                 bindings: &command.bindings,
+                identity_bindings: &BTreeMap::new(),
+                replace_identity_bindings: false,
                 manifest_yaml: None,
                 materialization_manifest_yaml: &bundled.manifest_yaml,
                 origin: SourceOrigin::Bundled,
@@ -265,6 +451,8 @@ impl SourceManager {
             InstallSourceRequest {
                 candidate: &candidate,
                 bindings: &command.bindings,
+                identity_bindings: &BTreeMap::new(),
+                replace_identity_bindings: false,
                 manifest_yaml: None,
                 materialization_manifest_yaml: &bundled.manifest_yaml,
                 origin: SourceOrigin::Bundled,
@@ -275,15 +463,34 @@ impl SourceManager {
         .await
     }
 
+    fn materialization_manifest_yaml_for_import(
+        &self,
+        authored_manifest_yaml: &str,
+        preflight: Option<&SourceImportPreflight>,
+    ) -> Result<String, AppError> {
+        if let Some(preflight) = preflight {
+            return Ok(preflight.materialization_manifest_yaml().to_string());
+        }
+        let manifest = parse_source_manifest_yaml(authored_manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_feature_enabled(&manifest)?;
+        durable_import_manifest_yaml(authored_manifest_yaml, &manifest)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "direct source-manager import seam is exercised by unit tests; the gRPC service uses the rollback-aware variant"
+        )
+    )]
     pub(crate) fn import_source(
         &self,
         workspace_name: &WorkspaceName,
         command: &ImportSourceCommand,
     ) -> Result<InstalledSource, AppError> {
-        let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
-            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
-        self.ensure_dsl_v4_feature_enabled(&manifest)?;
-        let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
+        let manifest_yaml =
+            self.materialization_manifest_yaml_for_import(&command.manifest_yaml, None)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         self.install_validated_source(
@@ -291,6 +498,8 @@ impl SourceManager {
             InstallSourceRequest {
                 candidate: &candidate,
                 bindings: &command.bindings,
+                identity_bindings: &command.identity_bindings,
+                replace_identity_bindings: command.replace_identity_bindings,
                 manifest_yaml: Some(&manifest_yaml),
                 materialization_manifest_yaml: &manifest_yaml,
                 origin: SourceOrigin::Imported,
@@ -298,16 +507,198 @@ impl SourceManager {
         )
     }
 
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "direct rollback-aware source import seam is retained for focused unit tests; the gRPC service uses the preflight-aware variant"
+        )
+    )]
+    pub(crate) fn import_source_with_rollback_state(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: &ImportSourceCommand,
+    ) -> Result<(InstalledSource, SourceImportRollbackState), AppError> {
+        self.import_source_with_rollback_state_after_preflight(workspace_name, command, None)
+    }
+
+    pub(crate) fn import_source_with_rollback_state_after_preflight(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: &ImportSourceCommand,
+        preflight: Option<SourceImportPreflight>,
+    ) -> Result<(InstalledSource, SourceImportRollbackState), AppError> {
+        let manifest_yaml = self
+            .materialization_manifest_yaml_for_import(&command.manifest_yaml, preflight.as_ref())?;
+        let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
+        candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        let persisted = self.install_validated_source_deferred(
+            workspace_name,
+            InstallSourceRequest {
+                candidate: &candidate,
+                bindings: &command.bindings,
+                identity_bindings: &command.identity_bindings,
+                replace_identity_bindings: command.replace_identity_bindings,
+                manifest_yaml: Some(&manifest_yaml),
+                materialization_manifest_yaml: &manifest_yaml,
+                origin: SourceOrigin::Imported,
+            },
+            preflight,
+        )?;
+        Ok((persisted.source, persisted.rollback))
+    }
+
+    pub(crate) fn preflight_import_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: &ImportSourceCommand,
+    ) -> Result<SourceImportPreflight, AppError> {
+        let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_feature_enabled(&manifest)?;
+        let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
+        let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
+        candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        self.preflight_install_source(
+            workspace_name,
+            InstallSourceRequest {
+                candidate: &candidate,
+                bindings: &command.bindings,
+                identity_bindings: &command.identity_bindings,
+                replace_identity_bindings: command.replace_identity_bindings,
+                manifest_yaml: Some(&manifest_yaml),
+                materialization_manifest_yaml: &manifest_yaml,
+                origin: SourceOrigin::Imported,
+            },
+            None,
+        )
+    }
+
+    pub(crate) fn restore_import_source_rollback_state(
+        &self,
+        workspace_name: &WorkspaceName,
+        rollback: SourceImportRollbackState,
+        installed: Option<&InstalledSource>,
+    ) {
+        let SourceImportRollbackState {
+            workspace_name: _,
+            source_name,
+            installed_record,
+            installed_manifest_yaml,
+            previous,
+            materialization_rollback,
+            stale_user_binding_surfaces: _,
+        } = rollback;
+        match self
+            .source_registry
+            .get_source(workspace_name.as_str(), source_name.as_str())
+        {
+            Ok(Some(current)) if current == installed_record => {
+                match self.import_manifest_yaml_snapshot(workspace_name, &source_name, &current) {
+                    Ok(current_manifest_yaml)
+                        if current_manifest_yaml == installed_manifest_yaml => {}
+                    Ok(_) => {
+                        warn!(
+                            source = %source_name,
+                            "rollback: skipped source restore because current source manifest changed"
+                        );
+                        materialization_rollback.cleanup();
+                        return;
+                    }
+                    Err(error) => {
+                        warn!(
+                            source = %source_name,
+                            error = %error,
+                            "rollback: skipped source restore because current source manifest could not be verified"
+                        );
+                        materialization_rollback.cleanup();
+                        return;
+                    }
+                }
+            }
+            Ok(_) => {
+                warn!(
+                    source = %source_name,
+                    "rollback: skipped source restore because current source state changed"
+                );
+                materialization_rollback.cleanup();
+                return;
+            }
+            Err(error) => {
+                warn!(
+                    source = %source_name,
+                    error = %error,
+                    "rollback: skipped source restore because current source state could not be verified"
+                );
+                materialization_rollback.cleanup();
+                return;
+            }
+        }
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let Ok(credential_guard) = self
+            .credential_manager
+            .material_guard(workspace_name, &credential_set_id)
+        else {
+            warn!(
+                source = %source_name,
+                "rollback: failed to lock source credential material"
+            );
+            return;
+        };
+        let new_material_storage =
+            installed.and_then(InstalledSource::credential_storage_for_material);
+        self.restore_source_rollback_state(
+            workspace_name,
+            &source_name,
+            previous,
+            new_material_storage,
+            &credential_guard,
+        );
+        if let Err(error) = self.restore_source_materialization_rollback(
+            workspace_name,
+            &source_name,
+            materialization_rollback,
+        ) {
+            warn!(
+                source = %source_name,
+                error = %error,
+                "rollback: failed to restore source materialization"
+            );
+        }
+    }
+
+    pub(crate) fn commit_import_source_rollback_state(
+        &self,
+        rollback: SourceImportRollbackState,
+        preserved_user_bindings: &[PreservedUserSourceIdentityBinding],
+    ) {
+        let stale_user_binding_surfaces = rollback.stale_user_binding_surfaces;
+        if !stale_user_binding_surfaces.is_empty() {
+            self.cleanup_user_source_identity_bindings_for_surfaces_best_effort(
+                &rollback.workspace_name,
+                &rollback.source_name,
+                &stale_user_binding_surfaces,
+                preserved_user_bindings,
+            );
+        }
+        rollback.materialization_rollback.cleanup();
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "direct source-manager OAuth import seam is exercised by unit tests; the gRPC service uses the rollback-aware variant"
+        )
+    )]
     pub(crate) async fn import_source_with_credentials(
         &self,
         workspace_name: &WorkspaceName,
         command: ImportSourceWithCredentialsCommand,
         events: OAuthProgressEventSender,
     ) -> Result<InstalledSource, AppError> {
-        let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
-            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
-        self.ensure_dsl_v4_feature_enabled(&manifest)?;
-        let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
+        let manifest_yaml =
+            self.materialization_manifest_yaml_for_import(&command.manifest_yaml, None)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         self.install_source_with_oauth(
@@ -315,6 +706,8 @@ impl SourceManager {
             InstallSourceRequest {
                 candidate: &candidate,
                 bindings: &command.bindings,
+                identity_bindings: &command.identity_bindings,
+                replace_identity_bindings: command.replace_identity_bindings,
                 manifest_yaml: Some(&manifest_yaml),
                 materialization_manifest_yaml: &manifest_yaml,
                 origin: SourceOrigin::Imported,
@@ -323,6 +716,82 @@ impl SourceManager {
             events,
         )
         .await
+    }
+
+    #[expect(
+        dead_code,
+        reason = "non-gRPC rollback-aware OAuth import seam is retained for focused source-manager callers; the gRPC service uses the preflight-aware variant"
+    )]
+    pub(crate) async fn import_source_with_credentials_and_rollback_state(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: ImportSourceWithCredentialsCommand,
+        events: OAuthProgressEventSender,
+    ) -> Result<(InstalledSource, SourceImportRollbackState), AppError> {
+        self.import_source_with_credentials_and_rollback_state_after_preflight(
+            workspace_name,
+            command,
+            events,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn import_source_with_credentials_and_rollback_state_after_preflight(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: ImportSourceWithCredentialsCommand,
+        events: OAuthProgressEventSender,
+        preflight: Option<SourceImportPreflight>,
+    ) -> Result<(InstalledSource, SourceImportRollbackState), AppError> {
+        let manifest_yaml = self
+            .materialization_manifest_yaml_for_import(&command.manifest_yaml, preflight.as_ref())?;
+        let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
+        candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        let persisted = self
+            .install_source_with_oauth_deferred(
+                workspace_name,
+                InstallSourceRequest {
+                    candidate: &candidate,
+                    bindings: &command.bindings,
+                    identity_bindings: &command.identity_bindings,
+                    replace_identity_bindings: command.replace_identity_bindings,
+                    manifest_yaml: Some(&manifest_yaml),
+                    materialization_manifest_yaml: &manifest_yaml,
+                    origin: SourceOrigin::Imported,
+                },
+                command.oauth_credential_retrievals,
+                events,
+                preflight,
+            )
+            .await?;
+        Ok((persisted.source, persisted.rollback))
+    }
+
+    pub(crate) fn preflight_import_source_with_credentials(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: &ImportSourceWithCredentialsCommand,
+    ) -> Result<SourceImportPreflight, AppError> {
+        let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_feature_enabled(&manifest)?;
+        let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
+        let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
+        candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        self.preflight_install_source(
+            workspace_name,
+            InstallSourceRequest {
+                candidate: &candidate,
+                bindings: &command.bindings,
+                identity_bindings: &command.identity_bindings,
+                replace_identity_bindings: command.replace_identity_bindings,
+                manifest_yaml: Some(&manifest_yaml),
+                materialization_manifest_yaml: &manifest_yaml,
+                origin: SourceOrigin::Imported,
+            },
+            Some(&command.oauth_credential_retrievals),
+        )
     }
 
     /// Validates `bindings` against any stored credential material and persists
@@ -334,6 +803,17 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         request: InstallSourceRequest<'_>,
     ) -> Result<InstalledSource, AppError> {
+        let persisted = self.install_validated_source_deferred(workspace_name, request, None)?;
+        self.commit_import_source_rollback_state(persisted.rollback, &[]);
+        Ok(persisted.source)
+    }
+
+    fn install_validated_source_deferred(
+        &self,
+        workspace_name: &WorkspaceName,
+        request: InstallSourceRequest<'_>,
+        mut preflight: Option<SourceImportPreflight>,
+    ) -> Result<PersistedSource, AppError> {
         let manifest = parse_source_manifest_yaml(request.materialization_manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         self.ensure_dsl_v4_feature_enabled(&manifest)?;
@@ -342,6 +822,14 @@ impl SourceManager {
             &request.candidate.name,
             &manifest,
         )?;
+        let identity_bindings = self.effective_source_identity_bindings(
+            workspace_name,
+            &request.candidate.name,
+            request.identity_bindings,
+            request.replace_identity_bindings,
+        )?;
+        validate_import_identity_bindings(&manifest, &identity_bindings)?;
+        ensure_identity_backed_imports_have_query_resolver(&manifest)?;
         let stored_material = self.source_stored_material_for_validation(
             workspace_name,
             request.candidate,
@@ -357,27 +845,90 @@ impl SourceManager {
             &bindings,
             !stored_material.is_empty(),
         )?;
-        self.persist_source(
+        self.persist_source_deferred(
             workspace_name,
             PersistSourceRequest {
                 candidate: request.candidate,
+                manifest: &manifest,
                 manifest_yaml: request.manifest_yaml,
                 bindings,
+                identity_bindings: &identity_bindings,
                 origin: request.origin,
                 credential_storage,
-                materialization_tmp: self
-                    .prepare_v4_materialization(
-                        workspace_name,
-                        request.candidate,
-                        &manifest,
-                        request.materialization_manifest_yaml,
-                        &materialization_inputs,
-                        request.origin,
-                        "tmp",
-                    )?
-                    .map(|build| build.temp_dir),
+                materialization_tmp: self.materialization_tmp_for_import(
+                    workspace_name,
+                    request,
+                    &manifest,
+                    &materialization_inputs,
+                    preflight.as_mut(),
+                )?,
             },
         )
+    }
+
+    fn preflight_install_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        request: InstallSourceRequest<'_>,
+        oauth_credential_retrievals: Option<&[SourceOAuthCredentialRetrieval]>,
+    ) -> Result<SourceImportPreflight, AppError> {
+        let manifest = parse_source_manifest_yaml(request.materialization_manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_feature_enabled(&manifest)?;
+        let identity_bindings = self.effective_source_identity_bindings(
+            workspace_name,
+            &request.candidate.name,
+            request.identity_bindings,
+            request.replace_identity_bindings,
+        )?;
+        validate_import_identity_bindings(&manifest, &identity_bindings)?;
+        // The service must validate user-owned identity selections before the
+        // query resolver fail-closed check runs in the real import path.
+        let oauth_input_keys = oauth_credential_retrievals
+            .unwrap_or_default()
+            .iter()
+            .map(|credential| credential.input_key.clone())
+            .collect::<BTreeSet<_>>();
+        let stored_material = self.source_stored_material_for_validation(
+            workspace_name,
+            request.candidate,
+            request.bindings,
+            &oauth_input_keys,
+        )?;
+        let bindings = if let Some(retrievals) = oauth_credential_retrievals {
+            Self::validate_oauth_import_preflight(
+                request.candidate,
+                request.bindings,
+                &stored_material,
+                retrievals,
+            )?
+        } else {
+            validate_bindings(request.candidate, request.bindings, &stored_material)?
+        };
+        let has_stored_material = !stored_material.is_empty();
+        let materialization_inputs =
+            materialization_inputs_from_bindings(&bindings, &stored_material);
+        let _credential_storage = self.source_persist_storage(
+            workspace_name,
+            &request.candidate.name,
+            &bindings,
+            has_stored_material,
+        )?;
+        let materialization_tmp = self
+            .prepare_v4_materialization(&PrepareV4MaterializationRequest {
+                workspace_name,
+                candidate: request.candidate,
+                manifest: &manifest,
+                manifest_yaml: request.materialization_manifest_yaml,
+                inputs: &materialization_inputs,
+                origin: request.origin,
+                suffix_prefix: "preflight",
+            })?
+            .map(|build| build.temp_dir);
+        Ok(SourceImportPreflight::new(
+            request.materialization_manifest_yaml,
+            materialization_tmp,
+        ))
     }
 
     /// Resolves OAuth credential material (driving the authorization flow over
@@ -391,6 +942,27 @@ impl SourceManager {
         oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
         events: OAuthProgressEventSender,
     ) -> Result<InstalledSource, AppError> {
+        let persisted = self
+            .install_source_with_oauth_deferred(
+                workspace_name,
+                request,
+                oauth_credential_retrievals,
+                events,
+                None,
+            )
+            .await?;
+        self.commit_import_source_rollback_state(persisted.rollback, &[]);
+        Ok(persisted.source)
+    }
+
+    async fn install_source_with_oauth_deferred(
+        &self,
+        workspace_name: &WorkspaceName,
+        request: InstallSourceRequest<'_>,
+        oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
+        events: OAuthProgressEventSender,
+        mut preflight: Option<SourceImportPreflight>,
+    ) -> Result<PersistedSource, AppError> {
         let manifest = parse_source_manifest_yaml(request.materialization_manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         self.ensure_dsl_v4_feature_enabled(&manifest)?;
@@ -399,6 +971,14 @@ impl SourceManager {
             &request.candidate.name,
             &manifest,
         )?;
+        let identity_bindings = self.effective_source_identity_bindings(
+            workspace_name,
+            &request.candidate.name,
+            request.identity_bindings,
+            request.replace_identity_bindings,
+        )?;
+        validate_import_identity_bindings(&manifest, &identity_bindings)?;
+        ensure_identity_backed_imports_have_query_resolver(&manifest)?;
         let oauth_input_keys = oauth_credential_retrievals
             .iter()
             .map(|credential| credential.input_key.clone())
@@ -428,25 +1008,23 @@ impl SourceManager {
             &bindings,
             has_stored_material,
         )?;
-        self.persist_source(
+        self.persist_source_deferred(
             workspace_name,
             PersistSourceRequest {
                 candidate: request.candidate,
+                manifest: &manifest,
                 manifest_yaml: request.manifest_yaml,
                 bindings,
+                identity_bindings: &identity_bindings,
                 origin: request.origin,
                 credential_storage,
-                materialization_tmp: self
-                    .prepare_v4_materialization(
-                        workspace_name,
-                        request.candidate,
-                        &manifest,
-                        request.materialization_manifest_yaml,
-                        &materialization_inputs,
-                        request.origin,
-                        "tmp",
-                    )?
-                    .map(|build| build.temp_dir),
+                materialization_tmp: self.materialization_tmp_for_import(
+                    workspace_name,
+                    request,
+                    &manifest,
+                    &materialization_inputs,
+                    preflight.as_mut(),
+                )?,
             },
         )
     }
@@ -456,8 +1034,10 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
-        let stored = self.config_store.get_source(workspace_name, source_name)?;
-        let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
+        let stored_record = self.require_registry_source_record(workspace_name, source_name)?;
+        let removed =
+            self.populate_registry_source_version_or_keep(workspace_name, stored_record.clone());
+        let stored = stored_record.source;
         let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
         let credential_guard = self
@@ -469,12 +1049,13 @@ impl SourceManager {
             .transpose()?;
         let previous = SourceRollbackState {
             source: stored,
-            manifest_yaml: match removed.origin {
-                SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
-            },
+            manifest_yaml: source_manifest_yaml_for_rollback(
+                workspace_name,
+                source_name,
+                &removed,
+                stored_record.imported_manifest_yaml.as_deref(),
+                &self.layout,
+            )?,
             credential_material,
         };
         if let Some(credential_storage) = credential_storage
@@ -507,7 +1088,10 @@ impl SourceManager {
                 return Err(error.into());
             }
         }
-        if let Err(error) = self.config_store.remove_source(workspace_name, source_name) {
+        if let Err(error) = self
+            .source_registry
+            .remove_source(workspace_name.as_str(), source_name.as_str())
+        {
             if had_source_dir
                 && source_dir_backup.exists()
                 && let Err(restore_error) = std::fs::rename(&source_dir_backup, &source_dir)
@@ -534,6 +1118,7 @@ impl SourceManager {
             &self.layout.workspaces_root(),
             self.layout.workspace_dir(workspace_name).parent(),
         );
+        self.cleanup_user_source_identity_bindings_best_effort(workspace_name, source_name);
         Ok(removed)
     }
 
@@ -551,11 +1136,11 @@ impl SourceManager {
         clippy::too_many_lines,
         reason = "Source persistence keeps rollback steps together so failure ordering is visible."
     )]
-    fn persist_source(
+    fn persist_source_deferred(
         &self,
         workspace_name: &WorkspaceName,
         request: PersistSourceRequest<'_>,
-    ) -> Result<InstalledSource, AppError> {
+    ) -> Result<PersistedSource, AppError> {
         let source_name = request.candidate.name.clone();
         let credential_set_id = CredentialSetId::for_source(&source_name);
         let credential_guard = self
@@ -628,7 +1213,7 @@ impl SourceManager {
                 (Vec::new(), None)
             };
 
-        let materialization_backup =
+        let materialization_rollback =
             if let Some(materialization_tmp) = request.materialization_tmp.as_ref() {
                 match replace_v4_materialization(
                     &self.layout,
@@ -636,7 +1221,7 @@ impl SourceManager {
                     &source_name,
                     materialization_tmp,
                 ) {
-                    Ok(backup) => backup,
+                    Ok(backup) => SourceMaterializationRollbackState::Replaced { backup },
                     Err(error) => {
                         cleanup_materialization_tmp(request.materialization_tmp.as_deref());
                         self.restore_source_rollback_state(
@@ -650,7 +1235,7 @@ impl SourceManager {
                     }
                 }
             } else {
-                None
+                SourceMaterializationRollbackState::Unchanged
             };
 
         let persisted_version = match request.origin {
@@ -663,17 +1248,18 @@ impl SourceManager {
             variables,
             secrets: visible_secret_keys,
             credential_storage,
+            identity_bindings: request.identity_bindings.clone(),
             origin: request.origin,
         };
-        if let Err(error) = self
-            .config_store
-            .upsert_source(workspace_name, stored.clone())
-        {
-            let restore_result = restore_materialization_backup(
-                &self.layout,
+        let stale_user_binding_surfaces =
+            stale_user_binding_surfaces(previous.as_ref(), &stored, request.manifest);
+        let mut record = record_from_installed_source(workspace_name, stored.clone());
+        record.manifest_yaml = request.manifest_yaml.map(ToString::to_string);
+        if let Err(error) = self.source_registry.upsert_source(record) {
+            let restore_result = self.restore_source_materialization_rollback(
                 workspace_name,
                 &source_name,
-                materialization_backup,
+                materialization_rollback,
             );
             self.restore_source_rollback_state(
                 workspace_name,
@@ -689,27 +1275,56 @@ impl SourceManager {
             }
             return Err(error);
         }
-        cleanup_materialization_backup(materialization_backup);
+        let (installed_record, installed_manifest_yaml) = match self
+            .import_rollback_installed_snapshot(workspace_name, &source_name)
+        {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                let restore_result = self.restore_source_materialization_rollback(
+                    workspace_name,
+                    &source_name,
+                    materialization_rollback,
+                );
+                self.restore_source_rollback_state(
+                    workspace_name,
+                    &source_name,
+                    previous,
+                    credential_storage,
+                    &credential_guard,
+                );
+                if let Err(restore_error) = restore_result {
+                    return Err(AppError::FailedPrecondition(format!(
+                        "failed to verify persisted source '{source_name}': {error}; failed to restore previous DSL v4 materialization: {restore_error}"
+                    )));
+                }
+                return Err(error);
+            }
+        };
         let mut resolved = stored;
         resolved.version.clone_from(&request.candidate.version);
-        Ok(resolved)
+        Ok(PersistedSource {
+            source: resolved,
+            rollback: SourceImportRollbackState {
+                workspace_name: workspace_name.clone(),
+                source_name,
+                installed_record,
+                installed_manifest_yaml,
+                previous,
+                materialization_rollback,
+                stale_user_binding_surfaces,
+            },
+        })
     }
 
     fn prepare_v4_materialization(
         &self,
-        workspace_name: &WorkspaceName,
-        candidate: &CandidateSource,
-        manifest: &ValidatedSourceManifest,
-        manifest_yaml: &str,
-        inputs: &MaterializationInputs,
-        origin: SourceOrigin,
-        suffix_prefix: &str,
+        request: &PrepareV4MaterializationRequest<'_>,
     ) -> Result<Option<MaterializationBuild>, AppError> {
-        let Some(v4) = manifest.as_v4() else {
+        let Some(v4) = request.manifest.as_v4() else {
             return Ok(None);
         };
         self.features.ensure_dsl_v4_enabled()?;
-        if matches!(origin, SourceOrigin::Bundled)
+        if matches!(request.origin, SourceOrigin::Bundled)
             && v4.surfaces.iter().any(|surface| {
                 matches!(
                     surface.descriptor,
@@ -724,12 +1339,12 @@ impl SourceManager {
         }
         build_v4_materialization_tmp(
             &self.layout,
-            workspace_name,
-            &candidate.name,
-            manifest_yaml,
+            request.workspace_name,
+            &request.candidate.name,
+            request.manifest_yaml,
             v4,
-            inputs,
-            &new_materialization_suffix(suffix_prefix),
+            request.inputs,
+            &new_materialization_suffix(request.suffix_prefix),
         )
         .map(Some)
     }
@@ -741,12 +1356,16 @@ impl SourceManager {
         candidate_manifest: &ValidatedSourceManifest,
     ) -> Result<(), AppError> {
         let candidate_schema_names = runtime_schema_names(candidate_manifest);
-        for installed in self.config_store.list_workspace_sources(workspace_name)? {
-            if installed.name == *candidate_name {
+        for installed in self.list_registry_source_records(workspace_name)? {
+            if installed.source.name == *candidate_name {
                 continue;
             }
-            let installed_manifest =
-                resolve_installed_manifest(workspace_name, &installed, &self.layout)?;
+            let installed_manifest = resolve_installed_manifest_with_imported_yaml(
+                workspace_name,
+                &installed.source,
+                installed.imported_manifest_yaml.as_deref(),
+                &self.layout,
+            )?;
             let installed_schema_names = runtime_schema_names(&installed_manifest.source_spec);
             if let Some(schema_name) = candidate_schema_names
                 .intersection(&installed_schema_names)
@@ -754,11 +1373,36 @@ impl SourceManager {
             {
                 return Err(AppError::InvalidInput(format!(
                     "source '{candidate_name}' runtime schema name '{schema_name}' conflicts with installed source '{}'",
-                    installed.name
+                    installed.source.name
                 )));
             }
         }
         Ok(())
+    }
+
+    fn materialization_tmp_for_import(
+        &self,
+        workspace_name: &WorkspaceName,
+        request: InstallSourceRequest<'_>,
+        manifest: &ValidatedSourceManifest,
+        inputs: &MaterializationInputs,
+        preflight: Option<&mut SourceImportPreflight>,
+    ) -> Result<Option<PathBuf>, AppError> {
+        if let Some(materialization_tmp) =
+            preflight.and_then(SourceImportPreflight::take_materialization_tmp)
+        {
+            return Ok(Some(materialization_tmp));
+        }
+        self.prepare_v4_materialization(&PrepareV4MaterializationRequest {
+            workspace_name,
+            candidate: request.candidate,
+            manifest,
+            manifest_yaml: request.materialization_manifest_yaml,
+            inputs,
+            origin: request.origin,
+            suffix_prefix: "tmp",
+        })
+        .map(|build| build.map(|build| build.temp_dir))
     }
 
     fn ensure_dsl_v4_feature_enabled(
@@ -776,10 +1420,44 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<bool, AppError> {
-        Ok(self
-            .config_store
-            .load_catalog()?
-            .contains(workspace_name, source_name))
+        self.get_registry_source(workspace_name, source_name)
+            .map(|source| source.is_some())
+    }
+
+    pub(crate) fn effective_source_identity_bindings_for_import(
+        &self,
+        workspace_name: &WorkspaceName,
+        manifest_yaml: &str,
+        requested: &BTreeMap<String, SourceIdentityBinding>,
+        replace_identity_bindings: bool,
+    ) -> Result<BTreeMap<String, SourceIdentityBinding>, AppError> {
+        let manifest = parse_source_manifest_yaml(manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        let source_name = SourceName::parse(manifest.schema_name())?;
+        self.effective_source_identity_bindings(
+            workspace_name,
+            &source_name,
+            requested,
+            replace_identity_bindings,
+        )
+    }
+
+    fn effective_source_identity_bindings(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        requested: &BTreeMap<String, SourceIdentityBinding>,
+        replace_identity_bindings: bool,
+    ) -> Result<BTreeMap<String, SourceIdentityBinding>, AppError> {
+        if replace_identity_bindings || !requested.is_empty() {
+            return Ok(requested.clone());
+        }
+        self.get_registry_source(workspace_name, source_name)
+            .map(|source| {
+                source
+                    .map(|source| source.identity_bindings)
+                    .unwrap_or_default()
+            })
     }
 
     fn read_source_material(
@@ -811,25 +1489,21 @@ impl SourceManager {
         bindings: &SourceBindings,
         filled_secret_keys: &BTreeSet<String>,
     ) -> Result<BTreeMap<String, String>, AppError> {
-        let (credential_storage, persisted_secret_keys) = match self
-            .config_store
-            .get_source(workspace_name, &candidate.name)
-        {
-            Ok(source) => (
-                source.credential_storage_for_material(),
-                Some(source.secrets.iter().cloned().collect::<BTreeSet<_>>()),
-            ),
-            Err(AppError::SourceNotFound(_))
-                if self
+        let (credential_storage, persisted_secret_keys) =
+            match self.get_registry_source(workspace_name, &candidate.name)? {
+                Some(source) => (
+                    source.credential_storage_for_material(),
+                    Some(source.secrets.iter().cloned().collect::<BTreeSet<_>>()),
+                ),
+                None if self
                     .layout
                     .secret_file(workspace_name, &candidate.name)
                     .exists() =>
-            {
-                (Some(CredentialStorageKind::File), None)
-            }
-            Err(AppError::SourceNotFound(_)) => (None, Some(BTreeSet::new())),
-            Err(error) => return Err(error),
-        };
+                {
+                    (Some(CredentialStorageKind::File), None)
+                }
+                None => (None, Some(BTreeSet::new())),
+            };
 
         if !source_needs_stored_material_for_validation(
             candidate,
@@ -855,19 +1529,12 @@ impl SourceManager {
         bindings: &ValidatedBindings,
         has_stored_material: bool,
     ) -> Result<Option<CredentialStorageKind>, AppError> {
-        match self.config_store.get_source(workspace_name, source_name) {
-            Ok(source) if !source.secrets.is_empty() => {
+        match self.get_registry_source(workspace_name, source_name)? {
+            Some(source) if !source.secrets.is_empty() => {
                 Ok(Some(source.effective_credential_storage()))
             }
-            Ok(_) | Err(AppError::SourceNotFound(_))
-                if bindings.secrets.is_empty() && !has_stored_material =>
-            {
-                Ok(None)
-            }
-            Ok(_) | Err(AppError::SourceNotFound(_)) => {
-                self.credential_manager.default_write_storage().map(Some)
-            }
-            Err(error) => Err(error),
+            Some(_) | None if bindings.secrets.is_empty() && !has_stored_material => Ok(None),
+            Some(_) | None => self.credential_manager.default_write_storage().map(Some),
         }
     }
 
@@ -996,25 +1663,61 @@ impl SourceManager {
         source_name: &SourceName,
         credential_material: &CredentialMaterialGuard<'_>,
     ) -> Result<Option<SourceRollbackState>, AppError> {
-        let source = match self.config_store.get_source(workspace_name, source_name) {
-            Ok(source) => source,
-            Err(AppError::SourceNotFound(_)) => return Ok(None),
-            Err(error) => return Err(error),
+        let Some(registry_source) = self.get_registry_source_record(workspace_name, source_name)?
+        else {
+            return Ok(None);
         };
+        let source = registry_source.source;
         let credential_material = source
             .credential_storage_for_material()
             .map(|credential_storage| credential_material.snapshot_material(credential_storage))
             .transpose()?;
         Ok(Some(SourceRollbackState {
-            manifest_yaml: match source.origin {
-                SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
-            },
+            manifest_yaml: source_manifest_yaml_for_rollback(
+                workspace_name,
+                source_name,
+                &source,
+                registry_source.imported_manifest_yaml.as_deref(),
+                &self.layout,
+            )?,
             source,
             credential_material,
         }))
+    }
+
+    fn import_rollback_installed_snapshot(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(SourceRegistryRecord, Option<String>), AppError> {
+        let installed_record = self
+            .source_registry
+            .get_source(workspace_name.as_str(), source_name.as_str())?
+            .ok_or_else(|| {
+                AppError::FailedPrecondition(format!(
+                    "source '{source_name}' was not found after persistence"
+                ))
+            })?;
+        let installed_manifest_yaml =
+            self.import_manifest_yaml_snapshot(workspace_name, source_name, &installed_record)?;
+        Ok((installed_record, installed_manifest_yaml))
+    }
+
+    fn import_manifest_yaml_snapshot(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        record: &SourceRegistryRecord,
+    ) -> Result<Option<String>, AppError> {
+        if record.origin != SourceRegistryOrigin::Imported {
+            return Ok(None);
+        }
+        if let Some(manifest_yaml) = &record.manifest_yaml {
+            return Ok(Some(manifest_yaml.clone()));
+        }
+        std::fs::read_to_string(self.layout.manifest_file(workspace_name, source_name))
+            .map(Some)
+            .map_err(Into::into)
     }
 
     fn restore_source_rollback_state(
@@ -1027,6 +1730,7 @@ impl SourceManager {
     ) {
         if let Some(previous) = previous {
             let manifest_path = self.layout.manifest_file(workspace_name, source_name);
+            let previous_manifest_yaml = previous.manifest_yaml.clone();
             match previous.manifest_yaml {
                 Some(manifest_yaml) => {
                     if let Some(parent) = manifest_path.parent()
@@ -1059,10 +1763,9 @@ impl SourceManager {
                     }
                 }
             }
-            if let Err(e) = self
-                .config_store
-                .upsert_source(workspace_name, previous.source)
-            {
+            let mut record = record_from_installed_source(workspace_name, previous.source);
+            record.manifest_yaml = previous_manifest_yaml;
+            if let Err(e) = self.source_registry.upsert_source(record) {
                 warn!("rollback: failed to restore source config: {e}");
             }
         } else {
@@ -1072,10 +1775,96 @@ impl SourceManager {
             {
                 warn!("rollback: failed to remove source directory: {e}");
             }
+            if let Err(e) = self
+                .source_registry
+                .remove_source(workspace_name.as_str(), source_name.as_str())
+            {
+                warn!("rollback: failed to remove source config: {e}");
+            }
             if let Some(storage) = new_material_storage
                 && let Err(e) = credential_material.remove_material(storage)
             {
                 warn!("rollback: failed to remove source credential material: {e}");
+            }
+        }
+    }
+
+    fn restore_source_materialization_rollback(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        rollback: SourceMaterializationRollbackState,
+    ) -> Result<(), AppError> {
+        match rollback {
+            SourceMaterializationRollbackState::Unchanged => Ok(()),
+            SourceMaterializationRollbackState::Replaced { backup } => {
+                restore_materialization_backup(&self.layout, workspace_name, source_name, backup)
+            }
+        }
+    }
+
+    fn cleanup_user_source_identity_bindings_best_effort(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        self.cleanup_user_source_identity_bindings_for_surfaces_best_effort(
+            workspace_name,
+            source_name,
+            &[],
+            &[],
+        );
+    }
+
+    fn cleanup_user_source_identity_bindings_for_surfaces_best_effort(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        surface_ids: &[String],
+        preserved_user_bindings: &[PreservedUserSourceIdentityBinding],
+    ) {
+        let bindings_root = self.layout.source_identity_bindings_root();
+        let users_root = bindings_root.join("users");
+        let Ok(users) = std::fs::read_dir(&users_root) else {
+            return;
+        };
+        for user in users {
+            let Ok(user) = user else {
+                continue;
+            };
+            let user_id = user.file_name().to_string_lossy().into_owned();
+            let source_bindings_dir = user
+                .path()
+                .join(workspace_name.as_str())
+                .join(source_name.as_str());
+            let cleanup_dirs = if surface_ids.is_empty() {
+                vec![source_bindings_dir]
+            } else {
+                surface_ids
+                    .iter()
+                    .filter(|surface_id| {
+                        !preserved_user_bindings.iter().any(|preserved| {
+                            preserved.user_id == user_id
+                                && preserved.surface_id == surface_id.as_str()
+                        })
+                    })
+                    .map(|surface_id| source_bindings_dir.join(surface_id))
+                    .collect()
+            };
+            for cleanup_dir in cleanup_dirs {
+                if !cleanup_dir.exists() {
+                    continue;
+                }
+                if let Err(error) = std::fs::remove_dir_all(&cleanup_dir) {
+                    warn!(
+                        source = %source_name,
+                        path = %cleanup_dir.display(),
+                        error = %error,
+                        "failed to clean up user source identity bindings"
+                    );
+                    continue;
+                }
+                cleanup_empty_parent(&bindings_root, cleanup_dir.parent());
             }
         }
     }
@@ -1103,24 +1892,49 @@ impl SourceManager {
         Ok(())
     }
 
-    fn populate_source_version(
+    fn populate_registry_source_version(
         &self,
         workspace_name: &WorkspaceName,
-        mut source: InstalledSource,
+        mut source: RegistrySource,
     ) -> Result<InstalledSource, AppError> {
-        source.version = resolve_installed_manifest(workspace_name, &source, &self.layout)?
-            .candidate
-            .version;
-        Ok(source)
+        source.source.version = resolve_installed_manifest_with_imported_yaml(
+            workspace_name,
+            &source.source,
+            source.imported_manifest_yaml.as_deref(),
+            &self.layout,
+        )?
+        .candidate
+        .version;
+        Ok(source.source)
     }
 
-    fn populate_source_version_or_keep(
+    fn populate_registry_source_version_or_keep(
         &self,
         workspace_name: &WorkspaceName,
-        source: InstalledSource,
+        source: RegistrySource,
     ) -> InstalledSource {
-        self.populate_source_version(workspace_name, source.clone())
-            .unwrap_or(source)
+        self.populate_registry_source_version(workspace_name, source.clone())
+            .unwrap_or(source.source)
+    }
+}
+
+fn source_manifest_yaml_for_rollback(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    source: &InstalledSource,
+    imported_manifest_yaml: Option<&str>,
+    layout: &AppStateLayout,
+) -> Result<Option<String>, AppError> {
+    match source.origin {
+        SourceOrigin::Bundled => Ok(None),
+        SourceOrigin::Imported => imported_manifest_yaml.map_or_else(
+            || {
+                std::fs::read_to_string(layout.manifest_file(workspace_name, source_name))
+                    .map(Some)
+                    .map_err(Into::into)
+            },
+            |manifest_yaml| Ok(Some(manifest_yaml.to_string())),
+        ),
     }
 }
 
@@ -1197,6 +2011,90 @@ fn validate_bindings(
         replaced_oauth_inputs: secret_values.keys().cloned().collect(),
         secrets: secret_values,
     })
+}
+
+fn validate_import_identity_bindings(
+    manifest: &ValidatedSourceManifest,
+    bindings: &BTreeMap<String, SourceIdentityBinding>,
+) -> Result<(), AppError> {
+    let Some(v4) = manifest.as_v4() else {
+        if bindings.is_empty() {
+            return Ok(());
+        }
+        return Err(AppError::InvalidInput(
+            "source identity bindings can only be configured for DSL v4 sources".to_string(),
+        ));
+    };
+    for surface in v4
+        .surfaces
+        .iter()
+        .filter(|surface| surface.identity_requirements.is_some())
+    {
+        if !bindings.contains_key(&surface.id) {
+            return Err(AppError::InvalidInput(format!(
+                "source '{}' surface '{}' declares identity_requirements but no identity binding was provided",
+                manifest.schema_name(),
+                surface.id
+            )));
+        }
+    }
+    for (surface_id, binding) in bindings {
+        binding.validate()?;
+        let surface = v4.surface(surface_id).ok_or_else(|| {
+            AppError::InvalidInput(format!(
+                "source '{}' identity binding targets unknown surface '{surface_id}'",
+                manifest.schema_name()
+            ))
+        })?;
+        let requirements = surface.identity_requirements.as_ref().ok_or_else(|| {
+            AppError::InvalidInput(format!(
+                "source '{}' surface '{surface_id}' does not declare identity_requirements",
+                manifest.schema_name()
+            ))
+        })?;
+        if binding.owner == SourceIdentityOwner::Workspace {
+            match binding.accepted_identity.as_deref() {
+                Some(accepted_identity)
+                    if requirements
+                        .accepts
+                        .iter()
+                        .any(|accepted| accepted.id == accepted_identity) => {}
+                Some(accepted_identity) => {
+                    return Err(AppError::InvalidInput(format!(
+                        "source '{}' surface '{surface_id}' identity binding references unknown accepted_identity '{accepted_identity}'",
+                        manifest.schema_name()
+                    )));
+                }
+                None if requirements.accepts.len() > 1 => {
+                    return Err(AppError::InvalidInput(format!(
+                        "source '{}' surface '{surface_id}' workspace-owned identity binding must include accepted_identity because the surface accepts multiple identities",
+                        manifest.schema_name()
+                    )));
+                }
+                None => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ensure_identity_backed_imports_have_query_resolver(
+    manifest: &ValidatedSourceManifest,
+) -> Result<(), AppError> {
+    let Some(v4) = manifest.as_v4() else {
+        return Ok(());
+    };
+    if !v4
+        .surfaces
+        .iter()
+        .any(|surface| surface.identity_requirements.is_some())
+    {
+        return Ok(());
+    }
+    Err(AppError::FailedPrecondition(format!(
+        "source '{}' declares identity_requirements, but request identity resolution is not installed for query execution in this build",
+        manifest.schema_name()
+    )))
 }
 
 fn source_needs_stored_material_for_validation(
@@ -1298,6 +2196,92 @@ fn merge_oauth_material_into_bindings(
         bindings.secrets.extend(internal_metadata);
     }
     Ok(())
+}
+
+fn stale_user_binding_surfaces(
+    previous: Option<&SourceRollbackState>,
+    stored: &InstalledSource,
+    current_manifest: &ValidatedSourceManifest,
+) -> Vec<String> {
+    let Some(previous) = previous else {
+        return Vec::new();
+    };
+    previous
+        .source
+        .identity_bindings
+        .iter()
+        .filter_map(|(surface_id, previous_binding)| {
+            if previous_binding.owner != SourceIdentityOwner::User {
+                return None;
+            }
+            let Some(current_binding) = stored.identity_bindings.get(surface_id) else {
+                return Some(surface_id.clone());
+            };
+            if current_binding.owner != SourceIdentityOwner::User {
+                return Some(surface_id.clone());
+            }
+            (!surface_identity_requirements_match(
+                previous.manifest_yaml.as_deref(),
+                current_manifest,
+                surface_id,
+            ))
+            .then(|| surface_id.clone())
+        })
+        .collect()
+}
+
+fn surface_identity_requirements_match(
+    previous_manifest_yaml: Option<&str>,
+    current_manifest: &ValidatedSourceManifest,
+    surface_id: &str,
+) -> bool {
+    let Some(previous_manifest_yaml) = previous_manifest_yaml else {
+        return false;
+    };
+    let Ok(previous_manifest) = parse_source_manifest_yaml(previous_manifest_yaml) else {
+        return false;
+    };
+    let Some(previous_requirements) =
+        identity_requirements_for_surface(&previous_manifest, surface_id)
+    else {
+        return false;
+    };
+    let Some(current_requirements) =
+        identity_requirements_for_surface(current_manifest, surface_id)
+    else {
+        return false;
+    };
+    canonical_identity_requirements(previous_requirements)
+        == canonical_identity_requirements(current_requirements)
+}
+
+fn identity_requirements_for_surface<'a>(
+    manifest: &'a ValidatedSourceManifest,
+    surface_id: &str,
+) -> Option<&'a IdentityRequirements> {
+    manifest
+        .as_v4()?
+        .surface(surface_id)?
+        .identity_requirements
+        .as_ref()
+}
+
+fn canonical_identity_requirements(
+    requirements: &IdentityRequirements,
+) -> BTreeMap<String, (BTreeSet<String>, BTreeMap<String, serde_json::Value>)> {
+    requirements
+        .accepts
+        .iter()
+        .map(|accepted| {
+            (
+                accepted.id.clone(),
+                (
+                    accepted.identity_specs.iter().cloned().collect(),
+                    accepted.audience.clone(),
+                ),
+            )
+        })
+        .collect()
 }
 
 fn collect_unique_variables(
@@ -1440,6 +2424,7 @@ mod tests {
     use std::net::TcpListener as StdTcpListener;
     use std::path::{Path, PathBuf};
     use std::sync::mpsc as std_mpsc;
+    use std::sync::{Arc, Mutex, MutexGuard};
     use std::thread;
     use std::time::Duration;
 
@@ -1449,11 +2434,15 @@ mod tests {
     use wiremock::matchers::method;
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    use coral_spec::parse_source_manifest_yaml;
+
     use super::{
-        AppError, ImportSourceCommand, ImportSourceWithCredentialsCommand, SourceBinding,
-        SourceBindings, SourceManager, SourceOAuthCredentialRetrieval, ValidatedBindings,
+        AppError, ImportSourceCommand, ImportSourceWithCredentialsCommand,
+        PreservedUserSourceIdentityBinding, SourceBinding, SourceBindings,
+        SourceImportRollbackState, SourceManager, SourceMaterializationRollbackState,
+        SourceOAuthCredentialRetrieval, SourceRollbackState, ValidatedBindings,
         materialization_inputs_from_bindings, normalize_binding_key,
-        source_needs_stored_material_for_validation,
+        source_needs_stored_material_for_validation, stale_user_binding_surfaces,
     };
     use crate::credentials::oauth::{
         OAuthProgressEvent, OAuthProgressEventSender, PendingOAuthProgressEvent,
@@ -1463,6 +2452,10 @@ mod tests {
         CredentialStore, CredentialsError,
     };
     use crate::features::{Features, dsl_v4_features};
+    use crate::identity::SourceIdentityBinding;
+    use crate::source_registry::{
+        SourceRegistry, SourceRegistryOrigin, SourceRegistryRecord, record_from_installed_source,
+    };
     use crate::sources::SourceName;
     use crate::sources::materialization::sha256_hex;
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
@@ -1676,6 +2669,49 @@ surfaces:
         )
     }
 
+    fn manifest_v4_with_identity_requirement(openapi_file: &Path, sha256: &str) -> String {
+        manifest_v4(
+            openapi_file,
+            sha256,
+            &format!(
+                r"{V4_LOCAL_BASE_URL_YAML}    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+          audience:
+            host: github.com
+"
+            ),
+        )
+    }
+
+    fn manifest_v4_with_identity_requirement_ids(
+        openapi_file: &Path,
+        sha256: &str,
+        github_requirement_id: &str,
+    ) -> String {
+        manifest_v4(
+            openapi_file,
+            sha256,
+            &format!(
+                r"{V4_LOCAL_BASE_URL_YAML}    identity_requirements:
+      accepts:
+        - id: {github_requirement_id}
+          identity_specs:
+            - github_oauth
+          audience:
+            host: github.com
+        - id: gitlab-rest-read
+          identity_specs:
+            - gitlab_oauth
+          audience:
+            host: gitlab.com
+"
+            ),
+        )
+    }
+
     fn manifest_v4_with_input_and_derived_base_url(openapi_file: &Path, sha256: &str) -> String {
         manifest_v4(
             openapi_file,
@@ -1692,25 +2728,8 @@ surfaces:
         manifest_v4(openapi_file, sha256, "")
     }
 
-    fn manifest_v4_with_variable_input() -> String {
-        r#"
-name: secured_messages_v4
-dsl_version: 4
-surfaces:
-  - id: rest
-    type: openapi
-    url: https://example.com/openapi.yaml
-    sha256: 0000000000000000000000000000000000000000000000000000000000000000
-    inputs:
-      API_BASE:
-        kind: variable
-    base_url: "{{input.API_BASE}}"
-"#
-        .to_string()
-    }
-
-    /// Authored-descriptor state plus a source manager over a fresh app
-    /// layout.
+    /// Authored-descriptor state plus a dsl_v4-enabled source manager over a
+    /// fresh app layout.
     struct V4ImportFixture {
         _temp: TempDir,
         _descriptor_temp: TempDir,
@@ -1767,16 +2786,17 @@ surfaces:
         }
     }
 
-    /// An [`ImportSourceCommand`] for `manifest_yaml` with `bindings`.
+    /// An [`ImportSourceCommand`] with no identity bindings.
     fn import_command(manifest_yaml: String, bindings: SourceBindings) -> ImportSourceCommand {
         ImportSourceCommand {
             manifest_yaml,
             bindings,
+            identity_bindings: BTreeMap::new(),
+            replace_identity_bindings: false,
         }
     }
 
-    /// An [`ImportSourceWithCredentialsCommand`] for `manifest_yaml` with
-    /// `bindings`.
+    /// An [`ImportSourceWithCredentialsCommand`] with no identity bindings.
     fn credentials_import_command(
         manifest_yaml: String,
         bindings: SourceBindings,
@@ -1785,6 +2805,8 @@ surfaces:
         ImportSourceWithCredentialsCommand {
             manifest_yaml,
             bindings,
+            identity_bindings: BTreeMap::new(),
+            replace_identity_bindings: false,
             oauth_credential_retrievals,
         }
     }
@@ -1880,6 +2902,36 @@ surfaces:
         assert!(message.contains(expected), "unexpected error: {message}");
     }
 
+    fn installed_source_with_identity_bindings(
+        source_name: SourceName,
+        identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+    ) -> InstalledSource {
+        InstalledSource {
+            name: source_name,
+            version: Some("0.1.0".to_string()),
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            identity_bindings,
+            origin: SourceOrigin::Imported,
+        }
+    }
+
+    fn source_rollback_state_with_identity_binding(
+        source_name: SourceName,
+        manifest_yaml: String,
+        binding: SourceIdentityBinding,
+    ) -> SourceRollbackState {
+        SourceRollbackState {
+            source: installed_source_with_identity_bindings(
+                source_name,
+                BTreeMap::from([("rest".to_string(), binding)]),
+            ),
+            manifest_yaml: Some(manifest_yaml),
+            credential_material: None,
+        }
+    }
+
     /// A plain (no v4 features) source manager over a fresh app layout.
     struct ManagerFixture {
         _temp: TempDir,
@@ -1887,6 +2939,77 @@ surfaces:
         credential_store: CredentialStore,
         credential_manager: CredentialManager,
         manager: SourceManager,
+    }
+
+    type RegistryRecordKey = (String, String);
+    type RegistryRecords = BTreeMap<RegistryRecordKey, SourceRegistryRecord>;
+
+    #[derive(Debug, Default)]
+    struct StaticSourceRegistry {
+        records: Mutex<RegistryRecords>,
+    }
+
+    impl StaticSourceRegistry {
+        fn with_records(records: Vec<SourceRegistryRecord>) -> Self {
+            Self {
+                records: Mutex::new(
+                    records
+                        .into_iter()
+                        .map(|record| {
+                            (
+                                (record.workspace_id.clone(), record.source_name.clone()),
+                                record,
+                            )
+                        })
+                        .collect(),
+                ),
+            }
+        }
+
+        fn records(&self) -> Result<MutexGuard<'_, RegistryRecords>, AppError> {
+            self.records.lock().map_err(|_error| {
+                AppError::FailedPrecondition("source registry records lock poisoned".to_string())
+            })
+        }
+    }
+
+    impl SourceRegistry for StaticSourceRegistry {
+        fn list_workspace_sources(
+            &self,
+            workspace_id: &str,
+        ) -> Result<Vec<SourceRegistryRecord>, AppError> {
+            Ok(self
+                .records()?
+                .values()
+                .filter(|record| record.workspace_id == workspace_id)
+                .cloned()
+                .collect())
+        }
+
+        fn get_source(
+            &self,
+            workspace_id: &str,
+            source_name: &str,
+        ) -> Result<Option<SourceRegistryRecord>, AppError> {
+            Ok(self
+                .records()?
+                .get(&(workspace_id.to_string(), source_name.to_string()))
+                .cloned())
+        }
+
+        fn upsert_source(&self, record: SourceRegistryRecord) -> Result<(), AppError> {
+            self.records()?.insert(
+                (record.workspace_id.clone(), record.source_name.clone()),
+                record,
+            );
+            Ok(())
+        }
+
+        fn remove_source(&self, workspace_id: &str, source_name: &str) -> Result<(), AppError> {
+            self.records()?
+                .remove(&(workspace_id.to_string(), source_name.to_string()));
+            Ok(())
+        }
     }
 
     impl ManagerFixture {
@@ -1930,6 +3053,30 @@ surfaces:
         manager_fixture_with_store(|layout| CredentialStore::new(layout.clone()))
     }
 
+    fn manager_fixture_with_source_registry(
+        source_registry: Arc<dyn SourceRegistry>,
+    ) -> ManagerFixture {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store.clone());
+        let manager = SourceManager::new_with_features_and_source_registry(
+            source_registry,
+            credential_manager.clone(),
+            layout.clone(),
+            Features::default(),
+        );
+        ManagerFixture {
+            _temp: temp,
+            layout,
+            credential_store,
+            credential_manager,
+            manager,
+        }
+    }
+
     fn manager_fixture_with_store(
         credential_store: impl FnOnce(&AppStateLayout) -> CredentialStore,
     ) -> ManagerFixture {
@@ -1951,6 +3098,23 @@ surfaces:
             credential_manager,
             manager,
         }
+    }
+
+    fn manifest_v4_with_variable_input() -> String {
+        r#"
+name: secured_messages_v4
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    inputs:
+      API_BASE:
+        kind: variable
+    base_url: "{{input.API_BASE}}"
+"#
+        .to_string()
     }
 
     fn manifest_with_templated_oauth_endpoints(
@@ -2055,6 +3219,7 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: vec!["OTHER_TOKEN".to_string()],
                     credential_storage: Some(CredentialStorageKind::Keychain),
+                    identity_bindings: BTreeMap::new(),
                     origin: SourceOrigin::Imported,
                 },
             )
@@ -2099,6 +3264,54 @@ surfaces:
                 .iter()
                 .any(|source| source.name.as_str() == "github_v4")
         );
+    }
+
+    #[test]
+    fn get_source_info_loads_imported_manifest_yaml_from_registry_record() {
+        let source_name = SourceName::parse("registry_messages").expect("source");
+        let manifest_yaml = r"
+name: registry_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Registry-backed messages
+    request:
+      path: /messages
+    columns:
+      - name: id
+        type: Utf8
+";
+        let fixture = manager_fixture_with_source_registry(Arc::new(
+            StaticSourceRegistry::with_records(vec![SourceRegistryRecord {
+                workspace_id: default_workspace().as_str().to_string(),
+                source_name: source_name.as_str().to_string(),
+                version: Some("0.1.0".to_string()),
+                manifest_yaml: Some(manifest_yaml.to_string()),
+                variables: BTreeMap::new(),
+                secrets: Vec::new(),
+                credential_storage: None,
+                identity_bindings: BTreeMap::new(),
+                origin: SourceRegistryOrigin::Imported,
+            }]),
+        ));
+        assert!(
+            !fixture
+                .layout
+                .manifest_file(&default_workspace(), &source_name)
+                .exists(),
+            "test should prove source info does not require a local manifest file"
+        );
+
+        let info = fixture
+            .manager
+            .get_source_info(&default_workspace(), &source_name)
+            .expect("registry manifest should describe source");
+
+        assert_eq!(info.name, source_name);
+        assert_eq!(info.version.as_deref(), Some("0.1.0"));
     }
 
     #[test]
@@ -2155,6 +3368,8 @@ surfaces:
                     manifest_yaml: manifest_without_secrets()
                         .replace("public_messages", "github_v4_rest"),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("install existing source");
@@ -2170,6 +3385,8 @@ surfaces:
                         "rest",
                     ),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect_err("surface namespace should collide with installed source schema");
@@ -2189,6 +3406,362 @@ surfaces:
                 .v4_materialized_dir(&default_workspace(), &rejected_source)
                 .exists(),
             "rejected source should not materialize artifacts"
+        );
+    }
+
+    #[test]
+    fn import_with_preflight_reuses_v4_materialization() {
+        let fixture = v4_import_fixture(&v4_openapi_fixture());
+        let manifest_yaml = fixture.manifest(manifest_v4_with_file_descriptor);
+        let command = import_command(manifest_yaml, SourceBindings::default());
+
+        let preflight = fixture
+            .manager
+            .preflight_import_source(&default_workspace(), &command)
+            .expect("preflight v4 source");
+        std::fs::remove_file(&fixture.openapi_file).expect("remove authored descriptor");
+        let (installed, rollback) = fixture
+            .manager
+            .import_source_with_rollback_state_after_preflight(
+                &default_workspace(),
+                &command,
+                Some(preflight),
+            )
+            .expect("import v4 source with preflight materialization");
+        fixture
+            .manager
+            .commit_import_source_rollback_state(rollback, &[]);
+
+        assert_eq!(installed.name.as_str(), "github_v4_test");
+        assert!(
+            fixture
+                .layout
+                .v4_materialized_dir(&default_workspace(), &installed.name)
+                .join("fingerprint.yaml")
+                .exists(),
+            "preflight materialization should be moved into the installed source"
+        );
+    }
+
+    #[test]
+    fn import_rollback_restores_previous_v4_materialization() {
+        let fixture = v4_import_fixture(&v4_openapi_fixture());
+        let initial_manifest = fixture.manifest(manifest_v4_with_file_descriptor);
+        fixture
+            .manager
+            .import_source(
+                &default_workspace(),
+                &import_command(initial_manifest, SourceBindings::default()),
+            )
+            .expect("initial import");
+
+        let replacement_descriptor = TempDir::new().expect("replacement descriptor dir");
+        let replacement_yaml = v4_openapi_fixture_with_metadata();
+        let replacement_file = replacement_descriptor.path().join("github-openapi.yaml");
+        std::fs::write(&replacement_file, &replacement_yaml).expect("write replacement");
+        let replacement_manifest = manifest_v4_with_file_descriptor(
+            &replacement_file,
+            &sha256_hex(replacement_yaml.as_bytes()),
+        );
+        let replacement_command =
+            import_command(replacement_manifest.clone(), SourceBindings::default());
+        let source_name = SourceName::parse("github_v4_test").expect("source");
+        let (replaced, rollback) = fixture
+            .manager
+            .import_source_with_rollback_state(&default_workspace(), &replacement_command)
+            .expect("replacement import");
+
+        fixture.manager.restore_import_source_rollback_state(
+            &default_workspace(),
+            rollback,
+            Some(&replaced),
+        );
+
+        let info = fixture
+            .manager
+            .get_source_info(&default_workspace(), &source_name)
+            .expect("rolled-back v4 source should be usable");
+        assert_eq!(info.name.as_str(), "github_v4_test");
+    }
+
+    #[test]
+    fn import_rollback_removes_new_source_config() {
+        let fixture = v4_import_fixture(&v4_openapi_fixture());
+        let manifest = fixture.manifest(manifest_v4_with_file_descriptor);
+        let command = import_command(manifest.clone(), SourceBindings::default());
+        let source_name = SourceName::parse("github_v4_test").expect("source");
+        let (installed, rollback) = fixture
+            .manager
+            .import_source_with_rollback_state(&default_workspace(), &command)
+            .expect("import source");
+
+        fixture.manager.restore_import_source_rollback_state(
+            &default_workspace(),
+            rollback,
+            Some(&installed),
+        );
+
+        assert!(
+            fixture
+                .manager
+                .list_workspace_sources(&default_workspace())
+                .expect("list sources")
+                .is_empty(),
+            "rollback of a new source should remove source config"
+        );
+        assert!(
+            !fixture
+                .layout
+                .v4_materialized_dir(&default_workspace(), &source_name)
+                .exists(),
+            "rollback of a new source should remove materialized artifacts"
+        );
+    }
+
+    #[test]
+    fn import_rollback_skips_restore_when_current_source_changed() {
+        let fixture = manager_fixture();
+        let source_name = SourceName::parse("rollback_messages").expect("source");
+        let manifest = |version: &str, description: &str| {
+            http_manifest(
+                &format!(
+                    r#"
+name: rollback_messages
+version: {version}
+dsl_version: 3
+backend: http
+base_url: "https://example.com"
+"#
+                ),
+                description,
+            )
+        };
+        let initial_command = import_command(
+            manifest("0.1.0", "Initial messages"),
+            SourceBindings::default(),
+        );
+        let (_initial, initial_rollback) = fixture
+            .manager
+            .import_source_with_rollback_state(&default_workspace(), &initial_command)
+            .expect("initial import");
+        fixture
+            .manager
+            .commit_import_source_rollback_state(initial_rollback, &[]);
+        let stale_command = import_command(
+            manifest("0.2.0", "Stale messages"),
+            SourceBindings::default(),
+        );
+        let (stale_source, stale_rollback) = fixture
+            .manager
+            .import_source_with_rollback_state(&default_workspace(), &stale_command)
+            .expect("stale import");
+        let current_command = import_command(
+            manifest("0.3.0", "Current messages"),
+            SourceBindings::default(),
+        );
+        let (_current, current_rollback) = fixture
+            .manager
+            .import_source_with_rollback_state(&default_workspace(), &current_command)
+            .expect("current import");
+        fixture
+            .manager
+            .commit_import_source_rollback_state(current_rollback, &[]);
+
+        fixture.manager.restore_import_source_rollback_state(
+            &default_workspace(),
+            stale_rollback,
+            Some(&stale_source),
+        );
+
+        let current = fixture
+            .manager
+            .get_source(&default_workspace(), &source_name)
+            .expect("current source should remain installed");
+        assert_eq!(current.version.as_deref(), Some("0.3.0"));
+    }
+
+    #[test]
+    fn import_v4_source_with_identity_binding_fails_closed_without_query_resolver() {
+        let fixture = v4_import_fixture(&v4_openapi_fixture());
+        let mut command = import_command(
+            fixture.manifest(manifest_v4_with_identity_requirement),
+            SourceBindings::default(),
+        );
+        command
+            .identity_bindings
+            .insert("rest".to_string(), SourceIdentityBinding::user_owned());
+
+        let error = fixture
+            .manager
+            .import_source(&default_workspace(), &command)
+            .expect_err("identity-backed v4 source import should fail closed");
+
+        assert_error_contains(&error, "request identity resolution is not installed");
+        assert!(
+            fixture
+                .manager
+                .list_workspace_sources(&default_workspace())
+                .expect("list sources")
+                .is_empty(),
+            "failed identity-backed import must not persist the source"
+        );
+    }
+
+    #[test]
+    fn replacing_user_owned_identity_bindings_removes_stale_user_selections() {
+        let fixture = v4_import_fixture(&v4_openapi_fixture());
+        let source_name = SourceName::parse("github_v4_test").expect("source");
+        let previous_manifest = fixture.manifest(manifest_v4_with_identity_requirement);
+        let current_manifest =
+            parse_source_manifest_yaml(&fixture.manifest(manifest_v4_with_file_descriptor))
+                .expect("current manifest");
+        let previous = source_rollback_state_with_identity_binding(
+            source_name.clone(),
+            previous_manifest,
+            SourceIdentityBinding::user_owned(),
+        );
+        let stored = installed_source_with_identity_bindings(source_name, BTreeMap::new());
+
+        let stale = stale_user_binding_surfaces(Some(&previous), &stored, &current_manifest);
+
+        assert_eq!(stale, vec!["rest".to_string()]);
+    }
+
+    #[test]
+    fn reimport_with_changed_user_owned_requirements_removes_stale_user_selections() {
+        let fixture = v4_import_fixture(&v4_openapi_fixture());
+        let source_name = SourceName::parse("github_v4_test").expect("source");
+        let previous_manifest = fixture.manifest(|openapi_file, sha256| {
+            manifest_v4_with_identity_requirement_ids(openapi_file, sha256, "github-rest-read")
+        });
+        let current_manifest =
+            parse_source_manifest_yaml(&fixture.manifest(|openapi_file, sha256| {
+                manifest_v4_with_identity_requirement_ids(openapi_file, sha256, "github-rest-write")
+            }))
+            .expect("current manifest");
+        let binding = SourceIdentityBinding::user_owned();
+        let previous = source_rollback_state_with_identity_binding(
+            source_name.clone(),
+            previous_manifest,
+            binding.clone(),
+        );
+        let stored = installed_source_with_identity_bindings(
+            source_name,
+            BTreeMap::from([("rest".to_string(), binding)]),
+        );
+
+        let stale = stale_user_binding_surfaces(Some(&previous), &stored, &current_manifest);
+
+        assert_eq!(stale, vec!["rest".to_string()]);
+    }
+
+    #[test]
+    fn commit_import_preserves_rebound_stale_user_identity_selection() {
+        let fixture = manager_fixture();
+        let source_name = SourceName::parse("github_v4_test").expect("source");
+        let rest_binding_path = fixture.layout.user_owned_source_identity_binding_file(
+            "saul",
+            &default_workspace(),
+            &source_name,
+            "rest",
+        );
+        let graphql_binding_path = fixture.layout.user_owned_source_identity_binding_file(
+            "saul",
+            &default_workspace(),
+            &source_name,
+            "graphql",
+        );
+        let other_user_rest_binding_path = fixture.layout.user_owned_source_identity_binding_file(
+            "ada",
+            &default_workspace(),
+            &source_name,
+            "rest",
+        );
+        for path in [
+            &rest_binding_path,
+            &graphql_binding_path,
+            &other_user_rest_binding_path,
+        ] {
+            std::fs::create_dir_all(path.parent().expect("binding parent"))
+                .expect("create binding parent");
+            std::fs::write(path, "version: 1\nidentity: github_saul\n").expect("write binding");
+        }
+        let rest_binding_dir = rest_binding_path
+            .parent()
+            .expect("rest binding dir")
+            .to_path_buf();
+        let graphql_binding_dir = graphql_binding_path
+            .parent()
+            .expect("graphql binding dir")
+            .to_path_buf();
+        let other_user_rest_binding_dir = other_user_rest_binding_path
+            .parent()
+            .expect("other user rest binding dir")
+            .to_path_buf();
+        let rollback = SourceImportRollbackState {
+            workspace_name: default_workspace(),
+            source_name: source_name.clone(),
+            installed_record: record_from_installed_source(
+                &default_workspace(),
+                installed_source_with_identity_bindings(source_name, BTreeMap::new()),
+            ),
+            installed_manifest_yaml: None,
+            previous: None,
+            materialization_rollback: SourceMaterializationRollbackState::Unchanged,
+            stale_user_binding_surfaces: vec!["rest".to_string(), "graphql".to_string()],
+        };
+
+        fixture.manager.commit_import_source_rollback_state(
+            rollback,
+            &[PreservedUserSourceIdentityBinding {
+                user_id: "saul".to_string(),
+                surface_id: "rest".to_string(),
+            }],
+        );
+
+        assert!(
+            rest_binding_dir.exists(),
+            "commit cleanup should preserve explicitly rebound user selections"
+        );
+        assert!(
+            !graphql_binding_dir.exists(),
+            "commit cleanup should remove stale user selections that were not rebound"
+        );
+        assert!(
+            !other_user_rest_binding_dir.exists(),
+            "commit cleanup should remove other users' stale selections for rebound surfaces"
+        );
+    }
+
+    #[test]
+    fn import_v4_source_requires_identity_binding_when_declared() {
+        let fixture = v4_import_fixture(&v4_openapi_fixture());
+
+        let error = fixture
+            .import(manifest_v4_with_identity_requirement)
+            .expect_err("identity-backed v4 source should require a binding");
+
+        assert_error_contains(&error, "no identity binding was provided");
+    }
+
+    #[test]
+    fn import_v4_source_rejects_derived_base_url_input_token_defaults() {
+        let fixture = v4_import_fixture(&v4_openapi_fixture_with_defaulted_input_server_url());
+
+        let error = fixture
+            .import(manifest_v4_with_input_and_derived_base_url)
+            .expect_err("source add should reject derived base_url input token defaults");
+
+        assert_error_contains(&error, "derived OpenAPI server base_url input token");
+        assert!(
+            !fixture
+                .layout
+                .v4_materialized_dir(
+                    &default_workspace(),
+                    &SourceName::parse("github_v4_test").expect("source")
+                )
+                .exists(),
+            "failed materialization should not install artifacts"
         );
     }
 
@@ -2225,27 +3798,6 @@ surfaces:
         assert!(
             event_rx.try_recv().is_err(),
             "feature gate should fail before import events"
-        );
-    }
-
-    #[test]
-    fn import_v4_source_rejects_derived_base_url_input_token_defaults() {
-        let fixture = v4_import_fixture(&v4_openapi_fixture_with_defaulted_input_server_url());
-
-        let error = fixture
-            .import(manifest_v4_with_input_and_derived_base_url)
-            .expect_err("source add should reject derived base_url input token defaults");
-
-        assert_error_contains(&error, "derived OpenAPI server base_url input token");
-        assert!(
-            !fixture
-                .layout
-                .v4_materialized_dir(
-                    &default_workspace(),
-                    &SourceName::parse("github_v4_test").expect("source")
-                )
-                .exists(),
-            "failed materialization should not install artifacts"
         );
     }
 
@@ -2515,6 +4067,81 @@ surfaces:
                 .expect("list sources")
                 .is_empty(),
             "source config should be removed"
+        );
+    }
+
+    #[test]
+    fn delete_source_uses_registry_imported_manifest_snapshot() {
+        let manifest_yaml = manifest_without_secrets();
+        let source_name = SourceName::parse("public_messages").expect("source");
+        let registry = Arc::new(StaticSourceRegistry::with_records(vec![
+            SourceRegistryRecord {
+                workspace_id: default_workspace().as_str().to_string(),
+                source_name: source_name.as_str().to_string(),
+                version: Some("0.1.0".to_string()),
+                manifest_yaml: Some(manifest_yaml),
+                variables: BTreeMap::new(),
+                secrets: Vec::new(),
+                credential_storage: None,
+                identity_bindings: BTreeMap::new(),
+                origin: SourceRegistryOrigin::Imported,
+            },
+        ]));
+        let fixture = manager_fixture_with_source_registry(registry.clone());
+        assert!(
+            !fixture
+                .layout
+                .manifest_file(&default_workspace(), &source_name)
+                .exists(),
+            "test should prove delete does not require a local manifest file"
+        );
+
+        let deleted = fixture
+            .manager
+            .delete_source(&default_workspace(), &source_name)
+            .expect("delete registry-backed source");
+
+        assert_eq!(deleted.name, source_name);
+        assert_eq!(deleted.version.as_deref(), Some("0.1.0"));
+        assert!(
+            registry
+                .get_source(default_workspace().as_str(), source_name.as_str())
+                .expect("read registry source")
+                .is_none(),
+            "delete should remove the registry record"
+        );
+    }
+
+    #[test]
+    fn delete_source_removes_user_source_identity_bindings() {
+        let fixture = manager_fixture();
+        let source_name = SourceName::parse("secured_messages").expect("source");
+        import_secured(&fixture.manager, api_token_bindings("secret-token"))
+            .expect("initial import");
+        let binding_path = fixture.layout.user_owned_source_identity_binding_file(
+            "saul",
+            &default_workspace(),
+            &source_name,
+            "rest",
+        );
+        std::fs::create_dir_all(binding_path.parent().expect("binding parent"))
+            .expect("create binding parent");
+        std::fs::write(&binding_path, "version: 1\nidentity: github_saul\n")
+            .expect("write binding");
+        let source_binding_dir = binding_path
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("source binding dir")
+            .to_path_buf();
+
+        fixture
+            .manager
+            .delete_source(&default_workspace(), &source_name)
+            .expect("delete source");
+
+        assert!(
+            !source_binding_dir.exists(),
+            "delete should remove user source identity bindings for the source"
         );
     }
 

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -553,10 +553,10 @@ pub(crate) fn incompatible_materialization_error(
     source_name: &SourceName,
     detail: impl AsRef<str>,
 ) -> AppError {
-    AppError::MissingOrIncompatibleV4Materialization {
-        source_name: source_name.to_string(),
-        detail: detail.as_ref().to_string(),
-    }
+    AppError::SourceUnservable(format!(
+        "source '{source_name}' has missing or incompatible DSL v4 materialized artifacts: {}. Re-add the source to regenerate them.",
+        detail.as_ref()
+    ))
 }
 
 fn write_materialization(
@@ -679,7 +679,6 @@ fn materialize_surface(
     surface: &coral_spec::v4::V4Surface,
     inputs: &MaterializationInputs,
 ) -> Result<MaterializedSurfaceBuild, AppError> {
-    reject_unsupported_identity_requirements(manifest, surface)?;
     match surface.surface_type {
         SurfaceType::OpenApi => materialize_openapi_surface(manifest, surface),
         SurfaceType::Mcp => materialize_mcp_surface(manifest, surface, inputs),
@@ -802,20 +801,6 @@ fn app_error_from_core(error: coral_engine::CoreError) -> AppError {
         other => AppError::FailedPrecondition(other.to_string()),
     }
 }
-
-fn reject_unsupported_identity_requirements(
-    manifest: &V4SourceManifest,
-    surface: &coral_spec::v4::V4Surface,
-) -> Result<(), AppError> {
-    if surface.identity_requirements.is_none() {
-        return Ok(());
-    }
-    Err(AppError::FailedPrecondition(format!(
-        "source '{}' surface '{}' declares identity_requirements, but this build does not support DSL v4 identity binding for source import",
-        manifest.common.name, surface.id
-    )))
-}
-
 fn validate_materialized_surface_base_url(
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
@@ -1611,54 +1596,6 @@ surfaces:
 
         assert!(
             error.to_string().contains("expected aaaaaa"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[test]
-    fn build_v4_materialization_rejects_identity_requirements_without_binding_support() {
-        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
-        let openapi_file = descriptor_temp.path().join("openapi.yaml");
-        std::fs::write(&openapi_file, openapi_fixture()).expect("write descriptor");
-        let state_temp = TempDir::new().expect("state temp dir");
-        let layout =
-            AppStateLayout::discover(Some(state_temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let manifest_yaml = format!(
-            r"
-name: github_v4_materialization_test
-dsl_version: 4
-surfaces:
-  - id: rest
-    type: openapi
-    file: {}
-    sha256: {}
-    identity_requirements:
-      accepts:
-        - id: github-rest-read
-          identity_specs: [github_oauth]
-    base_url: https://api.example.com
-",
-            openapi_file.display(),
-            sha256_hex(openapi_fixture().as_bytes())
-        );
-        let manifest = parse_v4_manifest(&manifest_yaml);
-
-        let error = build_v4_materialization_tmp(
-            &layout,
-            &workspace_name(),
-            &source_name(),
-            &manifest_yaml,
-            &manifest,
-            &MaterializationInputs::default(),
-            "test",
-        )
-        .expect_err("identity requirements should fail closed");
-
-        assert!(
-            error
-                .to_string()
-                .contains("does not support DSL v4 identity binding"),
             "unexpected error: {error}"
         );
     }

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -6,6 +6,7 @@ use coral_spec::ManifestInputSpec;
 use serde::{Deserialize, Serialize};
 
 use crate::credentials::CredentialStorageKind;
+use crate::identity::SourceIdentityBinding;
 use crate::sources::SourceName;
 
 /// App-owned description of a source candidate that can be installed.
@@ -43,6 +44,9 @@ pub(crate) struct InstalledSource {
     /// storage until the source is removed and re-added.
     #[serde(default)]
     pub(crate) credential_storage: Option<CredentialStorageKind>,
+    /// Source-local DSL v4 surface identity bindings for this workspace.
+    #[serde(default)]
+    pub(crate) identity_bindings: BTreeMap<String, SourceIdentityBinding>,
     /// Where this installed source came from.
     pub(crate) origin: SourceOrigin,
 }

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -32,9 +32,17 @@ pub(crate) fn runtime_components_for_v4_source(
         match surface.surface_type {
             SurfaceType::OpenApi => {
                 let http_manifest = http_manifest_for_surface(manifest, materialized, &surface.id)?;
-                components.push(RuntimeSourceComponent::Http(
-                    RuntimeHttpSourceComponent::new(http_manifest),
-                ));
+                let http_component =
+                    if let Some(identity_requirements) = surface.identity_requirements.clone() {
+                        RuntimeHttpSourceComponent::with_identity_requirements(
+                            http_manifest,
+                            surface.id.clone(),
+                            identity_requirements,
+                        )
+                    } else {
+                        RuntimeHttpSourceComponent::new(http_manifest)
+                    };
+                components.push(RuntimeSourceComponent::Http(http_component));
             }
             SurfaceType::Mcp => {
                 components.push(RuntimeSourceComponent::Mcp(mcp_manifest_for_surface(
@@ -159,7 +167,7 @@ fn http_manifest_for_surface(
         rate_limit: openapi_runtime.rate_limit.clone(),
         tables,
         functions,
-        declared_inputs: manifest.declared_inputs.clone(),
+        declared_inputs: surface.inputs.clone(),
     })
 }
 

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -1,32 +1,41 @@
 //! Implements the gRPC `SourceService` for source lifecycle APIs.
 
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use crate::identity::{
+    SourceIdentityBinding as AppSourceIdentityBinding,
+    SourceIdentityOwner as AppSourceIdentityOwner,
+    SourceIdentitySelection as AppSourceIdentitySelection,
+};
 use coral_api::v1::source_service_server::SourceService as SourceServiceApi;
 use coral_api::v1::{
     CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
     CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DeleteSourceResponse,
     DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest, GetSourceInfoResponse,
-    GetSourceRequest, GetSourceResponse, ImportSourceRequest, ImportSourceResponse,
-    ListSourcesRequest, ListSourcesResponse, OAuthCredentialClient, OAuthCredentialClientId,
-    OAuthCredentialClientSecret, OAuthCredentialEndpoints, OAuthCredentialInput,
-    OAuthCredentialMethod, OAuthCredentialRetrieval, OAuthCredentialScope, OAuthCredentialScopes,
-    OauthCredentialClientSecretTransport, OauthCredentialFlowType, OauthCredentialPkceMode,
-    OauthCredentialRedirectUriPortMode, OauthCredentialScopeDelimiter, Source,
-    SourceConfigCredentialMethod, SourceCredential, SourceCredentialMethod,
-    SourceCredentialStorage as ProtoSourceCredentialStorage, SourceInfo, SourceInputSpec,
+    GetSourceRequest, GetSourceResponse, IdentitySpecImportInputs, ImportSourceRequest,
+    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, OAuthCredentialClient,
+    OAuthCredentialClientId, OAuthCredentialClientSecret, OAuthCredentialEndpoints,
+    OAuthCredentialInput, OAuthCredentialMethod, OAuthCredentialRetrieval, OAuthCredentialScope,
+    OAuthCredentialScopes, OauthCredentialClientSecretTransport, OauthCredentialFlowType,
+    OauthCredentialPkceMode, OauthCredentialRedirectUriPortMode, OauthCredentialScopeDelimiter,
+    Source, SourceConfigCredentialMethod, SourceCredential, SourceCredentialMethod,
+    SourceCredentialStorage as ProtoSourceCredentialStorage,
+    SourceIdentityBinding as ProtoSourceIdentityBinding,
+    SourceIdentityOwner as ProtoSourceIdentityOwner, SourceInfo, SourceInputSpec,
     SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceSecretInput, SourceVariable,
-    SourceVariableInput, ValidateSourceRequest, ValidateSourceResponse,
-    create_bundled_source_with_o_auth_response, import_source_response,
-    source_credential_method::Method as ProtoCredentialMethod,
+    SourceVariableInput, UserSourceIdentityBinding as ProtoUserSourceIdentityBinding,
+    ValidateSourceRequest, ValidateSourceResponse, create_bundled_source_with_o_auth_response,
+    import_source_response, source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_spec::{
     ManifestCredentialMethodKind, ManifestCredentialSpec, ManifestInputKind, ManifestInputSpec,
     ManifestOAuthClientSecretTransport, ManifestOAuthCredentialSpec, ManifestOAuthFlowKind,
     ManifestOAuthPkceMode, ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter,
+    parse_identity_manifest_yaml, parse_source_manifest_yaml,
 };
 use tonic::{Request, Response, Status};
 
@@ -34,13 +43,15 @@ use crate::authorization::{ManagementAuthorizer, SourceMutationKind, authorizati
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
 use crate::credentials::oauth::{OAuthProgressEvent, OAuthProgressEventSender};
-use crate::identity::UserPrincipalProvider;
+use crate::identities::UserOwnedIdentityManager;
+use crate::identity::{UserPrincipal, UserPrincipalProvider};
+use crate::identity_specs::{IdentitySpecInputValue, IdentitySpecManager, IdentitySpecSnapshot};
 use crate::query::manager::QueryManager;
 use crate::sources::SourceName;
 use crate::sources::manager::{
     CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
-    ImportSourceWithCredentialsCommand, SourceBinding, SourceBindings, SourceManager,
-    SourceOAuthCredentialRetrieval,
+    ImportSourceWithCredentialsCommand, PreservedUserSourceIdentityBinding, SourceBinding,
+    SourceBindings, SourceImportRollbackState, SourceManager, SourceOAuthCredentialRetrieval,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::transport::{
@@ -51,11 +62,14 @@ use crate::transport::{
 use crate::workspaces::WorkspaceName;
 use tokio_stream::Stream;
 use tokio_stream::StreamExt as _;
+use tracing::warn;
 
 #[derive(Clone)]
 pub(crate) struct SourceService {
     sources: SourceManager,
     queries: QueryManager,
+    identity_specs: IdentitySpecManager,
+    user_owned_identities: UserOwnedIdentityManager,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
 }
@@ -64,12 +78,16 @@ impl SourceService {
     pub(crate) fn new(
         source_manager: SourceManager,
         query_manager: QueryManager,
+        identity_spec_manager: IdentitySpecManager,
+        user_owned_identity_manager: UserOwnedIdentityManager,
         user_principal_provider: Arc<dyn UserPrincipalProvider>,
         management_authorizer: Arc<dyn ManagementAuthorizer>,
     ) -> Self {
         Self {
             sources: source_manager,
             queries: query_manager,
+            identity_specs: identity_spec_manager,
+            user_owned_identities: user_owned_identity_manager,
             user_principal_provider,
             management_authorizer,
         }
@@ -267,59 +285,95 @@ impl SourceServiceApi for SourceService {
         request: Request<ImportSourceRequest>,
     ) -> Result<Response<Self::ImportSourceStream>, Status> {
         let sources = self.sources.clone();
+        let identity_specs = self.identity_specs.clone();
+        let user_owned_identities = self.user_owned_identities.clone();
         let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
-            |principal, request| async move {
+            |user_principal, request| async move {
                 let span = tracing::Span::current();
-                let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-                let mutation_kind = if request.oauth_credential_retrievals.is_empty() {
-                    SourceMutationKind::Import
-                } else {
-                    SourceMutationKind::ImportWithOAuth
-                };
-                management_authorizer
-                    .authorize_source_mutation(&principal, workspace_name.as_str(), mutation_kind)
-                    .await
-                    .map_err(authorization_status)?;
+                let ImportSourceRequest {
+                    workspace,
+                    manifest_yaml,
+                    variables,
+                    secrets,
+                    oauth_credential_retrievals,
+                    identity_spec_manifest_yamls,
+                    identity_spec_inputs: proto_identity_spec_inputs,
+                    identity_bindings: proto_identity_bindings,
+                    user_identity_bindings: proto_user_identity_bindings,
+                    replace_identity_bindings,
+                } = request;
+                let workspace_name = workspace_name_from_proto(workspace.as_ref())?;
+                authorize_import_source_request(
+                    management_authorizer.as_ref(),
+                    &user_principal,
+                    &workspace_name,
+                    !oauth_credential_retrievals.is_empty(),
+                    !identity_spec_manifest_yamls.is_empty()
+                        || !proto_identity_spec_inputs.is_empty(),
+                )
+                .await?;
                 let response_workspace_name = workspace_name.clone();
-                reject_unsupported_import_identity_fields(&request).map_err(app_status)?;
-                if request.oauth_credential_retrievals.is_empty() {
+                let identity_bindings =
+                    source_identity_bindings_from_proto(proto_identity_bindings)
+                        .map_err(app_status)?;
+                let user_identity_bindings =
+                    user_source_identity_bindings_from_proto(proto_user_identity_bindings)
+                        .map_err(app_status)?;
+                let identity_context = ImportSourceIdentityContext {
+                    identity_specs,
+                    user_owned_identities,
+                    manifest_yamls: identity_spec_manifest_yamls,
+                    inputs: identity_spec_import_inputs_from_proto(proto_identity_spec_inputs)
+                        .map_err(app_status)?,
+                    // The request principal matters only when user-owned
+                    // selections were supplied.
+                    user_principal: (!user_identity_bindings.is_empty()).then_some(user_principal),
+                    user_identity_bindings,
+                };
+                let bindings = source_bindings_from_proto(variables, secrets);
+                if oauth_credential_retrievals.is_empty() {
                     let command = ImportSourceCommand {
-                        manifest_yaml: request.manifest_yaml,
-                        bindings: source_bindings_from_proto(request.variables, request.secrets),
+                        manifest_yaml,
+                        bindings,
+                        identity_bindings,
+                        replace_identity_bindings,
                     };
-                    let installed = run_blocking_operation("source operation", move || {
-                        sources.import_source(&workspace_name, &command)
-                    })
-                    .await?;
-                    return Ok(single_import_source_response(
+                    return import_source_without_credentials(
+                        sources,
+                        identity_context,
+                        workspace_name,
                         &response_workspace_name,
-                        installed,
-                    ));
+                        command,
+                    )
+                    .await;
                 }
                 let command = ImportSourceWithCredentialsCommand {
-                    manifest_yaml: request.manifest_yaml,
-                    bindings: source_bindings_from_proto(request.variables, request.secrets),
-                    oauth_credential_retrievals: request
-                        .oauth_credential_retrievals
+                    manifest_yaml,
+                    bindings,
+                    oauth_credential_retrievals: oauth_credential_retrievals
                         .into_iter()
                         .map(oauth_credential_retrieval_from_proto)
                         .collect::<Result<Vec<_>, _>>()
                         .map_err(app_status)?,
+                    identity_bindings,
+                    replace_identity_bindings,
                 };
                 let stream =
                     import_source_response_stream(response_workspace_name, move |event_sender| {
                         instrument_grpc(span, async move {
-                            sources
-                                .import_source_with_credentials(
-                                    &workspace_name,
-                                    command,
-                                    event_sender,
-                                )
-                                .await
-                                .map_err(app_status)
+                            let installed = import_source_with_credentials_and_identity_specs(
+                                &sources,
+                                &identity_context,
+                                &workspace_name,
+                                command,
+                                event_sender,
+                            )
+                            .await
+                            .map_err(app_status)?;
+                            Ok(installed)
                         })
                     });
                 Ok(Response::new(stream))
@@ -366,11 +420,11 @@ impl SourceServiceApi for SourceService {
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
-            |_principal, request| async move {
+            |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
                 let source_name = SourceName::parse(&request.name).map_err(app_status)?;
                 let result = queries
-                    .validate_source(&workspace_name, &source_name)
+                    .validate_source(&workspace_name, &principal, &source_name)
                     .await
                     .map_err(query_status)?;
                 let crate::query::manager::ValidatedSource { source, report } = result;
@@ -384,22 +438,6 @@ impl SourceServiceApi for SourceService {
         )
         .await
     }
-}
-
-fn reject_unsupported_import_identity_fields(
-    request: &ImportSourceRequest,
-) -> Result<(), AppError> {
-    if request.identity_spec_manifest_yamls.is_empty()
-        && request.identity_bindings.is_empty()
-        && request.user_identity_bindings.is_empty()
-        && !request.replace_identity_bindings
-        && request.identity_spec_inputs.is_empty()
-    {
-        return Ok(());
-    }
-    Err(AppError::InvalidInput(
-        "ImportSourceRequest identity import fields are not supported by this build".to_string(),
-    ))
 }
 
 type CreateBundledSourceWithOAuthResponseStreamBox =
@@ -429,6 +467,522 @@ where
     )
 }
 
+async fn run_blocking_app_operation<T, F>(_label: &'static str, operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, AppError> + Send + 'static,
+{
+    let span = tracing::Span::current();
+    tokio::task::spawn_blocking(move || span.in_scope(operation))
+        .await
+        .map_err(AppError::TaskJoin)?
+}
+
+async fn authorize_import_source_request(
+    management_authorizer: &dyn ManagementAuthorizer,
+    user_principal: &UserPrincipal,
+    workspace_name: &WorkspaceName,
+    has_oauth_credential_retrievals: bool,
+    has_identity_spec_mutation: bool,
+) -> Result<(), Status> {
+    let mutation_kind = if has_oauth_credential_retrievals {
+        SourceMutationKind::ImportWithOAuth
+    } else {
+        SourceMutationKind::Import
+    };
+    management_authorizer
+        .authorize_source_mutation(user_principal, workspace_name.as_str(), mutation_kind)
+        .await
+        .map_err(authorization_status)?;
+    if has_identity_spec_mutation {
+        management_authorizer
+            .authorize_identity_spec_mutation(user_principal)
+            .await
+            .map_err(authorization_status)?;
+    }
+    Ok(())
+}
+
+async fn import_source_with_identity_specs(
+    sources: &SourceManager,
+    identity_context: &ImportSourceIdentityContext,
+    workspace_name: &WorkspaceName,
+    command: &ImportSourceCommand,
+) -> Result<InstalledSource, AppError> {
+    let preflight = {
+        // Prove source-side preconditions before mutating global identity specs.
+        let sources = sources.clone();
+        let workspace_name = workspace_name.clone();
+        let command = command.clone();
+        run_blocking_app_operation("source import preflight", move || {
+            sources.preflight_import_source(&workspace_name, &command)
+        })
+        .await?
+    };
+    let mut identity_spec_rollback = install_and_validate_identity_specs_for_import(
+        sources,
+        identity_context.as_import_context(),
+        workspace_name,
+        &command.manifest_yaml,
+        &command.identity_bindings,
+        command.replace_identity_bindings,
+    )
+    .await?;
+    let import_result = {
+        let sources = sources.clone();
+        let workspace_name = workspace_name.clone();
+        let command = command.clone();
+        run_blocking_app_operation("source import", move || {
+            let (source, source_rollback) = sources
+                .import_source_with_rollback_state_after_preflight(
+                    &workspace_name,
+                    &command,
+                    Some(preflight),
+                )?;
+            Ok(SourceImportRollbackGuard::new(
+                &sources,
+                &workspace_name,
+                source_rollback,
+                source,
+            ))
+        })
+        .await
+    };
+    match import_result {
+        Ok(source_rollback) => {
+            persist_bindings_or_rollback(
+                identity_context,
+                workspace_name,
+                source_rollback,
+                &mut identity_spec_rollback,
+            )
+            .await
+        }
+        Err(error) => {
+            identity_spec_rollback.rollback_now();
+            Err(error)
+        }
+    }
+}
+
+async fn import_source_with_credentials_and_identity_specs(
+    sources: &SourceManager,
+    identity_context: &ImportSourceIdentityContext,
+    workspace_name: &WorkspaceName,
+    command: ImportSourceWithCredentialsCommand,
+    event_sender: OAuthProgressEventSender,
+) -> Result<InstalledSource, AppError> {
+    let preflight = {
+        // Prove source-side preconditions before mutating global identity specs.
+        let sources = sources.clone();
+        let workspace_name = workspace_name.clone();
+        let command = command.clone();
+        run_blocking_app_operation("source import preflight", move || {
+            sources.preflight_import_source_with_credentials(&workspace_name, &command)
+        })
+        .await?
+    };
+    let mut identity_spec_rollback = install_and_validate_identity_specs_for_import(
+        sources,
+        identity_context.as_import_context(),
+        workspace_name,
+        &command.manifest_yaml,
+        &command.identity_bindings,
+        command.replace_identity_bindings,
+    )
+    .await?;
+    match sources
+        .import_source_with_credentials_and_rollback_state_after_preflight(
+            workspace_name,
+            command,
+            event_sender,
+            Some(preflight),
+        )
+        .await
+    {
+        Ok((source, source_rollback)) => {
+            let source_rollback =
+                SourceImportRollbackGuard::new(sources, workspace_name, source_rollback, source);
+            persist_bindings_or_rollback(
+                identity_context,
+                workspace_name,
+                source_rollback,
+                &mut identity_spec_rollback,
+            )
+            .await
+        }
+        Err(error) => {
+            identity_spec_rollback.rollback_now();
+            Err(error)
+        }
+    }
+}
+
+async fn persist_bindings_or_rollback(
+    identity_context: &ImportSourceIdentityContext,
+    workspace_name: &WorkspaceName,
+    mut source_rollback: SourceImportRollbackGuard,
+    identity_spec_rollback: &mut IdentitySpecImportRollbackGuard,
+) -> Result<InstalledSource, AppError> {
+    let rebound_user_bindings = identity_context.user_identity_bindings();
+    if let Err(error) = identity_context
+        .persist_bindings(workspace_name, source_rollback.installed())
+        .await
+    {
+        source_rollback.rollback_now();
+        identity_spec_rollback.rollback_now();
+        return Err(error);
+    }
+    identity_spec_rollback.disarm();
+    Ok(source_rollback.disarm(&rebound_user_bindings))
+}
+
+/// Installs the bundled identity specs and validates the user-owned identity
+/// selections, rolling the spec installs back if validation fails.
+async fn install_and_validate_identity_specs_for_import(
+    sources: &SourceManager,
+    identity_import: IdentitySpecImportContext<'_>,
+    workspace_name: &WorkspaceName,
+    manifest_yaml: &str,
+    requested_identity_bindings: &BTreeMap<String, AppSourceIdentityBinding>,
+    replace_identity_bindings: bool,
+) -> Result<IdentitySpecImportRollbackGuard, AppError> {
+    let identity_specs = identity_import.identity_specs.clone();
+    let manifest_yamls = identity_import.manifest_yamls.to_vec();
+    let inputs = identity_import.inputs.to_vec();
+    let mut rollback = run_blocking_app_operation("identity spec import", move || {
+        let rollback_items =
+            install_identity_specs_for_import(&identity_specs, &manifest_yamls, &inputs)?;
+        Ok(IdentitySpecImportRollbackGuard::new(
+            &identity_specs,
+            rollback_items,
+        ))
+    })
+    .await?;
+    if let Err(error) = validate_user_source_identity_import(ValidateUserSourceIdentityImport {
+        sources,
+        identities: identity_import.user_owned_identities,
+        principal: identity_import.user_principal,
+        workspace_name,
+        manifest_yaml,
+        requested_identity_bindings,
+        replace_identity_bindings,
+        user_identity_bindings: identity_import.user_identity_bindings,
+    })
+    .await
+    {
+        rollback.rollback_now();
+        return Err(error);
+    }
+    Ok(rollback)
+}
+
+#[derive(Debug)]
+struct IdentitySpecImportRollback {
+    name: String,
+    previous: Option<IdentitySpecSnapshot>,
+    installed: IdentitySpecSnapshot,
+    pre_import_usage_count: u32,
+}
+
+#[derive(Clone, Debug)]
+struct IdentitySpecImportInputValues {
+    identity_spec_name: String,
+    inputs: Vec<IdentitySpecInputValue>,
+}
+
+struct IdentitySpecImportRollbackGuard {
+    identity_specs: IdentitySpecManager,
+    rollback: Vec<IdentitySpecImportRollback>,
+    armed: bool,
+}
+
+impl IdentitySpecImportRollbackGuard {
+    fn new(
+        identity_specs: &IdentitySpecManager,
+        rollback: Vec<IdentitySpecImportRollback>,
+    ) -> Self {
+        Self {
+            identity_specs: identity_specs.clone(),
+            rollback,
+            armed: true,
+        }
+    }
+
+    fn rollback_now(&mut self) {
+        if !self.armed {
+            return;
+        }
+        self.armed = false;
+        rollback_identity_specs_for_import(
+            &self.identity_specs,
+            std::mem::take(&mut self.rollback),
+        );
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+        self.rollback.clear();
+    }
+}
+
+impl Drop for IdentitySpecImportRollbackGuard {
+    fn drop(&mut self) {
+        self.rollback_now();
+    }
+}
+
+struct SourceImportRollbackGuard {
+    sources: SourceManager,
+    workspace_name: WorkspaceName,
+    rollback: Option<SourceImportRollbackState>,
+    installed: Option<InstalledSource>,
+}
+
+impl SourceImportRollbackGuard {
+    fn new(
+        sources: &SourceManager,
+        workspace_name: &WorkspaceName,
+        rollback: SourceImportRollbackState,
+        installed: InstalledSource,
+    ) -> Self {
+        Self {
+            sources: sources.clone(),
+            workspace_name: workspace_name.clone(),
+            rollback: Some(rollback),
+            installed: Some(installed),
+        }
+    }
+
+    fn installed(&self) -> &InstalledSource {
+        self.installed.as_ref().expect("installed source")
+    }
+
+    fn rollback_now(&mut self) {
+        if let Some(rollback) = self.rollback.take() {
+            self.sources.restore_import_source_rollback_state(
+                &self.workspace_name,
+                rollback,
+                self.installed.as_ref(),
+            );
+        }
+    }
+
+    fn disarm(
+        mut self,
+        preserved_user_bindings: &[PreservedUserSourceIdentityBinding],
+    ) -> InstalledSource {
+        if let Some(rollback) = self.rollback.take() {
+            self.sources
+                .commit_import_source_rollback_state(rollback, preserved_user_bindings);
+        }
+        self.installed.take().expect("installed source")
+    }
+}
+
+impl Drop for SourceImportRollbackGuard {
+    fn drop(&mut self) {
+        self.rollback_now();
+    }
+}
+
+#[derive(Clone, Copy)]
+struct IdentitySpecImportContext<'a> {
+    identity_specs: &'a IdentitySpecManager,
+    user_owned_identities: &'a UserOwnedIdentityManager,
+    manifest_yamls: &'a [String],
+    inputs: &'a [IdentitySpecImportInputValues],
+    user_principal: Option<&'a UserPrincipal>,
+    user_identity_bindings: &'a BTreeMap<String, AppSourceIdentitySelection>,
+}
+
+/// Owned identity state for one import-source request, shared by the
+/// credential-less and credential-retrieving import paths.
+struct ImportSourceIdentityContext {
+    identity_specs: IdentitySpecManager,
+    user_owned_identities: UserOwnedIdentityManager,
+    manifest_yamls: Vec<String>,
+    inputs: Vec<IdentitySpecImportInputValues>,
+    user_principal: Option<UserPrincipal>,
+    user_identity_bindings: BTreeMap<String, AppSourceIdentitySelection>,
+}
+
+impl ImportSourceIdentityContext {
+    fn as_import_context(&self) -> IdentitySpecImportContext<'_> {
+        IdentitySpecImportContext {
+            identity_specs: &self.identity_specs,
+            user_owned_identities: &self.user_owned_identities,
+            manifest_yamls: &self.manifest_yamls,
+            inputs: &self.inputs,
+            user_principal: self.user_principal.as_ref(),
+            user_identity_bindings: &self.user_identity_bindings,
+        }
+    }
+
+    async fn persist_bindings(
+        &self,
+        workspace_name: &WorkspaceName,
+        installed: &InstalledSource,
+    ) -> Result<(), AppError> {
+        persist_user_source_identity_bindings(
+            &self.user_owned_identities,
+            self.user_principal.as_ref(),
+            workspace_name,
+            installed,
+            &self.user_identity_bindings,
+        )
+        .await
+    }
+
+    fn user_identity_bindings(&self) -> Vec<PreservedUserSourceIdentityBinding> {
+        let Some(principal) = self.user_principal.as_ref() else {
+            return Vec::new();
+        };
+        let user_id = principal.user_id().to_string();
+        self.user_identity_bindings
+            .keys()
+            .map(|surface_id| PreservedUserSourceIdentityBinding {
+                user_id: user_id.clone(),
+                surface_id: surface_id.clone(),
+            })
+            .collect()
+    }
+}
+
+async fn import_source_without_credentials(
+    sources: SourceManager,
+    identity_context: ImportSourceIdentityContext,
+    workspace_name: WorkspaceName,
+    response_workspace_name: &WorkspaceName,
+    command: ImportSourceCommand,
+) -> Result<Response<ImportSourceResponseStreamBox>, Status> {
+    let installed =
+        import_source_with_identity_specs(&sources, &identity_context, &workspace_name, &command)
+            .await
+            .map_err(app_status)?;
+    Ok(single_import_source_response(
+        response_workspace_name,
+        installed,
+    ))
+}
+
+fn identity_spec_import_inputs_from_proto(
+    inputs: Vec<IdentitySpecImportInputs>,
+) -> Result<Vec<IdentitySpecImportInputValues>, AppError> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut values = Vec::new();
+    for input_group in inputs {
+        if !seen.insert(input_group.identity_spec_name.clone()) {
+            return Err(AppError::InvalidInput(format!(
+                "identity spec inputs for '{}' are repeated",
+                input_group.identity_spec_name
+            )));
+        }
+        values.push(IdentitySpecImportInputValues {
+            identity_spec_name: input_group.identity_spec_name,
+            inputs: input_group
+                .inputs
+                .into_iter()
+                .map(|input| IdentitySpecInputValue {
+                    key: input.key,
+                    value: input.value,
+                })
+                .collect(),
+        });
+    }
+    Ok(values)
+}
+
+fn install_identity_specs_for_import(
+    identity_specs: &IdentitySpecManager,
+    manifest_yamls: &[String],
+    input_groups: &[IdentitySpecImportInputValues],
+) -> Result<Vec<IdentitySpecImportRollback>, AppError> {
+    let parsed = manifest_yamls
+        .iter()
+        .map(|manifest_yaml| {
+            parse_identity_manifest_yaml(manifest_yaml)
+                .map(|manifest| (manifest_yaml, manifest))
+                .map_err(|error| AppError::InvalidInput(error.to_string()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut parsed_names = std::collections::BTreeSet::new();
+    for (_manifest_yaml, manifest) in &parsed {
+        if !parsed_names.insert(manifest.name.as_str()) {
+            return Err(AppError::InvalidInput(format!(
+                "identity spec '{}' is included more than once in the source import",
+                manifest.name
+            )));
+        }
+    }
+    if let Some(unknown_name) = input_groups
+        .iter()
+        .map(|input_group| input_group.identity_spec_name.as_str())
+        .find(|name| !parsed_names.contains(name))
+    {
+        return Err(AppError::InvalidInput(format!(
+            "identity spec inputs were provided for '{unknown_name}', but no matching identity spec was included in the source import"
+        )));
+    }
+    let mut inputs_by_spec = input_groups
+        .iter()
+        .map(|input_group| {
+            (
+                input_group.identity_spec_name.as_str(),
+                input_group.inputs.clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut rollback = Vec::new();
+    for (manifest_yaml, manifest) in parsed {
+        let name = manifest.name;
+        let inputs = inputs_by_spec.remove(name.as_str()).unwrap_or_default();
+        let install =
+            match identity_specs.add_identity_spec_with_inputs_for_import(manifest_yaml, inputs) {
+                Ok(install) => install,
+                Err(error) => {
+                    rollback_identity_specs_for_import(identity_specs, rollback);
+                    return Err(error);
+                }
+            };
+        rollback.push(IdentitySpecImportRollback {
+            name: install.name,
+            previous: install.previous,
+            installed: install.installed,
+            pre_import_usage_count: install.pre_import_usage_count,
+        });
+    }
+    Ok(rollback)
+}
+
+fn rollback_identity_specs_for_import(
+    identity_specs: &IdentitySpecManager,
+    rollback: Vec<IdentitySpecImportRollback>,
+) {
+    for item in rollback.into_iter().rev() {
+        match identity_specs.rollback_import_if_current(
+            &item.installed,
+            item.previous.as_ref(),
+            item.pre_import_usage_count,
+        ) {
+            Ok(true) => {}
+            Ok(false) => {
+                warn!(
+                    identity_spec = item.name,
+                    "skipped identity spec import rollback because current state changed or is in use"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    identity_spec = item.name,
+                    error = %error,
+                    "failed to roll back identity spec import"
+                );
+            }
+        }
+    }
+}
+
 fn source_bindings_from_proto(
     variables: Vec<SourceVariable>,
     secrets: Vec<SourceSecret>,
@@ -439,6 +993,357 @@ fn source_bindings_from_proto(
             .map(source_variable_from_proto)
             .collect(),
         secrets: secrets.into_iter().map(source_secret_from_proto).collect(),
+    }
+}
+
+fn source_identity_bindings_from_proto(
+    bindings: Vec<ProtoSourceIdentityBinding>,
+) -> Result<BTreeMap<String, AppSourceIdentityBinding>, AppError> {
+    let mut result = BTreeMap::new();
+    for binding in bindings {
+        let (surface_id, binding) = source_identity_binding_from_proto(binding)?;
+        if result.insert(surface_id.clone(), binding).is_some() {
+            return Err(AppError::InvalidInput(format!(
+                "source identity binding for surface '{surface_id}' is repeated"
+            )));
+        }
+    }
+    Ok(result)
+}
+
+#[derive(Clone, Copy)]
+struct ValidateUserSourceIdentityImport<'a> {
+    sources: &'a SourceManager,
+    identities: &'a UserOwnedIdentityManager,
+    principal: Option<&'a UserPrincipal>,
+    workspace_name: &'a WorkspaceName,
+    manifest_yaml: &'a str,
+    requested_identity_bindings: &'a BTreeMap<String, AppSourceIdentityBinding>,
+    replace_identity_bindings: bool,
+    user_identity_bindings: &'a BTreeMap<String, AppSourceIdentitySelection>,
+}
+
+async fn validate_user_source_identity_import(
+    request: ValidateUserSourceIdentityImport<'_>,
+) -> Result<(), AppError> {
+    let effective_identity_bindings = request
+        .sources
+        .effective_source_identity_bindings_for_import(
+            request.workspace_name,
+            request.manifest_yaml,
+            request.requested_identity_bindings,
+            request.replace_identity_bindings,
+        )?;
+    let required_identity_bindings =
+        if request.replace_identity_bindings || !request.requested_identity_bindings.is_empty() {
+            &effective_identity_bindings
+        } else {
+            request.requested_identity_bindings
+        };
+    validate_user_source_identity_bindings_for_slots(
+        &effective_identity_bindings,
+        required_identity_bindings,
+        request.user_identity_bindings,
+    )?;
+    validate_user_source_identity_selections(
+        request.identities,
+        request.principal,
+        request.manifest_yaml,
+        &effective_identity_bindings,
+        request.user_identity_bindings,
+    )
+    .await
+}
+
+/// Errors unless `surface_id` names a user-owned source identity slot.
+fn require_user_owned_slot(
+    slots: &BTreeMap<String, AppSourceIdentityBinding>,
+    surface_id: &str,
+) -> Result<(), AppError> {
+    match slots.get(surface_id) {
+        Some(slot) if slot.owner == AppSourceIdentityOwner::User => Ok(()),
+        Some(_) => Err(AppError::InvalidInput(format!(
+            "user_identity_binding for surface '{surface_id}' targets a workspace-owned source identity binding"
+        ))),
+        None => Err(AppError::InvalidInput(format!(
+            "user_identity_binding targets unknown source identity surface '{surface_id}'"
+        ))),
+    }
+}
+
+fn source_identity_binding_from_proto(
+    binding: ProtoSourceIdentityBinding,
+) -> Result<(String, AppSourceIdentityBinding), AppError> {
+    let owner = match ProtoSourceIdentityOwner::try_from(binding.owner) {
+        Ok(ProtoSourceIdentityOwner::User) => AppSourceIdentityOwner::User,
+        Ok(ProtoSourceIdentityOwner::Workspace) => AppSourceIdentityOwner::Workspace,
+        Ok(ProtoSourceIdentityOwner::Unspecified) | Err(_) => {
+            return Err(AppError::InvalidInput(format!(
+                "source identity binding for surface '{}' has invalid owner",
+                binding.surface_id
+            )));
+        }
+    };
+    let accepted_identity = if binding.accepted_identity.is_empty() {
+        None
+    } else {
+        Some(binding.accepted_identity)
+    };
+    let surface_id = binding.surface_id;
+    let binding = match owner {
+        AppSourceIdentityOwner::User => {
+            if !binding.identity.is_empty() || accepted_identity.is_some() {
+                return Err(AppError::InvalidInput(format!(
+                    "user-owned source identity binding for surface '{surface_id}' must not include identity or accepted_identity"
+                )));
+            }
+            AppSourceIdentityBinding::user_owned()
+        }
+        AppSourceIdentityOwner::Workspace => {
+            AppSourceIdentityBinding::workspace_owned(binding.identity, accepted_identity)?
+        }
+    };
+    Ok((surface_id, binding))
+}
+
+fn user_source_identity_bindings_from_proto(
+    bindings: Vec<ProtoUserSourceIdentityBinding>,
+) -> Result<BTreeMap<String, AppSourceIdentitySelection>, AppError> {
+    let mut result = BTreeMap::new();
+    for binding in bindings {
+        let surface_id = binding.surface_id;
+        let accepted_identity = if binding.accepted_identity.is_empty() {
+            None
+        } else {
+            Some(binding.accepted_identity)
+        };
+        let selection = AppSourceIdentitySelection::new(binding.identity, accepted_identity)?;
+        if result.insert(surface_id.clone(), selection).is_some() {
+            return Err(AppError::InvalidInput(format!(
+                "user source identity binding for surface '{surface_id}' is repeated"
+            )));
+        }
+    }
+    Ok(result)
+}
+
+fn validate_user_source_identity_bindings_for_slots(
+    slots: &BTreeMap<String, AppSourceIdentityBinding>,
+    required_slots: &BTreeMap<String, AppSourceIdentityBinding>,
+    selections: &BTreeMap<String, AppSourceIdentitySelection>,
+) -> Result<(), AppError> {
+    for (surface_id, slot) in required_slots {
+        if slot.owner == AppSourceIdentityOwner::User && !selections.contains_key(surface_id) {
+            return Err(AppError::InvalidInput(format!(
+                "user-owned source identity binding for surface '{surface_id}' requires a user_identity_binding selection"
+            )));
+        }
+    }
+    if slots.is_empty() {
+        return Ok(());
+    }
+    for surface_id in selections.keys() {
+        require_user_owned_slot(slots, surface_id)?;
+    }
+    Ok(())
+}
+
+async fn validate_user_source_identity_selections(
+    identities: &UserOwnedIdentityManager,
+    principal: Option<&UserPrincipal>,
+    manifest_yaml: &str,
+    slots: &BTreeMap<String, AppSourceIdentityBinding>,
+    selections: &BTreeMap<String, AppSourceIdentitySelection>,
+) -> Result<(), AppError> {
+    if selections.is_empty() {
+        return Ok(());
+    }
+    let principal = principal.ok_or_else(|| {
+        AppError::FailedPrecondition(
+            "cannot validate user-owned source identity bindings without a request user principal"
+                .to_string(),
+        )
+    })?;
+    let manifest = parse_source_manifest_yaml(manifest_yaml)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    let source_name = SourceName::parse(manifest.schema_name())?;
+    let v4 = manifest.as_v4().ok_or_else(|| {
+        AppError::InvalidInput(
+            "user_identity_bindings can only be configured for DSL v4 sources".to_string(),
+        )
+    })?;
+    for (surface_id, selection) in selections {
+        require_user_owned_slot(slots, surface_id)?;
+        let surface = v4.surface(surface_id).ok_or_else(|| {
+            AppError::InvalidInput(format!(
+                "source '{}' user_identity_binding targets unknown surface '{surface_id}'",
+                manifest.schema_name()
+            ))
+        })?;
+        let requirements = surface.identity_requirements.as_ref().ok_or_else(|| {
+            AppError::InvalidInput(format!(
+                "source '{}' surface '{surface_id}' does not declare identity_requirements",
+                manifest.schema_name()
+            ))
+        })?;
+        let selected_requirements = selected_user_source_identity_requirements(
+            manifest.schema_name(),
+            surface_id,
+            selection,
+            requirements,
+        )?;
+        identities
+            .validate_user_owned_source_identity_selection(
+                principal,
+                &source_name,
+                surface_id,
+                selection,
+                &selected_requirements,
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+fn selected_user_source_identity_requirements(
+    source_name: &str,
+    surface_id: &str,
+    selection: &AppSourceIdentitySelection,
+    requirements: &coral_spec::v4::IdentityRequirements,
+) -> Result<coral_spec::v4::IdentityRequirements, AppError> {
+    if let Some(accepted_identity) = selection.accepted_identity.as_deref() {
+        if let Some(accepted) = requirements
+            .accepts
+            .iter()
+            .find(|accepted| accepted.id == accepted_identity)
+        {
+            return Ok(coral_spec::v4::IdentityRequirements {
+                accepts: vec![accepted.clone()],
+            });
+        }
+        return Err(AppError::InvalidInput(format!(
+            "source '{source_name}' surface '{surface_id}' user_identity_binding references unknown accepted_identity '{accepted_identity}'"
+        )));
+    }
+    if requirements.accepts.len() == 1 {
+        return Ok(requirements.clone());
+    }
+    Err(AppError::InvalidInput(format!(
+        "source '{source_name}' surface '{surface_id}' user_identity_binding must include accepted_identity because the surface accepts multiple identities"
+    )))
+}
+
+async fn persist_user_source_identity_bindings(
+    identities: &UserOwnedIdentityManager,
+    principal: Option<&UserPrincipal>,
+    workspace_name: &WorkspaceName,
+    installed: &InstalledSource,
+    bindings: &BTreeMap<String, AppSourceIdentitySelection>,
+) -> Result<(), AppError> {
+    if bindings.is_empty() {
+        return Ok(());
+    }
+    let principal = principal.ok_or_else(|| {
+        AppError::FailedPrecondition(
+            "cannot persist user-owned source identity bindings without a request user principal"
+                .to_string(),
+        )
+    })?;
+    let mut rollback = Vec::new();
+    for (surface_id, selection) in bindings {
+        match installed.identity_bindings.get(surface_id) {
+            Some(slot) if slot.owner == AppSourceIdentityOwner::User => {}
+            Some(_) => {
+                return Err(AppError::InvalidInput(format!(
+                    "user source identity binding for surface '{surface_id}' targets a workspace-owned source identity binding"
+                )));
+            }
+            None => {
+                return Err(AppError::InvalidInput(format!(
+                    "user source identity binding targets unknown source identity surface '{surface_id}'"
+                )));
+            }
+        }
+        let previous = match identities
+            .snapshot_user_owned_source_identity_binding(
+                principal,
+                workspace_name,
+                &installed.name,
+                surface_id,
+            )
+            .await
+        {
+            Ok(previous) => previous,
+            Err(error) => {
+                rollback_user_source_identity_bindings(
+                    identities,
+                    principal,
+                    workspace_name,
+                    &installed.name,
+                    rollback,
+                )
+                .await;
+                return Err(error);
+            }
+        };
+        rollback.push(UserSourceIdentityBindingRollback {
+            surface_id: surface_id.clone(),
+            previous,
+        });
+        if let Err(error) = identities
+            .replace_user_owned_source_identity_binding(
+                principal,
+                workspace_name,
+                &installed.name,
+                surface_id,
+                selection,
+            )
+            .await
+        {
+            rollback_user_source_identity_bindings(
+                identities,
+                principal,
+                workspace_name,
+                &installed.name,
+                rollback,
+            )
+            .await;
+            return Err(error);
+        }
+    }
+    Ok(())
+}
+
+struct UserSourceIdentityBindingRollback {
+    surface_id: String,
+    previous: Option<AppSourceIdentitySelection>,
+}
+
+async fn rollback_user_source_identity_bindings(
+    identities: &UserOwnedIdentityManager,
+    principal: &UserPrincipal,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    rollback: Vec<UserSourceIdentityBindingRollback>,
+) {
+    for item in rollback.into_iter().rev() {
+        if let Err(error) = identities
+            .restore_user_owned_source_identity_binding(
+                principal,
+                workspace_name,
+                source_name,
+                &item.surface_id,
+                item.previous.as_ref(),
+            )
+            .await
+        {
+            warn!(
+                source = %source_name,
+                surface_id = item.surface_id,
+                error = %error,
+                "failed to roll back user source identity binding"
+            );
+        }
     }
 }
 
@@ -817,6 +1722,20 @@ mod tests {
     #[test]
     fn missing_credential_metadata_remains_absent() {
         assert!(secret_proto(api_token_input(None)).credential.is_none());
+    }
+
+    #[tokio::test]
+    async fn blocking_app_operation_join_failures_are_task_join_errors() {
+        let error = run_blocking_app_operation("source import", || -> Result<(), AppError> {
+            panic!("blocking import panic")
+        })
+        .await
+        .expect_err("blocking panic should surface as task join");
+
+        assert!(
+            matches!(error, AppError::TaskJoin(_)),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -9,6 +9,11 @@ use tracing::{info_span, warn};
 
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialStorageKind;
+use crate::identity::SourceIdentityBinding;
+use crate::source_registry::{
+    SourceRegistry, SourceRegistryRecord, installed_source_from_record,
+    record_from_installed_source,
+};
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
@@ -33,18 +38,6 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
-    pub(crate) fn workspace_sources(&self, workspace_name: &WorkspaceName) -> Vec<InstalledSource> {
-        self.catalog.workspace_sources(workspace_name)
-    }
-
-    pub(crate) fn get_source(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Option<InstalledSource> {
-        self.catalog.get_source(workspace_name, source_name)
-    }
-
     pub(crate) fn dependent_join_config(
         &self,
         selected_source_names: &[String],
@@ -175,19 +168,23 @@ struct PersistedInstalledSource {
     secrets: Vec<String>,
     #[serde(default)]
     credential_storage: Option<CredentialStorageKind>,
+    #[serde(default)]
+    identity_bindings: BTreeMap<String, SourceIdentityBinding>,
     origin: SourceOrigin,
 }
 
 impl PersistedInstalledSource {
-    fn into_installed_source(self, source_name: SourceName) -> InstalledSource {
-        InstalledSource {
+    fn into_installed_source(self, source_name: SourceName) -> Result<InstalledSource, AppError> {
+        validate_identity_bindings(source_name.as_str(), &self.identity_bindings)?;
+        Ok(InstalledSource {
             name: source_name,
             version: self.version,
             variables: self.variables,
             secrets: self.secrets,
             credential_storage: self.credential_storage,
+            identity_bindings: self.identity_bindings,
             origin: self.origin,
-        }
+        })
     }
 }
 
@@ -198,6 +195,7 @@ impl From<&InstalledSource> for PersistedInstalledSource {
             variables: value.variables.clone(),
             secrets: value.secrets.clone(),
             credential_storage: value.credential_storage,
+            identity_bindings: value.identity_bindings.clone(),
             origin: value.origin,
         }
     }
@@ -223,16 +221,6 @@ impl SourceCatalog {
             .get(workspace_name)
             .and_then(|sources| sources.get(source_name))
             .cloned()
-    }
-
-    pub(crate) fn contains(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> bool {
-        self.0
-            .get(workspace_name)
-            .is_some_and(|sources| sources.contains_key(source_name))
     }
 
     pub(crate) fn upsert_source(
@@ -451,6 +439,47 @@ impl ConfigStore {
     }
 }
 
+impl SourceRegistry for ConfigStore {
+    fn list_workspace_sources(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Vec<SourceRegistryRecord>, AppError> {
+        let workspace_name = WorkspaceName::parse(workspace_id)?;
+        ConfigStore::list_workspace_sources(self, &workspace_name).map(|sources| {
+            sources
+                .into_iter()
+                .map(|source| record_from_installed_source(&workspace_name, source))
+                .collect()
+        })
+    }
+
+    fn get_source(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<SourceRegistryRecord>, AppError> {
+        let workspace_name = WorkspaceName::parse(workspace_id)?;
+        let source_name = SourceName::parse(source_name)?;
+        match ConfigStore::get_source(self, &workspace_name, &source_name) {
+            Ok(source) => Ok(Some(record_from_installed_source(&workspace_name, source))),
+            Err(AppError::SourceNotFound(_)) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn upsert_source(&self, record: SourceRegistryRecord) -> Result<(), AppError> {
+        let workspace_name = WorkspaceName::parse(&record.workspace_id)?;
+        let source = installed_source_from_record(&workspace_name, record)?;
+        ConfigStore::upsert_source(self, &workspace_name, source)
+    }
+
+    fn remove_source(&self, workspace_id: &str, source_name: &str) -> Result<(), AppError> {
+        let workspace_name = WorkspaceName::parse(workspace_id)?;
+        let source_name = SourceName::parse(source_name)?;
+        ConfigStore::remove_source(self, &workspace_name, &source_name)
+    }
+}
+
 #[expect(
     clippy::indexing_slicing,
     reason = "toml_edit indexing creates or accesses document paths while rebuilding the config table"
@@ -494,6 +523,15 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
                     .expect("source config entry should be a table after initialization");
                 source_table.remove("credential_storage");
             }
+            if source.identity_bindings.is_empty() {
+                let source_table = source_item
+                    .as_table_mut()
+                    .expect("source config entry should be a table after initialization");
+                source_table.remove("identity_bindings");
+            } else {
+                source_item["identity_bindings"] =
+                    Item::Value(render_identity_bindings(&source.identity_bindings));
+            }
             source_item["origin"] = value(source.origin.as_config_value());
         }
     }
@@ -519,7 +557,8 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
             let workspace_name = WorkspaceName::parse(&workspace_name)?;
             for (source_name, source) in workspace_config.sources {
                 let source_name = SourceName::parse(&source_name)?;
-                catalog.upsert_source(&workspace_name, source.into_installed_source(source_name));
+                let installed_source = source.into_installed_source(source_name)?;
+                catalog.upsert_source(&workspace_name, installed_source);
             }
         }
         Ok(Self {
@@ -549,6 +588,37 @@ impl From<&AppConfig> for PersistedAppConfig {
             engine: value.engine.clone(),
             workspaces,
         }
+    }
+}
+
+fn validate_identity_bindings(
+    source_name: &str,
+    bindings: &BTreeMap<String, SourceIdentityBinding>,
+) -> Result<(), AppError> {
+    for (surface_id, binding) in bindings {
+        validate_identity_binding_surface_id(source_name, surface_id)?;
+        binding.validate().map_err(|error| {
+            AppError::InvalidInput(format!(
+                "source '{source_name}' identity binding for surface '{surface_id}' is invalid: {error}"
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn validate_identity_binding_surface_id(
+    source_name: &str,
+    surface_id: &str,
+) -> Result<(), AppError> {
+    let mut chars = surface_id.chars();
+    let valid = matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+        && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+    if valid {
+        Ok(())
+    } else {
+        Err(AppError::InvalidInput(format!(
+            "source '{source_name}' identity binding surface '{surface_id}' must match [a-z][a-z0-9_]*"
+        )))
     }
 }
 
@@ -670,6 +740,24 @@ fn render_inline_table(values: &BTreeMap<String, String>) -> Value {
     Value::InlineTable(table)
 }
 
+fn render_identity_bindings(values: &BTreeMap<String, SourceIdentityBinding>) -> Value {
+    let mut table = InlineTable::new();
+    for (surface_id, binding) in values {
+        let mut binding_table = InlineTable::new();
+        binding_table.insert("owner", Value::from(binding.owner.as_config_value()));
+        if let Some(identity) = &binding.identity {
+            binding_table.insert("identity", Value::from(identity.clone()));
+        }
+        if let Some(accepted_identity) = &binding.accepted_identity {
+            binding_table.insert("accepted_identity", Value::from(accepted_identity.clone()));
+        }
+        binding_table.fmt();
+        table.insert(surface_id, Value::InlineTable(binding_table));
+    }
+    table.fmt();
+    Value::InlineTable(table)
+}
+
 fn render_string_array(values: &[String]) -> Value {
     values.iter().cloned().collect()
 }
@@ -691,7 +779,9 @@ mod tests {
         RawFeatureValue, SourceCatalog, load_raw_feature_overrides, render_config,
         set_raw_feature_override,
     };
+    use crate::bootstrap::AppError;
     use crate::credentials::CredentialStorageKind;
+    use crate::identity::{SourceIdentityBinding, SourceIdentityOwner};
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::AppStateLayout;
@@ -701,9 +791,13 @@ mod tests {
         WorkspaceName::default()
     }
 
+    fn source_name(name: &str) -> SourceName {
+        SourceName::parse(name).expect("source")
+    }
+
     fn installed_source(name: &str) -> InstalledSource {
         InstalledSource {
-            name: SourceName::parse(name).expect("source"),
+            name: source_name(name),
             version: Some("1.1.4".to_string()),
             variables: BTreeMap::from([(
                 "GITHUB_API_BASE".to_string(),
@@ -711,6 +805,7 @@ mod tests {
             )]),
             secrets: vec!["GITHUB_TOKEN".to_string()],
             credential_storage: None,
+            identity_bindings: BTreeMap::new(),
             origin: SourceOrigin::Imported,
         }
     }
@@ -719,7 +814,10 @@ mod tests {
         AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout")
     }
 
-    fn write_config(layout: &AppStateLayout, raw: &str) {
+    /// A fresh temp layout whose config file already holds `raw`.
+    fn layout_with_config(raw: &str) -> (TempDir, AppStateLayout) {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
         std::fs::create_dir_all(
             layout
                 .config_file()
@@ -728,6 +826,7 @@ mod tests {
         )
         .expect("create config dir");
         std::fs::write(layout.config_file(), raw).expect("write config");
+        (temp, layout)
     }
 
     fn raw_feature_entries(layout: &AppStateLayout) -> BTreeMap<String, RawFeatureValue> {
@@ -738,14 +837,66 @@ mod tests {
             .collect()
     }
 
-    fn raw_feature_container(layout: &AppStateLayout) -> RawFeatureContainerState {
-        load_raw_feature_overrides(layout)
-            .expect("feature overrides")
-            .container()
+    /// An app config whose catalog holds `source` in the default workspace.
+    fn config_with_source(source: InstalledSource) -> AppConfig {
+        let mut catalog = SourceCatalog::default();
+        catalog.upsert_source(&default_workspace(), source);
+        AppConfig {
+            version: 1,
+            engine: PersistedEngineConfig::default(),
+            catalog,
+        }
     }
 
-    fn selected_sources(names: &[&str]) -> Vec<String> {
-        names.iter().map(|name| (*name).to_string()).collect()
+    /// Parses raw TOML into the app config model.
+    #[expect(
+        clippy::unwrap_in_result,
+        reason = "test helper: TOML fixtures must parse; only app-model conversion is under test"
+    )]
+    fn load_config(raw: &str) -> Result<AppConfig, AppError> {
+        AppConfig::try_from(toml::from_str::<PersistedAppConfig>(raw).expect("config should parse"))
+    }
+
+    /// Prefixes `body` with the `version = 1` header every config file
+    /// starts with.
+    fn config_toml(body: &str) -> String {
+        format!("version = 1\n\n{body}")
+    }
+
+    /// Parses a config whose `body` follows the `version = 1` header.
+    fn load_config_body(body: &str) -> Result<AppConfig, AppError> {
+        load_config(&config_toml(body))
+    }
+
+    /// A full config holding one `github_v4` source with the given inline
+    /// `identity_bindings` TOML.
+    fn github_v4_config(identity_bindings: &str) -> String {
+        config_toml(&format!(
+            r#"[workspaces.default.sources.github_v4]
+variables = {{}}
+secrets = []
+identity_bindings = {identity_bindings}
+origin = "imported"
+"#
+        ))
+    }
+
+    /// Parses a config body (`version = 1` header implied) and resolves the
+    /// dependent-join runtime config for the selected source names.
+    #[expect(
+        clippy::unwrap_in_result,
+        reason = "test helper: TOML fixtures must parse; only runtime conversion is under test"
+    )]
+    fn dependent_join_runtime_config(
+        body: &str,
+        selected: &[&str],
+    ) -> Result<DependentJoinConfig, AppError> {
+        let selected: Vec<String> = selected.iter().map(|name| (*name).to_string()).collect();
+        toml::from_str::<PersistedAppConfig>(&config_toml(body))
+            .expect("dependent join config should parse")
+            .engine
+            .dependent_join
+            .try_into_runtime_config(&selected)
     }
 
     #[test]
@@ -755,14 +906,7 @@ mod tests {
 
     #[test]
     fn renders_sources_under_workspace_keyed_tables() {
-        let workspace_name = default_workspace();
-        let mut catalog = SourceCatalog::default();
-        catalog.upsert_source(&workspace_name, installed_source("github"));
-        let config = AppConfig {
-            version: 1,
-            engine: PersistedEngineConfig::default(),
-            catalog,
-        };
+        let config = config_with_source(installed_source("github"));
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
         assert!(raw.contains("[workspaces.default.sources.github]"));
@@ -776,17 +920,10 @@ mod tests {
 
     #[test]
     fn omits_empty_versions_from_rendered_source_entries() {
-        let workspace_name = default_workspace();
         let mut source = installed_source("github");
         source.version = None;
         source.origin = SourceOrigin::Bundled;
-        let mut catalog = SourceCatalog::default();
-        catalog.upsert_source(&workspace_name, source);
-        let config = AppConfig {
-            version: 1,
-            engine: PersistedEngineConfig::default(),
-            catalog,
-        };
+        let config = config_with_source(source);
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
         assert!(!raw.contains("version = \"\""));
@@ -796,8 +933,6 @@ mod tests {
     #[test]
     fn loads_sources_from_workspace_keyed_tables() {
         let raw = r#"
-version = 1
-
 [workspaces.default.sources.github]
 version = "1.1.4"
 variables = { GITHUB_API_BASE = "https://api.github.com" }
@@ -805,10 +940,7 @@ secrets = ["GITHUB_TOKEN"]
 origin = "bundled"
 "#;
 
-        let config = AppConfig::try_from(
-            toml::from_str::<PersistedAppConfig>(raw).expect("workspace-keyed config should parse"),
-        )
-        .expect("config");
+        let config = load_config_body(raw).expect("config");
         let sources = config.catalog.workspace_sources(&default_workspace());
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].name.as_str(), "github");
@@ -828,8 +960,6 @@ origin = "bundled"
     #[test]
     fn loads_dependent_join_engine_config() {
         let raw = r"
-version = 1
-
 [engine.dependent_join]
 enabled = false
 max_bindings = 7
@@ -844,11 +974,7 @@ max_bindings = 21
 max_concurrency = 4
 ";
 
-        let config = toml::from_str::<PersistedAppConfig>(raw)
-            .expect("dependent join config should parse")
-            .engine
-            .dependent_join
-            .try_into_runtime_config(&selected_sources(&["github"]))
+        let config = dependent_join_runtime_config(raw, &["github"])
             .expect("dependent join config should be valid");
 
         assert_eq!(
@@ -876,17 +1002,11 @@ max_concurrency = 4
     #[test]
     fn matches_dependent_join_source_config_after_source_name_normalization() {
         let raw = r#"
-version = 1
-
 [engine.dependent_join.per_source." github "]
 enabled = false
 "#;
 
-        let config = toml::from_str::<PersistedAppConfig>(raw)
-            .expect("dependent join config should parse")
-            .engine
-            .dependent_join
-            .try_into_runtime_config(&selected_sources(&["github"]))
+        let config = dependent_join_runtime_config(raw, &["github"])
             .expect("dependent join config should be valid");
 
         assert_eq!(
@@ -900,53 +1020,29 @@ enabled = false
 
     #[test]
     fn rejects_zero_dependent_join_limits() {
-        let raw = r"
-version = 1
+        for (label, body, selected, expected) in [
+            (
+                "zero limit should fail",
+                "[engine.dependent_join]\nmax_concurrency = 0\n",
+                &[][..],
+                "engine.dependent_join.max_concurrency must be greater than 0",
+            ),
+            (
+                "zero source limit should fail",
+                "[engine.dependent_join.per_source.github]\nmax_concurrency = 0\n",
+                &["github"][..],
+                "engine.dependent_join.per_source.github.max_concurrency must be greater than 0",
+            ),
+        ] {
+            let error = dependent_join_runtime_config(body, selected).expect_err(label);
 
-[engine.dependent_join]
-max_concurrency = 0
-";
-
-        let error = toml::from_str::<PersistedAppConfig>(raw)
-            .expect("dependent join config should parse")
-            .engine
-            .dependent_join
-            .try_into_runtime_config(&[])
-            .expect_err("zero limit should fail");
-
-        assert!(
-            error
-                .to_string()
-                .contains("engine.dependent_join.max_concurrency must be greater than 0")
-        );
-    }
-
-    #[test]
-    fn rejects_zero_dependent_join_source_limits() {
-        let raw = r"
-version = 1
-
-[engine.dependent_join.per_source.github]
-max_concurrency = 0
-";
-
-        let error = toml::from_str::<PersistedAppConfig>(raw)
-            .expect("dependent join config should parse")
-            .engine
-            .dependent_join
-            .try_into_runtime_config(&selected_sources(&["github"]))
-            .expect_err("zero source limit should fail");
-
-        assert!(error.to_string().contains(
-            "engine.dependent_join.per_source.github.max_concurrency must be greater than 0"
-        ));
+            assert!(error.to_string().contains(expected), "{label}: {error}");
+        }
     }
 
     #[test]
     fn ignores_dependent_join_source_limits_for_unselected_sources() {
         let raw = r"
-version = 1
-
 [engine.dependent_join.per_source.github]
 max_concurrency = 4
 
@@ -954,11 +1050,7 @@ max_concurrency = 4
 max_concurrency = 0
 ";
 
-        let config = toml::from_str::<PersistedAppConfig>(raw)
-            .expect("dependent join config should parse")
-            .engine
-            .dependent_join
-            .try_into_runtime_config(&selected_sources(&["github"]))
+        let config = dependent_join_runtime_config(raw, &["github"])
             .expect("unselected source override should not be validated");
 
         assert!(config.per_source.contains_key("github"));
@@ -967,29 +1059,92 @@ max_concurrency = 0
 
     #[test]
     fn round_trips_source_credential_storage() {
-        let workspace_name = default_workspace();
         let mut source = installed_source("github");
         source.credential_storage = Some(CredentialStorageKind::Keychain);
-        let mut catalog = SourceCatalog::default();
-        catalog.upsert_source(&workspace_name, source);
-        let config = AppConfig {
-            version: 1,
-            engine: PersistedEngineConfig::default(),
-            catalog,
-        };
+        let config = config_with_source(source);
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
         assert!(raw.contains("credential_storage = \"keychain\""));
 
-        let loaded = AppConfig::try_from(
-            toml::from_str::<PersistedAppConfig>(&raw).expect("config should parse"),
-        )
-        .expect("config");
-        let sources = loaded.catalog.workspace_sources(&workspace_name);
+        let loaded = load_config(&raw).expect("config");
+        let sources = loaded.catalog.workspace_sources(&default_workspace());
         assert_eq!(
             sources[0].credential_storage,
             Some(CredentialStorageKind::Keychain)
         );
+    }
+
+    #[test]
+    fn round_trips_source_identity_bindings() {
+        let mut source = installed_source("github_v4");
+        source
+            .identity_bindings
+            .insert("rest".to_string(), SourceIdentityBinding::user_owned());
+        let config = config_with_source(source);
+
+        let raw = render_config(&PersistedAppConfig::from(&config), None);
+
+        assert!(raw.contains("identity_bindings"));
+        assert!(raw.contains("owner = \"user\""));
+        assert!(!raw.contains("github_local"));
+        assert!(!raw.contains("accepted_identity"));
+        let loaded = load_config(&raw).expect("config");
+        let sources = loaded.catalog.workspace_sources(&default_workspace());
+        let binding = sources[0]
+            .identity_bindings
+            .get("rest")
+            .expect("rest identity binding");
+        assert_eq!(binding.identity, None);
+        assert_eq!(binding.owner, SourceIdentityOwner::User);
+        assert_eq!(binding.accepted_identity, None);
+    }
+
+    #[test]
+    fn loads_workspace_owned_source_identity_binding_from_config() {
+        let raw = github_v4_config(
+            r#"{ rest = { identity = "github_workspace", owner = "workspace" } }"#,
+        );
+
+        let config = load_config(&raw).expect("config");
+        let sources = config.catalog.workspace_sources(&default_workspace());
+        let binding = sources[0]
+            .identity_bindings
+            .get("rest")
+            .expect("rest identity binding");
+
+        assert_eq!(binding.identity.as_deref(), Some("github_workspace"));
+        assert_eq!(binding.owner, SourceIdentityOwner::Workspace);
+        assert_eq!(binding.accepted_identity, None);
+    }
+
+    #[test]
+    fn rejects_invalid_source_identity_bindings_from_config() {
+        for (identity_bindings, expected) in [
+            (
+                r#"{ "bad/rest" = { identity = "github_workspace", owner = "workspace" } }"#,
+                "identity binding surface 'bad/rest' must match [a-z][a-z0-9_]*",
+            ),
+            (
+                r#"{ rest = { identity = "bad/path", owner = "workspace" } }"#,
+                "identity name must not contain",
+            ),
+            (
+                r#"{ rest = { identity = "github_workspace", owner = "workspace", accepted_identity = "bad/path" } }"#,
+                "accepted identity name must not contain",
+            ),
+            (
+                r#"{ rest = { identity = "github_local", owner = "user" } }"#,
+                "user-owned source identity bindings store only owner",
+            ),
+        ] {
+            let error = load_config(&github_v4_config(identity_bindings))
+                .expect_err("invalid identity binding should fail config load");
+
+            assert!(
+                error.to_string().contains(expected),
+                "expected '{expected}' in '{error}'"
+            );
+        }
     }
 
     #[test]
@@ -1004,10 +1159,7 @@ max_concurrency = 0
         catalog.upsert_source(&workspace_name, updated);
 
         let stored = catalog
-            .get_source(
-                &workspace_name,
-                &SourceName::parse("github").expect("source"),
-            )
+            .get_source(&workspace_name, &source_name("github"))
             .expect("source should be present");
         assert_eq!(stored.version.as_deref(), Some("2.0.0"));
         assert_eq!(stored.origin, SourceOrigin::Imported);
@@ -1022,36 +1174,25 @@ max_concurrency = 0
         catalog.upsert_source(&default_workspace, installed_source("github"));
         catalog.upsert_source(&other_workspace_name, installed_source("slack"));
 
-        catalog.remove_source(
-            &default_workspace,
-            &SourceName::parse("github").expect("source"),
-        );
+        catalog.remove_source(&default_workspace, &source_name("github"));
 
         assert!(
             catalog
-                .get_source(
-                    &default_workspace,
-                    &SourceName::parse("github").expect("source")
-                )
+                .get_source(&default_workspace, &source_name("github"))
                 .is_none()
         );
         assert!(catalog.workspace_sources(&default_workspace).is_empty());
         assert!(
             catalog
-                .get_source(
-                    &other_workspace_name,
-                    &SourceName::parse("slack").expect("source")
-                )
+                .get_source(&other_workspace_name, &source_name("slack"))
                 .is_some()
         );
     }
 
     #[test]
     fn preserves_unrelated_sections_when_rendering_with_existing_config() {
-        let existing = r#"
-version = 1
-
-[otel]
+        let existing = config_toml(
+            r#"[otel]
 endpoint = "http://localhost:4318"
 headers = "from=config"
 
@@ -1072,61 +1213,30 @@ version = "1.0.0"
 variables = {}
 secrets = []
 origin = "bundled"
-"#;
+"#,
+        );
 
-        let workspace_name = default_workspace();
-        let mut catalog = SourceCatalog::default();
-        catalog.upsert_source(&workspace_name, installed_source("slack"));
-        let config = AppConfig {
-            version: 1,
-            engine: PersistedEngineConfig::default(),
-            catalog,
-        };
+        let config = config_with_source(installed_source("slack"));
 
-        let raw = render_config(&PersistedAppConfig::from(&config), Some(existing));
+        let raw = render_config(&PersistedAppConfig::from(&config), Some(existing.as_str()));
 
-        // OTel section must survive the round-trip.
-        assert!(raw.contains("[otel]"), "otel section should be preserved");
-        assert!(
-            raw.contains("endpoint = \"http://localhost:4318\""),
-            "otel endpoint should be preserved"
-        );
-        assert!(
-            raw.contains("headers = \"from=config\""),
-            "otel headers should be preserved"
-        );
-        assert!(
-            raw.contains("[trace_history]"),
-            "trace history section should be preserved"
-        );
-        assert!(
-            raw.contains("enabled = false"),
-            "trace history enabled flag should be preserved"
-        );
-        assert!(
-            raw.contains("retention_days = 3"),
-            "trace history retention should be preserved"
-        );
-        assert!(
-            raw.contains("[features]"),
-            "features section should be preserved"
-        );
-        assert!(
-            raw.contains("feedback = true"),
-            "known feature override should be preserved"
-        );
-        assert!(
-            raw.contains("future_feature = \"not-yet-known\""),
-            "future feature override should be preserved"
-        );
-        assert!(
-            raw.contains("[engine.dependent_join]"),
-            "dependent join config should be preserved"
-        );
-        assert!(
-            raw.contains("max_bindings = 250"),
-            "dependent join limit should be preserved"
-        );
+        // Unrelated sections (otel, trace history, features, dependent join)
+        // must survive the round-trip.
+        for needle in [
+            "[otel]",
+            "endpoint = \"http://localhost:4318\"",
+            "headers = \"from=config\"",
+            "[trace_history]",
+            "enabled = false",
+            "retention_days = 3",
+            "[features]",
+            "feedback = true",
+            "future_feature = \"not-yet-known\"",
+            "[engine.dependent_join]",
+            "max_bindings = 250",
+        ] {
+            assert!(raw.contains(needle), "{needle} should be preserved");
+        }
 
         // The newly added source must be present.
         assert!(raw.contains("[workspaces.default.sources.slack]"));
@@ -1138,29 +1248,18 @@ origin = "bundled"
     #[test]
     fn rejects_invalid_workspace_or_source_keys_when_loading() {
         let invalid_workspace = r#"
-version = 1
-
 [workspaces."bad\\workspace".sources.github]
 origin = "bundled"
 "#;
-        let error = AppConfig::try_from(
-            toml::from_str::<PersistedAppConfig>(invalid_workspace)
-                .expect("quoted workspace key should parse"),
-        )
-        .expect_err("invalid workspace key should fail");
+        let error =
+            load_config_body(invalid_workspace).expect_err("invalid workspace key should fail");
         assert!(error.to_string().contains("workspace name"));
 
         let invalid_source = r#"
-version = 1
-
 [workspaces.default.sources."bad\\source"]
 origin = "bundled"
 "#;
-        let error = AppConfig::try_from(
-            toml::from_str::<PersistedAppConfig>(invalid_source)
-                .expect("quoted source key should parse"),
-        )
-        .expect_err("invalid source key should fail");
+        let error = load_config_body(invalid_source).expect_err("invalid source key should fail");
         assert!(error.to_string().contains("source name"));
     }
 
@@ -1181,14 +1280,8 @@ origin = "bundled"
 
     #[test]
     fn raw_feature_overrides_load_supported_table_entries() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout = test_layout(&temp);
-        write_config(
-            &layout,
-            r#"
-version = 1
-
-[features]
+        let (_temp, layout) = layout_with_config(&config_toml(
+            r#"[features]
 feedback = true
 future_flag = false
 wrong_type = "yes"
@@ -1196,7 +1289,7 @@ wrong_type = "yes"
 [features.nested]
 enabled = true
 "#,
-        );
+        ));
 
         let entries = raw_feature_entries(&layout);
 
@@ -1217,9 +1310,7 @@ enabled = true
 
     #[test]
     fn raw_feature_overrides_accept_dotted_feature_table() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout = test_layout(&temp);
-        write_config(&layout, "features.feedback = false\n");
+        let (_temp, layout) = layout_with_config("features.feedback = false\n");
 
         let entries = raw_feature_entries(&layout);
 
@@ -1228,24 +1319,17 @@ enabled = true
 
     #[test]
     fn raw_feature_overrides_ignore_inline_feature_table() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout = test_layout(&temp);
-        write_config(&layout, "features = { feedback = true }\n");
+        let (_temp, layout) = layout_with_config("features = { feedback = true }\n");
 
-        let entries = raw_feature_entries(&layout);
+        let overrides = load_raw_feature_overrides(&layout).expect("feature overrides");
 
-        assert!(entries.is_empty());
-        assert_eq!(
-            raw_feature_container(&layout),
-            RawFeatureContainerState::Unsupported
-        );
+        assert!(overrides.iter().next().is_none());
+        assert_eq!(overrides.container(), RawFeatureContainerState::Unsupported);
     }
 
     #[test]
     fn raw_feature_overrides_fail_for_invalid_toml() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout = test_layout(&temp);
-        write_config(&layout, "[features\nfeedback = true\n");
+        let (_temp, layout) = layout_with_config("[features\nfeedback = true\n");
 
         let error = load_raw_feature_overrides(&layout).expect_err("invalid TOML should fail");
 
@@ -1267,10 +1351,7 @@ enabled = true
 
     #[test]
     fn set_raw_feature_override_preserves_unrelated_feature_entries() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout = test_layout(&temp);
-        write_config(
-            &layout,
+        let (_temp, layout) = layout_with_config(
             r#"
 [features]
 future_flag = "yes"
@@ -1278,23 +1359,19 @@ feedback = true
 "#,
         );
 
-        set_raw_feature_override(&layout, "feedback", false).expect("set feature");
-        let raw = std::fs::read_to_string(layout.config_file()).expect("config file");
-        assert!(raw.contains("feedback = false"));
-        assert!(raw.contains("future_flag = \"yes\""));
+        for (value, expected) in [(false, "feedback = false"), (true, "feedback = true")] {
+            set_raw_feature_override(&layout, "feedback", value).expect("set feature");
 
-        set_raw_feature_override(&layout, "feedback", true).expect("set feature");
-        let raw = std::fs::read_to_string(layout.config_file()).expect("config file");
-        assert!(raw.contains("feedback = true"));
-        assert!(raw.contains("future_flag = \"yes\""));
+            let raw = std::fs::read_to_string(layout.config_file()).expect("config file");
+            assert!(raw.contains(expected), "{expected}");
+            assert!(raw.contains("future_flag = \"yes\""), "set {value}");
+        }
     }
 
     #[test]
     fn feature_mutations_reject_inline_feature_container_without_rewriting_file() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout = test_layout(&temp);
         let original = "features = { feedback = true }\n";
-        write_config(&layout, original);
+        let (_temp, layout) = layout_with_config(original);
 
         let error =
             set_raw_feature_override(&layout, "feedback", true).expect_err("inline features");

--- a/crates/coral-app/tests/grpc/identity_spec_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_spec_tests.rs
@@ -1,11 +1,14 @@
 use coral_api::v1::{
-    AddIdentitySpecRequest, DeleteIdentitySpecRequest, GetIdentitySpecRequest, IdentitySpecInput,
-    ListIdentitySpecsRequest,
+    AddIdentitySpecRequest, DeleteIdentitySpecRequest, GetIdentitySpecRequest,
+    IdentitySpecImportInputs, IdentitySpecInput, ImportSourceRequest, ListIdentitySpecsRequest,
 };
 use coral_app::features::{Feature, FeatureOverrides};
 use tonic::{Code, Request};
 
-use crate::harness::{GrpcHarness, fixed_token_identity_spec_yaml};
+use crate::harness::{
+    GrpcHarness, fixed_token_identity_spec_yaml, fixture_manifest_with_inputs_yaml, import_request,
+    secret, variable,
+};
 
 fn oauth_identity_yaml_with_required_secret() -> String {
     r"
@@ -46,6 +49,17 @@ fn client_secret_input() -> IdentitySpecInput {
     IdentitySpecInput {
         key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
         value: "client-secret".to_string(),
+    }
+}
+
+/// Builds an import request for the fixture source that bundles
+/// `identity_spec_manifest_yamls`.
+fn bundled_import_request(identity_spec_manifest_yamls: Vec<String>) -> ImportSourceRequest {
+    ImportSourceRequest {
+        variables: vec![variable("API_BASE", "https://example.com")],
+        secrets: vec![secret("API_TOKEN", "secret-token")],
+        identity_spec_manifest_yamls,
+        ..import_request(fixture_manifest_with_inputs_yaml())
     }
 }
 
@@ -190,6 +204,28 @@ async fn identity_spec_service_stores_request_inputs_on_identity_spec() {
 }
 
 #[tokio::test]
+async fn source_import_stores_identity_spec_inputs_on_identity_spec() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = oauth_identity_yaml_with_required_secret();
+
+    harness
+        .try_import_source(ImportSourceRequest {
+            identity_spec_inputs: vec![IdentitySpecImportInputs {
+                identity_spec_name: "demo_oauth".to_string(),
+                inputs: vec![client_secret_input()],
+            }],
+            ..bundled_import_request(vec![manifest_yaml.clone()])
+        })
+        .await
+        .expect("source import with identity spec inputs");
+
+    harness
+        .try_add_identity_spec(manifest_yaml, Vec::new())
+        .await
+        .expect("source import should persist identity spec input material");
+}
+
+#[tokio::test]
 async fn identity_spec_service_rejects_replacing_spec_used_by_identity() {
     let harness = GrpcHarness::new().await;
 
@@ -217,4 +253,126 @@ async fn identity_spec_service_rejects_replacing_spec_used_by_identity() {
     let fetched = get_identity_spec_manifest(&harness, "github_pat").await;
     assert!(fetched.contains("host: github.com"));
     assert!(!fetched.contains("attacker.test"));
+}
+
+#[tokio::test]
+async fn source_import_installs_identity_specs_from_bundle_request() {
+    let harness = GrpcHarness::new().await;
+
+    harness
+        .try_import_source(bundled_import_request(vec![
+            fixed_token_identity_spec_yaml("github_oauth", "github.com"),
+        ]))
+        .await
+        .expect("import source");
+
+    let identity_specs = harness.list_identity_specs().await;
+    assert_eq!(identity_specs.len(), 1);
+    assert_eq!(
+        identity_specs
+            .first()
+            .expect("installed identity spec")
+            .name,
+        "github_oauth"
+    );
+}
+
+#[tokio::test]
+async fn source_import_rolls_back_identity_specs_when_source_import_fails() {
+    let harness = GrpcHarness::new().await;
+    let error = harness
+        .try_import_source(ImportSourceRequest {
+            identity_spec_manifest_yamls: vec![fixed_token_identity_spec_yaml(
+                "github_oauth",
+                "github.com",
+            )],
+            variables: vec![variable("API_BASE", "https://example.com")],
+            ..import_request(fixture_manifest_with_inputs_yaml())
+        })
+        .await
+        .expect_err("invalid source import should fail");
+
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(
+        error
+            .message()
+            .contains("missing required source secret 'API_TOKEN'"),
+        "unexpected error: {error}"
+    );
+    assert!(harness.list_identity_specs().await.is_empty());
+}
+
+#[tokio::test]
+async fn source_import_rolls_back_identity_spec_input_material_when_import_fails() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = oauth_identity_yaml_with_required_secret();
+    harness
+        .try_add_identity_spec(manifest_yaml.clone(), vec![client_secret_input()])
+        .await
+        .expect("add original identity spec with material");
+
+    let error = harness
+        .try_import_source(ImportSourceRequest {
+            identity_spec_manifest_yamls: vec![fixed_token_identity_spec_yaml(
+                "demo_oauth",
+                "github.com",
+            )],
+            variables: vec![variable("API_BASE", "https://example.com")],
+            ..import_request(fixture_manifest_with_inputs_yaml())
+        })
+        .await
+        .expect_err("invalid source import should fail");
+
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(
+        error
+            .message()
+            .contains("missing required source secret 'API_TOKEN'"),
+        "unexpected error: {error}"
+    );
+    harness
+        .try_add_identity_spec(manifest_yaml, Vec::new())
+        .await
+        .expect("restored input material should satisfy original required input");
+}
+
+#[tokio::test]
+async fn source_import_rejects_identity_spec_bundle_without_partial_install() {
+    let harness = GrpcHarness::new().await;
+    let error = harness
+        .try_import_source(bundled_import_request(vec![
+            fixed_token_identity_spec_yaml("github_oauth", "github.com"),
+            "kind: identity\nspec_version: 1\nname: broken_identity\n".to_string(),
+        ]))
+        .await
+        .expect_err("invalid identity spec bundle should fail");
+
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(
+        harness.list_identity_specs().await.is_empty(),
+        "valid identity spec before invalid bundle entry must not remain installed"
+    );
+}
+
+#[tokio::test]
+async fn source_import_rejects_duplicate_identity_spec_bundle_without_partial_install() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixed_token_identity_spec_yaml("github_oauth", "github.com");
+    let error = harness
+        .try_import_source(bundled_import_request(vec![
+            manifest_yaml.clone(),
+            manifest_yaml,
+        ]))
+        .await
+        .expect_err("duplicate identity spec bundle should fail");
+
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(
+        error.message().contains("included more than once"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        harness.list_identity_specs().await.is_empty(),
+        "duplicate bundle must not install either identity spec"
+    );
 }

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -4,26 +4,32 @@
     reason = "test code: assertion-style indexing is idiomatic in tests"
 )]
 
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExplainSqlRequest,
     GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest, ListCatalogRequest,
     ListCatalogResponse, OauthCredentialFlowType, OauthCredentialScopeDelimiter, PaginationRequest,
-    QueryTestFailure, QueryTestSuccess, Source, SourceCredentialStorage, SourceInfo, SourceOrigin,
-    SourceSecret, SourceVariable, Workspace, catalog_item, query_test_result,
+    QueryTestFailure, QueryTestSuccess, Source, SourceCredentialStorage, SourceIdentityBinding,
+    SourceIdentityOwner, SourceInfo, SourceOrigin, SourceSecret, SourceVariable,
+    UserSourceIdentityBinding, Workspace, catalog_item, query_test_result,
     source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::default_workspace;
+use sha2::{Digest as _, Sha256};
 use tempfile::TempDir;
 use tonic::Request;
 
 use crate::harness::{
-    FailingHttpFixture, GrpcHarness, fixture_function_only_manifest_yaml,
-    fixture_manifest_with_inputs_yaml, fixture_manifest_with_multiple_tables_yaml,
-    fixture_manifest_with_required_inputs_yaml, fixture_manifest_with_test_queries_yaml,
-    fixture_manifest_yaml, import_request, invalid_manifest_yaml, secret, source_dir, variable,
+    FailingHttpFixture, GrpcHarness, fixed_token_identity_spec_yaml,
+    fixture_function_only_manifest_yaml, fixture_manifest_with_inputs_yaml,
+    fixture_manifest_with_multiple_tables_yaml, fixture_manifest_with_required_inputs_yaml,
+    fixture_manifest_with_test_queries_yaml, fixture_manifest_yaml, import_request,
+    invalid_manifest_yaml, secret, source_dir, variable,
 };
 
 #[tokio::test]
@@ -70,8 +76,300 @@ async fn import_source_persists_and_lists() {
     );
 }
 
+#[tokio::test]
+async fn import_v4_source_with_identity_bindings_fails_closed_from_grpc() {
+    let harness = GrpcHarness::new().await;
+    create_fixed_token_identity(&harness, "github_local", "github_oauth", "github.com").await;
+    let manifest_yaml = write_v4_manifest(&harness, "http://127.0.0.1:1", "github.com");
+
+    let error = harness
+        .try_import_source(identity_import_request(manifest_yaml, "github_local"))
+        .await
+        .expect_err("identity-backed source import should fail closed");
+
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error
+            .message()
+            .contains("request identity resolution is not installed"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        harness.list_sources().await.is_empty(),
+        "failed identity-backed import must not install the source"
+    );
+    assert_no_preflight_materialization_dirs(&harness, "github_v4_grpc");
+}
+
+#[tokio::test]
+async fn import_v4_source_rejects_invalid_user_accepted_identity() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = write_v4_manifest(&harness, "http://127.0.0.1:1", "github.com");
+
+    let error = harness
+        .try_import_source(ImportSourceRequest {
+            identity_bindings: rest_identity_bindings(),
+            user_identity_bindings: rest_user_identity_bindings("github_local", "missing"),
+            ..import_request(manifest_yaml)
+        })
+        .await
+        .expect_err("invalid accepted identity should fail import");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(
+        error.message().contains(
+            "source 'github_v4_grpc' surface 'rest' user_identity_binding references unknown accepted_identity 'missing'"
+        ),
+        "unexpected error: {error}"
+    );
+    assert_no_preflight_materialization_dirs(&harness, "github_v4_grpc");
+}
+
+#[tokio::test]
+async fn import_v4_source_requires_user_accepted_identity_when_surface_accepts_multiple() {
+    let harness = GrpcHarness::new().await;
+    let (openapi_file, openapi_sha256) = write_v4_openapi(&harness, "http://127.0.0.1:1");
+    let manifest_yaml = format!(
+        r"
+name: github_v4_grpc
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    sha256: {}
+    identity_requirements:
+      accepts:
+        - id: github-device
+          identity_specs:
+            - github_oauth
+          audience:
+            host: github.com
+        - id: github-app
+          identity_specs:
+            - github_oauth_app
+          audience:
+            host: github.com
+",
+        openapi_file.display(),
+        openapi_sha256
+    );
+
+    let error = harness
+        .try_import_source(ImportSourceRequest {
+            identity_bindings: rest_identity_bindings(),
+            user_identity_bindings: rest_user_identity_bindings("github_local", ""),
+            ..import_request(manifest_yaml)
+        })
+        .await
+        .expect_err("ambiguous accepted identity should fail import");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(
+        error.message().contains(
+            "source 'github_v4_grpc' surface 'rest' user_identity_binding must include accepted_identity because the surface accepts multiple identities"
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn import_v4_source_rejects_incompatible_user_identity_binding() {
+    let harness = GrpcHarness::new().await;
+    create_fixed_token_identity(&harness, "github_local", "gitlab_oauth", "gitlab.com").await;
+    let manifest_yaml = write_v4_manifest(&harness, "http://127.0.0.1:1", "github.com");
+
+    let error = harness
+        .try_import_source(identity_import_request(manifest_yaml, "github_local"))
+        .await
+        .expect_err("incompatible user identity should fail import");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error
+            .message()
+            .contains("does not satisfy selected identity requirements"),
+        "unexpected error: {error}"
+    );
+    let listed = harness.list_sources().await;
+    assert!(
+        listed.is_empty(),
+        "invalid user identity selection must not install the source"
+    );
+}
+
+#[tokio::test]
+async fn import_v4_source_rejects_identity_after_spec_force_remove_and_readd() {
+    let harness = GrpcHarness::new().await;
+    create_fixed_token_identity(&harness, "github_local", "github_oauth", "github.com").await;
+    harness.force_delete_identity_spec("github_oauth").await;
+    harness
+        .add_identity_spec(fixed_token_identity_spec_yaml(
+            "github_oauth",
+            "attacker.test",
+        ))
+        .await;
+
+    let manifest_yaml = write_v4_manifest(&harness, "http://127.0.0.1:1", "attacker.test");
+
+    let error = harness
+        .try_import_source(identity_import_request(manifest_yaml, "github_local"))
+        .await
+        .expect_err("changed identity spec should fail import");
+
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error
+            .message()
+            .contains("has changed since the identity was created"),
+        "unexpected error: {error}"
+    );
+    let listed = harness.list_sources().await;
+    assert!(
+        listed.is_empty(),
+        "orphaned user identity selection must not install the source"
+    );
+}
+
+/// Adds a fixed-token identity spec named `spec_name` for `audience_host` and
+/// creates a user-owned identity bound to it.
+async fn create_fixed_token_identity(
+    harness: &GrpcHarness,
+    identity_name: &str,
+    spec_name: &str,
+    audience_host: &str,
+) {
+    harness
+        .add_identity_spec(fixed_token_identity_spec_yaml(spec_name, audience_host))
+        .await;
+    harness
+        .create_fixed_token_identity(identity_name, spec_name, "identity-token")
+        .await;
+}
+
+/// Import request binding the `rest` surface to a user-owned identity accepted
+/// as `github-rest-read`.
+fn identity_import_request(manifest_yaml: String, identity: &str) -> ImportSourceRequest {
+    ImportSourceRequest {
+        identity_bindings: rest_identity_bindings(),
+        user_identity_bindings: rest_user_identity_bindings(identity, "github-rest-read"),
+        ..import_request(manifest_yaml)
+    }
+}
+
+fn rest_identity_bindings() -> Vec<SourceIdentityBinding> {
+    vec![SourceIdentityBinding {
+        surface_id: "rest".to_string(),
+        owner: SourceIdentityOwner::User as i32,
+        ..Default::default()
+    }]
+}
+
+fn rest_user_identity_bindings(
+    identity: &str,
+    accepted_identity: &str,
+) -> Vec<UserSourceIdentityBinding> {
+    vec![UserSourceIdentityBinding {
+        surface_id: "rest".to_string(),
+        identity: identity.to_string(),
+        accepted_identity: accepted_identity.to_string(),
+    }]
+}
+
 fn read_config(harness: &GrpcHarness) -> String {
     fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config")
+}
+
+fn assert_no_preflight_materialization_dirs(harness: &GrpcHarness, source_name: &str) {
+    let materialized_parent = source_dir(harness.config_dir(), source_name).join("materialized");
+    if !materialized_parent.exists() {
+        return;
+    }
+    let leaked = fs::read_dir(&materialized_parent)
+        .expect("read materialized source dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with("v4.preflight."))
+        .collect::<Vec<_>>();
+    assert!(
+        leaked.is_empty(),
+        "preflight materialization dirs leaked: {leaked:?}"
+    );
+}
+
+/// Writes the shared `OpenAPI` fixture targeting `base_url`; returns its path
+/// and sha256.
+fn write_v4_openapi(harness: &GrpcHarness, base_url: &str) -> (PathBuf, String) {
+    let openapi_yaml = grpc_identity_openapi_yaml(base_url);
+    let openapi_file = harness.temp_path().join("openapi.yaml");
+    fs::write(&openapi_file, &openapi_yaml).expect("write openapi");
+    let openapi_sha256 = format!("{:x}", Sha256::digest(openapi_yaml.as_bytes()));
+    (openapi_file, openapi_sha256)
+}
+
+/// Writes the `OpenAPI` fixture and returns a `github_v4_grpc` manifest that
+/// accepts `github_oauth` identities for `audience_host`.
+fn write_v4_manifest(harness: &GrpcHarness, base_url: &str, audience_host: &str) -> String {
+    let (openapi_file, openapi_sha256) = write_v4_openapi(harness, base_url);
+    grpc_identity_manifest_yaml_for_host(
+        "github_v4_grpc",
+        &openapi_file,
+        &openapi_sha256,
+        audience_host,
+    )
+}
+
+fn grpc_identity_manifest_yaml_for_host(
+    name: &str,
+    openapi_file: &Path,
+    openapi_sha256: &str,
+    audience_host: &str,
+) -> String {
+    format!(
+        r"
+name: {name}
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    sha256: {}
+    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+          audience:
+            host: {audience_host}
+",
+        openapi_file.display(),
+        openapi_sha256
+    )
+}
+
+fn grpc_identity_openapi_yaml(base_url: &str) -> String {
+    format!(
+        r#"
+openapi: 3.0.0
+info:
+  title: Demo
+  version: 1.0.0
+servers:
+  - url: "{base_url}"
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+"#
+    )
 }
 
 #[tokio::test]
@@ -573,14 +871,6 @@ async fn import_source_invalid_inputs_return_invalid_argument() {
                 ..import_request(fixture_manifest_with_inputs_yaml())
             },
             "source secret 'API_TOKEN' is repeated",
-        ),
-        (
-            "unsupported identity import fields should fail",
-            ImportSourceRequest {
-                identity_spec_manifest_yamls: vec!["kind: identity".to_string()],
-                ..import_request(fixture_manifest_yaml(harness.temp_path()))
-            },
-            "identity import fields are not supported",
         ),
     ];
 


### PR DESCRIPTION
Wires DSL v4 source import end-to-end with identity specs and pins
materialized artifacts. Behind the default-off dsl_v4 flag; the
SourceRegistry default (ConfigStore) keeps existing source behavior
byte-identical:

- source_registry.rs: SourceRegistry trait + record/conversions and
  the spec-bundle seam; SourceManager swaps direct ConfigStore use for
  Arc<dyn SourceRegistry>, with ConfigStore as the default impl
- import flow (sources/service.rs + manager.rs): install/validate/
  rollback of identity specs from a manifest bundle, user-binding
  selection validation and persistence, identity-binding threading
  through ImportSourceRequest/PersistSourceRequest, and
  authorize_source_mutation on mutations
- config.rs: identity_bindings TOML persistence + validation;
  InstalledSource gains identity_bindings (model.rs)
- materialization.rs: descriptor sha256 pinning with fail-loud
  mismatch guidance; runtime_package.rs threads
  with_identity_requirements + per-surface declared_inputs
- AppError::SourceUnservable replaces MissingOrIncompatibleV4Materialization
- tests: gRPC identity-binding/import lifecycle (persist/clear/replace/
  reselect/preserve), identity-spec import + rollback, and the
  descriptor-hash materialization checks

Query-time resolution of these bindings and the server extension seams
land in the next PR; bindings persist here but are not yet consumed at
query time.