### PR TITLE
feat(app): query-time identity resolution and server extension seams

### DIFF
--- a/crates/coral-app/src/authorization.rs
+++ b/crates/coral-app/src/authorization.rs
@@ -1,4 +1,4 @@
-//! Product authorization seam for management-plane mutations.
+//! Product authorization seams for management-plane mutations and workspace data access.
 
 use std::fmt;
 
@@ -44,6 +44,15 @@ pub enum SourceMutationKind {
     Delete,
 }
 
+/// Workspace-scoped operation being authorized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceAccessKind {
+    /// Read workspace-scoped source metadata, catalog data, or query results.
+    Read,
+    /// Write workspace-scoped observational records such as feedback or episodes.
+    Write,
+}
+
 /// Product-provided authorization policy for management-plane mutations.
 ///
 /// OSS Coral installs [`AllowAllManagementAuthorizer`] by default to preserve
@@ -51,6 +60,15 @@ pub enum SourceMutationKind {
 /// and identity-spec mutations while reusing the shared gRPC service surface.
 #[tonic::async_trait]
 pub trait ManagementAuthorizer: fmt::Debug + Send + Sync + 'static {
+    /// Returns true for Coral's default allow-all management authorizer.
+    ///
+    /// Server startup uses this to prevent accidental public network exposure
+    /// with OSS local defaults. Product authorizers should use the default
+    /// implementation.
+    fn is_default_allow_all_authorizer(&self) -> bool {
+        false
+    }
+
     /// Authorizes creating or deleting global identity specs.
     ///
     /// # Errors
@@ -77,12 +95,47 @@ pub trait ManagementAuthorizer: fmt::Debug + Send + Sync + 'static {
     ) -> Result<(), AuthorizationError>;
 }
 
+/// Product-provided authorization policy for workspace-scoped data access.
+///
+/// OSS Coral installs [`AllowAllWorkspaceAuthorizer`] by default to preserve
+/// local single-user behavior. Product runtimes that expose native gRPC beyond
+/// loopback must replace it so authenticated users cannot select arbitrary
+/// workspace IDs.
+#[tonic::async_trait]
+pub trait WorkspaceAuthorizer: fmt::Debug + Send + Sync + 'static {
+    /// Returns true for Coral's default allow-all workspace authorizer.
+    ///
+    /// Server startup uses this to prevent accidental public network exposure
+    /// with OSS local defaults. Product authorizers should use the default
+    /// implementation.
+    fn is_default_allow_all_authorizer(&self) -> bool {
+        false
+    }
+
+    /// Authorizes a workspace-scoped operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthorizationError`] when the principal is not allowed to
+    /// access the workspace.
+    async fn authorize_workspace_access(
+        &self,
+        principal: &UserPrincipal,
+        workspace_id: &str,
+        kind: WorkspaceAccessKind,
+    ) -> Result<(), AuthorizationError>;
+}
+
 /// Default OSS authorizer for local single-user usage.
 #[derive(Debug, Default)]
 pub struct AllowAllManagementAuthorizer;
 
 #[tonic::async_trait]
 impl ManagementAuthorizer for AllowAllManagementAuthorizer {
+    fn is_default_allow_all_authorizer(&self) -> bool {
+        true
+    }
+
     async fn authorize_identity_spec_mutation(
         &self,
         _principal: &UserPrincipal,
@@ -95,6 +148,26 @@ impl ManagementAuthorizer for AllowAllManagementAuthorizer {
         _principal: &UserPrincipal,
         _workspace_id: &str,
         _kind: SourceMutationKind,
+    ) -> Result<(), AuthorizationError> {
+        Ok(())
+    }
+}
+
+/// Default OSS workspace authorizer for local single-user usage.
+#[derive(Debug, Default)]
+pub struct AllowAllWorkspaceAuthorizer;
+
+#[tonic::async_trait]
+impl WorkspaceAuthorizer for AllowAllWorkspaceAuthorizer {
+    fn is_default_allow_all_authorizer(&self) -> bool {
+        true
+    }
+
+    async fn authorize_workspace_access(
+        &self,
+        _principal: &UserPrincipal,
+        _workspace_id: &str,
+        _kind: WorkspaceAccessKind,
     ) -> Result<(), AuthorizationError> {
         Ok(())
     }

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -14,7 +14,10 @@ pub(crate) use error::MAX_STATUS_DETAIL_BYTES;
 pub(crate) use error::{app_status, core_status};
 
 pub use error::AppError;
-pub use server::{RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider};
+pub use server::{
+    RunningServer, ServerBuilder, ServerExtensionContext, ServerMode, StaticAsset,
+    StaticAssetsProvider,
+};
 
 pub(crate) fn discover_app_state_layout(
     config_dir_override: Option<PathBuf>,

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -13,7 +13,7 @@ use std::task::{Context, Poll};
 
 use axum::body::Body as AxumBody;
 use axum::extract::Request as AxumRequest;
-use axum::response::Response as AxumResponse;
+use axum::response::{IntoResponse as _, Response as AxumResponse};
 use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::episode_service_server::EpisodeServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
@@ -32,6 +32,7 @@ use tokio::task::JoinHandle;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::codegen::http::header::CONTENT_TYPE;
 use tonic::codegen::http::{HeaderValue, Method, Request, Response, StatusCode};
+use tonic::server::NamedService;
 use tonic::service::Routes;
 use tonic::transport::Server;
 use tonic_web::GrpcWebLayer;
@@ -39,30 +40,38 @@ use tower::{Layer, Service};
 
 use super::env::AppEnvironment;
 use super::error::AppError;
-use crate::authorization::{AllowAllManagementAuthorizer, ManagementAuthorizer};
+use crate::authorization::{
+    AllowAllManagementAuthorizer, AllowAllWorkspaceAuthorizer, ManagementAuthorizer,
+    WorkspaceAuthorizer,
+};
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
 use crate::credentials::{CredentialManager, CredentialStore};
 use crate::episode::service::EpisodeService;
 use crate::episode::store::EpisodeStore;
-use crate::features::{FeatureOverrides, FeatureStore};
+use crate::features::{FeatureOverrides, FeatureStore, Features};
 use crate::feedback::manager::FeedbackManager;
 use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
-use crate::identities::{IdentityService, UserOwnedIdentityManager};
-use crate::identity_specs::{IdentitySpecManager, IdentitySpecService, IdentitySpecUsageProvider};
+use crate::identities::{
+    IdentityManagementHandle, IdentityService, UserOwnedIdentityManager, UserOwnedIdentityStore,
+};
+use crate::identity_specs::{IdentitySpecManager, IdentitySpecRegistry, IdentitySpecService};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::source_registry::SourceRegistry;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
-use crate::state::ConfigStore;
+use crate::state::{AppStateLayout, ConfigStore};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
-use crate::{EngineExtensionsProvider, SingleUserPrincipalProvider, UserPrincipalProvider};
+use crate::{
+    EngineExtensionsProvider, IdentitySpecUsageProvider, SingleUserPrincipalProvider,
+    SourceIdentityProvider, UserPrincipalError, UserPrincipalProvider,
+};
 
 /// A static asset (e.g., a built SPA file) served on the same port as
 /// gRPC-Web.
@@ -83,6 +92,34 @@ pub trait StaticAssetsProvider: Send + Sync + 'static {
     fn get(&self, path: &str) -> Option<StaticAsset>;
 }
 
+type GrpcRouteExtender = Arc<
+    dyn Fn(&ServerExtensionContext, &Arc<dyn UserPrincipalProvider>, Routes) -> Routes
+        + Send
+        + Sync,
+>;
+type SourceIdentityProviderFactory =
+    Arc<dyn Fn(&ServerExtensionContext) -> Arc<dyn SourceIdentityProvider> + Send + Sync>;
+
+/// Runtime context supplied to product-specific server extensions.
+#[derive(Clone)]
+pub struct ServerExtensionContext {
+    identity_management: IdentityManagementHandle,
+}
+
+impl ServerExtensionContext {
+    fn new(identity_management: IdentityManagementHandle) -> Self {
+        Self {
+            identity_management,
+        }
+    }
+
+    /// Returns the shared identity management handle for this server.
+    #[must_use]
+    pub fn identity_management(&self) -> &IdentityManagementHandle {
+        &self.identity_management
+    }
+}
+
 /// Concrete local server mode.
 ///
 /// Each variant is a supported product mode instead of an independent
@@ -101,9 +138,11 @@ pub enum ServerMode {
 }
 
 impl ServerMode {
-    fn bind_addr(&self) -> SocketAddr {
+    fn bind_addr(&self, native_grpc_bind_addr: Option<SocketAddr>) -> SocketAddr {
         match self {
-            Self::NativeGrpc => SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+            Self::NativeGrpc => {
+                native_grpc_bind_addr.unwrap_or_else(|| SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            }
             Self::EmbeddedUi { port, .. } => SocketAddr::from((Ipv4Addr::LOCALHOST, *port)),
         }
     }
@@ -115,13 +154,22 @@ pub struct ServerBuilder {
     // Defaults preserve single-user local-first behavior; see `Self::new`.
     config_dir: Option<PathBuf>,
     mode: ServerMode,
-    feature_overrides: FeatureOverrides,
+    native_grpc_bind_addr: Option<SocketAddr>,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    source_identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
+    source_identity_provider_factories: Vec<SourceIdentityProviderFactory>,
+    identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+    source_registry: Option<Arc<dyn SourceRegistry>>,
+    identity_spec_registry: Option<Arc<dyn IdentitySpecRegistry>>,
+    user_owned_identity_store: Option<Arc<dyn UserOwnedIdentityStore>>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
-    identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+    workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
+    unsafe_public_native_grpc_bind: bool,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
+    grpc_route_extenders: Vec<GrpcRouteExtender>,
     enable_stderr_logs: bool,
+    feature_overrides: FeatureOverrides,
 }
 
 impl Default for ServerBuilder {
@@ -137,13 +185,22 @@ impl ServerBuilder {
         Self {
             config_dir: None,
             mode: ServerMode::NativeGrpc,
-            feature_overrides: FeatureOverrides::default(),
+            native_grpc_bind_addr: None,
             engine_extensions_providers: Vec::new(),
+            source_identity_providers: Vec::new(),
+            source_identity_provider_factories: Vec::new(),
+            identity_spec_usage_providers: Vec::new(),
+            source_registry: None,
+            identity_spec_registry: None,
+            user_owned_identity_store: None,
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             management_authorizer: Arc::new(AllowAllManagementAuthorizer),
-            identity_spec_usage_providers: Vec::new(),
+            workspace_authorizer: Arc::new(AllowAllWorkspaceAuthorizer),
+            unsafe_public_native_grpc_bind: false,
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
+            grpc_route_extenders: Vec::new(),
             enable_stderr_logs: false,
+            feature_overrides: FeatureOverrides::default(),
         }
     }
 
@@ -173,16 +230,33 @@ impl ServerBuilder {
     }
 
     #[must_use]
-    /// Overrides the Coral config directory used by the local server.
-    pub fn with_config_dir(mut self, config_dir: impl Into<PathBuf>) -> Self {
-        self.config_dir = Some(config_dir.into());
+    /// Selects the bind address for native gRPC mode.
+    ///
+    /// The default native gRPC address remains `127.0.0.1:0` for local-first
+    /// OSS callers. Product runtimes that install their own authentication and
+    /// management authorization can bind a public address such as `0.0.0.0:0`
+    /// only after explicitly calling [`Self::allow_unsafe_public_native_grpc_bind`].
+    pub fn with_native_grpc_bind_addr(mut self, bind_addr: SocketAddr) -> Self {
+        self.native_grpc_bind_addr = Some(bind_addr);
         self
     }
 
     #[must_use]
-    /// Applies process-local runtime feature overrides to the local server.
-    pub fn with_feature_overrides(mut self, feature_overrides: FeatureOverrides) -> Self {
-        self.feature_overrides = feature_overrides;
+    /// Allows native gRPC to bind a non-loopback address.
+    ///
+    /// This opt-in exists to keep OSS Coral's allow-all local defaults from
+    /// accidentally becoming a network service. Only product runtimes that have
+    /// installed request authentication and management authorization should use
+    /// it.
+    pub fn allow_unsafe_public_native_grpc_bind(mut self) -> Self {
+        self.unsafe_public_native_grpc_bind = true;
+        self
+    }
+
+    #[must_use]
+    /// Overrides the Coral config directory used by the local server.
+    pub fn with_config_dir(mut self, config_dir: impl Into<PathBuf>) -> Self {
+        self.config_dir = Some(config_dir.into());
         self
     }
 
@@ -230,13 +304,163 @@ impl ServerBuilder {
     }
 
     #[must_use]
-    /// Adds a provider that reports product-owned stored identities for
-    /// identity-spec replacement and deletion checks.
+    /// Sets the product-specific workspace data-access authorizer.
+    ///
+    /// The default authorizer allows all workspace reads and observational writes
+    /// to preserve OSS single-user behavior. Product runtimes can install a
+    /// stricter policy for multi-user data planes.
+    pub fn with_workspace_authorizer(
+        mut self,
+        workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
+    ) -> Self {
+        self.workspace_authorizer = workspace_authorizer;
+        self
+    }
+
+    #[must_use]
+    /// Adds a provider that can resolve configured source identity bindings.
+    pub fn add_source_identity_provider(
+        mut self,
+        source_identity_provider: Arc<dyn SourceIdentityProvider>,
+    ) -> Self {
+        self.source_identity_providers
+            .push(source_identity_provider);
+        self
+    }
+
+    #[must_use]
+    /// Adds a provider factory that receives server runtime extension context.
+    ///
+    /// Use this when a product-specific provider needs access to shared
+    /// managers created during server startup, such as identity management.
+    pub fn add_source_identity_provider_factory(
+        mut self,
+        source_identity_provider_factory: impl Fn(
+            &ServerExtensionContext,
+        ) -> Arc<dyn SourceIdentityProvider>
+        + Send
+        + Sync
+        + 'static,
+    ) -> Self {
+        self.source_identity_provider_factories
+            .push(Arc::new(source_identity_provider_factory));
+        self
+    }
+
+    #[must_use]
+    /// Adds a provider that reports stored identities using installed identity specs.
+    ///
+    /// OSS Coral stores only user-owned identities, but products built on Coral
+    /// can store workspace-owned identities too. Those products should install
+    /// a usage provider so identity-spec deletion can reject or report
+    /// orphaning for every stored identity owner and type.
     pub fn add_identity_spec_usage_provider(
         mut self,
-        usage_provider: Arc<dyn IdentitySpecUsageProvider>,
+        identity_spec_usage_provider: Arc<dyn IdentitySpecUsageProvider>,
     ) -> Self {
-        self.identity_spec_usage_providers.push(usage_provider);
+        self.identity_spec_usage_providers
+            .push(identity_spec_usage_provider);
+        self
+    }
+
+    #[must_use]
+    /// Sets the durable registry used for workspace-installed sources.
+    ///
+    /// The default registry persists source records in local `config.toml`.
+    /// Product-specific siblings can install a registry backed by their own
+    /// durable control-plane store.
+    pub fn with_source_registry(mut self, source_registry: Arc<dyn SourceRegistry>) -> Self {
+        self.source_registry = Some(source_registry);
+        self
+    }
+
+    #[must_use]
+    /// Sets the durable registry used for global identity specs.
+    ///
+    /// The default registry persists identity specs in local app state.
+    /// Product-specific siblings can install a registry backed by their own
+    /// control-plane store.
+    pub fn with_identity_spec_registry(
+        mut self,
+        identity_spec_registry: Arc<dyn IdentitySpecRegistry>,
+    ) -> Self {
+        self.identity_spec_registry = Some(identity_spec_registry);
+        self
+    }
+
+    #[must_use]
+    /// Sets the durable store used for user-owned identities and source
+    /// identity selections.
+    ///
+    /// The default store persists identities in local app state.
+    /// Product-specific siblings can install a store backed by their own
+    /// credential and identity persistence layer. Custom stores must also add
+    /// an [`IdentitySpecUsageProvider`] so identity-spec replacement and
+    /// deletion cannot orphan externally stored identities.
+    pub fn with_user_owned_identity_store(
+        mut self,
+        user_owned_identity_store: Arc<dyn UserOwnedIdentityStore>,
+    ) -> Self {
+        self.user_owned_identity_store = Some(user_owned_identity_store);
+        self
+    }
+
+    #[must_use]
+    /// Adds a product-specific gRPC service to the Coral server listener.
+    ///
+    /// OSS Coral owns the core gRPC service set. Product-specific sibling
+    /// crates can use this seam to mount their own generated tonic services onto
+    /// the same authenticated gRPC endpoint without adding product concepts to
+    /// OSS APIs.
+    pub fn add_grpc_service<S>(mut self, service: S) -> Self
+    where
+        S: Service<Request<tonic::body::Body>, Error = Infallible>
+            + NamedService
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        S::Response: axum::response::IntoResponse,
+        S::Future: Send + 'static,
+    {
+        let service = Arc::new(service);
+        self.grpc_route_extenders.push(Arc::new(
+            move |_context, user_principal_provider, routes| {
+                routes.add_service(AuthenticatedGrpcService::new(
+                    (*service).clone(),
+                    Arc::clone(user_principal_provider),
+                ))
+            },
+        ));
+        self
+    }
+
+    #[must_use]
+    /// Adds a product-specific gRPC service factory to the Coral listener.
+    ///
+    /// The factory runs after core server managers are initialized and receives
+    /// [`ServerExtensionContext`], allowing product services to reuse shared
+    /// Coral managers instead of rebuilding parallel logic.
+    pub fn add_grpc_service_factory<F, S>(mut self, factory: F) -> Self
+    where
+        F: Fn(&ServerExtensionContext) -> S + Send + Sync + 'static,
+        S: Service<Request<tonic::body::Body>, Error = Infallible>
+            + NamedService
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        S::Response: axum::response::IntoResponse,
+        S::Future: Send + 'static,
+    {
+        self.grpc_route_extenders.push(Arc::new(
+            move |context, user_principal_provider, routes| {
+                routes.add_service(AuthenticatedGrpcService::new(
+                    factory(context),
+                    Arc::clone(user_principal_provider),
+                ))
+            },
+        ));
         self
     }
 
@@ -248,6 +472,13 @@ impl ServerBuilder {
     /// leave it disabled and rely on OTEL export for logs.
     pub fn with_stderr_logs(mut self, enable_stderr_logs: bool) -> Self {
         self.enable_stderr_logs = enable_stderr_logs;
+        self
+    }
+
+    #[must_use]
+    /// Applies process-local runtime feature overrides to this local server.
+    pub fn with_feature_overrides(mut self, feature_overrides: FeatureOverrides) -> Self {
+        self.feature_overrides = feature_overrides;
         self
     }
 
@@ -270,6 +501,7 @@ impl ServerBuilder {
     /// required directories cannot be created, the config or credential backends
     /// fail to initialize, or the gRPC server cannot be started.
     pub async fn start(self) -> Result<RunningServer, AppError> {
+        self.ensure_compatible_extension_storage()?;
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config_dir)?;
         layout.ensure()?;
@@ -284,15 +516,17 @@ impl ServerBuilder {
             internal_trace_store_dir.clone(),
         )?;
         let config_store = ConfigStore::new(layout.clone());
+        let source_registry = self
+            .source_registry
+            .unwrap_or_else(|| Arc::new(config_store.clone()));
         let features =
             FeatureStore::new(layout.clone()).load_with_overrides(&self.feature_overrides)?;
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store.clone());
-        let source_registry: Arc<dyn SourceRegistry> = Arc::new(config_store.clone());
         let source_manager = SourceManager::new_with_features_and_source_registry(
-            source_registry.clone(),
+            Arc::clone(&source_registry),
             credential_manager.clone(),
             layout.clone(),
             features.clone(),
@@ -306,26 +540,38 @@ impl ServerBuilder {
         let query_runtime_context = env
             .query_runtime_context()
             .with_body_capture_max_bytes(body_capture_max_bytes);
-        let identity_spec_manager = IdentitySpecManager::new_with_credential_store(
-            layout.clone(),
-            credential_store.clone(),
-            features.clone(),
+        let identity_spec_manager = identity_spec_manager_for_server(
+            &layout,
+            &credential_store,
+            &features,
+            self.identity_spec_registry,
             self.identity_spec_usage_providers,
         );
-        let user_owned_identity_manager = UserOwnedIdentityManager::new(
-            layout.clone(),
-            identity_spec_manager.clone(),
-            credential_store,
-        );
+        let user_owned_identity_manager = if let Some(store) = self.user_owned_identity_store {
+            UserOwnedIdentityManager::new_with_store(identity_spec_manager.clone(), store)
+        } else {
+            UserOwnedIdentityManager::new(
+                layout.clone(),
+                identity_spec_manager.clone(),
+                credential_store,
+            )
+        };
+        let extension_context = ServerExtensionContext::new(user_owned_identity_manager.handle());
+        let mut source_identity_providers = self.source_identity_providers;
+        for source_identity_provider_factory in self.source_identity_provider_factories {
+            source_identity_providers.push(source_identity_provider_factory(&extension_context));
+        }
+        source_identity_providers.push(Arc::new(user_owned_identity_manager.clone()));
 
-        let query_manager = QueryManager::new_with_source_registry(
+        let query_manager = QueryManager::new_with_features_and_source_registry(
             config_store,
             source_registry,
             credential_manager,
             query_runtime_context,
-            layout,
-            features,
+            layout.clone(),
             self.engine_extensions_providers,
+            source_identity_providers,
+            features,
         );
         let trace_service = if telemetry_config.trace_history.enabled {
             installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))
@@ -339,12 +585,71 @@ impl ServerBuilder {
             user_owned_identity_manager,
             user_principal_provider: self.user_principal_provider,
             management_authorizer: self.management_authorizer,
+            workspace_authorizer: self.workspace_authorizer,
             feedback_manager,
             episode_store,
             trace_service,
             mode: self.mode,
+            native_grpc_bind_addr: self.native_grpc_bind_addr,
+            grpc_route_extenders: self.grpc_route_extenders,
+            extension_context,
         })
         .await
+    }
+
+    fn ensure_compatible_extension_storage(&self) -> Result<(), AppError> {
+        if let ServerMode::NativeGrpc = self.mode
+            && let Some(bind_addr) = self.native_grpc_bind_addr
+            && !bind_addr.ip().is_loopback()
+            && (!self.unsafe_public_native_grpc_bind
+                || self
+                    .user_principal_provider
+                    .is_default_single_user_provider()
+                || self.management_authorizer.is_default_allow_all_authorizer()
+                || self.workspace_authorizer.is_default_allow_all_authorizer())
+        {
+            return Err(AppError::FailedPrecondition(format!(
+                "non-loopback native gRPC bind address '{bind_addr}' requires allow_unsafe_public_native_grpc_bind(), a non-default user principal provider, a non-default management authorizer, and a non-default workspace authorizer"
+            )));
+        }
+        if self.identity_spec_registry.is_some() && self.user_owned_identity_store.is_none() {
+            return Err(AppError::FailedPrecondition(
+                "custom identity spec registries require a custom user-owned identity store"
+                    .to_string(),
+            ));
+        }
+        if self.user_owned_identity_store.is_some() && self.identity_spec_usage_providers.is_empty()
+        {
+            return Err(AppError::FailedPrecondition(
+                "custom user-owned identity stores require an identity spec usage provider"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn identity_spec_manager_for_server(
+    layout: &AppStateLayout,
+    credential_store: &CredentialStore,
+    features: &Features,
+    identity_spec_registry: Option<Arc<dyn IdentitySpecRegistry>>,
+    identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+) -> IdentitySpecManager {
+    if let Some(identity_spec_registry) = identity_spec_registry {
+        IdentitySpecManager::new_with_registry(
+            layout.clone(),
+            identity_spec_registry,
+            features.clone(),
+            identity_spec_usage_providers,
+        )
+    } else {
+        IdentitySpecManager::new_with_credential_store(
+            layout.clone(),
+            credential_store.clone(),
+            features.clone(),
+            identity_spec_usage_providers,
+        )
     }
 }
 
@@ -425,13 +730,38 @@ struct ServerServices {
     user_owned_identity_manager: UserOwnedIdentityManager,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
+    workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
     feedback_manager: FeedbackManager,
     episode_store: EpisodeStore,
     trace_service: Option<TraceService>,
     mode: ServerMode,
+    native_grpc_bind_addr: Option<SocketAddr>,
+    grpc_route_extenders: Vec<GrpcRouteExtender>,
+    extension_context: ServerExtensionContext,
 }
 
 async fn start_server(services: ServerServices) -> Result<RunningServer, AppError> {
+    let (routes, mode, native_grpc_bind_addr) = build_server_routes(services);
+
+    let listener = TcpListener::bind(mode.bind_addr(native_grpc_bind_addr)).await?;
+    let endpoint_uri = format!("http://{}", listener.local_addr()?);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let task = match mode {
+        ServerMode::NativeGrpc => start_grpc_server(listener, shutdown_rx, routes),
+        ServerMode::EmbeddedUi { assets, .. } => {
+            start_grpc_web_server(listener, shutdown_rx, routes, assets)
+        }
+    };
+
+    Ok(RunningServer {
+        endpoint_uri,
+        shutdown_tx: Mutex::new(Some(shutdown_tx)),
+        task: Mutex::new(Some(task)),
+    })
+}
+
+fn build_server_routes(services: ServerServices) -> (Routes, ServerMode, Option<SocketAddr>) {
     let ServerServices {
         source_manager,
         query_manager,
@@ -439,10 +769,14 @@ async fn start_server(services: ServerServices) -> Result<RunningServer, AppErro
         user_owned_identity_manager,
         user_principal_provider,
         management_authorizer,
+        workspace_authorizer,
         feedback_manager,
         episode_store,
         trace_service,
         mode,
+        native_grpc_bind_addr,
+        grpc_route_extenders,
+        extension_context,
     } = services;
     let source_service = SourceService::new(
         source_manager,
@@ -451,22 +785,37 @@ async fn start_server(services: ServerServices) -> Result<RunningServer, AppErro
         user_owned_identity_manager.clone(),
         Arc::clone(&user_principal_provider),
         Arc::clone(&management_authorizer),
+        Arc::clone(&workspace_authorizer),
     );
-    let catalog_service =
-        CatalogService::new(query_manager.clone(), Arc::clone(&user_principal_provider));
+    let catalog_service = CatalogService::new(
+        query_manager.clone(),
+        Arc::clone(&user_principal_provider),
+        Arc::clone(&workspace_authorizer),
+    );
     let identity_service = IdentityService::new(
         user_owned_identity_manager,
         Arc::clone(&user_principal_provider),
     );
-    let query_service = QueryService::new(query_manager, Arc::clone(&user_principal_provider));
+    let query_service = QueryService::new(
+        query_manager,
+        Arc::clone(&user_principal_provider),
+        Arc::clone(&workspace_authorizer),
+    );
     let identity_spec_service = IdentitySpecService::new(
         identity_spec_manager,
         Arc::clone(&user_principal_provider),
         Arc::clone(&management_authorizer),
     );
-    let feedback_service =
-        FeedbackService::new(feedback_manager, Arc::clone(&user_principal_provider));
-    let episode_service = EpisodeService::new(episode_store);
+    let feedback_service = FeedbackService::new(
+        feedback_manager,
+        Arc::clone(&user_principal_provider),
+        Arc::clone(&workspace_authorizer),
+    );
+    let episode_service = EpisodeService::new(
+        episode_store,
+        Arc::clone(&user_principal_provider),
+        Arc::clone(&workspace_authorizer),
+    );
     let mut routes = Routes::default()
         .add_service(GrpcMethodAnnotatedService::new(SourceServiceServer::new(
             source_service,
@@ -506,23 +855,11 @@ async fn start_server(services: ServerServices) -> Result<RunningServer, AppErro
                 .max_encoding_message_size(TRACE_RESPONSE_MAX_MESSAGE_SIZE),
         ));
     }
+    for extend_routes in grpc_route_extenders {
+        routes = extend_routes(&extension_context, &user_principal_provider, routes);
+    }
 
-    let listener = TcpListener::bind(mode.bind_addr()).await?;
-    let endpoint_uri = format!("http://{}", listener.local_addr()?);
-    let (shutdown_tx, shutdown_rx) = oneshot::channel();
-
-    let task = match mode {
-        ServerMode::NativeGrpc => start_grpc_server(listener, shutdown_rx, routes),
-        ServerMode::EmbeddedUi { assets, .. } => {
-            start_grpc_web_server(listener, shutdown_rx, routes, assets)
-        }
-    };
-
-    Ok(RunningServer {
-        endpoint_uri,
-        shutdown_tx: Mutex::new(Some(shutdown_tx)),
-        task: Mutex::new(Some(task)),
-    })
+    (routes, mode, native_grpc_bind_addr)
 }
 
 fn start_grpc_server(
@@ -568,6 +905,70 @@ fn start_grpc_web_server(
             })
             .await
     })
+}
+
+#[derive(Clone)]
+struct AuthenticatedGrpcService<S> {
+    inner: S,
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+}
+
+impl<S> AuthenticatedGrpcService<S> {
+    fn new(inner: S, user_principal_provider: Arc<dyn UserPrincipalProvider>) -> Self {
+        Self {
+            inner,
+            user_principal_provider,
+        }
+    }
+}
+
+impl<S> NamedService for AuthenticatedGrpcService<S>
+where
+    S: NamedService,
+{
+    const NAME: &'static str = S::NAME;
+}
+
+impl<S> Service<Request<tonic::body::Body>> for AuthenticatedGrpcService<S>
+where
+    S: Service<Request<tonic::body::Body>, Error = Infallible> + Clone + Send + 'static,
+    S::Response: axum::response::IntoResponse,
+    S::Future: Send + 'static,
+{
+    type Response = AxumResponse;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<tonic::body::Body>) -> Self::Future {
+        let metadata = tonic::metadata::MetadataMap::from_headers(request.headers().clone());
+        let user_principal_provider = Arc::clone(&self.user_principal_provider);
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        Box::pin(async move {
+            if let Err(error) = user_principal_provider
+                .principal_for_metadata(&metadata)
+                .await
+            {
+                return Ok(user_principal_status(error).into_http::<AxumBody>());
+            }
+            let response = inner.call(request).await?;
+            Ok(response.into_response())
+        })
+    }
+}
+
+fn user_principal_status(error: UserPrincipalError) -> tonic::Status {
+    match error {
+        UserPrincipalError::Unauthenticated(message) => tonic::Status::unauthenticated(message),
+        UserPrincipalError::InvalidInput(message) => {
+            tonic::Status::invalid_argument(format!("invalid user principal metadata: {message}"))
+        }
+        UserPrincipalError::Internal(message) => tonic::Status::internal(message),
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -719,15 +1120,19 @@ mod tests {
     )]
 
     use std::borrow::Cow;
+    use std::collections::BTreeMap;
+    use std::convert::Infallible;
     use std::future::Future;
-    use std::net::{Ipv4Addr, TcpListener};
+    use std::net::{Ipv4Addr, SocketAddr, TcpListener};
     use std::path::Path;
     use std::sync::Arc;
+    use std::task::{Context, Poll};
     use std::time::Duration;
 
     use coral_api::v1::catalog_service_client::CatalogServiceClient;
     use coral_api::v1::episode_service_client::EpisodeServiceClient;
     use coral_api::v1::feedback_service_client::FeedbackServiceClient;
+    use coral_api::v1::identity_service_client::IdentityServiceClient;
     use coral_api::v1::identity_spec_service_client::IdentitySpecServiceClient;
     use coral_api::v1::query_service_client::QueryServiceClient;
     use coral_api::v1::source_service_client::SourceServiceClient;
@@ -735,31 +1140,43 @@ mod tests {
     use coral_api::v1::{
         AddIdentitySpecRequest, CreateBundledSourceRequest, DeleteIdentitySpecRequest,
         ExecuteSqlRequest, ExecuteSqlResponse, ImportSourceRequest, ImportSourceResponse,
-        ListCatalogRequest, ListSourcesRequest, ListTracesRequest, ListTracesResponse,
-        OAuthCredentialRetrieval, OpenEpisodeRequest, SubmitFeedbackRequest, Workspace,
-        import_source_response,
+        ListCatalogRequest, ListIdentitySpecsRequest, ListSourcesRequest, ListTracesRequest,
+        ListTracesResponse, ListUserOwnedIdentitiesRequest, OAuthCredentialRetrieval,
+        OpenEpisodeRequest, SubmitFeedbackRequest, Workspace, import_source_response,
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
 
+    use crate::authorization::{
+        AllowAllManagementAuthorizer, AllowAllWorkspaceAuthorizer, AuthorizationError,
+        ManagementAuthorizer, SourceMutationKind, WorkspaceAccessKind, WorkspaceAuthorizer,
+    };
+    use crate::identities::{
+        IdentityOwnerKey, UserOwnedIdentityManager, UserOwnedIdentityMaterialGuard,
+        UserOwnedIdentityRecord, UserOwnedIdentityStore,
+    };
+    use crate::identity_specs::{
+        IdentitySpecManager, IdentitySpecRegistry, IdentitySpecRegistryRecord,
+        IdentitySpecUsageProvider,
+    };
     use tempfile::TempDir;
+    use tonic::body::Body as TonicBody;
+    use tonic::codegen::http::{Request as HttpRequest, Response as HttpResponse};
+    use tonic::server::NamedService;
     use tonic::transport::{Channel, Endpoint};
     use tonic::{Code, Request};
+    use tower::{Service, ServiceExt as _};
 
     use super::{
-        RunningServer, ServerBuilder, ServerMode, ServerServices, StaticAsset,
-        StaticAssetsProvider, is_grpc_web_content_type, is_native_grpc_content_type, start_server,
-    };
-    use crate::authorization::{
-        AllowAllManagementAuthorizer, AuthorizationError, ManagementAuthorizer, SourceMutationKind,
+        RunningServer, ServerBuilder, ServerExtensionContext, ServerMode, ServerServices,
+        StaticAsset, StaticAssetsProvider, is_grpc_web_content_type, is_native_grpc_content_type,
+        start_server,
     };
     use crate::bootstrap::AppError;
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::episode::store::EpisodeStore;
     use crate::features::{Feature, FeatureOverrides};
     use crate::feedback::manager::FeedbackManager;
-    use crate::identities::UserOwnedIdentityManager;
-    use crate::identity_specs::{IdentitySpecManager, IdentitySpecUsageProvider};
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
     use crate::state::{AppStateLayout, ConfigStore};
@@ -787,6 +1204,129 @@ mod tests {
             Err(UserPrincipalError::unauthenticated(
                 "rejected user principal",
             ))
+        }
+    }
+
+    #[derive(Clone)]
+    struct ExtensionProbeService;
+
+    impl NamedService for ExtensionProbeService {
+        const NAME: &'static str = "coral.test.ExtensionProbe";
+    }
+
+    impl Service<HttpRequest<TonicBody>> for ExtensionProbeService {
+        type Response = HttpResponse<TonicBody>;
+        type Error = Infallible;
+        type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _request: HttpRequest<TonicBody>) -> Self::Future {
+            std::future::ready(Ok(
+                tonic::Status::unimplemented("extension reached").into_http()
+            ))
+        }
+    }
+
+    #[derive(Debug)]
+    struct EmptyIdentitySpecRegistry;
+
+    impl IdentitySpecRegistry for EmptyIdentitySpecRegistry {
+        fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRegistryRecord>, AppError> {
+            Ok(Vec::new())
+        }
+
+        fn get_identity_spec(
+            &self,
+            _name: &str,
+        ) -> Result<Option<IdentitySpecRegistryRecord>, AppError> {
+            Ok(None)
+        }
+
+        fn upsert_identity_spec(
+            &self,
+            _name: &str,
+            _record: IdentitySpecRegistryRecord,
+        ) -> Result<(), AppError> {
+            Ok(())
+        }
+
+        fn remove_identity_spec(&self, _name: &str) -> Result<(), AppError> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct EmptyUserOwnedIdentityStore;
+
+    #[tonic::async_trait]
+    impl UserOwnedIdentityStore for EmptyUserOwnedIdentityStore {
+        async fn list_identities(
+            &self,
+            _owner: &IdentityOwnerKey,
+        ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+            Ok(Vec::new())
+        }
+
+        async fn load_identity(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _identity_name: &str,
+        ) -> Result<Option<UserOwnedIdentityRecord>, AppError> {
+            Ok(None)
+        }
+
+        async fn replace_identity(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _record: &UserOwnedIdentityRecord,
+            _material: &BTreeMap<String, String>,
+        ) -> Result<(), AppError> {
+            Ok(())
+        }
+
+        async fn delete_identity(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _identity_name: &str,
+        ) -> Result<bool, AppError> {
+            Ok(false)
+        }
+
+        async fn material_guard(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _identity_name: &str,
+        ) -> Result<Box<dyn UserOwnedIdentityMaterialGuard>, AppError> {
+            Ok(Box::new(EmptyUserOwnedIdentityMaterialGuard))
+        }
+
+        async fn delete_source_identity_bindings(
+            &self,
+            _workspace_name: &str,
+            _source_name: &str,
+            _surface_ids: &[String],
+            _preserved_user_id: Option<&str>,
+        ) -> Result<(), AppError> {
+            Ok(())
+        }
+    }
+
+    struct EmptyUserOwnedIdentityMaterialGuard;
+
+    #[tonic::async_trait]
+    impl UserOwnedIdentityMaterialGuard for EmptyUserOwnedIdentityMaterialGuard {
+        async fn read_material(&self) -> Result<BTreeMap<String, String>, AppError> {
+            Ok(BTreeMap::new())
+        }
+
+        async fn write_material(
+            &self,
+            _material: &BTreeMap<String, String>,
+        ) -> Result<(), AppError> {
+            Ok(())
         }
     }
 
@@ -860,6 +1400,36 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct DenyingWorkspaceAuthorizer;
+
+    #[tonic::async_trait]
+    impl WorkspaceAuthorizer for DenyingWorkspaceAuthorizer {
+        async fn authorize_workspace_access(
+            &self,
+            _principal: &UserPrincipal,
+            _workspace_id: &str,
+            _kind: WorkspaceAccessKind,
+        ) -> Result<(), AuthorizationError> {
+            Err(AuthorizationError::forbidden("workspace access is blocked"))
+        }
+    }
+
+    #[derive(Debug)]
+    struct AllowAllNonDefaultWorkspaceAuthorizer;
+
+    #[tonic::async_trait]
+    impl WorkspaceAuthorizer for AllowAllNonDefaultWorkspaceAuthorizer {
+        async fn authorize_workspace_access(
+            &self,
+            _principal: &UserPrincipal,
+            _workspace_id: &str,
+            _kind: WorkspaceAccessKind,
+        ) -> Result<(), AuthorizationError> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
     struct StaticIdentitySpecUsageProvider {
         identity_spec_name: String,
         count: u32,
@@ -924,6 +1494,7 @@ enabled = false
             identity_spec_manager.clone(),
             credential_store,
         );
+        let extension_context = ServerExtensionContext::new(user_owned_identity_manager.handle());
         let server = start_server(ServerServices {
             source_manager: SourceManager::new(
                 config_store.clone(),
@@ -935,17 +1506,20 @@ enabled = false
                 credential_manager,
                 runtime_context,
                 layout.clone(),
-                crate::features::dsl_v4_features(),
                 vec![Arc::new(NoopEngineExtensionsProvider)],
             ),
-            identity_spec_manager,
+            identity_spec_manager: identity_spec_manager.clone(),
             user_owned_identity_manager,
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+            workspace_authorizer: Arc::new(AllowAllWorkspaceAuthorizer),
             feedback_manager: FeedbackManager::new(layout.clone()),
             episode_store: EpisodeStore::new(layout.clone()),
             trace_service,
             mode: ServerMode::NativeGrpc,
+            native_grpc_bind_addr: None,
+            grpc_route_extenders: Vec::new(),
+            extension_context,
         })
         .await
         .expect("start server");
@@ -1034,6 +1608,17 @@ enabled = false
             .await
             .expect_err(&format!("{label} should require a request principal"));
         assert_eq!(status.code(), Code::Unauthenticated, "{label}");
+    }
+
+    /// Asserts that `call` is rejected with `PermissionDenied`.
+    async fn expect_permission_denied<T: std::fmt::Debug>(
+        label: &str,
+        call: impl Future<Output = Result<T, tonic::Status>>,
+    ) {
+        let status = call
+            .await
+            .expect_err(&format!("{label} should require workspace access"));
+        assert_eq!(status.code(), Code::PermissionDenied, "{label}");
     }
 
     #[tokio::test]
@@ -1338,6 +1923,105 @@ enabled = false
     }
 
     #[tokio::test]
+    async fn server_builder_rejects_public_native_grpc_bind_without_auth_overrides() {
+        let temp = TempDir::new().expect("temp dir");
+        let result = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_native_grpc_bind_addr(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+            .start()
+            .await;
+
+        let Err(error) = result else {
+            panic!("server should reject public native gRPC bind with default auth");
+        };
+        assert!(
+            error.to_string().contains(
+                "non-loopback native gRPC bind address '0.0.0.0:0' requires allow_unsafe_public_native_grpc_bind(), a non-default user principal provider, a non-default management authorizer, and a non-default workspace authorizer"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn server_builder_rejects_public_native_grpc_bind_with_unsafe_opt_in_and_local_defaults()
+    {
+        let temp = TempDir::new().expect("temp dir");
+        let result = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_native_grpc_bind_addr(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+            .allow_unsafe_public_native_grpc_bind()
+            .with_user_principal_provider(Arc::new(SingleUserPrincipalProvider))
+            .with_management_authorizer(Arc::new(AllowAllManagementAuthorizer))
+            .with_workspace_authorizer(Arc::new(AllowAllWorkspaceAuthorizer))
+            .start()
+            .await;
+
+        let Err(error) = result else {
+            panic!("server should reject public native gRPC bind with local default auth");
+        };
+        assert!(
+            error.to_string().contains(
+                "non-loopback native gRPC bind address '0.0.0.0:0' requires allow_unsafe_public_native_grpc_bind(), a non-default user principal provider, a non-default management authorizer, and a non-default workspace authorizer"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn server_builder_accepts_public_native_grpc_bind_with_explicit_opt_in() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_native_grpc_bind_addr(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+            .allow_unsafe_public_native_grpc_bind()
+            .with_user_principal_provider(Arc::new(RejectingUserPrincipalProvider))
+            .with_management_authorizer(Arc::new(DenyingManagementAuthorizer))
+            .with_workspace_authorizer(Arc::new(AllowAllNonDefaultWorkspaceAuthorizer))
+            .start()
+            .await
+            .expect("public bind should start once auth is explicit");
+
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn server_builder_rejects_custom_user_owned_identity_store_without_usage_provider() {
+        let temp = TempDir::new().expect("temp dir");
+        let result = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_user_owned_identity_store(Arc::new(EmptyUserOwnedIdentityStore))
+            .start()
+            .await;
+
+        let Err(error) = result else {
+            panic!("server should reject custom identity store without usage provider");
+        };
+        assert!(
+            error.to_string().contains(
+                "custom user-owned identity stores require an identity spec usage provider"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn server_builder_accepts_custom_user_owned_identity_store_with_usage_provider() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_user_owned_identity_store(Arc::new(EmptyUserOwnedIdentityStore))
+            .add_identity_spec_usage_provider(Arc::new(StaticIdentitySpecUsageProvider {
+                identity_spec_name: "demo_oauth".to_string(),
+                count: 0,
+            }))
+            .start()
+            .await
+            .expect("custom identity store should start with usage provider");
+
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
     async fn grpc_services_reject_unauthenticated_requests() {
         let temp = TempDir::new().expect("temp dir");
         let server = ServerBuilder::new()
@@ -1350,7 +2034,10 @@ enabled = false
         let mut source_client = SourceServiceClient::new(channel.clone());
         let mut query_client = QueryServiceClient::new(channel.clone());
         let mut catalog_client = CatalogServiceClient::new(channel.clone());
+        let mut identity_spec_client = IdentitySpecServiceClient::new(channel.clone());
+        let mut identity_client = IdentityServiceClient::new(channel.clone());
         let mut feedback_client = FeedbackServiceClient::new(channel.clone());
+        let mut episode_client = EpisodeServiceClient::new(channel.clone());
         let mut trace_client = TraceServiceClient::new(channel);
 
         expect_unauthenticated(
@@ -1368,6 +2055,16 @@ enabled = false
         )
         .await;
         expect_unauthenticated(
+            "identity specs",
+            identity_spec_client.list_identity_specs(ListIdentitySpecsRequest {}),
+        )
+        .await;
+        expect_unauthenticated(
+            "identity list",
+            identity_client.list_user_owned_identities(ListUserOwnedIdentitiesRequest {}),
+        )
+        .await;
+        expect_unauthenticated(
             "feedback",
             feedback_client.submit_feedback(SubmitFeedbackRequest {
                 workspace: Some(default_workspace()),
@@ -1377,9 +2074,140 @@ enabled = false
             }),
         )
         .await;
+        expect_unauthenticated(
+            "episodes",
+            episode_client.open_episode(OpenEpisodeRequest {
+                workspace: Some(default_workspace()),
+                episode_id: "ep_auth".to_string(),
+                intent: "test auth".to_string(),
+                parent_episode_id: String::new(),
+            }),
+        )
+        .await;
         expect_unauthenticated("traces", list_traces(&mut trace_client)).await;
 
         server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn workspace_scoped_services_reject_unauthorized_workspace_access() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_workspace_authorizer(Arc::new(DenyingWorkspaceAuthorizer))
+            .start()
+            .await
+            .expect("start server");
+        let channel = connect(&server).await;
+        let mut source_client = SourceServiceClient::new(channel.clone());
+        let mut query_client = QueryServiceClient::new(channel.clone());
+        let mut catalog_client = CatalogServiceClient::new(channel.clone());
+        let mut feedback_client = FeedbackServiceClient::new(channel.clone());
+        let mut episode_client = EpisodeServiceClient::new(channel);
+
+        expect_permission_denied(
+            "source list",
+            source_client.list_sources(list_sources_request()),
+        )
+        .await;
+        expect_permission_denied("query", execute_sql(&mut query_client, "SELECT 1")).await;
+        expect_permission_denied(
+            "catalog",
+            catalog_client.list_catalog(ListCatalogRequest {
+                workspace: Some(default_workspace()),
+                ..ListCatalogRequest::default()
+            }),
+        )
+        .await;
+        expect_permission_denied(
+            "feedback",
+            feedback_client.submit_feedback(SubmitFeedbackRequest {
+                workspace: Some(default_workspace()),
+                trying_to_do: "test".to_string(),
+                tried: "test".to_string(),
+                stuck: "test".to_string(),
+            }),
+        )
+        .await;
+        expect_permission_denied(
+            "episodes",
+            episode_client.open_episode(OpenEpisodeRequest {
+                workspace: Some(default_workspace()),
+                episode_id: "ep_authz".to_string(),
+                intent: "test authz".to_string(),
+                parent_episode_id: String::new(),
+            }),
+        )
+        .await;
+
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn extension_grpc_services_reject_unauthenticated_requests() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_user_principal_provider(Arc::new(RejectingUserPrincipalProvider))
+            .add_grpc_service(ExtensionProbeService)
+            .start()
+            .await
+            .expect("start server");
+        let mut channel = connect(&server).await;
+        let request = HttpRequest::builder()
+            .method("POST")
+            .uri("/coral.test.ExtensionProbe/Check")
+            .header("content-type", "application/grpc")
+            .body(TonicBody::empty())
+            .expect("extension request");
+
+        let response = channel
+            .ready()
+            .await
+            .expect("extension channel ready")
+            .call(request)
+            .await
+            .expect("extension auth response");
+
+        assert_eq!(
+            response
+                .headers()
+                .get("grpc-status")
+                .and_then(|value| value.to_str().ok()),
+            Some("16")
+        );
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn server_builder_rejects_custom_identity_spec_registry_without_custom_identity_store() {
+        let temp = TempDir::new().expect("temp dir");
+        let result = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_identity_spec_registry(Arc::new(EmptyIdentitySpecRegistry))
+            .start()
+            .await;
+
+        let Err(error) = result else {
+            panic!("server should reject incompatible identity spec registry/store configuration");
+        };
+        assert!(
+            error.to_string().contains(
+                "custom identity spec registries require a custom user-owned identity store"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn native_grpc_mode_uses_configured_bind_addr() {
+        let bind_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0));
+
+        assert_eq!(ServerMode::NativeGrpc.bind_addr(Some(bind_addr)), bind_addr);
+        assert_eq!(
+            ServerMode::NativeGrpc.bind_addr(None),
+            SocketAddr::from((Ipv4Addr::LOCALHOST, 0))
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -152,7 +152,7 @@ pub(crate) struct ListColumnsQuery<'a> {
     pub(crate) pagination: Pagination,
 }
 
-pub(crate) struct SearchCatalogQuery<'a> {
+pub(crate) struct CatalogSearchQuery<'a> {
     pub(crate) pattern: &'a str,
     pub(crate) schema_name: Option<&'a str>,
     pub(crate) kind: Option<CatalogItemKind>,
@@ -172,7 +172,7 @@ impl CatalogDiscovery {
         }
     }
 
-    pub(crate) async fn list_catalog_with_context(
+    pub(crate) async fn list_catalog(
         &self,
         workspace_name: &WorkspaceName,
         request_principal: &UserPrincipal,
@@ -182,7 +182,7 @@ impl CatalogDiscovery {
     ) -> Result<CatalogPage, QueryManagerError> {
         let catalog = self
             .queries
-            .list_catalog_with_context(workspace_name, request_principal, schema_name)
+            .list_catalog(workspace_name, request_principal, schema_name)
             .await?;
         let counts = catalog_counts(&catalog);
         let items = catalog_items(catalog, kind);
@@ -192,7 +192,7 @@ impl CatalogDiscovery {
         })
     }
 
-    async fn catalog_items_with_context(
+    async fn catalog_items(
         &self,
         workspace_name: &WorkspaceName,
         request_principal: &UserPrincipal,
@@ -201,12 +201,40 @@ impl CatalogDiscovery {
     ) -> Result<Vec<CatalogItem>, QueryManagerError> {
         let catalog = self
             .queries
-            .list_catalog_with_context(workspace_name, request_principal, schema_name)
+            .list_catalog(workspace_name, request_principal, schema_name)
             .await?;
         Ok(catalog_items(catalog, kind))
     }
 
-    pub(crate) async fn describe_table_with_context(
+    pub(crate) async fn search_catalog(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+        query: CatalogSearchQuery<'_>,
+    ) -> Result<Page<CatalogSearchResult>, QueryManagerError> {
+        let regex = compile_metadata_regex(query.pattern, query.ignore_case)
+            .map_err(QueryManagerError::App)?;
+        let matches = self
+            .catalog_items(
+                workspace_name,
+                request_principal,
+                query.schema_name,
+                query.kind,
+            )
+            .await?
+            .into_iter()
+            .filter_map(|item| {
+                let matched_fields = catalog_item_matched_fields(&item, &regex);
+                (!matched_fields.is_empty()).then_some(CatalogSearchResult {
+                    item,
+                    matched_fields,
+                })
+            })
+            .collect();
+        Ok(page_items(matches, query.pagination))
+    }
+
+    pub(crate) async fn describe_table(
         &self,
         workspace_name: &WorkspaceName,
         request_principal: &UserPrincipal,
@@ -214,7 +242,7 @@ impl CatalogDiscovery {
     ) -> Result<DescribeTableResult, QueryManagerError> {
         let table_lookup = self
             .queries
-            .describe_table_with_context(
+            .describe_table(
                 workspace_name,
                 request_principal,
                 table_ref.schema_name,
@@ -275,35 +303,7 @@ fn catalog_counts(catalog: &CatalogInfo) -> CatalogCounts {
 }
 
 impl CatalogDiscovery {
-    pub(crate) async fn search_catalog_with_context(
-        &self,
-        workspace_name: &WorkspaceName,
-        request_principal: &UserPrincipal,
-        query: SearchCatalogQuery<'_>,
-    ) -> Result<Page<CatalogSearchResult>, QueryManagerError> {
-        let regex = compile_metadata_regex(query.pattern, query.ignore_case)
-            .map_err(QueryManagerError::App)?;
-        let matches = self
-            .catalog_items_with_context(
-                workspace_name,
-                request_principal,
-                query.schema_name,
-                query.kind,
-            )
-            .await?
-            .into_iter()
-            .filter_map(|item| {
-                let matched_fields = catalog_item_matched_fields(&item, &regex);
-                (!matched_fields.is_empty()).then_some(CatalogSearchResult {
-                    item,
-                    matched_fields,
-                })
-            })
-            .collect();
-        Ok(page_items(matches, query.pagination))
-    }
-
-    pub(crate) async fn list_columns_with_context(
+    pub(crate) async fn list_columns(
         &self,
         workspace_name: &WorkspaceName,
         request_principal: &UserPrincipal,
@@ -311,7 +311,7 @@ impl CatalogDiscovery {
     ) -> Result<Option<Page<ColumnSearchResult>>, QueryManagerError> {
         let table = self
             .queries
-            .list_tables_with_context(
+            .list_tables(
                 workspace_name,
                 request_principal,
                 Some(query.table_ref.schema_name),

--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -11,10 +11,11 @@ use coral_api::v1::{
 };
 use tonic::{Request, Response, Status};
 
+use crate::authorization::{WorkspaceAccessKind, WorkspaceAuthorizer, authorization_status};
 use crate::bootstrap::app_status;
 use crate::catalog::discovery::{
-    CatalogDiscovery, CatalogItemKind, CatalogTableRef, ListColumnsQuery, Pagination,
-    SearchCatalogQuery, column_pagination, search_pagination,
+    CatalogDiscovery, CatalogItemKind, CatalogSearchQuery, CatalogTableRef, ListColumnsQuery,
+    Pagination, column_pagination, search_pagination,
 };
 use crate::identity::UserPrincipalProvider;
 use crate::query::manager::QueryManager;
@@ -28,16 +29,19 @@ use crate::transport::{
 pub(crate) struct CatalogService {
     catalog: CatalogDiscovery,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
 }
 
 impl CatalogService {
     pub(crate) fn new(
         query_manager: QueryManager,
         user_principal_provider: Arc<dyn UserPrincipalProvider>,
+        workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
     ) -> Self {
         Self {
             catalog: CatalogDiscovery::new(query_manager),
             user_principal_provider,
+            workspace_authorizer,
         }
     }
 }
@@ -49,22 +53,25 @@ impl CatalogServiceApi for CatalogService {
         request: Request<ListCatalogRequest>,
     ) -> Result<Response<ListCatalogResponse>, Status> {
         let catalog = self.catalog.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
             |principal, request| async move {
                 let pagination = pagination_from_proto(request.pagination.unwrap_or_default());
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                workspace_authorizer
+                    .authorize_workspace_access(
+                        &principal,
+                        workspace_name.as_str(),
+                        WorkspaceAccessKind::Read,
+                    )
+                    .await
+                    .map_err(authorization_status)?;
                 let schema_name = optional_trimmed(&request.schema_name);
                 let kind = catalog_item_kind_from_proto(request.kind)?;
                 let catalog_page = catalog
-                    .list_catalog_with_context(
-                        &workspace_name,
-                        &principal,
-                        schema_name,
-                        kind,
-                        pagination,
-                    )
+                    .list_catalog(&workspace_name, &principal, schema_name, kind, pagination)
                     .await
                     .map_err(query_status)?;
                 let page = catalog_page.items;
@@ -97,20 +104,29 @@ impl CatalogServiceApi for CatalogService {
         request: Request<SearchCatalogRequest>,
     ) -> Result<Response<SearchCatalogResponse>, Status> {
         let catalog = self.catalog.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
             |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                workspace_authorizer
+                    .authorize_workspace_access(
+                        &principal,
+                        workspace_name.as_str(),
+                        WorkspaceAccessKind::Read,
+                    )
+                    .await
+                    .map_err(authorization_status)?;
                 let schema_name = optional_trimmed(&request.schema_name);
                 let kind = catalog_item_kind_from_proto(request.kind)?;
                 let pagination = search_pagination(request.pagination.map(pagination_from_proto))
                     .map_err(app_status)?;
                 let page = catalog
-                    .search_catalog_with_context(
+                    .search_catalog(
                         &workspace_name,
                         &principal,
-                        SearchCatalogQuery {
+                        CatalogSearchQuery {
                             pattern: &request.pattern,
                             schema_name,
                             kind,
@@ -145,15 +161,24 @@ impl CatalogServiceApi for CatalogService {
         request: Request<DescribeTableRequest>,
     ) -> Result<Response<DescribeTableResponse>, Status> {
         let catalog = self.catalog.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
             |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                workspace_authorizer
+                    .authorize_workspace_access(
+                        &principal,
+                        workspace_name.as_str(),
+                        WorkspaceAccessKind::Read,
+                    )
+                    .await
+                    .map_err(authorization_status)?;
                 let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
                 let table_name = required_trimmed(&request.table_name, "table_name")?;
                 let result = catalog
-                    .describe_table_with_context(
+                    .describe_table(
                         &workspace_name,
                         &principal,
                         CatalogTableRef::new(&schema_name, &table_name),
@@ -174,17 +199,26 @@ impl CatalogServiceApi for CatalogService {
         request: Request<ListColumnsRequest>,
     ) -> Result<Response<ListColumnsResponse>, Status> {
         let catalog = self.catalog.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
             |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                workspace_authorizer
+                    .authorize_workspace_access(
+                        &principal,
+                        workspace_name.as_str(),
+                        WorkspaceAccessKind::Read,
+                    )
+                    .await
+                    .map_err(authorization_status)?;
                 let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
                 let table_name = required_trimmed(&request.table_name, "table_name")?;
                 let pagination = column_pagination(request.pagination.map(pagination_from_proto))
                     .map_err(app_status)?;
                 let page = catalog
-                    .list_columns_with_context(
+                    .list_columns(
                         &workspace_name,
                         &principal,
                         ListColumnsQuery {

--- a/crates/coral-app/src/episode/service.rs
+++ b/crates/coral-app/src/episode/service.rs
@@ -12,8 +12,11 @@
 //! *consumers* rather than the routes. The `episodes` feature gates the only
 //! caller — the `coral-mcp` capture path — so on a default/disabled install this
 //! endpoint is reachable but inert: nothing opens an episode, so no `intent`
-//! (possibly PII) is ever written. The always-registered write endpoint is the
-//! supported contract; see the `open_episode_*` server smoke tests.
+//! (possibly PII) is ever written. The always-registered write endpoint still
+//! authenticates through the app transport principal provider; see the
+//! `open_episode_*` server smoke tests.
+
+use std::sync::Arc;
 
 use coral_api::v1::episode_service_server::EpisodeService as EpisodeServiceApi;
 use coral_api::v1::{OpenEpisodeRequest, OpenEpisodeResponse};
@@ -22,17 +25,29 @@ use tracing::warn;
 
 use super::EpisodeId;
 use super::store::{Episode, EpisodeStore, EpisodeStoreError, now_unix_nanos};
+use crate::authorization::{WorkspaceAccessKind, WorkspaceAuthorizer, authorization_status};
 use crate::bootstrap::app_status;
-use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto};
+use crate::identity::UserPrincipalProvider;
+use crate::transport::{instrument_authenticated_grpc, workspace_name_from_proto};
 
 #[derive(Clone)]
 pub(crate) struct EpisodeService {
     store: EpisodeStore,
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
 }
 
 impl EpisodeService {
-    pub(crate) fn new(store: EpisodeStore) -> Self {
-        Self { store }
+    pub(crate) fn new(
+        store: EpisodeStore,
+        user_principal_provider: Arc<dyn UserPrincipalProvider>,
+        workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
+    ) -> Self {
+        Self {
+            store,
+            user_principal_provider,
+            workspace_authorizer,
+        }
     }
 }
 
@@ -42,31 +57,42 @@ impl EpisodeServiceApi for EpisodeService {
         &self,
         request: Request<OpenEpisodeRequest>,
     ) -> Result<Response<OpenEpisodeResponse>, Status> {
-        let span = grpc_span(&request);
         let store = self.store.clone();
-        instrument_grpc(span, async move {
-            let request = request.into_inner();
-            let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
-            let id = EpisodeId::parse(&request.episode_id).map_err(app_status)?;
-            let intent = non_blank("intent", &request.intent)?;
-            // Per AIP-149, an empty `parent_episode_id` means "no parent" (a root
-            // episode); any other value must satisfy the `EpisodeId` contract.
-            let parent_episode_id = match request.parent_episode_id.as_str() {
-                "" => None,
-                parent => Some(EpisodeId::parse(parent).map_err(app_status)?),
-            };
-            let episode = Episode {
-                id,
-                workspace,
-                intent,
-                parent_episode_id,
-                created_at_unix_nanos: now_unix_nanos(),
-            };
-            store
-                .open_episode(&episode)
-                .map_err(|error| open_episode_status(&error))?;
-            Ok(Response::new(OpenEpisodeResponse {}))
-        })
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |principal, request| async move {
+                let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+                workspace_authorizer
+                    .authorize_workspace_access(
+                        &principal,
+                        workspace.as_str(),
+                        WorkspaceAccessKind::Write,
+                    )
+                    .await
+                    .map_err(authorization_status)?;
+                let id = EpisodeId::parse(&request.episode_id).map_err(app_status)?;
+                let intent = non_blank("intent", &request.intent)?;
+                // Per AIP-149, an empty `parent_episode_id` means "no parent" (a root
+                // episode); any other value must satisfy the `EpisodeId` contract.
+                let parent_episode_id = match request.parent_episode_id.as_str() {
+                    "" => None,
+                    parent => Some(EpisodeId::parse(parent).map_err(app_status)?),
+                };
+                let episode = Episode {
+                    id,
+                    workspace,
+                    intent,
+                    parent_episode_id,
+                    created_at_unix_nanos: now_unix_nanos(),
+                };
+                store
+                    .open_episode(&episode)
+                    .map_err(|error| open_episode_status(&error))?;
+                Ok(Response::new(OpenEpisodeResponse {}))
+            },
+        )
         .await
     }
 }
@@ -99,6 +125,7 @@ fn open_episode_status(error: &EpisodeStoreError) -> Status {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::sync::Arc;
 
     use coral_api::v1::{OpenEpisodeRequest, Workspace};
     use tempfile::TempDir;
@@ -106,6 +133,8 @@ mod tests {
 
     use super::super::store::EpisodeStore;
     use super::{EpisodeService, EpisodeServiceApi};
+    use crate::authorization::AllowAllWorkspaceAuthorizer;
+    use crate::identity::SingleUserPrincipalProvider;
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
 
@@ -113,7 +142,11 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(dir.path().join("coral-config")))
             .expect("layout should resolve");
-        let service = EpisodeService::new(EpisodeStore::new(layout.clone()));
+        let service = EpisodeService::new(
+            EpisodeStore::new(layout.clone()),
+            Arc::new(SingleUserPrincipalProvider),
+            Arc::new(AllowAllWorkspaceAuthorizer),
+        );
         (dir, layout, service)
     }
 

--- a/crates/coral-app/src/feedback/service.rs
+++ b/crates/coral-app/src/feedback/service.rs
@@ -6,6 +6,7 @@ use coral_api::v1::{
 };
 use tonic::{Request, Response, Status};
 
+use crate::authorization::{WorkspaceAccessKind, WorkspaceAuthorizer, authorization_status};
 use crate::bootstrap::app_status;
 use crate::feedback::manager::{FeedbackManager, FeedbackReport};
 use crate::identity::UserPrincipalProvider;
@@ -17,16 +18,19 @@ use crate::transport::{
 pub(crate) struct FeedbackService {
     feedback: FeedbackManager,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
 }
 
 impl FeedbackService {
     pub(crate) fn new(
         feedback: FeedbackManager,
         user_principal_provider: Arc<dyn UserPrincipalProvider>,
+        workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
     ) -> Self {
         Self {
             feedback,
             user_principal_provider,
+            workspace_authorizer,
         }
     }
 }
@@ -38,11 +42,20 @@ impl FeedbackServiceApi for FeedbackService {
         request: Request<SubmitFeedbackRequest>,
     ) -> Result<Response<SubmitFeedbackResponse>, Status> {
         let feedback = self.feedback.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
-            |_principal, request| async move {
+            |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                workspace_authorizer
+                    .authorize_workspace_access(
+                        &principal,
+                        workspace_name.as_str(),
+                        WorkspaceAccessKind::Write,
+                    )
+                    .await
+                    .map_err(authorization_status)?;
                 let submission = feedback
                     .submit_feedback(
                         &workspace_name,

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -327,6 +328,30 @@ pub trait UserOwnedIdentityStore: Send + Sync + std::fmt::Debug + 'static {
                 .to_string(),
         ))
     }
+
+    /// Deletes user-owned source identity selections for one installed source.
+    ///
+    /// When `surface_ids` is empty, every user-owned selection for the source
+    /// should be removed. Otherwise only selections for the listed surface ids
+    /// should be removed. `preserved_user_id` lets callers retain the listed
+    /// surface selections for one user while removing them for every other
+    /// user.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot be written.
+    async fn delete_source_identity_bindings(
+        &self,
+        _workspace_name: &str,
+        _source_name: &str,
+        _surface_ids: &[String],
+        _preserved_user_id: Option<&str>,
+    ) -> Result<(), AppError> {
+        Err(AppError::FailedPrecondition(
+            "user-owned source identity binding storage is not supported by this identity store"
+                .to_string(),
+        ))
+    }
 }
 
 /// Manages provider-facing identities owned by Coral user principals.
@@ -444,10 +469,6 @@ impl UserOwnedIdentityManager {
         }
     }
 
-    #[expect(
-        dead_code,
-        reason = "consumed by the server extension context (ServerExtensionContext) in a later PR"
-    )]
     pub(crate) fn handle(&self) -> IdentityManagementHandle {
         IdentityManagementHandle {
             manager: self.clone(),
@@ -692,6 +713,28 @@ impl UserOwnedIdentityManager {
                 source_name.as_str(),
                 &surface_id,
                 selection,
+            )
+            .await
+    }
+
+    pub(crate) async fn delete_user_owned_source_identity_bindings(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        surface_ids: &[String],
+        preserved_user_id: Option<&str>,
+    ) -> Result<(), AppError> {
+        let surface_ids = surface_ids
+            .iter()
+            .map(|surface_id| validate_source_surface_id(surface_id))
+            .collect::<Result<Vec<_>, _>>()?;
+        let preserved_user_id = preserved_user_id.map(validate_user_id).transpose()?;
+        self.store
+            .delete_source_identity_bindings(
+                workspace_name.as_str(),
+                source_name.as_str(),
+                &surface_ids,
+                preserved_user_id.as_deref(),
             )
             .await
     }
@@ -1234,6 +1277,72 @@ impl UserOwnedIdentityStore for FileUserOwnedIdentityStore {
         })
         .await?
     }
+
+    async fn delete_source_identity_bindings(
+        &self,
+        workspace_name: &str,
+        source_name: &str,
+        surface_ids: &[String],
+        preserved_user_id: Option<&str>,
+    ) -> Result<(), AppError> {
+        let store = self.clone();
+        let workspace_name = workspace_name.to_string();
+        let source_name = source_name.to_string();
+        let surface_ids = surface_ids.to_vec();
+        let preserved_user_id = preserved_user_id.map(ToString::to_string);
+        tokio::task::spawn_blocking(move || {
+            let workspace_name = WorkspaceName::parse(&workspace_name)?;
+            let source_name = SourceName::parse(&source_name)?;
+            let surface_ids = surface_ids
+                .iter()
+                .map(|surface_id| validate_source_surface_id(surface_id))
+                .collect::<Result<Vec<_>, _>>()?;
+            let preserved_user_id = preserved_user_id
+                .as_deref()
+                .map(validate_user_id)
+                .transpose()?;
+            let _lock = FileLock::exclusive(store.layout.state_lock())?;
+            let bindings_root = store.layout.source_identity_bindings_root();
+            let users_root = bindings_root.join("users");
+            let Ok(users) = fs::read_dir(&users_root) else {
+                return Ok(());
+            };
+            for user in users {
+                let user = user?;
+                let is_preserved_user = user.file_name().to_str().and_then(|user_id| {
+                    preserved_user_id
+                        .as_deref()
+                        .map(|preserved_user_id| user_id == preserved_user_id)
+                }) == Some(true);
+                let source_bindings_dir = user
+                    .path()
+                    .join(workspace_name.as_str())
+                    .join(source_name.as_str());
+                if surface_ids.is_empty() && is_preserved_user {
+                    continue;
+                }
+                let cleanup_dirs = if surface_ids.is_empty() {
+                    vec![source_bindings_dir]
+                } else if is_preserved_user {
+                    Vec::new()
+                } else {
+                    surface_ids
+                        .iter()
+                        .map(|surface_id| source_bindings_dir.join(surface_id))
+                        .collect()
+                };
+                for cleanup_dir in cleanup_dirs {
+                    if !cleanup_dir.exists() {
+                        continue;
+                    }
+                    fs::remove_dir_all(&cleanup_dir)?;
+                    cleanup_empty_parent(&bindings_root, cleanup_dir.parent());
+                }
+            }
+            Ok(())
+        })
+        .await?
+    }
 }
 
 struct FileUserOwnedIdentityMaterialGuard {
@@ -1602,6 +1711,25 @@ fn restore_file_unlocked(
     match snapshot {
         Some(bytes) => write_file_unlocked(path, &bytes).map_err(Into::into),
         None => remove_file_if_exists_unlocked(path).map_err(Into::into),
+    }
+}
+
+fn cleanup_empty_parent(root: &Path, path: Option<&Path>) {
+    let Some(mut current) = path.map(Path::to_path_buf) else {
+        return;
+    };
+    while current.starts_with(root) && current != root {
+        let Ok(mut entries) = fs::read_dir(&current) else {
+            break;
+        };
+        if entries.next().is_some() {
+            break;
+        }
+        let next = current.parent().unwrap_or(root).to_path_buf();
+        if fs::remove_dir(&current).is_err() {
+            break;
+        }
+        current = next;
     }
 }
 
@@ -2273,6 +2401,145 @@ oauth:
             .resolve_source_identity_selection(&request)
             .await
             .expect_err("restored missing binding should not resolve");
+    }
+
+    #[tokio::test]
+    async fn deletes_user_owned_source_identity_bindings_for_source_and_surfaces() {
+        let (_temp, manager, _identity_specs) = manager();
+        let saul = UserPrincipal::for_user("saul").expect("principal");
+        let tina = UserPrincipal::for_user("tina").expect("principal");
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github_v4").expect("source");
+        let selection =
+            SourceIdentitySelection::new("github_saul", Some("github-rest-read".to_string()))
+                .expect("selection");
+
+        for principal in [&saul, &tina] {
+            for surface_id in ["rest", "issues"] {
+                manager
+                    .replace_user_owned_source_identity_binding(
+                        principal,
+                        &workspace_name,
+                        &source_name,
+                        surface_id,
+                        &selection,
+                    )
+                    .await
+                    .expect("write source identity binding");
+            }
+        }
+
+        manager
+            .delete_user_owned_source_identity_bindings(
+                &workspace_name,
+                &source_name,
+                &["rest".to_string()],
+                None,
+            )
+            .await
+            .expect("delete rest surface bindings");
+
+        for user_id in ["saul", "tina"] {
+            manager
+                .resolve_source_identity_selection(&SourceIdentitySelectionRequest {
+                    workspace_name: "default".to_string(),
+                    subject: SourceIdentitySubject::User(user_id.to_string()),
+                    source_name: "github_v4".to_string(),
+                    surface_id: "rest".to_string(),
+                    binding: SourceIdentityBinding::user_owned(),
+                })
+                .await
+                .expect_err("rest surface binding should be removed");
+            let remaining = manager
+                .resolve_source_identity_selection(&SourceIdentitySelectionRequest {
+                    workspace_name: "default".to_string(),
+                    subject: SourceIdentitySubject::User(user_id.to_string()),
+                    source_name: "github_v4".to_string(),
+                    surface_id: "issues".to_string(),
+                    binding: SourceIdentityBinding::user_owned(),
+                })
+                .await
+                .expect("issues surface should remain")
+                .expect("issues selection");
+            assert_eq!(remaining, selection);
+        }
+
+        manager
+            .delete_user_owned_source_identity_bindings(&workspace_name, &source_name, &[], None)
+            .await
+            .expect("delete all source bindings");
+
+        for user_id in ["saul", "tina"] {
+            manager
+                .resolve_source_identity_selection(&SourceIdentitySelectionRequest {
+                    workspace_name: "default".to_string(),
+                    subject: SourceIdentitySubject::User(user_id.to_string()),
+                    source_name: "github_v4".to_string(),
+                    surface_id: "issues".to_string(),
+                    binding: SourceIdentityBinding::user_owned(),
+                })
+                .await
+                .expect_err("all source bindings should be removed");
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_source_identity_bindings_preserves_requested_user() {
+        let (_temp, manager, _identity_specs) = manager();
+        let saul = UserPrincipal::for_user("saul").expect("principal");
+        let tina = UserPrincipal::for_user("tina").expect("principal");
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github_v4").expect("source");
+        let selection =
+            SourceIdentitySelection::new("github_saul", Some("github-rest-read".to_string()))
+                .expect("selection");
+
+        for principal in [&saul, &tina] {
+            manager
+                .replace_user_owned_source_identity_binding(
+                    principal,
+                    &workspace_name,
+                    &source_name,
+                    "rest",
+                    &selection,
+                )
+                .await
+                .expect("write source identity binding");
+        }
+
+        manager
+            .delete_user_owned_source_identity_bindings(
+                &workspace_name,
+                &source_name,
+                &["rest".to_string()],
+                Some("saul"),
+            )
+            .await
+            .expect("delete other users' rest surface bindings");
+
+        let preserved = manager
+            .resolve_source_identity_selection(&SourceIdentitySelectionRequest {
+                workspace_name: "default".to_string(),
+                subject: SourceIdentitySubject::User("saul".to_string()),
+                source_name: "github_v4".to_string(),
+                surface_id: "rest".to_string(),
+                binding: SourceIdentityBinding::user_owned(),
+            })
+            .await
+            .expect("preserved user's rest surface binding should resolve")
+            .expect("preserved rest selection");
+        assert_eq!(preserved, selection);
+
+        manager
+            .resolve_source_identity_selection(&SourceIdentitySelectionRequest {
+                workspace_name: "default".to_string(),
+                subject: SourceIdentitySubject::User("tina".to_string()),
+                source_name: "github_v4".to_string(),
+                surface_id: "rest".to_string(),
+                binding: SourceIdentityBinding::user_owned(),
+            })
+            .await
+            .expect_err("other user's rest surface binding should be removed");
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -159,6 +159,15 @@ impl UserPrincipalError {
 /// corresponding user principal.
 #[tonic::async_trait]
 pub trait UserPrincipalProvider: Send + Sync + std::fmt::Debug {
+    /// Returns true for Coral's default local single-user provider.
+    ///
+    /// Server startup uses this to prevent accidental public network exposure
+    /// with OSS local defaults. Product providers should use the default
+    /// implementation.
+    fn is_default_single_user_provider(&self) -> bool {
+        false
+    }
+
     /// Returns the user principal for one inbound gRPC request.
     ///
     /// # Errors
@@ -177,6 +186,10 @@ pub struct SingleUserPrincipalProvider;
 
 #[tonic::async_trait]
 impl UserPrincipalProvider for SingleUserPrincipalProvider {
+    fn is_default_single_user_provider(&self) -> bool {
+        true
+    }
+
     async fn principal_for_metadata(
         &self,
         _metadata: &tonic::metadata::MetadataMap,
@@ -213,13 +226,6 @@ pub enum SourceIdentitySubject {
     Workspace,
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "source identity vocabulary consumed and re-exported in later PRs"
-    )
-)]
 impl SourceIdentitySubject {
     pub(crate) fn for_binding_owner(
         owner: SourceIdentityOwner,
@@ -483,10 +489,6 @@ pub(crate) struct IdentityManager {
     providers: Arc<Vec<Arc<dyn SourceIdentityProvider>>>,
 }
 
-#[expect(
-    dead_code,
-    reason = "identity manager consumed by query-time identity resolution in a later PR"
-)]
 impl IdentityManager {
     pub(crate) fn new(providers: Vec<Arc<dyn SourceIdentityProvider>>) -> Self {
         Self {

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -54,12 +54,17 @@ mod transport;
 mod workspaces;
 
 pub use authorization::{
-    AllowAllManagementAuthorizer, AuthorizationError, ManagementAuthorizer, SourceMutationKind,
+    AllowAllManagementAuthorizer, AllowAllWorkspaceAuthorizer, AuthorizationError,
+    ManagementAuthorizer, SourceMutationKind, WorkspaceAccessKind, WorkspaceAuthorizer,
 };
 pub use bootstrap::{
-    AppError, RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider,
+    AppError, RunningServer, ServerBuilder, ServerExtensionContext, ServerMode, StaticAsset,
+    StaticAssetsProvider,
 };
-pub use coral_engine::{EngineExtensions, QuerySource};
+pub use coral_engine::{
+    EngineExtensions, QuerySource, RequestIdentityResolutionContext, RequestIdentityResolver,
+    RequestIdentityResolverError,
+};
 pub use credentials::oauth::{OAuthProgressEvent, OAuthProgressEventSender};
 pub use identities::{
     CreateFixedTokenIdentityCommand, CreateOAuthIdentityCommand, IdentityCredentialInput,

--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -94,7 +94,7 @@ impl SourceInputResolver for CredentialRefreshingInputResolver {
         let source_name = SourceName::parse(source.source_name())
             .map_err(|error| SourceInputResolverError::invalid_input(error.to_string()))?;
         let credential_set_id = CredentialSetId::for_source(&source_name);
-        let record = self
+        let source_record = self
             .source_registry
             .get_source(self.workspace_name.as_str(), source_name.as_str())
             .map_err(source_input_error)?
@@ -104,7 +104,7 @@ impl SourceInputResolver for CredentialRefreshingInputResolver {
                     self.workspace_name, source_name
                 )))
             })?;
-        let installed_source = installed_source_from_record(&self.workspace_name, record)
+        let installed_source = installed_source_from_record(&self.workspace_name, source_record)
             .map_err(source_input_error)?;
         let material =
             if let Some(credential_storage) = installed_source.credential_storage_for_material() {
@@ -220,9 +220,16 @@ mod tests {
         QueryResultObserver, QueryResultObserverError, RequestAuthenticator,
         RequestAuthenticatorError,
     };
+    use coral_spec::parse_source_manifest_yaml;
     use reqwest::header::{HeaderName, HeaderValue};
+    use tempfile::TempDir;
 
     use super::*;
+    use crate::credentials::{CredentialStorageKind, CredentialStore};
+    use crate::source_registry::{
+        SourceRegistryCredentialStorage, SourceRegistryOrigin, SourceRegistryRecord,
+    };
+    use crate::state::AppStateLayout;
 
     #[derive(Debug)]
     struct TestAuthenticator {
@@ -293,6 +300,48 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct SingleSourceRegistry {
+        record: SourceRegistryRecord,
+    }
+
+    impl SourceRegistry for SingleSourceRegistry {
+        fn list_workspace_sources(
+            &self,
+            workspace_id: &str,
+        ) -> Result<Vec<SourceRegistryRecord>, AppError> {
+            if self.record.workspace_id == workspace_id {
+                Ok(vec![self.record.clone()])
+            } else {
+                Ok(Vec::new())
+            }
+        }
+
+        fn get_source(
+            &self,
+            workspace_id: &str,
+            source_name: &str,
+        ) -> Result<Option<SourceRegistryRecord>, AppError> {
+            if self.record.workspace_id == workspace_id && self.record.source_name == source_name {
+                Ok(Some(self.record.clone()))
+            } else {
+                Ok(None)
+            }
+        }
+
+        fn upsert_source(&self, _record: SourceRegistryRecord) -> Result<(), AppError> {
+            Err(AppError::FailedPrecondition(
+                "test registry is read-only".to_string(),
+            ))
+        }
+
+        fn remove_source(&self, _workspace_id: &str, _source_name: &str) -> Result<(), AppError> {
+            Err(AppError::FailedPrecondition(
+                "test registry is read-only".to_string(),
+            ))
+        }
+    }
+
     #[test]
     fn noop_provider_installs_no_extensions() {
         let extensions = NoopEngineExtensionsProvider.extensions_for(&[]);
@@ -356,5 +405,91 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(observer_names, ["base", "extra"]);
+    }
+
+    #[tokio::test]
+    async fn input_resolver_uses_source_registry_for_installed_source_metadata() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("secured_messages").expect("source name");
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout));
+        credential_manager
+            .replace_material(
+                &workspace_name,
+                &CredentialSetId::for_source(&source_name),
+                CredentialStorageKind::File,
+                &BTreeMap::from([("API_TOKEN".to_string(), "stored-token".to_string())]),
+            )
+            .expect("write credential material");
+        let source_spec = parse_source_manifest_yaml(
+            r#"
+name: secured_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+inputs:
+  API_BASE:
+    kind: variable
+    default: https://example.com
+  API_TOKEN:
+    kind: secret
+base_url: "{{input.API_BASE}}"
+tables:
+  - name: messages
+    description: Secured messages
+    request:
+      path: /messages
+    columns:
+      - name: id
+        type: Utf8
+"#,
+        )
+        .expect("parse source manifest");
+        let query_source = QuerySource::new(
+            source_spec,
+            BTreeMap::from([(
+                "API_BASE".to_string(),
+                "https://registry.example".to_string(),
+            )]),
+            BTreeMap::new(),
+        );
+        let registry = SingleSourceRegistry {
+            record: SourceRegistryRecord {
+                workspace_id: workspace_name.as_str().to_string(),
+                source_name: source_name.as_str().to_string(),
+                version: Some("0.1.0".to_string()),
+                manifest_yaml: None,
+                variables: query_source.variables().clone(),
+                secrets: vec!["API_TOKEN".to_string()],
+                credential_storage: Some(SourceRegistryCredentialStorage::File),
+                identity_bindings: BTreeMap::new(),
+                origin: SourceRegistryOrigin::Imported,
+            },
+        };
+        let resolver = CredentialRefreshingInputResolver::new(
+            workspace_name,
+            Arc::new(registry),
+            credential_manager,
+            None,
+        );
+
+        let resolved_inputs = resolver
+            .resolve_inputs(&SourceInputResolutionContext::from_query_source(
+                &query_source,
+            ))
+            .await
+            .expect("resolve inputs through custom registry");
+
+        assert_eq!(
+            resolved_inputs.get("API_BASE").map(String::as_str),
+            Some("https://registry.example")
+        );
+        assert_eq!(
+            resolved_inputs.get("API_TOKEN").map(String::as_str),
+            Some("stored-token")
+        );
     }
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1,15 +1,18 @@
 //! Query-time loading, validation, and execution over installed sources.
 
 use std::collections::BTreeMap;
+use std::fmt;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
 
 use coral_engine::{
     CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, QueryExecution, QueryPlan,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RuntimeSourcePackage,
-    SourceValidationReport, StatusCode, TableInfo,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RequestIdentityResolutionContext,
+    RequestIdentityResolver, RequestIdentityResolverError, RuntimeIdentityRequirements,
+    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport, StatusCode, TableInfo,
 };
+use coral_spec::v4::IdentityRequirements;
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::{KeyValue, trace::Status as OtelStatus};
 use tracing::Instrument as _;
@@ -19,7 +22,11 @@ use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::episode::EpisodeId;
 use crate::features::Features;
-use crate::identity::UserPrincipal;
+use crate::identity::{
+    IdentityManager, SourceIdentityBinding, SourceIdentityProvider,
+    SourceIdentityResolutionRequest, SourceIdentitySelection, SourceIdentitySelectionRequest,
+    SourceIdentitySubject, UserPrincipal,
+};
 use crate::query::QueryAttribution;
 use crate::query::extensions::{
     CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
@@ -46,6 +53,15 @@ pub(crate) struct ValidatedSource {
     pub(crate) report: SourceValidationReport,
 }
 
+type SourceIdentityBindingsSnapshot = BTreeMap<String, BTreeMap<String, SourceIdentityBinding>>;
+
+#[derive(Debug)]
+struct LoadedQuerySource {
+    query_source: QuerySource,
+    version: Option<String>,
+    identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+}
+
 #[derive(Debug)]
 struct RegistryQuerySource {
     source: InstalledSource,
@@ -59,45 +75,66 @@ pub(crate) struct QueryManager {
     credential_manager: CredentialManager,
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
-    features: Features,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    identity_manager: IdentityManager,
+    features: Features,
 }
 
 impl QueryManager {
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "tests use the default ConfigStore-backed constructor; server bootstrap injects the shared SourceRegistry"
-        )
-    )]
+    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
         runtime_context: QueryRuntimeContext,
         layout: AppStateLayout,
-        features: Features,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
-        Self::new_with_source_registry(
+        Self::new_with_features(
+            config_store,
+            credential_manager,
+            runtime_context,
+            layout,
+            engine_extensions_providers,
+            Vec::new(),
+            Features::default(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_features(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
+        features: Features,
+    ) -> Self {
+        Self::new_with_features_and_source_registry(
             config_store.clone(),
             Arc::new(config_store),
             credential_manager,
             runtime_context,
             layout,
-            features,
             engine_extensions_providers,
+            identity_providers,
+            features,
         )
     }
 
-    pub(crate) fn new_with_source_registry(
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one-time wiring constructor; every argument is a distinct runtime dependency"
+    )]
+    pub(crate) fn new_with_features_and_source_registry(
         config_store: ConfigStore,
         source_registry: Arc<dyn SourceRegistry>,
         credential_manager: CredentialManager,
         runtime_context: QueryRuntimeContext,
         layout: AppStateLayout,
-        features: Features,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
+        features: Features,
     ) -> Self {
         Self {
             config_store,
@@ -105,248 +142,10 @@ impl QueryManager {
             credential_manager,
             runtime_context,
             layout,
-            features,
             engine_extensions_providers,
+            identity_manager: IdentityManager::new(identity_providers),
+            features,
         }
-    }
-
-    pub(crate) async fn list_tables(
-        &self,
-        workspace_name: &WorkspaceName,
-        schema_filter: Option<&str>,
-        table_filter: Option<&str>,
-    ) -> Result<Vec<TableInfo>, QueryManagerError> {
-        let config = self
-            .config_store
-            .load_config()
-            .map_err(QueryManagerError::App)?;
-        let sources = self
-            .load_query_sources(workspace_name)
-            .map_err(QueryManagerError::App)?;
-        let runtime = self
-            .runtime_config(workspace_name, &sources, &config)
-            .map_err(QueryManagerError::App)?;
-        CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
-            .await
-            .map_err(QueryManagerError::Core)
-    }
-
-    pub(crate) async fn list_tables_with_context(
-        &self,
-        workspace_name: &WorkspaceName,
-        _request_principal: &UserPrincipal,
-        schema_filter: Option<&str>,
-        table_filter: Option<&str>,
-    ) -> Result<Vec<TableInfo>, QueryManagerError> {
-        self.list_tables(workspace_name, schema_filter, table_filter)
-            .await
-    }
-
-    pub(crate) async fn list_catalog(
-        &self,
-        workspace_name: &WorkspaceName,
-        schema_filter: Option<&str>,
-    ) -> Result<CatalogInfo, QueryManagerError> {
-        let config = self
-            .config_store
-            .load_config()
-            .map_err(QueryManagerError::App)?;
-        let sources = self
-            .load_query_sources(workspace_name)
-            .map_err(QueryManagerError::App)?;
-        let runtime = self
-            .runtime_config(workspace_name, &sources, &config)
-            .map_err(QueryManagerError::App)?;
-        CoralQuery::list_catalog(&sources, runtime, schema_filter)
-            .await
-            .map_err(QueryManagerError::Core)
-    }
-
-    pub(crate) async fn list_catalog_with_context(
-        &self,
-        workspace_name: &WorkspaceName,
-        _request_principal: &UserPrincipal,
-        schema_filter: Option<&str>,
-    ) -> Result<CatalogInfo, QueryManagerError> {
-        self.list_catalog(workspace_name, schema_filter).await
-    }
-
-    pub(crate) async fn describe_table(
-        &self,
-        workspace_name: &WorkspaceName,
-        schema_name: &str,
-        table_name: &str,
-    ) -> Result<DescribeTableInfo, QueryManagerError> {
-        let config = self
-            .config_store
-            .load_config()
-            .map_err(QueryManagerError::App)?;
-        let sources = self
-            .load_query_sources(workspace_name)
-            .map_err(QueryManagerError::App)?;
-        let runtime = self
-            .runtime_config(workspace_name, &sources, &config)
-            .map_err(QueryManagerError::App)?;
-        CoralQuery::describe_table(&sources, runtime, schema_name, table_name)
-            .await
-            .map_err(QueryManagerError::Core)
-    }
-
-    pub(crate) async fn describe_table_with_context(
-        &self,
-        workspace_name: &WorkspaceName,
-        _request_principal: &UserPrincipal,
-        schema_name: &str,
-        table_name: &str,
-    ) -> Result<DescribeTableInfo, QueryManagerError> {
-        self.describe_table(workspace_name, schema_name, table_name)
-            .await
-    }
-
-    pub(crate) async fn execute_sql(
-        &self,
-        workspace_name: &WorkspaceName,
-        sql: &str,
-        attribution: &QueryAttribution,
-    ) -> Result<QueryExecution, QueryManagerError> {
-        run_query_operation(
-            QueryOperation::ExecuteSql,
-            workspace_name,
-            sql,
-            attribution.episode_id.as_ref(),
-            async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name)
-                    .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
-                CoralQuery::execute_sql(&sources, runtime, sql)
-                    .await
-                    .map_err(QueryManagerError::Core)
-            },
-            |execution| Some(u64::try_from(execution.row_count()).unwrap_or(u64::MAX)),
-        )
-        .await
-    }
-
-    pub(crate) async fn execute_sql_with_context(
-        &self,
-        workspace_name: &WorkspaceName,
-        _request_principal: &UserPrincipal,
-        sql: &str,
-        attribution: &QueryAttribution,
-    ) -> Result<QueryExecution, QueryManagerError> {
-        self.execute_sql(workspace_name, sql, attribution).await
-    }
-
-    pub(crate) async fn explain_sql(
-        &self,
-        workspace_name: &WorkspaceName,
-        sql: &str,
-        attribution: &QueryAttribution,
-    ) -> Result<QueryPlan, QueryManagerError> {
-        run_query_operation(
-            QueryOperation::ExplainSql,
-            workspace_name,
-            sql,
-            attribution.episode_id.as_ref(),
-            async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name)
-                    .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
-                CoralQuery::explain_sql(&sources, runtime, sql)
-                    .await
-                    .map_err(QueryManagerError::Core)
-            },
-            |_| None,
-        )
-        .await
-    }
-
-    pub(crate) async fn explain_sql_with_context(
-        &self,
-        workspace_name: &WorkspaceName,
-        _request_principal: &UserPrincipal,
-        sql: &str,
-        attribution: &QueryAttribution,
-    ) -> Result<QueryPlan, QueryManagerError> {
-        self.explain_sql(workspace_name, sql, attribution).await
-    }
-
-    pub(crate) async fn validate_source(
-        &self,
-        workspace_name: &WorkspaceName,
-        // Threaded by `SourceService::validate_source` for HEAD's gRPC
-        // surface; query-time identity resolution consumes it in PR 9.
-        _request_principal: &UserPrincipal,
-        source_name: &SourceName,
-    ) -> Result<ValidatedSource, QueryManagerError> {
-        let config = self
-            .config_store
-            .load_config()
-            .map_err(QueryManagerError::App)?;
-        let registry_source = self
-            .registry_source(workspace_name, source_name)
-            .map_err(QueryManagerError::App)?;
-        let (query_source, version) = self
-            .load_registry_query_source(workspace_name, &registry_source)
-            .map_err(QueryManagerError::App)?;
-        let runtime = self
-            .runtime_config(workspace_name, std::slice::from_ref(&query_source), &config)
-            .map_err(QueryManagerError::App)?;
-        let report =
-            CoralQuery::validate_source(&query_source, runtime, query_source.test_queries())
-                .await
-                .map_err(QueryManagerError::Core)?;
-        let mut source = registry_source.source;
-        source.version = version;
-
-        Ok(ValidatedSource { source, report })
-    }
-
-    fn load_query_sources(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<Vec<QuerySource>, AppError> {
-        let span = tracing::info_span!(
-            "coral.app.query_sources.load",
-            workspace = %workspace_name,
-            source.count = tracing::field::Empty,
-        );
-        let _guard = span.enter();
-        let mut query_sources = Vec::new();
-        for source in self.list_registry_sources(workspace_name)? {
-            match self.load_registry_query_source(workspace_name, &source) {
-                Ok((query_source, _version)) => query_sources.push(query_source),
-                Err(
-                    error @ (AppError::Credentials(CredentialsError::Unavailable(_))
-                    | AppError::SourceUnservable(_)),
-                ) => {
-                    return Err(error);
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        source = %source.source.name,
-                        detail = %error,
-                        "skipping source during query-source load"
-                    );
-                }
-            }
-        }
-        span.record("source.count", query_sources.len());
-        Ok(query_sources)
     }
 
     fn list_registry_sources(
@@ -368,34 +167,226 @@ impl QueryManager {
             .collect()
     }
 
-    fn registry_source(
+    fn require_registry_source(
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<RegistryQuerySource, AppError> {
-        let record = self
-            .source_registry
+        self.source_registry
             .get_source(workspace_name.as_str(), source_name.as_str())?
-            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))?;
-        let imported_manifest_yaml = record.manifest_yaml.clone();
-        installed_source_from_record(workspace_name, record).map(|source| RegistryQuerySource {
-            source,
-            imported_manifest_yaml,
-        })
+            .map(|record| {
+                let imported_manifest_yaml = record.manifest_yaml.clone();
+                installed_source_from_record(workspace_name, record).map(|source| {
+                    RegistryQuerySource {
+                        source,
+                        imported_manifest_yaml,
+                    }
+                })
+            })
+            .transpose()?
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "direct source loading is retained for focused unit tests; runtime paths keep registry manifest context"
+    /// Loads the workspace's query sources and the runtime config used to
+    /// execute one query-time operation against them.
+    fn load_query_runtime(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+    ) -> Result<(Vec<QuerySource>, QueryRuntimeConfig), QueryManagerError> {
+        let config = self
+            .config_store
+            .load_config()
+            .map_err(QueryManagerError::App)?;
+        let sources = self
+            .load_query_sources(workspace_name)
+            .map_err(QueryManagerError::App)?;
+        let identity_bindings = identity_binding_snapshot_for_sources(&sources);
+        let sources = query_sources_from_loaded(sources);
+        let runtime = self
+            .runtime_config(
+                workspace_name,
+                request_principal,
+                &sources,
+                identity_bindings,
+                &config,
+            )
+            .map_err(QueryManagerError::App)?;
+        Ok((sources, runtime))
+    }
+
+    pub(crate) async fn list_tables(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+        schema_filter: Option<&str>,
+        table_filter: Option<&str>,
+    ) -> Result<Vec<TableInfo>, QueryManagerError> {
+        let (sources, runtime) = self.load_query_runtime(workspace_name, request_principal)?;
+        CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
+            .await
+            .map_err(QueryManagerError::Core)
+    }
+
+    pub(crate) async fn list_catalog(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+        schema_filter: Option<&str>,
+    ) -> Result<CatalogInfo, QueryManagerError> {
+        let (sources, runtime) = self.load_query_runtime(workspace_name, request_principal)?;
+        CoralQuery::list_catalog(&sources, runtime, schema_filter)
+            .await
+            .map_err(QueryManagerError::Core)
+    }
+
+    pub(crate) async fn describe_table(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+        schema_name: &str,
+        table_name: &str,
+    ) -> Result<DescribeTableInfo, QueryManagerError> {
+        let (sources, runtime) = self.load_query_runtime(workspace_name, request_principal)?;
+        CoralQuery::describe_table(&sources, runtime, schema_name, table_name)
+            .await
+            .map_err(QueryManagerError::Core)
+    }
+
+    pub(crate) async fn execute_sql_with_context(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+        sql: &str,
+        attribution: &QueryAttribution,
+    ) -> Result<QueryExecution, QueryManagerError> {
+        run_query_operation(
+            QueryOperation::ExecuteSql,
+            workspace_name,
+            sql,
+            attribution.episode_id.as_ref(),
+            async {
+                let (sources, runtime) =
+                    self.load_query_runtime(workspace_name, request_principal)?;
+                CoralQuery::execute_sql(&sources, runtime, sql)
+                    .await
+                    .map_err(QueryManagerError::Core)
+            },
+            |execution| Some(u64::try_from(execution.row_count()).unwrap_or(u64::MAX)),
         )
-    )]
+        .await
+    }
+
+    pub(crate) async fn explain_sql_with_context(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+        sql: &str,
+        attribution: &QueryAttribution,
+    ) -> Result<QueryPlan, QueryManagerError> {
+        run_query_operation(
+            QueryOperation::ExplainSql,
+            workspace_name,
+            sql,
+            attribution.episode_id.as_ref(),
+            async {
+                let (sources, runtime) =
+                    self.load_query_runtime(workspace_name, request_principal)?;
+                CoralQuery::explain_sql(&sources, runtime, sql)
+                    .await
+                    .map_err(QueryManagerError::Core)
+            },
+            |_| None,
+        )
+        .await
+    }
+
+    pub(crate) async fn validate_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+        source_name: &SourceName,
+    ) -> Result<ValidatedSource, QueryManagerError> {
+        let config = self
+            .config_store
+            .load_config()
+            .map_err(QueryManagerError::App)?;
+        let registry_source = self
+            .require_registry_source(workspace_name, source_name)
+            .map_err(QueryManagerError::App)?;
+        let loaded_source = self
+            .load_registry_query_source(workspace_name, &registry_source)
+            .map_err(QueryManagerError::App)?;
+        self.validate_source_identity_bindings(workspace_name, request_principal, &loaded_source)
+            .await
+            .map_err(QueryManagerError::App)?;
+        let identity_bindings =
+            identity_binding_snapshot_for_sources(std::slice::from_ref(&loaded_source));
+        let runtime = self
+            .runtime_config(
+                workspace_name,
+                request_principal,
+                std::slice::from_ref(&loaded_source.query_source),
+                identity_bindings,
+                &config,
+            )
+            .map_err(QueryManagerError::App)?;
+        let report = CoralQuery::validate_source(
+            &loaded_source.query_source,
+            runtime,
+            loaded_source.query_source.test_queries(),
+        )
+        .await
+        .map_err(QueryManagerError::Core)?;
+        let mut source = registry_source.source;
+        source.version = loaded_source.version;
+
+        Ok(ValidatedSource { source, report })
+    }
+
+    fn load_query_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<LoadedQuerySource>, AppError> {
+        let span = tracing::info_span!(
+            "coral.app.query_sources.load",
+            workspace = %workspace_name,
+            source.count = tracing::field::Empty,
+        );
+        let _guard = span.enter();
+        let mut query_sources = Vec::new();
+        for source in self.list_registry_sources(workspace_name)? {
+            match self.load_registry_query_source(workspace_name, &source) {
+                Ok(query_source) => query_sources.push(query_source),
+                // A known source that cannot be served right now (unavailable
+                // credentials, disabled feature, incompatible materialization)
+                // must surface loudly rather than be silently dropped from the
+                // catalog.
+                Err(
+                    error @ (AppError::Credentials(CredentialsError::Unavailable(_))
+                    | AppError::SourceUnservable(_)),
+                ) => {
+                    return Err(error);
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        source = %source.source.name,
+                        detail = %error,
+                        "skipping source during query-source load"
+                    );
+                }
+            }
+        }
+        span.record("source.count", query_sources.len());
+        Ok(query_sources)
+    }
+
+    #[cfg(test)]
     fn load_query_source(
         &self,
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
-    ) -> Result<(QuerySource, Option<String>), AppError> {
+    ) -> Result<LoadedQuerySource, AppError> {
         self.load_query_source_with_imported_manifest(workspace_name, source, None)
     }
 
@@ -403,7 +394,7 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         source: &RegistryQuerySource,
-    ) -> Result<(QuerySource, Option<String>), AppError> {
+    ) -> Result<LoadedQuerySource, AppError> {
         self.load_query_source_with_imported_manifest(
             workspace_name,
             &source.source,
@@ -416,7 +407,7 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
         imported_manifest_yaml: Option<&str>,
-    ) -> Result<(QuerySource, Option<String>), AppError> {
+    ) -> Result<LoadedQuerySource, AppError> {
         let installed = resolve_installed_manifest_with_imported_yaml(
             workspace_name,
             source,
@@ -495,13 +486,41 @@ impl QueryManager {
         } else {
             QuerySource::from_manifest(&source_spec, source.variables.clone(), resolved_secrets)
         };
-        Ok((query_source, installed.candidate.version))
+        Ok(LoadedQuerySource {
+            query_source,
+            version: installed.candidate.version,
+            identity_bindings: source.identity_bindings.clone(),
+        })
+    }
+
+    fn request_identity_resolver(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+        selected_sources: &[QuerySource],
+        identity_bindings: SourceIdentityBindingsSnapshot,
+    ) -> Option<Arc<dyn RequestIdentityResolver>> {
+        if selected_sources
+            .iter()
+            .any(|source| identity_requirements_for_source(source).next().is_some())
+        {
+            Some(Arc::new(LazyRuntimeIdentityResolver {
+                workspace_name: workspace_name.clone(),
+                request_principal: request_principal.clone(),
+                source_identity_bindings: Arc::new(identity_bindings),
+                identity_manager: self.identity_manager.clone(),
+            }))
+        } else {
+            None
+        }
     }
 
     fn runtime_config(
         &self,
         workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
         selected_sources: &[QuerySource],
+        identity_bindings: SourceIdentityBindingsSnapshot,
         config: &AppConfig,
     ) -> Result<QueryRuntimeConfig, AppError> {
         let mut extensions =
@@ -513,15 +532,238 @@ impl QueryManager {
             self.credential_manager.clone(),
             provider_input_resolver,
         )));
+        let request_identity_resolver = self.request_identity_resolver(
+            workspace_name,
+            request_principal,
+            selected_sources,
+            identity_bindings,
+        );
         let mut runtime_context = self.runtime_context.clone();
         runtime_context.trace_context = Some(tracing::Span::current().context());
-        let mut runtime = QueryRuntimeConfig::new(runtime_context, extensions);
+        let mut runtime = QueryRuntimeConfig::new(runtime_context, extensions)
+            .with_request_identity_resolver(request_identity_resolver);
         let selected_source_names = selected_sources
             .iter()
             .map(|source| source.source_name().to_string())
             .collect::<Vec<_>>();
         runtime.dependent_join = config.dependent_join_config(&selected_source_names)?;
         Ok(runtime)
+    }
+
+    async fn validate_source_identity_bindings(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+        loaded_source: &LoadedQuerySource,
+    ) -> Result<(), AppError> {
+        let mut source_identity_bindings = BTreeMap::new();
+        source_identity_bindings.insert(
+            loaded_source.query_source.source_name().to_string(),
+            loaded_source.identity_bindings.clone(),
+        );
+        let resolver = LazyRuntimeIdentityResolver {
+            workspace_name: workspace_name.clone(),
+            request_principal: request_principal.clone(),
+            source_identity_bindings: Arc::new(source_identity_bindings),
+            identity_manager: self.identity_manager.clone(),
+        };
+        for requirements in identity_requirements_for_source(&loaded_source.query_source) {
+            let context = RequestIdentityResolutionContext::new(
+                loaded_source.query_source.source_name().to_string(),
+                requirements.surface_id,
+                requirements.requirements,
+            );
+            resolver.resolve_runtime_identity(&context).await?;
+        }
+        Ok(())
+    }
+}
+
+fn query_sources_from_loaded(loaded_sources: Vec<LoadedQuerySource>) -> Vec<QuerySource> {
+    loaded_sources
+        .into_iter()
+        .map(|loaded| loaded.query_source)
+        .collect()
+}
+
+fn identity_binding_snapshot_for_sources(
+    loaded_sources: &[LoadedQuerySource],
+) -> SourceIdentityBindingsSnapshot {
+    loaded_sources
+        .iter()
+        .map(|loaded| {
+            (
+                loaded.query_source.source_name().to_string(),
+                loaded.identity_bindings.clone(),
+            )
+        })
+        .collect()
+}
+
+#[derive(Clone)]
+struct LazyRuntimeIdentityResolver {
+    workspace_name: WorkspaceName,
+    request_principal: UserPrincipal,
+    source_identity_bindings: Arc<SourceIdentityBindingsSnapshot>,
+    identity_manager: IdentityManager,
+}
+
+impl fmt::Debug for LazyRuntimeIdentityResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LazyRuntimeIdentityResolver")
+            .field("workspace_name", &self.workspace_name)
+            .field("source_identity_bindings", &self.source_identity_bindings)
+            .field("identity_manager", &self.identity_manager)
+            .finish_non_exhaustive()
+    }
+}
+
+impl LazyRuntimeIdentityResolver {
+    async fn resolve_runtime_identity(
+        &self,
+        identity: &RequestIdentityResolutionContext,
+    ) -> Result<Arc<dyn crate::identity::RuntimeSourceIdentity>, AppError> {
+        SourceName::parse(identity.source_name())
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        let binding = identity_binding_for_surface(
+            &self.source_identity_bindings,
+            identity.source_name(),
+            identity.surface_id(),
+        )?;
+        let subject =
+            SourceIdentitySubject::for_binding_owner(binding.owner, &self.request_principal);
+        let selection = self
+            .identity_manager
+            .resolve_source_identity_selection(SourceIdentitySelectionRequest {
+                workspace_name: self.workspace_name.as_str().to_string(),
+                subject: subject.clone(),
+                source_name: identity.source_name().to_string(),
+                surface_id: identity.surface_id().to_string(),
+                binding: binding.clone(),
+            })
+            .await?;
+        let selected_requirements = select_identity_requirements_for_selection(
+            identity.source_name(),
+            identity.surface_id(),
+            identity.identity_requirements(),
+            &selection,
+        )?;
+        let runtime_identity = self
+            .identity_manager
+            .resolve_source_identity(SourceIdentityResolutionRequest {
+                workspace_name: self.workspace_name.as_str().to_string(),
+                subject,
+                source_name: identity.source_name().to_string(),
+                surface_id: identity.surface_id().to_string(),
+                binding,
+                selection,
+                identity_requirements: selected_requirements.clone(),
+            })
+            .await?;
+        let selected_context = RequestIdentityResolutionContext::new(
+            identity.source_name().to_string(),
+            identity.surface_id().to_string(),
+            selected_requirements,
+        );
+        if !selected_context.accepts_identity(
+            runtime_identity.identity_spec_id(),
+            runtime_identity.audience(),
+        ) {
+            return Err(AppError::FailedPrecondition(format!(
+                "resolved identity does not satisfy selected identity requirements for source '{}' surface '{}'",
+                identity.source_name(),
+                identity.surface_id()
+            )));
+        }
+        Ok(runtime_identity)
+    }
+}
+
+#[tonic::async_trait]
+impl RequestIdentityResolver for LazyRuntimeIdentityResolver {
+    async fn resolve_identity_headers(
+        &self,
+        identity: &RequestIdentityResolutionContext,
+        request: &reqwest::Request,
+        resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<
+        Vec<(reqwest::header::HeaderName, reqwest::header::HeaderValue)>,
+        RequestIdentityResolverError,
+    > {
+        let runtime_identity = self
+            .resolve_runtime_identity(identity)
+            .await
+            .map_err(|error| app_error_to_identity_resolver_error(&error))?;
+        runtime_identity
+            .resolve_headers(identity, request, resolved_inputs)
+            .await
+    }
+}
+
+fn identity_requirements_for_source(
+    source: &QuerySource,
+) -> impl Iterator<Item = RuntimeIdentityRequirements> + '_ {
+    source
+        .components()
+        .iter()
+        .filter_map(|component| match component {
+            RuntimeSourceComponent::Http(component) => component.identity_requirements.clone(),
+            RuntimeSourceComponent::File(_) | RuntimeSourceComponent::Mcp(_) => None,
+        })
+}
+
+fn identity_binding_for_surface(
+    source_identity_bindings: &SourceIdentityBindingsSnapshot,
+    source_name: &str,
+    surface_id: &str,
+) -> Result<SourceIdentityBinding, AppError> {
+    source_identity_bindings
+        .get(source_name)
+        .and_then(|bindings| bindings.get(surface_id))
+        .cloned()
+        .ok_or_else(|| {
+            AppError::FailedPrecondition(format!(
+                "source '{source_name}' surface '{surface_id}' declares identity_requirements but has no workspace identity binding"
+            ))
+        })
+}
+
+fn select_identity_requirements_for_selection(
+    source_name: &str,
+    surface_id: &str,
+    requirements: &IdentityRequirements,
+    selection: &SourceIdentitySelection,
+) -> Result<coral_spec::v4::IdentityRequirements, AppError> {
+    if let Some(accepted_identity) = selection.accepted_identity.as_deref() {
+        if let Some(accepted) = requirements
+            .accepts
+            .iter()
+            .find(|accepted| accepted.id == accepted_identity)
+        {
+            return Ok(coral_spec::v4::IdentityRequirements {
+                accepts: vec![accepted.clone()],
+            });
+        }
+        return Err(AppError::FailedPrecondition(format!(
+            "source '{source_name}' surface '{}' binds identity '{}' to unknown accepted_identity '{}'",
+            surface_id, selection.identity, accepted_identity
+        )));
+    }
+
+    if requirements.accepts.len() == 1 {
+        return Ok(requirements.clone());
+    }
+    Err(AppError::FailedPrecondition(format!(
+        "source '{source_name}' surface '{}' has multiple accepted identities; configure accepted_identity for binding '{}'",
+        surface_id, selection.identity
+    )))
+}
+
+fn app_error_to_identity_resolver_error(error: &AppError) -> RequestIdentityResolverError {
+    let detail = error.to_string();
+    match error {
+        AppError::InvalidInput(_) => RequestIdentityResolverError::invalid_input(detail),
+        _ => RequestIdentityResolverError::failed_precondition(detail),
     }
 }
 
@@ -711,19 +953,26 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use coral_engine::{
-        EngineExtensions, QueryExecution, SourceInputResolutionContext, SourceInputResolver,
+        EngineExtensions, QueryExecution, RequestIdentityResolutionContext,
+        RequestIdentityResolverError, SourceInputResolutionContext, SourceInputResolver,
         SourceInputResolverError,
     };
     use coral_spec::parse_source_manifest_yaml;
+    use reqwest::header::{HeaderName, HeaderValue};
     use serde_json::{Value, json};
     use tempfile::TempDir;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
-    use crate::features::dsl_v4_features;
-    use crate::identity::SingleUserPrincipalProvider;
+    use crate::features::{Features, dsl_v4_features};
+    use crate::identity::{
+        RuntimeSourceIdentity, SingleUserPrincipalProvider, SourceIdentityBinding,
+        SourceIdentityOwner, SourceIdentityProvider, SourceIdentityResolutionRequest,
+        SourceIdentitySelection, SourceIdentitySelectionRequest, SourceIdentitySubject,
+        UserPrincipal,
+    };
     use crate::source_registry::{
         SourceRegistryCredentialStorage, SourceRegistryOrigin, SourceRegistryRecord,
     };
@@ -785,7 +1034,7 @@ mod tests {
         runtime_context: QueryRuntimeContext,
         providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> QueryManagerFixture {
-        query_manager_with_features(runtime_context, providers, dsl_v4_features())
+        query_manager_with_features(runtime_context, providers, Features::default())
     }
 
     fn query_manager_with_features(
@@ -793,16 +1042,26 @@ mod tests {
         providers: Vec<Arc<dyn EngineExtensionsProvider>>,
         features: Features,
     ) -> QueryManagerFixture {
+        query_manager_with_features_and_identities(runtime_context, providers, Vec::new(), features)
+    }
+
+    fn query_manager_with_features_and_identities(
+        runtime_context: QueryRuntimeContext,
+        providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
+        features: Features,
+    ) -> QueryManagerFixture {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        let manager = QueryManager::new(
+        let manager = QueryManager::new_with_features(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             runtime_context,
             layout,
-            features,
             providers,
+            identity_providers,
+            features,
         );
         QueryManagerFixture {
             _temp: temp,
@@ -836,6 +1095,7 @@ mod tests {
         let service = QueryService::new(
             fixture.manager.clone(),
             Arc::new(SingleUserPrincipalProvider),
+            Arc::new(crate::authorization::AllowAllWorkspaceAuthorizer),
         );
 
         let mut request = Request::new(ExecuteSqlRequest {
@@ -874,19 +1134,74 @@ mod tests {
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let config_store = ConfigStore::new(layout.clone());
-        let manager = QueryManager::new_with_source_registry(
+        let manager = QueryManager::new_with_features_and_source_registry(
             config_store,
             source_registry,
             CredentialManager::new(CredentialStore::new(layout.clone())),
             QueryRuntimeContext::default(),
             layout,
-            dsl_v4_features(),
             Vec::new(),
+            Vec::new(),
+            Features::default(),
         );
         QueryManagerFixture {
             _temp: temp,
             manager,
         }
+    }
+
+    /// Builds a v4-enabled query manager backed by a [`TestIdentityProvider`]
+    /// that selects `selection_identity` for user-owned bindings.
+    fn identity_fixture(
+        selection_identity: &str,
+    ) -> (QueryManagerFixture, ObservedIdentityRequestCell) {
+        let observed = Arc::new(Mutex::new(None));
+        let fixture = query_manager_with_features_and_identities(
+            QueryRuntimeContext::default(),
+            Vec::new(),
+            vec![Arc::new(TestIdentityProvider::selecting(
+                &observed,
+                selection_identity,
+            ))],
+            dsl_v4_features(),
+        );
+        (fixture, observed)
+    }
+
+    fn local_request_principal() -> UserPrincipal {
+        UserPrincipal::local()
+    }
+
+    fn user_request_principal(user_id: &str) -> UserPrincipal {
+        UserPrincipal::for_user(user_id).expect("user")
+    }
+
+    async fn run_sql(
+        fixture: &QueryManagerFixture,
+        request_principal: &UserPrincipal,
+        sql: &str,
+    ) -> Result<QueryExecution, QueryManagerError> {
+        fixture
+            .manager
+            .execute_sql_with_context(
+                &WorkspaceName::default(),
+                request_principal,
+                sql,
+                &QueryAttribution::default(),
+            )
+            .await
+    }
+
+    /// Runs the canonical `github_v4_identity` query as request user `saul`.
+    async fn query_identity_issues(
+        fixture: &QueryManagerFixture,
+    ) -> Result<QueryExecution, QueryManagerError> {
+        run_sql(
+            fixture,
+            &user_request_principal("saul"),
+            "SELECT id, title FROM github_v4_identity.issues",
+        )
+        .await
     }
 
     fn execution_to_rows(execution: &QueryExecution) -> Vec<Value> {
@@ -901,8 +1216,398 @@ mod tests {
         serde_json::from_slice(&bytes).expect("json rows should decode")
     }
 
-    #[test]
-    fn runtime_config_preserves_app_owned_body_capture_max_bytes() {
+    type ObservedIdentityRequestCell = Arc<Mutex<Option<ObservedIdentityRequest>>>;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ObservedIdentityRequest {
+        workspace_name: String,
+        subject: SourceIdentitySubject,
+        source_name: String,
+        surface_id: String,
+        identity: String,
+        owner: SourceIdentityOwner,
+    }
+
+    /// Asserts the provider observed one identity resolution request for the
+    /// `github_v4_identity` source's `rest` surface in the default workspace.
+    #[track_caller]
+    fn assert_observed_identity(
+        observed: &ObservedIdentityRequestCell,
+        subject: SourceIdentitySubject,
+        identity: &str,
+        owner: SourceIdentityOwner,
+    ) {
+        assert_eq!(
+            *observed.lock().expect("observed identity request"),
+            Some(ObservedIdentityRequest {
+                workspace_name: "default".to_string(),
+                subject,
+                source_name: "github_v4_identity".to_string(),
+                surface_id: "rest".to_string(),
+                identity: identity.to_string(),
+                owner,
+            })
+        );
+    }
+
+    #[derive(Debug)]
+    struct TestIdentityProvider {
+        observed: ObservedIdentityRequestCell,
+        selection: SourceIdentitySelection,
+    }
+
+    impl TestIdentityProvider {
+        fn selecting(observed: &ObservedIdentityRequestCell, identity: &str) -> Self {
+            Self {
+                observed: Arc::clone(observed),
+                selection: SourceIdentitySelection::new(
+                    identity,
+                    Some("github-rest-read".to_string()),
+                )
+                .expect("selection"),
+            }
+        }
+    }
+
+    #[tonic::async_trait]
+    impl SourceIdentityProvider for TestIdentityProvider {
+        async fn resolve_source_identity_selection(
+            &self,
+            request: &SourceIdentitySelectionRequest,
+        ) -> Result<Option<SourceIdentitySelection>, AppError> {
+            if request.subject.user_id().is_some() {
+                Ok(Some(self.selection.clone()))
+            } else {
+                Ok(None)
+            }
+        }
+
+        async fn resolve_source_identity(
+            &self,
+            request: &SourceIdentityResolutionRequest,
+        ) -> Result<Option<Arc<dyn RuntimeSourceIdentity>>, AppError> {
+            *self.observed.lock().expect("observed identity request") =
+                Some(ObservedIdentityRequest {
+                    workspace_name: request.workspace_name.clone(),
+                    subject: request.subject.clone(),
+                    source_name: request.source_name.clone(),
+                    surface_id: request.surface_id.clone(),
+                    identity: request.selection.identity.clone(),
+                    owner: request.binding.owner,
+                });
+            let identity: Arc<dyn RuntimeSourceIdentity> = match request.selection.identity.as_str()
+            {
+                "github_local" | "github_workspace" => {
+                    Arc::new(TestRuntimeIdentity::new("github_oauth", "github.com"))
+                }
+                "gitlab_wrong" => Arc::new(TestRuntimeIdentity::new("gitlab_oauth", "gitlab.com")),
+                _ => return Ok(None),
+            };
+            Ok(Some(identity))
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestRuntimeIdentity {
+        identity_spec_id: &'static str,
+        audience: BTreeMap<String, Value>,
+    }
+
+    impl TestRuntimeIdentity {
+        fn new(identity_spec_id: &'static str, host: &str) -> Self {
+            Self {
+                identity_spec_id,
+                audience: BTreeMap::from([("host".to_string(), json!(host))]),
+            }
+        }
+    }
+
+    #[tonic::async_trait]
+    impl RuntimeSourceIdentity for TestRuntimeIdentity {
+        fn identity_spec_id(&self) -> &str {
+            self.identity_spec_id
+        }
+
+        fn audience(&self) -> &BTreeMap<String, Value> {
+            &self.audience
+        }
+
+        async fn resolve_headers(
+            &self,
+            _identity: &RequestIdentityResolutionContext,
+            _request: &reqwest::Request,
+            _resolved_inputs: &BTreeMap<String, String>,
+        ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
+            Ok(vec![(
+                HeaderName::from_static("x-coral-identity"),
+                HeaderValue::from_static("member-token"),
+            )])
+        }
+    }
+
+    /// Ensures the fixture layout exists and returns a v4-enabled source
+    /// manager that shares the fixture's stores.
+    fn v4_source_manager(fixture: &QueryManagerFixture) -> SourceManager {
+        fixture.manager.layout.ensure().expect("ensure layout");
+        SourceManager::new_with_features(
+            fixture.manager.config_store.clone(),
+            fixture.manager.credential_manager.clone(),
+            fixture.manager.layout.clone(),
+            dsl_v4_features(),
+        )
+    }
+
+    async fn mount_issues_endpoint(server: &MockServer, require_member_token: bool, body: Value) {
+        let mut mock = Mock::given(method("GET")).and(path("/issues"));
+        if require_member_token {
+            mock = mock.and(header("x-coral-identity", "member-token"));
+        }
+        mock.respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(server)
+            .await;
+    }
+
+    fn issues_openapi_yaml(server: &MockServer) -> String {
+        format!(
+            r"
+openapi: 3.0.3
+info:
+  title: GitHub
+servers:
+  - url: {}
+paths:
+  /issues:
+    get:
+      operationId: issues/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {{type: integer}}
+                    title: {{type: string}}
+",
+            server.uri()
+        )
+    }
+
+    const GITHUB_REST_ACCEPTS_YAML: &str = r"        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+            - github_pat
+          audience:
+            host: github.com
+";
+
+    /// Imports a DSL v4 source whose `rest` surface targets the mock server,
+    /// optionally declaring identity requirements, then removes the authored
+    /// descriptor so queries must run from materialized artifacts.
+    fn import_v4_source(
+        source_manager: &SourceManager,
+        workspace_name: &WorkspaceName,
+        source_name: &str,
+        server: &MockServer,
+        identity_accepts_yaml: Option<&str>,
+        identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+    ) {
+        let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
+        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
+        let openapi_yaml = issues_openapi_yaml(server);
+        let openapi_sha256 = sha256_hex(openapi_yaml.as_bytes());
+        std::fs::write(&openapi_file, openapi_yaml).expect("write OpenAPI fixture");
+        let identity_requirements_yaml = identity_accepts_yaml
+            .map(|accepts| format!("    identity_requirements:\n      accepts:\n{accepts}"))
+            .unwrap_or_default();
+        let command = ImportSourceCommand {
+            manifest_yaml: format!(
+                r"
+name: {source_name}
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    sha256: {}
+{identity_requirements_yaml}",
+                openapi_file.display(),
+                openapi_sha256
+            ),
+            bindings: SourceBindings::default(),
+            identity_bindings,
+            replace_identity_bindings: false,
+        };
+        // Query tests seed identity-backed sources so query-time resolver behavior
+        // can be exercised; the direct source-manager import API intentionally
+        // fails closed without that runtime resolver.
+        let (_source, rollback) = source_manager
+            .import_source_with_rollback_state(workspace_name, &command)
+            .expect("import v4 source");
+        SourceManager::commit_import_source_rollback_state(rollback, &[]);
+        std::fs::remove_file(&openapi_file).expect("remove authored descriptor after import");
+    }
+
+    /// Imports the `github_v4_identity` source with the standard GitHub accept
+    /// branch and the given identity binding into the default workspace.
+    fn import_identity_v4_source(
+        fixture: &QueryManagerFixture,
+        server: &MockServer,
+        identity: &str,
+        owner: SourceIdentityOwner,
+    ) {
+        import_v4_source(
+            &v4_source_manager(fixture),
+            &WorkspaceName::default(),
+            "github_v4_identity",
+            server,
+            Some(GITHUB_REST_ACCEPTS_YAML),
+            source_identity_bindings(identity, owner, "github-rest-read"),
+        );
+    }
+
+    fn source_identity_bindings(
+        identity: &str,
+        owner: SourceIdentityOwner,
+        accepted_identity: &str,
+    ) -> BTreeMap<String, SourceIdentityBinding> {
+        let binding = match owner {
+            SourceIdentityOwner::User => SourceIdentityBinding::user_owned(),
+            SourceIdentityOwner::Workspace => SourceIdentityBinding::workspace_owned(
+                identity,
+                Some(accepted_identity.to_string()),
+            )
+            .expect("workspace identity binding"),
+        };
+        BTreeMap::from([("rest".to_string(), binding)])
+    }
+
+    fn clear_identity_bindings(fixture: &QueryManagerFixture, source_name: &SourceName) {
+        let workspace_name = WorkspaceName::default();
+        let mut installed = fixture
+            .manager
+            .config_store
+            .get_source(&workspace_name, source_name)
+            .expect("installed source");
+        installed.identity_bindings.clear();
+        fixture
+            .manager
+            .config_store
+            .upsert_source(&workspace_name, installed)
+            .expect("clear identity binding");
+    }
+
+    fn imported_source(source_name: &SourceName) -> InstalledSource {
+        InstalledSource {
+            name: source_name.clone(),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            identity_bindings: BTreeMap::new(),
+            origin: SourceOrigin::Imported,
+        }
+    }
+
+    /// Ensures the fixture layout, writes `manifest_yaml` as the installed
+    /// manifest for `source_name` in the default workspace, and returns the
+    /// parsed source name.
+    fn write_manifest(
+        fixture: &QueryManagerFixture,
+        source_name: &str,
+        manifest_yaml: &str,
+    ) -> SourceName {
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let source_name = SourceName::parse(source_name).expect("source name");
+        let manifest_path = fixture
+            .manager
+            .layout
+            .manifest_file(&WorkspaceName::default(), &source_name);
+        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create source dir");
+        std::fs::write(&manifest_path, manifest_yaml).expect("write manifest");
+        source_name
+    }
+
+    fn persist_source(fixture: &QueryManagerFixture, source: InstalledSource) {
+        fixture
+            .manager
+            .config_store
+            .upsert_source(&WorkspaceName::default(), source)
+            .expect("persist source");
+    }
+
+    /// Stores `material` as the source's file-backed credential set in the
+    /// default workspace.
+    fn persist_file_secrets(
+        fixture: &QueryManagerFixture,
+        source_name: &SourceName,
+        material: &[(&str, &str)],
+    ) {
+        let material = material
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect();
+        fixture
+            .manager
+            .credential_manager
+            .replace_material(
+                &WorkspaceName::default(),
+                &CredentialSetId::for_source(source_name),
+                CredentialStorageKind::File,
+                &material,
+            )
+            .expect("persist secret material");
+    }
+
+    #[tokio::test]
+    async fn lazy_identity_resolver_uses_loaded_source_binding_snapshot() {
+        let observed = Arc::new(Mutex::new(None));
+        let resolver = LazyRuntimeIdentityResolver {
+            workspace_name: WorkspaceName::default(),
+            request_principal: user_request_principal("saul"),
+            source_identity_bindings: Arc::new(BTreeMap::from([(
+                "github_v4_identity".to_string(),
+                source_identity_bindings(
+                    "github_workspace",
+                    SourceIdentityOwner::Workspace,
+                    "github-rest-read",
+                ),
+            )])),
+            identity_manager: IdentityManager::new(vec![Arc::new(
+                TestIdentityProvider::selecting(&observed, "github_local"),
+            )]),
+        };
+        let context = RequestIdentityResolutionContext::new(
+            "github_v4_identity",
+            "rest",
+            coral_spec::v4::IdentityRequirements {
+                accepts: vec![coral_spec::v4::AcceptedIdentityRequirement {
+                    id: "github-rest-read".to_string(),
+                    identity_specs: vec!["github_oauth".to_string()],
+                    audience: BTreeMap::from([("host".to_string(), json!("github.com"))]),
+                }],
+            },
+        );
+
+        let identity = resolver
+            .resolve_runtime_identity(&context)
+            .await
+            .expect("resolve identity from snapshot");
+
+        assert_eq!(identity.identity_spec_id(), "github_oauth");
+        assert_observed_identity(
+            &observed,
+            SourceIdentitySubject::Workspace,
+            "github_workspace",
+            SourceIdentityOwner::Workspace,
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_config_preserves_app_owned_body_capture_max_bytes() {
         let fixture = query_manager_with(
             QueryRuntimeContext::default().with_body_capture_max_bytes(Some(42)),
             Vec::new(),
@@ -910,7 +1615,13 @@ mod tests {
 
         let runtime = fixture
             .manager
-            .runtime_config(&WorkspaceName::default(), &[], &AppConfig::default())
+            .runtime_config(
+                &WorkspaceName::default(),
+                &local_request_principal(),
+                &[],
+                BTreeMap::new(),
+                &AppConfig::default(),
+            )
             .expect("runtime config");
 
         let config = runtime
@@ -923,17 +1634,10 @@ mod tests {
     #[test]
     fn load_query_source_passes_present_optional_secrets_to_runtime() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
-        fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("optional_auth").expect("source name");
-        let manifest_path = fixture
-            .manager
-            .layout
-            .manifest_file(&workspace_name, &source_name);
-        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
-            .expect("create source dir");
-        std::fs::write(
-            &manifest_path,
+        let source_name = write_manifest(
+            &fixture,
+            "optional_auth",
             r"
 name: optional_auth
 version: 0.1.0
@@ -966,40 +1670,21 @@ tables:
       - name: id
         type: Utf8
 ",
-        )
-        .expect("write manifest");
-        let source = InstalledSource {
-            name: source_name.clone(),
-            version: Some("0.1.0".to_string()),
-            variables: BTreeMap::new(),
-            secrets: vec!["API_KEY".to_string(), "OAUTH_TOKEN".to_string()],
-            credential_storage: Some(CredentialStorageKind::File),
-            identity_bindings: BTreeMap::new(),
-            origin: SourceOrigin::Imported,
-        };
-        fixture
-            .manager
-            .config_store
-            .upsert_source(&workspace_name, source.clone())
-            .expect("persist source");
-        fixture
-            .manager
-            .credential_manager
-            .replace_material(
-                &workspace_name,
-                &CredentialSetId::for_source(&source_name),
-                CredentialStorageKind::File,
-                &BTreeMap::from([("OAUTH_TOKEN".to_string(), "oauth-token".to_string())]),
-            )
-            .expect("persist secret material");
+        );
+        let mut source = imported_source(&source_name);
+        source.version = Some("0.1.0".to_string());
+        source.secrets = vec!["API_KEY".to_string(), "OAUTH_TOKEN".to_string()];
+        source.credential_storage = Some(CredentialStorageKind::File);
+        persist_source(&fixture, source.clone());
+        persist_file_secrets(&fixture, &source_name, &[("OAUTH_TOKEN", "oauth-token")]);
 
-        let (query_source, _) = fixture
+        let loaded = fixture
             .manager
             .load_query_source(&workspace_name, &source)
             .expect("optional secret should load when present");
 
         assert_eq!(
-            query_source.secrets(),
+            loaded.query_source.secrets(),
             &BTreeMap::from([("OAUTH_TOKEN".to_string(), "oauth-token".to_string())])
         );
     }
@@ -1007,86 +1692,34 @@ tables:
     #[tokio::test]
     async fn installed_v4_source_queries_through_app_assembled_runtime_component() {
         let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/issues"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
-                {"id": 1, "title": "Generated runtime package"}
-            ])))
-            .mount(&server)
-            .await;
+        mount_issues_endpoint(
+            &server,
+            false,
+            json!([{"id": 1, "title": "Generated runtime package"}]),
+        )
+        .await;
 
-        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
-        fixture.manager.layout.ensure().expect("ensure layout");
-        let source_manager = SourceManager::new_with_features(
-            fixture.manager.config_store.clone(),
-            fixture.manager.credential_manager.clone(),
-            fixture.manager.layout.clone(),
+        let fixture = query_manager_with_features(
+            QueryRuntimeContext::default(),
+            Vec::new(),
             dsl_v4_features(),
         );
-        let workspace_name = WorkspaceName::default();
-        let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
-        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
-        let openapi_yaml = format!(
-            r"
-openapi: 3.0.3
-info:
-  title: GitHub
-servers:
-  - url: {}
-paths:
-  /issues:
-    get:
-      operationId: issues/list
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id: {{type: integer}}
-                    title: {{type: string}}
-",
-            server.uri()
+        import_v4_source(
+            &v4_source_manager(&fixture),
+            &WorkspaceName::default(),
+            "github_v4_query",
+            &server,
+            None,
+            BTreeMap::new(),
         );
-        let openapi_sha256 = sha256_hex(openapi_yaml.as_bytes());
-        std::fs::write(&openapi_file, openapi_yaml).expect("write OpenAPI fixture");
-        source_manager
-            .import_source(
-                &workspace_name,
-                &ImportSourceCommand {
-                    manifest_yaml: format!(
-                        r"
-name: github_v4_query
-dsl_version: 4
-surfaces:
-  - id: rest
-    type: openapi
-    file: {}
-    sha256: {}
-",
-                        openapi_file.display(),
-                        openapi_sha256
-                    ),
-                    bindings: SourceBindings::default(),
-                    identity_bindings: BTreeMap::new(),
-                    replace_identity_bindings: false,
-                },
-            )
-            .expect("import v4 source");
-        std::fs::remove_file(&openapi_file).expect("remove authored descriptor after import");
 
-        let execution = fixture
-            .manager
-            .execute_sql(
-                &workspace_name,
-                "SELECT id, title FROM github_v4_query.issues",
-                &QueryAttribution::default(),
-            )
-            .await
-            .expect("query executes");
+        let execution = run_sql(
+            &fixture,
+            &local_request_principal(),
+            "SELECT id, title FROM github_v4_query.issues",
+        )
+        .await
+        .expect("query executes");
 
         assert_eq!(
             execution_to_rows(&execution),
@@ -1094,20 +1727,202 @@ surfaces:
         );
     }
 
+    #[tokio::test]
+    async fn identity_backed_v4_source_uses_workspace_binding_for_request_user() {
+        let server = MockServer::start().await;
+        mount_issues_endpoint(&server, true, json!([{"id": 9, "title": "Bound identity"}])).await;
+
+        let (fixture, observed) = identity_fixture("github_local");
+        import_identity_v4_source(&fixture, &server, "github_local", SourceIdentityOwner::User);
+
+        let execution = query_identity_issues(&fixture)
+            .await
+            .expect("query executes");
+
+        assert_eq!(
+            execution_to_rows(&execution),
+            vec![json!({"id": 9, "title": "Bound identity"})]
+        );
+        assert_observed_identity(
+            &observed,
+            SourceIdentitySubject::User("saul".to_string()),
+            "github_local",
+            SourceIdentityOwner::User,
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_backed_v4_source_uses_workspace_owned_binding_without_request_user() {
+        let server = MockServer::start().await;
+        mount_issues_endpoint(
+            &server,
+            true,
+            json!([{"id": 10, "title": "Workspace identity"}]),
+        )
+        .await;
+
+        let (fixture, observed) = identity_fixture("github_local");
+        import_identity_v4_source(
+            &fixture,
+            &server,
+            "github_workspace",
+            SourceIdentityOwner::Workspace,
+        );
+
+        let execution = query_identity_issues(&fixture)
+            .await
+            .expect("query executes");
+
+        assert_eq!(
+            execution_to_rows(&execution),
+            vec![json!({"id": 10, "title": "Workspace identity"})]
+        );
+        assert_observed_identity(
+            &observed,
+            SourceIdentitySubject::Workspace,
+            "github_workspace",
+            SourceIdentityOwner::Workspace,
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_backed_v4_source_rejects_identity_matching_unselected_accept_branch() {
+        let server = MockServer::start().await;
+        mount_issues_endpoint(
+            &server,
+            true,
+            json!([{"id": 11, "title": "Wrong identity branch"}]),
+        )
+        .await;
+
+        let (fixture, observed) = identity_fixture("gitlab_wrong");
+        import_v4_source(
+            &v4_source_manager(&fixture),
+            &WorkspaceName::default(),
+            "github_v4_identity",
+            &server,
+            Some(
+                r"        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+            - github_pat
+          audience:
+            host: github.com
+        - id: gitlab-project-read
+          identity_specs:
+            - gitlab_oauth
+          audience:
+            host: gitlab.com
+",
+            ),
+            source_identity_bindings(
+                "gitlab_wrong",
+                SourceIdentityOwner::User,
+                "github-rest-read",
+            ),
+        );
+
+        let error = query_identity_issues(&fixture)
+            .await
+            .expect_err("identity matching only the unselected accepted branch should fail");
+
+        let message = query_error_message(&error);
+        assert!(
+            message.contains("selected identity requirements"),
+            "unexpected error: {message}"
+        );
+        assert_observed_identity(
+            &observed,
+            SourceIdentitySubject::User("saul".to_string()),
+            "gitlab_wrong",
+            SourceIdentityOwner::User,
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_backed_v4_source_fails_without_workspace_binding() {
+        let server = MockServer::start().await;
+        let (fixture, _observed) = identity_fixture("github_local");
+        import_identity_v4_source(&fixture, &server, "github_local", SourceIdentityOwner::User);
+        let source_name = SourceName::parse("github_v4_identity").expect("source name");
+        clear_identity_bindings(&fixture, &source_name);
+
+        let error = query_identity_issues(&fixture)
+            .await
+            .expect_err("missing identity binding should fail when the source is used");
+
+        let message = query_error_message(&error);
+        assert!(
+            message.contains("has no workspace identity binding"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unrelated_query_ignores_broken_identity_backed_source() {
+        let server = MockServer::start().await;
+        let (fixture, observed) = identity_fixture("github_local");
+        import_identity_v4_source(&fixture, &server, "github_local", SourceIdentityOwner::User);
+        let source_name = SourceName::parse("github_v4_identity").expect("source name");
+        clear_identity_bindings(&fixture, &source_name);
+
+        let execution = run_sql(
+            &fixture,
+            &user_request_principal("saul"),
+            "SELECT 1 AS value",
+        )
+        .await
+        .expect("unrelated query should not resolve broken source identity");
+
+        assert_eq!(execution_to_rows(&execution), vec![json!({"value": 1})]);
+        assert_eq!(
+            *observed.lock().expect("observed identity request"),
+            None,
+            "unrelated query should not resolve source identities"
+        );
+    }
+
+    #[test]
+    fn load_query_source_rejects_v4_when_dsl_v4_feature_is_disabled() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        let workspace_name = WorkspaceName::default();
+        let source_name = write_manifest(
+            &fixture,
+            "github_v4_disabled",
+            r"
+name: github_v4_disabled
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+",
+        );
+        let source = imported_source(&source_name);
+
+        let error = fixture
+            .manager
+            .load_query_source(&workspace_name, &source)
+            .expect_err("disabled v4 feature should reject query loading");
+
+        assert!(
+            error.to_string().contains("dsl_v4"),
+            "unexpected error: {error}"
+        );
+    }
+
     #[test]
     fn load_query_sources_fails_closed_for_missing_v4_materialization() {
-        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
-        fixture.manager.layout.ensure().expect("ensure layout");
+        let fixture = query_manager_with_features(
+            QueryRuntimeContext::default(),
+            Vec::new(),
+            dsl_v4_features(),
+        );
         let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("github_v4_missing_artifacts").expect("source name");
-        let manifest_path = fixture
-            .manager
-            .layout
-            .manifest_file(&workspace_name, &source_name);
-        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
-            .expect("create source dir");
-        std::fs::write(
-            &manifest_path,
+        let source_name = write_manifest(
+            &fixture,
+            "github_v4_missing_artifacts",
             r"
 name: github_v4_missing_artifacts
 dsl_version: 4
@@ -1117,24 +1932,8 @@ surfaces:
     url: https://example.com/openapi.yaml
     sha256: 0000000000000000000000000000000000000000000000000000000000000000
 ",
-        )
-        .expect("write manifest");
-        fixture
-            .manager
-            .config_store
-            .upsert_source(
-                &workspace_name,
-                InstalledSource {
-                    name: source_name.clone(),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    identity_bindings: BTreeMap::new(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
-            .expect("persist source");
+        );
+        persist_source(&fixture, imported_source(&source_name));
 
         let error = fixture
             .manager
@@ -1148,63 +1947,6 @@ surfaces:
     }
 
     #[test]
-    fn load_query_sources_fails_closed_when_dsl_v4_is_disabled() {
-        let fixture = query_manager_with_features(
-            QueryRuntimeContext::default(),
-            Vec::new(),
-            Features::default(),
-        );
-        fixture.manager.layout.ensure().expect("ensure layout");
-        let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("github_v4_disabled").expect("source name");
-        let manifest_path = fixture
-            .manager
-            .layout
-            .manifest_file(&workspace_name, &source_name);
-        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
-            .expect("create source dir");
-        std::fs::write(
-            &manifest_path,
-            r"
-name: github_v4_disabled
-dsl_version: 4
-surfaces:
-  - id: rest
-    type: openapi
-    url: https://example.com/openapi.yaml
-    sha256: 0000000000000000000000000000000000000000000000000000000000000000
-",
-        )
-        .expect("write manifest");
-        fixture
-            .manager
-            .config_store
-            .upsert_source(
-                &workspace_name,
-                InstalledSource {
-                    name: source_name.clone(),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    identity_bindings: BTreeMap::new(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
-            .expect("persist source");
-
-        let error = fixture
-            .manager
-            .load_query_sources(&workspace_name)
-            .expect_err("disabled dsl_v4 feature should fail closed");
-
-        assert!(
-            matches!(error, AppError::SourceUnservable(ref message) if message.contains("dsl_v4")),
-            "unexpected error: {error:#}"
-        );
-    }
-
-    #[test]
     fn load_query_sources_fails_closed_for_unavailable_keychain_source() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
@@ -1212,20 +1954,12 @@ surfaces:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("github").expect("source name");
+        let mut source = imported_source(&SourceName::parse("github").expect("source name"));
+        source.secrets = vec!["GITHUB_TOKEN".to_string()];
+        source.credential_storage = Some(CredentialStorageKind::Keychain);
+        source.origin = SourceOrigin::Bundled;
         config_store
-            .upsert_source(
-                &workspace_name,
-                InstalledSource {
-                    name: source_name,
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: vec!["GITHUB_TOKEN".to_string()],
-                    credential_storage: Some(CredentialStorageKind::Keychain),
-                    identity_bindings: BTreeMap::new(),
-                    origin: SourceOrigin::Bundled,
-                },
-            )
+            .upsert_source(&workspace_name, source)
             .expect("persist source");
         let credential_store = CredentialStore::with_unavailable_keychain_for_test(
             layout.clone(),
@@ -1236,7 +1970,6 @@ surfaces:
             CredentialManager::new(credential_store),
             QueryRuntimeContext::default(),
             layout,
-            dsl_v4_features(),
             Vec::new(),
         );
         let error = manager
@@ -1297,50 +2030,7 @@ surfaces:
         }
     }
 
-    #[tokio::test]
-    #[expect(
-        clippy::too_many_lines,
-        reason = "inlined source/credential setup; PR 9 extracts the shared test helpers that shorten this body"
-    )]
-    async fn runtime_config_composes_provider_input_resolver_with_refreshed_inputs() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let observed_token = Arc::new(Mutex::new(None));
-        let fixture = query_manager_with(
-            QueryRuntimeContext::default(),
-            vec![Arc::new(DelegatingInputResolverProvider {
-                calls: Arc::clone(&calls),
-                observed_token: Arc::clone(&observed_token),
-            })],
-        );
-        let source_name = SourceName::parse("secured_messages").expect("source name");
-        let workspace_name = WorkspaceName::default();
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        fixture
-            .manager
-            .config_store
-            .upsert_source(
-                &workspace_name,
-                InstalledSource {
-                    name: source_name.clone(),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: vec!["API_TOKEN".to_string()],
-                    credential_storage: Some(CredentialStorageKind::File),
-                    identity_bindings: BTreeMap::new(),
-                    origin: SourceOrigin::Bundled,
-                },
-            )
-            .expect("persist source");
-        fixture
-            .manager
-            .credential_manager
-            .replace_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-                &BTreeMap::from([("API_TOKEN".to_string(), "stored-token".to_string())]),
-            )
-            .expect("write credential material");
+    fn secured_messages_query_source() -> QuerySource {
         let source_spec = parse_source_manifest_yaml(
             r#"
 name: secured_messages
@@ -1367,12 +2057,36 @@ tables:
 "#,
         )
         .expect("parse source manifest");
-        let source = QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new());
+        QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new())
+    }
+
+    #[tokio::test]
+    async fn runtime_config_composes_provider_input_resolver_with_refreshed_inputs() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed_token = Arc::new(Mutex::new(None));
+        let fixture = query_manager_with(
+            QueryRuntimeContext::default(),
+            vec![Arc::new(DelegatingInputResolverProvider {
+                calls: Arc::clone(&calls),
+                observed_token: Arc::clone(&observed_token),
+            })],
+        );
+        let source_name = SourceName::parse("secured_messages").expect("source name");
+        let workspace_name = WorkspaceName::default();
+        let mut installed = imported_source(&source_name);
+        installed.secrets = vec!["API_TOKEN".to_string()];
+        installed.credential_storage = Some(CredentialStorageKind::File);
+        installed.origin = SourceOrigin::Bundled;
+        persist_source(&fixture, installed);
+        persist_file_secrets(&fixture, &source_name, &[("API_TOKEN", "stored-token")]);
+        let source = secured_messages_query_source();
         let runtime = fixture
             .manager
             .runtime_config(
                 &workspace_name,
+                &local_request_principal(),
                 std::slice::from_ref(&source),
+                BTreeMap::new(),
                 &AppConfig::default(),
             )
             .expect("runtime config");
@@ -1464,7 +2178,9 @@ tables:
             .manager
             .runtime_config(
                 &workspace_name,
+                &local_request_principal(),
                 std::slice::from_ref(&source),
+                BTreeMap::new(),
                 &AppConfig::default(),
             )
             .expect("runtime config");
@@ -1524,7 +2240,7 @@ tables:
 
         let tables = fixture
             .manager
-            .list_tables(&workspace_name, None, None)
+            .list_tables(&workspace_name, &local_request_principal(), None, None)
             .await
             .expect("registry manifest should load");
 

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -11,6 +11,7 @@ use coral_api::v1::{
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
 
+use crate::authorization::{WorkspaceAccessKind, WorkspaceAuthorizer, authorization_status};
 use crate::bootstrap::core_status;
 use crate::identity::UserPrincipalProvider;
 use crate::query::QueryAttribution;
@@ -24,16 +25,19 @@ use crate::transport::{
 pub(crate) struct QueryService {
     queries: QueryManager,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
 }
 
 impl QueryService {
     pub(crate) fn new(
         query_manager: QueryManager,
         user_principal_provider: Arc<dyn UserPrincipalProvider>,
+        workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
     ) -> Self {
         Self {
             queries: query_manager,
             user_principal_provider,
+            workspace_authorizer,
         }
     }
 }
@@ -45,6 +49,7 @@ impl QueryServiceApi for QueryService {
         request: Request<ExecuteSqlRequest>,
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
         let queries = self.queries.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         let attribution = QueryAttribution {
             episode_id: episode_id_from_metadata(request.metadata()),
         };
@@ -53,6 +58,14 @@ impl QueryServiceApi for QueryService {
             request,
             |principal, inner| async move {
                 let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+                workspace_authorizer
+                    .authorize_workspace_access(
+                        &principal,
+                        workspace_name.as_str(),
+                        WorkspaceAccessKind::Read,
+                    )
+                    .await
+                    .map_err(authorization_status)?;
                 let execution = queries
                     .execute_sql_with_context(&workspace_name, &principal, &inner.sql, &attribution)
                     .await
@@ -77,6 +90,7 @@ impl QueryServiceApi for QueryService {
         request: Request<ExplainSqlRequest>,
     ) -> Result<Response<ExplainSqlResponse>, Status> {
         let queries = self.queries.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         let attribution = QueryAttribution {
             episode_id: episode_id_from_metadata(request.metadata()),
         };
@@ -85,6 +99,14 @@ impl QueryServiceApi for QueryService {
             request,
             |principal, inner| async move {
                 let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+                workspace_authorizer
+                    .authorize_workspace_access(
+                        &principal,
+                        workspace_name.as_str(),
+                        WorkspaceAccessKind::Read,
+                    )
+                    .await
+                    .map_err(authorization_status)?;
                 let plan = queries
                     .explain_sql_with_context(&workspace_name, &principal, &inner.sql, &attribution)
                     .await

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -66,10 +66,10 @@ pub(crate) fn resolve_installed_manifest_with_imported_yaml(
 ) -> Result<InstalledSourceManifest, AppError> {
     let manifest_yaml = match source.origin {
         SourceOrigin::Bundled => load_bundled_source(&source.name)?.manifest_yaml,
-        SourceOrigin::Imported => match imported_manifest_yaml {
-            Some(manifest_yaml) => manifest_yaml.to_string(),
-            None => std::fs::read_to_string(layout.manifest_file(workspace_name, &source.name))?,
-        },
+        SourceOrigin::Imported => imported_manifest_yaml.map_or_else(
+            || std::fs::read_to_string(layout.manifest_file(workspace_name, &source.name)),
+            |manifest_yaml| Ok(manifest_yaml.to_string()),
+        )?,
     };
     let source_spec = parse_source_manifest_yaml(&manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -189,6 +189,12 @@ impl Drop for SourceImportPreflight {
     }
 }
 
+pub(crate) struct UserSourceIdentityBindingCleanup {
+    pub(crate) all_users_surface_ids: Vec<String>,
+    pub(crate) other_users_surface_ids: Vec<String>,
+    pub(crate) preserved_user_id: Option<String>,
+}
+
 #[derive(Clone)]
 struct RegistrySource {
     source: InstalledSource,
@@ -196,7 +202,6 @@ struct RegistrySource {
 }
 
 pub(crate) struct SourceImportRollbackState {
-    workspace_name: WorkspaceName,
     source_name: SourceName,
     installed_record: SourceRegistryRecord,
     installed_manifest_yaml: Option<String>,
@@ -274,6 +279,29 @@ impl SourceManager {
         }
     }
 
+    pub(crate) fn source_identity_binding_cleanup_plan(
+        rollback: &SourceImportRollbackState,
+        preserved_user_bindings: &[PreservedUserSourceIdentityBinding],
+    ) -> UserSourceIdentityBindingCleanup {
+        let preserved_user_id = preserved_user_bindings
+            .first()
+            .map(|preserved| preserved.user_id.clone());
+        let (other_users_surface_ids, all_users_surface_ids): (Vec<_>, Vec<_>) = rollback
+            .stale_user_binding_surfaces
+            .iter()
+            .cloned()
+            .partition(|surface_id| {
+                preserved_user_bindings
+                    .iter()
+                    .any(|preserved| preserved.surface_id == *surface_id)
+            });
+        UserSourceIdentityBindingCleanup {
+            all_users_surface_ids,
+            other_users_surface_ids,
+            preserved_user_id,
+        }
+    }
+
     fn list_registry_sources(
         &self,
         workspace_name: &WorkspaceName,
@@ -341,7 +369,10 @@ impl SourceManager {
         Ok(self
             .list_registry_source_records(workspace_name)?
             .into_iter()
-            .map(|source| self.populate_registry_source_version_or_keep(workspace_name, source))
+            .map(|source| {
+                self.populate_registry_source_version_or_keep(workspace_name, source)
+                    .source
+            })
             .collect())
     }
 
@@ -350,10 +381,12 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
-        Ok(self.populate_registry_source_version_or_keep(
-            workspace_name,
-            self.require_registry_source_record(workspace_name, source_name)?,
-        ))
+        Ok(self
+            .populate_registry_source_version_or_keep(
+                workspace_name,
+                self.require_registry_source_record(workspace_name, source_name)?,
+            )
+            .source)
     }
 
     pub(crate) fn get_source_info(
@@ -421,7 +454,7 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         command: &CreateBundledSourceCommand,
-    ) -> Result<InstalledSource, AppError> {
+    ) -> Result<(InstalledSource, UserSourceIdentityBindingCleanup), AppError> {
         let bundled = load_bundled_source(&command.name)?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
         self.install_validated_source(
@@ -430,7 +463,7 @@ impl SourceManager {
                 candidate: &candidate,
                 bindings: &command.bindings,
                 identity_bindings: &BTreeMap::new(),
-                replace_identity_bindings: false,
+                replace_identity_bindings: true,
                 manifest_yaml: None,
                 materialization_manifest_yaml: &bundled.manifest_yaml,
                 origin: SourceOrigin::Bundled,
@@ -443,7 +476,7 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         command: CreateBundledSourceWithOAuthCommand,
         events: OAuthProgressEventSender,
-    ) -> Result<InstalledSource, AppError> {
+    ) -> Result<(InstalledSource, UserSourceIdentityBindingCleanup), AppError> {
         let bundled = load_bundled_source(&command.name)?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
         self.install_source_with_oauth(
@@ -452,7 +485,7 @@ impl SourceManager {
                 candidate: &candidate,
                 bindings: &command.bindings,
                 identity_bindings: &BTreeMap::new(),
-                replace_identity_bindings: false,
+                replace_identity_bindings: true,
                 manifest_yaml: None,
                 materialization_manifest_yaml: &bundled.manifest_yaml,
                 origin: SourceOrigin::Bundled,
@@ -493,7 +526,7 @@ impl SourceManager {
             self.materialization_manifest_yaml_for_import(&command.manifest_yaml, None)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
-        self.install_validated_source(
+        let (source, cleanup) = self.install_validated_source(
             workspace_name,
             InstallSourceRequest {
                 candidate: &candidate,
@@ -504,7 +537,13 @@ impl SourceManager {
                 materialization_manifest_yaml: &manifest_yaml,
                 origin: SourceOrigin::Imported,
             },
-        )
+        )?;
+        self.cleanup_user_source_identity_bindings_for_plan_best_effort(
+            workspace_name,
+            &source.name,
+            &cleanup,
+        );
+        Ok(source)
     }
 
     #[cfg_attr(
@@ -581,7 +620,6 @@ impl SourceManager {
         installed: Option<&InstalledSource>,
     ) {
         let SourceImportRollbackState {
-            workspace_name: _,
             source_name,
             installed_record,
             installed_manifest_yaml,
@@ -668,20 +706,13 @@ impl SourceManager {
     }
 
     pub(crate) fn commit_import_source_rollback_state(
-        &self,
         rollback: SourceImportRollbackState,
         preserved_user_bindings: &[PreservedUserSourceIdentityBinding],
-    ) {
-        let stale_user_binding_surfaces = rollback.stale_user_binding_surfaces;
-        if !stale_user_binding_surfaces.is_empty() {
-            self.cleanup_user_source_identity_bindings_for_surfaces_best_effort(
-                &rollback.workspace_name,
-                &rollback.source_name,
-                &stale_user_binding_surfaces,
-                preserved_user_bindings,
-            );
-        }
+    ) -> UserSourceIdentityBindingCleanup {
+        let cleanup =
+            Self::source_identity_binding_cleanup_plan(&rollback, preserved_user_bindings);
         rollback.materialization_rollback.cleanup();
+        cleanup
     }
 
     #[cfg_attr(
@@ -701,21 +732,28 @@ impl SourceManager {
             self.materialization_manifest_yaml_for_import(&command.manifest_yaml, None)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
-        self.install_source_with_oauth(
+        let (source, cleanup) = self
+            .install_source_with_oauth(
+                workspace_name,
+                InstallSourceRequest {
+                    candidate: &candidate,
+                    bindings: &command.bindings,
+                    identity_bindings: &command.identity_bindings,
+                    replace_identity_bindings: command.replace_identity_bindings,
+                    manifest_yaml: Some(&manifest_yaml),
+                    materialization_manifest_yaml: &manifest_yaml,
+                    origin: SourceOrigin::Imported,
+                },
+                command.oauth_credential_retrievals,
+                events,
+            )
+            .await?;
+        self.cleanup_user_source_identity_bindings_for_plan_best_effort(
             workspace_name,
-            InstallSourceRequest {
-                candidate: &candidate,
-                bindings: &command.bindings,
-                identity_bindings: &command.identity_bindings,
-                replace_identity_bindings: command.replace_identity_bindings,
-                manifest_yaml: Some(&manifest_yaml),
-                materialization_manifest_yaml: &manifest_yaml,
-                origin: SourceOrigin::Imported,
-            },
-            command.oauth_credential_retrievals,
-            events,
-        )
-        .await
+            &source.name,
+            &cleanup,
+        );
+        Ok(source)
     }
 
     #[expect(
@@ -802,10 +840,34 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         request: InstallSourceRequest<'_>,
-    ) -> Result<InstalledSource, AppError> {
+    ) -> Result<(InstalledSource, UserSourceIdentityBindingCleanup), AppError> {
+        self.ensure_direct_install_has_no_identity_bindings(workspace_name, request)?;
         let persisted = self.install_validated_source_deferred(workspace_name, request, None)?;
-        self.commit_import_source_rollback_state(persisted.rollback, &[]);
-        Ok(persisted.source)
+        let cleanup = Self::commit_import_source_rollback_state(persisted.rollback, &[]);
+        Ok((persisted.source, cleanup))
+    }
+
+    fn ensure_direct_install_has_no_identity_bindings(
+        &self,
+        workspace_name: &WorkspaceName,
+        request: InstallSourceRequest<'_>,
+    ) -> Result<(), AppError> {
+        let manifest = parse_source_manifest_yaml(request.materialization_manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_feature_enabled(&manifest)?;
+        let identity_bindings = self.effective_source_identity_bindings(
+            workspace_name,
+            &request.candidate.name,
+            request.identity_bindings,
+            request.replace_identity_bindings,
+        )?;
+        validate_import_identity_bindings(&manifest, &identity_bindings)?;
+        if identity_bindings.is_empty() {
+            return Ok(());
+        }
+        Err(AppError::FailedPrecondition(
+            "request identity resolution is not installed".to_string(),
+        ))
     }
 
     fn install_validated_source_deferred(
@@ -829,7 +891,6 @@ impl SourceManager {
             request.replace_identity_bindings,
         )?;
         validate_import_identity_bindings(&manifest, &identity_bindings)?;
-        ensure_identity_backed_imports_have_query_resolver(&manifest)?;
         let stored_material = self.source_stored_material_for_validation(
             workspace_name,
             request.candidate,
@@ -941,7 +1002,8 @@ impl SourceManager {
         request: InstallSourceRequest<'_>,
         oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
         events: OAuthProgressEventSender,
-    ) -> Result<InstalledSource, AppError> {
+    ) -> Result<(InstalledSource, UserSourceIdentityBindingCleanup), AppError> {
+        self.ensure_direct_install_has_no_identity_bindings(workspace_name, request)?;
         let persisted = self
             .install_source_with_oauth_deferred(
                 workspace_name,
@@ -951,8 +1013,8 @@ impl SourceManager {
                 None,
             )
             .await?;
-        self.commit_import_source_rollback_state(persisted.rollback, &[]);
-        Ok(persisted.source)
+        let cleanup = Self::commit_import_source_rollback_state(persisted.rollback, &[]);
+        Ok((persisted.source, cleanup))
     }
 
     async fn install_source_with_oauth_deferred(
@@ -978,7 +1040,6 @@ impl SourceManager {
             request.replace_identity_bindings,
         )?;
         validate_import_identity_bindings(&manifest, &identity_bindings)?;
-        ensure_identity_backed_imports_have_query_resolver(&manifest)?;
         let oauth_input_keys = oauth_credential_retrievals
             .iter()
             .map(|credential| credential.input_key.clone())
@@ -1035,8 +1096,9 @@ impl SourceManager {
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
         let stored_record = self.require_registry_source_record(workspace_name, source_name)?;
-        let removed =
-            self.populate_registry_source_version_or_keep(workspace_name, stored_record.clone());
+        let removed = self
+            .populate_registry_source_version_or_keep(workspace_name, stored_record.clone())
+            .source;
         let stored = stored_record.source;
         let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
@@ -1305,7 +1367,6 @@ impl SourceManager {
         Ok(PersistedSource {
             source: resolved,
             rollback: SourceImportRollbackState {
-                workspace_name: workspace_name.clone(),
                 source_name,
                 installed_record,
                 installed_manifest_yaml,
@@ -1816,6 +1877,43 @@ impl SourceManager {
         );
     }
 
+    fn cleanup_user_source_identity_bindings_for_plan_best_effort(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        cleanup: &UserSourceIdentityBindingCleanup,
+    ) {
+        if !cleanup.all_users_surface_ids.is_empty() {
+            self.cleanup_user_source_identity_bindings_for_surfaces_best_effort(
+                workspace_name,
+                source_name,
+                &cleanup.all_users_surface_ids,
+                &[],
+            );
+        }
+        if cleanup.other_users_surface_ids.is_empty() {
+            return;
+        }
+        let preserved_user_bindings = cleanup
+            .preserved_user_id
+            .iter()
+            .flat_map(|user_id| {
+                cleanup.other_users_surface_ids.iter().map(|surface_id| {
+                    PreservedUserSourceIdentityBinding {
+                        user_id: user_id.clone(),
+                        surface_id: surface_id.clone(),
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        self.cleanup_user_source_identity_bindings_for_surfaces_best_effort(
+            workspace_name,
+            source_name,
+            &cleanup.other_users_surface_ids,
+            &preserved_user_bindings,
+        );
+    }
+
     fn cleanup_user_source_identity_bindings_for_surfaces_best_effort(
         &self,
         workspace_name: &WorkspaceName,
@@ -1896,7 +1994,7 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         mut source: RegistrySource,
-    ) -> Result<InstalledSource, AppError> {
+    ) -> Result<RegistrySource, AppError> {
         source.source.version = resolve_installed_manifest_with_imported_yaml(
             workspace_name,
             &source.source,
@@ -1905,16 +2003,16 @@ impl SourceManager {
         )?
         .candidate
         .version;
-        Ok(source.source)
+        Ok(source)
     }
 
     fn populate_registry_source_version_or_keep(
         &self,
         workspace_name: &WorkspaceName,
         source: RegistrySource,
-    ) -> InstalledSource {
+    ) -> RegistrySource {
         self.populate_registry_source_version(workspace_name, source.clone())
-            .unwrap_or(source.source)
+            .unwrap_or(source)
     }
 }
 
@@ -2076,25 +2174,6 @@ fn validate_import_identity_bindings(
         }
     }
     Ok(())
-}
-
-fn ensure_identity_backed_imports_have_query_resolver(
-    manifest: &ValidatedSourceManifest,
-) -> Result<(), AppError> {
-    let Some(v4) = manifest.as_v4() else {
-        return Ok(());
-    };
-    if !v4
-        .surfaces
-        .iter()
-        .any(|surface| surface.identity_requirements.is_some())
-    {
-        return Ok(());
-    }
-    Err(AppError::FailedPrecondition(format!(
-        "source '{}' declares identity_requirements, but request identity resolution is not installed for query execution in this build",
-        manifest.schema_name()
-    )))
 }
 
 fn source_needs_stored_material_for_validation(
@@ -3100,6 +3179,61 @@ surfaces:
         }
     }
 
+    fn registry_record_with_imported_manifest(
+        source_name: &str,
+        manifest_yaml: String,
+    ) -> SourceRegistryRecord {
+        SourceRegistryRecord {
+            workspace_id: default_workspace().as_str().to_string(),
+            source_name: source_name.to_string(),
+            version: None,
+            manifest_yaml: Some(manifest_yaml),
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            identity_bindings: BTreeMap::new(),
+            origin: SourceRegistryOrigin::Imported,
+        }
+    }
+
+    #[test]
+    fn registry_backed_imported_manifest_supports_info_and_delete_without_local_file() {
+        let manifest_yaml = manifest_without_secrets();
+        let source_name = SourceName::parse("public_messages").expect("source name");
+        let registry = Arc::new(StaticSourceRegistry::with_records(vec![
+            registry_record_with_imported_manifest(source_name.as_str(), manifest_yaml),
+        ]));
+        let fixture = manager_fixture_with_source_registry(registry.clone());
+        assert!(
+            !fixture
+                .layout
+                .manifest_file(&default_workspace(), &source_name)
+                .exists(),
+            "test must exercise registry manifest storage, not local manifest files"
+        );
+
+        let source_info = fixture
+            .manager
+            .get_source_info(&default_workspace(), &source_name)
+            .expect("get source info from registry manifest");
+        assert_eq!(source_info.name, source_name);
+        assert_eq!(source_info.version.as_deref(), Some("0.1.0"));
+
+        let removed = fixture
+            .manager
+            .delete_source(&default_workspace(), &source_name)
+            .expect("delete registry-backed source");
+        assert_eq!(removed.name, source_name);
+        assert_eq!(removed.version.as_deref(), Some("0.1.0"));
+        assert!(
+            registry
+                .get_source(default_workspace().as_str(), source_name.as_str())
+                .expect("registry read")
+                .is_none(),
+            "delete should remove the registry record"
+        );
+    }
+
     fn manifest_v4_with_variable_input() -> String {
         r#"
 name: secured_messages_v4
@@ -3428,9 +3562,7 @@ tables:
                 Some(preflight),
             )
             .expect("import v4 source with preflight materialization");
-        fixture
-            .manager
-            .commit_import_source_rollback_state(rollback, &[]);
+        SourceManager::commit_import_source_rollback_state(rollback, &[]);
 
         assert_eq!(installed.name.as_str(), "github_v4_test");
         assert!(
@@ -3544,9 +3676,7 @@ base_url: "https://example.com"
             .manager
             .import_source_with_rollback_state(&default_workspace(), &initial_command)
             .expect("initial import");
-        fixture
-            .manager
-            .commit_import_source_rollback_state(initial_rollback, &[]);
+        SourceManager::commit_import_source_rollback_state(initial_rollback, &[]);
         let stale_command = import_command(
             manifest("0.2.0", "Stale messages"),
             SourceBindings::default(),
@@ -3563,9 +3693,7 @@ base_url: "https://example.com"
             .manager
             .import_source_with_rollback_state(&default_workspace(), &current_command)
             .expect("current import");
-        fixture
-            .manager
-            .commit_import_source_rollback_state(current_rollback, &[]);
+        SourceManager::commit_import_source_rollback_state(current_rollback, &[]);
 
         fixture.manager.restore_import_source_rollback_state(
             &default_workspace(),
@@ -3656,50 +3784,9 @@ base_url: "https://example.com"
     }
 
     #[test]
-    fn commit_import_preserves_rebound_stale_user_identity_selection() {
-        let fixture = manager_fixture();
+    fn commit_import_returns_stale_user_identity_cleanup_plan() {
         let source_name = SourceName::parse("github_v4_test").expect("source");
-        let rest_binding_path = fixture.layout.user_owned_source_identity_binding_file(
-            "saul",
-            &default_workspace(),
-            &source_name,
-            "rest",
-        );
-        let graphql_binding_path = fixture.layout.user_owned_source_identity_binding_file(
-            "saul",
-            &default_workspace(),
-            &source_name,
-            "graphql",
-        );
-        let other_user_rest_binding_path = fixture.layout.user_owned_source_identity_binding_file(
-            "ada",
-            &default_workspace(),
-            &source_name,
-            "rest",
-        );
-        for path in [
-            &rest_binding_path,
-            &graphql_binding_path,
-            &other_user_rest_binding_path,
-        ] {
-            std::fs::create_dir_all(path.parent().expect("binding parent"))
-                .expect("create binding parent");
-            std::fs::write(path, "version: 1\nidentity: github_saul\n").expect("write binding");
-        }
-        let rest_binding_dir = rest_binding_path
-            .parent()
-            .expect("rest binding dir")
-            .to_path_buf();
-        let graphql_binding_dir = graphql_binding_path
-            .parent()
-            .expect("graphql binding dir")
-            .to_path_buf();
-        let other_user_rest_binding_dir = other_user_rest_binding_path
-            .parent()
-            .expect("other user rest binding dir")
-            .to_path_buf();
         let rollback = SourceImportRollbackState {
-            workspace_name: default_workspace(),
             source_name: source_name.clone(),
             installed_record: record_from_installed_source(
                 &default_workspace(),
@@ -3711,7 +3798,7 @@ base_url: "https://example.com"
             stale_user_binding_surfaces: vec!["rest".to_string(), "graphql".to_string()],
         };
 
-        fixture.manager.commit_import_source_rollback_state(
+        let cleanup = SourceManager::commit_import_source_rollback_state(
             rollback,
             &[PreservedUserSourceIdentityBinding {
                 user_id: "saul".to_string(),
@@ -3719,18 +3806,9 @@ base_url: "https://example.com"
             }],
         );
 
-        assert!(
-            rest_binding_dir.exists(),
-            "commit cleanup should preserve explicitly rebound user selections"
-        );
-        assert!(
-            !graphql_binding_dir.exists(),
-            "commit cleanup should remove stale user selections that were not rebound"
-        );
-        assert!(
-            !other_user_rest_binding_dir.exists(),
-            "commit cleanup should remove other users' stale selections for rebound surfaces"
-        );
+        assert_eq!(cleanup.all_users_surface_ids, vec!["graphql".to_string()]);
+        assert_eq!(cleanup.other_users_surface_ids, vec!["rest".to_string()]);
+        assert_eq!(cleanup.preserved_user_id.as_deref(), Some("saul"));
     }
 
     #[test]

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -39,7 +39,10 @@ use coral_spec::{
 };
 use tonic::{Request, Response, Status};
 
-use crate::authorization::{ManagementAuthorizer, SourceMutationKind, authorization_status};
+use crate::authorization::{
+    ManagementAuthorizer, SourceMutationKind, WorkspaceAccessKind, WorkspaceAuthorizer,
+    authorization_status,
+};
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
 use crate::credentials::oauth::{OAuthProgressEvent, OAuthProgressEventSender};
@@ -52,6 +55,7 @@ use crate::sources::manager::{
     CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
     ImportSourceWithCredentialsCommand, PreservedUserSourceIdentityBinding, SourceBinding,
     SourceBindings, SourceImportRollbackState, SourceManager, SourceOAuthCredentialRetrieval,
+    UserSourceIdentityBindingCleanup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::transport::{
@@ -72,6 +76,7 @@ pub(crate) struct SourceService {
     user_owned_identities: UserOwnedIdentityManager,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
+    workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
 }
 
 impl SourceService {
@@ -82,6 +87,7 @@ impl SourceService {
         user_owned_identity_manager: UserOwnedIdentityManager,
         user_principal_provider: Arc<dyn UserPrincipalProvider>,
         management_authorizer: Arc<dyn ManagementAuthorizer>,
+        workspace_authorizer: Arc<dyn WorkspaceAuthorizer>,
     ) -> Self {
         Self {
             sources: source_manager,
@@ -90,6 +96,7 @@ impl SourceService {
             user_owned_identities: user_owned_identity_manager,
             user_principal_provider,
             management_authorizer,
+            workspace_authorizer,
         }
     }
 }
@@ -104,11 +111,18 @@ impl SourceServiceApi for SourceService {
         request: Request<DiscoverSourcesRequest>,
     ) -> Result<Response<DiscoverSourcesResponse>, Status> {
         let sources = self.sources.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
-            |_principal, request| async move {
+            |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                authorize_workspace_read(
+                    workspace_authorizer.as_ref(),
+                    &principal,
+                    workspace_name.as_str(),
+                )
+                .await?;
                 let sources = sources
                     .discover_sources(&workspace_name)
                     .map_err(app_status)?
@@ -126,11 +140,18 @@ impl SourceServiceApi for SourceService {
         request: Request<ListSourcesRequest>,
     ) -> Result<Response<ListSourcesResponse>, Status> {
         let sources = self.sources.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
-            |_principal, request| async move {
+            |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                authorize_workspace_read(
+                    workspace_authorizer.as_ref(),
+                    &principal,
+                    workspace_name.as_str(),
+                )
+                .await?;
                 let sources: Vec<_> = sources
                     .list_workspace_sources(&workspace_name)
                     .map_err(app_status)?
@@ -148,11 +169,18 @@ impl SourceServiceApi for SourceService {
         request: Request<GetSourceRequest>,
     ) -> Result<Response<GetSourceResponse>, Status> {
         let sources = self.sources.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
-            |_principal, request| async move {
+            |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                authorize_workspace_read(
+                    workspace_authorizer.as_ref(),
+                    &principal,
+                    workspace_name.as_str(),
+                )
+                .await?;
                 let source_name = SourceName::parse(&request.name).map_err(app_status)?;
                 let source = sources
                     .get_source(&workspace_name, &source_name)
@@ -170,11 +198,18 @@ impl SourceServiceApi for SourceService {
         request: Request<GetSourceInfoRequest>,
     ) -> Result<Response<GetSourceInfoResponse>, Status> {
         let sources = self.sources.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
-            |_principal, request| async move {
+            |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                authorize_workspace_read(
+                    workspace_authorizer.as_ref(),
+                    &principal,
+                    workspace_name.as_str(),
+                )
+                .await?;
                 let source_name = SourceName::parse(&request.name).map_err(app_status)?;
                 let source = sources
                     .get_source_info(&workspace_name, &source_name)
@@ -192,6 +227,7 @@ impl SourceServiceApi for SourceService {
         request: Request<CreateBundledSourceRequest>,
     ) -> Result<Response<CreateBundledSourceResponse>, Status> {
         let sources = self.sources.clone();
+        let user_owned_identities = self.user_owned_identities.clone();
         let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
@@ -212,10 +248,19 @@ impl SourceServiceApi for SourceService {
                     bindings: source_bindings_from_proto(request.variables, request.secrets),
                 };
                 let response_workspace_name = workspace_name.clone();
-                let installed = run_blocking_operation("source operation", move || {
+                let cleanup_workspace_name = workspace_name.clone();
+                let cleanup_source_name = command.name.clone();
+                let (installed, cleanup) = run_blocking_operation("source operation", move || {
                     sources.create_bundled_source(&workspace_name, &command)
                 })
                 .await?;
+                cleanup_stale_user_identity_bindings_best_effort(
+                    &user_owned_identities,
+                    &cleanup_workspace_name,
+                    &cleanup_source_name,
+                    &cleanup,
+                )
+                .await;
                 Ok(Response::new(CreateBundledSourceResponse {
                     source: Some(installed_source_to_proto(
                         &response_workspace_name,
@@ -232,6 +277,7 @@ impl SourceServiceApi for SourceService {
         request: Request<CreateBundledSourceWithOAuthRequest>,
     ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
         let sources = self.sources.clone();
+        let user_owned_identities = self.user_owned_identities.clone();
         let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
@@ -258,17 +304,28 @@ impl SourceServiceApi for SourceService {
                         .collect::<Result<Vec<_>, _>>()
                         .map_err(app_status)?,
                 };
+                let cleanup_workspace_name = workspace_name.clone();
+                let cleanup_source_name = command.name.clone();
                 let stream =
                     import_source_response_stream(response_workspace_name, move |event_sender| {
+                        let user_owned_identities = user_owned_identities.clone();
                         instrument_grpc(span, async move {
-                            sources
+                            let (installed, cleanup) = sources
                                 .create_bundled_source_with_oauth(
                                     &workspace_name,
                                     command,
                                     event_sender,
                                 )
                                 .await
-                                .map_err(app_status)
+                                .map_err(app_status)?;
+                            cleanup_stale_user_identity_bindings_best_effort(
+                                &user_owned_identities,
+                                &cleanup_workspace_name,
+                                &cleanup_source_name,
+                                &cleanup,
+                            )
+                            .await;
+                            Ok(installed)
                         })
                     });
                 Ok(Response::new(Box::pin(stream.map(|response| {
@@ -387,6 +444,7 @@ impl SourceServiceApi for SourceService {
         request: Request<DeleteSourceRequest>,
     ) -> Result<Response<DeleteSourceResponse>, Status> {
         let sources = self.sources.clone();
+        let user_owned_identities = self.user_owned_identities.clone();
         let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
@@ -402,10 +460,27 @@ impl SourceServiceApi for SourceService {
                     .await
                     .map_err(authorization_status)?;
                 let source_name = SourceName::parse(&request.name).map_err(app_status)?;
+                let cleanup_workspace_name = workspace_name.clone();
+                let cleanup_source_name = source_name.clone();
                 run_blocking_operation("source operation", move || {
                     sources.delete_source(&workspace_name, &source_name)
                 })
                 .await?;
+                if let Err(error) = cleanup_user_source_identity_bindings(
+                    &user_owned_identities,
+                    &cleanup_workspace_name,
+                    &cleanup_source_name,
+                    &[],
+                    None,
+                )
+                .await
+                {
+                    warn!(
+                        source = %cleanup_source_name,
+                        error = %error,
+                        "failed to clean up user source identity bindings after source delete"
+                    );
+                }
                 Ok(Response::new(DeleteSourceResponse {}))
             },
         )
@@ -417,11 +492,18 @@ impl SourceServiceApi for SourceService {
         request: Request<ValidateSourceRequest>,
     ) -> Result<Response<ValidateSourceResponse>, Status> {
         let queries = self.queries.clone();
+        let workspace_authorizer = Arc::clone(&self.workspace_authorizer);
         instrument_authenticated_grpc(
             &self.user_principal_provider,
             request,
             |principal, request| async move {
                 let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+                authorize_workspace_read(
+                    workspace_authorizer.as_ref(),
+                    &principal,
+                    workspace_name.as_str(),
+                )
+                .await?;
                 let source_name = SourceName::parse(&request.name).map_err(app_status)?;
                 let result = queries
                     .validate_source(&workspace_name, &principal, &source_name)
@@ -501,6 +583,17 @@ async fn authorize_import_source_request(
             .map_err(authorization_status)?;
     }
     Ok(())
+}
+
+async fn authorize_workspace_read(
+    workspace_authorizer: &dyn WorkspaceAuthorizer,
+    user_principal: &UserPrincipal,
+    workspace_id: &str,
+) -> Result<(), Status> {
+    workspace_authorizer
+        .authorize_workspace_access(user_principal, workspace_id, WorkspaceAccessKind::Read)
+        .await
+        .map_err(authorization_status)
 }
 
 async fn import_source_with_identity_specs(
@@ -634,7 +727,15 @@ async fn persist_bindings_or_rollback(
         return Err(error);
     }
     identity_spec_rollback.disarm();
-    Ok(source_rollback.disarm(&rebound_user_bindings))
+    let (installed, stale_user_binding_cleanup) = source_rollback.disarm(&rebound_user_bindings);
+    identity_context
+        .cleanup_stale_user_identity_bindings_best_effort(
+            workspace_name,
+            &installed.name,
+            &stale_user_binding_cleanup,
+        )
+        .await;
+    Ok(installed)
 }
 
 /// Installs the bundled identity specs and validates the user-owned identity
@@ -771,12 +872,22 @@ impl SourceImportRollbackGuard {
     fn disarm(
         mut self,
         preserved_user_bindings: &[PreservedUserSourceIdentityBinding],
-    ) -> InstalledSource {
+    ) -> (InstalledSource, UserSourceIdentityBindingCleanup) {
         if let Some(rollback) = self.rollback.take() {
-            self.sources
-                .commit_import_source_rollback_state(rollback, preserved_user_bindings);
+            let cleanup = SourceManager::commit_import_source_rollback_state(
+                rollback,
+                preserved_user_bindings,
+            );
+            return (self.installed.take().expect("installed source"), cleanup);
         }
-        self.installed.take().expect("installed source")
+        (
+            self.installed.take().expect("installed source"),
+            UserSourceIdentityBindingCleanup {
+                all_users_surface_ids: Vec::new(),
+                other_users_surface_ids: Vec::new(),
+                preserved_user_id: None,
+            },
+        )
     }
 }
 
@@ -823,7 +934,7 @@ impl ImportSourceIdentityContext {
         &self,
         workspace_name: &WorkspaceName,
         installed: &InstalledSource,
-    ) -> Result<(), AppError> {
+    ) -> Result<Vec<UserSourceIdentityBindingRollback>, AppError> {
         persist_user_source_identity_bindings(
             &self.user_owned_identities,
             self.user_principal.as_ref(),
@@ -846,6 +957,61 @@ impl ImportSourceIdentityContext {
                 surface_id: surface_id.clone(),
             })
             .collect()
+    }
+
+    async fn cleanup_stale_user_identity_bindings_best_effort(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        cleanup: &UserSourceIdentityBindingCleanup,
+    ) {
+        cleanup_stale_user_identity_bindings_best_effort(
+            &self.user_owned_identities,
+            workspace_name,
+            source_name,
+            cleanup,
+        )
+        .await;
+    }
+}
+
+async fn cleanup_stale_user_identity_bindings_best_effort(
+    identities: &UserOwnedIdentityManager,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    cleanup: &UserSourceIdentityBindingCleanup,
+) {
+    if !cleanup.all_users_surface_ids.is_empty()
+        && let Err(error) = cleanup_user_source_identity_bindings(
+            identities,
+            workspace_name,
+            source_name,
+            &cleanup.all_users_surface_ids,
+            None,
+        )
+        .await
+    {
+        warn!(
+            source = %source_name,
+            error = %error,
+            "failed to clean up stale user source identity bindings after source install"
+        );
+    }
+    if !cleanup.other_users_surface_ids.is_empty()
+        && let Err(error) = cleanup_user_source_identity_bindings(
+            identities,
+            workspace_name,
+            source_name,
+            &cleanup.other_users_surface_ids,
+            cleanup.preserved_user_id.as_deref(),
+        )
+        .await
+    {
+        warn!(
+            source = %source_name,
+            error = %error,
+            "failed to clean up stale user source identity bindings after source install"
+        );
     }
 }
 
@@ -1239,9 +1405,9 @@ async fn persist_user_source_identity_bindings(
     workspace_name: &WorkspaceName,
     installed: &InstalledSource,
     bindings: &BTreeMap<String, AppSourceIdentitySelection>,
-) -> Result<(), AppError> {
+) -> Result<Vec<UserSourceIdentityBindingRollback>, AppError> {
     if bindings.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
     let principal = principal.ok_or_else(|| {
         AppError::FailedPrecondition(
@@ -1311,7 +1477,7 @@ async fn persist_user_source_identity_bindings(
             return Err(error);
         }
     }
-    Ok(())
+    Ok(rollback)
 }
 
 struct UserSourceIdentityBindingRollback {
@@ -1345,6 +1511,23 @@ async fn rollback_user_source_identity_bindings(
             );
         }
     }
+}
+
+async fn cleanup_user_source_identity_bindings(
+    identities: &UserOwnedIdentityManager,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    surface_ids: &[String],
+    preserved_user_id: Option<&str>,
+) -> Result<(), AppError> {
+    identities
+        .delete_user_owned_source_identity_bindings(
+            workspace_name,
+            source_name,
+            surface_ids,
+            preserved_user_id,
+        )
+        .await
 }
 
 fn single_import_source_response(
@@ -1618,12 +1801,148 @@ mod tests {
     )]
 
     use super::*;
+    use std::{
+        fs,
+        sync::{Arc, Mutex, MutexGuard},
+    };
+
+    use coral_api::v1::Workspace;
+    use coral_engine::QueryRuntimeContext;
     use coral_spec::{
         ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
         ManifestOAuthClientIdSpec, ManifestOAuthClientSpec, ManifestOAuthCredentialSpec,
         ManifestOAuthFlowKind, ManifestOAuthFlowSpec, ManifestOAuthPkceMode,
         ManifestOAuthRedirectUriPortMode,
     };
+    use tempfile::TempDir;
+
+    use crate::authorization::{AllowAllManagementAuthorizer, AllowAllWorkspaceAuthorizer};
+    use crate::credentials::{CredentialManager, CredentialStore};
+    use crate::features::Features;
+    use crate::identities::{
+        IdentityOwnerKey, UserOwnedIdentityMaterialGuard, UserOwnedIdentityRecord,
+        UserOwnedIdentityStore,
+    };
+    use crate::identity::SingleUserPrincipalProvider;
+    use crate::query::manager::QueryManager;
+    use crate::state::AppStateLayout;
+    use crate::state::ConfigStore;
+
+    type DeletedSourceIdentityBindings = Vec<(String, String, Vec<String>, Option<String>)>;
+
+    #[derive(Debug, Default)]
+    struct RecordingUserOwnedIdentityStore {
+        deleted_source_bindings: Mutex<DeletedSourceIdentityBindings>,
+        delete_source_bindings_error: Mutex<Option<String>>,
+    }
+
+    impl RecordingUserOwnedIdentityStore {
+        fn deleted_source_bindings(
+            &self,
+        ) -> Result<MutexGuard<'_, DeletedSourceIdentityBindings>, AppError> {
+            self.deleted_source_bindings.lock().map_err(|_error| {
+                AppError::FailedPrecondition(
+                    "deleted source binding records lock poisoned".to_string(),
+                )
+            })
+        }
+
+        fn fail_delete_source_bindings_with(&self, error: &str) {
+            *self
+                .delete_source_bindings_error
+                .lock()
+                .expect("delete source binding error lock") = Some(error.to_string());
+        }
+
+        fn delete_source_bindings_error(&self) -> Result<Option<String>, AppError> {
+            self.delete_source_bindings_error
+                .lock()
+                .map_err(|_error| {
+                    AppError::FailedPrecondition(
+                        "delete source binding error lock poisoned".to_string(),
+                    )
+                })
+                .map(|error| error.clone())
+        }
+    }
+
+    #[tonic::async_trait]
+    impl UserOwnedIdentityStore for RecordingUserOwnedIdentityStore {
+        async fn list_identities(
+            &self,
+            _owner: &IdentityOwnerKey,
+        ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+            Ok(Vec::new())
+        }
+
+        async fn load_identity(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _identity_name: &str,
+        ) -> Result<Option<UserOwnedIdentityRecord>, AppError> {
+            Ok(None)
+        }
+
+        async fn replace_identity(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _record: &UserOwnedIdentityRecord,
+            _material: &BTreeMap<String, String>,
+        ) -> Result<(), AppError> {
+            Ok(())
+        }
+
+        async fn delete_identity(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _identity_name: &str,
+        ) -> Result<bool, AppError> {
+            Ok(false)
+        }
+
+        async fn material_guard(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _identity_name: &str,
+        ) -> Result<Box<dyn UserOwnedIdentityMaterialGuard>, AppError> {
+            Ok(Box::new(RecordingMaterialGuard))
+        }
+
+        async fn delete_source_identity_bindings(
+            &self,
+            workspace_name: &str,
+            source_name: &str,
+            surface_ids: &[String],
+            preserved_user_id: Option<&str>,
+        ) -> Result<(), AppError> {
+            self.deleted_source_bindings()?.push((
+                workspace_name.to_string(),
+                source_name.to_string(),
+                surface_ids.to_vec(),
+                preserved_user_id.map(ToString::to_string),
+            ));
+            if let Some(error) = self.delete_source_bindings_error()? {
+                return Err(AppError::FailedPrecondition(error));
+            }
+            Ok(())
+        }
+    }
+
+    struct RecordingMaterialGuard;
+
+    #[tonic::async_trait]
+    impl UserOwnedIdentityMaterialGuard for RecordingMaterialGuard {
+        async fn read_material(&self) -> Result<BTreeMap<String, String>, AppError> {
+            Ok(BTreeMap::new())
+        }
+
+        async fn write_material(
+            &self,
+            _material: &BTreeMap<String, String>,
+        ) -> Result<(), AppError> {
+            Ok(())
+        }
+    }
 
     /// A required `API_TOKEN` secret input with the given credential spec.
     fn api_token_input(credential: Option<ManifestCredentialSpec>) -> ManifestInputSpec {
@@ -1643,6 +1962,297 @@ mod tests {
             ProtoSourceInput::Secret(secret) => secret,
             ProtoSourceInput::Variable(_) => panic!("expected secret input"),
         }
+    }
+
+    fn user_owned_identity_manager_with_store(
+        store: Arc<dyn UserOwnedIdentityStore>,
+    ) -> (TempDir, UserOwnedIdentityManager) {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout");
+        let identity_specs =
+            IdentitySpecManager::new_with_usage_providers(layout, Features::default(), Vec::new());
+        (
+            temp,
+            UserOwnedIdentityManager::new_with_store(identity_specs, store),
+        )
+    }
+
+    fn identity_spec_manager() -> (TempDir, IdentitySpecManager) {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout");
+        (
+            temp,
+            IdentitySpecManager::new_with_usage_providers(layout, Features::default(), Vec::new()),
+        )
+    }
+
+    #[tokio::test]
+    async fn cleanup_user_source_identity_bindings_uses_configured_identity_store() {
+        let store = Arc::new(RecordingUserOwnedIdentityStore::default());
+        let (_temp, identities) = user_owned_identity_manager_with_store(store.clone());
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github_v4").expect("source");
+        let surface_ids = vec!["rest".to_string()];
+
+        cleanup_user_source_identity_bindings(
+            &identities,
+            &workspace_name,
+            &source_name,
+            &surface_ids,
+            Some("saul"),
+        )
+        .await
+        .expect("cleanup source identity bindings");
+
+        assert_eq!(
+            *store.deleted_source_bindings().expect("deleted bindings"),
+            vec![(
+                "default".to_string(),
+                "github_v4".to_string(),
+                surface_ids,
+                Some("saul".to_string())
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_source_cleans_configured_identity_store_without_current_user_slots() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let sources = SourceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+        );
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("public_messages").expect("source");
+        sources
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: r"
+name: public_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Public messages
+    request:
+      path: /messages
+    columns:
+      - name: id
+        type: Utf8
+"
+                    .to_string(),
+                    bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
+                },
+            )
+            .expect("import source without user-owned slots");
+        let store = Arc::new(RecordingUserOwnedIdentityStore::default());
+        let (_identity_temp, user_owned_identities) =
+            user_owned_identity_manager_with_store(store.clone());
+        let (_spec_temp, identity_specs) = identity_spec_manager();
+        let queries = QueryManager::new(
+            config_store,
+            credential_manager,
+            QueryRuntimeContext::default(),
+            layout,
+            Vec::new(),
+        );
+        let service = SourceService::new(
+            sources,
+            queries,
+            identity_specs,
+            user_owned_identities,
+            Arc::new(SingleUserPrincipalProvider),
+            Arc::new(AllowAllManagementAuthorizer),
+            Arc::new(AllowAllWorkspaceAuthorizer),
+        );
+
+        service
+            .delete_source(Request::new(DeleteSourceRequest {
+                workspace: Some(Workspace {
+                    name: workspace_name.as_str().to_string(),
+                }),
+                name: source_name.as_str().to_string(),
+            }))
+            .await
+            .expect("delete source");
+
+        assert_eq!(
+            *store.deleted_source_bindings().expect("deleted bindings"),
+            vec![(
+                workspace_name.as_str().to_string(),
+                source_name.as_str().to_string(),
+                Vec::new(),
+                None
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn create_bundled_source_cleans_stale_configured_identity_store_bindings() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source");
+        let previous_manifest_yaml = r"
+name: github
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/github-openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+          audience:
+            host: github.com
+";
+        let previous_manifest_file = layout.manifest_file(&workspace_name, &source_name);
+        fs::create_dir_all(previous_manifest_file.parent().expect("manifest parent"))
+            .expect("create manifest parent");
+        fs::write(&previous_manifest_file, previous_manifest_yaml).expect("write manifest");
+        config_store
+            .upsert_source(
+                &workspace_name,
+                InstalledSource {
+                    name: source_name.clone(),
+                    version: Some("0.1.0".to_string()),
+                    variables: BTreeMap::new(),
+                    secrets: Vec::new(),
+                    credential_storage: None,
+                    identity_bindings: BTreeMap::from([(
+                        "rest".to_string(),
+                        AppSourceIdentityBinding::user_owned(),
+                    )]),
+                    origin: SourceOrigin::Imported,
+                },
+            )
+            .expect("seed imported source");
+        let sources = SourceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+        );
+        let store = Arc::new(RecordingUserOwnedIdentityStore::default());
+        let (_identity_temp, user_owned_identities) =
+            user_owned_identity_manager_with_store(store.clone());
+        let (_spec_temp, identity_specs) = identity_spec_manager();
+        let queries = QueryManager::new(
+            config_store,
+            credential_manager,
+            QueryRuntimeContext::default(),
+            layout,
+            Vec::new(),
+        );
+        let service = SourceService::new(
+            sources,
+            queries,
+            identity_specs,
+            user_owned_identities,
+            Arc::new(SingleUserPrincipalProvider),
+            Arc::new(AllowAllManagementAuthorizer),
+            Arc::new(AllowAllWorkspaceAuthorizer),
+        );
+
+        service
+            .create_bundled_source(Request::new(CreateBundledSourceRequest {
+                workspace: Some(Workspace {
+                    name: workspace_name.as_str().to_string(),
+                }),
+                name: source_name.as_str().to_string(),
+                variables: vec![SourceVariable {
+                    key: "GITHUB_API_BASE".to_string(),
+                    value: "https://api.github.com".to_string(),
+                }],
+                secrets: vec![SourceSecret {
+                    key: "GITHUB_TOKEN".to_string(),
+                    value: "github-token".to_string(),
+                }],
+            }))
+            .await
+            .expect("create bundled source");
+
+        assert_eq!(
+            *store.deleted_source_bindings().expect("deleted bindings"),
+            vec![(
+                workspace_name.as_str().to_string(),
+                source_name.as_str().to_string(),
+                vec!["rest".to_string()],
+                None
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_user_source_identity_cleanup_is_best_effort_after_import_commit() {
+        let store = Arc::new(RecordingUserOwnedIdentityStore::default());
+        store.fail_delete_source_bindings_with("cleanup failed");
+        let (_identity_temp, identities) = user_owned_identity_manager_with_store(store.clone());
+        let (_spec_temp, identity_specs) = identity_spec_manager();
+        let identity_context = ImportSourceIdentityContext {
+            identity_specs,
+            user_owned_identities: identities,
+            manifest_yamls: Vec::new(),
+            inputs: Vec::new(),
+            user_principal: None,
+            user_identity_bindings: BTreeMap::new(),
+        };
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github_v4").expect("source");
+        let cleanup = UserSourceIdentityBindingCleanup {
+            all_users_surface_ids: vec!["graphql".to_string()],
+            other_users_surface_ids: vec!["rest".to_string()],
+            preserved_user_id: Some("saul".to_string()),
+        };
+
+        identity_context
+            .cleanup_stale_user_identity_bindings_best_effort(
+                &workspace_name,
+                &source_name,
+                &cleanup,
+            )
+            .await;
+
+        assert_eq!(
+            *store.deleted_source_bindings().expect("deleted bindings"),
+            vec![
+                (
+                    "default".to_string(),
+                    "github_v4".to_string(),
+                    vec!["graphql".to_string()],
+                    None
+                ),
+                (
+                    "default".to_string(),
+                    "github_v4".to_string(),
+                    vec!["rest".to_string()],
+                    Some("saul".to_string())
+                )
+            ]
+        );
     }
 
     #[test]

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -337,6 +337,17 @@ pub(crate) fn secret(key: &str, value: &str) -> SourceSecret {
 }
 
 pub(crate) fn fixed_token_identity_spec_yaml(spec_name: &str, audience_host: &str) -> String {
+    fixed_token_identity_spec_yaml_with_scheme(spec_name, audience_host, None)
+}
+
+pub(crate) fn fixed_token_identity_spec_yaml_with_scheme(
+    spec_name: &str,
+    audience_host: &str,
+    audience_scheme: Option<&str>,
+) -> String {
+    let scheme_yaml = audience_scheme
+        .map(|scheme| format!("\n  scheme: {scheme}"))
+        .unwrap_or_default();
     format!(
         r"
 kind: identity
@@ -347,7 +358,7 @@ description: Test token identity.
 issuer: github
 type: fixed_token
 audience:
-  host: {audience_host}
+  host: {audience_host}{scheme_yaml}
 "
     )
 }
@@ -423,6 +434,18 @@ impl OAuthFixture {
         name: &str,
         audience_host: &str,
     ) -> String {
+        self.identity_spec_yaml_with_audience_origin(name, audience_host, None)
+    }
+
+    pub(crate) fn identity_spec_yaml_with_audience_origin(
+        &self,
+        name: &str,
+        audience_host: &str,
+        audience_scheme: Option<&str>,
+    ) -> String {
+        let scheme_yaml = audience_scheme
+            .map(|scheme| format!("\n  scheme: {scheme}"))
+            .unwrap_or_default();
         format!(
             r"
 kind: identity
@@ -433,7 +456,7 @@ description: GitHub OAuth test identity.
 issuer: github
 type: oauth
 audience:
-  host: {audience_host}
+  host: {audience_host}{scheme_yaml}
 oauth:
   method:
     label: Test device flow

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -20,12 +20,17 @@ use coral_api::v1::{
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::default_workspace;
+use serde_json::json;
 use sha2::{Digest as _, Sha256};
 use tempfile::TempDir;
 use tonic::Request;
+use url::Url;
+use wiremock::matchers::{header, method, path as request_path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::harness::{
-    FailingHttpFixture, GrpcHarness, fixed_token_identity_spec_yaml,
+    FailingHttpFixture, GrpcHarness, OAuthFixture, create_github_oauth_identity,
+    fixed_token_identity_spec_yaml, fixed_token_identity_spec_yaml_with_scheme,
     fixture_function_only_manifest_yaml, fixture_manifest_with_inputs_yaml,
     fixture_manifest_with_multiple_tables_yaml, fixture_manifest_with_required_inputs_yaml,
     fixture_manifest_with_test_queries_yaml, fixture_manifest_yaml, import_request,
@@ -77,26 +82,131 @@ async fn import_source_persists_and_lists() {
 }
 
 #[tokio::test]
-async fn import_v4_source_with_identity_bindings_fails_closed_from_grpc() {
+async fn import_v4_source_persists_identity_bindings_from_grpc() {
     let harness = GrpcHarness::new().await;
     create_fixed_token_identity(&harness, "github_local", "github_oauth", "github.com").await;
     let manifest_yaml = write_v4_manifest(&harness, "http://127.0.0.1:1", "github.com");
 
-    let error = harness
-        .try_import_source(identity_import_request(manifest_yaml, "github_local"))
-        .await
-        .expect_err("identity-backed source import should fail closed");
+    let added = import_grpc_identity_source(&harness, manifest_yaml, "github_local").await;
+    assert_eq!(added.name, "github_v4_grpc");
 
-    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    let config_raw = read_config(&harness);
     assert!(
-        error
-            .message()
-            .contains("request identity resolution is not installed"),
-        "unexpected error: {error}"
+        config_raw.contains("identity_bindings = { rest = { owner = \"user\" } }"),
+        "expected source identity binding in config: {config_raw}"
+    );
+    let user_binding_raw = read_user_binding(&harness);
+    assert!(user_binding_raw.contains("identity: github_local"));
+    assert!(user_binding_raw.contains("accepted_identity: github-rest-read"));
+}
+
+#[tokio::test]
+async fn reimport_source_can_clear_identity_bindings_from_grpc() {
+    let harness = GrpcHarness::new().await;
+    create_fixed_token_identity(&harness, "github_local", "github_oauth", "github.com").await;
+    let (openapi_file, openapi_sha256) = write_v4_openapi(&harness, "http://127.0.0.1:1");
+    let manifest_yaml = grpc_identity_manifest_yaml_for_host(
+        "github_v4_grpc",
+        &openapi_file,
+        &openapi_sha256,
+        "github.com",
+    );
+
+    import_grpc_identity_source(&harness, manifest_yaml, "github_local").await;
+
+    let manifest_without_identity = format!(
+        r"
+name: github_v4_grpc
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    sha256: {}
+",
+        openapi_file.display(),
+        openapi_sha256
+    );
+    harness
+        .try_import_source(ImportSourceRequest {
+            replace_identity_bindings: true,
+            ..import_request(manifest_without_identity)
+        })
+        .await
+        .expect("reimport source");
+
+    let config_raw = read_config(&harness);
+    assert!(
+        !config_raw.contains("identity_bindings"),
+        "expected source identity bindings to be cleared: {config_raw}"
+    );
+}
+
+#[tokio::test]
+async fn reimport_v4_source_replaces_user_identity_binding_from_grpc() {
+    let harness = GrpcHarness::new().await;
+    create_fixed_token_identity(&harness, "github_local", "github_oauth", "github.com").await;
+    create_fixed_token_identity(&harness, "github_reauth", "github_oauth", "github.com").await;
+    let manifest_yaml = write_v4_manifest(&harness, "http://127.0.0.1:1", "github.com");
+
+    import_grpc_identity_source(&harness, manifest_yaml.clone(), "github_local").await;
+    import_grpc_identity_source(&harness, manifest_yaml, "github_reauth").await;
+
+    let user_binding_raw = read_user_binding(&harness);
+    assert!(
+        user_binding_raw.contains("identity: github_reauth"),
+        "expected reimport to replace user identity binding: {user_binding_raw}"
     );
     assert!(
-        harness.list_sources().await.is_empty(),
-        "failed identity-backed import must not install the source"
+        !user_binding_raw.contains("identity: github_local"),
+        "expected prior identity binding to be replaced: {user_binding_raw}"
+    );
+}
+
+#[tokio::test]
+async fn reimport_v4_source_can_reselect_user_identity_with_preserved_slot_from_grpc() {
+    let harness = GrpcHarness::new().await;
+    create_fixed_token_identity(&harness, "github_local", "github_oauth", "github.com").await;
+    create_fixed_token_identity(&harness, "github_reauth", "github_oauth", "github.com").await;
+    let manifest_yaml = write_v4_manifest(&harness, "http://127.0.0.1:1", "github.com");
+
+    import_grpc_identity_source(&harness, manifest_yaml.clone(), "github_local").await;
+
+    harness
+        .try_import_source(ImportSourceRequest {
+            user_identity_bindings: rest_user_identity_bindings(
+                "github_reauth",
+                "github-rest-read",
+            ),
+            ..import_request(manifest_yaml)
+        })
+        .await
+        .expect("reimport should use preserved source identity slot");
+
+    let user_binding_raw = read_user_binding(&harness);
+    assert!(
+        user_binding_raw.contains("identity: github_reauth"),
+        "expected preserved slot reimport to replace user identity binding: {user_binding_raw}"
+    );
+}
+
+#[tokio::test]
+async fn reimport_v4_source_can_preserve_user_identity_selection_from_grpc() {
+    let harness = GrpcHarness::new().await;
+    create_fixed_token_identity(&harness, "github_local", "github_oauth", "github.com").await;
+    let manifest_yaml = write_v4_manifest(&harness, "http://127.0.0.1:1", "github.com");
+
+    import_grpc_identity_source(&harness, manifest_yaml.clone(), "github_local").await;
+
+    harness
+        .try_import_source(import_request(manifest_yaml))
+        .await
+        .expect("reimport should preserve existing user identity selection");
+
+    let user_binding_raw = read_user_binding(&harness);
+    assert!(
+        user_binding_raw.contains("identity: github_local"),
+        "expected no-op reimport to preserve user identity binding: {user_binding_raw}"
     );
     assert_no_preflight_materialization_dirs(&harness, "github_v4_grpc");
 }
@@ -172,6 +282,70 @@ surfaces:
 }
 
 #[tokio::test]
+async fn v4_source_uses_user_owned_oauth_identity_end_to_end() {
+    let harness = GrpcHarness::new().await;
+    let oauth = OAuthFixture::start().await;
+    let api = MockServer::start().await;
+    let api_host = host_of(&api.uri());
+    harness
+        .add_identity_spec(oauth.identity_spec_yaml_with_audience_origin(
+            "github_oauth",
+            &api_host,
+            Some("http"),
+        ))
+        .await;
+    let identity = create_github_oauth_identity(&harness, &oauth).await;
+    assert_eq!(identity.name, "github_local");
+
+    mount_users_endpoint(&api, "Bearer identity-access-token").await;
+
+    let manifest_yaml = write_v4_manifest(&harness, &api.uri(), &api_host);
+    import_grpc_identity_source(&harness, manifest_yaml, &identity.name).await;
+
+    let rows = harness
+        .execute_sql_rows("SELECT id FROM github_v4_grpc.users")
+        .await;
+    assert_eq!(rows, vec![json!({"id": "u1"})]);
+}
+
+#[tokio::test]
+async fn v4_source_rejects_identity_header_injection_for_off_audience_request_host() {
+    let harness = GrpcHarness::new().await;
+    let oauth = OAuthFixture::start().await;
+    harness
+        .add_identity_spec(oauth.identity_spec_yaml("github_oauth"))
+        .await;
+    let identity = create_github_oauth_identity(&harness, &oauth).await;
+    assert_eq!(identity.name, "github_local");
+
+    let api = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(request_path("/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {"id": "u1"}
+        ])))
+        .expect(0)
+        .mount(&api)
+        .await;
+
+    let manifest_yaml = write_v4_manifest(&harness, &api.uri(), "github.com");
+    import_grpc_identity_source(&harness, manifest_yaml, &identity.name).await;
+
+    let error = harness
+        .try_execute_sql("SELECT id FROM github_v4_grpc.users")
+        .await
+        .expect_err("off-audience query should fail before HTTP request");
+
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error
+            .message()
+            .contains("audience host 'github.com' does not match request host"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
 async fn import_v4_source_rejects_incompatible_user_identity_binding() {
     let harness = GrpcHarness::new().await;
     create_fixed_token_identity(&harness, "github_local", "gitlab_oauth", "gitlab.com").await;
@@ -228,6 +402,54 @@ async fn import_v4_source_rejects_identity_after_spec_force_remove_and_readd() {
     );
 }
 
+#[tokio::test]
+async fn import_v4_source_uses_identity_after_same_spec_force_remove_and_readd() {
+    let harness = GrpcHarness::new().await;
+    let api = MockServer::start().await;
+    let api_host = host_of(&api.uri());
+    let spec_yaml =
+        fixed_token_identity_spec_yaml_with_scheme("github_oauth", &api_host, Some("http"));
+    harness.add_identity_spec(spec_yaml.clone()).await;
+    harness
+        .create_fixed_token_identity("github_local", "github_oauth", "identity-token")
+        .await;
+    harness.force_delete_identity_spec("github_oauth").await;
+    harness.add_identity_spec(spec_yaml).await;
+
+    mount_users_endpoint(&api, "Bearer identity-token").await;
+
+    let manifest_yaml = write_v4_manifest(&harness, &api.uri(), &api_host);
+    import_grpc_identity_source(&harness, manifest_yaml, "github_local").await;
+
+    let rows = harness
+        .execute_sql_rows("SELECT id FROM github_v4_grpc.users")
+        .await;
+    assert_eq!(rows, vec![json!({"id": "u1"})]);
+}
+
+#[tokio::test]
+async fn validate_v4_source_rejects_orphaned_user_identity_without_test_queries() {
+    let harness = GrpcHarness::new().await;
+    create_fixed_token_identity(&harness, "github_local", "github_oauth", "github.com").await;
+    let manifest_yaml = write_v4_manifest(&harness, "http://127.0.0.1:1", "github.com");
+    import_grpc_identity_source(&harness, manifest_yaml, "github_local").await;
+
+    harness.force_delete_identity_spec("github_oauth").await;
+
+    let error = harness
+        .try_validate_source("github_v4_grpc")
+        .await
+        .expect_err("orphaned identity-backed source should fail validation");
+
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error
+            .message()
+            .contains("identity 'github_local' is orphaned"),
+        "unexpected error: {error}"
+    );
+}
+
 /// Adds a fixed-token identity spec named `spec_name` for `audience_host` and
 /// creates a user-owned identity bound to it.
 async fn create_fixed_token_identity(
@@ -273,6 +495,17 @@ fn rest_user_identity_bindings(
     }]
 }
 
+async fn import_grpc_identity_source(
+    harness: &GrpcHarness,
+    manifest_yaml: String,
+    identity: &str,
+) -> Source {
+    harness
+        .try_import_source(identity_import_request(manifest_yaml, identity))
+        .await
+        .expect("import source")
+}
+
 fn read_config(harness: &GrpcHarness) -> String {
     fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config")
 }
@@ -292,6 +525,34 @@ fn assert_no_preflight_materialization_dirs(harness: &GrpcHarness, source_name: 
         leaked.is_empty(),
         "preflight materialization dirs leaked: {leaked:?}"
     );
+}
+
+fn read_user_binding(harness: &GrpcHarness) -> String {
+    let binding = harness
+        .config_dir()
+        .join("identities/source-bindings/users/local/default/github_v4_grpc/rest/binding.yaml");
+    fs::read_to_string(binding).expect("read user binding")
+}
+
+fn host_of(uri: &str) -> String {
+    Url::parse(uri)
+        .expect("api uri")
+        .host_str()
+        .expect("api host")
+        .to_string()
+}
+
+/// Mounts a `GET /users` endpoint on `api` that requires the given
+/// authorization header value and returns one user row.
+async fn mount_users_endpoint(api: &MockServer, authorization: &str) {
+    Mock::given(method("GET"))
+        .and(request_path("/users"))
+        .and(header("authorization", authorization))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {"id": "u1"}
+        ])))
+        .mount(api)
+        .await;
 }
 
 /// Writes the shared `OpenAPI` fixture targeting `base_url`; returns its path

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use coral_app::{AwsEngineExtensionsProvider, features::FeatureOverrides};
+use coral_app::AwsEngineExtensionsProvider;
 use coral_client::{
     AppClient, ClientError,
     local::{LocalServerError, RunningServer, ServerBuilder},
@@ -14,7 +14,7 @@ pub(crate) struct Bootstrap {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct BootstrapOptions {
     pub(crate) enable_stderr_logs: bool,
-    pub(crate) feature_overrides: FeatureOverrides,
+    pub(crate) feature_overrides: coral_app::features::FeatureOverrides,
 }
 
 impl Bootstrap {
@@ -54,7 +54,7 @@ pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, Bo
 #[cfg(feature = "embedded-ui")]
 pub(crate) async fn start_ui_server(
     port: u16,
-    feature_overrides: FeatureOverrides,
+    feature_overrides: coral_app::features::FeatureOverrides,
 ) -> Result<RunningServer, BootstrapError> {
     let server = configure_server_builder(
         ServerBuilder::embedded_ui_loopback(port, crate::embedded_ui_assets()),

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -90,7 +90,8 @@
           "reference/engine-configuration",
           "reference/bundled-sources",
           "reference/community-sources",
-          "reference/source-spec-reference"
+          "reference/source-spec-reference",
+          "reference/identity-spec-reference"
         ]
       },
       {

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -224,6 +224,7 @@ Important files include:
 - `config.toml` for installed-source metadata, non-secret variables, and runtime settings. See [Configuration](/reference/configuration).
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
+- DSL v4 materialized OpenAPI artifacts under `workspaces/<workspace>/sources/<source>/materialized/v4/`
 
 <Note>
   [Bundled source](/reference/bundled-sources) specs are not copied into the config directory. Coral resolves them from the current binary when you validate or query a bundled source, so upgrades pick up newer bundled manifests without re-adding the source.

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -10,10 +10,57 @@ Coral stores local configuration in `config.toml` inside its platform-specific [
 Coral writes source installation state to `config.toml` when you run commands such as `coral source add` and `coral source remove`.
 
 This state includes installed-source metadata and non-secret source variables. Source secrets are stored separately within the same local trust boundary.
+Global identity specs live under `identity-specs/` in the same local state
+directory and are shared by every workspace. Declared identity-spec input
+material, including secret inputs, is stored with the installed identity spec
+through Coral credential storage rather than with identities created from the
+spec.
+User-owned identities live under `identities/users/local/` in the same local
+state directory. A user-owned
+identity is provider-facing credential material owned by a Coral user principal.
+OSS Coral has one user principal, `local`; products built on Coral can provide
+workspace-owned identity storage through Coral's runtime identity provider seam.
+Ownership is independent of identity type, so user-owned and workspace-owned
+identity stores can hold identities of any type, such as OAuth or fixed-token.
+User-owned source-surface selections live separately under
+`identities/source-bindings/users/<user>/<workspace>/<source>/<surface>/`.
 
 <Note>
   Prefer the `coral source` commands for source state instead of editing workspace entries manually.
 </Note>
+
+DSL v4 sources that declare surface `identity_requirements` may also carry
+workspace source-surface identity bindings. Bindings live on the installed
+source entry because surface ids are source-local:
+
+```toml
+[workspaces.default.sources.github_v4]
+variables = {}
+secrets = []
+identity_bindings = { rest = { owner = "user" } }
+origin = "imported"
+```
+
+For user-owned identity slots (shown above), app config stores only the owner
+because the concrete identity and accepted branch can differ per Coral user
+principal. In OSS Coral the only user principal is `local`. Changing that
+user's selected identity is an identity-selection operation, not a manual
+config edit. Source imports that explicitly replace identity bindings replace
+the source's binding set with the bindings required by the new manifest, so
+removing a surface identity requirement clears the stale workspace binding from
+config.
+
+For workspace-owned identity slots, app config stores the concrete workspace
+selection because all callers share it:
+
+```toml
+identity_bindings = { rest = { owner = "workspace", identity = "github_workspace", accepted_identity = "github-rest-read" } }
+```
+
+Each binding key is a surface id. `owner` is either `user` or `workspace`.
+`identity` names an existing identity reference and `accepted_identity`
+optionally selects one entry from the surface's `identity_requirements.accepts`
+list for workspace-owned bindings.
 
 ## Runtime features
 
@@ -41,6 +88,7 @@ Feature values must be booleans. Unknown feature keys are preserved in `config.t
 
 | Feature | Default | Description |
 | ------- | ------- | ----------- |
+| `dsl_v4` | `false` | Experimental. Enables preview DSL v4 manifests imported with `coral source add --file`. |
 | `feedback` | `false` | Experimental. Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral. |
 
 ## OpenTelemetry

--- a/docs/reference/identity-spec-reference.mdx
+++ b/docs/reference/identity-spec-reference.mdx
@@ -1,0 +1,167 @@
+---
+title: Identity Spec Reference
+description: YAML format for declaring Coral identity types and setup behavior.
+---
+
+Identity specs describe reusable app-owned identity types. The identity `type`
+determines both how Coral can instantiate the identity and how the resolved
+credential material is applied to outbound HTTP requests.
+
+Identity specs do not install sources or bind a source surface to an identity.
+They are the declarative contract that identity setup and runtime providers can
+consume. Coral instantiates stored user-owned identities from installed OAuth
+or fixed-token identity specs through identity management services and product
+extension flows. A user-owned
+identity represents a Coral user principal to a source provider — it is not the
+principal itself. OSS Coral has one local principal, `local`, so identity
+material is stored under that principal.
+
+Identity ownership is independent of identity type: an `oauth` or `fixed_token`
+identity can be user-owned or workspace-owned. OSS Coral implements local
+storage for user-owned identities; products built on Coral can provide
+workspace-owned storage and additional type-specific instantiation flows
+through the app identity seams.
+
+Identity specs are installed globally for the local Coral app — every workspace
+uses the same installed spec. Identity specs and the identities created from
+them are part of DSL v4 and gated behind the same `dsl_v4` runtime feature as
+v4 sources; enable it with `coral features enable dsl_v4` first.
+
+Source imports can bind identity-required surfaces only to identity slots that
+the caller has explicitly selected. The source manifest declares acceptable
+identity spec ids and audience; the identity spec declares how a stored
+identity is created and how its material is injected at request time.
+
+Stored identities are separate from identity specs. Removing an identity spec
+(along with its spec-owned input material) does not delete stored identities or
+source bindings created from it, but those identities become orphaned and
+cannot satisfy source identity requirements until the same manifest is
+reinstalled or the identity is recreated; installing a different manifest under
+the same spec name does not reattach them. Because identity specs define where
+and how stored identity material may be injected, Coral refuses to replace an
+installed spec with a different manifest while stored identities reference that
+spec, and removing a spec that stored identities depend on must be forced and
+reports the orphan count.
+
+## Example
+
+```yaml
+kind: identity
+spec_version: 1
+name: google_oauth
+version: 0.1.0
+description: Google OAuth access token for Google APIs.
+issuer: google
+type: oauth
+audience:
+  host: googleapis.com
+inputs:
+  GOOGLE_OAUTH_CLIENT_SECRET:
+    kind: secret
+    hint: Client secret from your Google OAuth desktop app.
+oauth:
+  method:
+    label: Connect with Google
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    endpoints:
+      authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+      token_url: https://oauth2.googleapis.com/token
+    client:
+      id:
+        default: your-public-client-id.apps.googleusercontent.com
+      secret:
+        input: GOOGLE_OAUTH_CLIENT_SECRET
+        transport: request_body
+    scopes:
+      scope:
+        delimiter: space
+        values:
+          - https://www.googleapis.com/auth/calendar.readonly
+```
+
+## Top-Level Fields
+
+| Field | Description |
+| --- | --- |
+| `kind` | Must be `identity`. |
+| `spec_version` | Identity spec format version. The current version is `1`. |
+| `name` | Stable identity spec name. Use an identifier such as `github_oauth` or `github_pat`. |
+| `version` | Version of this identity spec. |
+| `description` | Optional human-readable description. |
+| `issuer` | Provider or issuer name, such as `github` or `google`. |
+| `type` | Identity type. Supported values are `oauth` and `fixed_token`. |
+| `audience` | Optional provider-specific object that scopes the identity target, such as a host, tenant, organization, or account. Built-in HTTP request injection requires a string `audience.host`. |
+| `inputs` | Optional setup inputs for OAuth identity creation. Inputs can be `kind: variable` or `kind: secret`. |
+| `oauth` | Required only for `type: oauth`; declares exactly one OAuth setup method. |
+
+Identity specs do not declare source-style `auth` or `injection_method`. The
+identity `type` determines request injection. OAuth identity specs may declare
+setup `inputs`; fixed-token identity specs currently must not.
+
+## Identity Types
+
+Use separate identity specs when the instantiation behavior or semantics differ.
+For example, `github_oauth`, `github_oauth_app`, and `github_pat` are distinct
+specs even though all ultimately authenticate GitHub HTTP requests.
+
+The built-in HTTP identity runtimes require `audience.host` before injecting an
+`Authorization` header. At request time, Coral compares that host to the actual
+outbound request host and only injects credentials for that exact host. For
+example, an identity with `audience.host: api.github.com` may authenticate
+requests to `api.github.com`, but not `github.com` or `uploads.github.com`.
+
+`type: oauth` uses the `oauth.method` block to describe the provider flow,
+endpoints, client, and scopes. At request time, OAuth identities refresh stored
+token material when needed and inject `Authorization: Bearer <access-token>`
+from the identity's `ACCESS_TOKEN` material.
+
+`type: fixed_token` represents a user-supplied bearer token. At request time,
+fixed-token identities inject `Authorization: Bearer <token>` from the
+identity's `TOKEN` material.
+
+Request injection is owned by the identity provider for that type, not by the
+source spec. A source can require acceptable identity spec ids and audience, but
+it does not author how that identity mutates outbound HTTP requests.
+
+## OAuth Setup
+
+OAuth identity specs declare one setup method directly under `oauth.method`.
+The method can declare display metadata plus the OAuth `flow`, `endpoints`,
+`client`, and `scopes` blocks. If a provider supports multiple OAuth setup
+paths, author multiple identity specs and let sources list the acceptable spec
+ids.
+
+`oauth.client.id` may declare `default`, `input`, or both. A default client ID
+lets Coral run the OAuth flow without prompting the user for that value; when
+both are present, an entered input value overrides the default. If
+`oauth.client.id.input` references a declared identity input, that input must be
+`kind: variable`.
+
+Confidential OAuth clients declare `oauth.client.secret.input` plus
+`oauth.client.secret.transport`. When the secret input is declared under
+`inputs`, it must be `kind: secret`. Coral stores declared identity input
+material with the installed identity spec, not with identities instantiated
+from it, so identity materialization and token refresh can retrieve the
+spec-owned values.
+
+OAuth endpoint templates may reference declared identity inputs with
+`{{input.KEY}}`, but only `kind: variable` inputs can be used in URLs. Use this
+for non-secret endpoint components such as a tenant, host, or realm. Endpoint
+templates do not use source inputs; identity setup is global rather than
+source-scoped.
+
+## Source Identity Requirements
+
+DSL v4 source surfaces can declare `identity_requirements`. An identity spec's
+`name` is the spec id that source requirements list under `identity_specs`.
+Matching uses that spec id plus the source-declared `audience`; issuer and
+identity type do not participate in source matching.
+
+Workspace source config stores the owner slot for each identity-required
+surface; user-owned slots record only the owner while workspace-owned slots
+record the concrete selection. See
+[configuration](/reference/configuration) for the `identity_bindings` config
+format for stored source identity selections.

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -12,6 +12,34 @@ Coral is extensible through source specs. These are YAML files that describe how
   response mapping, pagination, search functions, and file-backed tables.
 </Tip>
 
+## DSL versions
+
+Coral supports the existing table-authored `dsl_version: 3` manifests and the
+additive `dsl_version: 4` surface-first manifest shape. DSL v3 keeps top-level
+`backend`, `tables`, `functions`, and source-level `inputs`. DSL v4 removes
+those top-level execution/projection fields and declares one or more upstream
+`surfaces` instead.
+
+DSL v4 is OpenAPI-first in this release. Coral imports pinned OpenAPI 3.0.x
+descriptions during `coral source add`, materializes semantic IR plus generated
+SQL projections under the installed source directory, and uses those artifacts
+at query time. Query loading does not fetch OpenAPI documents, rerun importers,
+or regenerate projections. GraphQL and other surface types are reserved for a
+future release.
+
+DSL v4 is currently experimental and gated behind the `dsl_v4` runtime feature.
+Enable it before importing a `dsl_version: 4` manifest with `coral source add
+--file`:
+
+```shellscript
+coral features enable dsl_v4
+```
+
+Preview v4 sources use distinct schema names such as `github_v4`, so
+they can coexist with stable v3 sources such as `github`. Enabling the feature
+does not migrate or replace installed sources. Any migration from a v3 source
+to a v4 source is explicit and source-specific.
+
 ## Top-level fields
 
 Every source spec starts with:
@@ -29,9 +57,136 @@ test_queries:
 | ------------- | -------------------------------------------------- |
 | `name`        | Source name, also used as the SQL schema name      |
 | `version`     | Source spec version string                         |
-| `dsl_version` | Coral source spec DSL version (currently `3`)      |
-| `backend`     | How data is fetched: `http`, `file`, or `mcp` |
-| `test_queries` | Optional read-only SQL checks Coral runs during source validation |
+| `dsl_version` | Coral source spec DSL version: `3` or `4`          |
+| `backend`     | DSL v3 only. How data is fetched: `http`, `file`, or `mcp` |
+| `test_queries` | Optional read-only SQL checks Coral runs during `coral source test` |
+
+DSL v4 top-level fields are limited to `name`, `version`, `dsl_version`,
+`description`, `test_queries`, `onboarding`, `surfaces`, and
+`projection_policy`. If `description` is omitted, Coral uses the OpenAPI
+document's `info.description` when available during source add/materialization.
+Top-level `backend`, `inputs`, `tables`, `functions`, HTTP runtime fields, and
+`projection_overrides` are rejected for DSL v4.
+
+## DSL v4 surfaces
+
+A v4 manifest declares upstream surfaces and lets Coral generate SQL projections
+from imported provider descriptions:
+
+```yaml
+name: github_v4
+version: 2.0.0
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/pinned/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    inputs:
+      GITHUB_API_BASE:
+        kind: variable
+        default: https://api.github.com
+    base_url: "{{input.GITHUB_API_BASE}}"
+    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+            - github_oauth_app
+            - github_pat
+          audience:
+            host: api.github.com
+    request_headers:
+      - name: X-GitHub-Api-Version
+        from: literal
+        value: "2022-11-28"
+projection_policy:
+  default: derive_read_operations
+```
+
+Each surface requires:
+
+- `id`: stable source-local identifier matching `[a-z][a-z0-9_]*`
+- `type`: currently only `openapi`
+- exactly one descriptor location, either `url` or `file`
+- `sha256`: lowercase hex SHA-256 of the exact descriptor bytes
+- `base_url`: optional runtime base URL template. If omitted, Coral derives it
+  from the OpenAPI document's first non-empty `servers[].url` during source
+  add/materialization, substituting OpenAPI server variable defaults.
+- `identity_requirements`: optional request identity contract. Use this when
+  access should come from a configured source-surface identity binding.
+- `inputs`: optional surface-scoped variables. DSL v4 source inputs cannot be
+  secrets; use `identity_requirements` and identity specs for credentials.
+- `request_headers`: optional non-auth headers applied to every request, such
+  as API version or User-Agent.
+
+Remote descriptors must use HTTPS and are always pinned by `sha256`. Local
+`file` descriptors are for imported development sources only; they must be
+regular files under the current working directory, must not be symlinks, and
+are bounded to the same descriptor size limit as remote descriptors. Bundled
+sources must not depend on local OpenAPI files. Providers with mutable OpenAPI
+URLs should be mirrored to a stable Coral-owned artifact URL and pinned there.
+
+Surface `inputs` reuse the v3 variable declaration shape, but v4 inputs are
+scoped to the surface that uses them and must be `kind: variable`. During
+`source add`, Coral prompts for the union of compatible surface variables and
+persists them through source-scoped variable storage. Reusing an input key
+across surfaces is valid only when the declarations are structurally identical.
+
+Surface `identity_requirements` (shown in the example above) declare which
+bound identities can satisfy the surface. `accepts` is a non-empty list. Each
+accepted identity requires:
+
+- `id`: stable source-local identifier for this accepted identity entry
+- `identity_specs`: non-empty list of global identity spec names, such as
+  `github_oauth`, `github_oauth_app`, or `github_pat`
+- `audience`: optional provider-specific object that narrows the target API,
+  tenant, host, organization, or account. Built-in HTTP identity specs need a
+  string `audience.host`; Coral injects Authorization headers only when the
+  outbound request host exactly matches that host.
+
+Accepted identity entries have OR semantics: any one accepted entry may satisfy
+the surface. Within an accepted entry, the resolved identity must have one of
+the listed identity spec ids and its audience must include every key/value
+declared by the source. At query time Coral selects the configured workspace
+binding for the source surface, resolves it for either the current Coral user
+principal or the workspace depending on the binding's owner (ownership and
+identity type are independent), and delegates outbound request mutation to the
+resolved identity's spec type. If a surface declares `identity_requirements`
+and the installed source has no matching workspace binding, queries against
+that surface's generated projections fail closed. `identity_requirements`
+never collects or stores source credentials, and DSL v4 manifests do not
+declare source-scoped secrets or `auth`.
+
+Identity instantiation is described by separate
+[identity specs](/reference/identity-spec-reference): the source declares which
+spec ids and audience are acceptable, while the spec describes the identity
+type and setup needed to create one. Identity specs must be installed and
+stored identities must be selected before an identity-required surface can
+resolve credentials at query time. The installed source stores only the binding
+owner slot for each identity-required surface; it does not embed identity setup
+flows in the source manifest.
+
+## DSL v4 projection generation
+
+`projection_policy.default` currently supports only
+`derive_read_operations`, which is also the default when the block is omitted.
+Coral publishes deterministic SQL tables and table functions for supported
+read-only OpenAPI `GET` operations. Mutating operations, request-body
+operations, no-body responses, unsupported parameter serialization, and
+unknown-cardinality responses are imported as diagnostics or hidden projections.
+
+Generated artifacts are stored under:
+
+```text
+workspaces/<workspace>/sources/<source>/materialized/v4/
+```
+
+The directory contains `fingerprint.yaml`, `diagnostics.yaml`,
+`projections.yaml`, per-surface `semantic-ir.yaml`, the exact
+`source-document.raw`, and a normalized `source-document.yaml`. If these
+artifacts are missing or stale, catalog and query operations fail with a
+message that points to re-adding or reinstalling the source.
 
 ## Test queries
 
@@ -1299,7 +1454,8 @@ explicit `pkce` of `required` or `disabled`, `redirect_uri`,
 declare `client.id.default`, `client.id.input`, or both; an interactive `input`
 value overrides `default`. Authorization-code OAuth methods whose token
 endpoint requires client-secret authentication must prompt for both OAuth
-client values: set `client.id.input`, `client.secret.input`, and a
+client values unless a client ID default is authored: set `client.id.default`,
+`client.id.input`, or both, plus `client.secret.input` and a
 `client.secret.transport` of `basic_auth` or `request_body`. Client secrets are
 sent only to the token endpoint and are never included in the authorization URL.
 They may be stored as internal credential metadata so Coral can refresh the


### PR DESCRIPTION
Closes the DSL v4 identity loop at query time and exposes the seams
embedders use to override identity components. With dsl_v4 enabled the
full pipeline is now live; default-off keeps behavior unchanged:

- query/manager.rs: registry-backed source loading and the
  *_with_context method collapse into principal-taking methods;
  LazyRuntimeIdentityResolver resolves a query's source bindings to a
  user-owned identity, narrows to the accepted requirement branch,
  re-checks accepts_identity, and resolves headers (fail-closed)
- bootstrap/server.rs: ServerExtensionContext + builder seams
  (with_source_registry / with_identity_spec_registry /
  with_user_owned_identity_store / add_source_identity_provider(_factory)
  / add_identity_spec_usage_provider / add_grpc_service /
  with_native_grpc_bind_addr / with_management_authorizer /
  with_feature_overrides) and QueryManager resolver wiring
- catalog discovery/service renames riding the same principal API change
- coral-cli bootstrap --enable-dsl-v4 feature-override plumbing
- end-to-end gRPC SQL identity tests: user-owned OAuth identity used at
  query time, off-audience header-injection rejection, force-remove/
  re-add reuse, orphaned-identity validation
- v4/identity reference docs (source-spec, identity-spec, configuration,
  installation, docs.json)

retires the last identity-vocabulary #[expect(dead_code)] markers now
that the query resolver consumes them.