### PR TITLE
feat(cli): manifest bundles and identity binding in source add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
  "regex",
  "rmcp",
  "rust-embed",
+ "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -1306,6 +1307,7 @@ dependencies = [
  "tonic",
  "tonic-types",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -83,6 +83,15 @@ message ListUserOwnedIdentitiesResponse {
   repeated Identity identities = 1;
 }
 
+// Deletes one identity owned by the request Coral user principal.
+message DeleteUserOwnedIdentityRequest {
+  // Stable identity name to delete.
+  string name = 1;
+}
+
+// Empty response for DeleteUserOwnedIdentity.
+message DeleteUserOwnedIdentityResponse {}
+
 // Stored identity APIs.
 service IdentityService {
   // Creates or replaces one OAuth identity owned by the request Coral user principal.
@@ -94,4 +103,7 @@ service IdentityService {
   // Lists user-owned identities.
   rpc ListUserOwnedIdentities(ListUserOwnedIdentitiesRequest)
       returns (ListUserOwnedIdentitiesResponse);
+  // Deletes one user-owned identity.
+  rpc DeleteUserOwnedIdentity(DeleteUserOwnedIdentityRequest)
+      returns (DeleteUserOwnedIdentityResponse);
 }

--- a/crates/coral-api/proto/coral/v1/identity_specs.proto
+++ b/crates/coral-api/proto/coral/v1/identity_specs.proto
@@ -30,6 +30,15 @@ message AddIdentitySpecRequest {
   repeated IdentitySpecInput inputs = 2;
 }
 
+// Installs one global identity spec only when no spec with the same name exists.
+message CreateIdentitySpecRequest {
+  // Raw identity spec manifest YAML to validate and install.
+  string manifest_yaml = 1;
+  // Setup input values owned by the installed identity spec. Secret values are
+  // persisted in Coral credential storage for later identity materialization.
+  repeated IdentitySpecInput inputs = 2;
+}
+
 // One setup input value for an installed identity spec.
 message IdentitySpecInput {
   // Declared identity spec input key.
@@ -45,6 +54,12 @@ message AddIdentitySpecResponse {
   IdentitySpec identity_spec = 1;
   // Whether an existing spec with the same name was replaced.
   bool replaced = 2;
+}
+
+// Returns the installed identity spec.
+message CreateIdentitySpecResponse {
+  // The installed identity spec.
+  IdentitySpec identity_spec = 1;
 }
 
 // Lists all globally installed identity specs.
@@ -88,6 +103,8 @@ message DeleteIdentitySpecResponse {
 service IdentitySpecService {
   // Installs one global identity spec, or replaces an unused existing spec.
   rpc AddIdentitySpec(AddIdentitySpecRequest) returns (AddIdentitySpecResponse);
+  // Installs one global identity spec only when no spec with the same name exists.
+  rpc CreateIdentitySpec(CreateIdentitySpecRequest) returns (CreateIdentitySpecResponse);
   // Lists globally installed identity specs.
   rpc ListIdentitySpecs(ListIdentitySpecsRequest) returns (ListIdentitySpecsResponse);
   // Fetches one globally installed identity spec.

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -502,18 +502,20 @@ impl ServerBuilder {
     /// fail to initialize, or the gRPC server cannot be started.
     pub async fn start(self) -> Result<RunningServer, AppError> {
         self.ensure_compatible_extension_storage()?;
+        let uses_non_loopback_native_grpc_bind = self.uses_non_loopback_native_grpc_bind();
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config_dir)?;
         layout.ensure()?;
         let telemetry_config = TelemetryConfig::load(&layout)?;
-        let internal_trace_store_dir = telemetry_config
-            .trace_history
-            .enabled
-            .then(|| layout.local_trace_store_dir());
+        let local_trace_history = local_trace_history_setup(
+            &telemetry_config,
+            &layout,
+            uses_non_loopback_native_grpc_bind,
+        );
         let installed_trace_store = crate::telemetry::init_tracing(
             &telemetry_config,
             self.enable_stderr_logs,
-            internal_trace_store_dir.clone(),
+            local_trace_history.store_dir.clone(),
         )?;
         let config_store = ConfigStore::new(layout.clone());
         let source_registry = self
@@ -534,12 +536,9 @@ impl ServerBuilder {
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.feedback_publisher);
         let episode_store = EpisodeStore::new(layout.clone());
-        let body_capture_max_bytes = telemetry_config
-            .trace_history
-            .http_body_recording_max_bytes();
         let query_runtime_context = env
             .query_runtime_context()
-            .with_body_capture_max_bytes(body_capture_max_bytes);
+            .with_body_capture_max_bytes(local_trace_history.body_capture_max_bytes);
         let identity_spec_manager = identity_spec_manager_for_server(
             &layout,
             &credential_store,
@@ -573,7 +572,7 @@ impl ServerBuilder {
             source_identity_providers,
             features,
         );
-        let trace_service = if telemetry_config.trace_history.enabled {
+        let trace_service = if local_trace_history.enabled {
             installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))
         } else {
             None
@@ -595,6 +594,13 @@ impl ServerBuilder {
             extension_context,
         })
         .await
+    }
+
+    fn uses_non_loopback_native_grpc_bind(&self) -> bool {
+        matches!(self.mode, ServerMode::NativeGrpc)
+            && self
+                .native_grpc_bind_addr
+                .is_some_and(|bind_addr| !bind_addr.ip().is_loopback())
     }
 
     fn ensure_compatible_extension_storage(&self) -> Result<(), AppError> {
@@ -626,6 +632,34 @@ impl ServerBuilder {
             ));
         }
         Ok(())
+    }
+}
+
+struct LocalTraceHistorySetup {
+    enabled: bool,
+    store_dir: Option<PathBuf>,
+    body_capture_max_bytes: Option<usize>,
+}
+
+fn local_trace_history_setup(
+    telemetry_config: &TelemetryConfig,
+    layout: &AppStateLayout,
+    uses_non_loopback_native_grpc_bind: bool,
+) -> LocalTraceHistorySetup {
+    let enabled = telemetry_config.trace_history.enabled && !uses_non_loopback_native_grpc_bind;
+    if telemetry_config.trace_history.enabled && uses_non_loopback_native_grpc_bind {
+        tracing::warn!("local trace history is disabled for non-loopback native gRPC servers");
+    }
+    LocalTraceHistorySetup {
+        enabled,
+        store_dir: enabled.then(|| layout.local_trace_store_dir()),
+        body_capture_max_bytes: enabled
+            .then(|| {
+                telemetry_config
+                    .trace_history
+                    .http_body_recording_max_bytes()
+            })
+            .flatten(),
     }
 }
 
@@ -1138,11 +1172,12 @@ mod tests {
     use coral_api::v1::source_service_client::SourceServiceClient;
     use coral_api::v1::trace_service_client::TraceServiceClient;
     use coral_api::v1::{
-        AddIdentitySpecRequest, CreateBundledSourceRequest, DeleteIdentitySpecRequest,
-        ExecuteSqlRequest, ExecuteSqlResponse, ImportSourceRequest, ImportSourceResponse,
-        ListCatalogRequest, ListIdentitySpecsRequest, ListSourcesRequest, ListTracesRequest,
-        ListTracesResponse, ListUserOwnedIdentitiesRequest, OAuthCredentialRetrieval,
-        OpenEpisodeRequest, SubmitFeedbackRequest, Workspace, import_source_response,
+        AddIdentitySpecRequest, CreateBundledSourceRequest, CreateIdentitySpecRequest,
+        DeleteIdentitySpecRequest, ExecuteSqlRequest, ExecuteSqlResponse, ImportSourceRequest,
+        ImportSourceResponse, ListCatalogRequest, ListIdentitySpecsRequest, ListSourcesRequest,
+        ListTracesRequest, ListTracesResponse, ListUserOwnedIdentitiesRequest,
+        OAuthCredentialRetrieval, OpenEpisodeRequest, SubmitFeedbackRequest, Workspace,
+        import_source_response,
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
@@ -1204,6 +1239,19 @@ mod tests {
             Err(UserPrincipalError::unauthenticated(
                 "rejected user principal",
             ))
+        }
+    }
+
+    #[derive(Debug)]
+    struct AcceptingUserPrincipalProvider;
+
+    #[tonic::async_trait]
+    impl UserPrincipalProvider for AcceptingUserPrincipalProvider {
+        async fn principal_for_metadata(
+            &self,
+            _metadata: &tonic::metadata::MetadataMap,
+        ) -> Result<UserPrincipal, UserPrincipalError> {
+            Ok(UserPrincipal::for_user("test-user").expect("valid test user principal"))
         }
     }
 
@@ -1707,6 +1755,39 @@ enabled = false
     }
 
     #[tokio::test]
+    async fn trace_history_service_is_unregistered_for_public_native_grpc() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_native_grpc_bind_addr(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+            .allow_unsafe_public_native_grpc_bind()
+            .with_user_principal_provider(Arc::new(AcceptingUserPrincipalProvider))
+            .with_management_authorizer(Arc::new(DenyingManagementAuthorizer))
+            .with_workspace_authorizer(Arc::new(AllowAllNonDefaultWorkspaceAuthorizer))
+            .start()
+            .await
+            .expect("public server should start with explicit auth");
+        let endpoint_uri = server
+            .endpoint_uri()
+            .to_string()
+            .replace("0.0.0.0", "127.0.0.1");
+        let channel = Endpoint::from_shared(endpoint_uri)
+            .expect("endpoint")
+            .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
+            .connect()
+            .await
+            .expect("connect");
+        let mut trace_client = TraceServiceClient::new(channel);
+
+        let status = list_traces(&mut trace_client)
+            .await
+            .expect_err("public native gRPC must not expose local trace history");
+
+        assert_eq!(status.code(), Code::Unimplemented);
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
     async fn server_builder_installs_identity_spec_management_authorizer() {
         let temp = TempDir::new().expect("temp dir");
         let server = ServerBuilder::new()
@@ -1717,7 +1798,7 @@ enabled = false
             .expect("start server");
         let mut client = IdentitySpecServiceClient::new(connect(&server).await);
 
-        let status = client
+        let add_status = client
             .add_identity_spec(Request::new(AddIdentitySpecRequest {
                 manifest_yaml: String::new(),
                 inputs: Vec::new(),
@@ -1725,8 +1806,18 @@ enabled = false
             .await
             .expect_err("identity spec mutation should be denied");
 
-        assert_eq!(status.code(), Code::PermissionDenied);
-        assert!(status.message().contains("identity specs are blocked"));
+        let create_status = client
+            .create_identity_spec(Request::new(CreateIdentitySpecRequest {
+                manifest_yaml: String::new(),
+                inputs: Vec::new(),
+            }))
+            .await
+            .expect_err("identity spec create should be denied");
+
+        for status in [add_status, create_status] {
+            assert_eq!(status.code(), Code::PermissionDenied);
+            assert!(status.message().contains("identity specs are blocked"));
+        }
         server.shutdown().await.expect("shutdown");
     }
 

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -641,6 +641,18 @@ impl UserOwnedIdentityManager {
         self.list_identities(&owner).await
     }
 
+    pub(crate) async fn delete_user_owned_identity(
+        &self,
+        principal: &UserPrincipal,
+        identity_name: &str,
+    ) -> Result<bool, AppError> {
+        let span = info_span!("coral.app.identities.delete_user_owned");
+        let _guard = span.enter();
+        self.identity_specs.ensure_dsl_v4_enabled()?;
+        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+        self.delete_identity(&owner, identity_name).await
+    }
+
     async fn delete_identity(
         &self,
         owner: &IdentityOwnerKey,

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -7,8 +7,9 @@ use coral_api::v1::identity_service_server::IdentityService as IdentityServiceAp
 use coral_api::v1::{
     CreateUserOwnedIdentityWithFixedTokenRequest, CreateUserOwnedIdentityWithFixedTokenResponse,
     CreateUserOwnedIdentityWithOAuthRequest, CreateUserOwnedIdentityWithOAuthResponse,
-    CredentialMetadata, Identity, IdentityOwner, ListUserOwnedIdentitiesRequest,
-    ListUserOwnedIdentitiesResponse, create_user_owned_identity_with_o_auth_response,
+    CredentialMetadata, DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse, Identity,
+    IdentityOwner, ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
+    create_user_owned_identity_with_o_auth_response,
 };
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
@@ -129,6 +130,25 @@ impl IdentityServiceApi for IdentityService {
                 Ok(Response::new(ListUserOwnedIdentitiesResponse {
                     identities: records.into_iter().map(identity_record_to_proto).collect(),
                 }))
+            },
+        )
+        .await
+    }
+
+    async fn delete_user_owned_identity(
+        &self,
+        request: Request<DeleteUserOwnedIdentityRequest>,
+    ) -> Result<Response<DeleteUserOwnedIdentityResponse>, Status> {
+        let identities = self.identities.clone();
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |principal, request| async move {
+                identities
+                    .delete_user_owned_identity(&principal, &request.name)
+                    .await
+                    .map_err(app_status)?;
+                Ok(Response::new(DeleteUserOwnedIdentityResponse {}))
             },
         )
         .await

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -239,7 +239,6 @@ impl IdentitySpecSnapshot {
 
 #[derive(Debug, Clone)]
 pub(crate) struct IdentitySpecImportInstall {
-    pub(crate) name: String,
     pub(crate) previous: Option<IdentitySpecSnapshot>,
     pub(crate) installed: IdentitySpecSnapshot,
     pub(crate) pre_import_usage_count: u32,
@@ -248,6 +247,7 @@ pub(crate) struct IdentitySpecImportInstall {
 struct IdentitySpecAddOutcome {
     record: IdentitySpecRecord,
     replaced: bool,
+    #[cfg(test)]
     import_install: IdentitySpecImportInstall,
 }
 
@@ -358,24 +358,103 @@ impl IdentitySpecManager {
         manifest_yaml: &str,
         inputs: Vec<IdentitySpecInputValue>,
     ) -> Result<(IdentitySpecRecord, bool), AppError> {
-        let outcome = self.add_identity_spec_with_inputs_inner(manifest_yaml, inputs)?;
+        let outcome = self.add_identity_spec_with_inputs_inner(manifest_yaml, inputs, false)?;
         Ok((outcome.record, outcome.replaced))
     }
 
+    pub(crate) fn add_identity_spec_with_inputs_create_only(
+        &self,
+        manifest_yaml: &str,
+        inputs: Vec<IdentitySpecInputValue>,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        let outcome = self.add_identity_spec_with_inputs_inner(manifest_yaml, inputs, true)?;
+        Ok(outcome.record)
+    }
+
+    #[cfg(test)]
     pub(crate) fn add_identity_spec_with_inputs_for_import(
         &self,
         manifest_yaml: &str,
         inputs: Vec<IdentitySpecInputValue>,
     ) -> Result<IdentitySpecImportInstall, AppError> {
         Ok(self
-            .add_identity_spec_with_inputs_inner(manifest_yaml, inputs)?
+            .add_identity_spec_with_inputs_inner(manifest_yaml, inputs, false)?
             .import_install)
+    }
+
+    pub(crate) fn add_identity_spec_with_inputs_for_import_create_only(
+        &self,
+        manifest_yaml: &str,
+        inputs: Vec<IdentitySpecInputValue>,
+    ) -> Result<Option<IdentitySpecImportInstall>, AppError> {
+        let span = info_span!("coral.app.identity_specs.import_create_only");
+        let _guard = span.enter();
+        self.features.ensure_dsl_v4_enabled()?;
+        let record = parse_identity_spec_record(manifest_yaml)?;
+        let name = record.manifest.name.clone();
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        let previous = self.snapshot_identity_spec_unlocked(&name)?;
+        let pre_import_usage_count = self.count_identities_for_spec_unlocked(&name)?;
+        let provided_inputs = unique_input_map(
+            inputs.into_iter().map(|input| (input.key, input.value)),
+            "identity spec input",
+        )?;
+
+        if let Some(previous) = previous {
+            if previous.record.manifest != record.manifest {
+                return Err(AppError::FailedPrecondition(format!(
+                    "identity spec '{name}' is already installed with a different manifest; remove or update it before importing this source bundle"
+                )));
+            }
+            let merged_input_material = merge_identity_spec_input_material(
+                &record.manifest,
+                &previous.input_material,
+                &provided_inputs,
+            )?;
+            if merged_input_material != previous.input_material {
+                return Err(AppError::FailedPrecondition(format!(
+                    "identity spec '{name}' is already installed; source import cannot update identity spec input material"
+                )));
+            }
+            return Ok(None);
+        }
+
+        let input_material = merge_identity_spec_input_material(
+            &record.manifest,
+            &BTreeMap::new(),
+            &provided_inputs,
+        )?;
+        self.registry.upsert_identity_spec(
+            &record.manifest.name,
+            IdentitySpecRegistryRecord {
+                manifest_yaml: record.manifest_yaml.clone(),
+                input_material,
+            },
+        )?;
+        let installed = match self.snapshot_identity_spec_unlocked(&name) {
+            Ok(Some(installed)) => installed,
+            Ok(None) => {
+                let error = AppError::FailedPrecondition(format!(
+                    "identity spec '{name}' was not available after import"
+                ));
+                return Err(self.restore_identity_spec_import_unlocked_or_error(&name, None, error));
+            }
+            Err(error) => {
+                return Err(self.restore_identity_spec_import_unlocked_or_error(&name, None, error));
+            }
+        };
+        Ok(Some(IdentitySpecImportInstall {
+            previous: None,
+            installed,
+            pre_import_usage_count,
+        }))
     }
 
     fn add_identity_spec_with_inputs_inner(
         &self,
         manifest_yaml: &str,
         inputs: Vec<IdentitySpecInputValue>,
+        create_only: bool,
     ) -> Result<IdentitySpecAddOutcome, AppError> {
         let span = info_span!("coral.app.identity_specs.add");
         let _guard = span.enter();
@@ -385,6 +464,11 @@ impl IdentitySpecManager {
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
         let previous = self.snapshot_identity_spec_unlocked(&name)?;
         let replaced = previous.is_some();
+        if create_only && replaced {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity spec '{name}' is already installed"
+            )));
+        }
         let existing_input_material = previous
             .as_ref()
             .map(|snapshot| snapshot.input_material.clone())
@@ -436,11 +520,13 @@ impl IdentitySpecManager {
                 ));
             }
         };
+        #[cfg(not(test))]
+        let _ = installed;
         Ok(IdentitySpecAddOutcome {
             record,
             replaced,
+            #[cfg(test)]
             import_install: IdentitySpecImportInstall {
-                name,
                 previous,
                 installed,
                 pre_import_usage_count,
@@ -1479,7 +1565,7 @@ mod tests {
     }
 
     #[track_caller]
-    fn assert_failed_precondition(error: &AppError, fragments: [&str; 2]) {
+    fn assert_failed_precondition<const N: usize>(error: &AppError, fragments: [&str; N]) {
         match error {
             AppError::FailedPrecondition(message) => {
                 for fragment in fragments {
@@ -1693,6 +1779,25 @@ oauth:
                 .list_identity_specs()
                 .expect("list again")
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn create_only_add_does_not_replace_existing_identity_spec() {
+        let (_temp, manager, _layout) = manager();
+        add_spec(&manager, &identity_yaml("github_oauth", "0.1.0"));
+
+        let error = manager
+            .add_identity_spec_with_inputs_create_only(
+                &identity_yaml("github_oauth", "0.2.0"),
+                Vec::new(),
+            )
+            .expect_err("create-only add should not replace");
+
+        assert_failed_precondition(&error, ["already installed"]);
+        assert_eq!(
+            stored_spec(&manager, "github_oauth").manifest.version,
+            "0.1.0"
         );
     }
 

--- a/crates/coral-app/src/identity_specs/mod.rs
+++ b/crates/coral-app/src/identity_specs/mod.rs
@@ -3,14 +3,14 @@
 mod manager;
 mod service;
 
+pub(crate) use manager::{
+    IdentitySpecImportInstall, IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord,
+    identity_spec_fingerprint, validate_identity_spec_name,
+};
 pub use manager::{
     IdentitySpecInputMaterialStorage, IdentitySpecManifestMetadata, IdentitySpecRegistry,
     IdentitySpecRegistryRecord, IdentitySpecUsageProvider,
     identity_spec_input_material_from_manifest,
     identity_spec_input_material_from_manifest_with_existing, identity_spec_manifest_metadata,
-};
-pub(crate) use manager::{
-    IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord, IdentitySpecSnapshot,
-    identity_spec_fingerprint, validate_identity_spec_name,
 };
 pub(crate) use service::IdentitySpecService;

--- a/crates/coral-app/src/identity_specs/service.rs
+++ b/crates/coral-app/src/identity_specs/service.rs
@@ -4,9 +4,10 @@ use std::sync::Arc;
 
 use coral_api::v1::identity_spec_service_server::IdentitySpecService as IdentitySpecServiceApi;
 use coral_api::v1::{
-    AddIdentitySpecRequest, AddIdentitySpecResponse, DeleteIdentitySpecRequest,
-    DeleteIdentitySpecResponse, GetIdentitySpecRequest, GetIdentitySpecResponse, IdentitySpec,
-    ListIdentitySpecsRequest, ListIdentitySpecsResponse,
+    AddIdentitySpecRequest, AddIdentitySpecResponse, CreateIdentitySpecRequest,
+    CreateIdentitySpecResponse, DeleteIdentitySpecRequest, DeleteIdentitySpecResponse,
+    GetIdentitySpecRequest, GetIdentitySpecResponse, IdentitySpec, ListIdentitySpecsRequest,
+    ListIdentitySpecsResponse,
 };
 use tonic::{Request, Response, Status};
 
@@ -70,6 +71,41 @@ impl IdentitySpecServiceApi for IdentitySpecService {
                 Ok(Response::new(AddIdentitySpecResponse {
                     identity_spec: Some(identity_spec_record_to_proto(record)),
                     replaced,
+                }))
+            },
+        )
+        .await
+    }
+
+    async fn create_identity_spec(
+        &self,
+        request: Request<CreateIdentitySpecRequest>,
+    ) -> Result<Response<CreateIdentitySpecResponse>, Status> {
+        let identity_specs = self.identity_specs.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |principal, request| async move {
+                management_authorizer
+                    .authorize_identity_spec_mutation(&principal)
+                    .await
+                    .map_err(authorization_status)?;
+                let inputs = request
+                    .inputs
+                    .into_iter()
+                    .map(|input| IdentitySpecInputValue {
+                        key: input.key,
+                        value: input.value,
+                    })
+                    .collect::<Vec<_>>();
+                let record = run_blocking_operation("identity spec operation", move || {
+                    identity_specs
+                        .add_identity_spec_with_inputs_create_only(&request.manifest_yaml, inputs)
+                })
+                .await?;
+                Ok(Response::new(CreateIdentitySpecResponse {
+                    identity_spec: Some(identity_spec_record_to_proto(record)),
                 }))
             },
         )

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -48,7 +48,9 @@ use crate::credentials::CredentialStorageKind;
 use crate::credentials::oauth::{OAuthProgressEvent, OAuthProgressEventSender};
 use crate::identities::UserOwnedIdentityManager;
 use crate::identity::{UserPrincipal, UserPrincipalProvider};
-use crate::identity_specs::{IdentitySpecInputValue, IdentitySpecManager, IdentitySpecSnapshot};
+use crate::identity_specs::{
+    IdentitySpecImportInstall, IdentitySpecInputValue, IdentitySpecManager,
+};
 use crate::query::manager::QueryManager;
 use crate::sources::SourceName;
 use crate::sources::manager::{
@@ -363,11 +365,12 @@ impl SourceServiceApi for SourceService {
                     replace_identity_bindings,
                 } = request;
                 let workspace_name = workspace_name_from_proto(workspace.as_ref())?;
+                let mutation_kind = source_import_mutation_kind(&oauth_credential_retrievals);
                 authorize_import_source_request(
                     management_authorizer.as_ref(),
                     &user_principal,
                     &workspace_name,
-                    !oauth_credential_retrievals.is_empty(),
+                    mutation_kind,
                     !identity_spec_manifest_yamls.is_empty()
                         || !proto_identity_spec_inputs.is_empty(),
                 )
@@ -522,6 +525,16 @@ impl SourceServiceApi for SourceService {
     }
 }
 
+fn source_import_mutation_kind(
+    oauth_credential_retrievals: &[OAuthCredentialRetrieval],
+) -> SourceMutationKind {
+    if oauth_credential_retrievals.is_empty() {
+        SourceMutationKind::Import
+    } else {
+        SourceMutationKind::ImportWithOAuth
+    }
+}
+
 type CreateBundledSourceWithOAuthResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithOAuthResponse, Status>> + Send>>;
 type ImportSourceResponseStreamBox =
@@ -564,14 +577,9 @@ async fn authorize_import_source_request(
     management_authorizer: &dyn ManagementAuthorizer,
     user_principal: &UserPrincipal,
     workspace_name: &WorkspaceName,
-    has_oauth_credential_retrievals: bool,
+    mutation_kind: SourceMutationKind,
     has_identity_spec_mutation: bool,
 ) -> Result<(), Status> {
-    let mutation_kind = if has_oauth_credential_retrievals {
-        SourceMutationKind::ImportWithOAuth
-    } else {
-        SourceMutationKind::Import
-    };
     management_authorizer
         .authorize_source_mutation(user_principal, workspace_name.as_str(), mutation_kind)
         .await
@@ -749,13 +757,14 @@ async fn install_and_validate_identity_specs_for_import(
     replace_identity_bindings: bool,
 ) -> Result<IdentitySpecImportRollbackGuard, AppError> {
     let identity_specs = identity_import.identity_specs.clone();
+    let install_identity_specs = identity_specs.clone();
     let manifest_yamls = identity_import.manifest_yamls.to_vec();
     let inputs = identity_import.inputs.to_vec();
     let mut rollback = run_blocking_app_operation("identity spec import", move || {
         let rollback_items =
-            install_identity_specs_for_import(&identity_specs, &manifest_yamls, &inputs)?;
+            install_identity_specs_for_import(&install_identity_specs, &manifest_yamls, &inputs)?;
         Ok(IdentitySpecImportRollbackGuard::new(
-            &identity_specs,
+            install_identity_specs,
             rollback_items,
         ))
     })
@@ -778,14 +787,6 @@ async fn install_and_validate_identity_specs_for_import(
     Ok(rollback)
 }
 
-#[derive(Debug)]
-struct IdentitySpecImportRollback {
-    name: String,
-    previous: Option<IdentitySpecSnapshot>,
-    installed: IdentitySpecSnapshot,
-    pre_import_usage_count: u32,
-}
-
 #[derive(Clone, Debug)]
 struct IdentitySpecImportInputValues {
     identity_spec_name: String,
@@ -794,17 +795,14 @@ struct IdentitySpecImportInputValues {
 
 struct IdentitySpecImportRollbackGuard {
     identity_specs: IdentitySpecManager,
-    rollback: Vec<IdentitySpecImportRollback>,
+    rollback: Vec<IdentitySpecImportInstall>,
     armed: bool,
 }
 
 impl IdentitySpecImportRollbackGuard {
-    fn new(
-        identity_specs: &IdentitySpecManager,
-        rollback: Vec<IdentitySpecImportRollback>,
-    ) -> Self {
+    fn new(identity_specs: IdentitySpecManager, rollback: Vec<IdentitySpecImportInstall>) -> Self {
         Self {
-            identity_specs: identity_specs.clone(),
+            identity_specs,
             rollback,
             armed: true,
         }
@@ -1063,7 +1061,7 @@ fn install_identity_specs_for_import(
     identity_specs: &IdentitySpecManager,
     manifest_yamls: &[String],
     input_groups: &[IdentitySpecImportInputValues],
-) -> Result<Vec<IdentitySpecImportRollback>, AppError> {
+) -> Result<Vec<IdentitySpecImportInstall>, AppError> {
     let parsed = manifest_yamls
         .iter()
         .map(|manifest_yaml| {
@@ -1103,29 +1101,28 @@ fn install_identity_specs_for_import(
     for (manifest_yaml, manifest) in parsed {
         let name = manifest.name;
         let inputs = inputs_by_spec.remove(name.as_str()).unwrap_or_default();
-        let install =
-            match identity_specs.add_identity_spec_with_inputs_for_import(manifest_yaml, inputs) {
-                Ok(install) => install,
-                Err(error) => {
-                    rollback_identity_specs_for_import(identity_specs, rollback);
-                    return Err(error);
-                }
-            };
-        rollback.push(IdentitySpecImportRollback {
-            name: install.name,
-            previous: install.previous,
-            installed: install.installed,
-            pre_import_usage_count: install.pre_import_usage_count,
-        });
+        let install = match identity_specs
+            .add_identity_spec_with_inputs_for_import_create_only(manifest_yaml, inputs)
+        {
+            Ok(install) => install,
+            Err(error) => {
+                rollback_identity_specs_for_import(identity_specs, rollback);
+                return Err(error);
+            }
+        };
+        if let Some(install) = install {
+            rollback.push(install);
+        }
     }
     Ok(rollback)
 }
 
 fn rollback_identity_specs_for_import(
     identity_specs: &IdentitySpecManager,
-    rollback: Vec<IdentitySpecImportRollback>,
+    rollback: Vec<IdentitySpecImportInstall>,
 ) {
     for item in rollback.into_iter().rev() {
+        let identity_spec_name = item.installed.name().to_string();
         match identity_specs.rollback_import_if_current(
             &item.installed,
             item.previous.as_ref(),
@@ -1134,15 +1131,15 @@ fn rollback_identity_specs_for_import(
             Ok(true) => {}
             Ok(false) => {
                 warn!(
-                    identity_spec = item.name,
-                    "skipped identity spec import rollback because current state changed or is in use"
+                    identity_spec = %identity_spec_name,
+                    "left identity spec installed after source import failed because it changed or gained usage after installation"
                 );
             }
             Err(error) => {
                 warn!(
-                    identity_spec = item.name,
+                    identity_spec = %identity_spec_name,
                     error = %error,
-                    "failed to roll back identity spec import"
+                    "failed to roll back identity spec after source import failed"
                 );
             }
         }
@@ -1818,7 +1815,7 @@ mod tests {
 
     use crate::authorization::{AllowAllManagementAuthorizer, AllowAllWorkspaceAuthorizer};
     use crate::credentials::{CredentialManager, CredentialStore};
-    use crate::features::Features;
+    use crate::features::{Feature, FeatureOverrides, Features};
     use crate::identities::{
         IdentityOwnerKey, UserOwnedIdentityMaterialGuard, UserOwnedIdentityRecord,
         UserOwnedIdentityStore,
@@ -1984,10 +1981,61 @@ mod tests {
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         layout.ensure().expect("layout");
+        let mut features = Features::default();
+        let mut overrides = FeatureOverrides::default();
+        overrides.set(Feature::DslV4, true);
+        features.apply_overrides(&overrides);
         (
             temp,
-            IdentitySpecManager::new_with_usage_providers(layout, Features::default(), Vec::new()),
+            IdentitySpecManager::new_with_usage_providers(layout, features, Vec::new()),
         )
+    }
+
+    fn fixed_token_identity_spec_yaml(name: &str) -> String {
+        format!(
+            r"
+kind: identity
+spec_version: 1
+name: {name}
+version: 0.1.0
+description: Demo identity.
+issuer: github
+type: fixed_token
+audience:
+  host: github.com
+"
+        )
+    }
+
+    fn source_manifest_with_user_identity_slot() -> &'static str {
+        r"
+name: github_v4
+version: 0.1.0
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/github-openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+          audience:
+            host: github.com
+"
+    }
+
+    fn user_identity_selection() -> BTreeMap<String, AppSourceIdentitySelection> {
+        BTreeMap::from([(
+            "rest".to_string(),
+            AppSourceIdentitySelection::new("saul_github", None).expect("identity selection"),
+        )])
+    }
+
+    fn user_identity_binding_slot() -> BTreeMap<String, AppSourceIdentityBinding> {
+        BTreeMap::from([("rest".to_string(), AppSourceIdentityBinding::user_owned())])
     }
 
     #[tokio::test]
@@ -2016,6 +2064,109 @@ mod tests {
                 surface_ids,
                 Some("saul".to_string())
             )]
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_source_import_rolls_back_new_identity_specs() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout");
+        let sources = SourceManager::new(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout,
+        );
+        let store = Arc::new(RecordingUserOwnedIdentityStore::default());
+        let (_identity_temp, identities) = user_owned_identity_manager_with_store(store);
+        let (_spec_temp, identity_specs) = identity_spec_manager();
+        let identity_context = ImportSourceIdentityContext {
+            identity_specs: identity_specs.clone(),
+            user_owned_identities: identities,
+            manifest_yamls: vec![fixed_token_identity_spec_yaml("github_oauth")],
+            inputs: Vec::new(),
+            user_principal: None,
+            user_identity_bindings: user_identity_selection(),
+        };
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+
+        let result = install_and_validate_identity_specs_for_import(
+            &sources,
+            identity_context.as_import_context(),
+            &workspace_name,
+            source_manifest_with_user_identity_slot(),
+            &user_identity_binding_slot(),
+            false,
+        )
+        .await;
+        let Err(error) = result else {
+            panic!("missing principal should fail after identity spec install");
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("cannot validate user-owned source identity bindings"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            identity_specs
+                .list_identity_specs()
+                .expect("list identity specs")
+                .is_empty(),
+            "failed import should roll back newly installed identity specs"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_source_import_keeps_existing_identity_specs() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout");
+        let sources = SourceManager::new(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout,
+        );
+        let store = Arc::new(RecordingUserOwnedIdentityStore::default());
+        let (_identity_temp, identities) = user_owned_identity_manager_with_store(store);
+        let (_spec_temp, identity_specs) = identity_spec_manager();
+        let identity_spec_yaml = fixed_token_identity_spec_yaml("github_oauth");
+        identity_specs
+            .add_identity_spec_with_inputs_create_only(&identity_spec_yaml, Vec::new())
+            .expect("preinstall identity spec");
+        let identity_context = ImportSourceIdentityContext {
+            identity_specs: identity_specs.clone(),
+            user_owned_identities: identities,
+            manifest_yamls: vec![identity_spec_yaml],
+            inputs: Vec::new(),
+            user_principal: None,
+            user_identity_bindings: user_identity_selection(),
+        };
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+
+        let result = install_and_validate_identity_specs_for_import(
+            &sources,
+            identity_context.as_import_context(),
+            &workspace_name,
+            source_manifest_with_user_identity_slot(),
+            &user_identity_binding_slot(),
+            false,
+        )
+        .await;
+        let Err(_error) = result else {
+            panic!("missing principal should fail after identity spec check");
+        };
+
+        assert_eq!(
+            identity_specs
+                .list_identity_specs()
+                .expect("list identity specs")
+                .len(),
+            1,
+            "failed import should not remove an existing identity spec"
         );
     }
 

--- a/crates/coral-app/tests/grpc/identity_spec_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_spec_tests.rs
@@ -1,6 +1,7 @@
 use coral_api::v1::{
-    AddIdentitySpecRequest, DeleteIdentitySpecRequest, GetIdentitySpecRequest,
-    IdentitySpecImportInputs, IdentitySpecInput, ImportSourceRequest, ListIdentitySpecsRequest,
+    AddIdentitySpecRequest, CreateIdentitySpecRequest, DeleteIdentitySpecRequest,
+    GetIdentitySpecRequest, IdentitySpecImportInputs, IdentitySpecInput, ImportSourceRequest,
+    ListIdentitySpecsRequest, UserSourceIdentityBinding,
 };
 use coral_app::features::{Feature, FeatureOverrides};
 use tonic::{Code, Request};
@@ -89,6 +90,13 @@ async fn identity_spec_subcommand_requires_dsl_v4_feature() {
         }))
         .await
         .expect_err("add requires the dsl_v4 feature");
+    let create = client
+        .create_identity_spec(Request::new(CreateIdentitySpecRequest {
+            manifest_yaml: fixed_token_identity_spec_yaml("github_oauth", "github.com"),
+            inputs: Vec::new(),
+        }))
+        .await
+        .expect_err("create requires the dsl_v4 feature");
     let list = client
         .list_identity_specs(Request::new(ListIdentitySpecsRequest {}))
         .await
@@ -107,7 +115,7 @@ async fn identity_spec_subcommand_requires_dsl_v4_feature() {
         .await
         .expect_err("remove requires the dsl_v4 feature");
 
-    for status in [add, list, get, delete] {
+    for status in [add, create, list, get, delete] {
         assert_eq!(
             status.code(),
             Code::FailedPrecondition,
@@ -172,6 +180,33 @@ async fn identity_spec_service_adds_lists_gets_and_deletes_global_specs() {
     assert_eq!(deleted.orphaned_identities, 0);
 
     assert!(harness.list_identity_specs().await.is_empty());
+}
+
+#[tokio::test]
+async fn identity_spec_service_create_only_does_not_replace_global_spec() {
+    let harness = GrpcHarness::new().await;
+
+    harness
+        .add_identity_spec(fixed_token_identity_spec_yaml("github_oauth", "github.com"))
+        .await;
+
+    let error = harness
+        .identity_spec_client()
+        .create_identity_spec(Request::new(CreateIdentitySpecRequest {
+            manifest_yaml: fixed_token_identity_spec_yaml("github_oauth", "attacker.test"),
+            inputs: Vec::new(),
+        }))
+        .await
+        .expect_err("create-only add should reject existing identity spec");
+
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error.message().contains("already installed"),
+        "unexpected error: {error}"
+    );
+    let fetched = get_identity_spec_manifest(&harness, "github_oauth").await;
+    assert!(fetched.contains("host: github.com"));
+    assert!(!fetched.contains("attacker.test"));
 }
 
 #[tokio::test]
@@ -278,6 +313,52 @@ async fn source_import_installs_identity_specs_from_bundle_request() {
 }
 
 #[tokio::test]
+async fn source_import_accepts_matching_existing_identity_spec_bundle() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixed_token_identity_spec_yaml("github_oauth", "github.com");
+
+    harness.add_identity_spec(manifest_yaml.clone()).await;
+    harness
+        .try_import_source(bundled_import_request(vec![manifest_yaml]))
+        .await
+        .expect("matching existing identity spec should be accepted");
+
+    let identity_specs = harness.list_identity_specs().await;
+    assert_eq!(identity_specs.len(), 1);
+    assert_eq!(
+        identity_specs
+            .first()
+            .expect("installed identity spec")
+            .name,
+        "github_oauth"
+    );
+}
+
+#[tokio::test]
+async fn source_import_rejects_replacing_existing_identity_spec_bundle() {
+    let harness = GrpcHarness::new().await;
+
+    harness
+        .add_identity_spec(fixed_token_identity_spec_yaml("github_oauth", "github.com"))
+        .await;
+    let error = harness
+        .try_import_source(bundled_import_request(vec![
+            fixed_token_identity_spec_yaml("github_oauth", "attacker.test"),
+        ]))
+        .await
+        .expect_err("source import must not replace an existing identity spec");
+
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error.message().contains("different manifest"),
+        "unexpected error: {error}"
+    );
+    let fetched = get_identity_spec_manifest(&harness, "github_oauth").await;
+    assert!(fetched.contains("host: github.com"));
+    assert!(!fetched.contains("attacker.test"));
+}
+
+#[tokio::test]
 async fn source_import_rolls_back_identity_specs_when_source_import_fails() {
     let harness = GrpcHarness::new().await;
     let error = harness
@@ -286,8 +367,12 @@ async fn source_import_rolls_back_identity_specs_when_source_import_fails() {
                 "github_oauth",
                 "github.com",
             )],
-            variables: vec![variable("API_BASE", "https://example.com")],
-            ..import_request(fixture_manifest_with_inputs_yaml())
+            user_identity_bindings: vec![UserSourceIdentityBinding {
+                surface_id: "missing_surface".to_string(),
+                identity: "missing_identity".to_string(),
+                accepted_identity: String::new(),
+            }],
+            ..bundled_import_request(Vec::new())
         })
         .await
         .expect_err("invalid source import should fail");
@@ -296,14 +381,18 @@ async fn source_import_rolls_back_identity_specs_when_source_import_fails() {
     assert!(
         error
             .message()
-            .contains("missing required source secret 'API_TOKEN'"),
+            .contains("user_identity_bindings can only be configured for DSL v4 sources"),
         "unexpected error: {error}"
     );
-    assert!(harness.list_identity_specs().await.is_empty());
+    let identity_specs = harness.list_identity_specs().await;
+    assert!(
+        identity_specs.is_empty(),
+        "failed source import should roll back newly installed identity specs"
+    );
 }
 
 #[tokio::test]
-async fn source_import_rolls_back_identity_spec_input_material_when_import_fails() {
+async fn source_import_rejects_updating_existing_identity_spec_input_material() {
     let harness = GrpcHarness::new().await;
     let manifest_yaml = oauth_identity_yaml_with_required_secret();
     harness
@@ -313,21 +402,23 @@ async fn source_import_rolls_back_identity_spec_input_material_when_import_fails
 
     let error = harness
         .try_import_source(ImportSourceRequest {
-            identity_spec_manifest_yamls: vec![fixed_token_identity_spec_yaml(
-                "demo_oauth",
-                "github.com",
-            )],
-            variables: vec![variable("API_BASE", "https://example.com")],
-            ..import_request(fixture_manifest_with_inputs_yaml())
+            identity_spec_inputs: vec![IdentitySpecImportInputs {
+                identity_spec_name: "demo_oauth".to_string(),
+                inputs: vec![IdentitySpecInput {
+                    key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                    value: "rotated-secret".to_string(),
+                }],
+            }],
+            ..bundled_import_request(vec![manifest_yaml.clone()])
         })
         .await
-        .expect_err("invalid source import should fail");
+        .expect_err("source import must not update existing identity spec input material");
 
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
     assert!(
         error
             .message()
-            .contains("missing required source secret 'API_TOKEN'"),
+            .contains("cannot update identity spec input material"),
         "unexpected error: {error}"
     );
     harness

--- a/crates/coral-cli/Cargo.toml
+++ b/crates/coral-cli/Cargo.toml
@@ -25,12 +25,14 @@ clap_complete.workspace = true
 crossterm.workspace = true
 dialoguer.workspace = true
 rust-embed = { workspace = true, optional = true }
+serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tonic.workspace = true
 url.workspace = true
+uuid.workspace = true
 
 coral-api.workspace = true
 coral-app.workspace = true

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -18,6 +18,7 @@ mod query_error;
 mod source_ops;
 
 use std::borrow::Cow;
+use std::future::Future;
 use std::path::PathBuf;
 #[cfg(feature = "embedded-ui")]
 use std::sync::Arc;
@@ -27,7 +28,7 @@ use clap::{
     Parser, Subcommand, ValueEnum,
 };
 use clap_complete::{Shell, generate};
-use coral_api::v1::ExecuteSqlRequest;
+use coral_api::v1::{ExecuteSqlRequest, ExecuteSqlResponse, Workspace};
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
 use coral_client::{
@@ -35,6 +36,7 @@ use coral_client::{
     format_batches_table, manifest_input_from_proto,
 };
 use dialoguer::console::measure_text_width;
+use serde::Deserialize as _;
 use tonic::Request;
 
 #[cfg(test)]
@@ -83,6 +85,26 @@ enum Command {
 enum RequiredRuntime {
     AppClient,
     None,
+}
+
+/// Runtime options parsed from the shared CLI surface before an app client is
+/// needed.
+#[derive(Debug, Clone)]
+pub struct SuppliedRuntimeOptions {
+    /// Whether the supplied server should render logs to stderr for this
+    /// invocation.
+    pub enable_stderr_logs: bool,
+    /// Process-local runtime feature overrides parsed from global CLI flags.
+    pub feature_overrides: coral_app::features::FeatureOverrides,
+}
+
+/// Product-specific defaults used by a sibling binary that supplies the app
+/// runtime.
+#[derive(Debug, Clone, Default)]
+pub struct AppRuntimeConfig {
+    /// Baseline process-local feature overrides. Explicit global CLI feature
+    /// flags still take precedence.
+    pub feature_overrides: coral_app::features::FeatureOverrides,
 }
 
 #[cfg(feature = "embedded-ui")]
@@ -291,9 +313,12 @@ enum SourceCommand {
     },
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
-enum OutputFormat {
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+/// Output format for rendered SQL query results.
+pub enum OutputFormat {
+    /// Render query results as an aligned terminal table.
     Table,
+    /// Render query results as JSON.
     Json,
 }
 
@@ -464,6 +489,112 @@ pub async fn run_from_env() -> Result<(), CliError> {
     }
 }
 
+/// Parses CLI arguments and runs them against an app runtime supplied by a
+/// sibling binary.
+///
+/// This keeps shared command parsing, feature override handling, output
+/// rendering, and telemetry classification in `coral-cli` while allowing a
+/// product-specific binary to own server startup and extension composition.
+/// The runtime factory is called only for commands that need an app client, and
+/// receives parsed runtime options before the app client is constructed.
+///
+/// # Errors
+///
+/// Returns an error if runtime startup, command execution, or output formatting
+/// fails.
+pub async fn run_with_app_runtime<Start, StartFuture, RuntimeGuard>(
+    ctx: coral_app::RunContext,
+    start_runtime: Start,
+) -> Result<(), CliError>
+where
+    Start: FnOnce(SuppliedRuntimeOptions) -> StartFuture,
+    StartFuture: Future<Output = Result<(AppClient, RuntimeGuard), anyhow::Error>>,
+{
+    run_with_app_runtime_config(ctx, AppRuntimeConfig::default(), start_runtime).await
+}
+
+/// Parses CLI arguments and runs them against an app runtime supplied by a
+/// sibling binary, applying product-specific runtime defaults before command
+/// execution.
+///
+/// Explicit global CLI feature flags override `config` defaults. This lets a
+/// sibling binary keep no-runtime commands such as `features list` aligned with
+/// the runtime it would supply for app-backed commands.
+///
+/// # Errors
+///
+/// Returns an error if runtime startup, command execution, or output formatting
+/// fails.
+pub async fn run_with_app_runtime_config<Start, StartFuture, RuntimeGuard>(
+    ctx: coral_app::RunContext,
+    config: AppRuntimeConfig,
+    start_runtime: Start,
+) -> Result<(), CliError>
+where
+    Start: FnOnce(SuppliedRuntimeOptions) -> StartFuture,
+    StartFuture: Future<Output = Result<(AppClient, RuntimeGuard), anyhow::Error>>,
+{
+    let Cli {
+        feature_overrides,
+        command,
+    } = Cli::parse();
+    let feature_overrides =
+        feature_overrides_with_defaults(feature_overrides.into_overrides(), &config);
+
+    match command.required_runtime() {
+        RequiredRuntime::AppClient => {
+            let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
+            let (app, _runtime_guard) = start_runtime(SuppliedRuntimeOptions {
+                enable_stderr_logs: command.enables_stderr_logs(),
+                feature_overrides: feature_overrides.clone(),
+            })
+            .await?;
+            if is_mcp_stdio {
+                run_app_command(app, command, Some(&ctx), &feature_overrides).await
+            } else {
+                coral_app::run_with_context(
+                    &ctx,
+                    Box::pin(run_app_command(app, command, None, &feature_overrides)),
+                )
+                .await
+            }
+        }
+        RequiredRuntime::None => {
+            coral_app::run_with_context(
+                &ctx,
+                Box::pin(run_no_runtime_command(command, &feature_overrides)),
+            )
+            .await
+        }
+    }
+}
+
+fn feature_overrides_with_defaults(
+    mut feature_overrides: coral_app::features::FeatureOverrides,
+    config: &AppRuntimeConfig,
+) -> coral_app::features::FeatureOverrides {
+    feature_overrides.apply_defaults_from(&config.feature_overrides);
+    feature_overrides
+}
+
+/// Parses CLI arguments and runs them against an already-configured app client.
+///
+/// Use [`run_with_app_runtime`] instead when parsed feature overrides or stderr
+/// log settings must affect the server that backs the client.
+///
+/// # Errors
+///
+/// Returns an error if command execution or output formatting fails.
+pub async fn run(app: AppClient, ctx: coral_app::RunContext) -> Result<(), CliError> {
+    run_with_app_runtime(ctx, |_| async move { Ok((app, ())) }).await
+}
+
+/// Returns the shared OSS Coral CLI command definition.
+#[must_use]
+pub fn command() -> clap::Command {
+    Cli::command()
+}
+
 /// Returns the embedded Coral UI assets for the local server to serve.
 #[cfg(feature = "embedded-ui")]
 #[must_use]
@@ -538,25 +669,7 @@ async fn run_app_command(
 ) -> Result<(), CliError> {
     match command {
         Command::Sql(args) => {
-            let response = match app
-                .query_client()
-                .execute_sql(Request::new(ExecuteSqlRequest {
-                    workspace: Some(default_workspace()),
-                    sql: args.sql,
-                }))
-                .await
-            {
-                Ok(response) => response.into_inner(),
-                Err(status) => {
-                    return Err(CliError::Query {
-                        error_message: query_error::telemetry_error_message(&status),
-                        error_type: query_error::telemetry_error_type(&status),
-                        rendered_stderr: query_error::render_query_error(&status),
-                    });
-                }
-            };
-            let result = decode_execute_sql_response(&response).map_err(anyhow::Error::from)?;
-            print_batches(result.batches(), args.format)?;
+            run_sql(&app, default_workspace(), args.sql, args.format).await?;
         }
         Command::Source(args) => run_source(&app, args, feature_overrides).await?,
         Command::Onboard => {
@@ -690,6 +803,79 @@ async fn run_source(
     Ok(())
 }
 
+/// Build a workspace selector for shared CLI query helpers.
+#[must_use]
+pub fn workspace_with_name(name: impl Into<String>) -> Workspace {
+    Workspace { name: name.into() }
+}
+
+/// Execute a SQL query against the given workspace and return the raw response.
+///
+/// The OSS CLI calls this with [`default_workspace`]. Cloud-specific CLIs can
+/// reuse the same transport path for server-managed workspaces without adding a
+/// workspace selector to the OSS `coral sql` command.
+///
+/// # Errors
+///
+/// Returns the gRPC status from query execution when the server rejects or fails
+/// the request.
+pub async fn execute_sql(
+    app: &AppClient,
+    workspace: Workspace,
+    sql: String,
+) -> Result<ExecuteSqlResponse, tonic::Status> {
+    app.query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(workspace),
+            sql,
+        }))
+        .await
+        .map(tonic::Response::into_inner)
+}
+
+/// Render a SQL response in the same format used by the shared CLI.
+///
+/// # Errors
+///
+/// Returns an error when the response payload cannot be decoded or formatted.
+pub fn print_sql_response(
+    response: &ExecuteSqlResponse,
+    format: OutputFormat,
+) -> Result<(), anyhow::Error> {
+    let result = decode_execute_sql_response(response).map_err(anyhow::Error::from)?;
+    print_batches(result.batches(), format)
+}
+
+/// Execute and render a SQL query using the shared CLI's query diagnostics.
+///
+/// # Errors
+///
+/// Returns [`CliError::Query`] when the server rejects query execution, or
+/// [`CliError::Internal`] when the successful response cannot be decoded or
+/// rendered.
+pub async fn run_sql(
+    app: &AppClient,
+    workspace: Workspace,
+    sql: String,
+    format: OutputFormat,
+) -> Result<(), CliError> {
+    let response = execute_sql(app, workspace, sql)
+        .await
+        .map_err(|status| sql_status_to_cli_error(&status))?;
+    print_sql_response(&response, format)?;
+    Ok(())
+}
+
+/// Convert a query status into the shared CLI's structured query diagnostic.
+#[must_use]
+pub fn sql_status_to_cli_error(status: &tonic::Status) -> CliError {
+    CliError::Query {
+        error_message: query_error::telemetry_error_message(status),
+        error_type: query_error::telemetry_error_type(status),
+        rendered_stderr: query_error::render_query_error(status),
+    }
+}
+
 fn print_batches(
     batches: &[arrow::record_batch::RecordBatch],
     format: OutputFormat,
@@ -817,34 +1003,14 @@ async fn run_source_add(
             }
         }
         (None, Some(file)) => {
-            let raw_manifest_yaml = std::fs::read_to_string(&file).map_err(anyhow::Error::from)?;
-            ensure_source_add_manifest_yaml_features(&raw_manifest_yaml, feature_overrides)?;
-            let (manifest_yaml, manifest) =
-                source_ops::load_validated_manifest_file_yaml(&file, &raw_manifest_yaml)?;
-            ensure_source_add_manifest_features(&manifest, feature_overrides)?;
-            if interactive {
-                let inputs = source_ops::prompt_for_inputs_with_credential_methods(
-                    manifest.declared_inputs(),
-                )?;
-                source_ops::import_source_with_credentials(app, manifest_yaml, inputs).await?
-            } else {
-                let (variables, secrets) = source_ops::collect_inputs_from_env(
-                    manifest.declared_inputs(),
-                    format!(
-                        "coral source add --interactive --file {}",
-                        source_ops::shell_quote_arg(&file.display().to_string())
-                    ),
-                )?;
-                source_ops::import_source(app, manifest_yaml, variables, secrets).await?
-            }
+            add_source_from_file(app, file, interactive, feature_overrides).await?
         }
         _ => unreachable!("clap enforces exactly one of name or file"),
     };
-    println!(
-        "Added source {} (secrets: {})",
-        response.name,
-        source_ops::source_credential_storage_label(response.credential_storage)
-    );
+    match source_ops::added_source_secret_storage_label(response.credential_storage) {
+        Some(label) => println!("Added source {} (secrets: {label})", response.name),
+        None => println!("Added source {}", response.name),
+    }
     source_ops::validate_and_warn(app, &response.name, source_ops::TableDisplayLimit::DEFAULT)
         .await
         .map_err(Into::into)
@@ -864,16 +1030,36 @@ fn ensure_source_add_manifest_yaml_features(
     manifest_yaml: &str,
     feature_overrides: &coral_app::features::FeatureOverrides,
 ) -> Result<(), anyhow::Error> {
-    let manifest_value: serde_yaml::Value = serde_yaml::from_str(manifest_yaml)?;
-    if manifest_value
-        .as_mapping()
-        .and_then(|mapping| mapping.get(serde_yaml::Value::String("dsl_version".to_string())))
-        .and_then(serde_yaml::Value::as_u64)
-        .is_none_or(|dsl_version| dsl_version != 4)
-    {
+    if !source_add_manifest_yaml_requires_dsl_v4(manifest_yaml)? {
         return Ok(());
     }
     ensure_dsl_v4_source_add_enabled(feature_overrides)
+}
+
+fn source_add_manifest_yaml_requires_dsl_v4(manifest_yaml: &str) -> Result<bool, anyhow::Error> {
+    let kind_key = serde_yaml::Value::String("kind".to_string());
+    let dsl_version_key = serde_yaml::Value::String("dsl_version".to_string());
+    for document in serde_yaml::Deserializer::from_str(manifest_yaml) {
+        let value = serde_yaml::Value::deserialize(document)?;
+        let Some(mapping) = value.as_mapping() else {
+            continue;
+        };
+        if mapping
+            .get(&kind_key)
+            .and_then(serde_yaml::Value::as_str)
+            .is_some_and(|kind| kind == "identity")
+        {
+            return Ok(true);
+        }
+        if mapping
+            .get(&dsl_version_key)
+            .and_then(serde_yaml::Value::as_u64)
+            .is_some_and(|dsl_version| dsl_version == 4)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn ensure_dsl_v4_source_add_enabled(
@@ -891,13 +1077,132 @@ fn ensure_dsl_v4_source_add_enabled(
     }
 }
 
+async fn add_source_from_file(
+    app: &AppClient,
+    file: PathBuf,
+    interactive: bool,
+    feature_overrides: &coral_app::features::FeatureOverrides,
+) -> Result<coral_api::v1::Source, CliError> {
+    let raw_manifest_yaml = std::fs::read_to_string(&file).map_err(anyhow::Error::from)?;
+    ensure_source_add_manifest_yaml_features(&raw_manifest_yaml, feature_overrides)?;
+    let bundle = source_ops::load_validated_manifest_bundle_file_yaml(&file, &raw_manifest_yaml)?;
+    ensure_source_add_manifest_features(&bundle.source_manifest, feature_overrides)?;
+    let identity_spec_interactive_command = format!(
+        "coral source add --interactive --file {}",
+        source_ops::shell_quote_arg(&file.display().to_string())
+    );
+    if source_ops::source_has_identity_requirements(&bundle.source_manifest) {
+        return add_source_with_identity_requirements_from_file(
+            app,
+            bundle,
+            interactive,
+            &identity_spec_interactive_command,
+        )
+        .await;
+    }
+    let identity_specs = source_ops::prepare_identity_specs_for_source_import(
+        app,
+        &bundle.identity_manifests,
+        interactive,
+        &identity_spec_interactive_command,
+    )
+    .await?;
+    if interactive {
+        let inputs = source_ops::prompt_for_inputs_with_credential_methods(
+            bundle.source_manifest.declared_inputs(),
+        )?;
+        return Ok(source_ops::import_source_with_credentials(
+            app,
+            bundle.source_manifest_yaml,
+            identity_specs,
+            Vec::new(),
+            Vec::new(),
+            inputs,
+        )
+        .await?);
+    }
+    let (variables, secrets) = source_ops::collect_inputs_from_env(
+        bundle.source_manifest.declared_inputs(),
+        identity_spec_interactive_command,
+    )?;
+    Ok(source_ops::import_source(
+        app,
+        bundle.source_manifest_yaml,
+        identity_specs,
+        Vec::new(),
+        Vec::new(),
+        variables,
+        secrets,
+    )
+    .await?)
+}
+
+async fn add_source_with_identity_requirements_from_file(
+    app: &AppClient,
+    bundle: source_ops::ValidatedManifestBundleFile,
+    interactive: bool,
+    identity_spec_interactive_command: &str,
+) -> Result<coral_api::v1::Source, CliError> {
+    source_ops::require_interactive_for("source identity setup")?;
+    let installed_identity_specs = source_ops::install_identity_specs_for_source_add(
+        app,
+        &bundle.identity_manifests,
+        interactive,
+        identity_spec_interactive_command,
+    )
+    .await?;
+    let inputs = match source_ops::prompt_for_inputs_with_credential_methods(
+        bundle.source_manifest.declared_inputs(),
+    ) {
+        Ok(inputs) => inputs,
+        Err(error) => {
+            source_ops::rollback_identity_specs_for_source_add(installed_identity_specs);
+            return Err(error.into());
+        }
+    };
+    let identity_bindings = match source_ops::prompt_for_source_identity_bindings(
+        app,
+        &bundle.source_manifest,
+        &bundle.identity_manifests,
+    )
+    .await
+    {
+        Ok(identity_bindings) => identity_bindings,
+        Err(error) => {
+            source_ops::rollback_identity_specs_for_source_add(installed_identity_specs);
+            return Err(error.into());
+        }
+    };
+    let source_ops::PromptedSourceIdentityBindings {
+        identity_bindings,
+        user_identity_bindings,
+        created_user_identities,
+    } = identity_bindings;
+    let import_result = source_ops::import_source_with_credentials(
+        app,
+        bundle.source_manifest_yaml,
+        source_ops::ImportSourceIdentitySpecs::default(),
+        identity_bindings,
+        user_identity_bindings,
+        inputs,
+    )
+    .await;
+    if import_result.is_err() {
+        source_ops::rollback_user_owned_identities_for_source_add(created_user_identities);
+        source_ops::rollback_identity_specs_for_source_add(installed_identity_specs);
+    }
+    Ok(import_result?)
+}
+
 #[cfg(test)]
 mod tests {
     use clap::{CommandFactory, Parser};
+    use coral_app::features::{Feature, FeatureOverrides};
 
     use super::{
-        Cli, RequiredRuntime, command_enables_stderr_logs, ensure_source_add_manifest_features,
-        ensure_source_add_manifest_yaml_features,
+        AppRuntimeConfig, Cli, RequiredRuntime, command_enables_stderr_logs,
+        ensure_source_add_manifest_features, ensure_source_add_manifest_yaml_features,
+        feature_overrides_with_defaults,
     };
 
     fn v4_manifest_with_required_input() -> coral_spec::ValidatedSourceManifest {
@@ -1029,6 +1334,91 @@ surfaces:
     }
 
     #[test]
+    fn source_add_file_rejects_raw_v4_bundle_before_descriptor_validation_when_feature_disabled() {
+        let mut overrides = coral_app::features::FeatureOverrides::default();
+        overrides.set(coral_app::features::Feature::DslV4, false);
+
+        let error = ensure_source_add_manifest_yaml_features(
+            r"
+---
+kind: identity
+spec_version: 1
+name: github_oauth
+version: 0.1.0
+issuer: github
+type: fixed_token
+---
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /definitely/missing/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+",
+            &overrides,
+        )
+        .expect_err("disabled v4 feature should reject bundle before descriptor validation");
+
+        assert!(
+            error.to_string().contains("DSL v4 sources require"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn source_add_file_rejects_identity_bundle_before_input_collection_when_feature_disabled() {
+        let mut overrides = coral_app::features::FeatureOverrides::default();
+        overrides.set(coral_app::features::Feature::DslV4, false);
+
+        let error = ensure_source_add_manifest_yaml_features(
+            r"
+---
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+issuer: demo
+type: oauth
+audience:
+  host: api.example.test
+inputs:
+  DEMO_OAUTH_CLIENT_SECRET:
+    kind: secret
+    required: true
+oauth:
+  method:
+    label: Demo OAuth
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/callback
+    endpoints:
+      authorization_url: https://auth.example.test/authorize
+      token_url: https://auth.example.test/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+---
+name: demo
+dsl_version: 3
+backend: http
+base_url: https://api.example.test
+tables: []
+",
+            &overrides,
+        )
+        .expect_err("disabled v4 feature should reject identity bundle before input collection");
+
+        assert!(
+            error.to_string().contains("DSL v4 sources require"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
     fn source_add_file_accepts_v4_when_feature_enabled() {
         let manifest = v4_manifest_with_required_input();
         let mut overrides = coral_app::features::FeatureOverrides::default();
@@ -1039,6 +1429,14 @@ surfaces:
     }
 
     #[test]
+    fn dsl_v4_feature_override_parse_before_subcommand() {
+        let cli = Cli::try_parse_from(["coral", "--enable-dsl-v4", "source", "discover"])
+            .expect("global dsl v4 feature override should parse before subcommand");
+
+        assert!(matches!(cli.command, super::Command::Source(_)));
+    }
+
+    #[test]
     fn global_feature_overrides_are_hidden_from_help() {
         let mut help = Vec::new();
         Cli::command()
@@ -1046,14 +1444,17 @@ surfaces:
             .expect("help should render");
         let help = String::from_utf8(help).expect("help should be utf8");
 
-        assert!(
-            !help.contains("--enable-feedback"),
-            "feature override flags should not be visible in help: {help}"
-        );
-        assert!(
-            !help.contains("--disable-feedback"),
-            "feature override flags should not be visible in help: {help}"
-        );
+        for flag in [
+            "--enable-feedback",
+            "--disable-feedback",
+            "--enable-dsl-v4",
+            "--disable-dsl-v4",
+        ] {
+            assert!(
+                !help.contains(flag),
+                "feature override flags should not be visible in help: {help}"
+            );
+        }
     }
 
     #[test]
@@ -1067,6 +1468,36 @@ surfaces:
         .expect_err("conflicting feature overrides should fail");
 
         assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    fn dsl_v4_overrides(enabled: bool) -> FeatureOverrides {
+        let mut overrides = FeatureOverrides::default();
+        overrides.set(Feature::DslV4, enabled);
+        overrides
+    }
+
+    #[test]
+    fn runtime_config_feature_overrides_apply_as_defaults() {
+        let merged = feature_overrides_with_defaults(
+            FeatureOverrides::default(),
+            &AppRuntimeConfig {
+                feature_overrides: dsl_v4_overrides(true),
+            },
+        );
+
+        assert_eq!(merged.get(Feature::DslV4), Some(true));
+    }
+
+    #[test]
+    fn cli_feature_overrides_win_over_runtime_config_defaults() {
+        let merged = feature_overrides_with_defaults(
+            dsl_v4_overrides(false),
+            &AppRuntimeConfig {
+                feature_overrides: dsl_v4_overrides(true),
+            },
+        );
+
+        assert_eq!(merged.get(Feature::DslV4), Some(false));
     }
 
     #[test]

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{IsTerminal, Read as _, Write, stdin, stdout};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
@@ -11,19 +11,24 @@ use std::time::Duration;
 use anyhow::{Context as _, bail};
 use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
-    CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest, DeleteSourceRequest,
-    DiscoverSourcesRequest, GetSourceInfoRequest, ImportSourceRequest, ListSourcesRequest,
-    OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source,
-    SourceCredentialStorage, SourceInfo, SourceOrigin, SourceSecret, SourceVariable,
-    ValidateSourceRequest, ValidateSourceResponse, create_bundled_source_with_o_auth_response,
+    CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest, CreateIdentitySpecRequest,
+    CreateUserOwnedIdentityWithFixedTokenRequest, CreateUserOwnedIdentityWithOAuthRequest,
+    DeleteSourceRequest, DiscoverSourcesRequest, GetIdentitySpecRequest, GetSourceInfoRequest,
+    Identity, IdentitySpec, IdentitySpecImportInputs, IdentitySpecInput, ImportSourceRequest,
+    ListSourcesRequest, ListUserOwnedIdentitiesRequest, OAuthCredentialInput,
+    OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source, SourceCredentialStorage,
+    SourceIdentityBinding, SourceIdentityOwner, SourceInfo, SourceOrigin, SourceSecret,
+    SourceVariable, UserSourceIdentityBinding, ValidateSourceRequest, ValidateSourceResponse,
+    create_bundled_source_with_o_auth_response, create_user_owned_identity_with_o_auth_response,
     import_source_response, query_test_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::{AppClient, DecodedStatusError, decode_status_error, default_workspace};
-use coral_spec::v4::SurfaceDescriptor;
+use coral_spec::v4::{AcceptedIdentityRequirement, SurfaceDescriptor};
 use coral_spec::{
+    IdentityManifest, IdentityManifestDocument, IdentitySpecConfig, IdentitySpecType,
     ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
     ManifestInputKind, ManifestInputSpec, ManifestOAuthCredentialSpec, ValidatedSourceManifest,
-    parse_source_manifest_yaml,
+    parse_identity_manifest_yaml, parse_manifest_bundle_yaml, parse_source_manifest_yaml,
 };
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
@@ -34,6 +39,7 @@ use tonic::Request;
 use url::{Host, Url};
 
 const MAX_TABLES_PER_SCHEMA: usize = 9;
+const IDENTITY_OAUTH_PROGRESS_INPUT_KEY: &str = "ACCESS_TOKEN";
 
 /// How many tables to show per schema when pretty-printing validation results.
 #[derive(Debug, Clone, Copy)]
@@ -91,6 +97,112 @@ pub(crate) async fn list_sources(app: &AppClient) -> Result<Vec<Source>, anyhow:
         .sources)
 }
 
+/// Generates a thin gRPC call wrapper: builds the request, sends it through
+/// the named client, and maps the response with `$map` (`response` in scope).
+macro_rules! rpc_fn {
+    (
+        $(#[$meta:meta])*
+        fn $name:ident($($arg:ident: $arg_ty:ty),*) -> $ok:ty;
+        $client:ident.$rpc:ident($req:expr);
+        |$response:ident| $map:expr
+    ) => {
+        $(#[$meta])*
+        pub(crate) async fn $name(
+            app: &AppClient,
+            $($arg: $arg_ty),*
+        ) -> Result<$ok, anyhow::Error> {
+            let $response = app.$client().$rpc(Request::new($req)).await?.into_inner();
+            Ok($map)
+        }
+    };
+}
+
+rpc_fn! {
+    fn get_identity_spec(name: &str) -> IdentitySpec;
+    identity_spec_client.get_identity_spec(GetIdentitySpecRequest {
+        name: name.to_string(),
+    });
+    |response| response
+        .identity_spec
+        .ok_or_else(|| anyhow::anyhow!("get identity spec response missing identity_spec"))?
+}
+
+rpc_fn! {
+    fn create_identity_spec(
+        manifest_yaml: String,
+        inputs: Vec<IdentitySpecInput>
+    ) -> IdentitySpec;
+    identity_spec_client.create_identity_spec(CreateIdentitySpecRequest {
+        manifest_yaml,
+        inputs,
+    });
+    |response| response
+        .identity_spec
+        .ok_or_else(|| anyhow::anyhow!("create identity spec response missing identity_spec"))?
+}
+
+rpc_fn! {
+    fn list_user_owned_identities() -> Vec<Identity>;
+    identity_client.list_user_owned_identities(ListUserOwnedIdentitiesRequest {});
+    |response| response.identities
+}
+
+pub(crate) async fn create_user_owned_identity_with_oauth(
+    app: &AppClient,
+    name: &str,
+    identity_spec: &str,
+    credential_inputs: Vec<OAuthCredentialInput>,
+    label: &str,
+) -> Result<Identity, anyhow::Error> {
+    let response = app
+        .identity_client()
+        .create_user_owned_identity_with_o_auth(Request::new(
+            CreateUserOwnedIdentityWithOAuthRequest {
+                name: name.to_string(),
+                identity_spec: identity_spec.to_string(),
+                credential_inputs,
+            },
+        ))
+        .await?;
+    let oauth_labels = BTreeMap::from([(
+        IDENTITY_OAUTH_PROGRESS_INPUT_KEY.to_string(),
+        label.to_string(),
+    )]);
+    completion_from_oauth_stream(
+        response.into_inner(),
+        &oauth_labels,
+        OAuthStreamContext {
+            ended_message: "identity OAuth stream ended before identity creation completed",
+            error_action: "identity creation",
+            retry_command: "coral source add --interactive --file <manifest.yaml>",
+        },
+        |response| response.event.map(CredentialStreamEvent::from),
+    )
+    .await
+}
+
+pub(crate) async fn create_user_owned_identity_with_fixed_token(
+    app: &AppClient,
+    name: &str,
+    identity_spec: &str,
+    token: String,
+) -> Result<Identity, anyhow::Error> {
+    let response = app
+        .identity_client()
+        .create_user_owned_identity_with_fixed_token(Request::new(
+            CreateUserOwnedIdentityWithFixedTokenRequest {
+                name: name.to_string(),
+                identity_spec: identity_spec.to_string(),
+                token,
+            },
+        ))
+        .await?
+        .into_inner();
+    response
+        .identity
+        .ok_or_else(|| anyhow::anyhow!("create fixed-token identity response missing identity"))
+}
+
 pub(crate) async fn add_bundled_source(
     app: &AppClient,
     name: &str,
@@ -115,6 +227,9 @@ pub(crate) async fn add_bundled_source(
 pub(crate) async fn import_source(
     app: &AppClient,
     manifest_yaml: String,
+    identity_specs: ImportSourceIdentitySpecs,
+    identity_bindings: Vec<SourceIdentityBinding>,
+    user_identity_bindings: Vec<UserSourceIdentityBinding>,
     variables: Vec<SourceVariable>,
     secrets: Vec<SourceSecret>,
 ) -> Result<Source, anyhow::Error> {
@@ -126,7 +241,11 @@ pub(crate) async fn import_source(
             variables,
             secrets,
             oauth_credential_retrievals: Vec::new(),
-            ..Default::default()
+            identity_spec_manifest_yamls: identity_specs.manifest_yamls,
+            identity_spec_inputs: identity_specs.inputs,
+            identity_bindings,
+            user_identity_bindings,
+            replace_identity_bindings: true,
         }))
         .await?
         .into_inner();
@@ -136,6 +255,12 @@ pub(crate) async fn import_source(
         }
     }
     Err(anyhow::anyhow!("import source stream ended without source"))
+}
+
+#[derive(Default)]
+pub(crate) struct ImportSourceIdentitySpecs {
+    pub(crate) manifest_yamls: Vec<String>,
+    pub(crate) inputs: Vec<IdentitySpecImportInputs>,
 }
 
 pub(crate) struct CollectedSourceInputs {
@@ -208,10 +333,22 @@ pub(crate) async fn add_bundled_source_with_credentials(
 pub(crate) async fn import_source_with_credentials(
     app: &AppClient,
     manifest_yaml: String,
+    identity_specs: ImportSourceIdentitySpecs,
+    identity_bindings: Vec<SourceIdentityBinding>,
+    user_identity_bindings: Vec<UserSourceIdentityBinding>,
     inputs: CollectedSourceInputs,
 ) -> Result<Source, anyhow::Error> {
     if inputs.oauth_credential_retrievals.is_empty() {
-        return import_source(app, manifest_yaml, inputs.variables, inputs.secrets).await;
+        return import_source(
+            app,
+            manifest_yaml,
+            identity_specs,
+            identity_bindings,
+            user_identity_bindings,
+            inputs.variables,
+            inputs.secrets,
+        )
+        .await;
     }
     let response = app
         .source_client()
@@ -221,7 +358,11 @@ pub(crate) async fn import_source_with_credentials(
             variables: inputs.variables,
             secrets: inputs.secrets,
             oauth_credential_retrievals: inputs.oauth_credential_retrievals,
-            ..Default::default()
+            identity_spec_manifest_yamls: identity_specs.manifest_yamls,
+            identity_spec_inputs: identity_specs.inputs,
+            identity_bindings,
+            user_identity_bindings,
+            replace_identity_bindings: true,
         }))
         .await?;
     completion_from_oauth_stream(
@@ -236,6 +377,561 @@ pub(crate) async fn import_source_with_credentials(
         |response| response.event.map(CredentialStreamEvent::from),
     )
     .await
+}
+
+pub(crate) fn source_has_identity_requirements(manifest: &ValidatedSourceManifest) -> bool {
+    source_identity_requirements(manifest).next().is_some()
+}
+
+pub(crate) async fn prepare_identity_specs_for_source_import(
+    app: &AppClient,
+    identity_manifests: &[IdentityManifestDocument],
+    interactive: bool,
+    interactive_command: &str,
+) -> Result<ImportSourceIdentitySpecs, anyhow::Error> {
+    let mut identity_specs = ImportSourceIdentitySpecs::default();
+    for document in identity_manifests {
+        if matching_identity_spec_exists(app, document).await? {
+            continue;
+        }
+        let inputs = identity_spec_inputs_for_add(
+            &document.manifest,
+            interactive,
+            interactive_command.to_string(),
+        )?;
+        identity_specs
+            .manifest_yamls
+            .push(document.manifest_yaml.clone());
+        if !inputs.is_empty() {
+            identity_specs.inputs.push(IdentitySpecImportInputs {
+                identity_spec_name: document.manifest.name.clone(),
+                inputs,
+            });
+        }
+    }
+    Ok(identity_specs)
+}
+
+pub(crate) async fn install_identity_specs_for_source_add(
+    app: &AppClient,
+    identity_manifests: &[IdentityManifestDocument],
+    interactive: bool,
+    interactive_command: &str,
+) -> Result<Vec<String>, anyhow::Error> {
+    let mut prepared = Vec::new();
+    for document in identity_manifests {
+        if matching_identity_spec_exists(app, document).await? {
+            continue;
+        }
+        let inputs = identity_spec_inputs_for_add(
+            &document.manifest,
+            interactive,
+            interactive_command.to_string(),
+        )?;
+        prepared.push((document, inputs));
+    }
+
+    let mut newly_installed_names = Vec::new();
+    for (document, inputs) in prepared {
+        let exists = match matching_identity_spec_exists(app, document).await {
+            Ok(exists) => exists,
+            Err(error) => {
+                rollback_identity_specs_for_source_add(newly_installed_names);
+                return Err(error);
+            }
+        };
+        if exists {
+            if !document.manifest.inputs.is_empty() {
+                rollback_identity_specs_for_source_add(newly_installed_names);
+                bail!(
+                    "identity spec '{}' was installed concurrently while source add was preparing setup inputs; retry source add",
+                    document.manifest.name
+                );
+            }
+            continue;
+        }
+        let has_setup_inputs = !document.manifest.inputs.is_empty();
+        match create_identity_spec(app, document.manifest_yaml.clone(), inputs).await {
+            Ok(_spec) => {
+                newly_installed_names.push(document.manifest.name.clone());
+            }
+            Err(error) => {
+                if tonic_status_code(&error) == Some(tonic::Code::FailedPrecondition) {
+                    if has_setup_inputs {
+                        rollback_identity_specs_for_source_add(newly_installed_names);
+                        bail!(
+                            "identity spec '{}' was installed concurrently while source add was preparing setup inputs; retry source add",
+                            document.manifest.name
+                        );
+                    }
+                    match matching_identity_spec_exists(app, document).await {
+                        Ok(true) => continue,
+                        Ok(false) => {}
+                        Err(recheck_error) => {
+                            rollback_identity_specs_for_source_add(newly_installed_names);
+                            return Err(recheck_error.context(format!(
+                                "failed to re-check identity spec '{}' after create-only install conflict",
+                                document.manifest.name
+                            )));
+                        }
+                    }
+                }
+                rollback_identity_specs_for_source_add(newly_installed_names);
+                return Err(error);
+            }
+        }
+    }
+    Ok(newly_installed_names)
+}
+
+async fn matching_identity_spec_exists(
+    app: &AppClient,
+    document: &IdentityManifestDocument,
+) -> Result<bool, anyhow::Error> {
+    match get_identity_spec(app, &document.manifest.name).await {
+        Ok(existing) => {
+            let existing_manifest = parse_identity_manifest_yaml(&existing.manifest_yaml)
+                .with_context(|| {
+                    format!(
+                        "installed identity spec '{}' could not be parsed",
+                        document.manifest.name
+                    )
+                })?;
+            if existing_manifest != document.manifest {
+                bail!(
+                    "identity spec '{}' is already installed with a different manifest; remove or update it before using this source bundle",
+                    document.manifest.name
+                );
+            }
+            Ok(true)
+        }
+        Err(error) => {
+            if tonic_status_code(&error) == Some(tonic::Code::NotFound) {
+                return Ok(false);
+            }
+            Err(error)
+        }
+    }
+}
+
+fn tonic_status_code(error: &anyhow::Error) -> Option<tonic::Code> {
+    error
+        .downcast_ref::<tonic::Status>()
+        .map(tonic::Status::code)
+}
+
+pub(crate) fn rollback_identity_specs_for_source_add(identity_spec_names: Vec<String>) {
+    for name in identity_spec_names {
+        eprintln!("{}", identity_spec_left_installed_warning(&name));
+    }
+}
+
+pub(crate) fn rollback_user_owned_identities_for_source_add(identity_names: Vec<String>) {
+    for name in identity_names {
+        eprintln!("{}", user_owned_identity_left_installed_warning(&name));
+    }
+}
+
+fn identity_spec_left_installed_warning(name: &str) -> String {
+    format!(
+        "Warning: source add installed identity spec '{name}' before a later step failed. It was left installed because deleting by name could remove concurrently changed state. Retry source add to reuse it, or remove it through the identity-spec management API after confirming no concurrent source add is using it."
+    )
+}
+
+fn user_owned_identity_left_installed_warning(name: &str) -> String {
+    format!(
+        "Warning: source add created user-owned identity '{name}' before a later step failed. It was left installed because deleting by name could remove concurrently changed credential state. Retry source add to reuse or select it, or remove it through the identity management API after confirming it still belongs to this failed setup."
+    )
+}
+
+pub(crate) async fn prompt_for_source_identity_bindings(
+    app: &AppClient,
+    manifest: &ValidatedSourceManifest,
+    identity_manifests: &[IdentityManifestDocument],
+) -> Result<PromptedSourceIdentityBindings, anyhow::Error> {
+    let requirements = source_identity_requirements(manifest).collect::<Vec<_>>();
+    if requirements.is_empty() {
+        return Ok(PromptedSourceIdentityBindings::default());
+    }
+    let mut available_identities = list_user_owned_identities(app).await?;
+    let mut reserved_identity_names = available_identities
+        .iter()
+        .map(|identity| identity.name.clone())
+        .collect::<BTreeSet<_>>();
+    let mut identity_specs = identity_manifests
+        .iter()
+        .map(|document| (document.manifest.name.clone(), document.manifest.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let mut identity_bindings = Vec::new();
+    let mut user_identity_bindings = Vec::new();
+    let mut created_user_identities = Vec::new();
+    for requirement in requirements {
+        let selected = match select_or_create_identity_for_surface(
+            app,
+            manifest.schema_name(),
+            &requirement,
+            &available_identities,
+            &mut reserved_identity_names,
+            &mut identity_specs,
+        )
+        .await
+        {
+            Ok(selected) => selected,
+            Err(error) => {
+                rollback_user_owned_identities_for_source_add(created_user_identities);
+                return Err(error);
+            }
+        };
+        if !available_identities
+            .iter()
+            .any(|identity| identity.name == selected.identity.name)
+        {
+            available_identities.push(selected.identity.clone());
+        }
+        if selected.created {
+            created_user_identities.push(selected.identity.name.clone());
+        }
+        identity_bindings.push(SourceIdentityBinding {
+            surface_id: requirement.surface_id.clone(),
+            identity: String::new(),
+            owner: SourceIdentityOwner::User as i32,
+            accepted_identity: String::new(),
+        });
+        user_identity_bindings.push(UserSourceIdentityBinding {
+            surface_id: requirement.surface_id.clone(),
+            identity: selected.identity.name,
+            accepted_identity: selected.accepted_identity,
+        });
+    }
+    Ok(PromptedSourceIdentityBindings {
+        identity_bindings,
+        user_identity_bindings,
+        created_user_identities,
+    })
+}
+
+#[derive(Default)]
+pub(crate) struct PromptedSourceIdentityBindings {
+    pub(crate) identity_bindings: Vec<SourceIdentityBinding>,
+    pub(crate) user_identity_bindings: Vec<UserSourceIdentityBinding>,
+    pub(crate) created_user_identities: Vec<String>,
+}
+
+#[derive(Clone)]
+struct SurfaceIdentityRequirement {
+    surface_id: String,
+    accepts: Vec<AcceptedIdentityRequirement>,
+}
+
+#[derive(Clone)]
+struct SelectedSurfaceIdentity {
+    identity: Identity,
+    accepted_identity: String,
+    created: bool,
+}
+
+#[derive(Clone)]
+struct IdentityCreationOption {
+    accepted_identity: String,
+    identity_spec: IdentityManifest,
+    method: IdentityCreationMethod,
+}
+
+#[derive(Clone)]
+enum IdentityCreationMethod {
+    OAuth { label: String },
+    FixedToken,
+}
+
+impl IdentityCreationMethod {
+    fn label(&self) -> &str {
+        match self {
+            Self::OAuth { label } => label,
+            Self::FixedToken => "Fixed token",
+        }
+    }
+}
+
+fn source_identity_requirements(
+    manifest: &ValidatedSourceManifest,
+) -> impl Iterator<Item = SurfaceIdentityRequirement> + '_ {
+    manifest.as_v4().into_iter().flat_map(|v4| {
+        v4.surfaces.iter().filter_map(|surface| {
+            surface
+                .identity_requirements
+                .as_ref()
+                .map(|requirements| SurfaceIdentityRequirement {
+                    surface_id: surface.id.clone(),
+                    accepts: requirements.accepts.clone(),
+                })
+        })
+    })
+}
+
+async fn select_or_create_identity_for_surface(
+    app: &AppClient,
+    source_name: &str,
+    requirement: &SurfaceIdentityRequirement,
+    existing_identities: &[Identity],
+    reserved_identity_names: &mut BTreeSet<String>,
+    identity_specs: &mut BTreeMap<String, IdentityManifest>,
+) -> Result<SelectedSurfaceIdentity, anyhow::Error> {
+    let compatible =
+        compatible_existing_identities(app, requirement, existing_identities, identity_specs)
+            .await?;
+    if let Some(selected) =
+        prompt_existing_identity_or_create(&requirement.surface_id, &compatible)?
+    {
+        return Ok(selected);
+    }
+    create_identity_for_surface(
+        app,
+        source_name,
+        requirement,
+        reserved_identity_names,
+        identity_specs,
+    )
+    .await
+}
+
+async fn compatible_existing_identities(
+    app: &AppClient,
+    requirement: &SurfaceIdentityRequirement,
+    existing_identities: &[Identity],
+    identity_specs: &mut BTreeMap<String, IdentityManifest>,
+) -> Result<Vec<SelectedSurfaceIdentity>, anyhow::Error> {
+    let mut compatible = Vec::new();
+    for identity in existing_identities {
+        let Some(identity_spec) =
+            identity_spec_manifest_cached(app, identity_specs, &identity.identity_spec).await?
+        else {
+            continue;
+        };
+        if let Some(accepted) = requirement.accepts.iter().find(|accepted| {
+            accepted
+                .identity_specs
+                .iter()
+                .any(|name| name == &identity.identity_spec)
+                && audience_matches(&accepted.audience, &identity_spec.audience)
+        }) {
+            compatible.push(SelectedSurfaceIdentity {
+                identity: identity.clone(),
+                accepted_identity: accepted.id.clone(),
+                created: false,
+            });
+        }
+    }
+    Ok(compatible)
+}
+
+fn prompt_existing_identity_or_create(
+    surface_id: &str,
+    compatible: &[SelectedSurfaceIdentity],
+) -> Result<Option<SelectedSurfaceIdentity>, anyhow::Error> {
+    if compatible.is_empty() {
+        return Ok(None);
+    }
+    let theme = ColorfulTheme::default();
+    let mut items = compatible
+        .iter()
+        .map(|candidate| {
+            format!(
+                "Use {} ({})",
+                candidate.identity.name, candidate.identity.identity_spec
+            )
+        })
+        .collect::<Vec<_>>();
+    items.push("Create new identity".to_string());
+    let selected = Select::with_theme(&theme)
+        .with_prompt(format!("{surface_id} identity"))
+        .items(&items)
+        .default(0)
+        .interact()?;
+    if selected == compatible.len() {
+        Ok(None)
+    } else {
+        Ok(compatible.get(selected).cloned())
+    }
+}
+
+async fn create_identity_for_surface(
+    app: &AppClient,
+    source_name: &str,
+    requirement: &SurfaceIdentityRequirement,
+    reserved_identity_names: &mut BTreeSet<String>,
+    identity_specs: &mut BTreeMap<String, IdentityManifest>,
+) -> Result<SelectedSurfaceIdentity, anyhow::Error> {
+    let options = identity_creation_options(app, requirement, identity_specs).await?;
+    if options.is_empty() {
+        return Err(anyhow::anyhow!(
+            "source surface '{}' has no installed identity spec that can be created",
+            requirement.surface_id
+        ));
+    }
+    let selected = select_identity_creation_option(&requirement.surface_id, options)?;
+    let identity_name = generated_source_identity_name(
+        source_name,
+        &requirement.surface_id,
+        &selected.identity_spec.name,
+        reserved_identity_names,
+    );
+    let identity = match selected.method {
+        IdentityCreationMethod::OAuth { label } => {
+            let method = identity_oauth_method(&selected.identity_spec)?;
+            print_oauth_hint(method.hint);
+            let credential_inputs =
+                prompt_identity_oauth_inputs(&selected.identity_spec, method.oauth)?;
+            create_user_owned_identity_with_oauth(
+                app,
+                &identity_name,
+                &selected.identity_spec.name,
+                credential_inputs,
+                &label,
+            )
+            .await?
+        }
+        IdentityCreationMethod::FixedToken => {
+            let token = prompt_fixed_token_identity_token(&selected.identity_spec.name)?;
+            create_user_owned_identity_with_fixed_token(
+                app,
+                &identity_name,
+                &selected.identity_spec.name,
+                token,
+            )
+            .await?
+        }
+    };
+    Ok(SelectedSurfaceIdentity {
+        identity,
+        accepted_identity: selected.accepted_identity,
+        created: true,
+    })
+}
+
+async fn identity_creation_options(
+    app: &AppClient,
+    requirement: &SurfaceIdentityRequirement,
+    identity_specs: &mut BTreeMap<String, IdentityManifest>,
+) -> Result<Vec<IdentityCreationOption>, anyhow::Error> {
+    let mut options = Vec::new();
+    for accepted in &requirement.accepts {
+        for identity_spec_name in &accepted.identity_specs {
+            let Some(identity_spec) =
+                identity_spec_manifest_cached(app, identity_specs, identity_spec_name).await?
+            else {
+                continue;
+            };
+            if !audience_matches(&accepted.audience, &identity_spec.audience) {
+                continue;
+            }
+            let method = match identity_spec.identity_type {
+                IdentitySpecType::OAuth => {
+                    let method = identity_oauth_method(&identity_spec)?;
+                    IdentityCreationMethod::OAuth {
+                        label: method.label.clone(),
+                    }
+                }
+                IdentitySpecType::FixedToken => IdentityCreationMethod::FixedToken,
+            };
+            options.push(IdentityCreationOption {
+                accepted_identity: accepted.id.clone(),
+                identity_spec,
+                method,
+            });
+        }
+    }
+    Ok(options)
+}
+
+fn select_identity_creation_option(
+    surface_id: &str,
+    options: Vec<IdentityCreationOption>,
+) -> Result<IdentityCreationOption, anyhow::Error> {
+    if options.len() == 1 {
+        return options
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("missing identity creation option"));
+    }
+    let theme = ColorfulTheme::default();
+    let items = options
+        .iter()
+        .map(|option| {
+            format!(
+                "{} ({}, {})",
+                option.identity_spec.name,
+                option.method.label(),
+                option.identity_spec.issuer
+            )
+        })
+        .collect::<Vec<_>>();
+    let selected = Select::with_theme(&theme)
+        .with_prompt(format!("Create identity for {surface_id}"))
+        .items(&items)
+        .default(0)
+        .interact()?;
+    options
+        .into_iter()
+        .nth(selected)
+        .ok_or_else(|| anyhow::anyhow!("identity selection {selected} is out of range"))
+}
+
+pub(crate) fn prompt_fixed_token_identity_token(
+    identity_spec_name: &str,
+) -> Result<String, anyhow::Error> {
+    let token = Password::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!("Token for {identity_spec_name}"))
+        .allow_empty_password(false)
+        .interact()?;
+    Ok(token)
+}
+
+async fn identity_spec_manifest_cached(
+    app: &AppClient,
+    identity_specs: &mut BTreeMap<String, IdentityManifest>,
+    name: &str,
+) -> Result<Option<IdentityManifest>, anyhow::Error> {
+    if let Some(manifest) = identity_specs.get(name) {
+        return Ok(Some(manifest.clone()));
+    }
+    let record = match get_identity_spec(app, name).await {
+        Ok(record) => record,
+        Err(error)
+            if error
+                .downcast_ref::<tonic::Status>()
+                .is_some_and(|status| status.code() == tonic::Code::NotFound) =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(error),
+    };
+    let manifest = parse_identity_manifest_yaml(&record.manifest_yaml)?;
+    identity_specs.insert(name.to_string(), manifest.clone());
+    Ok(Some(manifest))
+}
+
+fn audience_matches(
+    required: &BTreeMap<String, serde_json::Value>,
+    candidate: &BTreeMap<String, serde_json::Value>,
+) -> bool {
+    required
+        .iter()
+        .all(|(key, value)| candidate.get(key) == Some(value))
+}
+
+fn generated_source_identity_name(
+    source_name: &str,
+    surface_id: &str,
+    identity_spec_name: &str,
+    reserved_names: &mut BTreeSet<String>,
+) -> String {
+    let base = format!("{source_name}_{surface_id}_{identity_spec_name}");
+    loop {
+        let candidate = format!("{base}_{}", uuid::Uuid::new_v4().simple());
+        if reserved_names.insert(candidate.clone()) {
+            return candidate;
+        }
+    }
 }
 
 struct OAuthStreamContext {
@@ -324,6 +1020,28 @@ impl From<import_source_response::Event> for CredentialStreamEvent<Source> {
     }
 }
 
+impl From<create_user_owned_identity_with_o_auth_response::Event>
+    for CredentialStreamEvent<Identity>
+{
+    fn from(event: create_user_owned_identity_with_o_auth_response::Event) -> Self {
+        match event {
+            create_user_owned_identity_with_o_auth_response::Event::Identity(identity) => {
+                Self::Completed(identity)
+            }
+            create_user_owned_identity_with_o_auth_response::Event::OauthAuthorization(
+                authorization,
+            ) => Self::OAuthAuthorization {
+                input_key: authorization.input_key,
+                authorization_url: authorization.authorization_url,
+                user_code: authorization.user_code,
+            },
+            create_user_owned_identity_with_o_auth_response::Event::OauthCompleted(_) => {
+                Self::OAuthCompleted
+            }
+        }
+    }
+}
+
 fn handle_credential_stream_event<T>(
     event: Option<CredentialStreamEvent<T>>,
     oauth_labels: &BTreeMap<String, String>,
@@ -363,9 +1081,7 @@ fn handle_oauth_authorization_event(
     oauth_labels: &BTreeMap<String, String>,
     redirect_prompt: &mut OAuthRedirectPastePrompt,
 ) {
-    let label = oauth_labels
-        .get(input_key)
-        .map_or(input_key, String::as_str);
+    let label = oauth_label_for_input_key(input_key, oauth_labels);
     println!("Open this URL to connect {label}:");
     println!("{authorization_url}");
     redirect_prompt.cancel_and_join();
@@ -377,6 +1093,15 @@ fn handle_oauth_authorization_event(
     if let Err(err) = crate::browser::open_url(authorization_url) {
         println!("{}", style(format!("Could not open browser: {err}")).dim());
     }
+}
+
+fn oauth_label_for_input_key<'a>(
+    input_key: &'a str,
+    oauth_labels: &'a BTreeMap<String, String>,
+) -> &'a str {
+    oauth_labels
+        .get(input_key)
+        .map_or(input_key, String::as_str)
 }
 
 pub(crate) async fn validate_source(
@@ -403,20 +1128,40 @@ async fn validate_source_request(
 pub(crate) fn load_validated_manifest_file(
     file: &Path,
 ) -> Result<(String, ValidatedSourceManifest), anyhow::Error> {
-    let manifest_yaml = std::fs::read_to_string(file)?;
-    load_validated_manifest_file_yaml(file, &manifest_yaml)
+    let bundle = load_validated_manifest_bundle_file(file)?;
+    Ok((bundle.source_manifest_yaml, bundle.source_manifest))
 }
 
-pub(crate) fn load_validated_manifest_file_yaml(
+pub(crate) struct ValidatedManifestBundleFile {
+    pub(crate) source_manifest_yaml: String,
+    pub(crate) source_manifest: ValidatedSourceManifest,
+    pub(crate) identity_manifests: Vec<IdentityManifestDocument>,
+}
+
+pub(crate) fn load_validated_manifest_bundle_file(
+    file: &Path,
+) -> Result<ValidatedManifestBundleFile, anyhow::Error> {
+    let raw = std::fs::read_to_string(file)?;
+    load_validated_manifest_bundle_file_yaml(file, raw.as_str())
+}
+
+pub(crate) fn load_validated_manifest_bundle_file_yaml(
     file: &Path,
     manifest_yaml: &str,
-) -> Result<(String, ValidatedSourceManifest), anyhow::Error> {
-    let manifest = parse_source_manifest_yaml(manifest_yaml)?;
+) -> Result<ValidatedManifestBundleFile, anyhow::Error> {
+    let bundle = parse_manifest_bundle_yaml(manifest_yaml)?;
     let manifest_dir = manifest_file_parent_dir(file)?;
-    let manifest_yaml =
-        durable_manifest_file_yaml(manifest_yaml, &manifest, manifest_dir.as_path())?;
-    let manifest = parse_source_manifest_yaml(manifest_yaml.as_str())?;
-    Ok((manifest_yaml, manifest))
+    let source_manifest_yaml = durable_manifest_file_yaml(
+        &bundle.source_manifest_yaml,
+        &bundle.source_manifest,
+        manifest_dir.as_path(),
+    )?;
+    let source_manifest = parse_source_manifest_yaml(source_manifest_yaml.as_str())?;
+    Ok(ValidatedManifestBundleFile {
+        source_manifest_yaml,
+        source_manifest,
+        identity_manifests: bundle.identity_manifests,
+    })
 }
 
 fn manifest_file_parent_dir(file: &Path) -> Result<PathBuf, anyhow::Error> {
@@ -623,8 +1368,12 @@ pub(crate) async fn delete_source(app: &AppClient, name: &str) -> Result<(), any
 }
 
 pub(crate) fn require_interactive() -> Result<(), anyhow::Error> {
+    require_interactive_for("interactive source install")
+}
+
+pub(crate) fn require_interactive_for(action: &str) -> Result<(), anyhow::Error> {
     if !stdin().is_terminal() || !stdout().is_terminal() {
-        return Err(anyhow::anyhow!("interactive source install requires a TTY"));
+        return Err(anyhow::anyhow!("{action} requires a TTY"));
     }
     Ok(())
 }
@@ -723,6 +1472,80 @@ pub(crate) fn collect_inputs_from_env(
     )
 }
 
+pub(crate) fn identity_spec_inputs_for_add(
+    manifest: &IdentityManifest,
+    interactive: bool,
+    interactive_command: String,
+) -> Result<Vec<IdentitySpecInput>, anyhow::Error> {
+    if manifest.inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+    if interactive {
+        return prompt_identity_spec_inputs(manifest);
+    }
+    collect_identity_spec_inputs_from_env(manifest, interactive_command)
+}
+
+pub(crate) fn collect_identity_spec_inputs_from_env(
+    manifest: &IdentityManifest,
+    interactive_command: String,
+) -> Result<Vec<IdentitySpecInput>, anyhow::Error> {
+    let mut values = Vec::new();
+    let mut missing = Vec::new();
+
+    for input in &manifest.inputs {
+        let value = read_identity_spec_input_env(&input.key).filter(|value| !value.is_empty());
+        if let Some(value) = value {
+            values.push(IdentitySpecInput {
+                key: input.key.clone(),
+                value,
+            });
+            continue;
+        }
+        let default_resolves_in_manifest =
+            input.kind == ManifestInputKind::Variable && !input.default_value.is_empty();
+        if input.required && !default_resolves_in_manifest {
+            missing.push(input.key.clone());
+        }
+    }
+
+    if !missing.is_empty() {
+        return Err(missing_environment_variables_error(
+            &missing,
+            Some(interactive_command),
+        ));
+    }
+
+    Ok(values)
+}
+
+pub(crate) fn prompt_identity_spec_inputs(
+    manifest: &IdentityManifest,
+) -> Result<Vec<IdentitySpecInput>, anyhow::Error> {
+    let mut values = Vec::new();
+    for input in &manifest.inputs {
+        match input.kind {
+            ManifestInputKind::Variable => {
+                if let Some(variable) = prompt_variable(input)? {
+                    values.push(IdentitySpecInput {
+                        key: variable.key,
+                        value: variable.value,
+                    });
+                }
+            }
+            ManifestInputKind::Secret => {
+                if let Some(secret) = prompt_source_config_secret(input, None)? {
+                    values.push(IdentitySpecInput {
+                        key: secret.key,
+                        value: secret.value,
+                    });
+                }
+            }
+        }
+    }
+    Ok(values)
+}
+
 pub(crate) fn shell_quote_arg(value: &str) -> String {
     if value
         .chars()
@@ -738,6 +1561,14 @@ pub(crate) fn shell_quote_arg(value: &str) -> String {
     reason = "`coral source add` reads install-time source inputs from matching environment variables."
 )]
 fn read_source_input_env(key: &str) -> Option<String> {
+    std::env::var(key).ok()
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "Identity spec setup reads install-time inputs from matching environment variables."
+)]
+fn read_identity_spec_input_env(key: &str) -> Option<String> {
     std::env::var(key).ok()
 }
 
@@ -776,19 +1607,29 @@ fn collect_inputs_with_hint(
     }
 
     if !missing.is_empty() {
-        let interactive_hint = interactive_command.map_or_else(
-            || "--interactive".to_string(),
-            |command| format!("`{command}`"),
-        );
-        return Err(anyhow::anyhow!(
-            "missing required environment variable{}: {}. Set the variable{} or run {interactive_hint}.",
-            if missing.len() == 1 { "" } else { "s" },
-            missing.join(", "),
-            if missing.len() == 1 { "" } else { "s" },
+        return Err(missing_environment_variables_error(
+            &missing,
+            interactive_command,
         ));
     }
 
     Ok((variables, secrets))
+}
+
+fn missing_environment_variables_error(
+    missing: &[String],
+    interactive_command: Option<String>,
+) -> anyhow::Error {
+    let interactive_hint = interactive_command.map_or_else(
+        || "--interactive".to_string(),
+        |command| format!("`{command}`"),
+    );
+    anyhow::anyhow!(
+        "missing required environment variable{}: {}. Set the variable{} or run {interactive_hint}.",
+        if missing.len() == 1 { "" } else { "s" },
+        missing.join(", "),
+        if missing.len() == 1 { "" } else { "s" },
+    )
 }
 
 pub(crate) fn source_origin_label(origin: i32) -> &'static str {
@@ -806,6 +1647,49 @@ pub(crate) fn source_credential_storage_label(storage: i32) -> &'static str {
         Ok(SourceCredentialStorage::Keychain) => "keychain",
         Err(_) => "unknown",
     }
+}
+
+/// Secret-storage label for a `coral source add` summary, or `None` when the
+/// source stores no secrets.
+///
+/// DSL v4 sources never store secrets — they authenticate through identities —
+/// so this returns `None` for them, as well as for any source whose inputs
+/// declared no secrets. Callers omit the secret summary entirely in that case.
+pub(crate) fn added_source_secret_storage_label(storage: i32) -> Option<&'static str> {
+    match SourceCredentialStorage::try_from(storage) {
+        Ok(SourceCredentialStorage::File | SourceCredentialStorage::Keychain) => {
+            Some(source_credential_storage_label(storage))
+        }
+        _ => None,
+    }
+}
+
+pub(crate) struct SelectedIdentityOAuthMethod<'a> {
+    pub(crate) label: String,
+    pub(crate) hint: Option<&'a str>,
+    pub(crate) oauth: &'a ManifestOAuthCredentialSpec,
+}
+
+pub(crate) fn identity_oauth_method(
+    manifest: &IdentityManifest,
+) -> Result<SelectedIdentityOAuthMethod<'_>, anyhow::Error> {
+    let IdentitySpecConfig::OAuth(oauth) = &manifest.config else {
+        return Err(anyhow::anyhow!(
+            "identity spec '{}' has type '{}'; expected oauth",
+            manifest.name,
+            manifest.identity_type.label()
+        ));
+    };
+    let method = &oauth.method;
+    Ok(SelectedIdentityOAuthMethod {
+        label: identity_oauth_method_label(method),
+        hint: method.hint.as_deref(),
+        oauth: &method.oauth,
+    })
+}
+
+pub(crate) fn print_oauth_hint(hint: Option<&str>) {
+    print_prompt_hint(hint);
 }
 
 pub(crate) async fn validate_and_print(
@@ -1213,6 +2097,13 @@ fn credential_method_label(method: &ManifestCredentialMethod) -> String {
     })
 }
 
+fn identity_oauth_method_label(method: &coral_spec::IdentityOAuthMethodSpec) -> String {
+    method
+        .label
+        .clone()
+        .unwrap_or_else(|| "Connect with OAuth".to_string())
+}
+
 fn collect_oauth_credential_method(
     input: &ManifestInputSpec,
     method_index: usize,
@@ -1576,11 +2467,31 @@ fn http_status_is_success(status: &str) -> bool {
         .is_some_and(|code| (200..300).contains(&code))
 }
 
-fn prompt_oauth_credential_inputs(
+pub(crate) fn prompt_oauth_credential_inputs(
     oauth: &ManifestOAuthCredentialSpec,
+) -> Result<Vec<OAuthCredentialInput>, anyhow::Error> {
+    prompt_oauth_credential_inputs_excluding(oauth, &BTreeSet::new())
+}
+
+pub(crate) fn prompt_identity_oauth_inputs(
+    manifest: &IdentityManifest,
+    oauth: &ManifestOAuthCredentialSpec,
+) -> Result<Vec<OAuthCredentialInput>, anyhow::Error> {
+    let declared = manifest
+        .inputs
+        .iter()
+        .map(|input| input.key.as_str())
+        .collect::<BTreeSet<_>>();
+    prompt_oauth_credential_inputs_excluding(oauth, &declared)
+}
+
+fn prompt_oauth_credential_inputs_excluding(
+    oauth: &ManifestOAuthCredentialSpec,
+    excluded_inputs: &BTreeSet<&str>,
 ) -> Result<Vec<OAuthCredentialInput>, anyhow::Error> {
     let mut values = Vec::new();
     if let Some(input_key) = oauth.client.id.input.as_deref()
+        && !excluded_inputs.contains(input_key)
         && let Some(value) = prompt_oauth_client_id(input_key, oauth.client.id.default.as_deref())?
     {
         values.push(OAuthCredentialInput {
@@ -1588,7 +2499,9 @@ fn prompt_oauth_credential_inputs(
             value,
         });
     }
-    if let Some(secret) = oauth.client.secret.as_ref() {
+    if let Some(secret) = oauth.client.secret.as_ref()
+        && !excluded_inputs.contains(secret.input.as_str())
+    {
         let value = prompt_oauth_client_secret(&secret.input)?;
         values.push(OAuthCredentialInput {
             key: secret.input.clone(),
@@ -1690,23 +2603,85 @@ mod tests {
     use coral_api::v1::ValidateSourceResponse;
     use coral_spec::{
         ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
-        ManifestInputKind, ManifestInputSpec,
+        ManifestInputKind, ManifestInputSpec, parse_identity_manifest_yaml,
     };
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
     use std::io::{Read as _, Write as _};
     use std::net::TcpListener;
     use std::thread;
+    use tempfile::TempDir;
     use url::Url;
 
     use super::{
-        CredentialPromptMode, RedirectPromptAction, ValidationFollowUp, ValidationSeverityMode,
-        apply_redirect_prompt_key, collect_inputs_with_hint, expected_oauth_redirect,
-        finalize_input_value, render_redirect_prompt_key_echo, resolve_prompt_hint,
-        shell_quote_arg, source_name_arg, submit_oauth_redirect_url, validate_oauth_redirect_url,
+        CredentialPromptMode, IDENTITY_OAUTH_PROGRESS_INPUT_KEY, RedirectPromptAction,
+        ValidationFollowUp, ValidationSeverityMode, apply_redirect_prompt_key, audience_matches,
+        collect_inputs_with_hint, expected_oauth_redirect, finalize_input_value,
+        generated_source_identity_name, identity_spec_inputs_for_add,
+        identity_spec_left_installed_warning, load_validated_manifest_file, oauth_error,
+        oauth_label_for_input_key, render_redirect_prompt_key_echo, resolve_prompt_hint,
+        shell_quote_arg, source_name_arg, submit_oauth_redirect_url,
+        user_owned_identity_left_installed_warning, validate_oauth_redirect_url,
         validation_follow_up,
     };
+
+    #[test]
+    fn added_source_secret_storage_label_omits_summary_for_secretless_sources() {
+        use coral_api::v1::SourceCredentialStorage;
+
+        assert_eq!(
+            super::added_source_secret_storage_label(SourceCredentialStorage::Unspecified as i32),
+            None,
+            "DSL v4 and other secretless sources should not show a secret summary"
+        );
+        assert_eq!(
+            super::added_source_secret_storage_label(SourceCredentialStorage::File as i32),
+            Some("file (plaintext)")
+        );
+        assert_eq!(
+            super::added_source_secret_storage_label(SourceCredentialStorage::Keychain as i32),
+            Some("keychain")
+        );
+    }
+
+    #[test]
+    fn load_validated_manifest_file_resolves_v4_file_descriptors_relative_to_manifest() {
+        let temp = TempDir::new().expect("temp dir");
+        let source_dir = temp.path().join("statusgator_v4");
+        std::fs::create_dir_all(&source_dir).expect("source dir");
+        std::fs::write(source_dir.join("openapi.yaml"), "openapi: 3.0.0\n").expect("write openapi");
+        let manifest_file = source_dir.join("manifest.yaml");
+        std::fs::write(
+            &manifest_file,
+            r"
+name: statusgator_v4
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+",
+        )
+        .expect("write manifest");
+
+        let (manifest_yaml, manifest) =
+            load_validated_manifest_file(&manifest_file).expect("load manifest");
+
+        assert_eq!(manifest.schema_name(), "statusgator_v4");
+        let value: serde_yaml::Value =
+            serde_yaml::from_str(&manifest_yaml).expect("rewritten yaml parses");
+        let file = value["surfaces"][0]["file"].as_str().expect("surface file");
+        assert_eq!(
+            file,
+            source_dir
+                .join("openapi.yaml")
+                .canonicalize()
+                .expect("canonical descriptor")
+                .to_string_lossy()
+        );
+    }
 
     #[test]
     fn collect_inputs_reads_variables_and_secrets_from_lookup() {
@@ -1925,6 +2900,111 @@ mod tests {
     }
 
     #[test]
+    fn identity_spec_inputs_for_add_noninteractive_uses_environment_only() {
+        let input_key = format!(
+            "CORAL_CLI_TEST_REQUIRED_IDENTITY_INPUT_{}",
+            std::process::id()
+        );
+        let manifest = parse_identity_manifest_yaml(&format!(
+            r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+issuer: demo
+type: oauth
+audience:
+  host: api.example.test
+inputs:
+  {input_key}:
+    kind: secret
+    required: true
+oauth:
+  method:
+    label: Demo OAuth
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/callback
+    endpoints:
+      authorization_url: https://auth.example.test/authorize
+      token_url: https://auth.example.test/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: {input_key}
+        transport: request_body
+"
+        ))
+        .expect("identity manifest");
+
+        let error = identity_spec_inputs_for_add(
+            &manifest,
+            false,
+            "coral source add --interactive --file bundle.yaml".to_string(),
+        )
+        .expect_err("noninteractive identity spec inputs should require env");
+        let message = error.to_string();
+        assert!(message.contains(&input_key), "unexpected error: {message}");
+        assert!(
+            message.contains("coral source add --interactive --file bundle.yaml"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn rollback_warnings_explain_non_destructive_cleanup() {
+        let identity_spec = identity_spec_left_installed_warning("github_oauth");
+        assert!(identity_spec.contains("github_oauth"));
+        assert!(identity_spec.contains("left installed"));
+        assert!(identity_spec.contains("identity-spec management API"));
+        assert!(identity_spec.contains("Retry source add"));
+
+        let identity = user_owned_identity_left_installed_warning("github_users_github_oauth");
+        assert!(identity.contains("github_users_github_oauth"));
+        assert!(identity.contains("left installed"));
+        assert!(identity.contains("identity management API"));
+        assert!(identity.contains("Retry source add"));
+    }
+
+    #[test]
+    fn identity_oauth_error_points_back_to_source_add() {
+        let error = oauth_error(
+            "identity creation",
+            &tonic::Status::unavailable("provider unavailable"),
+            "coral source add --interactive --file <manifest.yaml>",
+        );
+        let message = error.to_string();
+
+        assert!(
+            message.contains("coral source add --interactive --file <manifest.yaml>"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            !message.contains("coral identity add"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn identity_oauth_progress_label_uses_access_token_event_key() {
+        let labels = BTreeMap::from([(
+            IDENTITY_OAUTH_PROGRESS_INPUT_KEY.to_string(),
+            "GitHub OAuth".to_string(),
+        )]);
+
+        assert_eq!(
+            oauth_label_for_input_key(IDENTITY_OAUTH_PROGRESS_INPUT_KEY, &labels),
+            "GitHub OAuth"
+        );
+        assert_eq!(
+            oauth_label_for_input_key("OTHER_TOKEN", &labels),
+            "OTHER_TOKEN"
+        );
+    }
+
+    #[test]
     fn source_name_arg_rejects_dot_segments() {
         let error = source_name_arg(Some("..")).expect_err("dot segment should fail");
         assert!(error.to_string().contains("must not be '.' or '..'"));
@@ -1989,6 +3069,49 @@ mod tests {
             "'fixtures/my source.yaml'"
         );
         assert_eq!(shell_quote_arg("it'demo.yaml"), "'it'\\''demo.yaml'");
+    }
+
+    #[test]
+    fn audience_matches_requires_required_subset() {
+        let required = BTreeMap::from([("host".to_string(), serde_json::json!("github.com"))]);
+        let candidate = BTreeMap::from([
+            ("host".to_string(), serde_json::json!("github.com")),
+            ("scheme".to_string(), serde_json::json!("https")),
+        ]);
+        assert!(audience_matches(&required, &candidate));
+
+        let mismatched =
+            BTreeMap::from([("host".to_string(), serde_json::json!("api.github.com"))]);
+        assert!(!audience_matches(&required, &mismatched));
+
+        let missing = BTreeMap::new();
+        assert!(!audience_matches(&required, &missing));
+    }
+
+    #[test]
+    fn generated_source_identity_name_uses_unique_suffix() {
+        let mut reserved_names = BTreeSet::from([
+            "github_v4_rest_github_oauth".to_string(),
+            "github_v4_rest_github_oauth_2".to_string(),
+        ]);
+
+        let generated = generated_source_identity_name(
+            "github_v4",
+            "rest",
+            "github_oauth",
+            &mut reserved_names,
+        );
+
+        let prefix = "github_v4_rest_github_oauth_";
+        assert!(generated.starts_with(prefix));
+        let suffix = generated
+            .strip_prefix(prefix)
+            .expect("generated name should use expected prefix");
+        assert_eq!(suffix.len(), 32);
+        assert!(suffix.chars().all(|ch| ch.is_ascii_hexdigit()));
+        assert!(reserved_names.contains(&generated));
+        assert_ne!(generated, "github_v4_rest_github_oauth");
+        assert_ne!(generated, "github_v4_rest_github_oauth_2");
     }
 
     #[test]

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -18,8 +18,8 @@ use arrow::record_batch::RecordBatch;
 use assert_cmd::Command;
 use assert_cmd::assert::Assert;
 use coral_api::v1::{
-    DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, Source,
-    SourceCredentialStorage, SourceInfo, SourceOrigin,
+    DiscoverSourcesResponse, ExecuteSqlResponse, GetIdentitySpecResponse, IdentitySpec,
+    ListSourcesResponse, Source, SourceCredentialStorage, SourceInfo, SourceOrigin,
 };
 use tempfile::{TempDir, tempdir};
 use tonic::Code;
@@ -728,6 +728,73 @@ fn v4_github_source_dir(manifest_suffix: &str) -> (TempDir, PathBuf) {
     (source_dir, manifest_file)
 }
 
+/// Minimal fixed-token identity spec manifest for the given spec name.
+fn fixed_token_spec_yaml(name: &str) -> String {
+    format!(
+        r"
+kind: identity
+spec_version: 1
+name: {name}
+version: 0.1.0
+issuer: github
+type: fixed_token
+"
+    )
+}
+
+/// OAuth identity spec manifest with one install-time input.
+fn oauth_spec_with_required_input_yaml(name: &str, input_key: &str) -> String {
+    format!(
+        r"
+kind: identity
+spec_version: 1
+name: {name}
+version: 0.1.0
+issuer: github
+type: oauth
+audience:
+  host: github.com
+inputs:
+  {input_key}:
+    kind: secret
+    required: true
+oauth:
+  method:
+    label: GitHub OAuth
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    endpoints:
+      authorization_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+    client:
+      id:
+        default: github-client
+      secret:
+        input: {input_key}
+        transport: request_body
+"
+    )
+}
+
+fn identity_spec_response(
+    name: &str,
+    identity_type: &str,
+    manifest_yaml: String,
+) -> GetIdentitySpecResponse {
+    GetIdentitySpecResponse {
+        identity_spec: Some(IdentitySpec {
+            name: name.to_string(),
+            version: "0.1.0".to_string(),
+            description: String::new(),
+            issuer: "github".to_string(),
+            identity_type: identity_type.to_string(),
+            manifest_yaml,
+        }),
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn source_add_file_resolves_v4_relative_descriptor_from_manifest_dir() {
     let server = MockServer::start().await;
@@ -761,6 +828,406 @@ async fn source_add_file_resolves_v4_relative_descriptor_from_manifest_dir() {
     assert!(
         !manifest_yaml.contains("file: openapi.yaml"),
         "expected relative descriptor to be replaced before import: {manifest_yaml}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_file_with_v4_identity_requirements_requires_tty() {
+    let server = MockServer::start().await;
+    let (_source_dir, manifest_file) = v4_github_source_dir(
+        r"    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+          audience:
+            host: github.com
+",
+    );
+
+    let assert = server
+        .cmd()
+        .args([
+            "--enable-dsl-v4",
+            "source",
+            "add",
+            "--file",
+            manifest_file.to_str().expect("fixture path utf8"),
+        ])
+        .assert()
+        .failure();
+
+    let stderr = stderr_text(&assert);
+    assert!(
+        stderr.contains("source identity setup requires a TTY"),
+        "expected source identity TTY requirement error: {stderr}"
+    );
+    assert!(
+        server.import_source_requests().is_empty(),
+        "source import must not run before identity setup"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_file_rejects_identity_spec_bundle_before_server_import_when_dsl_v4_disabled() {
+    let server = MockServer::start().await;
+    let source_dir = tempdir().expect("source dir");
+    let manifest_file = write_yaml(
+        &source_dir,
+        "bundle.yaml",
+        &format!(
+            r"
+---{spec}---
+name: github
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables: []
+",
+            spec = fixed_token_spec_yaml("github_oauth")
+        ),
+    );
+
+    let assert = server
+        .cmd()
+        .args([
+            "source",
+            "add",
+            "--file",
+            manifest_file.to_str().expect("fixture path utf8"),
+        ])
+        .assert()
+        .failure();
+
+    let stderr = stderr_text(&assert);
+    assert!(
+        stderr.contains("DSL v4 sources require"),
+        "expected dsl_v4 feature error: {stderr}"
+    );
+    assert!(
+        server.import_source_requests().is_empty(),
+        "source import must not run when identity bundle is feature-gated"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_file_imports_identity_specs_from_manifest_bundle_when_dsl_v4_enabled() {
+    let server = MockServer::start_with_config(
+        MockServerConfig::default()
+            .with_get_identity_spec_error(Code::NotFound, "identity spec not found"),
+    )
+    .await;
+    let source_dir = tempdir().expect("source dir");
+    let manifest_file = write_yaml(
+        &source_dir,
+        "bundle.yaml",
+        &format!(
+            r"
+---{spec}---
+name: github
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: users
+    description: Demo users
+    request:
+      method: GET
+      path: /users
+    columns:
+      - name: id
+        type: Utf8
+",
+            spec = fixed_token_spec_yaml("github_oauth")
+        ),
+    );
+
+    server
+        .cmd()
+        .args([
+            "--enable-dsl-v4",
+            "source",
+            "add",
+            "--file",
+            manifest_file.to_str().expect("fixture path utf8"),
+        ])
+        .assert()
+        .success();
+
+    let requests = server.import_source_requests();
+    assert_eq!(requests.len(), 1, "expected one import_source call");
+    assert!(
+        requests[0].replace_identity_bindings,
+        "source add should replace source identity bindings on import"
+    );
+    assert_eq!(
+        requests[0].identity_spec_manifest_yamls.len(),
+        1,
+        "expected bundled identity spec to be imported with the source"
+    );
+    assert!(
+        requests[0].identity_spec_manifest_yamls[0].contains("name: github_oauth"),
+        "expected github_oauth identity spec in import request"
+    );
+    assert!(
+        requests[0].identity_spec_inputs.is_empty(),
+        "fixed-token identity spec should not require setup inputs"
+    );
+    assert!(
+        server.add_identity_spec_requests().is_empty(),
+        "source bundle identity specs must not use replace-capable add_identity_spec"
+    );
+    assert_eq!(
+        server.create_identity_spec_requests().len(),
+        0,
+        "source import should own bundled identity spec installation"
+    );
+    assert!(
+        !requests[0].manifest_yaml.contains("kind: identity"),
+        "source manifest sent to import should contain only the source document"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_file_forwards_identity_spec_inputs_from_env_without_interactive() {
+    let source_dir = tempdir().expect("source dir");
+    let input_key = "CORAL_CLI_TEST_IDENTITY_SPEC_SECRET";
+    let spec = oauth_spec_with_required_input_yaml("github_oauth", input_key);
+    let server = MockServer::start_with_config(
+        MockServerConfig::default()
+            .with_get_identity_spec_error(Code::NotFound, "identity spec not found"),
+    )
+    .await;
+    let manifest_file = write_yaml(
+        &source_dir,
+        "bundle.yaml",
+        &format!(
+            r"
+---{spec}---
+name: github
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: users
+    description: Demo users
+    request:
+      method: GET
+      path: /users
+    columns:
+      - name: id
+        type: Utf8
+"
+        ),
+    );
+
+    server
+        .cmd()
+        .env(input_key, "identity-input-secret")
+        .args([
+            "--enable-dsl-v4",
+            "source",
+            "add",
+            "--file",
+            manifest_file.to_str().expect("fixture path utf8"),
+        ])
+        .assert()
+        .success();
+
+    let requests = server.import_source_requests();
+    assert_eq!(requests.len(), 1, "expected one import_source call");
+    assert_eq!(
+        requests[0].identity_spec_manifest_yamls.len(),
+        1,
+        "expected bundled identity spec to be imported with the source"
+    );
+    assert!(
+        requests[0].identity_spec_manifest_yamls[0].contains("name: github_oauth"),
+        "expected github_oauth identity spec in import request"
+    );
+    assert_eq!(
+        requests[0].identity_spec_inputs.len(),
+        1,
+        "identity spec setup inputs should be forwarded to source import"
+    );
+    assert_eq!(
+        requests[0].identity_spec_inputs[0].identity_spec_name,
+        "github_oauth"
+    );
+    assert_eq!(requests[0].identity_spec_inputs[0].inputs.len(), 1);
+    assert_eq!(requests[0].identity_spec_inputs[0].inputs[0].key, input_key);
+    assert_eq!(
+        requests[0].identity_spec_inputs[0].inputs[0].value,
+        "identity-input-secret"
+    );
+    assert!(
+        server.add_identity_spec_requests().is_empty(),
+        "source bundle identity specs must not use replace-capable add_identity_spec"
+    );
+    assert_eq!(
+        server.create_identity_spec_requests().len(),
+        0,
+        "source import should own bundled identity spec installation"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_file_skips_installed_identity_spec_setup_inputs_without_interactive() {
+    let source_dir = tempdir().expect("source dir");
+    let input_key = "CORAL_CLI_TEST_IDENTITY_SPEC_SECRET";
+    let spec = oauth_spec_with_required_input_yaml("github_oauth", input_key);
+    let server = MockServer::start_with_config(MockServerConfig::default().with_get_identity_spec(
+        identity_spec_response("github_oauth", "oauth", spec.clone()),
+    ))
+    .await;
+    let manifest_file = write_yaml(
+        &source_dir,
+        "bundle.yaml",
+        &format!(
+            r"
+---{spec}---
+name: github
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: users
+    description: Demo users
+    request:
+      method: GET
+      path: /users
+    columns:
+      - name: id
+        type: Utf8
+"
+        ),
+    );
+
+    server
+        .cmd()
+        .args([
+            "--enable-dsl-v4",
+            "source",
+            "add",
+            "--file",
+            manifest_file.to_str().expect("fixture path utf8"),
+        ])
+        .assert()
+        .success();
+
+    assert!(
+        server.create_identity_spec_requests().is_empty(),
+        "matching installed identity spec should not be reinstalled"
+    );
+    assert!(
+        server.add_identity_spec_requests().is_empty(),
+        "matching installed identity spec should not use replace-capable add_identity_spec"
+    );
+    let requests = server.import_source_requests();
+    assert_eq!(requests.len(), 1, "expected one import_source call");
+    assert!(
+        requests[0].identity_spec_manifest_yamls.is_empty(),
+        "matching installed identity spec should not be imported again"
+    );
+    assert!(
+        requests[0].identity_spec_inputs.is_empty(),
+        "matching installed identity spec should not require setup inputs"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_file_does_not_install_identity_spec_before_later_source_input_failure() {
+    let source_dir = tempdir().expect("source dir");
+    let source_secret = "CORAL_CLI_TEST_SOURCE_ADD_LATER_FAILURE_TOKEN";
+    let spec = fixed_token_spec_yaml("github_oauth");
+    let server = MockServer::start_with_config(
+        MockServerConfig::default()
+            .with_get_identity_spec_error(Code::NotFound, "identity spec not found"),
+    )
+    .await;
+    let manifest_file = write_yaml(
+        &source_dir,
+        "bundle.yaml",
+        &format!(
+            r"
+---{spec}---
+name: github
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+inputs:
+  {source_secret}:
+    kind: secret
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: 'Bearer {{{{input.{source_secret}}}}}'
+tables:
+  - name: users
+    description: Demo users
+    request:
+      method: GET
+      path: /users
+    columns:
+      - name: id
+        type: Utf8
+"
+        ),
+    );
+
+    let assert = server
+        .cmd()
+        .env_remove(source_secret)
+        .args([
+            "--enable-dsl-v4",
+            "source",
+            "add",
+            "--file",
+            manifest_file.to_str().expect("fixture path utf8"),
+        ])
+        .assert()
+        .failure();
+
+    let stderr = stderr_text(&assert);
+    assert!(
+        stderr.contains("missing required environment variable"),
+        "expected missing source input error: {stderr}"
+    );
+    assert!(
+        !stderr.contains("source add installed identity spec 'github_oauth'"),
+        "identity spec should not be installed before source input collection fails: {stderr}"
+    );
+    assert_eq!(server.create_identity_spec_requests().len(), 0);
+    assert!(
+        server.delete_identity_spec_requests().is_empty(),
+        "source add must not delete identity specs by name during rollback"
+    );
+    assert!(
+        server.delete_user_owned_identity_requests().is_empty(),
+        "source add must not delete user identities by name during rollback"
+    );
+    assert!(
+        server.import_source_requests().is_empty(),
+        "source import must not run after source input collection fails"
     );
 
     server.shutdown().await;

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -3,6 +3,7 @@
     reason = "Integration test crates share this harness, but each target only uses a subset of the helpers."
 )]
 
+use std::collections::VecDeque;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -14,21 +15,31 @@ use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
 use assert_cmd::Command;
 use coral_api::v1::catalog_service_server::{CatalogService, CatalogServiceServer};
+use coral_api::v1::identity_service_server::{IdentityService, IdentityServiceServer};
+use coral_api::v1::identity_spec_service_server::{IdentitySpecService, IdentitySpecServiceServer};
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::{
-    CatalogCounts, CatalogItem, CatalogSearchResult, Column, ColumnSearchResult,
-    CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
-    CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DeleteSourceResponse,
+    AddIdentitySpecRequest, AddIdentitySpecResponse, CatalogCounts, CatalogItem,
+    CatalogSearchResult, Column, ColumnSearchResult, CreateBundledSourceRequest,
+    CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
+    CreateBundledSourceWithOAuthResponse, CreateIdentitySpecRequest, CreateIdentitySpecResponse,
+    CreateUserOwnedIdentityWithFixedTokenRequest, CreateUserOwnedIdentityWithFixedTokenResponse,
+    CreateUserOwnedIdentityWithOAuthRequest, CreateUserOwnedIdentityWithOAuthResponse,
+    DeleteIdentitySpecRequest, DeleteIdentitySpecResponse, DeleteSourceRequest,
+    DeleteSourceResponse, DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse,
     DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
     ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
-    GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest, GetSourceResponse,
+    GetIdentitySpecRequest, GetIdentitySpecResponse, GetSourceInfoRequest, GetSourceInfoResponse,
+    GetSourceRequest, GetSourceResponse, Identity, IdentityOwner, IdentitySpec,
     ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
-    ListColumnsRequest, ListColumnsResponse, ListSourcesRequest, ListSourcesResponse,
-    PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse,
-    Source, SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput,
-    Table, TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
-    create_bundled_source_with_o_auth_response, import_source_response,
+    ListColumnsRequest, ListColumnsResponse, ListIdentitySpecsRequest, ListIdentitySpecsResponse,
+    ListSourcesRequest, ListSourcesResponse, ListUserOwnedIdentitiesRequest,
+    ListUserOwnedIdentitiesResponse, PaginationRequest, PaginationResponse, QueryPlan,
+    SearchCatalogRequest, SearchCatalogResponse, Source, SourceCredentialStorage, SourceInfo,
+    SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableSummary, ValidateSourceRequest,
+    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
+    create_user_owned_identity_with_o_auth_response, import_source_response,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
@@ -57,6 +68,46 @@ fn mock_source() -> Source {
         variables: Vec::new(),
         origin: SourceOrigin::Bundled as i32,
         credential_storage: SourceCredentialStorage::File as i32,
+    }
+}
+
+fn mock_identity_spec() -> IdentitySpec {
+    IdentitySpec {
+        name: "github_oauth".to_string(),
+        version: "0.1.0".to_string(),
+        description: "GitHub OAuth identity.".to_string(),
+        issuer: "github".to_string(),
+        identity_type: "oauth".to_string(),
+        manifest_yaml: r"
+kind: identity
+spec_version: 1
+name: github_oauth
+version: 0.1.0
+issuer: github
+type: oauth
+oauth:
+  method:
+    flow:
+      type: device_code
+    endpoints:
+      device_authorization_url: https://github.com/login/device/code
+      token_url: https://github.com/login/oauth/access_token
+    client:
+      id:
+        input: GITHUB_OAUTH_CLIENT_ID
+"
+        .to_string(),
+    }
+}
+
+fn mock_identity() -> Identity {
+    Identity {
+        name: "github_local".to_string(),
+        identity_spec: "github_oauth".to_string(),
+        issuer: "github".to_string(),
+        identity_type: "oauth".to_string(),
+        owner: IdentityOwner::User as i32,
+        metadata: Vec::new(),
     }
 }
 
@@ -413,6 +464,7 @@ impl MockError {
 enum MockResult<T> {
     Ok(T),
     Err(MockError),
+    Sequence(Arc<Mutex<VecDeque<MockResult<T>>>>),
 }
 
 impl<T> MockResult<T> {
@@ -428,10 +480,31 @@ impl<T> MockResult<T> {
         Self::Err(MockError::source_not_found(qualified))
     }
 
+    fn sequence(results: Vec<MockResult<T>>) -> Self {
+        Self::Sequence(Arc::new(Mutex::new(VecDeque::from(results))))
+    }
+}
+
+impl<T: Clone> MockResult<T> {
     fn into_tonic_result(self) -> Result<T, Status> {
         match self {
             Self::Ok(value) => Ok(value),
             Self::Err(error) => Err(error.status()),
+            Self::Sequence(results) => {
+                let mut results = results.lock().map_err(|error| {
+                    Status::internal(format!("mock result sequence lock poisoned: {error}"))
+                })?;
+                let next = if results.len() > 1 {
+                    results.pop_front().ok_or_else(|| {
+                        Status::internal("mock result sequence should not be empty")
+                    })?
+                } else {
+                    results.front().cloned().ok_or_else(|| {
+                        Status::internal("mock result sequence should not be empty")
+                    })?
+                };
+                next.into_tonic_result()
+            }
         }
     }
 }
@@ -441,6 +514,13 @@ pub(crate) struct MockServerConfig {
     execute_sql_override: Option<MockResult<ExecuteSqlResponse>>,
     discover_sources: MockResult<DiscoverSourcesResponse>,
     list_sources: MockResult<ListSourcesResponse>,
+    list_user_owned_identities: MockResult<ListUserOwnedIdentitiesResponse>,
+    delete_user_owned_identity: MockResult<DeleteUserOwnedIdentityResponse>,
+    list_identity_specs: MockResult<ListIdentitySpecsResponse>,
+    get_identity_spec: MockResult<GetIdentitySpecResponse>,
+    add_identity_spec: MockResult<AddIdentitySpecResponse>,
+    create_identity_spec: MockResult<CreateIdentitySpecResponse>,
+    delete_identity_spec: MockResult<()>,
     validate_source: MockResult<ValidateSourceResponse>,
     delete_source: MockResult<()>,
 }
@@ -450,6 +530,24 @@ impl Default for MockServerConfig {
         Self {
             execute_sql_override: None,
             discover_sources: MockResult::ok(mock_discover_response()),
+            list_identity_specs: MockResult::ok(ListIdentitySpecsResponse {
+                identity_specs: vec![mock_identity_spec()],
+            }),
+            get_identity_spec: MockResult::ok(GetIdentitySpecResponse {
+                identity_spec: Some(mock_identity_spec()),
+            }),
+            add_identity_spec: MockResult::ok(AddIdentitySpecResponse {
+                identity_spec: Some(mock_identity_spec()),
+                replaced: false,
+            }),
+            create_identity_spec: MockResult::ok(CreateIdentitySpecResponse {
+                identity_spec: Some(mock_identity_spec()),
+            }),
+            list_user_owned_identities: MockResult::ok(ListUserOwnedIdentitiesResponse {
+                identities: vec![mock_identity()],
+            }),
+            delete_user_owned_identity: MockResult::ok(DeleteUserOwnedIdentityResponse {}),
+            delete_identity_spec: MockResult::ok(()),
             list_sources: MockResult::ok(ListSourcesResponse {
                 sources: vec![
                     Source {
@@ -486,6 +584,82 @@ impl MockServerConfig {
 
     pub(crate) fn with_list_sources(mut self, response: ListSourcesResponse) -> Self {
         self.list_sources = MockResult::ok(response);
+        self
+    }
+
+    pub(crate) fn with_get_identity_spec(mut self, response: GetIdentitySpecResponse) -> Self {
+        self.get_identity_spec = MockResult::ok(response);
+        self
+    }
+
+    pub(crate) fn with_get_identity_spec_error(
+        mut self,
+        code: Code,
+        message: impl Into<String>,
+    ) -> Self {
+        self.get_identity_spec = MockResult::err(code, message);
+        self
+    }
+
+    pub(crate) fn with_get_identity_spec_error_then_response(
+        mut self,
+        code: Code,
+        message: impl Into<String>,
+        response: GetIdentitySpecResponse,
+    ) -> Self {
+        self.get_identity_spec = MockResult::sequence(vec![
+            MockResult::err(code, message),
+            MockResult::ok(response),
+        ]);
+        self
+    }
+
+    pub(crate) fn with_get_identity_spec_error_twice_then_response(
+        mut self,
+        code: Code,
+        message: impl Into<String>,
+        response: GetIdentitySpecResponse,
+    ) -> Self {
+        let message = message.into();
+        self.get_identity_spec = MockResult::sequence(vec![
+            MockResult::err(code, message.clone()),
+            MockResult::err(code, message),
+            MockResult::ok(response),
+        ]);
+        self
+    }
+
+    pub(crate) fn with_add_identity_spec_response(
+        mut self,
+        response: AddIdentitySpecResponse,
+    ) -> Self {
+        self.add_identity_spec = MockResult::ok(response);
+        self
+    }
+
+    pub(crate) fn with_add_identity_spec_error(
+        mut self,
+        code: Code,
+        message: impl Into<String>,
+    ) -> Self {
+        self.add_identity_spec = MockResult::err(code, message);
+        self
+    }
+
+    pub(crate) fn with_create_identity_spec_response(
+        mut self,
+        response: CreateIdentitySpecResponse,
+    ) -> Self {
+        self.create_identity_spec = MockResult::ok(response);
+        self
+    }
+
+    pub(crate) fn with_create_identity_spec_error(
+        mut self,
+        code: Code,
+        message: impl Into<String>,
+    ) -> Self {
+        self.create_identity_spec = MockResult::err(code, message);
         self
     }
 
@@ -607,6 +781,20 @@ captured_requests! {
     create_bundled_source_with_oauth as create_bundled_source_with_oauth_requests:
         CreateBundledSourceWithOAuthRequest,
     import_source as import_source_requests: ImportSourceRequest,
+    add_identity_spec as add_identity_spec_requests: AddIdentitySpecRequest,
+    create_identity_spec as create_identity_spec_requests: CreateIdentitySpecRequest,
+    list_identity_specs as list_identity_specs_requests: ListIdentitySpecsRequest,
+    get_identity_spec as get_identity_spec_requests: GetIdentitySpecRequest,
+    delete_identity_spec as delete_identity_spec_requests: DeleteIdentitySpecRequest,
+    create_user_owned_identity_with_oauth as create_user_owned_identity_with_oauth_requests:
+        CreateUserOwnedIdentityWithOAuthRequest,
+    create_user_owned_identity_with_fixed_token
+        as create_user_owned_identity_with_fixed_token_requests:
+        CreateUserOwnedIdentityWithFixedTokenRequest,
+    list_user_owned_identities as list_user_owned_identities_requests:
+        ListUserOwnedIdentitiesRequest,
+    delete_user_owned_identity as delete_user_owned_identity_requests:
+        DeleteUserOwnedIdentityRequest,
     delete_source as delete_source_requests: DeleteSourceRequest,
     validate_source as validate_source_requests: ValidateSourceRequest,
 }
@@ -823,6 +1011,12 @@ impl CatalogService for MockCatalogService {
     }
 }
 
+#[derive(Clone)]
+struct MockIdentitySpecService {
+    config: Arc<MockServerConfig>,
+    captured: Arc<Captured>,
+}
+
 /// Generates one mock service impl. Every method records the request in its
 /// `captured` slot, then evaluates `$body` (with the captured request and the
 /// server config in scope) to produce the response. Generating the whole
@@ -846,6 +1040,66 @@ macro_rules! mock_service {
             )*
         }
     };
+}
+
+mock_service! {
+    impl IdentitySpecService for MockIdentitySpecService {
+        fn add_identity_spec(add_identity_spec, AddIdentitySpecRequest) -> AddIdentitySpecResponse =
+            |cfg, _request| cfg.add_identity_spec.clone().into_tonic_result()?;
+        fn create_identity_spec(create_identity_spec, CreateIdentitySpecRequest)
+            -> CreateIdentitySpecResponse =
+            |cfg, _request| cfg.create_identity_spec.clone().into_tonic_result()?;
+        fn list_identity_specs(list_identity_specs, ListIdentitySpecsRequest)
+            -> ListIdentitySpecsResponse =
+            |cfg, _request| cfg.list_identity_specs.clone().into_tonic_result()?;
+        fn get_identity_spec(get_identity_spec, GetIdentitySpecRequest) -> GetIdentitySpecResponse =
+            |cfg, _request| cfg.get_identity_spec.clone().into_tonic_result()?;
+        fn delete_identity_spec(delete_identity_spec, DeleteIdentitySpecRequest)
+            -> DeleteIdentitySpecResponse =
+            |cfg, _request| {
+                cfg.delete_identity_spec.clone().into_tonic_result()?;
+                DeleteIdentitySpecResponse {
+                    orphaned_identities: 0,
+                }
+            };
+    }
+}
+
+#[derive(Clone)]
+struct MockIdentityService {
+    config: Arc<MockServerConfig>,
+    captured: Arc<Captured>,
+}
+
+mock_service! {
+    impl IdentityService for MockIdentityService {
+        type CreateUserOwnedIdentityWithOAuthStream =
+            EventStream<CreateUserOwnedIdentityWithOAuthResponse>;
+        fn create_user_owned_identity_with_o_auth(
+            create_user_owned_identity_with_oauth,
+            CreateUserOwnedIdentityWithOAuthRequest
+        ) -> EventStream<CreateUserOwnedIdentityWithOAuthResponse> =
+            |_cfg, _request| single_event_stream(CreateUserOwnedIdentityWithOAuthResponse {
+                event: Some(
+                    create_user_owned_identity_with_o_auth_response::Event::Identity(
+                        mock_identity(),
+                    ),
+                ),
+            });
+        fn create_user_owned_identity_with_fixed_token(
+            create_user_owned_identity_with_fixed_token,
+            CreateUserOwnedIdentityWithFixedTokenRequest
+        ) -> CreateUserOwnedIdentityWithFixedTokenResponse =
+            |_cfg, _request| CreateUserOwnedIdentityWithFixedTokenResponse {
+                identity: Some(mock_identity()),
+            };
+        fn list_user_owned_identities(list_user_owned_identities, ListUserOwnedIdentitiesRequest)
+            -> ListUserOwnedIdentitiesResponse =
+            |cfg, _request| cfg.list_user_owned_identities.clone().into_tonic_result()?;
+        fn delete_user_owned_identity(delete_user_owned_identity, DeleteUserOwnedIdentityRequest)
+            -> DeleteUserOwnedIdentityResponse =
+            |cfg, _request| cfg.delete_user_owned_identity.clone().into_tonic_result()?;
+    }
 }
 
 #[derive(Clone)]
@@ -929,6 +1183,14 @@ impl MockServer {
                     captured: Arc::clone(&captured),
                 }))
                 .add_service(QueryServiceServer::new(MockQueryService {
+                    config: Arc::clone(&config),
+                    captured: Arc::clone(&captured),
+                }))
+                .add_service(IdentitySpecServiceServer::new(MockIdentitySpecService {
+                    config: Arc::clone(&config),
+                    captured: Arc::clone(&captured),
+                }))
+                .add_service(IdentityServiceServer::new(MockIdentityService {
                     config: Arc::clone(&config),
                     captured: Arc::clone(&captured),
                 }))

--- a/docs/guides/observe-with-opentelemetry.mdx
+++ b/docs/guides/observe-with-opentelemetry.mdx
@@ -22,6 +22,11 @@ The `endpoint` is the OTLP/HTTP base URL. Coral automatically appends `/v1/trace
 
 Coral keeps a local trace history for the UI by default. Local traces include query, source-loading, HTTP, and DataFusion spans. They also include DataFusion optimizer-rule spans so the trace view can show the planning work that happened for a query. This local filter is separate from `trace_filter`, which only controls OTLP span export.
 
+Trace history is local-only. When native gRPC binds a non-loopback address,
+Coral disables the local trace history store and TraceService because trace
+records are not workspace-scoped. Use external OTLP export for shared or
+multi-user deployments.
+
 By default, Coral retains seven days of local spans. To change that window:
 
 ```toml

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -135,6 +135,41 @@ Coral stores the source secrets in plaintext file storage and shows
 `file (plaintext)` in source output. Sources with no stored secret material show
 `none`.
 
+### `coral source add --file <PATH>`
+
+Add a custom source spec from a YAML file. Input values come from environment variables by default; add `--interactive` to be prompted.
+
+```shellscript
+coral source add --file ./local-messages.yaml
+```
+
+The file may also be a YAML stream with multiple documents separated by
+`---`: exactly one source spec document plus zero or more `kind: identity`
+identity spec documents. Coral installs identity specs globally for all
+workspaces before importing the source. Bundled identity specs and DSL v4 source
+specs require the `dsl_v4` runtime feature; run `coral features enable dsl_v4`
+or pass `--enable-dsl-v4` and retry. If a bundled identity spec declares
+`inputs`, Coral collects those setup values while installing the spec: from
+matching environment variables by default, or from prompts with `--interactive`.
+Secret identity-spec inputs are stored as identity-spec material, not source
+secrets or identity-instance material.
+
+When the source is a DSL v4 source with `identity_requirements`,
+`coral source add --file` runs interactively: it prompts for required source
+inputs, lets you select an existing compatible user-owned identity when one is
+available, or creates a new user-owned identity from a compatible identity spec.
+If more than one compatible identity spec can create the identity, Coral prompts
+for which one to use. The source surface is configured with a user-owned
+identity slot in the workspace, and the created or selected identity is recorded
+as the current user's selection for that slot. OSS Coral has one local user,
+`local`; products built on Coral can resolve different selections for different
+users.
+
+To change the selected identity for an imported DSL v4 source, run
+`coral source add --file <PATH>` again with the same source manifest. Coral
+re-runs the same interactive identity selection flow and replaces the current
+local user's source-surface identity selection.
+
 ### `coral source lint <FILE>`
 
 Validate a source spec YAML file without installing it. Checks YAML syntax, JSON schema conformance, and semantic rules such as duplicate columns or references to unknown filters.

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -112,4 +112,8 @@ enabled = true
 retention_days = 7
 ```
 
+Trace history is a local inspection feature. Coral disables the local trace
+history store and TraceService when native gRPC binds a non-loopback address;
+multi-user deployments should export traces through `[otel]` instead.
+
 See [Observe with OpenTelemetry](/guides/observe-with-opentelemetry) for the full telemetry setup guide.


### PR DESCRIPTION
Completes the DSL v4 identity surface in the CLI:

- source_ops.rs: identity-spec and user-owned-identity RPC wrappers
  (add/get identity spec; list/create identities incl. streaming OAuth),
  load_validated_manifest_bundle_file, and the add_source_from_file
  rewrite that installs identity specs from a manifest bundle and runs
  interactive per-surface identity binding (select-or-create) behind a
  TTY gate, threading ImportSourceIdentitySpecs into the import request
- lib.rs: identity command wiring and the CLI embedding seam
- cli test harness MockIdentityService/MockIdentitySpecService and
  end-to-end source-add identity tests
- cli-reference.mdx identity-flow docs

This is the top of the carve stack; its tree is identical to the
original squashed PR #1109.