### PR TITLE
feat(spec): support v4 XML responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,6 +1349,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "parquet",
+ "quick-xml",
  "reqwest 0.13.3",
  "rmcp",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ opentelemetry-otlp = "0.31.0"
 opentelemetry_sdk = "0.31.0"
 parquet = { version = "58.1.0", features = ["arrow"] }
 prost = "0.14.1"
+quick-xml = "0.39.4"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "charset", "form", "http2", "json", "query", "rustls", "system-proxy"] }
 regex = "1"
 rmcp = { version = "1.6.0", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client-reqwest"] }

--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -25,6 +25,7 @@ httpdate.workspace = true
 object_store.workspace = true
 opentelemetry.workspace = true
 parquet.workspace = true
+quick-xml.workspace = true
 reqwest.workspace = true
 rmcp.workspace = true
 serde.workspace = true

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -168,7 +168,7 @@ pub(super) async fn fetch_rows(
                 url: &url,
                 query_pairs: &query_pairs,
                 body: body.as_ref(),
-                response_format: target.response().format,
+                response: target.response(),
                 source_schema: &client.source_schema,
                 rate_limit: &client.rate_limit,
                 body_capture: client.body_capture,

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -37,6 +37,7 @@ mod test_support;
 mod trace;
 mod transport;
 mod url;
+mod xml;
 
 pub(crate) use client::{HttpSourceClient, HttpSourceClientRuntime};
 pub(crate) use error::ProviderQueryError;

--- a/crates/coral-engine/src/backends/http/response.rs
+++ b/crates/coral-engine/src/backends/http/response.rs
@@ -4,7 +4,8 @@ use serde_json::Value;
 
 use crate::backends::http::ProviderQueryError;
 use crate::backends::http::trace::HttpBodyCapture;
-use coral_spec::ResponseBodyFormat;
+use crate::backends::http::xml::decode_xml_response;
+use coral_spec::{ResponseBodyFormat, ResponseSpec};
 
 pub(super) struct ResponseDecodeContext<'a> {
     pub(super) source_schema: &'a str,
@@ -16,9 +17,13 @@ pub(super) struct ResponseDecodeContext<'a> {
     pub(super) request_id: u64,
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "HTTP body decoding keeps format branches together so error context stays identical."
+)]
 pub(super) async fn decode_response_body(
     response: reqwest::Response,
-    format: ResponseBodyFormat,
+    response_spec: &ResponseSpec,
     context: ResponseDecodeContext<'_>,
 ) -> Result<Value, ProviderQueryError> {
     let ResponseDecodeContext {
@@ -30,7 +35,7 @@ pub(super) async fn decode_response_body(
         response_span,
         request_id,
     } = context;
-    match format {
+    match response_spec.format {
         ResponseBodyFormat::Json => {
             let bytes = response.bytes().await.map_err(|error| {
                 // A read failure mid-body is transient, so it is eligible for retry.
@@ -93,6 +98,42 @@ pub(super) async fn decode_response_body(
                 rows.push(row);
             }
             Ok(Value::Array(rows))
+        }
+        ResponseBodyFormat::Xml => {
+            let bytes = response.bytes().await.map_err(|error| {
+                // A read failure mid-body is transient, so it is eligible for retry.
+                decode_error(
+                    source_schema,
+                    table_name,
+                    method_label,
+                    logged_url,
+                    format!("source API response decoding failed: {error}"),
+                    true,
+                )
+            })?;
+            response_span.record("http.response.body.size", bytes.len());
+            let trace_body = String::from_utf8_lossy(&bytes);
+            body_capture.record_response(response_span, request_id, trace_body.as_ref());
+            let Some(xml_spec) = response_spec.xml.as_ref() else {
+                return Err(decode_error(
+                    source_schema,
+                    table_name,
+                    method_label,
+                    logged_url,
+                    "source API response decoding failed: XML response format is missing xml normalization plan".to_string(),
+                    false,
+                ));
+            };
+            decode_xml_response(&bytes, xml_spec).map_err(|error| {
+                decode_error(
+                    source_schema,
+                    table_name,
+                    method_label,
+                    logged_url,
+                    error,
+                    false,
+                )
+            })
         }
     }
 }

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -28,7 +28,7 @@ use crate::backends::http::trace::{
 };
 use crate::backends::shared::template::{RenderContext, resolve_value_source, value_to_string};
 use coral_spec::backends::http::RateLimitSpec;
-use coral_spec::{AuthSpec, HeaderSpec, HttpMethod, ResponseBodyFormat};
+use coral_spec::{AuthSpec, HeaderSpec, HttpMethod, ResponseSpec};
 
 static NEXT_HTTP_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -44,7 +44,7 @@ pub(super) struct OutgoingHttpRequest<'a> {
     pub(super) url: &'a str,
     pub(super) query_pairs: &'a [(String, String)],
     pub(super) body: Option<&'a RequestBody>,
-    pub(super) response_format: ResponseBodyFormat,
+    pub(super) response: &'a ResponseSpec,
     pub(super) source_schema: &'a str,
     pub(super) rate_limit: &'a RateLimitSpec,
     pub(super) body_capture: HttpBodyCapture,
@@ -79,7 +79,7 @@ pub(super) async fn execute_request(
         url,
         query_pairs,
         body,
-        response_format,
+        response: response_spec,
         source_schema,
         rate_limit,
         body_capture,
@@ -319,7 +319,7 @@ pub(super) async fn execute_request(
 
             match decode_response_body(
                 response,
-                response_format,
+                response_spec,
                 ResponseDecodeContext {
                     source_schema,
                     table_name,
@@ -459,7 +459,7 @@ mod tests {
     use crate::backends::http::trace::HttpBodyCapture;
     use crate::backends::shared::template::RenderContext;
     use coral_spec::backends::http::RateLimitSpec;
-    use coral_spec::{AuthSpec, HttpMethod, ResponseBodyFormat};
+    use coral_spec::{AuthSpec, HttpMethod, ResponseSpec};
 
     async fn spawn_hanging_http_server() -> (String, JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0")
@@ -506,7 +506,7 @@ mod tests {
                 url: &url,
                 query_pairs: &query_pairs,
                 body: None,
-                response_format: ResponseBodyFormat::default(),
+                response: &ResponseSpec::default(),
                 source_schema: "demo",
                 rate_limit: &RateLimitSpec::default(),
                 body_capture: HttpBodyCapture::default(),

--- a/crates/coral-engine/src/backends/http/xml.rs
+++ b/crates/coral-engine/src/backends/http/xml.rs
@@ -1,0 +1,448 @@
+//! XML response parsing and schema-driven normalization.
+
+use std::collections::BTreeMap;
+use std::str;
+
+use quick_xml::Reader;
+use quick_xml::escape::unescape;
+use quick_xml::events::{BytesStart, Event};
+use serde_json::{Map, Number, Value};
+
+use coral_spec::{XmlFieldSpec, XmlListSpec, XmlResponseSpec, XmlScalarType, XmlValueSpec};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct XmlElement {
+    name: String,
+    attributes: BTreeMap<String, String>,
+    children: Vec<XmlElement>,
+    text: String,
+}
+
+pub(super) fn decode_xml_response(bytes: &[u8], spec: &XmlResponseSpec) -> Result<Value, String> {
+    let root = parse_xml(bytes)?;
+    if let Some(expected) = &spec.root_name
+        && !name_matches(&root.name, expected)
+    {
+        return Err(format!(
+            "XML response root '{}' did not match expected root '{}'",
+            root.name, expected
+        ));
+    }
+    let root_name = spec.root_name.as_deref().unwrap_or(&root.name).to_string();
+    let normalized = normalize_value(&root, &spec.root);
+    let mut object = Map::new();
+    object.insert(root_name, normalized);
+    Ok(Value::Object(object))
+}
+
+fn parse_xml(bytes: &[u8]) -> Result<XmlElement, String> {
+    let mut reader = Reader::from_reader(bytes);
+    reader.config_mut().trim_text(true);
+    let mut buf = Vec::new();
+    let mut stack = Vec::new();
+    let mut root = None;
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(start)) => {
+                stack.push(element_from_start(&start)?);
+            }
+            Ok(Event::Empty(start)) => {
+                let element = element_from_start(&start)?;
+                attach_element(element, &mut stack, &mut root)?;
+            }
+            Ok(Event::End(_end)) => {
+                let Some(element) = stack.pop() else {
+                    return Err("XML response had an unexpected closing element".to_string());
+                };
+                attach_element(element, &mut stack, &mut root)?;
+            }
+            Ok(Event::Text(text)) => {
+                let decoded = text
+                    .xml_content()
+                    .map_err(|error| format!("XML text decode failed: {error}"))?;
+                append_text(&mut stack, decoded.as_ref());
+            }
+            Ok(Event::CData(cdata)) => {
+                let decoded = cdata
+                    .decode()
+                    .map_err(|error| format!("XML CDATA decode failed: {error}"))?;
+                append_text(&mut stack, decoded.as_ref());
+            }
+            Ok(Event::GeneralRef(reference)) => {
+                let raw = str::from_utf8(reference.as_ref())
+                    .map_err(|error| format!("XML entity reference was not UTF-8: {error}"))?;
+                let escaped = format!("&{raw};");
+                let decoded = unescape(&escaped)
+                    .map_err(|error| format!("XML entity reference decode failed: {error}"))?;
+                append_text(&mut stack, decoded.as_ref());
+            }
+            Ok(Event::Decl(_) | Event::PI(_) | Event::DocType(_) | Event::Comment(_)) => {}
+            Ok(Event::Eof) => break,
+            Err(error) => return Err(format!("XML response decoding failed: {error}")),
+        }
+        buf.clear();
+    }
+
+    if !stack.is_empty() {
+        return Err("XML response ended before all elements were closed".to_string());
+    }
+    root.ok_or_else(|| "XML response did not contain a document element".to_string())
+}
+
+fn element_from_start(start: &BytesStart<'_>) -> Result<XmlElement, String> {
+    let name = local_name_bytes(start.name().as_ref())?.to_string();
+    let mut attributes = BTreeMap::new();
+    for attribute in start.attributes() {
+        let attribute =
+            attribute.map_err(|error| format!("XML attribute decode failed: {error}"))?;
+        let name = local_name_bytes(attribute.key.as_ref())?.to_string();
+        let value = attribute
+            .unescape_value()
+            .map_err(|error| format!("XML attribute value decode failed: {error}"))?
+            .into_owned();
+        attributes.insert(name, value);
+    }
+    Ok(XmlElement {
+        name,
+        attributes,
+        children: Vec::new(),
+        text: String::new(),
+    })
+}
+
+fn attach_element(
+    element: XmlElement,
+    stack: &mut [XmlElement],
+    root: &mut Option<XmlElement>,
+) -> Result<(), String> {
+    if let Some(parent) = stack.last_mut() {
+        parent.children.push(element);
+        return Ok(());
+    }
+    if root.replace(element).is_some() {
+        return Err("XML response contained multiple document elements".to_string());
+    }
+    Ok(())
+}
+
+fn append_text(stack: &mut [XmlElement], text: &str) {
+    let Some(element) = stack.last_mut() else {
+        return;
+    };
+    element.text.push_str(text);
+}
+
+fn normalize_value(element: &XmlElement, spec: &XmlValueSpec) -> Value {
+    match spec {
+        XmlValueSpec::Scalar(scalar) => coerce_scalar(&element.text, scalar.scalar_type),
+        XmlValueSpec::Object(object) => {
+            if object.fields.is_empty() {
+                return generic_element_value(element);
+            }
+            let mut map = Map::new();
+            for field in &object.fields {
+                if let Some(value) = normalize_field(element, field) {
+                    map.insert(field.name.clone(), value);
+                }
+            }
+            Value::Object(map)
+        }
+        XmlValueSpec::List(list) => normalize_list_element(element, list),
+        XmlValueSpec::Json(_json) => generic_element_value(element),
+    }
+}
+
+fn normalize_field(element: &XmlElement, field: &XmlFieldSpec) -> Option<Value> {
+    if field.attribute {
+        return element
+            .attributes
+            .get(local_name(&field.xml_name))
+            .map(|value| coerce_attribute(value, &field.value));
+    }
+    if let XmlValueSpec::List(list) = &field.value {
+        return Some(normalize_list_field(element, &field.xml_name, list));
+    }
+    element
+        .children
+        .iter()
+        .find(|child| name_matches(&child.name, &field.xml_name))
+        .map(|child| normalize_value(child, &field.value))
+}
+
+fn normalize_list_field(parent: &XmlElement, field_xml_name: &str, list: &XmlListSpec) -> Value {
+    let containers = parent
+        .children
+        .iter()
+        .filter(|child| name_matches(&child.name, field_xml_name))
+        .collect::<Vec<_>>();
+    if containers.is_empty() {
+        return Value::Array(Vec::new());
+    }
+    if list.wrapped {
+        let mut items = Vec::new();
+        for container in containers {
+            append_wrapped_items(container, list, &mut items);
+        }
+        Value::Array(items)
+    } else {
+        Value::Array(
+            containers
+                .into_iter()
+                .map(|container| normalize_value(container, &list.item))
+                .collect(),
+        )
+    }
+}
+
+fn normalize_list_element(element: &XmlElement, list: &XmlListSpec) -> Value {
+    if list.wrapped {
+        let mut items = Vec::new();
+        append_wrapped_items(element, list, &mut items);
+        Value::Array(items)
+    } else {
+        Value::Array(vec![normalize_value(element, &list.item)])
+    }
+}
+
+fn append_wrapped_items(container: &XmlElement, list: &XmlListSpec, items: &mut Vec<Value>) {
+    let item_xml_name = list.item_xml_name.as_deref().unwrap_or("member");
+    let matching_children = container
+        .children
+        .iter()
+        .filter(|child| name_matches(&child.name, item_xml_name))
+        .collect::<Vec<_>>();
+    if matching_children.is_empty() {
+        if container.children.is_empty() && container.text.trim().is_empty() {
+            return;
+        }
+        items.push(normalize_value(container, &list.item));
+        return;
+    }
+    items.extend(
+        matching_children
+            .into_iter()
+            .map(|child| normalize_value(child, &list.item)),
+    );
+}
+
+fn coerce_attribute(value: &str, spec: &XmlValueSpec) -> Value {
+    match spec {
+        XmlValueSpec::Scalar(scalar) => coerce_scalar(value, scalar.scalar_type),
+        XmlValueSpec::Object(_) | XmlValueSpec::List(_) | XmlValueSpec::Json(_) => {
+            Value::String(value.to_string())
+        }
+    }
+}
+
+fn coerce_scalar(value: &str, scalar_type: XmlScalarType) -> Value {
+    let trimmed = value.trim();
+    match scalar_type {
+        XmlScalarType::String => Value::String(trimmed.to_string()),
+        XmlScalarType::Integer => trimmed.parse::<i64>().map_or_else(
+            |_error| Value::String(trimmed.to_string()),
+            |value| Value::Number(Number::from(value)),
+        ),
+        XmlScalarType::Number => trimmed
+            .parse::<f64>()
+            .ok()
+            .and_then(Number::from_f64)
+            .map_or_else(|| Value::String(trimmed.to_string()), Value::Number),
+        XmlScalarType::Boolean => match trimmed.to_ascii_lowercase().as_str() {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            _ => Value::String(trimmed.to_string()),
+        },
+    }
+}
+
+fn generic_element_value(element: &XmlElement) -> Value {
+    if element.attributes.is_empty() && element.children.is_empty() {
+        return Value::String(element.text.trim().to_string());
+    }
+    let mut map = Map::new();
+    for (name, value) in &element.attributes {
+        map.insert(name.clone(), Value::String(value.clone()));
+    }
+    if !element.text.trim().is_empty() {
+        map.insert(
+            "#text".to_string(),
+            Value::String(element.text.trim().to_string()),
+        );
+    }
+    for child in &element.children {
+        insert_grouped_child(&mut map, child.name.clone(), generic_element_value(child));
+    }
+    Value::Object(map)
+}
+
+fn insert_grouped_child(map: &mut Map<String, Value>, key: String, value: Value) {
+    match map.get_mut(&key) {
+        Some(Value::Array(values)) => values.push(value),
+        Some(existing) => {
+            let previous = std::mem::replace(existing, Value::Null);
+            *existing = Value::Array(vec![previous, value]);
+        }
+        None => {
+            map.insert(key, value);
+        }
+    }
+}
+
+fn local_name_bytes(bytes: &[u8]) -> Result<&str, String> {
+    let name = str::from_utf8(bytes)
+        .map_err(|error| format!("XML element name was not UTF-8: {error}"))?;
+    Ok(local_name(name))
+}
+
+fn local_name(name: &str) -> &str {
+    name.rsplit_once(':').map_or(name, |(_, local)| local)
+}
+
+fn name_matches(actual: &str, expected: &str) -> bool {
+    local_name(actual) == local_name(expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use coral_spec::{
+        XmlFieldSpec, XmlListSpec, XmlObjectSpec, XmlResponseSpec, XmlScalarSpec, XmlScalarType,
+        XmlValueSpec,
+    };
+    use serde_json::json;
+
+    use super::decode_xml_response;
+
+    fn alarm_response_spec() -> XmlResponseSpec {
+        XmlResponseSpec {
+            root_name: Some("DescribeAlarmsResponse".to_string()),
+            root: XmlValueSpec::Object(XmlObjectSpec {
+                xml_name: Some("DescribeAlarmsResponse".to_string()),
+                fields: vec![XmlFieldSpec {
+                    name: "DescribeAlarmsResult".to_string(),
+                    xml_name: "DescribeAlarmsResult".to_string(),
+                    attribute: false,
+                    value: XmlValueSpec::Object(XmlObjectSpec {
+                        xml_name: Some("DescribeAlarmsResult".to_string()),
+                        fields: vec![XmlFieldSpec {
+                            name: "MetricAlarms".to_string(),
+                            xml_name: "MetricAlarms".to_string(),
+                            attribute: false,
+                            value: XmlValueSpec::List(XmlListSpec {
+                                xml_name: Some("MetricAlarms".to_string()),
+                                wrapped: true,
+                                item_xml_name: Some("member".to_string()),
+                                item: Box::new(XmlValueSpec::Object(XmlObjectSpec {
+                                    xml_name: Some("member".to_string()),
+                                    fields: vec![
+                                        XmlFieldSpec {
+                                            name: "AlarmName".to_string(),
+                                            xml_name: "AlarmName".to_string(),
+                                            attribute: false,
+                                            value: XmlValueSpec::Scalar(XmlScalarSpec {
+                                                xml_name: Some("AlarmName".to_string()),
+                                                scalar_type: XmlScalarType::String,
+                                            }),
+                                        },
+                                        XmlFieldSpec {
+                                            name: "ActionsEnabled".to_string(),
+                                            xml_name: "ActionsEnabled".to_string(),
+                                            attribute: false,
+                                            value: XmlValueSpec::Scalar(XmlScalarSpec {
+                                                xml_name: Some("ActionsEnabled".to_string()),
+                                                scalar_type: XmlScalarType::Boolean,
+                                            }),
+                                        },
+                                    ],
+                                })),
+                            }),
+                        }],
+                    }),
+                }],
+            }),
+        }
+    }
+
+    #[test]
+    fn normalizes_single_member_as_array() {
+        let payload = br"
+<DescribeAlarmsResponse>
+  <DescribeAlarmsResult>
+    <MetricAlarms>
+      <member>
+        <AlarmName>cpu</AlarmName>
+        <ActionsEnabled>true</ActionsEnabled>
+      </member>
+    </MetricAlarms>
+  </DescribeAlarmsResult>
+</DescribeAlarmsResponse>
+";
+        let value = decode_xml_response(payload, &alarm_response_spec()).expect("decode xml");
+        assert_eq!(
+            value,
+            json!({
+                "DescribeAlarmsResponse": {
+                    "DescribeAlarmsResult": {
+                        "MetricAlarms": [{
+                            "AlarmName": "cpu",
+                            "ActionsEnabled": true
+                        }]
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn normalizes_multiple_members_as_array() {
+        let payload = br"
+<DescribeAlarmsResponse>
+  <DescribeAlarmsResult>
+    <MetricAlarms>
+      <member><AlarmName>cpu</AlarmName></member>
+      <member><AlarmName>memory</AlarmName></member>
+    </MetricAlarms>
+  </DescribeAlarmsResult>
+</DescribeAlarmsResponse>
+";
+        let value = decode_xml_response(payload, &alarm_response_spec()).expect("decode xml");
+        assert_eq!(
+            *value
+                .pointer("/DescribeAlarmsResponse/DescribeAlarmsResult/MetricAlarms")
+                .expect("metric alarms"),
+            json!([
+                {"AlarmName": "cpu"},
+                {"AlarmName": "memory"}
+            ])
+        );
+    }
+
+    #[test]
+    fn matches_namespaces_by_local_name_and_reads_attributes() {
+        let spec = XmlResponseSpec {
+            root_name: Some("entry".to_string()),
+            root: XmlValueSpec::Object(XmlObjectSpec {
+                xml_name: Some("entry".to_string()),
+                fields: vec![XmlFieldSpec {
+                    name: "id".to_string(),
+                    xml_name: "id".to_string(),
+                    attribute: true,
+                    value: XmlValueSpec::Scalar(XmlScalarSpec {
+                        xml_name: Some("id".to_string()),
+                        scalar_type: XmlScalarType::Integer,
+                    }),
+                }],
+            }),
+        };
+        let value =
+            decode_xml_response(br#"<atom:entry atom:id="42"/>"#, &spec).expect("decode xml");
+        assert_eq!(value, json!({"entry": {"id": 42}}));
+    }
+
+    #[test]
+    fn rejects_malformed_xml() {
+        let error = decode_xml_response(br"<root><broken></root>", &alarm_response_spec())
+            .expect_err("malformed xml should fail");
+        assert!(error.contains("XML response decoding failed"), "{error}");
+    }
+}

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -505,6 +505,8 @@ pub enum ValueSourceSpec {
 pub struct ResponseSpec {
     #[serde(default)]
     pub format: ResponseBodyFormat,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub xml: Option<XmlResponseSpec>,
     #[serde(default)]
     pub rows_path: Vec<String>,
     #[serde(default)]
@@ -528,6 +530,86 @@ pub enum ResponseBodyFormat {
     /// Each non-empty line is parsed as one JSON value and collected into an
     /// array before row extraction.
     JsonEachRow,
+    /// XML document normalized through a schema-derived response plan.
+    Xml,
+}
+
+/// Schema-derived instructions for normalizing an XML response into JSON.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct XmlResponseSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_name: Option<String>,
+    pub root: XmlValueSpec,
+}
+
+/// One node in a schema-derived XML normalization plan.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+pub enum XmlValueSpec {
+    Scalar(XmlScalarSpec),
+    Object(XmlObjectSpec),
+    List(XmlListSpec),
+    Json(XmlJsonSpec),
+}
+
+/// XML scalar normalization.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct XmlScalarSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub xml_name: Option<String>,
+    pub scalar_type: XmlScalarType,
+}
+
+/// XML object normalization.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct XmlObjectSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub xml_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fields: Vec<XmlFieldSpec>,
+}
+
+/// XML array normalization.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct XmlListSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub xml_name: Option<String>,
+    #[serde(default = "default_true")]
+    pub wrapped: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item_xml_name: Option<String>,
+    pub item: Box<XmlValueSpec>,
+}
+
+/// Opaque XML-to-JSON fallback for schema branches that cannot be planned.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct XmlJsonSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub xml_name: Option<String>,
+}
+
+/// One field on a normalized XML object.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct XmlFieldSpec {
+    pub name: String,
+    pub xml_name: String,
+    #[serde(default)]
+    pub attribute: bool,
+    pub value: XmlValueSpec,
+}
+
+/// Scalar target used while normalizing XML text.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum XmlScalarType {
+    String,
+    Integer,
+    Number,
+    Boolean,
+}
+
+const fn default_true() -> bool {
+    true
 }
 
 /// How the engine converts a selected response value into logical rows.

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -99,7 +99,9 @@ pub use common::{
     PaginationSpec, QueryParamSpec, RequestRouteSpec, RequestSpec, ResponseBodyFormat,
     ResponseSpec, RowStrategy, SearchLimitsSpec, SourceBackend, SourceManifestCommon,
     SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon, TableFunctionArgSpec,
-    TimestampInput, ValidatedPagination, ValidatedPaginationMode, ValueSourceSpec,
+    TimestampInput, ValidatedPagination, ValidatedPaginationMode, ValueSourceSpec, XmlFieldSpec,
+    XmlJsonSpec, XmlListSpec, XmlObjectSpec, XmlResponseSpec, XmlScalarSpec, XmlScalarType,
+    XmlValueSpec,
 };
 pub use error::{ManifestError, Result};
 pub use inputs::{

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -3,8 +3,8 @@
     reason = "DSL v4 contracts are field-heavy artifact models documented in the PRD."
 )]
 
-pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 1;
-pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v3";
+pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 2;
+pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v4";
 pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v4";
 
 mod artifacts;

--- a/crates/coral-spec/src/v4/naming.rs
+++ b/crates/coral-spec/src/v4/naming.rs
@@ -18,6 +18,28 @@ pub fn normalize_identifier(value: &str, prefix: &str) -> String {
     }
 }
 
+pub(crate) fn normalize_schema_identifier(value: &str, prefix: &str) -> String {
+    normalize_identifier(&entity_identifier_seed(value), prefix)
+}
+
+fn entity_identifier_seed(raw: &str) -> String {
+    let mut seed = String::new();
+    let mut previous_was_lowercase_or_digit = false;
+    for ch in raw.chars() {
+        if ch.is_ascii_uppercase() && previous_was_lowercase_or_digit {
+            seed.push('_');
+        }
+        if ch == '-' || ch == ' ' {
+            seed.push('_');
+            previous_was_lowercase_or_digit = false;
+        } else {
+            seed.push(ch.to_ascii_lowercase());
+            previous_was_lowercase_or_digit = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+        }
+    }
+    seed
+}
+
 pub(crate) fn singularize(value: &str) -> String {
     if let Some(stem) = value.strip_suffix("ies")
         && !stem.is_empty()

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use super::*;
-use crate::parse_source_manifest_yaml;
+use crate::{ResponseBodyFormat, XmlValueSpec, parse_source_manifest_yaml};
 
 #[test]
 fn extracts_openapi_document_metadata() {
@@ -170,6 +170,238 @@ components:
     let projection = catalog.projections.first().expect("projection");
     assert_eq!(projection.name, "repositories");
     assert!(matches!(projection.kind, ProjectionKind::Table));
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "This fixture intentionally carries the full XML envelope and multiple response collections."
+)]
+fn importer_selects_xml_response_and_builds_schema_normalization_plan() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: cloudwatch
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://monitoring.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /:
+    get:
+      operationId: DescribeAlarms
+      parameters:
+        - {name: Action, in: query, required: true, schema: {type: string}}
+        - {name: Version, in: query, required: true, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            text/xml:
+              schema: {$ref: '#/components/schemas/DescribeAlarmsResponse'}
+components:
+  schemas:
+    DescribeAlarmsResponse:
+      type: object
+      xml: {name: DescribeAlarmsResponse}
+      properties:
+        DescribeAlarmsResult:
+          $ref: '#/components/schemas/DescribeAlarmsResult'
+        ResponseMetadata:
+          type: object
+          properties:
+            RequestId: {type: string}
+    DescribeAlarmsResult:
+      type: object
+      properties:
+        CompositeAlarms:
+          allOf:
+            - {$ref: '#/components/schemas/CompositeAlarms'}
+            - {description: The returned composite alarms.}
+        MetricAlarms:
+          allOf:
+            - {$ref: '#/components/schemas/MetricAlarms'}
+            - {description: The returned metric alarms.}
+        NextToken: {type: string}
+    CompositeAlarms:
+      type: array
+      items: {$ref: '#/components/schemas/CompositeAlarm'}
+    CompositeAlarm:
+      type: object
+      properties:
+        AlarmName: {type: string}
+        AlarmRule: {type: string}
+    MetricAlarms:
+      type: array
+      items: {$ref: '#/components/schemas/MetricAlarm'}
+    MetricAlarm:
+      type: object
+      properties:
+        AlarmName: {type: string}
+        ActionsEnabled: {type: boolean}
+"
+        .as_bytes(),
+    )
+    .expect("import XML response");
+    assert_eq!(ir.operations.len(), 2);
+    let operation = ir
+        .operations
+        .iter()
+        .find(|operation| {
+            operation.output.row_path
+                == vec![
+                    "DescribeAlarmsResponse".to_string(),
+                    "DescribeAlarmsResult".to_string(),
+                    "MetricAlarms".to_string(),
+                ]
+        })
+        .expect("metric alarm operation");
+    assert!(
+        ir.operations.iter().any(|operation| {
+            operation.output.row_path
+                == vec![
+                    "DescribeAlarmsResponse".to_string(),
+                    "DescribeAlarmsResult".to_string(),
+                    "CompositeAlarms".to_string(),
+                ]
+        }),
+        "composite alarms should get a separate operation"
+    );
+    assert_eq!(operation.output.cardinality, OutputCardinality::WrappedList);
+    assert_eq!(
+        operation.output.row_path,
+        vec![
+            "DescribeAlarmsResponse".to_string(),
+            "DescribeAlarmsResult".to_string(),
+            "MetricAlarms".to_string()
+        ]
+    );
+    let IrExecutionAttachment::Rest(rest) = &operation.execution;
+    assert_eq!(rest.response.media_type, "text/xml");
+    assert_eq!(rest.response.response.format, ResponseBodyFormat::Xml);
+    let xml = rest.response.response.xml.as_ref().expect("xml plan");
+    assert_eq!(xml.root_name.as_deref(), Some("DescribeAlarmsResponse"));
+    let XmlValueSpec::Object(root) = &xml.root else {
+        panic!("root should be an object plan");
+    };
+    let result = root
+        .fields
+        .iter()
+        .find(|field| field.name == "DescribeAlarmsResult")
+        .expect("result field");
+    let XmlValueSpec::Object(result) = &result.value else {
+        panic!("result should be an object plan");
+    };
+    let alarms = result
+        .fields
+        .iter()
+        .find(|field| field.name == "MetricAlarms")
+        .expect("metric alarms field");
+    let XmlValueSpec::List(alarms) = &alarms.value else {
+        panic!("metric alarms should be a list plan");
+    };
+    assert_eq!(alarms.item_xml_name.as_deref(), Some("member"));
+
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
+    let projection_names = catalog
+        .projections
+        .iter()
+        .map(|projection| projection.name.as_str())
+        .collect::<Vec<_>>();
+    let projection = catalog
+        .projections
+        .iter()
+        .find(|projection| projection.name == "metric_alarms")
+        .unwrap_or_else(|| panic!("metric alarm projection in {projection_names:?}"));
+    assert!(
+        catalog
+            .projections
+            .iter()
+            .any(|projection| projection.name == "composite_alarms"),
+        "composite alarms should get a projection"
+    );
+    assert_eq!(projection.name, "metric_alarms");
+    let columns = projection
+        .columns
+        .iter()
+        .map(|column| (column.name.as_str(), column.data_type))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        columns,
+        vec![
+            ("alarm_name", crate::ManifestDataType::Utf8),
+            ("actions_enabled", crate::ManifestDataType::Boolean)
+        ]
+    );
+}
+
+#[test]
+fn importer_preserves_xml_name_local_part_and_attribute_fields() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: feed
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://feed.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /entry:
+    get:
+      operationId: getEntry
+      responses:
+        '200':
+          content:
+            application/xml:
+              schema:
+                type: object
+                xml: {name: atom:entry}
+                properties:
+                  id:
+                    type: integer
+                    xml: {attribute: true}
+                  title:
+                    type: string
+components: {schemas: {}}
+"
+        .as_bytes(),
+    )
+    .expect("import XML response");
+    let operation = ir.operations.first().expect("operation");
+    assert_eq!(operation.output.row_path, vec!["entry".to_string()]);
+    let IrExecutionAttachment::Rest(rest) = &operation.execution;
+    let xml = rest.response.response.xml.as_ref().expect("xml plan");
+    assert_eq!(xml.root_name.as_deref(), Some("entry"));
+    let XmlValueSpec::Object(root) = &xml.root else {
+        panic!("root should be an object plan");
+    };
+    let id = root
+        .fields
+        .iter()
+        .find(|field| field.name == "id")
+        .expect("id field");
+    assert!(id.attribute);
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -6,7 +6,7 @@ use crate::v4::ir::{
     IrScalarType, IrTypeShape, OutputCardinality, SemanticIr,
 };
 use crate::v4::manifest::V4SourceManifest;
-use crate::v4::naming::{normalize_identifier, stable_suffix};
+use crate::v4::naming::{normalize_identifier, normalize_schema_identifier, stable_suffix};
 use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
 use crate::{ManifestDataType, Result, SearchLimitsSpec, SourceTableFunctionKind};
 
@@ -106,7 +106,7 @@ fn generate_projection(
                 ));
             }
             ProjectionInput {
-                name: normalize_identifier(&input.name, "input"),
+                name: normalize_schema_identifier(&input.name, "input"),
                 sql_exposure: exposure,
                 source_location: input.location,
                 wire_name: input.name.clone(),
@@ -194,7 +194,7 @@ fn projection_columns(ir: &SemanticIr, operation: &IrOperation) -> Vec<Projectio
     let mut columns = Vec::new();
     let mut names = HashSet::new();
     for field in fields {
-        let mut name = normalize_identifier(&field.name, "column");
+        let mut name = normalize_schema_identifier(&field.name, "column");
         if !names.insert(name.clone()) {
             let suffix = stable_suffix(&field.name);
             name = format!("{name}__{suffix}");

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrType, SemanticIr};
@@ -67,15 +67,17 @@ impl<'a> OpenApiImporter<'a> {
                 let Some(operation_value) = path_item.get(method_name) else {
                     continue;
                 };
-                let operation =
+                let imported_operations =
                     self.import_operation(path, path_item, method_name, operation_value)?;
-                if !operation_ids.insert(operation.id.clone()) {
-                    return Err(ManifestError::validation(format!(
-                        "source '{}' surface '{}' imports duplicate operation id '{}'",
-                        self.manifest.common.name, self.surface.id, operation.id
-                    )));
+                for operation in imported_operations {
+                    if !operation_ids.insert(operation.id.clone()) {
+                        return Err(ManifestError::validation(format!(
+                            "source '{}' surface '{}' imports duplicate operation id '{}'",
+                            self.manifest.common.name, self.surface.id, operation.id
+                        )));
+                    }
+                    operations.push(operation);
                 }
-                operations.push(operation);
             }
         }
         Ok(SemanticIr {
@@ -119,6 +121,54 @@ impl<'a> OpenApiImporter<'a> {
                 Some(operation_id.to_string()),
             ));
             None
+        }
+    }
+
+    pub(super) fn effective_schema(
+        &self,
+        schema: &Value,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<Value> {
+        let resolved = self.resolve_ref(schema, operation_id, diagnostics)?;
+        let Some(all_of) = resolved.get("allOf").and_then(Value::as_array) else {
+            return Some(resolved);
+        };
+
+        let mut merged = Map::new();
+        for (key, value) in resolved.as_object()? {
+            if key != "allOf" {
+                merged.insert(key.clone(), value.clone());
+            }
+        }
+        for item in all_of {
+            let item = self.effective_schema(item, operation_id, diagnostics)?;
+            merge_schema_object(&mut merged, &item);
+        }
+        Some(Value::Object(merged))
+    }
+}
+
+fn merge_schema_object(target: &mut Map<String, Value>, item: &Value) {
+    let Some(item) = item.as_object() else {
+        return;
+    };
+    for (key, value) in item {
+        if key == "properties" {
+            let target_properties = target
+                .entry(key.clone())
+                .or_insert_with(|| Value::Object(Map::new()));
+            if let (Some(target_map), Some(value_map)) =
+                (target_properties.as_object_mut(), value.as_object())
+            {
+                for (property_name, property_schema) in value_map {
+                    target_map
+                        .entry(property_name.clone())
+                        .or_insert_with(|| property_schema.clone());
+                }
+            }
+        } else {
+            target.entry(key.clone()).or_insert_with(|| value.clone());
         }
     }
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -19,7 +19,7 @@ impl OpenApiImporter<'_> {
         path_item: &Map<String, Value>,
         method_name: &str,
         operation: &Value,
-    ) -> Result<IrOperation> {
+    ) -> Result<Vec<IrOperation>> {
         let op_obj = operation.as_object().ok_or_else(|| {
             ManifestError::validation(format!(
                 "OpenAPI operation {method_name} {path} must be a mapping"
@@ -36,10 +36,10 @@ impl OpenApiImporter<'_> {
         let mut diagnostics = Vec::new();
         let parameters = self.import_parameters(path_item, op_obj, &operation_id, &mut diagnostics);
         let request_body = self.import_request_body(op_obj, &operation_id, &mut diagnostics);
-        let (output, response, entity) =
-            self.import_response(path, op_obj, &operation_id, &mut diagnostics);
+        let response_variants =
+            self.import_response_variants(path, op_obj, &operation_id, &mut diagnostics);
         let pagination = detect_pagination(&parameters);
-        let rest_parameters = parameters
+        let rest_parameters: Vec<RestParameterBinding> = parameters
             .iter()
             .map(|input| RestParameterBinding {
                 input_name: input.name.clone(),
@@ -49,37 +49,55 @@ impl OpenApiImporter<'_> {
                 data_type: input.data_type,
             })
             .collect();
-        Ok(IrOperation {
-            id: operation_id.clone(),
-            method_name: op_obj
-                .get("operationId")
-                .and_then(Value::as_str)
-                .unwrap_or(method_name)
-                .to_string(),
-            description: op_obj
-                .get("description")
-                .or_else(|| op_obj.get("summary"))
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_string(),
-            deprecated: op_obj
-                .get("deprecated")
-                .and_then(Value::as_bool)
-                .unwrap_or(false),
-            read_only: method == HttpMethod::Get,
-            inputs: parameters,
-            output,
-            entity,
-            execution: IrExecutionAttachment::Rest(RestExecutionAttachment {
-                method,
-                path_template: path.to_string(),
-                parameters: rest_parameters,
-                request_body,
-                response,
-                pagination,
-            }),
-            diagnostics,
-        })
+        let method_name_value = op_obj
+            .get("operationId")
+            .and_then(Value::as_str)
+            .unwrap_or(method_name)
+            .to_string();
+        let description = op_obj
+            .get("description")
+            .or_else(|| op_obj.get("summary"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let deprecated = op_obj
+            .get("deprecated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let multiple_variants = response_variants.len() > 1;
+        Ok(response_variants
+            .into_iter()
+            .map(|variant| {
+                let id = if multiple_variants {
+                    format!(
+                        "{}_{}",
+                        operation_id,
+                        normalize_identifier(&variant.name_suffix, "response")
+                    )
+                } else {
+                    operation_id.clone()
+                };
+                IrOperation {
+                    id,
+                    method_name: method_name_value.clone(),
+                    description: description.clone(),
+                    deprecated,
+                    read_only: method == HttpMethod::Get,
+                    inputs: parameters.clone(),
+                    output: variant.output,
+                    entity: variant.entity,
+                    execution: IrExecutionAttachment::Rest(RestExecutionAttachment {
+                        method,
+                        path_template: path.to_string(),
+                        parameters: rest_parameters.clone(),
+                        request_body: request_body.clone(),
+                        response: variant.response,
+                        pagination: pagination.clone(),
+                    }),
+                    diagnostics: diagnostics.clone(),
+                }
+            })
+            .collect())
     }
 
     fn import_parameters(

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -1,111 +1,194 @@
+use std::collections::BTreeSet;
+
 use serde_json::{Map, Value};
 
-use crate::ResponseSpec;
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{
     IrEntityCandidate, IrOperationOutput, OutputCardinality, RestResponseAttachment,
 };
+use crate::{
+    ResponseBodyFormat, ResponseSpec, XmlFieldSpec, XmlJsonSpec, XmlListSpec, XmlObjectSpec,
+    XmlResponseSpec, XmlScalarSpec, XmlScalarType, XmlValueSpec,
+};
 
 use super::import::OpenApiImporter;
 
+pub(super) struct ImportedResponseVariant {
+    pub(super) name_suffix: String,
+    pub(super) output: IrOperationOutput,
+    pub(super) response: RestResponseAttachment,
+    pub(super) entity: Option<IrEntityCandidate>,
+}
+
+#[derive(Debug, Clone)]
+struct ClassifiedResponse {
+    name_suffix: String,
+    cardinality: OutputCardinality,
+    row_path: Vec<String>,
+    row_schema: Value,
+    entity_name: Option<String>,
+    xml: Option<XmlResponseSpec>,
+}
+
+#[derive(Debug, Clone)]
+struct XmlCollectionCandidate {
+    name: String,
+    item_schema: Value,
+    entity_name: Option<String>,
+}
+
 impl OpenApiImporter<'_> {
-    pub(super) fn import_response(
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Response import has to keep JSON and XML variant assembly close to preserve response-selection behavior."
+    )]
+    pub(super) fn import_response_variants(
         &mut self,
         path: &str,
         operation: &Map<String, Value>,
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
-    ) -> (
-        IrOperationOutput,
-        RestResponseAttachment,
-        Option<IrEntityCandidate>,
-    ) {
-        let Some((status_code, media_type, schema)) = self.select_json_response(
+    ) -> Vec<ImportedResponseVariant> {
+        let Some(selected) = self.select_success_response(
             operation.get("responses").and_then(Value::as_object),
             operation_id,
             diagnostics,
         ) else {
             let response = ResponseSpec::default();
-            return (
-                IrOperationOutput {
+            return vec![ImportedResponseVariant {
+                name_suffix: "response".to_string(),
+                output: IrOperationOutput {
                     cardinality: OutputCardinality::None,
                     type_ref: "none".to_string(),
                     row_path: Vec::new(),
                 },
-                RestResponseAttachment {
+                response: RestResponseAttachment {
                     status_code: 204,
                     media_type: "application/json".to_string(),
                     response,
                 },
-                None,
-            );
+                entity: None,
+            }];
         };
 
-        let Some(resolved) = self.resolve_ref(&schema, operation_id, diagnostics) else {
+        let Some(resolved) = self.resolve_ref(&selected.schema, operation_id, diagnostics) else {
             diagnostics.push(Diagnostic::warning(
                 "OPENAPI_RESPONSE_SCHEMA_UNRESOLVED",
                 format!("operation '{operation_id}' response schema could not be resolved"),
                 self.surface.id.clone(),
                 Some(operation_id.to_string()),
             ));
-            return (
-                IrOperationOutput {
+            return vec![ImportedResponseVariant {
+                name_suffix: "response".to_string(),
+                output: IrOperationOutput {
                     cardinality: OutputCardinality::Unknown,
                     type_ref: "json".to_string(),
                     row_path: Vec::new(),
                 },
-                RestResponseAttachment {
-                    status_code,
-                    media_type,
-                    response: ResponseSpec::default(),
+                response: RestResponseAttachment {
+                    status_code: selected.status_code,
+                    media_type: selected.media_type,
+                    response: ResponseSpec {
+                        format: selected.format,
+                        ..ResponseSpec::default()
+                    },
                 },
-                None,
-            );
+                entity: None,
+            }];
         };
-        let (cardinality, row_path, row_schema, entity_name) =
-            classify_response_schema(path, &resolved);
-        let type_ref = self
-            .import_schema(
-                &row_schema,
-                &format!("{operation_id}_row"),
-                operation_id,
-                diagnostics,
-            )
-            .unwrap_or_else(|| "json".to_string());
-        let response = ResponseSpec {
-            rows_path: row_path.clone(),
-            ..ResponseSpec::default()
+
+        let classified = match selected.format {
+            ResponseBodyFormat::Json | ResponseBodyFormat::JsonEachRow => {
+                let (cardinality, row_path, row_schema, entity_name) =
+                    classify_response_schema(path, &resolved);
+                vec![ClassifiedResponse {
+                    name_suffix: entity_name
+                        .clone()
+                        .unwrap_or_else(|| entity_name_from_path(path)),
+                    cardinality,
+                    row_path,
+                    row_schema,
+                    entity_name,
+                    xml: None,
+                }]
+            }
+            ResponseBodyFormat::Xml => {
+                let root_name = response_root_name(
+                    path,
+                    &selected.schema,
+                    &resolved,
+                    selected.schema_name.as_deref(),
+                );
+                let xml = self.build_xml_response_spec(
+                    &selected.schema,
+                    root_name.clone(),
+                    operation_id,
+                    diagnostics,
+                );
+                self.classify_xml_response_variants(
+                    path,
+                    &selected.schema,
+                    &root_name,
+                    xml,
+                    operation_id,
+                    diagnostics,
+                )
+            }
         };
-        let entity = (cardinality != OutputCardinality::None
-            && cardinality != OutputCardinality::Unknown)
-            .then(|| IrEntityCandidate {
-                name: entity_name.unwrap_or_else(|| entity_name_from_path(path)),
-                type_ref: type_ref.clone(),
-                identity_fields: vec!["id".to_string()],
-            });
-        (
-            IrOperationOutput {
-                cardinality,
-                type_ref,
-                row_path,
-            },
-            RestResponseAttachment {
-                status_code,
-                media_type,
-                response,
-            },
-            entity,
-        )
+
+        classified
+            .into_iter()
+            .map(|classified| {
+                let name_suffix = classified.name_suffix;
+                let type_ref = self
+                    .import_schema(
+                        &classified.row_schema,
+                        &format!("{operation_id}_{name_suffix}_row"),
+                        operation_id,
+                        diagnostics,
+                    )
+                    .unwrap_or_else(|| "json".to_string());
+                let response = ResponseSpec {
+                    format: selected.format,
+                    xml: classified.xml,
+                    rows_path: classified.row_path.clone(),
+                    ..ResponseSpec::default()
+                };
+                let entity = (classified.cardinality != OutputCardinality::None
+                    && classified.cardinality != OutputCardinality::Unknown)
+                    .then(|| IrEntityCandidate {
+                        name: classified
+                            .entity_name
+                            .unwrap_or_else(|| entity_name_from_path(path)),
+                        type_ref: type_ref.clone(),
+                        identity_fields: vec!["id".to_string()],
+                    });
+                ImportedResponseVariant {
+                    name_suffix,
+                    output: IrOperationOutput {
+                        cardinality: classified.cardinality,
+                        type_ref,
+                        row_path: classified.row_path,
+                    },
+                    response: RestResponseAttachment {
+                        status_code: selected.status_code,
+                        media_type: selected.media_type.clone(),
+                        response,
+                    },
+                    entity,
+                }
+            })
+            .collect()
     }
-    fn select_json_response(
+
+    fn select_success_response(
         &self,
         responses: Option<&Map<String, Value>>,
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
-    ) -> Option<(u16, String, Value)> {
+    ) -> Option<SelectedResponse> {
         let responses = responses?;
-        let mut numeric_candidates = Vec::new();
-        let mut range_candidates = Vec::new();
+        let mut candidates = Vec::new();
         for (status, response) in responses {
             let Some(status) = success_response_status(status) else {
                 continue;
@@ -116,24 +199,431 @@ impl OpenApiImporter<'_> {
             let Some(content) = response.get("content").and_then(Value::as_object) else {
                 continue;
             };
-            let Some(json) = content.get("application/json") else {
-                continue;
-            };
-            let schema = json.get("schema").cloned().unwrap_or(Value::Null);
-            let candidate = (
-                status.representative_status_code(),
-                "application/json".to_string(),
-                schema,
-            );
-            if status.is_range() {
-                range_candidates.push(candidate);
-            } else {
-                numeric_candidates.push(candidate);
+            for (media_type, media) in content {
+                let Some((format, media_rank)) = response_media_format(media_type) else {
+                    continue;
+                };
+                candidates.push(SelectedResponse {
+                    status_code: status.representative_status_code(),
+                    status_rank: status.preference_rank(),
+                    media_type: media_type.clone(),
+                    media_rank,
+                    format,
+                    schema: media.get("schema").cloned().unwrap_or(Value::Null),
+                    schema_name: media
+                        .get("schema")
+                        .and_then(Value::as_object)
+                        .and_then(|schema| schema.get("$ref"))
+                        .and_then(Value::as_str)
+                        .map(entity_name_from_ref),
+                });
             }
         }
-        preferred_numeric_response(numeric_candidates)
-            .or_else(|| range_candidates.into_iter().next())
+        candidates.into_iter().min_by_key(|candidate| {
+            (
+                candidate.media_rank,
+                candidate.status_rank,
+                candidate.status_code,
+            )
+        })
     }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "XML row classification has several conservative schema branches that are clearer kept together."
+    )]
+    fn classify_xml_response_variants(
+        &self,
+        path: &str,
+        schema: &Value,
+        root_name: &str,
+        xml: Option<XmlResponseSpec>,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Vec<ClassifiedResponse> {
+        let Some(effective) = self.effective_schema(schema, operation_id, diagnostics) else {
+            return vec![ClassifiedResponse {
+                name_suffix: entity_name_from_path(path),
+                cardinality: OutputCardinality::Unknown,
+                row_path: Vec::new(),
+                row_schema: schema.clone(),
+                entity_name: None,
+                xml,
+            }];
+        };
+        if effective == Value::Null {
+            return vec![ClassifiedResponse {
+                name_suffix: "response".to_string(),
+                cardinality: OutputCardinality::None,
+                row_path: Vec::new(),
+                row_schema: Value::Null,
+                entity_name: None,
+                xml,
+            }];
+        }
+        if schema_type(&effective) == "array" {
+            let item = effective.get("items").cloned().unwrap_or(Value::Null);
+            return vec![ClassifiedResponse {
+                name_suffix: item
+                    .get("$ref")
+                    .and_then(Value::as_str)
+                    .map_or_else(|| root_name.to_string(), entity_name_from_ref),
+                cardinality: OutputCardinality::List,
+                row_path: vec![root_name.to_string()],
+                row_schema: item.clone(),
+                entity_name: item
+                    .get("$ref")
+                    .and_then(Value::as_str)
+                    .map(entity_name_from_ref),
+                xml,
+            }];
+        }
+        if schema_type(&effective) == "object" {
+            let collections = self.xml_collection_properties(&effective, operation_id, diagnostics);
+            if !collections.is_empty() {
+                return collections
+                    .into_iter()
+                    .map(|collection| {
+                        let name_suffix = collection
+                            .entity_name
+                            .clone()
+                            .unwrap_or_else(|| collection.name.clone());
+                        ClassifiedResponse {
+                            name_suffix,
+                            cardinality: OutputCardinality::WrappedList,
+                            row_path: vec![root_name.to_string(), collection.name],
+                            row_schema: collection.item_schema,
+                            entity_name: collection.entity_name,
+                            xml: xml.clone(),
+                        }
+                    })
+                    .collect();
+            }
+
+            if let Some((property_name, property_schema)) =
+                self.single_xml_payload_object_property(&effective, operation_id, diagnostics)
+            {
+                let property_schema = self
+                    .effective_schema(&property_schema, operation_id, diagnostics)
+                    .unwrap_or(property_schema);
+                let collections =
+                    self.xml_collection_properties(&property_schema, operation_id, diagnostics);
+                if !collections.is_empty() {
+                    return collections
+                        .into_iter()
+                        .map(|collection| {
+                            let name_suffix = collection
+                                .entity_name
+                                .clone()
+                                .unwrap_or_else(|| collection.name.clone());
+                            ClassifiedResponse {
+                                name_suffix,
+                                cardinality: OutputCardinality::WrappedList,
+                                row_path: vec![
+                                    root_name.to_string(),
+                                    property_name.clone(),
+                                    collection.name,
+                                ],
+                                row_schema: collection.item_schema,
+                                entity_name: collection.entity_name,
+                                xml: xml.clone(),
+                            }
+                        })
+                        .collect();
+                }
+                let entity_name = property_name.clone();
+                return vec![ClassifiedResponse {
+                    name_suffix: entity_name.clone(),
+                    cardinality: OutputCardinality::Singleton,
+                    row_path: vec![root_name.to_string(), property_name],
+                    row_schema: property_schema.clone(),
+                    entity_name: property_schema
+                        .get("$ref")
+                        .and_then(Value::as_str)
+                        .map(entity_name_from_ref)
+                        .or(Some(entity_name)),
+                    xml,
+                }];
+            }
+
+            return vec![ClassifiedResponse {
+                name_suffix: schema
+                    .get("$ref")
+                    .and_then(Value::as_str)
+                    .map_or_else(|| entity_name_from_path(path), entity_name_from_ref),
+                cardinality: OutputCardinality::Singleton,
+                row_path: vec![root_name.to_string()],
+                row_schema: effective.clone(),
+                entity_name: schema
+                    .get("$ref")
+                    .and_then(Value::as_str)
+                    .map(entity_name_from_ref)
+                    .or_else(|| Some(entity_name_from_path(path))),
+                xml,
+            }];
+        }
+        vec![ClassifiedResponse {
+            name_suffix: entity_name_from_path(path),
+            cardinality: OutputCardinality::Unknown,
+            row_path: Vec::new(),
+            row_schema: effective,
+            entity_name: None,
+            xml,
+        }]
+    }
+
+    fn xml_collection_properties(
+        &self,
+        schema: &Value,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Vec<XmlCollectionCandidate> {
+        let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+            return Vec::new();
+        };
+        properties
+            .iter()
+            .filter(|(name, _)| !is_xml_wrapper_metadata_property(name))
+            .filter_map(|(name, property)| {
+                let effective = self.effective_schema(property, operation_id, diagnostics)?;
+                if schema_type(&effective) != "array" {
+                    return None;
+                }
+                let item_schema = effective.get("items").cloned().unwrap_or(Value::Null);
+                let name = property_xml_name(property, &effective, name);
+                let entity_name = item_schema
+                    .get("$ref")
+                    .and_then(Value::as_str)
+                    .map(entity_name_from_ref);
+                Some(XmlCollectionCandidate {
+                    name,
+                    item_schema,
+                    entity_name,
+                })
+            })
+            .collect()
+    }
+
+    fn single_xml_payload_object_property(
+        &self,
+        schema: &Value,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<(String, Value)> {
+        let properties = schema.get("properties").and_then(Value::as_object)?;
+        let payloads = properties
+            .iter()
+            .filter(|(name, _)| !is_xml_wrapper_metadata_property(name))
+            .filter_map(|(name, property)| {
+                let effective = self.effective_schema(property, operation_id, diagnostics)?;
+                (schema_type(&effective) == "object").then(|| {
+                    (
+                        property_xml_name(property, &effective, name),
+                        property.clone(),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        match payloads.as_slice() {
+            [(name, property)] => Some((name.clone(), property.clone())),
+            [] | [_, _, ..] => None,
+        }
+    }
+
+    fn build_xml_response_spec(
+        &self,
+        schema: &Value,
+        root_name: String,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<XmlResponseSpec> {
+        let mut seen_refs = BTreeSet::new();
+        let root = self.build_xml_value_spec(
+            schema,
+            &root_name,
+            operation_id,
+            diagnostics,
+            &mut seen_refs,
+        )?;
+        Some(XmlResponseSpec {
+            root_name: Some(root_name),
+            root,
+        })
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Recursive XML plan construction mirrors OpenAPI schema branches and is easier to audit in one place."
+    )]
+    fn build_xml_value_spec(
+        &self,
+        schema: &Value,
+        fallback_name: &str,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+        seen_refs: &mut BTreeSet<String>,
+    ) -> Option<XmlValueSpec> {
+        let reference = schema
+            .get("$ref")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if let Some(reference) = &reference
+            && !seen_refs.insert(reference.clone())
+        {
+            return Some(XmlValueSpec::Json(XmlJsonSpec {
+                xml_name: Some(local_name(fallback_name).to_string()),
+            }));
+        }
+
+        let effective = self.effective_schema(schema, operation_id, diagnostics)?;
+        let xml_name = property_xml_name(schema, &effective, fallback_name);
+        let spec = match schema_type(&effective) {
+            "array" => {
+                let items = effective.get("items").unwrap_or(&Value::Null);
+                let wrapped = xml_wrapped(schema)
+                    .or_else(|| xml_wrapped(&effective))
+                    .unwrap_or(true);
+                let item_effective = self
+                    .effective_schema(items, operation_id, diagnostics)
+                    .unwrap_or_else(|| items.clone());
+                let item_xml_name = array_item_xml_name(
+                    schema,
+                    &effective,
+                    items,
+                    &item_effective,
+                    &xml_name,
+                    fallback_name,
+                    wrapped,
+                );
+                let item = self
+                    .build_xml_value_spec(
+                        items,
+                        &item_xml_name,
+                        operation_id,
+                        diagnostics,
+                        seen_refs,
+                    )
+                    .unwrap_or_else(|| {
+                        XmlValueSpec::Json(XmlJsonSpec {
+                            xml_name: Some(item_xml_name.clone()),
+                        })
+                    });
+                XmlValueSpec::List(XmlListSpec {
+                    xml_name: Some(xml_name),
+                    wrapped,
+                    item_xml_name: Some(item_xml_name),
+                    item: Box::new(item),
+                })
+            }
+            "object" => {
+                let fields = effective
+                    .get("properties")
+                    .and_then(Value::as_object)
+                    .map(|properties| {
+                        properties
+                            .iter()
+                            .filter_map(|(name, property)| {
+                                let property_effective =
+                                    self.effective_schema(property, operation_id, diagnostics)?;
+                                let field_xml_name =
+                                    property_xml_name(property, &property_effective, name);
+                                let attribute =
+                                    xml_attribute(property).or_else(|| xml_attribute(&property_effective));
+                                let value = self
+                                    .build_xml_value_spec(
+                                        property,
+                                        &field_xml_name,
+                                        operation_id,
+                                        diagnostics,
+                                        seen_refs,
+                                    )
+                                    .unwrap_or_else(|| {
+                                        XmlValueSpec::Json(XmlJsonSpec {
+                                            xml_name: Some(field_xml_name.clone()),
+                                        })
+                                    });
+                                if attribute == Some(true) && !matches!(value, XmlValueSpec::Scalar(_))
+                                {
+                                    diagnostics.push(Diagnostic::warning(
+                                        "OPENAPI_XML_ATTRIBUTE_NON_SCALAR",
+                                        format!(
+                                            "operation '{operation_id}' XML attribute field '{name}' is not scalar"
+                                        ),
+                                        self.surface.id.clone(),
+                                        Some(operation_id.to_string()),
+                                    ));
+                                }
+                                Some(XmlFieldSpec {
+                                    name: name.clone(),
+                                    xml_name: field_xml_name,
+                                    attribute: attribute.unwrap_or(false),
+                                    value,
+                                })
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                if fields.is_empty()
+                    && effective
+                        .get("additionalProperties")
+                        .is_some_and(|additional| additional.as_bool() != Some(false))
+                {
+                    XmlValueSpec::Json(XmlJsonSpec {
+                        xml_name: Some(xml_name),
+                    })
+                } else {
+                    XmlValueSpec::Object(XmlObjectSpec {
+                        xml_name: Some(xml_name),
+                        fields,
+                    })
+                }
+            }
+            "integer" => XmlValueSpec::Scalar(XmlScalarSpec {
+                xml_name: Some(xml_name),
+                scalar_type: XmlScalarType::Integer,
+            }),
+            "number" => XmlValueSpec::Scalar(XmlScalarSpec {
+                xml_name: Some(xml_name),
+                scalar_type: XmlScalarType::Number,
+            }),
+            "boolean" => XmlValueSpec::Scalar(XmlScalarSpec {
+                xml_name: Some(xml_name),
+                scalar_type: XmlScalarType::Boolean,
+            }),
+            "string" => XmlValueSpec::Scalar(XmlScalarSpec {
+                xml_name: Some(xml_name),
+                scalar_type: XmlScalarType::String,
+            }),
+            _ => {
+                if effective.get("enum").and_then(Value::as_array).is_some() {
+                    XmlValueSpec::Scalar(XmlScalarSpec {
+                        xml_name: Some(xml_name),
+                        scalar_type: XmlScalarType::String,
+                    })
+                } else {
+                    XmlValueSpec::Json(XmlJsonSpec {
+                        xml_name: Some(xml_name),
+                    })
+                }
+            }
+        };
+
+        if let Some(reference) = reference {
+            seen_refs.remove(&reference);
+        }
+        Some(spec)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SelectedResponse {
+    status_code: u16,
+    status_rank: u16,
+    media_type: String,
+    media_rank: u8,
+    format: ResponseBodyFormat,
+    schema: Value,
+    schema_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -150,8 +640,12 @@ impl SuccessResponseStatus {
         }
     }
 
-    fn is_range(self) -> bool {
-        matches!(self, Self::Range2xx)
+    fn preference_rank(self) -> u16 {
+        match self {
+            Self::Numeric(200) => 0,
+            Self::Numeric(status_code) => status_code,
+            Self::Range2xx => u16::MAX,
+        }
     }
 }
 
@@ -166,14 +660,22 @@ fn success_response_status(status: &str) -> Option<SuccessResponseStatus> {
         .then_some(SuccessResponseStatus::Range2xx)
 }
 
-fn preferred_numeric_response(
-    candidates: Vec<(u16, String, Value)>,
-) -> Option<(u16, String, Value)> {
-    candidates
-        .iter()
-        .position(|(status, _, _)| *status == 200)
-        .and_then(|index| candidates.get(index).cloned())
-        .or_else(|| candidates.into_iter().min_by_key(|(status, _, _)| *status))
+fn response_media_format(media_type: &str) -> Option<(ResponseBodyFormat, u8)> {
+    let normalized = media_type
+        .split(';')
+        .next()
+        .unwrap_or(media_type)
+        .trim()
+        .to_ascii_lowercase();
+    match normalized.as_str() {
+        "application/json" => Some((ResponseBodyFormat::Json, 0)),
+        "text/xml" | "application/xml" => Some((ResponseBodyFormat::Xml, 2)),
+        other if other.ends_with("+json") => Some((ResponseBodyFormat::Json, 1)),
+        other if other.ends_with("+xml") || other.ends_with("/xml") => {
+            Some((ResponseBodyFormat::Xml, 3))
+        }
+        _ => None,
+    }
 }
 
 fn classify_response_schema(
@@ -260,6 +762,117 @@ fn is_wrapper_metadata_property(name: &str) -> bool {
     )
 }
 
+fn is_xml_wrapper_metadata_property(name: &str) -> bool {
+    let normalized = name.to_ascii_lowercase();
+    matches!(
+        normalized.as_str(),
+        "responsemetadata"
+            | "response_metadata"
+            | "metadata"
+            | "total_count"
+            | "incomplete_results"
+            | "has_more"
+            | "next"
+            | "previous"
+    )
+}
+
+fn response_root_name(
+    path: &str,
+    schema: &Value,
+    resolved: &Value,
+    schema_name: Option<&str>,
+) -> String {
+    schema_xml_name(schema)
+        .or_else(|| schema_xml_name(resolved))
+        .or(schema_name)
+        .map(local_name)
+        .map_or_else(|| entity_name_from_path(path), ToString::to_string)
+}
+
+fn property_xml_name(schema: &Value, effective: &Value, fallback: &str) -> String {
+    schema_xml_name(schema)
+        .or_else(|| schema_xml_name(effective))
+        .map(local_name)
+        .map_or_else(|| local_name(fallback).to_string(), ToString::to_string)
+}
+
+fn array_item_xml_name(
+    schema: &Value,
+    effective: &Value,
+    items: &Value,
+    item_effective: &Value,
+    array_xml_name: &str,
+    fallback_name: &str,
+    wrapped: bool,
+) -> String {
+    items
+        .get("xml")
+        .and_then(Value::as_object)
+        .and_then(|xml| xml.get("name"))
+        .and_then(Value::as_str)
+        .or_else(|| schema_xml_name(item_effective))
+        .or_else(|| (!wrapped).then_some(array_xml_name))
+        .or_else(|| schema_xml_name(schema))
+        .or_else(|| schema_xml_name(effective))
+        .map(local_name)
+        .map_or_else(
+            || {
+                if wrapped {
+                    "member".to_string()
+                } else {
+                    local_name(fallback_name).to_string()
+                }
+            },
+            ToString::to_string,
+        )
+}
+
+fn schema_xml_name(schema: &Value) -> Option<&str> {
+    schema
+        .get("xml")
+        .and_then(Value::as_object)
+        .and_then(|xml| xml.get("name"))
+        .and_then(Value::as_str)
+}
+
+fn xml_attribute(schema: &Value) -> Option<bool> {
+    schema
+        .get("xml")
+        .and_then(Value::as_object)
+        .and_then(|xml| xml.get("attribute"))
+        .and_then(Value::as_bool)
+}
+
+fn xml_wrapped(schema: &Value) -> Option<bool> {
+    schema
+        .get("xml")
+        .and_then(Value::as_object)
+        .and_then(|xml| xml.get("wrapped"))
+        .and_then(Value::as_bool)
+}
+
+fn schema_type(schema: &Value) -> &str {
+    schema
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| {
+            if schema.get("properties").is_some() || schema.get("additionalProperties").is_some() {
+                "object"
+            } else if schema.get("items").is_some() {
+                "array"
+            } else if schema.get("enum").is_some() {
+                "string"
+            } else {
+                "object"
+            }
+        })
+}
+
+fn local_name(name: &str) -> &str {
+    name.rsplit_once(':').map_or(name, |(_, local)| local)
+}
+
 fn entity_name_from_ref(reference: &str) -> String {
     reference
         .rsplit('/')
@@ -272,4 +885,22 @@ fn entity_name_from_path(path: &str) -> String {
         .rfind(|segment| !segment.is_empty() && !segment.starts_with('{'))
         .unwrap_or("entity")
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::response_media_format;
+    use crate::ResponseBodyFormat;
+
+    #[test]
+    fn response_media_format_accepts_xml_suffixes_and_parameters() {
+        assert_eq!(
+            response_media_format("application/xml; charset=utf-8"),
+            Some((ResponseBodyFormat::Xml, 2))
+        );
+        assert_eq!(
+            response_media_format("application/problem+xml"),
+            Some((ResponseBodyFormat::Xml, 3))
+        );
+    }
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -21,6 +21,7 @@ impl OpenApiImporter<'_> {
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Option<String> {
         let resolved = self.resolve_ref(schema, operation_id, diagnostics)?;
+        let effective = self.effective_schema(schema, operation_id, diagnostics)?;
         let type_id = schema.get("$ref").and_then(Value::as_str).map_or_else(
             || normalize_identifier(suggested_id, "type"),
             type_id_from_ref,
@@ -30,11 +31,13 @@ impl OpenApiImporter<'_> {
         }
         let description = resolved
             .get("description")
+            .or_else(|| effective.get("description"))
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string();
         let nullable = resolved
             .get("nullable")
+            .or_else(|| effective.get("nullable"))
             .and_then(Value::as_bool)
             .unwrap_or(false);
         self.types.insert(
@@ -46,50 +49,20 @@ impl OpenApiImporter<'_> {
                 description: description.clone(),
             },
         );
-        let shape = if let Some(all_of) = resolved.get("allOf").and_then(Value::as_array) {
-            let mut merged = Map::new();
-            for item in all_of {
-                let item = self.resolve_ref(item, operation_id, diagnostics)?;
-                if let Some(properties) = item.get("properties").and_then(Value::as_object) {
-                    for (name, property) in properties {
-                        if let Some(existing) = merged.get(name)
-                            && existing != property
-                        {
-                            diagnostics.push(Diagnostic::warning(
-                                "OPENAPI_ALLOF_CONFLICT",
-                                format!("allOf property '{name}' conflicts in operation '{operation_id}'"),
-                                self.surface.id.clone(),
-                                Some(operation_id.to_string()),
-                            ));
-                            return None;
-                        }
-                        merged.insert(name.clone(), property.clone());
-                    }
-                }
-            }
-            IrTypeShape::Object {
-                fields: self.import_object_fields(
-                    &merged,
-                    &BTreeSet::new(),
-                    &type_id,
-                    operation_id,
-                    diagnostics,
-                ),
-            }
-        } else if let Some(values) = resolved.get("enum").and_then(Value::as_array) {
+        let shape = if let Some(values) = effective.get("enum").and_then(Value::as_array) {
             IrTypeShape::Enum {
                 values: values.iter().map(enum_value).collect(),
             }
         } else {
-            match resolved
+            match effective
                 .get("type")
                 .and_then(Value::as_str)
                 .unwrap_or("object")
             {
                 "object" => {
-                    if let Some(properties) = resolved.get("properties").and_then(Value::as_object)
+                    if let Some(properties) = effective.get("properties").and_then(Value::as_object)
                     {
-                        let required = required_fields(&resolved);
+                        let required = required_fields(&effective);
                         IrTypeShape::Object {
                             fields: self.import_object_fields(
                                 properties,
@@ -99,7 +72,7 @@ impl OpenApiImporter<'_> {
                                 diagnostics,
                             ),
                         }
-                    } else if let Some(additional) = resolved.get("additionalProperties") {
+                    } else if let Some(additional) = effective.get("additionalProperties") {
                         if additional.as_bool() == Some(false) {
                             IrTypeShape::Object { fields: Vec::new() }
                         } else {
@@ -118,7 +91,7 @@ impl OpenApiImporter<'_> {
                     }
                 }
                 "array" => {
-                    let item = resolved.get("items").unwrap_or(&Value::Null);
+                    let item = effective.get("items").unwrap_or(&Value::Null);
                     let item_type_ref = self
                         .import_schema(item, &format!("{type_id}_item"), operation_id, diagnostics)
                         .unwrap_or_else(|| "json".to_string());
@@ -126,7 +99,7 @@ impl OpenApiImporter<'_> {
                 }
                 "string" => {
                     let scalar =
-                        if resolved.get("format").and_then(Value::as_str) == Some("date-time") {
+                        if effective.get("format").and_then(Value::as_str) == Some("date-time") {
                             IrScalarType::Timestamp
                         } else {
                             IrScalarType::String

--- a/crates/coral-spec/src/v4/xml_response_design.md
+++ b/crates/coral-spec/src/v4/xml_response_design.md
@@ -1,0 +1,353 @@
+# V4 XML Response Normalization Design
+
+## Problem
+
+DSL v4 OpenAPI sources currently assume JSON response bodies. XML-only APIs such
+as AWS Query APIs publish OpenAPI documents with `text/xml` responses and return
+real XML envelopes such as `DescribeAlarmsResponse`. Coral needs to consume those
+responses without requiring endpoint-specific code.
+
+The first-pass XML parser must not be a generic XML-to-JSON guesser. XML has no
+native array marker, so generic conversion creates unstable shapes: one
+`<member>` element becomes an object, while multiple `<member>` siblings become
+an array. V4 should normalize XML according to the OpenAPI response schema and
+`xml` metadata so SQL-facing columns see stable JSON-equivalent shapes.
+
+## Current Context
+
+- `crates/coral-spec/src/v4/surfaces/openapi/responses.rs` selects only
+  `application/json` success responses and builds `ResponseSpec` with JSON
+  defaults.
+- `crates/coral-spec/src/v4/surfaces/openapi/schemas.rs` imports OpenAPI schema
+  shapes into `IrType` and `IrTypeShape`, but it drops OpenAPI `xml` metadata.
+- `crates/coral-spec/src/v4/ir/rest.rs` stores `RestResponseAttachment` with
+  status code, media type, and `ResponseSpec`; it has no XML-specific response
+  plan.
+- `crates/coral-spec/src/common.rs` defines `ResponseBodyFormat` as `json` or
+  `json_each_row`.
+- `crates/coral-engine/src/backends/http/response.rs` decodes response bytes
+  according to `ResponseBodyFormat`. It parses JSON and JSON-each-row only.
+- `crates/coral-engine/src/backends/http/fetch.rs` calls `extract_rows` after
+  decoding. Row extraction is already format-neutral because it operates on
+  `serde_json::Value`.
+- `crates/coral-spec/src/v4/projections/derive.rs` generates projection columns
+  from the selected row type. Object fields become scalar or JSON columns;
+  nested lists remain JSON columns.
+
+Live validation against AWS CloudWatch showed the exact gap. A patched OpenAPI
+descriptor could make Coral call AWS and decode XML into JSON blobs, but a
+generic conversion produced AWS `member` lists whose shape varied with item
+count.
+
+## Technical Plan
+
+Add schema-driven XML response support to v4 in two layers:
+
+1. Import-time response planning in `coral-spec`.
+2. Runtime XML normalization in `coral-engine`.
+
+The importer should select XML success responses when JSON is unavailable, set
+`ResponseBodyFormat::Xml`, and attach an XML response shape derived from the
+OpenAPI response schema. The runtime should parse XML bytes into a small XML DOM
+using `quick-xml`, then normalize that DOM through the stored response shape into
+`serde_json::Value`.
+
+The normalized JSON value should represent the OpenAPI schema, not raw XML
+parser guesses. For example, if the schema says `MetricAlarms` is an array, then
+this XML:
+
+```xml
+<MetricAlarms>
+  <member>
+    <AlarmName>x</AlarmName>
+  </member>
+</MetricAlarms>
+```
+
+normalizes to:
+
+```json
+{"MetricAlarms":[{"AlarmName":"x"}]}
+```
+
+even when only one `<member>` exists.
+
+### Response Shape Model
+
+Extend `ResponseSpec` with an optional XML plan used only when
+`format: xml`:
+
+```text
+ResponseSpec {
+  format: Xml,
+  xml: Some(XmlResponseSpec),
+  rows_path: ...
+}
+```
+
+The XML plan should be serializable because v4 materialization writes response
+specs into backend-ready projection artifacts.
+
+Suggested shape:
+
+```text
+XmlResponseSpec {
+  root_name: Option<String>,
+  root: XmlValueSpec,
+}
+
+XmlValueSpec =
+  Scalar { xml_name, scalar_type }
+  Object { xml_name, fields }
+  List { xml_name, wrapped, item_xml_name, item }
+  Json { xml_name }
+
+XmlFieldSpec {
+  name,
+  xml_name,
+  attribute,
+  value
+}
+```
+
+The names in `name` are normalized JSON/schema field names used by existing
+projection paths. The names in `xml_name` are wire XML names from OpenAPI
+`xml.name` or the schema/property name fallback.
+
+The XML document root is emitted as a JSON object key. `root_name` is both a
+matcher and the top-level normalized key. This preserves the existing
+`rows_path` model:
+
+```xml
+<DescribeAlarmsResponse>
+  <DescribeAlarmsResult>
+    <MetricAlarms><member><AlarmName>x</AlarmName></member></MetricAlarms>
+  </DescribeAlarmsResult>
+</DescribeAlarmsResponse>
+```
+
+normalizes to:
+
+```json
+{
+  "DescribeAlarmsResponse": {
+    "DescribeAlarmsResult": {
+      "MetricAlarms": [{"AlarmName": "x"}]
+    }
+  }
+}
+```
+
+For a collection table, `rows_path:
+["DescribeAlarmsResponse","DescribeAlarmsResult","MetricAlarms"]` selects the
+normalized array. This keeps XML behavior aligned with the current JSON row
+extractor instead of adding a second path interpretation model.
+
+The XML response plan is built directly from the resolved OpenAPI response
+schema, not by extending `IrType` in the first slice. That keeps OpenAPI XML
+wire metadata local to HTTP response decoding while preserving existing
+projection type generation. `$ref` is resolved through the existing importer
+helper. `allOf` is flattened with the same conservative property merge behavior
+as `import_schema`; conflicting properties produce the same diagnostic class and
+fall back to JSON for that branch.
+
+### OpenAPI XML Metadata Rules
+
+Use OpenAPI metadata where present:
+
+- `xml.name` changes the wire element or attribute name.
+- `xml.attribute: true` reads a value from the current element attributes.
+- `xml.wrapped` controls array wrapper behavior.
+- Array item names come from `items.xml.name` when present.
+
+Fallbacks must remain schema-driven:
+
+- Array item element name fallback order is:
+  1. `items.xml.name`
+  2. `xml.name` on the array schema when `xml.wrapped` is explicitly `false`
+  3. `member`
+  4. the array field/property name
+
+  The `member` fallback is acceptable only because the OpenAPI schema has
+  already said the field is an array. It is a generic XML collection convention,
+  not endpoint-specific AWS code. Empty array containers normalize to `[]`.
+- If no explicit XML root name exists, use the schema name or selected response
+  type name when available, then fall back to the first XML document element.
+- Namespaces should compare by local name in the first pass. Preserve neither
+  namespace prefixes nor namespace URIs in normalized JSON keys unless a later
+  API proves that namespace distinction is required.
+- Missing elements or attributes normalize as absent fields, not empty strings.
+- Attribute fields are scalar values read from the current element's attributes.
+  If an attribute field is declared with a non-scalar schema, emit a diagnostic
+  at import time and treat that field as JSON/string-compatible for the first
+  slice.
+
+Scalar text should be coerced according to schema in the first slice:
+
+- `integer` -> JSON number if parse succeeds, otherwise string
+- `number` -> JSON number if parse succeeds, otherwise string
+- `boolean` -> JSON boolean for `true`/`false` case-insensitively, otherwise
+  string
+- `string`, `date-time`, enum, and unknown scalar-compatible values -> string
+
+Failed scalar coercion should not fail the whole request because many XML APIs
+are loose. It should preserve the original string.
+
+Media type selection is:
+
+1. Prefer success responses with exact `application/json`.
+2. Then JSON structured syntax suffixes such as `application/*+json`.
+3. Then exact `text/xml` or `application/xml`.
+4. Then XML structured syntax suffixes such as `application/*+xml`.
+5. Ignore media type parameters while comparing, so `application/xml; charset=utf-8`
+   is XML.
+
+### Runtime Decode Flow
+
+`decode_response_body` should gain an XML branch:
+
+```text
+response bytes
+  -> quick-xml parser
+  -> XmlElement DOM
+  -> normalize_with_plan(XmlElement, XmlResponseSpec)
+  -> serde_json::Value
+  -> existing extract_rows(ResponseSpec, payload)
+```
+
+The XML parser should rely on `quick-xml` escaping/unescaping instead of custom
+entity-reference code. Unsupported XML features should fail with a decode error
+that includes source, table/function, method, and URL, matching JSON decode
+errors.
+
+### Projection Behavior
+
+For the first implementation slice, keep projection generation schema-driven:
+
+- Top-level or row-level object fields become columns exactly as they do for
+  JSON.
+- Schema-normalized arrays become stable JSON columns.
+- Existing `rows_path` still controls whether the table returns a singleton,
+  list, or wrapped list.
+- XML response wrappers that contain one or more non-metadata array payloads
+  produce one imported row variant per collection. For AWS-style envelopes this
+  turns `DescribeAlarmsResponse -> DescribeAlarmsResult -> MetricAlarms/member`
+  into a `metric_alarms` projection with `MetricAlarm` fields as columns, while
+  preserving the same HTTP request and full XML response plan.
+
+Response classification stays intentionally conservative. The importer may
+identify a single object payload wrapper, then split only direct array fields of
+that wrapper into collection variants. It should not attempt arbitrary deep
+nested collection table generation. If a schema cannot be classified safely,
+expose the normalized XML object as singleton JSON/object columns rather than
+inventing rows.
+
+## Alternatives
+
+### Generic XML-to-JSON Only
+
+Rejected. It was enough to prove live AWS calls, but it creates object-or-array
+instability for single-element collections and cannot reach JSON parity.
+
+### AWS-Specific Response Helpers
+
+Rejected. AWS Query APIs motivated the work, but Coral should not encode
+endpoint-specific wrappers such as `DescribeAlarmsResult` in runtime code.
+Wrapper behavior must come from the OpenAPI descriptor and generic XML rules.
+
+### Normalize XML Directly During Streaming Parse
+
+Deferred. A streaming normalizer can be more memory efficient, but a small DOM
+first is simpler and matches the existing JSON payload model. Response bodies
+already become `serde_json::Value` before row extraction.
+
+### Full Nested Row Projection Generation Now
+
+Deferred. Stable arrays are the prerequisite. Generating nested collection
+tables before normalized arrays exist would couple projection behavior to the
+wrong parser shape.
+
+## Detailed Implementation
+
+Expected files:
+
+- `crates/coral-spec/src/common.rs`
+  Add `ResponseBodyFormat::Xml` and serializable XML response-plan structs under
+  `ResponseSpec`.
+
+- `crates/coral-spec/src/v4/surfaces/openapi/schemas.rs`
+  Preserve enough OpenAPI XML metadata while importing schema fields, or add
+  helper functions that build XML plans from resolved schemas without changing
+  the existing `IrType` model more than necessary.
+
+- `crates/coral-spec/src/v4/surfaces/openapi/responses.rs`
+  Select `application/json` first, then XML media types such as `text/xml`,
+  `application/xml`, and `*/xml`. Build `ResponseSpec { format: Xml, xml:
+  Some(...) }` for XML responses. Classify rows using schema names and XML
+  wrapper names rather than JSON-only assumptions.
+
+- `crates/coral-spec/src/v4/ir/rest.rs`
+  No change expected unless the XML plan is kept in REST-specific IR instead of
+  `ResponseSpec`. Prefer `ResponseSpec` so compiled HTTP tables/functions carry
+  all runtime decode data.
+
+- `crates/coral-spec/src/v4/openapi_tests.rs`
+  Add importer tests for XML-only responses, `xml.name`, attributes, wrapped
+  arrays, and AWS-style `member` item fallback.
+
+- `crates/coral-spec/src/v4/projection_tests.rs`
+  Add tests proving XML row fields generate stable JSON columns for array
+  fields.
+
+- `crates/coral-engine/Cargo.toml`
+  Add direct `quick-xml` dependency if not already direct. `Cargo.lock` already
+  contains it transitively through `object_store`, but the engine should declare
+  what it uses.
+
+- `crates/coral-engine/src/backends/http/response.rs`
+  Add the XML decode branch. Keep JSON behavior unchanged.
+
+- `crates/coral-engine/src/backends/http/xml.rs`
+  New module for XML parsing and schema normalization. Keep it backend-local
+  because it is response-body decode behavior, not source-spec parsing.
+
+- `crates/coral-engine/src/backends/http/mod.rs`
+  Export the new `xml` module privately.
+
+- `crates/coral-engine/src/backends/http/fetch.rs` and
+  `crates/coral-engine/src/backends/http/transport.rs`
+  Thread the XML plan alongside `ResponseBodyFormat` if the existing transport
+  only receives the format enum.
+
+- `crates/coral-engine/src/backends/http/*tests*.rs`
+  Add decode tests covering single and multiple XML array items, attributes,
+  namespaces by local name, and malformed XML errors.
+
+- `crates/coral-spec/src/schema/source_manifest.schema.json` and
+  `crates/coral-spec/src/schema/source_manifest_v4.schema.json`
+  Regenerate if schema-generation detects changes from the new response fields.
+
+## Acceptance Criteria
+
+- V4 OpenAPI import accepts XML-only success responses and materializes
+  `format: xml` plus an XML response plan.
+- V3 authored manifests are not expanded for XML in this change.
+- JSON and JSON-each-row behavior remains unchanged.
+- A schema array normalizes to a JSON array even when the XML body contains one
+  item.
+- AWS-style collection containers such as `MetricAlarms/member` normalize to a
+  stable array when the schema says `MetricAlarms` is an array.
+- XML attributes map to fields when `xml.attribute: true` is present.
+- Namespaced element names match by local name in the first pass.
+- Malformed XML produces a normal HTTP decode error.
+- Focused unit tests pass for `coral-spec` and `coral-engine`.
+- `make schema-check` passes if response schema files are affected.
+- A live CloudWatch query against the patched OpenAPI descriptor returns
+  `metric_alarms` rows with alarm fields as columns, including the one-item page
+  case that previously collapsed to a JSON object in generic XML parsing.
+
+## Open Questions
+
+- Should deeper nested array row projections be generated automatically after
+  direct response collections, or should v4 require an explicit projection rule
+  for nested collections?


### PR DESCRIPTION
## Summary

Adds v4 XML response support for OpenAPI-imported HTTP APIs.

- adds schema-driven XML response plans for OpenAPI response metadata, including `xml.name`, `xml.attribute`, and `xml.wrapped`
- decodes XML responses through `quick-xml` and normalizes them into the same JSON-shaped row pipeline used by existing HTTP tables
- preserves XML roots, strips namespace prefixes for JSON-compatible field matching, keeps text-only elements scalar, and uses `#text` only for mixed/object text fallback
- imports XML collection wrappers as separate row variants so AWS-style responses such as CloudWatch alarm lists become typed relational tables instead of one packed JSON column
- keeps arrays stable from schema metadata when the XML body contains a single member
- adds the v4 XML design note used for implementation review

## Validation

- `cargo test -p coral-spec --lib`
- `cargo test -p coral-engine --lib`
- `cargo test -p coral-app --lib`
- `make schema-check`
- `make rust-checks`
- live CloudWatch XML source from the ApiGuru spec: installed as a v4 source, listed `metric_alarms` / `composite_alarms`, and queried typed columns such as `alarm_name`, `state_value`, `actions_enabled`, `threshold`, and `period`
- live S3 XML smoke check from the ApiGuru spec: installed a v4 source and confirmed `ListBuckets` returns parsed XML rows

## Notes

S3 object listing exposed a separate generated-OpenAPI parameter naming collision around duplicate normalized query parameter names. This PR keeps that out of the XML parser path and leaves it as follow-up importer hardening.
