### PR TITLE
feat(sources/community/lynx): add Lynx source

### DIFF
--- a/sources/community/lynx/README.md
+++ b/sources/community/lynx/README.md
@@ -21,16 +21,21 @@ byte leaving your machine.
 
    ```bash
    pipx install lynx-mcp                     # or: uv tool install lynx-mcp
-   lynx manager init                         # downloads the embedding model (writes an EMPTY config)
+   lynx manager init                         # downloads the embedding model + writes a default config (NO sources yet)
    lynx manager ui --port 8765 --no-browser  # serves the local API on 127.0.0.1:8765
    ```
 
-   `lynx manager init` creates an **empty** config — it does not index
-   anything on its own. Open <http://127.0.0.1:8765> and use
-   **+ Add your first source** to add a codebase, docs site, or PDF folder;
-   the UI indexes it for you. Leave this process running — it's the API
-   Coral talks to. (Prefer config-based setup? Edit `config.json` to add a
-   source, then `lynx build`.)
+   `lynx manager init` writes a default config with **no sources yet** — it
+   does not index anything on its own. Open <http://127.0.0.1:8765> and use
+   **+ Add your first source** to add a codebase, docs site, or PDF folder.
+   Adding a source only writes its config; it starts at **0 chunks**. On the
+   source detail page that opens, click **Rebuild index** and wait for it to
+   finish — that step is what actually indexes the source. A source with 0
+   chunks returns empty Coral results, so do this before validating. Leave the
+   `lynx manager ui` process running afterwards; it's the API Coral talks to.
+   (Prefer a config-based setup? Add the source to `config.json`, run
+   `lynx build --source <name>`, then start `lynx manager ui`. Don't run a CLI
+   build against a source while another process is writing to it.)
 
 2. Register this source. The only input is `LYNX_PORT` (default `8765`):
 

--- a/sources/community/lynx/README.md
+++ b/sources/community/lynx/README.md
@@ -7,8 +7,10 @@ and **join the results with live data** from other Coral sources — without a
 byte leaving your machine.
 
 - `lynx.sources` — the sources you've indexed (codebases / docs sites / PDFs).
-- `lynx.search(q => '...')` — ranked hybrid (dense + BM25) search. Each row
-  carries `file`, `file_path`, `symbol`, `kind`, `language`,
+- `lynx.search(q => '...', source => '...', top_k => N)` — ranked hybrid
+  (dense + BM25) search. `q` is required; `source` and `top_k` are optional
+  (omit `source` to search every indexed source at once). Each row carries
+  `source`, `file`, `file_path`, `symbol`, `kind`, `language`,
   `start_line`/`end_line`, `score`, and the code `content` itself.
 
 ## Setup

--- a/sources/community/lynx/README.md
+++ b/sources/community/lynx/README.md
@@ -7,22 +7,30 @@ and **join the results with live data** from other Coral sources — without a
 byte leaving your machine.
 
 - `lynx.sources` — the sources you've indexed (codebases / docs sites / PDFs).
-- `lynx.search(q => '...', source => '...', top_k => N)` — ranked hybrid
-  (dense + BM25) search. `q` is required; `source` and `top_k` are optional
-  (omit `source` to search every indexed source at once). Each row carries
+- `lynx.search(q => '...', source => '...')` — ranked hybrid (dense + BM25)
+  search. `q` is required; `source` is optional (omit it to search every
+  indexed source at once). Control how many results Lynx returns with SQL
+  `LIMIT` — Coral maps it to Lynx's `top_k` (clamped to 50). Each row carries
   `source`, `file`, `file_path`, `symbol`, `kind`, `language`,
   `start_line`/`end_line`, `score`, and the code `content` itself.
 
 ## Setup
 
-1. Install and run Lynx locally (it serves the API on `127.0.0.1`):
+1. Install Lynx and index at least one source (it serves the API on
+   `127.0.0.1`):
 
    ```bash
-   pipx install lynx-mcp        # or: uv tool install lynx-mcp
-   lynx manager init            # point it at your codebase
-   lynx build                   # index it
-   lynx manager ui --port 8765 --no-browser
+   pipx install lynx-mcp                     # or: uv tool install lynx-mcp
+   lynx manager init                         # downloads the embedding model (writes an EMPTY config)
+   lynx manager ui --port 8765 --no-browser  # serves the local API on 127.0.0.1:8765
    ```
+
+   `lynx manager init` creates an **empty** config — it does not index
+   anything on its own. Open <http://127.0.0.1:8765> and use
+   **+ Add your first source** to add a codebase, docs site, or PDF folder;
+   the UI indexes it for you. Leave this process running — it's the API
+   Coral talks to. (Prefer config-based setup? Edit `config.json` to add a
+   source, then `lynx build`.)
 
 2. Register this source. The only input is `LYNX_PORT` (default `8765`):
 
@@ -43,20 +51,22 @@ Find code by behavior, not keywords:
 
 ```sql
 SELECT file, symbol, score
-FROM lynx.search(q => 'where the camera zoom is clamped')
+FROM lynx.search(q => 'clamp a value between a min and max')
 WHERE language = 'c_sharp'
-ORDER BY score DESC
 LIMIT 5;
 ```
 
-Line up a code search against the repo's open PRs:
+Broad context: pair the top code hits with the repo's open PRs. This is a
+`CROSS JOIN` — every hit against every open PR — so keep the `LIMIT`s small
+and treat it as a context dump, not a precise match:
 
 ```sql
 SELECT s.file, s.symbol, s.score, p.html_url
 FROM lynx.search(q => 'retry logic for payment webhooks') s
 CROSS JOIN github.pulls p
 WHERE p.owner = 'your-org' AND p.repo = 'your-repo' AND p.state = 'open'
-ORDER BY s.score DESC;
+ORDER BY s.score DESC
+LIMIT 20;
 ```
 
 List what you've indexed:
@@ -64,6 +74,75 @@ List what you've indexed:
 ```sql
 SELECT name, type, chunk_count FROM lynx.sources;
 ```
+
+## Live validation
+
+Captured with coral 0.4.2 against a running Lynx API (`lynx manager ui --port
+8765`) and one indexed codebase source. Everything runs on `127.0.0.1`; local
+paths redacted.
+
+```console
+$ LYNX_PORT=8765 coral source add --file sources/community/lynx/manifest.yaml
+Added source lynx (secrets: none)
+
+  ✓ lynx connected successfully
+  Secrets: none
+
+    lynx (1 table)
+    └─ sources
+    Query tests
+    2 declared · 2 passed · 0 failed
+
+    ✓ SELECT name, type, chunk_count FROM lynx.sources
+      1 row
+
+    ✓ SELECT file, symbol, score FROM lynx.search(q => 'where passwords are hashed') LIMIT 5
+      5 rows
+
+$ coral source test lynx
+
+  ✓ lynx connected successfully
+  Secrets: none
+
+    lynx (1 table)
+    └─ sources
+    Query tests
+    2 declared · 2 passed · 0 failed
+
+    ✓ SELECT name, type, chunk_count FROM lynx.sources
+      1 row
+
+    ✓ SELECT file, symbol, score FROM lynx.search(q => 'where passwords are hashed') LIMIT 5
+      5 rows
+
+$ coral sql "SELECT name, type, chunk_count FROM lynx.sources"
++-----------+----------+-------------+
+| name      | type     | chunk_count |
++-----------+----------+-------------+
+| framework | codebase | 12656       |
++-----------+----------+-------------+
+
+$ coral sql "SELECT file, symbol, score FROM lynx.search(q => 'clamp a value between a min and max') WHERE language = 'c_sharp' LIMIT 5"
++---------------------------+-----------------------------------------------------------------------------+----------------------+
+| file                      | symbol                                                                      | score                |
++---------------------------+-----------------------------------------------------------------------------+----------------------+
+| Math.cs                   | Framework.Utility.Math.Clamp                                                | 0.01639344262295082  |
+| SplineSamplingConfig.cs   | Framework.SplineUtility.Sampler.SplineSamplingConfig.ClampToValidRanges     | 0.016129032258064516 |
+| WheelGripConfiguration.cs | Framework.Vehicle.WheelGripConfiguration.ClampGrip                          | 0.015873015873015872 |
+| MinMaxValueAttributes.cs  | Framework.Utility.MinMaxCacheSegmentsAttribute.MinMaxCacheSegmentsAttribute | 0.015384615384615384 |
+| InspectorValidation.cs    | Framework.UIEditorKit.InspectorValidation.Range                             | 0.014925373134328358 |
++---------------------------+-----------------------------------------------------------------------------+----------------------+
+```
+
+`LIMIT` sets how many candidates Lynx returns (its `top_k`); any `WHERE` then
+filters that fetched set. With no `WHERE`, `LIMIT n` returns exactly `n` rows,
+capped at 50:
+
+| Query | Rows returned |
+|-------|---------------|
+| `SELECT file FROM lynx.search(...) LIMIT 3`   | 3 |
+| `SELECT file FROM lynx.search(...) LIMIT 12`  | 12 — exceeds Lynx's default 8, so `LIMIT` is driving `top_k` |
+| `SELECT file FROM lynx.search(...) LIMIT 100` | 50 — Lynx clamps `top_k` to its `[1, 50]` ceiling |
 
 ## Notes
 

--- a/sources/community/lynx/README.md
+++ b/sources/community/lynx/README.md
@@ -1,0 +1,75 @@
+# Lynx
+
+[Lynx](https://github.com/lorenzo-cambiaghi/LynxMCP) is a **100% local** semantic
+code-search engine (an MCP server) for codebases, library docs, and PDFs. This
+source exposes its local API as SQL, so you can query your code by *behavior*
+and **join the results with live data** from other Coral sources — without a
+byte leaving your machine.
+
+- `lynx.sources` — the sources you've indexed (codebases / docs sites / PDFs).
+- `lynx.search(q => '...')` — ranked hybrid (dense + BM25) search. Each row
+  carries `file`, `file_path`, `symbol`, `kind`, `language`,
+  `start_line`/`end_line`, `score`, and the code `content` itself.
+
+## Setup
+
+1. Install and run Lynx locally (it serves the API on `127.0.0.1`):
+
+   ```bash
+   pipx install lynx-mcp        # or: uv tool install lynx-mcp
+   lynx manager init            # point it at your codebase
+   lynx build                   # index it
+   lynx manager ui --port 8765 --no-browser
+   ```
+
+2. Register this source. The only input is `LYNX_PORT` (default `8765`):
+
+   ```bash
+   coral source add --file sources/community/lynx/manifest.yaml
+   coral source test lynx
+   ```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `LYNX_PORT` | no | `8765` | Port of the local Lynx API (`lynx manager ui --port 8765`). |
+
+## Examples
+
+Find code by behavior, not keywords:
+
+```sql
+SELECT file, symbol, score
+FROM lynx.search(q => 'where the camera zoom is clamped')
+WHERE language = 'c_sharp'
+ORDER BY score DESC
+LIMIT 5;
+```
+
+Line up a code search against the repo's open PRs:
+
+```sql
+SELECT s.file, s.symbol, s.score, p.html_url
+FROM lynx.search(q => 'retry logic for payment webhooks') s
+CROSS JOIN github.pulls p
+WHERE p.owner = 'your-org' AND p.repo = 'your-repo' AND p.state = 'open'
+ORDER BY s.score DESC;
+```
+
+List what you've indexed:
+
+```sql
+SELECT name, type, chunk_count FROM lynx.sources;
+```
+
+## Notes
+
+- **Local-first.** The codebase and embeddings never leave your machine; only
+  the live-data side of a join touches an API.
+- The search string is a **literal** you pass — Coral resolves table-function
+  arguments at plan time, so `lynx.search` is a joinable source, not a per-row
+  enrichment of another table. For one search per row of another table, Lynx
+  ships a batch endpoint (`POST /api/v1/search`) and a small Python helper.
+- Requires the Lynx API to be running (`lynx manager ui`). See the
+  [Lynx Coral guide](https://github.com/lorenzo-cambiaghi/LynxMCP/blob/main/docs/CORAL.md).

--- a/sources/community/lynx/README.md
+++ b/sources/community/lynx/README.md
@@ -135,7 +135,7 @@ $ coral sql "SELECT file, symbol, score FROM lynx.search(q => 'clamp a value bet
 ```
 
 `LIMIT` sets how many candidates Lynx returns (its `top_k`); any `WHERE` then
-filters that fetched set. With no `WHERE`, `LIMIT n` returns exactly `n` rows,
+filters that fetched set. With no `WHERE`, `LIMIT n` returns up to `n` rows,
 capped at 50:
 
 | Query | Rows returned |

--- a/sources/community/lynx/manifest.yaml
+++ b/sources/community/lynx/manifest.yaml
@@ -77,11 +77,12 @@ functions:
     description: >-
       Semantic + lexical hybrid search over the indexed sources. Phrase the
       query as what the code DOES ("method that clamps camera zoom"), not as
-      an identifier. Omit `source` to search every source at once. Call it as
-      a function: lynx.search(q => '...').
+      an identifier. Omit `source` to search every source at once. Control the
+      result count with SQL `LIMIT` (Coral maps it to the `top_k` request
+      param). Call it as a function: lynx.search(q => '...').
     search_limits:
       default_top_k: 8
-      max_top_k: 100
+      max_top_k: 50
       max_calls_per_query: 1
     args:
       - name: q
@@ -90,9 +91,6 @@ functions:
       - name: source
         required: false
         bind: {arg: source}
-      - name: top_k
-        required: false
-        bind: {arg: top_k}
     request:
       method: GET
       path: /api/v1/search
@@ -103,14 +101,17 @@ functions:
         - name: source
           from: arg
           key: source
-        - name: top_k
-          from: arg_int
-          key: top_k
     response:
       rows_path:
         - results
+    # SQL `LIMIT` → the Lynx `top_k` query param. Lynx clamps top_k to [1, 50]
+    # (GET /api/v1/search), so a larger LIMIT is capped at 50 server-side.
     pagination:
       mode: none
+      page_size:
+        default: 8
+        max: 50
+        query_param: top_k
     columns:
       - name: source
         type: Utf8

--- a/sources/community/lynx/manifest.yaml
+++ b/sources/community/lynx/manifest.yaml
@@ -1,0 +1,164 @@
+# Lynx — 100% local semantic code search, as a Coral source.
+# Repo: https://github.com/lorenzo-cambiaghi/LynxMCP
+#
+# Exposes Lynx's local API as SQL: `lynx.sources` (a table) and
+# `lynx.search(q => '...')` (a ranked search function), so agents can JOIN
+# semantic code search with live data from other Coral sources — all local.
+#
+# Prerequisite: the Lynx local API must be running on the same machine:
+#   lynx manager ui --port 8765 --no-browser
+# Everything stays on localhost; no credentials involved.
+name: lynx
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  100% local semantic code search over your codebases, library docs, and
+  PDFs (Lynx MCP server). Hybrid dense + BM25 retrieval with AST-aware
+  chunks: every row carries file, symbol, line range, and the code itself.
+
+inputs:
+  LYNX_PORT:
+    kind: variable
+    default: "8765"
+    hint: >-
+      Port of the local Lynx API, started with
+      `lynx manager ui --port 8765 --no-browser`.
+
+base_url: "http://127.0.0.1:{{input.LYNX_PORT}}"
+
+test_queries:
+  - SELECT name, type, chunk_count FROM lynx.sources
+  - SELECT file, symbol, score FROM lynx.search(q => 'where passwords are hashed') LIMIT 5
+
+tables:
+  - name: sources
+    description: Sources configured in the local Lynx index (codebases, docs sites, PDF folders).
+    request:
+      method: GET
+      path: /api/v1/sources
+    response:
+      rows_path:
+        - sources
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Source name — pass it as the `source` argument of lynx.search.
+        expr: {kind: path, path: [name]}
+      - name: type
+        type: Utf8
+        nullable: false
+        description: Source type (codebase | webdoc | pdf).
+        expr: {kind: path, path: [type]}
+      - name: location
+        type: Utf8
+        nullable: true
+        description: Indexed path or crawled URL.
+        expr: {kind: path, path: [location]}
+      - name: chunk_count
+        type: Int64
+        nullable: true
+        description: Number of indexed chunks.
+        expr: {kind: path, path: [chunk_count]}
+      - name: last_update
+        type: Utf8
+        nullable: true
+        description: Timestamp of the last index update.
+        expr: {kind: path, path: [last_update]}
+
+functions:
+  # Ranked retrieval surface → a `kind: search` function (called as
+  # lynx.search(q => '...')), not a table with filters.
+  - name: search
+    kind: search
+    description: >-
+      Semantic + lexical hybrid search over the indexed sources. Phrase the
+      query as what the code DOES ("method that clamps camera zoom"), not as
+      an identifier. Omit `source` to search every source at once. Call it as
+      a function: lynx.search(q => '...').
+    search_limits:
+      default_top_k: 8
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: q
+        required: true
+        bind: {arg: q}
+      - name: source
+        required: false
+        bind: {arg: source}
+      - name: top_k
+        required: false
+        bind: {arg: top_k}
+    request:
+      method: GET
+      path: /api/v1/search
+      query:
+        - name: q
+          from: arg
+          key: q
+        - name: source
+          from: arg
+          key: source
+        - name: top_k
+          from: arg_int
+          key: top_k
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: none
+    columns:
+      - name: source
+        type: Utf8
+        nullable: false
+        description: Which Lynx source produced this hit.
+        expr: {kind: path, path: [source]}
+      - name: file
+        type: Utf8
+        nullable: false
+        description: File name of the hit.
+        expr: {kind: path, path: [file]}
+      - name: file_path
+        type: Utf8
+        nullable: true
+        description: Full path of the file inside the indexed tree.
+        expr: {kind: path, path: [file_path]}
+      - name: symbol
+        type: Utf8
+        nullable: true
+        description: Qualified symbol of the AST chunk (e.g. MyClass.handle_click).
+        expr: {kind: path, path: [symbol]}
+      - name: kind
+        type: Utf8
+        nullable: true
+        description: Symbol kind (function, class, method, ...).
+        expr: {kind: path, path: [kind]}
+      - name: language
+        type: Utf8
+        nullable: true
+        description: Programming language of the chunk.
+        expr: {kind: path, path: [language]}
+      - name: start_line
+        type: Int64
+        nullable: true
+        description: First line of the chunk (1-based).
+        expr: {kind: path, path: [start_line]}
+      - name: end_line
+        type: Int64
+        nullable: true
+        description: Last line of the chunk.
+        expr: {kind: path, path: [end_line]}
+      - name: score
+        type: Float64
+        nullable: false
+        description: Relevance score (hybrid RRF — ~0.03 is already a strong match).
+        expr: {kind: path, path: [score]}
+      - name: content
+        type: Utf8
+        nullable: true
+        description: The code chunk itself.
+        expr: {kind: path, path: [content]}


### PR DESCRIPTION
Adds a community source for [Lynx](https://github.com/lorenzo-cambiaghi/LynxMCP) — a 100% local semantic code-search engine (MCP server) for codebases, library docs, and PDFs. It exposes Lynx's local HTTP API as SQL, so you can query code by **behavior** and join the results with live data from other Coral sources.

Notes for reviewers:

- Local source. Like couchdb, the base_url defaults to localhost (http://127.0.0.1:{{input.LYNX_PORT}}); the user runs the Lynx API themselves (lynx manager ui --port 8765). The single input is LYNX_PORT (default 8765), no credentials.
- The test_queries therefore hit a local service and aren't meant to run in default CI, consistent with the live-source policy in CONTRIBUTING.md. They validate via the source lint.
- No new dependencies — this is a source spec only.
- lynx.search's query is a literal (resolved at plan time), so it's a joinable source, not a per-row enrichment.