### PR TITLE
feat(cli): add identity management commands

### DIFF
--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -83,6 +83,18 @@ message ListUserOwnedIdentitiesResponse {
   repeated Identity identities = 1;
 }
 
+// Fetches one user-owned identity for the request Coral user principal.
+message GetUserOwnedIdentityRequest {
+  // Stored identity name.
+  string name = 1;
+}
+
+// Returns one user-owned identity.
+message GetUserOwnedIdentityResponse {
+  // Stored identity.
+  Identity identity = 1;
+}
+
 // Deletes one identity owned by the request Coral user principal.
 message DeleteUserOwnedIdentityRequest {
   // Stable identity name to delete.
@@ -103,6 +115,8 @@ service IdentityService {
   // Lists user-owned identities.
   rpc ListUserOwnedIdentities(ListUserOwnedIdentitiesRequest)
       returns (ListUserOwnedIdentitiesResponse);
+  // Fetches one user-owned identity.
+  rpc GetUserOwnedIdentity(GetUserOwnedIdentityRequest) returns (GetUserOwnedIdentityResponse);
   // Deletes one user-owned identity.
   rpc DeleteUserOwnedIdentity(DeleteUserOwnedIdentityRequest)
       returns (DeleteUserOwnedIdentityResponse);

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -14,7 +14,7 @@ use coral_spec::{
     IdentityManifest, IdentitySpecConfig, IdentitySpecType, ManifestOAuthCredentialSpec,
 };
 use serde::{Deserialize, Serialize};
-use tracing::info_span;
+use tracing::{info_span, warn};
 
 use crate::bootstrap::AppError;
 use crate::credentials::oauth::{
@@ -38,7 +38,7 @@ use crate::identity_specs::{
     IdentitySpecManager, IdentitySpecRecord, identity_spec_fingerprint, validate_identity_spec_name,
 };
 use crate::sources::SourceName;
-use crate::state::AppStateLayout;
+use crate::state::{AppStateLayout, INSTALLED_SOURCE_IDENTITY_BINDING_FILE_NAME};
 use crate::storage::fs::{self as storage_fs, FileLock};
 use crate::workspaces::WorkspaceName;
 
@@ -641,6 +641,22 @@ impl UserOwnedIdentityManager {
         self.list_identities(&owner).await
     }
 
+    pub(crate) async fn get_user_owned_identity(
+        &self,
+        principal: &UserPrincipal,
+        identity_name: &str,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        let span = info_span!("coral.app.identities.get_user_owned");
+        let _guard = span.enter();
+        self.identity_specs.ensure_dsl_v4_enabled()?;
+        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+        let identity_name = validate_identity_name(identity_name)?;
+        self.store
+            .load_identity(&owner, &identity_name)
+            .await?
+            .ok_or_else(|| AppError::IdentityNotFound(identity_name))
+    }
+
     pub(crate) async fn delete_user_owned_identity(
         &self,
         principal: &UserPrincipal,
@@ -898,6 +914,49 @@ impl FileUserOwnedIdentityStore {
             .map_err(Into::into)
     }
 
+    fn cleanup_user_source_identity_bindings_for_deleted_identity_unlocked(
+        &self,
+        user_id: &str,
+        identity_name: &str,
+    ) {
+        let bindings_root = self.layout.source_identity_bindings_root();
+        let user_root = bindings_root.join("users").join(user_id);
+        if !user_root.exists() {
+            return;
+        }
+
+        let mut binding_files = Vec::new();
+        if let Err(error) = collect_binding_files_unlocked(&user_root, &mut binding_files) {
+            warn!(
+                user_id,
+                identity_name,
+                error = %error,
+                "failed to collect source identity bindings while cleaning up a deleted user identity"
+            );
+            return;
+        }
+        for binding_file in binding_files {
+            let result = (|| -> Result<(), AppError> {
+                let raw = fs::read_to_string(&binding_file)?;
+                let document: UserSourceIdentityBindingDocument = serde_yaml::from_str(&raw)?;
+                if document.identity == identity_name {
+                    remove_file_if_exists_unlocked(&binding_file)?;
+                    cleanup_empty_parent(&bindings_root, binding_file.parent());
+                }
+                Ok(())
+            })();
+            if let Err(error) = result {
+                warn!(
+                    user_id,
+                    identity_name,
+                    binding_path = %binding_file.display(),
+                    error = %error,
+                    "failed to clean up source identity binding for a deleted user identity"
+                );
+            }
+        }
+    }
+
     fn validate_identity_spec_write_precondition_unlocked(
         layout: &AppStateLayout,
         record: &UserOwnedIdentityRecord,
@@ -1099,6 +1158,10 @@ impl UserOwnedIdentityStore for FileUserOwnedIdentityStore {
                     Err(error) => return Err(error.into()),
                 }
             }
+            store.cleanup_user_source_identity_bindings_for_deleted_identity_unlocked(
+                &owner_key,
+                &identity_name,
+            );
             Ok(true)
         })
         .await?
@@ -1724,6 +1787,26 @@ fn restore_file_unlocked(
         Some(bytes) => write_file_unlocked(path, &bytes).map_err(Into::into),
         None => remove_file_if_exists_unlocked(path).map_err(Into::into),
     }
+}
+
+fn collect_binding_files_unlocked(
+    dir: &Path,
+    binding_files: &mut Vec<PathBuf>,
+) -> Result<(), AppError> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            collect_binding_files_unlocked(&path, binding_files)?;
+            continue;
+        }
+        if path.file_name().and_then(|name| name.to_str())
+            == Some(INSTALLED_SOURCE_IDENTITY_BINDING_FILE_NAME)
+        {
+            binding_files.push(path);
+        }
+    }
+    Ok(())
 }
 
 fn cleanup_empty_parent(root: &Path, path: Option<&Path>) {
@@ -2493,6 +2576,134 @@ oauth:
                 .await
                 .expect_err("all source bindings should be removed");
         }
+    }
+
+    #[tokio::test]
+    async fn deleting_user_owned_identity_removes_source_bindings_that_reference_it() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        let principal = UserPrincipal::local();
+        create_github_local(&manager, "pat-token").await;
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github_v4").expect("source");
+        let deleted_selection =
+            SourceIdentitySelection::new("github_local", Some("github-rest-read".to_string()))
+                .expect("deleted identity selection");
+        let retained_selection =
+            SourceIdentitySelection::new("github_other", Some("github-rest-read".to_string()))
+                .expect("retained identity selection");
+
+        manager
+            .replace_user_owned_source_identity_binding(
+                &principal,
+                &workspace_name,
+                &source_name,
+                "rest",
+                &deleted_selection,
+            )
+            .await
+            .expect("write deleted identity binding");
+        manager
+            .replace_user_owned_source_identity_binding(
+                &principal,
+                &workspace_name,
+                &source_name,
+                "issues",
+                &retained_selection,
+            )
+            .await
+            .expect("write retained identity binding");
+
+        assert!(
+            manager
+                .delete_user_owned_identity(&principal, "github_local")
+                .await
+                .expect("delete identity")
+        );
+
+        let deleted = manager
+            .snapshot_user_owned_source_identity_binding(
+                &principal,
+                &workspace_name,
+                &source_name,
+                "rest",
+            )
+            .await
+            .expect("snapshot deleted binding");
+        assert_eq!(deleted, None);
+
+        let retained = manager
+            .snapshot_user_owned_source_identity_binding(
+                &principal,
+                &workspace_name,
+                &source_name,
+                "issues",
+            )
+            .await
+            .expect("snapshot retained binding");
+        assert_eq!(retained, Some(retained_selection));
+    }
+
+    #[tokio::test]
+    async fn deleting_user_owned_identity_treats_source_binding_cleanup_as_best_effort() {
+        let (temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        let layout = test_layout(&temp);
+        let principal = UserPrincipal::local();
+        create_github_local(&manager, "pat-token").await;
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github_v4").expect("source");
+        let deleted_selection =
+            SourceIdentitySelection::new("github_local", Some("github-rest-read".to_string()))
+                .expect("deleted identity selection");
+
+        manager
+            .replace_user_owned_source_identity_binding(
+                &principal,
+                &workspace_name,
+                &source_name,
+                "rest",
+                &deleted_selection,
+            )
+            .await
+            .expect("write deleted identity binding");
+
+        let malformed_source = SourceName::parse("malformed_v4").expect("malformed source");
+        let malformed_path = layout.user_owned_source_identity_binding_file(
+            principal.user_id(),
+            &workspace_name,
+            &malformed_source,
+            "rest",
+        );
+        fs::create_dir_all(malformed_path.parent().expect("binding parent"))
+            .expect("create malformed binding parent");
+        fs::write(&malformed_path, "identity: [unterminated").expect("write malformed binding");
+
+        assert!(
+            manager
+                .delete_user_owned_identity(&principal, "github_local")
+                .await
+                .expect("delete identity")
+        );
+
+        let error = manager
+            .get_user_owned_identity(&principal, "github_local")
+            .await
+            .expect_err("identity delete should commit despite binding cleanup failures");
+        assert!(matches!(error, AppError::IdentityNotFound(name) if name == "github_local"));
+
+        let deleted = manager
+            .snapshot_user_owned_source_identity_binding(
+                &principal,
+                &workspace_name,
+                &source_name,
+                "rest",
+            )
+            .await
+            .expect("snapshot deleted binding");
+        assert_eq!(deleted, None);
+        assert!(
+            malformed_path.exists(),
+            "malformed unrelated binding should be left for later repair"
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -7,8 +7,9 @@ use coral_api::v1::identity_service_server::IdentityService as IdentityServiceAp
 use coral_api::v1::{
     CreateUserOwnedIdentityWithFixedTokenRequest, CreateUserOwnedIdentityWithFixedTokenResponse,
     CreateUserOwnedIdentityWithOAuthRequest, CreateUserOwnedIdentityWithOAuthResponse,
-    CredentialMetadata, DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse, Identity,
-    IdentityOwner, ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
+    CredentialMetadata, DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse,
+    GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse, Identity, IdentityOwner,
+    ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
     create_user_owned_identity_with_o_auth_response,
 };
 use tokio_stream::Stream;
@@ -129,6 +130,27 @@ impl IdentityServiceApi for IdentityService {
                     .map_err(app_status)?;
                 Ok(Response::new(ListUserOwnedIdentitiesResponse {
                     identities: records.into_iter().map(identity_record_to_proto).collect(),
+                }))
+            },
+        )
+        .await
+    }
+
+    async fn get_user_owned_identity(
+        &self,
+        request: Request<GetUserOwnedIdentityRequest>,
+    ) -> Result<Response<GetUserOwnedIdentityResponse>, Status> {
+        let identities = self.identities.clone();
+        instrument_authenticated_grpc(
+            &self.user_principal_provider,
+            request,
+            |principal, request| async move {
+                let record = identities
+                    .get_user_owned_identity(&principal, &request.name)
+                    .await
+                    .map_err(app_status)?;
+                Ok(Response::new(GetUserOwnedIdentityResponse {
+                    identity: Some(identity_record_to_proto(record)),
                 }))
             },
         )

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -8,4 +8,6 @@ pub(crate) use config::{
     RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue, load_raw_feature_overrides,
     set_raw_feature_override,
 };
-pub(crate) use layout::{AppStateLayout, INSTALLED_IDENTITY_FILE_NAME};
+pub(crate) use layout::{
+    AppStateLayout, INSTALLED_IDENTITY_FILE_NAME, INSTALLED_SOURCE_IDENTITY_BINDING_FILE_NAME,
+};

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -1,4 +1,6 @@
-use coral_api::v1::ListUserOwnedIdentitiesRequest;
+use coral_api::v1::{
+    DeleteUserOwnedIdentityRequest, GetUserOwnedIdentityRequest, ListUserOwnedIdentitiesRequest,
+};
 use tonic::Request;
 
 use crate::harness::{GrpcHarness, OAuthFixture, create_github_oauth_identity};
@@ -75,4 +77,64 @@ type: fixed_token
 
     let material = identity_material(&harness, "github_pat_local");
     assert!(material.contains("TOKEN=pat-token"));
+}
+
+#[tokio::test]
+async fn identity_service_gets_and_deletes_user_identity() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .add_identity_spec(
+            r"
+kind: identity
+spec_version: 1
+name: github_pat
+version: 0.1.0
+issuer: github
+type: fixed_token
+"
+            .to_string(),
+        )
+        .await;
+
+    harness
+        .create_fixed_token_identity("github_pat_local", "github_pat", "pat-token")
+        .await;
+
+    let fetched = harness
+        .identity_client()
+        .get_user_owned_identity(Request::new(GetUserOwnedIdentityRequest {
+            name: "github_pat_local".to_string(),
+        }))
+        .await
+        .expect("get identity")
+        .into_inner()
+        .identity
+        .expect("identity");
+    assert_eq!(fetched.name, "github_pat_local");
+    assert_eq!(fetched.identity_spec, "github_pat");
+
+    harness
+        .identity_client()
+        .delete_user_owned_identity(Request::new(DeleteUserOwnedIdentityRequest {
+            name: "github_pat_local".to_string(),
+        }))
+        .await
+        .expect("delete identity");
+
+    let status = harness
+        .identity_client()
+        .get_user_owned_identity(Request::new(GetUserOwnedIdentityRequest {
+            name: "github_pat_local".to_string(),
+        }))
+        .await
+        .expect_err("deleted identity should not be found");
+    assert_eq!(status.code(), tonic::Code::NotFound);
+
+    harness
+        .identity_client()
+        .delete_user_owned_identity(Request::new(DeleteUserOwnedIdentityRequest {
+            name: "github_pat_local".to_string(),
+        }))
+        .await
+        .expect("second delete should remain idempotent");
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -19,6 +19,7 @@ mod source_ops;
 
 use std::borrow::Cow;
 use std::future::Future;
+use std::io::IsTerminal as _;
 use std::path::PathBuf;
 #[cfg(feature = "embedded-ui")]
 use std::sync::Arc;
@@ -67,6 +68,10 @@ enum Command {
     Sql(SqlArgs),
     /// Manage data sources
     Source(SourceArgs),
+    /// Manage stored user-owned identities
+    Identity(IdentityArgs),
+    /// Manage global identity specs used by source identity requirements
+    IdentitySpec(IdentitySpecArgs),
     /// Interactive wizard to set up Coral and explore use cases
     Onboard,
     /// Start the MCP server over stdio
@@ -313,6 +318,72 @@ enum SourceCommand {
     },
 }
 
+#[derive(Debug, Args)]
+/// Manage stored user-owned identities
+struct IdentityArgs {
+    #[command(subcommand)]
+    command: IdentityCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum IdentityCommand {
+    /// List stored user-owned identities
+    List,
+    /// Show a stored user-owned identity
+    Info {
+        /// Identity name
+        name: String,
+    },
+    /// Create or replace a user-owned identity from an identity spec
+    Add {
+        /// Identity name used by source identity bindings
+        name: String,
+        /// Installed identity spec name
+        #[arg(long = "identity-spec")]
+        identity_spec: String,
+        /// Read the fixed-token credential from stdin instead of prompting
+        #[arg(long = "token-stdin")]
+        token_stdin: bool,
+    },
+    /// Remove a stored user-owned identity
+    Remove {
+        /// Identity name
+        name: String,
+    },
+}
+
+#[derive(Debug, Args)]
+/// Manage global identity specs used by source identity requirements
+struct IdentitySpecArgs {
+    #[command(subcommand)]
+    command: IdentitySpecCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum IdentitySpecCommand {
+    /// List installed identity specs
+    List,
+    /// Show an installed identity spec
+    Info {
+        /// Identity spec name
+        name: String,
+    },
+    /// Install an identity spec or replace an unused existing spec from a manifest file
+    Add {
+        /// Path to an identity spec YAML file
+        #[arg(long)]
+        file: PathBuf,
+    },
+    /// Remove an installed identity spec
+    Remove {
+        /// Identity spec name
+        name: String,
+        /// Confirm removal when stored identity instances would become orphaned
+        #[arg(long)]
+        force: bool,
+    },
+}
+
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 /// Output format for rendered SQL query results.
 pub enum OutputFormat {
@@ -383,9 +454,12 @@ impl CliError {
 impl Command {
     fn required_runtime(&self) -> RequiredRuntime {
         match self {
-            Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
-                RequiredRuntime::AppClient
-            }
+            Command::Sql(_)
+            | Command::Source(_)
+            | Command::Identity(_)
+            | Command::IdentitySpec(_)
+            | Command::Onboard
+            | Command::McpStdio(_) => RequiredRuntime::AppClient,
             Command::Features(_) | Command::Completion(_) => RequiredRuntime::None,
             #[cfg(feature = "embedded-ui")]
             Command::Ui(_) => RequiredRuntime::None,
@@ -655,7 +729,12 @@ async fn run_no_runtime_command(
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args, feature_overrides).await.map_err(Into::into),
-        Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
+        Command::Sql(_)
+        | Command::Source(_)
+        | Command::Identity(_)
+        | Command::IdentitySpec(_)
+        | Command::Onboard
+        | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
         }
     }
@@ -672,6 +751,8 @@ async fn run_app_command(
             run_sql(&app, default_workspace(), args.sql, args.format).await?;
         }
         Command::Source(args) => run_source(&app, args, feature_overrides).await?,
+        Command::Identity(args) => run_identity(&app, args).await?,
+        Command::IdentitySpec(args) => run_identity_spec(&app, args).await?,
         Command::Onboard => {
             onboard::run(&app).await?;
         }
@@ -798,6 +879,171 @@ async fn run_source(
         }
         SourceCommand::Remove { name } => {
             source_ops::remove_and_print(app, &name).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn run_identity(app: &AppClient, args: IdentityArgs) -> Result<(), CliError> {
+    match args.command {
+        IdentityCommand::List => {
+            let identities = source_ops::list_user_owned_identities(app).await?;
+            if identities.is_empty() {
+                println!("No identities configured.");
+            } else {
+                let rows = identities.into_iter().map(|identity| {
+                    [
+                        identity.name,
+                        identity.identity_spec,
+                        identity.issuer,
+                        identity.identity_type,
+                        source_ops::identity_owner_label(identity.owner).to_string(),
+                    ]
+                });
+                print_text_table(
+                    ["Identity", "Identity Spec", "Issuer", "Type", "Owner"],
+                    rows,
+                );
+            }
+        }
+        IdentityCommand::Info { name } => {
+            let identity = source_ops::get_user_owned_identity(app, &name).await?;
+            print_identity_info(&identity);
+        }
+        IdentityCommand::Add {
+            name,
+            identity_spec,
+            token_stdin,
+        } => {
+            let identity_spec_record = source_ops::get_identity_spec(app, &identity_spec).await?;
+            let manifest =
+                coral_spec::parse_identity_manifest_yaml(&identity_spec_record.manifest_yaml)
+                    .map_err(anyhow::Error::from)?;
+            let identity = match manifest.identity_type {
+                coral_spec::IdentitySpecType::OAuth => {
+                    if token_stdin {
+                        return Err(anyhow::anyhow!(
+                            "--token-stdin is only supported for fixed-token identity specs"
+                        )
+                        .into());
+                    }
+                    source_ops::require_interactive_for("identity OAuth setup")?;
+                    let selected = source_ops::identity_oauth_method(&manifest)?;
+                    source_ops::print_oauth_hint(selected.hint);
+                    let credential_inputs =
+                        source_ops::prompt_identity_oauth_inputs(&manifest, selected.oauth)?;
+                    source_ops::create_user_owned_identity_with_oauth(
+                        app,
+                        &name,
+                        &identity_spec,
+                        credential_inputs,
+                        &selected.label,
+                        "coral identity add",
+                    )
+                    .await?
+                }
+                coral_spec::IdentitySpecType::FixedToken => {
+                    let token = if token_stdin {
+                        source_ops::read_fixed_token_identity_token_from_stdin()?
+                    } else {
+                        source_ops::require_interactive_for("fixed-token identity setup")?;
+                        source_ops::prompt_fixed_token_identity_token(&identity_spec)?
+                    };
+                    source_ops::create_user_owned_identity_with_fixed_token(
+                        app,
+                        &name,
+                        &identity_spec,
+                        token,
+                    )
+                    .await?
+                }
+            };
+            println!(
+                "Created identity {} ({})",
+                identity.name, identity.identity_spec
+            );
+        }
+        IdentityCommand::Remove { name } => {
+            source_ops::get_user_owned_identity(app, &name).await?;
+            source_ops::delete_user_owned_identity(app, &name).await?;
+            println!("Removed identity {name}");
+        }
+    }
+    Ok(())
+}
+
+fn print_identity_info(identity: &coral_api::v1::Identity) {
+    println!("{}", identity.name);
+    println!("  Identity spec: {}", identity.identity_spec);
+    println!("  Issuer:        {}", identity.issuer);
+    println!("  Type:          {}", identity.identity_type);
+    println!(
+        "  Owner:         {}",
+        source_ops::identity_owner_label(identity.owner)
+    );
+    if !identity.metadata.is_empty() {
+        println!("  Metadata:");
+        for item in &identity.metadata {
+            println!("    {}: {}", item.key, item.value);
+        }
+    }
+}
+
+async fn run_identity_spec(app: &AppClient, args: IdentitySpecArgs) -> Result<(), CliError> {
+    match args.command {
+        IdentitySpecCommand::List => {
+            let identity_specs = source_ops::list_identity_specs(app).await?;
+            if identity_specs.is_empty() {
+                println!("No identity specs installed.");
+            } else {
+                let rows = identity_specs.into_iter().map(|identity_spec| {
+                    [
+                        identity_spec.name,
+                        source_ops::display_version(&identity_spec.version),
+                        identity_spec.issuer,
+                        identity_spec.identity_type,
+                    ]
+                });
+                print_text_table(["Identity Spec", "Version", "Issuer", "Type"], rows);
+            }
+        }
+        IdentitySpecCommand::Info { name } => {
+            let identity_spec = source_ops::get_identity_spec(app, &name).await?;
+            print!("{}", identity_spec.manifest_yaml);
+        }
+        IdentitySpecCommand::Add { file } => {
+            let (manifest_yaml, manifest) = source_ops::load_validated_identity_spec_file(&file)?;
+            let interactive = std::io::stdin().is_terminal();
+            let installed_manifest =
+                source_ops::parseable_installed_identity_spec_manifest(app, &manifest.name).await?;
+            let inputs = if installed_manifest.as_ref() == Some(&manifest) {
+                Vec::new()
+            } else {
+                source_ops::identity_spec_inputs_for_add(
+                    &manifest,
+                    interactive,
+                    format!(
+                        "coral identity-spec add --file {}",
+                        source_ops::shell_quote_arg(&file.display().to_string())
+                    ),
+                )?
+            };
+            let (identity_spec, replaced) =
+                source_ops::add_identity_spec(app, manifest_yaml, inputs).await?;
+            let action = if replaced { "Replaced" } else { "Added" };
+            println!(
+                "{action} identity spec {} ({})",
+                identity_spec.name,
+                source_ops::display_version(&identity_spec.version)
+            );
+        }
+        IdentitySpecCommand::Remove { name, force } => {
+            let orphaned = source_ops::remove_identity_spec(app, &name, force).await?;
+            if orphaned == 0 {
+                println!("Removed identity spec {name}");
+            } else {
+                println!("Removed identity spec {name} (orphaned identities: {orphaned})");
+            }
         }
     }
     Ok(())

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -11,10 +11,12 @@ use std::time::Duration;
 use anyhow::{Context as _, bail};
 use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
-    CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest, CreateIdentitySpecRequest,
-    CreateUserOwnedIdentityWithFixedTokenRequest, CreateUserOwnedIdentityWithOAuthRequest,
-    DeleteSourceRequest, DiscoverSourcesRequest, GetIdentitySpecRequest, GetSourceInfoRequest,
-    Identity, IdentitySpec, IdentitySpecImportInputs, IdentitySpecInput, ImportSourceRequest,
+    AddIdentitySpecRequest, CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
+    CreateIdentitySpecRequest, CreateUserOwnedIdentityWithFixedTokenRequest,
+    CreateUserOwnedIdentityWithOAuthRequest, DeleteIdentitySpecRequest, DeleteSourceRequest,
+    DeleteUserOwnedIdentityRequest, DiscoverSourcesRequest, GetIdentitySpecRequest,
+    GetSourceInfoRequest, GetUserOwnedIdentityRequest, Identity, IdentityOwner, IdentitySpec,
+    IdentitySpecImportInputs, IdentitySpecInput, ImportSourceRequest, ListIdentitySpecsRequest,
     ListSourcesRequest, ListUserOwnedIdentitiesRequest, OAuthCredentialInput,
     OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source, SourceCredentialStorage,
     SourceIdentityBinding, SourceIdentityOwner, SourceInfo, SourceOrigin, SourceSecret,
@@ -118,6 +120,12 @@ macro_rules! rpc_fn {
 }
 
 rpc_fn! {
+    fn list_identity_specs() -> Vec<IdentitySpec>;
+    identity_spec_client.list_identity_specs(ListIdentitySpecsRequest {});
+    |response| response.identity_specs
+}
+
+rpc_fn! {
     fn get_identity_spec(name: &str) -> IdentitySpec;
     identity_spec_client.get_identity_spec(GetIdentitySpecRequest {
         name: name.to_string(),
@@ -125,6 +133,23 @@ rpc_fn! {
     |response| response
         .identity_spec
         .ok_or_else(|| anyhow::anyhow!("get identity spec response missing identity_spec"))?
+}
+
+rpc_fn! {
+    fn add_identity_spec(
+        manifest_yaml: String,
+        inputs: Vec<IdentitySpecInput>
+    ) -> (IdentitySpec, bool);
+    identity_spec_client.add_identity_spec(AddIdentitySpecRequest {
+        manifest_yaml,
+        inputs,
+    });
+    |response| (
+        response
+            .identity_spec
+            .ok_or_else(|| anyhow::anyhow!("add identity spec response missing identity_spec"))?,
+        response.replaced,
+    )
 }
 
 rpc_fn! {
@@ -142,9 +167,38 @@ rpc_fn! {
 }
 
 rpc_fn! {
+    fn remove_identity_spec(name: &str, force: bool) -> u32;
+    identity_spec_client.delete_identity_spec(DeleteIdentitySpecRequest {
+        name: name.to_string(),
+        force,
+    });
+    |response| response.orphaned_identities
+}
+
+rpc_fn! {
     fn list_user_owned_identities() -> Vec<Identity>;
     identity_client.list_user_owned_identities(ListUserOwnedIdentitiesRequest {});
     |response| response.identities
+}
+
+rpc_fn! {
+    fn get_user_owned_identity(name: &str) -> Identity;
+    identity_client.get_user_owned_identity(GetUserOwnedIdentityRequest {
+        name: name.to_string(),
+    });
+    |response| response
+        .identity
+        .ok_or_else(|| anyhow::anyhow!("get user-owned identity response missing identity"))?
+}
+
+rpc_fn! {
+    fn delete_user_owned_identity(name: &str) -> ();
+    identity_client.delete_user_owned_identity(DeleteUserOwnedIdentityRequest {
+        name: name.to_string(),
+    });
+    |response| {
+        let _ = response;
+    }
 }
 
 pub(crate) async fn create_user_owned_identity_with_oauth(
@@ -153,6 +207,7 @@ pub(crate) async fn create_user_owned_identity_with_oauth(
     identity_spec: &str,
     credential_inputs: Vec<OAuthCredentialInput>,
     label: &str,
+    retry_command: &'static str,
 ) -> Result<Identity, anyhow::Error> {
     let response = app
         .identity_client()
@@ -174,7 +229,7 @@ pub(crate) async fn create_user_owned_identity_with_oauth(
         OAuthStreamContext {
             ended_message: "identity OAuth stream ended before identity creation completed",
             error_action: "identity creation",
-            retry_command: "coral source add --interactive --file <manifest.yaml>",
+            retry_command,
         },
         |response| response.event.map(CredentialStreamEvent::from),
     )
@@ -484,6 +539,17 @@ pub(crate) async fn install_identity_specs_for_source_add(
     Ok(newly_installed_names)
 }
 
+pub(crate) async fn parseable_installed_identity_spec_manifest(
+    app: &AppClient,
+    name: &str,
+) -> Result<Option<IdentityManifest>, anyhow::Error> {
+    match get_identity_spec(app, name).await {
+        Ok(existing) => Ok(parse_identity_manifest_yaml(&existing.manifest_yaml).ok()),
+        Err(error) if tonic_status_code(&error) == Some(tonic::Code::NotFound) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
 async fn matching_identity_spec_exists(
     app: &AppClient,
     document: &IdentityManifestDocument,
@@ -787,6 +853,7 @@ async fn create_identity_for_surface(
                 &selected.identity_spec.name,
                 credential_inputs,
                 &label,
+                "coral source add --interactive --file <manifest.yaml>",
             )
             .await?
         }
@@ -883,6 +950,18 @@ pub(crate) fn prompt_fixed_token_identity_token(
         .with_prompt(format!("Token for {identity_spec_name}"))
         .allow_empty_password(false)
         .interact()?;
+    Ok(token)
+}
+
+pub(crate) fn read_fixed_token_identity_token_from_stdin() -> Result<String, anyhow::Error> {
+    let mut token = String::new();
+    stdin().read_to_string(&mut token)?;
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        return Err(anyhow::anyhow!(
+            "fixed token identity token must not be empty"
+        ));
+    }
     Ok(token)
 }
 
@@ -1130,6 +1209,14 @@ pub(crate) fn load_validated_manifest_file(
 ) -> Result<(String, ValidatedSourceManifest), anyhow::Error> {
     let bundle = load_validated_manifest_bundle_file(file)?;
     Ok((bundle.source_manifest_yaml, bundle.source_manifest))
+}
+
+pub(crate) fn load_validated_identity_spec_file(
+    file: &Path,
+) -> Result<(String, IdentityManifest), anyhow::Error> {
+    let raw = std::fs::read_to_string(file)?;
+    let manifest = parse_identity_manifest_yaml(&raw)?;
+    Ok((raw, manifest))
 }
 
 pub(crate) struct ValidatedManifestBundleFile {
@@ -1646,6 +1733,13 @@ pub(crate) fn source_credential_storage_label(storage: i32) -> &'static str {
         Ok(SourceCredentialStorage::File) => "file (plaintext)",
         Ok(SourceCredentialStorage::Keychain) => "keychain",
         Err(_) => "unknown",
+    }
+}
+
+pub(crate) fn identity_owner_label(owner: i32) -> &'static str {
+    match IdentityOwner::try_from(owner) {
+        Ok(IdentityOwner::User) => "user",
+        Ok(IdentityOwner::Unspecified) | Err(_) => "unknown",
     }
 }
 

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -18,8 +18,8 @@ use arrow::record_batch::RecordBatch;
 use assert_cmd::Command;
 use assert_cmd::assert::Assert;
 use coral_api::v1::{
-    DiscoverSourcesResponse, ExecuteSqlResponse, GetIdentitySpecResponse, IdentitySpec,
-    ListSourcesResponse, Source, SourceCredentialStorage, SourceInfo, SourceOrigin,
+    AddIdentitySpecResponse, DiscoverSourcesResponse, ExecuteSqlResponse, GetIdentitySpecResponse,
+    IdentitySpec, ListSourcesResponse, Source, SourceCredentialStorage, SourceInfo, SourceOrigin,
 };
 use tempfile::{TempDir, tempdir};
 use tonic::Code;
@@ -793,6 +793,358 @@ fn identity_spec_response(
             manifest_yaml,
         }),
     }
+}
+
+fn demo_oauth_identity_spec_yaml() -> &'static str {
+    r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+description: Demo OAuth identity.
+issuer: demo
+type: oauth
+audience:
+  host: example.test
+inputs:
+  DEMO_TENANT:
+    kind: variable
+    default: tenant-a
+  DEMO_OAUTH_CLIENT_SECRET:
+    kind: secret
+oauth:
+  method:
+    label: Demo OAuth
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    endpoints:
+      authorization_url: https://{{input.DEMO_TENANT}}.example.test/oauth/authorize
+      token_url: https://{{input.DEMO_TENANT}}.example.test/oauth/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+        transport: request_body
+"
+}
+
+fn legacy_demo_identity_spec_yaml() -> &'static str {
+    r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+issuer: demo
+type: fixed_token
+audience:
+  host: example.test
+"
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_commands_use_identity_spec_service() {
+    let server = MockServer::start().await;
+    let source_dir = tempdir().expect("identity spec dir");
+    let identity_file = write_yaml(
+        &source_dir,
+        "github_oauth.yaml",
+        &fixed_token_spec_yaml("github_oauth"),
+    );
+
+    server
+        .cmd()
+        .args([
+            "identity-spec",
+            "add",
+            "--file",
+            identity_file.to_str().expect("fixture path utf8"),
+        ])
+        .assert()
+        .success();
+    run_cli(&server, &["identity-spec", "list"]).success();
+    run_cli(&server, &["identity-spec", "info", "github_oauth"]).success();
+    run_cli(
+        &server,
+        &["identity-spec", "remove", "github_oauth", "--force"],
+    )
+    .success();
+
+    assert_eq!(server.add_identity_spec_requests().len(), 1);
+    assert_eq!(server.create_identity_spec_requests().len(), 0);
+    assert_eq!(server.list_identity_specs_requests().len(), 1);
+    assert_eq!(server.get_identity_spec_requests()[0].name, "github_oauth");
+    let delete_requests = server.delete_identity_spec_requests();
+    assert_eq!(delete_requests[0].name, "github_oauth");
+    assert!(delete_requests[0].force);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_add_noninteractive_does_not_send_manifest_defaults_as_inputs() {
+    let server = MockServer::start_with_config(
+        MockServerConfig::default()
+            .with_get_identity_spec_error(Code::NotFound, "identity spec not found"),
+    )
+    .await;
+    let source_dir = tempdir().expect("identity spec dir");
+    let identity_file = write_yaml(
+        &source_dir,
+        "demo_oauth.yaml",
+        demo_oauth_identity_spec_yaml(),
+    );
+
+    server
+        .cmd()
+        .args([
+            "identity-spec",
+            "add",
+            "--file",
+            identity_file.to_str().expect("fixture path utf8"),
+        ])
+        .env_remove("DEMO_TENANT")
+        .env("DEMO_OAUTH_CLIENT_SECRET", "client-secret")
+        .assert()
+        .success();
+
+    let requests = server.add_identity_spec_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].inputs.len(), 1);
+    assert_eq!(requests[0].inputs[0].key, "DEMO_OAUTH_CLIENT_SECRET");
+    assert_eq!(requests[0].inputs[0].value, "client-secret");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_add_reuses_stored_inputs_for_installed_specs() {
+    let source_dir = tempdir().expect("identity spec dir");
+    let manifest_yaml = demo_oauth_identity_spec_yaml().to_string();
+    let identity_file = write_yaml(&source_dir, "demo_oauth.yaml", &manifest_yaml);
+    let server = MockServer::start_with_config(
+        MockServerConfig::default()
+            .with_get_identity_spec(identity_spec_response(
+                "demo_oauth",
+                "oauth",
+                manifest_yaml.clone(),
+            ))
+            .with_add_identity_spec_response(AddIdentitySpecResponse {
+                identity_spec: Some(IdentitySpec {
+                    name: "demo_oauth".to_string(),
+                    version: "0.1.0".to_string(),
+                    description: "Demo OAuth identity.".to_string(),
+                    issuer: "demo".to_string(),
+                    identity_type: "oauth".to_string(),
+                    manifest_yaml,
+                }),
+                replaced: true,
+            }),
+    )
+    .await;
+
+    server
+        .cmd()
+        .args([
+            "identity-spec",
+            "add",
+            "--file",
+            identity_file.to_str().expect("fixture path utf8"),
+        ])
+        .env("DEMO_TENANT", "ambient-tenant")
+        .env("DEMO_OAUTH_CLIENT_SECRET", "ambient-client-secret")
+        .assert()
+        .success();
+
+    assert_eq!(server.get_identity_spec_requests()[0].name, "demo_oauth");
+    let requests = server.add_identity_spec_requests();
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0].inputs.is_empty(),
+        "installed specs should reuse stored setup inputs"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_add_collects_inputs_for_installed_replacements() {
+    let source_dir = tempdir().expect("identity spec dir");
+    let manifest_yaml = demo_oauth_identity_spec_yaml().to_string();
+    let identity_file = write_yaml(&source_dir, "demo_oauth.yaml", &manifest_yaml);
+    let server = MockServer::start_with_config(
+        MockServerConfig::default()
+            .with_get_identity_spec(identity_spec_response(
+                "demo_oauth",
+                "fixed_token",
+                legacy_demo_identity_spec_yaml().to_string(),
+            ))
+            .with_add_identity_spec_response(AddIdentitySpecResponse {
+                identity_spec: Some(IdentitySpec {
+                    name: "demo_oauth".to_string(),
+                    version: "0.1.0".to_string(),
+                    description: "Demo OAuth identity.".to_string(),
+                    issuer: "demo".to_string(),
+                    identity_type: "oauth".to_string(),
+                    manifest_yaml,
+                }),
+                replaced: true,
+            }),
+    )
+    .await;
+
+    server
+        .cmd()
+        .args([
+            "identity-spec",
+            "add",
+            "--file",
+            identity_file.to_str().expect("fixture path utf8"),
+        ])
+        .env_remove("DEMO_TENANT")
+        .env("DEMO_OAUTH_CLIENT_SECRET", "client-secret")
+        .assert()
+        .success();
+
+    let requests = server.add_identity_spec_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].inputs.len(), 1);
+    assert_eq!(requests[0].inputs[0].key, "DEMO_OAUTH_CLIENT_SECRET");
+    assert_eq!(requests[0].inputs[0].value, "client-secret");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_commands_use_identity_service() {
+    let server = MockServer::start().await;
+
+    run_cli(&server, &["identity", "list"]).success();
+    run_cli(&server, &["identity", "info", "github_local"]).success();
+    run_cli(&server, &["identity", "remove", "github_local"]).success();
+
+    assert_eq!(server.list_user_owned_identities_requests().len(), 1);
+    assert_eq!(
+        server.get_user_owned_identity_requests()[0].name,
+        "github_local"
+    );
+    assert_eq!(
+        server.delete_user_owned_identity_requests()[0].name,
+        "github_local"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_remove_surfaces_missing_identity() {
+    let server = MockServer::start_with_config(
+        MockServerConfig::default()
+            .with_get_user_owned_identity_error(Code::NotFound, "identity 'missing' not found"),
+    )
+    .await;
+
+    let assert = run_cli(&server, &["identity", "remove", "missing"]).failure();
+
+    let stdout = stdout_text(&assert);
+    assert!(
+        !stdout.contains("Removed identity"),
+        "missing identity must not print success: {stdout}"
+    );
+    let stderr = stderr_text(&assert);
+    assert!(
+        stderr.contains("identity 'missing' not found"),
+        "expected missing identity error: {stderr}"
+    );
+    assert!(
+        server.delete_user_owned_identity_requests().is_empty(),
+        "missing identity should fail before delete"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_add_fixed_token_reads_trimmed_token_from_stdin() {
+    let server = MockServer::start_with_config(MockServerConfig::default().with_get_identity_spec(
+        identity_spec_response(
+            "github_pat",
+            "fixed_token",
+            fixed_token_spec_yaml("github_pat"),
+        ),
+    ))
+    .await;
+
+    server
+        .cmd()
+        .args([
+            "identity",
+            "add",
+            "github_local",
+            "--identity-spec",
+            "github_pat",
+            "--token-stdin",
+        ])
+        .write_stdin("  pat-token  \n")
+        .assert()
+        .success();
+
+    assert_eq!(server.get_identity_spec_requests()[0].name, "github_pat");
+    let requests = server.create_user_owned_identity_with_fixed_token_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].name, "github_local");
+    assert_eq!(requests[0].identity_spec, "github_pat");
+    assert_eq!(requests[0].token, "pat-token");
+    assert!(
+        server
+            .create_user_owned_identity_with_oauth_requests()
+            .is_empty(),
+        "fixed-token identity add must not use OAuth creation"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_add_fixed_token_rejects_whitespace_only_stdin_token() {
+    let server = MockServer::start_with_config(MockServerConfig::default().with_get_identity_spec(
+        identity_spec_response(
+            "github_pat",
+            "fixed_token",
+            fixed_token_spec_yaml("github_pat"),
+        ),
+    ))
+    .await;
+
+    let assert = server
+        .cmd()
+        .args([
+            "identity",
+            "add",
+            "github_local",
+            "--identity-spec",
+            "github_pat",
+            "--token-stdin",
+        ])
+        .write_stdin("   \n")
+        .assert()
+        .failure();
+
+    let stderr = stderr_text(&assert);
+    assert!(
+        stderr.contains("fixed token identity token must not be empty"),
+        "expected empty token error: {stderr}"
+    );
+    assert!(
+        server
+            .create_user_owned_identity_with_fixed_token_requests()
+            .is_empty(),
+        "whitespace-only token must not create an identity"
+    );
+
+    server.shutdown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -31,16 +31,16 @@ use coral_api::v1::{
     DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
     ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
     GetIdentitySpecRequest, GetIdentitySpecResponse, GetSourceInfoRequest, GetSourceInfoResponse,
-    GetSourceRequest, GetSourceResponse, Identity, IdentityOwner, IdentitySpec,
-    ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
-    ListColumnsRequest, ListColumnsResponse, ListIdentitySpecsRequest, ListIdentitySpecsResponse,
-    ListSourcesRequest, ListSourcesResponse, ListUserOwnedIdentitiesRequest,
-    ListUserOwnedIdentitiesResponse, PaginationRequest, PaginationResponse, QueryPlan,
-    SearchCatalogRequest, SearchCatalogResponse, Source, SourceCredentialStorage, SourceInfo,
-    SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
-    create_user_owned_identity_with_o_auth_response, import_source_response,
-    source_input_spec::Input as ProtoSourceInput,
+    GetSourceRequest, GetSourceResponse, GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse,
+    Identity, IdentityOwner, IdentitySpec, ImportSourceRequest, ImportSourceResponse,
+    ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListColumnsResponse,
+    ListIdentitySpecsRequest, ListIdentitySpecsResponse, ListSourcesRequest, ListSourcesResponse,
+    ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse, PaginationRequest,
+    PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse, Source,
+    SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table,
+    TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
+    create_bundled_source_with_o_auth_response, create_user_owned_identity_with_o_auth_response,
+    import_source_response, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
 use tempfile::TempDir;
@@ -515,6 +515,7 @@ pub(crate) struct MockServerConfig {
     discover_sources: MockResult<DiscoverSourcesResponse>,
     list_sources: MockResult<ListSourcesResponse>,
     list_user_owned_identities: MockResult<ListUserOwnedIdentitiesResponse>,
+    get_user_owned_identity: MockResult<GetUserOwnedIdentityResponse>,
     delete_user_owned_identity: MockResult<DeleteUserOwnedIdentityResponse>,
     list_identity_specs: MockResult<ListIdentitySpecsResponse>,
     get_identity_spec: MockResult<GetIdentitySpecResponse>,
@@ -545,6 +546,9 @@ impl Default for MockServerConfig {
             }),
             list_user_owned_identities: MockResult::ok(ListUserOwnedIdentitiesResponse {
                 identities: vec![mock_identity()],
+            }),
+            get_user_owned_identity: MockResult::ok(GetUserOwnedIdentityResponse {
+                identity: Some(mock_identity()),
             }),
             delete_user_owned_identity: MockResult::ok(DeleteUserOwnedIdentityResponse {}),
             delete_identity_spec: MockResult::ok(()),
@@ -660,6 +664,24 @@ impl MockServerConfig {
         message: impl Into<String>,
     ) -> Self {
         self.create_identity_spec = MockResult::err(code, message);
+        self
+    }
+
+    pub(crate) fn with_get_user_owned_identity_error(
+        mut self,
+        code: Code,
+        message: impl Into<String>,
+    ) -> Self {
+        self.get_user_owned_identity = MockResult::err(code, message);
+        self
+    }
+
+    pub(crate) fn with_delete_user_owned_identity_error(
+        mut self,
+        code: Code,
+        message: impl Into<String>,
+    ) -> Self {
+        self.delete_user_owned_identity = MockResult::err(code, message);
         self
     }
 
@@ -793,6 +815,7 @@ captured_requests! {
         CreateUserOwnedIdentityWithFixedTokenRequest,
     list_user_owned_identities as list_user_owned_identities_requests:
         ListUserOwnedIdentitiesRequest,
+    get_user_owned_identity as get_user_owned_identity_requests: GetUserOwnedIdentityRequest,
     delete_user_owned_identity as delete_user_owned_identity_requests:
         DeleteUserOwnedIdentityRequest,
     delete_source as delete_source_requests: DeleteSourceRequest,
@@ -1096,6 +1119,9 @@ mock_service! {
         fn list_user_owned_identities(list_user_owned_identities, ListUserOwnedIdentitiesRequest)
             -> ListUserOwnedIdentitiesResponse =
             |cfg, _request| cfg.list_user_owned_identities.clone().into_tonic_result()?;
+        fn get_user_owned_identity(get_user_owned_identity, GetUserOwnedIdentityRequest)
+            -> GetUserOwnedIdentityResponse =
+            |cfg, _request| cfg.get_user_owned_identity.clone().into_tonic_result()?;
         fn delete_user_owned_identity(delete_user_owned_identity, DeleteUserOwnedIdentityRequest)
             -> DeleteUserOwnedIdentityResponse =
             |cfg, _request| cfg.delete_user_owned_identity.clone().into_tonic_result()?;

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -195,6 +195,100 @@ Remove an installed source.
 coral source remove github
 ```
 
+## `coral identity`
+
+Manage stored user-owned identities (see the
+[identity spec reference](/reference/identity-spec-reference) for what
+user-owned identities are and how DSL v4 sources resolve them).
+
+### `coral identity list`
+
+List stored user-owned identities.
+
+```shellscript
+coral identity list
+```
+
+### `coral identity info <NAME>`
+
+Show one stored user-owned identity without revealing credential material.
+
+```shellscript
+coral identity info github_local
+```
+
+### `coral identity add <NAME> --identity-spec <SPEC> [--token-stdin]`
+
+Create or replace a user-owned identity from an installed OAuth or fixed-token
+identity spec. For OAuth specs, Coral runs the spec's OAuth setup method. For
+fixed-token specs, Coral prompts for the bearer token by default, or reads it
+from stdin when `--token-stdin` is set. In both cases, Coral stores provider
+identity material for the local Coral user principal.
+
+```shellscript
+coral identity add github_local --identity-spec github_oauth
+printf '%s\n' "$GITHUB_TOKEN" | coral identity add github_pat --identity-spec github_pat --token-stdin
+```
+
+### `coral identity remove <NAME>`
+
+Remove one stored user-owned identity, its local credential material, and any
+source identity selections for the local user that reference it.
+
+```shellscript
+coral identity remove github_local
+```
+
+## `coral identity-spec`
+
+Manage global identity specs used by DSL v4 source `identity_requirements`.
+Identity specs are installed once for the local Coral app and are visible to all
+workspaces. Installing a spec does not instantiate an identity; use
+`coral identity add` for that.
+
+### `coral identity-spec list`
+
+List installed identity specs.
+
+```shellscript
+coral identity-spec list
+```
+
+### `coral identity-spec info <NAME>`
+
+Print one installed identity spec manifest.
+
+```shellscript
+coral identity-spec info github_oauth
+```
+
+### `coral identity-spec add --file <PATH>`
+
+Install one identity spec from a YAML file. If a spec with the same name already
+exists, Coral replaces it only when no stored identities reference it, or when
+the new manifest is equivalent to the installed manifest.
+
+If the identity spec declares `inputs`, `coral identity-spec add` collects those
+values when the spec is installed. In an interactive terminal Coral prompts for
+missing values; otherwise it reads environment variables matching the input
+keys. Secret inputs are stored as identity-spec material and are not stored on
+identities created from the spec.
+
+```shellscript
+coral identity-spec add --file ./github-oauth.identity.yaml
+```
+
+### `coral identity-spec remove <NAME>`
+
+Remove one installed identity spec. Stored identities that depend on the spec
+become orphaned (see
+[identity spec reference](/reference/identity-spec-reference)); when any exist,
+the command fails unless `--force` is passed.
+
+```shellscript
+coral identity-spec remove github_oauth --force
+```
+
 ## `coral onboard`
 
 Run the guided source setup flow.


### PR DESCRIPTION
## Intent

Port PR #1249's identity management CLI functionality onto the current DSL v4 stack without touching PR #1249 or its branch.

## What it enables

- `coral identity` can list, inspect, create, and remove user-owned identities.
- `coral identity-spec` can list, inspect, add, replace, and remove installed identity specs.
- Direct identity-spec installs use `AddIdentitySpec`, while source bundle imports keep the create-only `CreateIdentitySpec` semantics already used by `coral source add`.
- Identity deletion now also cleans local source identity selections that reference the deleted user-owned identity, while preserving idempotent delete RPC compatibility.
- Exact identity-spec re-adds reuse stored setup material instead of accidentally replacing it from ambient environment variables.

## Usage examples

```bash
coral identity-spec add --file identities/core/github.yaml
coral identity add github_local --identity-spec github_pat --token-stdin
coral identity list
coral identity info github_local
coral identity remove github_local
coral identity-spec remove github_pat --force
```
