### PR TITLE
fix(spec): refactor MCP importer into topic-focused modules

### DIFF
--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -279,6 +279,7 @@ fn mcp_table_spec(
         filter_bindings: mcp_filter_bindings(projection),
         limit_binding: None,
         pagination: mcp.pagination.clone(),
+        offset_pagination: mcp.offset_pagination.clone(),
         response: mcp_response_for_operation(operation),
     }
 }
@@ -292,6 +293,7 @@ fn mcp_table_function_spec(
     McpTableFunctionSpec {
         tool: mcp.tool_name.clone(),
         pagination: mcp.pagination.clone(),
+        offset_pagination: mcp.offset_pagination.clone(),
         common: SourceTableFunctionSpec {
             name: projection.name.clone(),
             kind: function_kind,
@@ -395,7 +397,7 @@ mod tests {
     use std::path::PathBuf;
 
     use coral_spec::backends::http::{AuthSpec, RateLimitSpec};
-    use coral_spec::backends::mcp::{McpPaginationSpec, McpServerSpec};
+    use coral_spec::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec, McpServerSpec};
     use coral_spec::v4::{
         Fingerprint, IrExecutionAttachment, IrOperation, IrOperationOutput, MCP_IMPORTER_VERSION,
         MaterializedSurface, McpExecutionAttachment, McpRuntimeConfig, OPENAPI_IMPORTER_VERSION,
@@ -485,6 +487,20 @@ mod tests {
         operation_id: &str,
         pagination: Option<McpPaginationSpec>,
     ) -> MaterializedSurface {
+        mcp_materialized_surface_with_pagination_and_offset(
+            surface_id,
+            operation_id,
+            pagination,
+            None,
+        )
+    }
+
+    fn mcp_materialized_surface_with_pagination_and_offset(
+        surface_id: &str,
+        operation_id: &str,
+        pagination: Option<McpPaginationSpec>,
+        offset_pagination: Option<McpOffsetPaginationSpec>,
+    ) -> MaterializedSurface {
         MaterializedSurface {
             surface_id: surface_id.to_string(),
             semantic_ir: SemanticIr {
@@ -509,6 +525,7 @@ mod tests {
                     execution: IrExecutionAttachment::Mcp(McpExecutionAttachment {
                         tool_name: operation_id.to_string(),
                         pagination,
+                        offset_pagination,
                     }),
                     diagnostics: Vec::new(),
                 }],
@@ -648,6 +665,74 @@ mod tests {
         assert_eq!(
             mcp.tables.first().expect("mcp table").pagination.as_ref(),
             Some(&pagination)
+        );
+    }
+
+    #[test]
+    fn mcp_runtime_component_keeps_operation_offset_pagination() {
+        let surface = mcp_surface("mcp", "github_v4_mcp");
+        let manifest = V4SourceManifest {
+            common: V4SourceCommon {
+                dsl_version: 4,
+                name: "github_v4".to_string(),
+                description: String::new(),
+                test_queries: Vec::new(),
+            },
+            declared_inputs: Vec::new(),
+            surfaces: vec![surface],
+        };
+        let offset_pagination = McpOffsetPaginationSpec {
+            limit_arg: "limit".to_string(),
+            default_limit: 50,
+            max_limit: 200,
+            offset_arg: "offset".to_string(),
+            offset_start: 0,
+            max_pages: None,
+        };
+        let materialized = V4MaterializedSource {
+            fingerprint: Fingerprint {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "github_v4".to_string(),
+                manifest_sha256: String::new(),
+                surfaces: Vec::new(),
+                importer_version: SURFACE_IMPORTER_VERSION.to_string(),
+                projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+            },
+            surfaces: vec![mcp_materialized_surface_with_pagination_and_offset(
+                "mcp",
+                "mcp_list_issues",
+                None,
+                Some(offset_pagination.clone()),
+            )],
+            projections: ProjectionCatalog {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "github_v4".to_string(),
+                generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+                projections: vec![published_projection(
+                    "mcp",
+                    "github_v4_mcp",
+                    "mcp_list_issues",
+                )],
+                diagnostics: Vec::new(),
+            },
+            diagnostics: Vec::new(),
+        };
+
+        let components =
+            runtime_components_for_v4_source(&manifest, &materialized).expect("runtime components");
+        let coral_engine::RuntimeSourceComponent::Mcp(mcp) =
+            components.first().expect("mcp component")
+        else {
+            panic!("expected MCP component");
+        };
+
+        assert_eq!(
+            mcp.tables
+                .first()
+                .expect("mcp table")
+                .offset_pagination
+                .as_ref(),
+            Some(&offset_pagination)
         );
     }
 

--- a/crates/coral-engine/src/backends/mcp/fetch.rs
+++ b/crates/coral-engine/src/backends/mcp/fetch.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use coral_spec::ResponseSpec;
 use coral_spec::ValueSourceSpec;
-use coral_spec::backends::mcp::McpPaginationSpec;
+use coral_spec::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
 use datafusion::error::{DataFusionError, Result};
 use rmcp::model::JsonObject;
 use serde_json::Value;
@@ -30,6 +30,7 @@ pub(super) struct McpFetchPlan {
     pub(super) source_tool_args: Arc<BTreeMap<String, ValueSourceSpec>>,
     pub(super) response: ResponseSpec,
     pub(super) pagination: Option<McpPaginationSpec>,
+    pub(super) offset_pagination: Option<McpOffsetPaginationSpec>,
     pub(super) limit: Option<usize>,
 }
 
@@ -38,15 +39,30 @@ impl RowFetcher for McpFetchPlan {
     async fn fetch(&self) -> Result<Vec<Value>> {
         let mut all_rows = Vec::new();
         let mut next_cursor: Option<Value> = None;
+        let mut next_offset = self
+            .offset_pagination
+            .as_ref()
+            .map(|pagination| pagination.offset_start);
         let mut seen_cursors = BTreeSet::new();
         let mut page_count = 0usize;
         let max_pages = self
             .pagination
             .as_ref()
             .and_then(|pagination| pagination.max_pages)
+            .or_else(|| {
+                self.offset_pagination
+                    .as_ref()
+                    .and_then(|pagination| pagination.max_pages)
+            })
             .unwrap_or(DEFAULT_MCP_MAX_PAGES);
 
         loop {
+            let offset_page_limit =
+                offset_page_limit(self.offset_pagination.as_ref(), self.limit, all_rows.len());
+            if offset_page_limit == Some(0) {
+                break;
+            }
+
             page_count += 1;
             if page_count > max_pages {
                 return Err(DataFusionError::External(Box::new(
@@ -59,7 +75,9 @@ impl RowFetcher for McpFetchPlan {
                 )));
             }
 
-            let arguments = self.arguments_for_cursor(next_cursor.as_ref()).await?;
+            let arguments = self
+                .arguments_for_page(next_cursor.as_ref(), next_offset, offset_page_limit)
+                .await?;
             let payload = self
                 .backend
                 .call_tool(&self.relation, &self.tool_name, arguments)
@@ -75,6 +93,7 @@ impl RowFetcher for McpFetchPlan {
                 )));
             }
             let mut rows = extract_rows(&self.response, &payload);
+            let rows_on_page = rows.len();
             all_rows.append(&mut rows);
             if let Some(limit) = self.limit
                 && all_rows.len() >= limit
@@ -83,33 +102,49 @@ impl RowFetcher for McpFetchPlan {
                 break;
             }
 
-            let Some(pagination) = &self.pagination else {
-                break;
-            };
-            match next_page_cursor(pagination, &payload) {
-                Some(cursor) => {
-                    let cursor_key = cursor_identity(&cursor);
-                    if !seen_cursors.insert(cursor_key.clone()) {
-                        return Err(DataFusionError::External(Box::new(
-                            McpProviderQueryError::Pagination {
-                                source_schema: self.source_schema.clone(),
-                                relation: self.relation.clone(),
-                                tool: self.tool_name.clone(),
-                                detail: format!("returned repeated cursor {cursor_key}"),
-                            },
-                        )));
+            if let Some(pagination) = &self.pagination {
+                match next_page_cursor(pagination, &payload) {
+                    Some(cursor) => {
+                        let cursor_key = cursor_identity(&cursor);
+                        if !seen_cursors.insert(cursor_key.clone()) {
+                            return Err(DataFusionError::External(Box::new(
+                                McpProviderQueryError::Pagination {
+                                    source_schema: self.source_schema.clone(),
+                                    relation: self.relation.clone(),
+                                    tool: self.tool_name.clone(),
+                                    detail: format!("returned repeated cursor {cursor_key}"),
+                                },
+                            )));
+                        }
+                        next_cursor = Some(cursor);
                     }
-                    next_cursor = Some(cursor);
+                    None => break,
                 }
-                None => break,
+                continue;
             }
+            if let Some(current_offset) = next_offset {
+                let Some(page_limit) = offset_page_limit else {
+                    break;
+                };
+                if rows_on_page == 0 || rows_on_page < page_limit {
+                    break;
+                }
+                next_offset = Some(current_offset.saturating_add(rows_on_page));
+                continue;
+            }
+            break;
         }
         Ok(all_rows)
     }
 }
 
 impl McpFetchPlan {
-    async fn arguments_for_cursor(&self, cursor: Option<&Value>) -> Result<JsonObject> {
+    async fn arguments_for_page(
+        &self,
+        cursor: Option<&Value>,
+        offset: Option<usize>,
+        limit: Option<usize>,
+    ) -> Result<JsonObject> {
         let mut arguments = JsonObject::new();
         if !self.source_tool_args.is_empty() {
             let source_inputs = self.source_inputs.as_ref().ok_or_else(|| {
@@ -130,7 +165,28 @@ impl McpFetchPlan {
         if let Some((pagination, cursor)) = self.pagination.as_ref().zip(cursor) {
             arguments.insert(pagination.cursor_arg.clone(), cursor.clone());
         }
+        if let Some(pagination) = &self.offset_pagination
+            && let (Some(offset), Some(limit)) = (offset, limit)
+        {
+            arguments.insert(pagination.limit_arg.clone(), Value::from(limit));
+            arguments.insert(pagination.offset_arg.clone(), Value::from(offset));
+        }
         Ok(arguments)
+    }
+}
+
+fn offset_page_limit(
+    pagination: Option<&McpOffsetPaginationSpec>,
+    total_limit: Option<usize>,
+    rows_so_far: usize,
+) -> Option<usize> {
+    let pagination = pagination?;
+    match total_limit {
+        Some(total_limit) => {
+            let remaining = total_limit.saturating_sub(rows_so_far);
+            Some(remaining.min(pagination.max_limit))
+        }
+        None => Some(pagination.default_limit.min(pagination.max_limit)),
     }
 }
 

--- a/crates/coral-engine/src/backends/mcp/function.rs
+++ b/crates/coral-engine/src/backends/mcp/function.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use coral_spec::ResponseSpec;
-use coral_spec::backends::mcp::{McpPaginationSpec, McpTableFunctionSpec};
+use coral_spec::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec, McpTableFunctionSpec};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result};
@@ -35,6 +35,7 @@ struct McpFunctionState {
     schema: SchemaRef,
     response: ResponseSpec,
     pagination: Option<McpPaginationSpec>,
+    offset_pagination: Option<McpOffsetPaginationSpec>,
     columns: Arc<[coral_spec::ColumnSpec]>,
     fetch_limit_default: Option<usize>,
 }
@@ -72,6 +73,7 @@ impl McpSourceTableFunction {
         let columns = function.common.columns.clone();
         let fetch_limit_default = function.fetch_limit_default();
         let pagination = function.pagination.clone();
+        let offset_pagination = function.offset_pagination.clone();
         Ok(Self {
             spec: Arc::new(function),
             state: Arc::new(McpFunctionState {
@@ -82,6 +84,7 @@ impl McpSourceTableFunction {
                 schema,
                 response,
                 pagination,
+                offset_pagination,
                 columns: Arc::from(columns),
                 fetch_limit_default,
             }),
@@ -164,6 +167,7 @@ impl TableProvider for McpFunctionCallTableProvider {
             source_tool_args: Arc::new(BTreeMap::default()),
             response: self.state.response.clone(),
             pagination: self.state.pagination.clone(),
+            offset_pagination: self.state.offset_pagination.clone(),
             limit: limit.or(self.state.fetch_limit_default),
         });
         let arg_strings: Arc<HashMap<String, String>> =

--- a/crates/coral-engine/src/backends/mcp/provider.rs
+++ b/crates/coral-engine/src/backends/mcp/provider.rs
@@ -148,6 +148,7 @@ impl TableProvider for McpTableProvider {
             source_tool_args: Arc::new(self.table.tool_args.clone()),
             response: self.table.response.clone(),
             pagination: self.table.pagination.clone(),
+            offset_pagination: self.table.offset_pagination.clone(),
             limit: limits.truncate,
         });
         let columns: Arc<[coral_spec::ColumnSpec]> = Arc::from(self.table.columns().to_vec());

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -110,6 +110,49 @@ impl McpToolCaller for FakePaginatedMcpTableCaller {
     }
 }
 
+/// Returns offset-paginated pages and records each MCP tool call.
+#[derive(Debug)]
+struct FakeOffsetPaginatedMcpTableCaller {
+    calls: Mutex<Vec<(String, JsonObject)>>,
+}
+
+#[async_trait]
+impl McpToolCaller for FakeOffsetPaginatedMcpTableCaller {
+    async fn call_tool(
+        &self,
+        _relation: &str,
+        tool_name: &str,
+        arguments: JsonObject,
+    ) -> Result<Value> {
+        self.calls
+            .lock()
+            .expect("calls lock")
+            .push((tool_name.to_string(), arguments.clone()));
+        let offset = arguments
+            .get("offset")
+            .and_then(Value::as_u64)
+            .unwrap_or_default();
+        let limit = arguments
+            .get("limit")
+            .and_then(Value::as_u64)
+            .unwrap_or_default();
+        match (offset, limit) {
+            (0, 2) => Ok(json!({
+                "issues": [
+                    { "id": "1", "title": "Bug A", "state": "open" },
+                    { "id": "2", "title": "Bug B", "state": "open" }
+                ]
+            })),
+            (2, 1) => Ok(json!({
+                "issues": [
+                    { "id": "3", "title": "Bug C", "state": "closed" }
+                ]
+            })),
+            other => panic!("unexpected offset pagination call: {other:?}"),
+        }
+    }
+}
+
 /// Repeats the same next cursor forever unless the fetch plan stops it.
 #[derive(Debug)]
 struct FakeRepeatedCursorMcpTableCaller {
@@ -238,6 +281,24 @@ fn compile_sources(
     caller: Arc<dyn McpToolCaller>,
 ) -> Vec<CompiledQuerySource> {
     compile_sources_with_inputs(manifest, caller, BTreeMap::new(), None)
+}
+
+fn compile_sources_with_mcp_manifest(
+    source_manifest: coral_spec::ValidatedSourceManifest,
+    mcp_manifest: coral_spec::backends::mcp::McpSourceManifest,
+    caller: Arc<dyn McpToolCaller>,
+) -> Vec<CompiledQuerySource> {
+    let source = QuerySource::new(source_manifest, BTreeMap::new(), BTreeMap::new());
+    let source_input_resolution = SourceInputResolutionContext::from_query_source(&source);
+    let resolved_inputs = Arc::new(coral_spec::resolve_inputs(
+        &mcp_manifest.declared_inputs,
+        source_input_resolution.secrets(),
+        source_input_resolution.variables(),
+    ));
+    let source_inputs = Arc::new(McpSourceInputs::static_inputs(resolved_inputs));
+    let compiled =
+        compile_source_with_caller(mcp_manifest, source_input_resolution, source_inputs, caller);
+    vec![CompiledQuerySource { source, compiled }]
 }
 
 fn compile_sources_with_inputs(
@@ -1172,6 +1233,78 @@ async fn limit_binding_omits_arg_when_no_limit_set() {
         "unbounded scan should not pass page_size: {:?}",
         call.1
     );
+}
+
+fn mcp_table_with_generated_offset_pagination_manifest() -> (
+    coral_spec::ValidatedSourceManifest,
+    coral_spec::backends::mcp::McpSourceManifest,
+) {
+    let source_manifest = coral_spec::parse_source_manifest_value(json!({
+        "dsl_version": 3,
+        "name": "test_mcp",
+        "version": "0.1.0",
+        "backend": "mcp",
+        "server": { "transport": "stdio", "command": "unused" },
+        "tables": [{
+            "name": "issues",
+            "description": "issues with generated offset pagination",
+            "tool": "list_issues",
+            "response": { "rows_path": ["issues"] },
+            "columns": [
+                { "name": "id", "type": "Utf8" },
+                { "name": "title", "type": "Utf8" },
+                { "name": "state", "type": "Utf8" }
+            ]
+        }]
+    }))
+    .expect("offset pagination manifest should parse");
+    let mut mcp_manifest = source_manifest.as_mcp().expect("mcp manifest").clone();
+    let table = mcp_manifest.tables.first_mut().expect("table");
+    table.offset_pagination = Some(coral_spec::backends::mcp::McpOffsetPaginationSpec {
+        limit_arg: "limit".to_string(),
+        default_limit: 2,
+        max_limit: 2,
+        offset_arg: "offset".to_string(),
+        offset_start: 0,
+        max_pages: Some(5),
+    });
+    (source_manifest, mcp_manifest)
+}
+
+#[tokio::test]
+async fn generated_offset_pagination_pushes_limit_and_offset_pages() {
+    let ctx = SessionContext::new();
+    let caller = Arc::new(FakeOffsetPaginatedMcpTableCaller {
+        calls: Mutex::new(Vec::new()),
+    });
+    let (source_manifest, mcp_manifest) = mcp_table_with_generated_offset_pagination_manifest();
+    register_test_sources(
+        &ctx,
+        compile_sources_with_mcp_manifest(source_manifest, mcp_manifest, caller.clone()),
+    );
+
+    let batches = ctx
+        .sql("SELECT id FROM test_mcp.issues LIMIT 3")
+        .await
+        .expect("offset pagination query should plan")
+        .collect()
+        .await
+        .expect("offset pagination query should execute");
+
+    let total_rows: usize = batches
+        .iter()
+        .map(datafusion::arrow::array::RecordBatch::num_rows)
+        .sum();
+    assert_eq!(total_rows, 3);
+
+    let calls = caller.calls.lock().expect("calls lock");
+    assert_eq!(calls.len(), 2);
+    let first_call = calls.first().expect("first call");
+    let second_call = calls.get(1).expect("second call");
+    assert_eq!(first_call.1.get("limit"), Some(&Value::from(2_u64)));
+    assert_eq!(first_call.1.get("offset"), Some(&Value::from(0_u64)));
+    assert_eq!(second_call.1.get("limit"), Some(&Value::from(1_u64)));
+    assert_eq!(second_call.1.get("offset"), Some(&Value::from(2_u64)));
 }
 
 #[tokio::test]

--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -137,6 +137,7 @@ pub struct McpTableFunctionSpec {
     pub common: SourceTableFunctionSpec,
     pub tool: String,
     pub pagination: Option<McpPaginationSpec>,
+    pub offset_pagination: Option<McpOffsetPaginationSpec>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -173,6 +174,7 @@ pub struct McpTableSpec {
     pub filter_bindings: Vec<McpTableFilterBinding>,
     pub limit_binding: Option<McpLimitBinding>,
     pub pagination: Option<McpPaginationSpec>,
+    pub offset_pagination: Option<McpOffsetPaginationSpec>,
     pub response: ResponseSpec,
 }
 
@@ -191,6 +193,20 @@ pub struct McpLimitBinding {
 pub struct McpPaginationSpec {
     pub cursor_arg: String,
     pub response_cursor_path: Vec<String>,
+    #[serde(default)]
+    pub max_pages: Option<usize>,
+}
+
+/// Offset pagination for generated MCP tool-backed relations.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct McpOffsetPaginationSpec {
+    pub limit_arg: String,
+    pub default_limit: usize,
+    pub max_limit: usize,
+    pub offset_arg: String,
+    #[serde(default)]
+    pub offset_start: usize,
     #[serde(default)]
     pub max_pages: Option<usize>,
 }
@@ -308,6 +324,7 @@ impl RawMcpTableFunctionSpec {
         Ok(McpTableFunctionSpec {
             tool: self.tool,
             pagination: self.pagination,
+            offset_pagination: None,
             common: SourceTableFunctionSpec {
                 name: self.name,
                 kind: SourceTableFunctionKind::default(),
@@ -354,6 +371,7 @@ impl RawMcpTableSpec {
             filter_bindings,
             limit_binding: self.limit_binding,
             pagination: self.pagination,
+            offset_pagination: None,
             response: self.response,
         })
     }

--- a/crates/coral-spec/src/v4/ir/mcp.rs
+++ b/crates/coral-spec/src/v4/ir/mcp.rs
@@ -1,10 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-use crate::backends::mcp::McpPaginationSpec;
+use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpExecutionAttachment {
     pub tool_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pagination: Option<McpPaginationSpec>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset_pagination: Option<McpOffsetPaginationSpec>,
 }

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -249,6 +249,7 @@ mod tests {
                 execution: IrExecutionAttachment::Mcp(McpExecutionAttachment {
                     tool_name: "list_items".to_string(),
                     pagination: None,
+                    offset_pagination: None,
                 }),
                 diagnostics: Vec::new(),
             }],

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -245,11 +245,15 @@ fn mcp_pagination_owns_input(
     mcp: &crate::v4::McpExecutionAttachment,
     input: &IrOperationInput,
 ) -> bool {
-    input.location == IrInputLocation::ToolArg
-        && mcp
-            .pagination
-            .as_ref()
-            .is_some_and(|pagination| input.name == pagination.cursor_arg)
+    if input.location != IrInputLocation::ToolArg {
+        return false;
+    }
+    mcp.pagination
+        .as_ref()
+        .is_some_and(|pagination| input.name == pagination.cursor_arg)
+        || mcp.offset_pagination.as_ref().is_some_and(|pagination| {
+            input.name == pagination.limit_arg || input.name == pagination.offset_arg
+        })
 }
 
 fn projection_input_name(

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -1,21 +1,13 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
-use serde_json::Value;
-
-use crate::backends::mcp::McpPaginationSpec;
 use crate::v4::diagnostics::Diagnostic;
-use crate::v4::ir::{
-    IrEntityCandidate, IrExecutionAttachment, IrField, IrInputLocation, IrOperation,
-    IrOperationInput, IrOperationOutput, IrScalarType, IrType, IrTypeShape, McpExecutionAttachment,
-    OutputCardinality, SemanticIr,
-};
+use crate::v4::ir::{IrScalarType, IrType, IrTypeShape, SemanticIr};
 use crate::v4::manifest::{SurfaceType, V4SourceManifest, V4Surface};
 use crate::v4::naming::normalize_identifier;
-use crate::v4::surfaces::json_schema::{json_schema_scalar_type, json_schema_type_contains};
 use crate::v4::{MCP_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
 use crate::{ManifestError, Result};
 
-use super::model::{McpToolCatalog, McpToolDescriptor};
+use super::model::McpToolCatalog;
 
 pub fn normalize_mcp_tool_catalog(catalog: &McpToolCatalog) -> Result<Vec<u8>> {
     let mut normalized = catalog.clone();
@@ -42,11 +34,11 @@ pub fn import_mcp_surface(
     importer.import(catalog)
 }
 
-struct McpImporter<'a> {
-    manifest: &'a V4SourceManifest,
-    surface: &'a V4Surface,
-    types: BTreeMap<String, IrType>,
-    diagnostics: Vec<Diagnostic>,
+pub(super) struct McpImporter<'a> {
+    pub(super) manifest: &'a V4SourceManifest,
+    pub(super) surface: &'a V4Surface,
+    pub(super) types: BTreeMap<String, IrType>,
+    pub(super) diagnostics: Vec<Diagnostic>,
 }
 
 impl<'a> McpImporter<'a> {
@@ -93,210 +85,7 @@ impl<'a> McpImporter<'a> {
         })
     }
 
-    fn import_tool(&mut self, tool: &McpToolDescriptor, operation_id: &str) -> Option<IrOperation> {
-        let mut diagnostics = Vec::new();
-        let imported_inputs = self.import_inputs(tool, operation_id, &mut diagnostics);
-        let input_schema_complete = imported_inputs.schema_complete;
-        if !input_schema_complete {
-            self.diagnostics.extend(diagnostics);
-            return None;
-        }
-
-        let inputs = imported_inputs.inputs;
-        let output = self.import_output(operation_id, tool.output_schema.as_ref());
-        let pagination = infer_mcp_pagination(&inputs, &output, tool.output_schema.as_ref());
-        Some(IrOperation {
-            id: operation_id.to_string(),
-            method_name: "tools/call".to_string(),
-            description: tool
-                .description
-                .clone()
-                .or_else(|| tool.title.clone())
-                .unwrap_or_default(),
-            deprecated: false,
-            read_only: tool.read_only_hint.unwrap_or(false),
-            inputs,
-            output,
-            entity: Some(IrEntityCandidate {
-                name: operation_id.to_string(),
-                type_ref: format!("{operation_id}_row"),
-                identity_fields: Vec::new(),
-            }),
-            execution: IrExecutionAttachment::Mcp(McpExecutionAttachment {
-                tool_name: tool.name.clone(),
-                pagination,
-            }),
-            diagnostics,
-        })
-    }
-
-    fn import_inputs(
-        &mut self,
-        tool: &McpToolDescriptor,
-        operation_id: &str,
-        diagnostics: &mut Vec<Diagnostic>,
-    ) -> ImportedInputs {
-        let mut resolving_refs = BTreeSet::new();
-        let mut schema_complete = true;
-        let Some(shape) = input_object_shape(
-            &tool.input_schema,
-            &tool.input_schema,
-            &self.surface.id,
-            operation_id,
-            &mut resolving_refs,
-            diagnostics,
-            &mut schema_complete,
-        ) else {
-            return ImportedInputs {
-                inputs: Vec::new(),
-                schema_complete: false,
-            };
-        };
-        let inputs = shape
-            .properties
-            .iter()
-            .map(|(name, property)| {
-                let data_type = json_schema_scalar_type(property).unwrap_or(IrScalarType::Json);
-                self.ensure_type_for_scalar(data_type);
-                IrOperationInput {
-                    name: name.clone(),
-                    location: IrInputLocation::ToolArg,
-                    required: shape.required.contains(name.as_str()),
-                    data_type,
-                    default_value: property_default(property),
-                    description: schema_description(property),
-                }
-            })
-            .collect();
-        ImportedInputs {
-            inputs,
-            schema_complete,
-        }
-    }
-
-    fn import_output(
-        &mut self,
-        operation_id: &str,
-        output_schema: Option<&Value>,
-    ) -> IrOperationOutput {
-        let row_type_id = format!("{operation_id}_row");
-        let Some(schema) = output_schema else {
-            self.insert_generic_row_type(&row_type_id);
-            return IrOperationOutput {
-                cardinality: OutputCardinality::Singleton,
-                type_ref: row_type_id,
-                row_path: Vec::new(),
-            };
-        };
-        if json_schema_type_contains(schema, "array") {
-            let item_schema = schema.get("items");
-            self.insert_row_type_from_schema(&row_type_id, item_schema);
-            return IrOperationOutput {
-                cardinality: OutputCardinality::List,
-                type_ref: row_type_id,
-                row_path: Vec::new(),
-            };
-        }
-        if let Some((array_property, item_schema)) = wrapped_list_property(schema) {
-            self.insert_row_type_from_schema(&row_type_id, item_schema);
-            return IrOperationOutput {
-                cardinality: OutputCardinality::WrappedList,
-                type_ref: row_type_id,
-                row_path: vec![array_property.to_string()],
-            };
-        }
-        self.insert_row_type_from_schema(&row_type_id, Some(schema));
-        IrOperationOutput {
-            cardinality: OutputCardinality::Singleton,
-            type_ref: row_type_id,
-            row_path: Vec::new(),
-        }
-    }
-
-    fn insert_generic_row_type(&mut self, type_id: &str) {
-        let json_type = self.ensure_type_for_scalar(IrScalarType::Json);
-        self.types.insert(
-            type_id.to_string(),
-            IrType {
-                id: type_id.to_string(),
-                shape: IrTypeShape::Object {
-                    fields: vec![
-                        IrField {
-                            name: "result".to_string(),
-                            type_ref: json_type.clone(),
-                            required: false,
-                            nullable: true,
-                            description: String::new(),
-                        },
-                        IrField {
-                            name: "raw".to_string(),
-                            type_ref: json_type,
-                            required: false,
-                            nullable: true,
-                            description: "Raw MCP tool payload.".to_string(),
-                        },
-                    ],
-                },
-                nullable: false,
-                description: String::new(),
-            },
-        );
-    }
-
-    fn insert_row_type_from_schema(&mut self, type_id: &str, schema: Option<&Value>) {
-        let Some(schema) = schema else {
-            self.insert_generic_row_type(type_id);
-            return;
-        };
-        let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
-            self.insert_generic_row_type(type_id);
-            return;
-        };
-        let required = schema
-            .get("required")
-            .and_then(Value::as_array)
-            .map(|items| {
-                items
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .collect::<BTreeSet<_>>()
-            })
-            .unwrap_or_default();
-        let mut fields = properties
-            .iter()
-            .map(|(name, property)| {
-                let data_type = json_schema_scalar_type(property).unwrap_or(IrScalarType::Json);
-                IrField {
-                    name: name.clone(),
-                    type_ref: self.ensure_type_for_scalar(data_type),
-                    required: required.contains(name.as_str()),
-                    nullable: !required.contains(name.as_str()),
-                    description: schema_description(property),
-                }
-            })
-            .collect::<Vec<_>>();
-        if !fields.iter().any(|field| field.name == "raw") {
-            let json_type = self.ensure_type_for_scalar(IrScalarType::Json);
-            fields.push(IrField {
-                name: "raw".to_string(),
-                type_ref: json_type,
-                required: false,
-                nullable: true,
-                description: "Raw MCP tool payload.".to_string(),
-            });
-        }
-        self.types.insert(
-            type_id.to_string(),
-            IrType {
-                id: type_id.to_string(),
-                shape: IrTypeShape::Object { fields },
-                nullable: false,
-                description: schema_description(schema),
-            },
-        );
-    }
-
-    fn ensure_type_for_scalar(&mut self, scalar: IrScalarType) -> String {
+    pub(super) fn ensure_type_for_scalar(&mut self, scalar: IrScalarType) -> String {
         let base = match scalar {
             IrScalarType::String => "string",
             IrScalarType::Integer => "integer",
@@ -317,357 +106,16 @@ impl<'a> McpImporter<'a> {
     }
 }
 
-#[derive(Default)]
-struct InputObjectShape {
-    properties: BTreeMap<String, Value>,
-    required: BTreeSet<String>,
-}
-
-struct ImportedInputs {
-    inputs: Vec<IrOperationInput>,
-    schema_complete: bool,
-}
-
-fn input_object_shape(
-    root: &Value,
-    schema: &Value,
-    surface_id: &str,
-    operation_id: &str,
-    resolving_refs: &mut BTreeSet<String>,
-    diagnostics: &mut Vec<Diagnostic>,
-    schema_complete: &mut bool,
-) -> Option<InputObjectShape> {
-    let schema = resolve_input_schema_ref(
-        root,
-        schema,
-        surface_id,
-        operation_id,
-        resolving_refs,
-        diagnostics,
-        schema_complete,
-    )?;
-
-    if schema.get("anyOf").is_some() || schema.get("oneOf").is_some() {
-        *schema_complete = false;
-        diagnostics.push(Diagnostic::warning(
-            "MCP_INPUT_SCHEMA_COMPOSITION_UNSUPPORTED",
-            "MCP input schema uses anyOf/oneOf, which cannot be safely imported as SQL inputs",
-            surface_id.to_string(),
-            Some(operation_id.to_string()),
-        ));
-        return None;
-    }
-
-    let mut shape = direct_input_object_shape(schema);
-    if let Some(all_of) = schema.get("allOf").and_then(Value::as_array) {
-        for item in all_of {
-            let item_shape = input_object_shape(
-                root,
-                item,
-                surface_id,
-                operation_id,
-                resolving_refs,
-                diagnostics,
-                schema_complete,
-            )?;
-            if !merge_input_object_shape(
-                &mut shape,
-                item_shape,
-                surface_id,
-                operation_id,
-                diagnostics,
-                schema_complete,
-            ) {
-                return None;
-            }
-        }
-    }
-    Some(shape)
-}
-
-fn resolve_input_schema_ref<'a>(
-    root: &'a Value,
-    schema: &'a Value,
-    surface_id: &str,
-    operation_id: &str,
-    resolving_refs: &mut BTreeSet<String>,
-    diagnostics: &mut Vec<Diagnostic>,
-    schema_complete: &mut bool,
-) -> Option<&'a Value> {
-    let Some(reference) = schema.get("$ref").and_then(Value::as_str) else {
-        return Some(schema);
-    };
-    if !reference.starts_with("#/") {
-        *schema_complete = false;
-        diagnostics.push(Diagnostic::warning(
-            "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
-            format!("MCP input schema external reference '{reference}' is unsupported"),
-            surface_id.to_string(),
-            Some(operation_id.to_string()),
-        ));
-        return None;
-    }
-    if !resolving_refs.insert(reference.to_string()) {
-        *schema_complete = false;
-        diagnostics.push(Diagnostic::warning(
-            "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
-            format!("MCP input schema reference cycle includes '{reference}'"),
-            surface_id.to_string(),
-            Some(operation_id.to_string()),
-        ));
-        return None;
-    }
-    let pointer = reference.strip_prefix('#').unwrap_or(reference);
-    let resolved = root.pointer(pointer);
-    resolving_refs.remove(reference);
-    if let Some(resolved) = resolved {
-        Some(resolved)
-    } else {
-        *schema_complete = false;
-        diagnostics.push(Diagnostic::warning(
-            "MCP_INPUT_SCHEMA_REF_NOT_FOUND",
-            format!("MCP input schema reference '{reference}' was not found"),
-            surface_id.to_string(),
-            Some(operation_id.to_string()),
-        ));
-        None
-    }
-}
-
-fn direct_input_object_shape(schema: &Value) -> InputObjectShape {
-    let Some(schema) = schema.as_object() else {
-        return InputObjectShape::default();
-    };
-    let required = schema
-        .get("required")
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(Value::as_str)
-                .map(str::to_string)
-                .collect::<BTreeSet<_>>()
-        })
-        .unwrap_or_default();
-    let properties = schema
-        .get("properties")
-        .and_then(Value::as_object)
-        .map(|properties| {
-            properties
-                .iter()
-                .map(|(name, property)| (name.clone(), property.clone()))
-                .collect()
-        })
-        .unwrap_or_default();
-    InputObjectShape {
-        properties,
-        required,
-    }
-}
-
-fn merge_input_object_shape(
-    target: &mut InputObjectShape,
-    source: InputObjectShape,
-    surface_id: &str,
-    operation_id: &str,
-    diagnostics: &mut Vec<Diagnostic>,
-    schema_complete: &mut bool,
-) -> bool {
-    for (name, property) in source.properties {
-        if let Some(existing) = target.properties.get_mut(&name) {
-            if input_property_schemas_conflict(existing, &property) {
-                *schema_complete = false;
-                diagnostics.push(Diagnostic::warning(
-                    "MCP_INPUT_SCHEMA_CONFLICT",
-                    format!("MCP input schema defines conflicting property '{name}'"),
-                    surface_id.to_string(),
-                    Some(operation_id.to_string()),
-                ));
-                return false;
-            }
-            merge_input_property_metadata(existing, &property);
-        } else {
-            target.properties.insert(name, property);
-        }
-    }
-    target.required.extend(source.required);
-    true
-}
-
-fn input_property_schemas_conflict(existing: &Value, candidate: &Value) -> bool {
-    schema_without_annotation_metadata(existing) != schema_without_annotation_metadata(candidate)
-}
-
-fn schema_without_annotation_metadata(schema: &Value) -> Value {
-    schema_without_annotation_metadata_at_key(None, schema)
-}
-
-fn schema_without_annotation_metadata_at_key(key: Option<&str>, schema: &Value) -> Value {
-    const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
-    match schema {
-        Value::Object(object) => {
-            let is_schema_name_map = matches!(
-                key,
-                Some("$defs" | "definitions" | "patternProperties" | "properties")
-            );
-            Value::Object(
-                object
-                    .iter()
-                    .filter(|(key, _value)| {
-                        is_schema_name_map || !ANNOTATION_KEYS.contains(&key.as_str())
-                    })
-                    .map(|(key, value)| {
-                        (
-                            key.clone(),
-                            schema_without_annotation_metadata_at_key(Some(key), value),
-                        )
-                    })
-                    .collect(),
-            )
-        }
-        Value::Array(values) => {
-            let mut values = values
-                .iter()
-                .map(|value| schema_without_annotation_metadata_at_key(None, value))
-                .collect::<Vec<_>>();
-            if key == Some("type") {
-                values.sort_by_key(Value::to_string);
-            }
-            Value::Array(values)
-        }
-        other => other.clone(),
-    }
-}
-
-fn merge_input_property_metadata(existing: &mut Value, candidate: &Value) {
-    const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
-    let (Some(existing), Some(candidate)) = (existing.as_object_mut(), candidate.as_object())
-    else {
-        return;
-    };
-    for key in ANNOTATION_KEYS {
-        if !existing.contains_key(*key)
-            && let Some(value) = candidate.get(*key)
-        {
-            existing.insert((*key).to_string(), value.clone());
-        }
-    }
-}
-
-fn schema_description(schema: &Value) -> String {
-    schema
-        .get("description")
-        .and_then(Value::as_str)
-        .or_else(|| schema.get("title").and_then(Value::as_str))
-        .unwrap_or_default()
-        .to_string()
-}
-
-fn property_default(schema: &Value) -> Option<String> {
-    schema.get("default").map(|value| match value {
-        Value::String(text) => text.clone(),
-        other => other.to_string(),
-    })
-}
-
-fn wrapped_list_property(schema: &Value) -> Option<(&str, Option<&Value>)> {
-    if !json_schema_type_contains(schema, "object") {
-        return None;
-    }
-    let properties = schema.get("properties").and_then(Value::as_object)?;
-    let mut arrays = properties
-        .iter()
-        .filter(|(_name, property)| json_schema_type_contains(property, "array"));
-    let (name, property) = arrays.next()?;
-    if arrays.next().is_some() {
-        return None;
-    }
-    if properties.len() != 1 && find_response_cursor_path(schema).is_none() {
-        return None;
-    }
-    Some((name.as_str(), property.get("items")))
-}
-
-fn infer_mcp_pagination(
-    inputs: &[IrOperationInput],
-    output: &IrOperationOutput,
-    output_schema: Option<&Value>,
-) -> Option<McpPaginationSpec> {
-    if !matches!(
-        output.cardinality,
-        OutputCardinality::List | OutputCardinality::WrappedList
-    ) {
-        return None;
-    }
-    let cursor_arg = cursor_input_name(inputs)?;
-    let response_cursor_path = find_response_cursor_path(output_schema?)?;
-    Some(McpPaginationSpec {
-        cursor_arg: cursor_arg.to_string(),
-        response_cursor_path,
-        max_pages: None,
-    })
-}
-
-fn cursor_input_name(inputs: &[IrOperationInput]) -> Option<&str> {
-    const CURSOR_INPUTS: &[&str] = &[
-        "cursor",
-        "after",
-        "page_token",
-        "pagetoken",
-        "next_cursor",
-        "nextcursor",
-        "next_token",
-        "nexttoken",
-    ];
-    inputs
-        .iter()
-        .filter(|input| !input.required)
-        .find(|input| {
-            let normalized = cursor_token(&input.name);
-            CURSOR_INPUTS.contains(&normalized.as_str())
-        })
-        .map(|input| input.name.as_str())
-}
-
-fn find_response_cursor_path(schema: &Value) -> Option<Vec<String>> {
-    let properties = schema.get("properties").and_then(Value::as_object)?;
-    for (name, property) in properties {
-        if is_response_cursor_property(name, property) {
-            return Some(vec![name.clone()]);
-        }
-    }
-    for (name, property) in properties {
-        if !json_schema_type_contains(property, "object") {
-            continue;
-        }
-        if let Some(mut path) = find_response_cursor_path(property) {
-            path.insert(0, name.clone());
-            return Some(path);
-        }
-    }
-    None
-}
-
-fn is_response_cursor_property(name: &str, schema: &Value) -> bool {
-    const RESPONSE_CURSORS: &[&str] = &["nextcursor", "nextpagetoken", "nexttoken", "endcursor"];
-    RESPONSE_CURSORS.contains(&cursor_token(name).as_str())
-        && (json_schema_type_contains(schema, "string") || schema.get("type").is_none())
-}
-
-fn cursor_token(value: &str) -> String {
-    value
-        .chars()
-        .filter(char::is_ascii_alphanumeric)
-        .flat_map(char::to_lowercase)
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use serde_json::{Value, json};
 
+    use super::super::model::McpToolDescriptor;
     use super::*;
-    use crate::v4::{ProjectionVisibility, generate_projection_catalog};
+    use crate::v4::ir::{
+        IrExecutionAttachment, IrField, IrOperation, IrScalarType, IrTypeShape, OutputCardinality,
+    };
+    use crate::v4::{ProjectionVisibility, SqlInputExposure, generate_projection_catalog};
     use crate::{ValidatedSourceManifest, parse_source_manifest_yaml};
 
     fn manifest() -> ValidatedSourceManifest {
@@ -728,6 +176,40 @@ surfaces:
             .iter()
             .find(|operation| operation.id == id)
             .expect("operation")
+    }
+
+    fn assert_no_offset_pagination_for_input_schema(input_schema: Value) {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "list-catalog",
+                input_schema,
+                Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"}
+                                }
+                            }
+                        },
+                        "limit": {"type": "integer"},
+                        "offset": {"type": "integer"},
+                        "has_more": {"type": "boolean"}
+                    }
+                })),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "list_catalog");
+        let IrExecutionAttachment::Mcp(mcp) = &operation.execution else {
+            panic!("expected MCP execution");
+        };
+        assert!(mcp.offset_pagination.is_none());
     }
 
     fn row_fields<'a>(ir: &'a SemanticIr, type_id: &str) -> &'a [IrField] {
@@ -1196,6 +678,138 @@ surfaces:
         assert_eq!(pagination.cursor_arg, "cursor");
         assert_eq!(pagination.response_cursor_path, ["meta", "nextCursor"]);
         assert_eq!(pagination.max_pages, None);
+    }
+
+    #[test]
+    fn infers_offset_pagination_for_mcp_discovery_contract() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "list-catalog",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 200,
+                            "default": 50
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 4_294_967_295_u64,
+                            "default": 0
+                        }
+                    }
+                }),
+                Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"}
+                                }
+                            }
+                        },
+                        "total": {"type": "integer"},
+                        "limit": {"type": "integer"},
+                        "offset": {"type": "integer"},
+                        "has_more": {"type": "boolean"}
+                    }
+                })),
+                Some(true),
+            )],
+        };
+
+        let manifest = manifest();
+        let v4 = manifest.as_v4().expect("v4");
+        let surface = v4.surfaces.first().expect("surface");
+        let ir = import_mcp_surface(v4, surface, &catalog).expect("import");
+        let operation = operation(&ir, "list_catalog");
+        let IrExecutionAttachment::Mcp(mcp) = &operation.execution else {
+            panic!("expected MCP execution");
+        };
+        assert!(mcp.pagination.is_none());
+        let pagination = mcp.offset_pagination.as_ref().expect("offset pagination");
+        assert_eq!(pagination.limit_arg, "limit");
+        assert_eq!(pagination.default_limit, 50);
+        assert_eq!(pagination.max_limit, 200);
+        assert_eq!(pagination.offset_arg, "offset");
+        assert_eq!(pagination.offset_start, 0);
+
+        let projections =
+            generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("projection catalog");
+        let projection = projections
+            .projections
+            .iter()
+            .find(|projection| projection.operation_id == "list_catalog")
+            .expect("projection");
+        assert!(matches!(projection.kind, crate::v4::ProjectionKind::Table));
+        for input in &projection.inputs {
+            assert_eq!(input.sql_exposure, SqlInputExposure::Internal);
+        }
+    }
+
+    #[test]
+    fn offset_pagination_requires_positive_limit_default() {
+        assert_no_offset_pagination_for_input_schema(json!({
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 200,
+                    "default": 0
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                }
+            }
+        }));
+    }
+
+    #[test]
+    fn offset_pagination_requires_bounded_limit_maximum() {
+        assert_no_offset_pagination_for_input_schema(json!({
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 50
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                }
+            }
+        }));
+    }
+
+    #[test]
+    fn offset_pagination_requires_offset_zero_to_be_allowed() {
+        assert_no_offset_pagination_for_input_schema(json!({
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 200,
+                    "default": 50
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 0
+                }
+            }
+        }));
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
@@ -1,0 +1,309 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::Value;
+
+use crate::v4::diagnostics::Diagnostic;
+use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
+use crate::v4::surfaces::json_schema::json_schema_scalar_type;
+
+use super::import::McpImporter;
+use super::model::McpToolDescriptor;
+
+impl McpImporter<'_> {
+    pub(super) fn import_inputs(
+        &mut self,
+        tool: &McpToolDescriptor,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> ImportedInputs {
+        let mut resolving_refs = BTreeSet::new();
+        let mut schema_complete = true;
+        let Some(shape) = input_object_shape(
+            &tool.input_schema,
+            &tool.input_schema,
+            &self.surface.id,
+            operation_id,
+            &mut resolving_refs,
+            diagnostics,
+            &mut schema_complete,
+        ) else {
+            return ImportedInputs {
+                inputs: Vec::new(),
+                schema_complete: false,
+            };
+        };
+        let inputs = shape
+            .properties
+            .iter()
+            .map(|(name, property)| {
+                let data_type = json_schema_scalar_type(property).unwrap_or(IrScalarType::Json);
+                self.ensure_type_for_scalar(data_type);
+                IrOperationInput {
+                    name: name.clone(),
+                    location: IrInputLocation::ToolArg,
+                    required: shape.required.contains(name.as_str()),
+                    data_type,
+                    default_value: property_default(property),
+                    description: schema_description(property),
+                }
+            })
+            .collect();
+        ImportedInputs {
+            inputs,
+            schema_complete,
+        }
+    }
+}
+
+pub(super) struct ImportedInputs {
+    pub(super) inputs: Vec<IrOperationInput>,
+    pub(super) schema_complete: bool,
+}
+
+#[derive(Default)]
+struct InputObjectShape {
+    properties: BTreeMap<String, Value>,
+    required: BTreeSet<String>,
+}
+
+fn input_object_shape(
+    root: &Value,
+    schema: &Value,
+    surface_id: &str,
+    operation_id: &str,
+    resolving_refs: &mut BTreeSet<String>,
+    diagnostics: &mut Vec<Diagnostic>,
+    schema_complete: &mut bool,
+) -> Option<InputObjectShape> {
+    let schema = resolve_input_schema_ref(
+        root,
+        schema,
+        surface_id,
+        operation_id,
+        resolving_refs,
+        diagnostics,
+        schema_complete,
+    )?;
+
+    if schema.get("anyOf").is_some() || schema.get("oneOf").is_some() {
+        *schema_complete = false;
+        diagnostics.push(Diagnostic::warning(
+            "MCP_INPUT_SCHEMA_COMPOSITION_UNSUPPORTED",
+            "MCP input schema uses anyOf/oneOf, which cannot be safely imported as SQL inputs",
+            surface_id.to_string(),
+            Some(operation_id.to_string()),
+        ));
+        return None;
+    }
+
+    let mut shape = direct_input_object_shape(schema);
+    if let Some(all_of) = schema.get("allOf").and_then(Value::as_array) {
+        for item in all_of {
+            let item_shape = input_object_shape(
+                root,
+                item,
+                surface_id,
+                operation_id,
+                resolving_refs,
+                diagnostics,
+                schema_complete,
+            )?;
+            if !merge_input_object_shape(
+                &mut shape,
+                item_shape,
+                surface_id,
+                operation_id,
+                diagnostics,
+                schema_complete,
+            ) {
+                return None;
+            }
+        }
+    }
+    Some(shape)
+}
+
+fn resolve_input_schema_ref<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    surface_id: &str,
+    operation_id: &str,
+    resolving_refs: &mut BTreeSet<String>,
+    diagnostics: &mut Vec<Diagnostic>,
+    schema_complete: &mut bool,
+) -> Option<&'a Value> {
+    let Some(reference) = schema.get("$ref").and_then(Value::as_str) else {
+        return Some(schema);
+    };
+    if !reference.starts_with("#/") {
+        *schema_complete = false;
+        diagnostics.push(Diagnostic::warning(
+            "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
+            format!("MCP input schema external reference '{reference}' is unsupported"),
+            surface_id.to_string(),
+            Some(operation_id.to_string()),
+        ));
+        return None;
+    }
+    if !resolving_refs.insert(reference.to_string()) {
+        *schema_complete = false;
+        diagnostics.push(Diagnostic::warning(
+            "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
+            format!("MCP input schema reference cycle includes '{reference}'"),
+            surface_id.to_string(),
+            Some(operation_id.to_string()),
+        ));
+        return None;
+    }
+    let pointer = reference.strip_prefix('#').unwrap_or(reference);
+    let resolved = root.pointer(pointer);
+    resolving_refs.remove(reference);
+    if let Some(resolved) = resolved {
+        Some(resolved)
+    } else {
+        *schema_complete = false;
+        diagnostics.push(Diagnostic::warning(
+            "MCP_INPUT_SCHEMA_REF_NOT_FOUND",
+            format!("MCP input schema reference '{reference}' was not found"),
+            surface_id.to_string(),
+            Some(operation_id.to_string()),
+        ));
+        None
+    }
+}
+
+fn direct_input_object_shape(schema: &Value) -> InputObjectShape {
+    let Some(schema) = schema.as_object() else {
+        return InputObjectShape::default();
+    };
+    let required = schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    let properties = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|properties| {
+            properties
+                .iter()
+                .map(|(name, property)| (name.clone(), property.clone()))
+                .collect()
+        })
+        .unwrap_or_default();
+    InputObjectShape {
+        properties,
+        required,
+    }
+}
+
+fn merge_input_object_shape(
+    target: &mut InputObjectShape,
+    source: InputObjectShape,
+    surface_id: &str,
+    operation_id: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+    schema_complete: &mut bool,
+) -> bool {
+    for (name, property) in source.properties {
+        if let Some(existing) = target.properties.get_mut(&name) {
+            if input_property_schemas_conflict(existing, &property) {
+                *schema_complete = false;
+                diagnostics.push(Diagnostic::warning(
+                    "MCP_INPUT_SCHEMA_CONFLICT",
+                    format!("MCP input schema defines conflicting property '{name}'"),
+                    surface_id.to_string(),
+                    Some(operation_id.to_string()),
+                ));
+                return false;
+            }
+            merge_input_property_metadata(existing, &property);
+        } else {
+            target.properties.insert(name, property);
+        }
+    }
+    target.required.extend(source.required);
+    true
+}
+
+fn input_property_schemas_conflict(existing: &Value, candidate: &Value) -> bool {
+    schema_without_annotation_metadata(existing) != schema_without_annotation_metadata(candidate)
+}
+
+fn schema_without_annotation_metadata(schema: &Value) -> Value {
+    schema_without_annotation_metadata_at_key(None, schema)
+}
+
+fn schema_without_annotation_metadata_at_key(key: Option<&str>, schema: &Value) -> Value {
+    const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
+    match schema {
+        Value::Object(object) => {
+            let is_schema_name_map = matches!(
+                key,
+                Some("$defs" | "definitions" | "patternProperties" | "properties")
+            );
+            Value::Object(
+                object
+                    .iter()
+                    .filter(|(key, _value)| {
+                        is_schema_name_map || !ANNOTATION_KEYS.contains(&key.as_str())
+                    })
+                    .map(|(key, value)| {
+                        (
+                            key.clone(),
+                            schema_without_annotation_metadata_at_key(Some(key), value),
+                        )
+                    })
+                    .collect(),
+            )
+        }
+        Value::Array(values) => {
+            let mut values = values
+                .iter()
+                .map(|value| schema_without_annotation_metadata_at_key(None, value))
+                .collect::<Vec<_>>();
+            if key == Some("type") {
+                values.sort_by_key(Value::to_string);
+            }
+            Value::Array(values)
+        }
+        other => other.clone(),
+    }
+}
+
+fn merge_input_property_metadata(existing: &mut Value, candidate: &Value) {
+    const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
+    let (Some(existing), Some(candidate)) = (existing.as_object_mut(), candidate.as_object())
+    else {
+        return;
+    };
+    for key in ANNOTATION_KEYS {
+        if !existing.contains_key(*key)
+            && let Some(value) = candidate.get(*key)
+        {
+            existing.insert((*key).to_string(), value.clone());
+        }
+    }
+}
+
+pub(super) fn schema_description(schema: &Value) -> String {
+    schema
+        .get("description")
+        .and_then(Value::as_str)
+        .or_else(|| schema.get("title").and_then(Value::as_str))
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn property_default(schema: &Value) -> Option<String> {
+    schema.get("default").map(|value| match value {
+        Value::String(text) => text.clone(),
+        other => other.to_string(),
+    })
+}

--- a/crates/coral-spec/src/v4/surfaces/mcp/mod.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/mod.rs
@@ -1,5 +1,9 @@
 mod import;
+mod input_schema;
 mod model;
+mod operations;
+mod output_schema;
+mod pagination;
 
 pub use import::{import_mcp_surface, normalize_mcp_tool_catalog};
 pub use model::{McpToolCatalog, McpToolDescriptor};

--- a/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
@@ -1,0 +1,56 @@
+use crate::v4::ir::{
+    IrEntityCandidate, IrExecutionAttachment, IrOperation, McpExecutionAttachment,
+};
+
+use super::import::McpImporter;
+use super::model::McpToolDescriptor;
+use super::pagination::infer_mcp_pagination_contracts;
+
+impl McpImporter<'_> {
+    pub(super) fn import_tool(
+        &mut self,
+        tool: &McpToolDescriptor,
+        operation_id: &str,
+    ) -> Option<IrOperation> {
+        let mut diagnostics = Vec::new();
+        let imported_inputs = self.import_inputs(tool, operation_id, &mut diagnostics);
+        let input_schema_complete = imported_inputs.schema_complete;
+        if !input_schema_complete {
+            self.diagnostics.extend(diagnostics);
+            return None;
+        }
+
+        let inputs = imported_inputs.inputs;
+        let output = self.import_output(operation_id, tool.output_schema.as_ref());
+        let (pagination, offset_pagination) = infer_mcp_pagination_contracts(
+            &inputs,
+            &output,
+            tool.output_schema.as_ref(),
+            &tool.input_schema,
+        );
+        Some(IrOperation {
+            id: operation_id.to_string(),
+            method_name: "tools/call".to_string(),
+            description: tool
+                .description
+                .clone()
+                .or_else(|| tool.title.clone())
+                .unwrap_or_default(),
+            deprecated: false,
+            read_only: tool.read_only_hint.unwrap_or(false),
+            inputs,
+            output,
+            entity: Some(IrEntityCandidate {
+                name: operation_id.to_string(),
+                type_ref: format!("{operation_id}_row"),
+                identity_fields: Vec::new(),
+            }),
+            execution: IrExecutionAttachment::Mcp(McpExecutionAttachment {
+                tool_name: tool.name.clone(),
+                pagination,
+                offset_pagination,
+            }),
+            diagnostics,
+        })
+    }
+}

--- a/crates/coral-spec/src/v4/surfaces/mcp/output_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/output_schema.rs
@@ -1,0 +1,169 @@
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+use crate::v4::ir::{
+    IrField, IrOperationOutput, IrScalarType, IrType, IrTypeShape, OutputCardinality,
+};
+use crate::v4::surfaces::json_schema::{json_schema_scalar_type, json_schema_type_contains};
+
+use super::import::McpImporter;
+use super::input_schema::schema_description;
+use super::pagination::find_response_cursor_path;
+
+impl McpImporter<'_> {
+    pub(super) fn import_output(
+        &mut self,
+        operation_id: &str,
+        output_schema: Option<&Value>,
+    ) -> IrOperationOutput {
+        let row_type_id = format!("{operation_id}_row");
+        let Some(schema) = output_schema else {
+            self.insert_generic_row_type(&row_type_id);
+            return IrOperationOutput {
+                cardinality: OutputCardinality::Singleton,
+                type_ref: row_type_id,
+                row_path: Vec::new(),
+            };
+        };
+        if json_schema_type_contains(schema, "array") {
+            let item_schema = schema.get("items");
+            self.insert_row_type_from_schema(&row_type_id, item_schema);
+            return IrOperationOutput {
+                cardinality: OutputCardinality::List,
+                type_ref: row_type_id,
+                row_path: Vec::new(),
+            };
+        }
+        if let Some((array_property, item_schema)) = wrapped_list_property(schema) {
+            self.insert_row_type_from_schema(&row_type_id, item_schema);
+            return IrOperationOutput {
+                cardinality: OutputCardinality::WrappedList,
+                type_ref: row_type_id,
+                row_path: vec![array_property.to_string()],
+            };
+        }
+        self.insert_row_type_from_schema(&row_type_id, Some(schema));
+        IrOperationOutput {
+            cardinality: OutputCardinality::Singleton,
+            type_ref: row_type_id,
+            row_path: Vec::new(),
+        }
+    }
+
+    fn insert_generic_row_type(&mut self, type_id: &str) {
+        let json_type = self.ensure_type_for_scalar(IrScalarType::Json);
+        self.types.insert(
+            type_id.to_string(),
+            IrType {
+                id: type_id.to_string(),
+                shape: IrTypeShape::Object {
+                    fields: vec![
+                        IrField {
+                            name: "result".to_string(),
+                            type_ref: json_type.clone(),
+                            required: false,
+                            nullable: true,
+                            description: String::new(),
+                        },
+                        IrField {
+                            name: "raw".to_string(),
+                            type_ref: json_type,
+                            required: false,
+                            nullable: true,
+                            description: "Raw MCP tool payload.".to_string(),
+                        },
+                    ],
+                },
+                nullable: false,
+                description: String::new(),
+            },
+        );
+    }
+
+    fn insert_row_type_from_schema(&mut self, type_id: &str, schema: Option<&Value>) {
+        let Some(schema) = schema else {
+            self.insert_generic_row_type(type_id);
+            return;
+        };
+        let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+            self.insert_generic_row_type(type_id);
+            return;
+        };
+        let required = schema
+            .get("required")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .collect::<BTreeSet<_>>()
+            })
+            .unwrap_or_default();
+        let mut fields = properties
+            .iter()
+            .map(|(name, property)| {
+                let data_type = json_schema_scalar_type(property).unwrap_or(IrScalarType::Json);
+                IrField {
+                    name: name.clone(),
+                    type_ref: self.ensure_type_for_scalar(data_type),
+                    required: required.contains(name.as_str()),
+                    nullable: !required.contains(name.as_str()),
+                    description: schema_description(property),
+                }
+            })
+            .collect::<Vec<_>>();
+        if !fields.iter().any(|field| field.name == "raw") {
+            let json_type = self.ensure_type_for_scalar(IrScalarType::Json);
+            fields.push(IrField {
+                name: "raw".to_string(),
+                type_ref: json_type,
+                required: false,
+                nullable: true,
+                description: "Raw MCP tool payload.".to_string(),
+            });
+        }
+        self.types.insert(
+            type_id.to_string(),
+            IrType {
+                id: type_id.to_string(),
+                shape: IrTypeShape::Object { fields },
+                nullable: false,
+                description: schema_description(schema),
+            },
+        );
+    }
+}
+
+fn wrapped_list_property(schema: &Value) -> Option<(&str, Option<&Value>)> {
+    if !json_schema_type_contains(schema, "object") {
+        return None;
+    }
+    let properties = schema.get("properties").and_then(Value::as_object)?;
+    let mut arrays = properties
+        .iter()
+        .filter(|(_name, property)| json_schema_type_contains(property, "array"));
+    let (name, property) = arrays.next()?;
+    if arrays.next().is_some() {
+        return None;
+    }
+    if properties.len() != 1
+        && find_response_cursor_path(schema).is_none()
+        && !is_offset_pagination_envelope(properties)
+    {
+        return None;
+    }
+    Some((name.as_str(), property.get("items")))
+}
+
+fn is_offset_pagination_envelope(properties: &serde_json::Map<String, Value>) -> bool {
+    properties
+        .get("limit")
+        .is_some_and(|schema| json_schema_type_contains(schema, "integer"))
+        && properties
+            .get("offset")
+            .is_some_and(|schema| json_schema_type_contains(schema, "integer"))
+        && properties
+            .get("has_more")
+            .is_some_and(|schema| json_schema_type_contains(schema, "boolean"))
+}

--- a/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
@@ -1,0 +1,173 @@
+use serde_json::Value;
+
+use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
+use crate::v4::ir::{IrOperationInput, IrOperationOutput, IrScalarType, OutputCardinality};
+use crate::v4::surfaces::json_schema::json_schema_type_contains;
+
+pub(super) fn infer_mcp_pagination_contracts(
+    inputs: &[IrOperationInput],
+    output: &IrOperationOutput,
+    output_schema: Option<&Value>,
+    input_schema: &Value,
+) -> (Option<McpPaginationSpec>, Option<McpOffsetPaginationSpec>) {
+    let pagination = infer_mcp_pagination(inputs, output, output_schema);
+    let offset_pagination = pagination
+        .is_none()
+        .then(|| infer_mcp_offset_pagination(inputs, output, input_schema))
+        .flatten();
+    (pagination, offset_pagination)
+}
+
+fn infer_mcp_pagination(
+    inputs: &[IrOperationInput],
+    output: &IrOperationOutput,
+    output_schema: Option<&Value>,
+) -> Option<McpPaginationSpec> {
+    if !matches!(
+        output.cardinality,
+        OutputCardinality::List | OutputCardinality::WrappedList
+    ) {
+        return None;
+    }
+    let cursor_arg = cursor_input_name(inputs)?;
+    let response_cursor_path = find_response_cursor_path(output_schema?)?;
+    Some(McpPaginationSpec {
+        cursor_arg: cursor_arg.to_string(),
+        response_cursor_path,
+        max_pages: None,
+    })
+}
+
+fn infer_mcp_offset_pagination(
+    inputs: &[IrOperationInput],
+    output: &IrOperationOutput,
+    input_schema: &Value,
+) -> Option<McpOffsetPaginationSpec> {
+    if !matches!(
+        output.cardinality,
+        OutputCardinality::List | OutputCardinality::WrappedList
+    ) {
+        return None;
+    }
+    let properties = input_schema.get("properties").and_then(Value::as_object)?;
+    let limit = offset_pagination_input(inputs, properties.get("limit")?, "limit")?;
+    if limit.default == 0
+        || limit.maximum.is_none_or(|maximum| maximum == 0)
+        || !schema_minimum_rejects_values_below(properties.get("limit")?, 1)
+    {
+        return None;
+    }
+    let offset = offset_pagination_input(inputs, properties.get("offset")?, "offset")?;
+    if offset.default != 0 || !schema_allows_unsigned_value(properties.get("offset")?, 0) {
+        return None;
+    }
+    Some(McpOffsetPaginationSpec {
+        limit_arg: limit.name.to_string(),
+        default_limit: limit.default,
+        max_limit: limit.maximum?,
+        offset_arg: offset.name.to_string(),
+        offset_start: offset.default,
+        max_pages: None,
+    })
+}
+
+struct OffsetPaginationInput<'a> {
+    name: &'a str,
+    default: usize,
+    maximum: Option<usize>,
+}
+
+fn offset_pagination_input<'a>(
+    inputs: &'a [IrOperationInput],
+    schema: &Value,
+    name: &str,
+) -> Option<OffsetPaginationInput<'a>> {
+    let input = inputs.iter().find(|input| {
+        input.name == name && !input.required && input.data_type == IrScalarType::Integer
+    })?;
+    Some(OffsetPaginationInput {
+        name: input.name.as_str(),
+        default: input
+            .default_value
+            .as_deref()
+            .and_then(|value| value.parse::<usize>().ok())
+            .or_else(|| schema_unsigned_integer(schema, "default"))?,
+        maximum: schema_unsigned_integer(schema, "maximum"),
+    })
+}
+
+fn schema_minimum_rejects_values_below(schema: &Value, expected: usize) -> bool {
+    schema_unsigned_integer(schema, "minimum").is_some_and(|minimum| minimum >= expected)
+}
+
+fn schema_allows_unsigned_value(schema: &Value, value: usize) -> bool {
+    schema_unsigned_integer(schema, "minimum").is_none_or(|minimum| minimum <= value)
+        && schema_unsigned_integer(schema, "maximum").is_none_or(|maximum| maximum >= value)
+}
+
+fn schema_unsigned_integer(schema: &Value, key: &str) -> Option<usize> {
+    let value = schema.get(key)?;
+    value
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())
+        .or_else(|| {
+            value
+                .as_i64()
+                .filter(|value| *value >= 0)
+                .and_then(|value| usize::try_from(value).ok())
+        })
+}
+
+fn cursor_input_name(inputs: &[IrOperationInput]) -> Option<&str> {
+    const CURSOR_INPUTS: &[&str] = &[
+        "cursor",
+        "after",
+        "page_token",
+        "pagetoken",
+        "next_cursor",
+        "nextcursor",
+        "next_token",
+        "nexttoken",
+    ];
+    inputs
+        .iter()
+        .filter(|input| !input.required)
+        .find(|input| {
+            let normalized = cursor_token(&input.name);
+            CURSOR_INPUTS.contains(&normalized.as_str())
+        })
+        .map(|input| input.name.as_str())
+}
+
+pub(super) fn find_response_cursor_path(schema: &Value) -> Option<Vec<String>> {
+    let properties = schema.get("properties").and_then(Value::as_object)?;
+    for (name, property) in properties {
+        if is_response_cursor_property(name, property) {
+            return Some(vec![name.clone()]);
+        }
+    }
+    for (name, property) in properties {
+        if !json_schema_type_contains(property, "object") {
+            continue;
+        }
+        if let Some(mut path) = find_response_cursor_path(property) {
+            path.insert(0, name.clone());
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn is_response_cursor_property(name: &str, schema: &Value) -> bool {
+    const RESPONSE_CURSORS: &[&str] = &["nextcursor", "nextpagetoken", "nexttoken", "endcursor"];
+    RESPONSE_CURSORS.contains(&cursor_token(name).as_str())
+        && (json_schema_type_contains(schema, "string") || schema.get("type").is_none())
+}
+
+fn cursor_token(value: &str) -> String {
+    value
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .flat_map(char::to_lowercase)
+        .collect()
+}


### PR DESCRIPTION
## Summary

Closes #1302.

- Splits the MCP importer into topic-focused modules for operation import, input schema handling, output schema handling, and pagination inference.
- Recognizes Coral-style MCP `limit`/`offset` discovery contracts as generated offset pagination instead of exposing them as public SQL inputs.
- Rejects offset pagination inference when the discovered input schema lacks a positive bounded `limit` contract or would reject `offset = 0`.
- Carries generated offset pagination through v4 projection/runtime assembly and MCP fetch execution with bounded per-page requests.

## Validation

- `make rust-checks`