### PR TITLE
fix(spec): continue MCP cursor scan after deep siblings

### DIFF
--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -9,6 +9,8 @@ use crate::{ManifestError, Result};
 
 use super::model::McpToolCatalog;
 
+pub(super) const MAX_SCHEMA_DEPTH: usize = 64;
+
 pub fn normalize_mcp_tool_catalog(catalog: &McpToolCatalog) -> Result<Vec<u8>> {
     let mut normalized = catalog.clone();
     normalized
@@ -231,6 +233,37 @@ surfaces:
             .expect("field")
     }
 
+    fn nested_cursor_schema(depth: usize) -> Value {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "nextCursor": {"type": "string"}
+            }
+        });
+        for _ in 0..depth {
+            schema = json!({
+                "type": "object",
+                "properties": {
+                    "child": schema
+                }
+            });
+        }
+        schema
+    }
+
+    fn nested_input_property_schema(depth: usize) -> Value {
+        let mut schema = json!({"type": "string"});
+        for _ in 0..depth {
+            schema = json!({
+                "type": "object",
+                "properties": {
+                    "child": schema
+                }
+            });
+        }
+        schema
+    }
+
     #[test]
     fn imports_input_schema_types_required_flags_and_defaults() {
         let catalog = McpToolCatalog {
@@ -373,6 +406,39 @@ surfaces:
     }
 
     #[test]
+    fn input_schema_ref_cycles_through_all_of_are_not_exposed() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "search-items",
+                json!({
+                    "$defs": {
+                        "A": {
+                            "allOf": [
+                                {"$ref": "#/$defs/B"}
+                            ]
+                        },
+                        "B": {
+                            "allOf": [
+                                {"$ref": "#/$defs/A"}
+                            ]
+                        }
+                    },
+                    "$ref": "#/$defs/A"
+                }),
+                Some(json!({"type": "object", "properties": {}})),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        assert!(ir.operations.is_empty());
+        assert!(ir.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "MCP_INPUT_SCHEMA_REF_UNSUPPORTED"
+                && diagnostic.message.contains("reference cycle")
+        }));
+    }
+
+    #[test]
     fn imports_all_of_properties_with_metadata_only_differences() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
@@ -501,6 +567,47 @@ surfaces:
             ir.diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.code == "MCP_INPUT_SCHEMA_CONFLICT")
+        );
+    }
+
+    #[test]
+    fn all_of_duplicate_property_comparison_uses_depth_budget() {
+        let deep_property_schema = nested_input_property_schema(MAX_SCHEMA_DEPTH + 1);
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "search-items",
+                json!({
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "filter": deep_property_schema.clone()
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "filter": deep_property_schema
+                            }
+                        }
+                    ]
+                }),
+                Some(json!({"type": "object", "properties": {}})),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        assert!(ir.operations.is_empty());
+        assert!(
+            ir.diagnostics
+                .iter()
+                .any(|diagnostic| { diagnostic.code == "MCP_INPUT_SCHEMA_DEPTH_EXCEEDED" })
+        );
+        assert!(
+            !ir.diagnostics
+                .iter()
+                .any(|diagnostic| { diagnostic.code == "MCP_INPUT_SCHEMA_CONFLICT" })
         );
     }
 
@@ -810,6 +917,104 @@ surfaces:
                 }
             }
         }));
+    }
+
+    #[test]
+    fn deeply_nested_cursor_discovery_preserves_wrapped_list_row_path() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "list-items",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "cursor": {"type": "string"}
+                    }
+                }),
+                Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {"type": "string"}
+                                }
+                            }
+                        },
+                        "meta": nested_cursor_schema(MAX_SCHEMA_DEPTH + 1)
+                    }
+                })),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "list_items");
+        assert_eq!(operation.output.cardinality, OutputCardinality::WrappedList);
+        assert_eq!(operation.output.row_path, vec!["items".to_string()]);
+        assert!(
+            operation
+                .diagnostics
+                .iter()
+                .any(|diagnostic| { diagnostic.code == "MCP_RESPONSE_SCHEMA_DEPTH_EXCEEDED" })
+        );
+        let IrExecutionAttachment::Mcp(mcp) = &operation.execution else {
+            panic!("expected MCP execution");
+        };
+        assert!(mcp.pagination.is_none());
+    }
+
+    #[test]
+    fn cursor_discovery_continues_after_deep_sibling_branch() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "list-items",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "cursor": {"type": "string"}
+                    }
+                }),
+                Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "aaa_deep": nested_cursor_schema(MAX_SCHEMA_DEPTH + 1),
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {"type": "string"}
+                                }
+                            }
+                        },
+                        "zzz_meta": {
+                            "type": "object",
+                            "properties": {
+                                "nextCursor": {"type": ["string", "null"]}
+                            }
+                        }
+                    }
+                })),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "list_items");
+        assert_eq!(operation.output.cardinality, OutputCardinality::WrappedList);
+        assert!(
+            !operation
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "MCP_RESPONSE_SCHEMA_DEPTH_EXCEEDED")
+        );
+        let IrExecutionAttachment::Mcp(mcp) = &operation.execution else {
+            panic!("expected MCP execution");
+        };
+        let pagination = mcp.pagination.as_ref().expect("pagination");
+        assert_eq!(pagination.response_cursor_path, ["zzz_meta", "nextCursor"]);
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
@@ -1,12 +1,17 @@
+#![allow(
+    clippy::too_many_arguments,
+    reason = "MCP schema walking threads shared traversal state through recursive helpers."
+)]
+
 use std::collections::{BTreeMap, BTreeSet};
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
 use crate::v4::surfaces::json_schema::json_schema_scalar_type;
 
-use super::import::McpImporter;
+use super::import::{MAX_SCHEMA_DEPTH, McpImporter};
 use super::model::McpToolDescriptor;
 
 impl McpImporter<'_> {
@@ -26,6 +31,7 @@ impl McpImporter<'_> {
             &mut resolving_refs,
             diagnostics,
             &mut schema_complete,
+            0,
         ) else {
             return ImportedInputs {
                 inputs: Vec::new(),
@@ -74,16 +80,26 @@ fn input_object_shape(
     resolving_refs: &mut BTreeSet<String>,
     diagnostics: &mut Vec<Diagnostic>,
     schema_complete: &mut bool,
+    depth: usize,
 ) -> Option<InputObjectShape> {
-    let schema = resolve_input_schema_ref(
-        root,
-        schema,
-        surface_id,
-        operation_id,
-        resolving_refs,
-        diagnostics,
-        schema_complete,
-    )?;
+    if depth > MAX_SCHEMA_DEPTH {
+        *schema_complete = false;
+        warn_input_schema_depth_exceeded(surface_id, operation_id, diagnostics);
+        return None;
+    }
+
+    if let Some(reference) = schema.get("$ref").and_then(Value::as_str) {
+        return referenced_input_object_shape(
+            root,
+            reference,
+            surface_id,
+            operation_id,
+            resolving_refs,
+            diagnostics,
+            schema_complete,
+            depth,
+        );
+    }
 
     if schema.get("anyOf").is_some() || schema.get("oneOf").is_some() {
         *schema_complete = false;
@@ -107,6 +123,7 @@ fn input_object_shape(
                 resolving_refs,
                 diagnostics,
                 schema_complete,
+                depth + 1,
             )?;
             if !merge_input_object_shape(
                 &mut shape,
@@ -123,18 +140,16 @@ fn input_object_shape(
     Some(shape)
 }
 
-fn resolve_input_schema_ref<'a>(
-    root: &'a Value,
-    schema: &'a Value,
+fn referenced_input_object_shape(
+    root: &Value,
+    reference: &str,
     surface_id: &str,
     operation_id: &str,
     resolving_refs: &mut BTreeSet<String>,
     diagnostics: &mut Vec<Diagnostic>,
     schema_complete: &mut bool,
-) -> Option<&'a Value> {
-    let Some(reference) = schema.get("$ref").and_then(Value::as_str) else {
-        return Some(schema);
-    };
+    depth: usize,
+) -> Option<InputObjectShape> {
     if !reference.starts_with("#/") {
         *schema_complete = false;
         diagnostics.push(Diagnostic::warning(
@@ -145,7 +160,8 @@ fn resolve_input_schema_ref<'a>(
         ));
         return None;
     }
-    if !resolving_refs.insert(reference.to_string()) {
+    let reference = reference.to_string();
+    if !resolving_refs.insert(reference.clone()) {
         *schema_complete = false;
         diagnostics.push(Diagnostic::warning(
             "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
@@ -155,11 +171,18 @@ fn resolve_input_schema_ref<'a>(
         ));
         return None;
     }
-    let pointer = reference.strip_prefix('#').unwrap_or(reference);
-    let resolved = root.pointer(pointer);
-    resolving_refs.remove(reference);
-    if let Some(resolved) = resolved {
-        Some(resolved)
+    let pointer = reference.strip_prefix('#').unwrap_or(&reference);
+    let result = if let Some(resolved) = root.pointer(pointer) {
+        input_object_shape(
+            root,
+            resolved,
+            surface_id,
+            operation_id,
+            resolving_refs,
+            diagnostics,
+            schema_complete,
+            depth + 1,
+        )
     } else {
         *schema_complete = false;
         diagnostics.push(Diagnostic::warning(
@@ -169,7 +192,9 @@ fn resolve_input_schema_ref<'a>(
             Some(operation_id.to_string()),
         ));
         None
-    }
+    };
+    resolving_refs.remove(&reference);
+    result
 }
 
 fn direct_input_object_shape(schema: &Value) -> InputObjectShape {
@@ -213,17 +238,26 @@ fn merge_input_object_shape(
 ) -> bool {
     for (name, property) in source.properties {
         if let Some(existing) = target.properties.get_mut(&name) {
-            if input_property_schemas_conflict(existing, &property) {
-                *schema_complete = false;
-                diagnostics.push(Diagnostic::warning(
-                    "MCP_INPUT_SCHEMA_CONFLICT",
-                    format!("MCP input schema defines conflicting property '{name}'"),
-                    surface_id.to_string(),
-                    Some(operation_id.to_string()),
-                ));
-                return false;
+            match compare_input_property_schemas(existing, &property) {
+                InputPropertySchemaComparison::Equivalent => {
+                    merge_input_property_metadata(existing, &property);
+                }
+                InputPropertySchemaComparison::Conflict => {
+                    *schema_complete = false;
+                    diagnostics.push(Diagnostic::warning(
+                        "MCP_INPUT_SCHEMA_CONFLICT",
+                        format!("MCP input schema defines conflicting property '{name}'"),
+                        surface_id.to_string(),
+                        Some(operation_id.to_string()),
+                    ));
+                    return false;
+                }
+                InputPropertySchemaComparison::DepthExceeded => {
+                    *schema_complete = false;
+                    warn_input_schema_depth_exceeded(surface_id, operation_id, diagnostics);
+                    return false;
+                }
             }
-            merge_input_property_metadata(existing, &property);
         } else {
             target.properties.insert(name, property);
         }
@@ -232,49 +266,84 @@ fn merge_input_object_shape(
     true
 }
 
-fn input_property_schemas_conflict(existing: &Value, candidate: &Value) -> bool {
-    schema_without_annotation_metadata(existing) != schema_without_annotation_metadata(candidate)
+enum InputPropertySchemaComparison {
+    Equivalent,
+    Conflict,
+    DepthExceeded,
 }
 
-fn schema_without_annotation_metadata(schema: &Value) -> Value {
-    schema_without_annotation_metadata_at_key(None, schema)
+fn compare_input_property_schemas(
+    existing: &Value,
+    candidate: &Value,
+) -> InputPropertySchemaComparison {
+    let Some(existing) = schema_without_annotation_metadata(existing) else {
+        return InputPropertySchemaComparison::DepthExceeded;
+    };
+    let Some(candidate) = schema_without_annotation_metadata(candidate) else {
+        return InputPropertySchemaComparison::DepthExceeded;
+    };
+    if existing == candidate {
+        InputPropertySchemaComparison::Equivalent
+    } else {
+        InputPropertySchemaComparison::Conflict
+    }
 }
 
-fn schema_without_annotation_metadata_at_key(key: Option<&str>, schema: &Value) -> Value {
+fn schema_without_annotation_metadata(schema: &Value) -> Option<Value> {
+    schema_without_annotation_metadata_at_key(None, schema, 0)
+}
+
+fn schema_without_annotation_metadata_at_key(
+    key: Option<&str>,
+    schema: &Value,
+    depth: usize,
+) -> Option<Value> {
     const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
+    if depth > MAX_SCHEMA_DEPTH {
+        return None;
+    }
     match schema {
         Value::Object(object) => {
             let is_schema_name_map = matches!(
                 key,
                 Some("$defs" | "definitions" | "patternProperties" | "properties")
             );
-            Value::Object(
-                object
-                    .iter()
-                    .filter(|(key, _value)| {
-                        is_schema_name_map || !ANNOTATION_KEYS.contains(&key.as_str())
-                    })
-                    .map(|(key, value)| {
-                        (
-                            key.clone(),
-                            schema_without_annotation_metadata_at_key(Some(key), value),
-                        )
-                    })
-                    .collect(),
-            )
+            let mut normalized = Map::new();
+            for (key, value) in object.iter().filter(|(key, _value)| {
+                is_schema_name_map || !ANNOTATION_KEYS.contains(&key.as_str())
+            }) {
+                normalized.insert(
+                    key.clone(),
+                    schema_without_annotation_metadata_at_key(Some(key), value, depth + 1)?,
+                );
+            }
+            Some(Value::Object(normalized))
         }
         Value::Array(values) => {
             let mut values = values
                 .iter()
-                .map(|value| schema_without_annotation_metadata_at_key(None, value))
-                .collect::<Vec<_>>();
+                .map(|value| schema_without_annotation_metadata_at_key(None, value, depth + 1))
+                .collect::<Option<Vec<_>>>()?;
             if key == Some("type") {
                 values.sort_by_key(Value::to_string);
             }
-            Value::Array(values)
+            Some(Value::Array(values))
         }
-        other => other.clone(),
+        other => Some(other.clone()),
     }
+}
+
+fn warn_input_schema_depth_exceeded(
+    surface_id: &str,
+    operation_id: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    diagnostics.push(Diagnostic::warning(
+        "MCP_INPUT_SCHEMA_DEPTH_EXCEEDED",
+        format!("MCP input schema exceeds maximum depth of {MAX_SCHEMA_DEPTH}"),
+        surface_id.to_string(),
+        Some(operation_id.to_string()),
+    ));
 }
 
 fn merge_input_property_metadata(existing: &mut Value, candidate: &Value) {

--- a/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
@@ -27,6 +27,9 @@ impl McpImporter<'_> {
             &output,
             tool.output_schema.as_ref(),
             &tool.input_schema,
+            &self.surface.id,
+            operation_id,
+            &mut diagnostics,
         );
         Some(IrOperation {
             id: operation_id.to_string(),

--- a/crates/coral-spec/src/v4/surfaces/mcp/output_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/output_schema.rs
@@ -9,7 +9,7 @@ use crate::v4::surfaces::json_schema::{json_schema_scalar_type, json_schema_type
 
 use super::import::McpImporter;
 use super::input_schema::schema_description;
-use super::pagination::find_response_cursor_path;
+use super::pagination::{CursorPathSearch, find_response_cursor_path};
 
 impl McpImporter<'_> {
     pub(super) fn import_output(
@@ -148,8 +148,11 @@ fn wrapped_list_property(schema: &Value) -> Option<(&str, Option<&Value>)> {
         return None;
     }
     if properties.len() != 1
-        && find_response_cursor_path(schema).is_none()
         && !is_offset_pagination_envelope(properties)
+        && matches!(
+            find_response_cursor_path(schema),
+            CursorPathSearch::NotFound
+        )
     {
         return None;
     }

--- a/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
@@ -1,16 +1,29 @@
 use serde_json::Value;
 
 use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
+use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrOperationInput, IrOperationOutput, IrScalarType, OutputCardinality};
 use crate::v4::surfaces::json_schema::json_schema_type_contains;
+
+use super::import::MAX_SCHEMA_DEPTH;
 
 pub(super) fn infer_mcp_pagination_contracts(
     inputs: &[IrOperationInput],
     output: &IrOperationOutput,
     output_schema: Option<&Value>,
     input_schema: &Value,
+    surface_id: &str,
+    operation_id: &str,
+    diagnostics: &mut Vec<Diagnostic>,
 ) -> (Option<McpPaginationSpec>, Option<McpOffsetPaginationSpec>) {
-    let pagination = infer_mcp_pagination(inputs, output, output_schema);
+    let pagination = infer_mcp_pagination(
+        inputs,
+        output,
+        output_schema,
+        surface_id,
+        operation_id,
+        diagnostics,
+    );
     let offset_pagination = pagination
         .is_none()
         .then(|| infer_mcp_offset_pagination(inputs, output, input_schema))
@@ -22,6 +35,9 @@ fn infer_mcp_pagination(
     inputs: &[IrOperationInput],
     output: &IrOperationOutput,
     output_schema: Option<&Value>,
+    surface_id: &str,
+    operation_id: &str,
+    diagnostics: &mut Vec<Diagnostic>,
 ) -> Option<McpPaginationSpec> {
     if !matches!(
         output.cardinality,
@@ -30,7 +46,8 @@ fn infer_mcp_pagination(
         return None;
     }
     let cursor_arg = cursor_input_name(inputs)?;
-    let response_cursor_path = find_response_cursor_path(output_schema?)?;
+    let response_cursor_path =
+        find_response_cursor_path_or_warn(output_schema?, surface_id, operation_id, diagnostics)?;
     Some(McpPaginationSpec {
         cursor_arg: cursor_arg.to_string(),
         response_cursor_path,
@@ -139,23 +156,70 @@ fn cursor_input_name(inputs: &[IrOperationInput]) -> Option<&str> {
         .map(|input| input.name.as_str())
 }
 
-pub(super) fn find_response_cursor_path(schema: &Value) -> Option<Vec<String>> {
-    let properties = schema.get("properties").and_then(Value::as_object)?;
-    for (name, property) in properties {
-        if is_response_cursor_property(name, property) {
-            return Some(vec![name.clone()]);
+pub(super) fn find_response_cursor_path_or_warn(
+    schema: &Value,
+    surface_id: &str,
+    operation_id: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<Vec<String>> {
+    match find_response_cursor_path(schema) {
+        CursorPathSearch::Found(path) => Some(path),
+        CursorPathSearch::NotFound => None,
+        CursorPathSearch::DepthExceeded => {
+            diagnostics.push(Diagnostic::warning(
+                "MCP_RESPONSE_SCHEMA_DEPTH_EXCEEDED",
+                format!("MCP response schema exceeds maximum depth of {MAX_SCHEMA_DEPTH}"),
+                surface_id.to_string(),
+                Some(operation_id.to_string()),
+            ));
+            None
         }
     }
+}
+
+pub(super) enum CursorPathSearch {
+    Found(Vec<String>),
+    NotFound,
+    DepthExceeded,
+}
+
+pub(super) fn find_response_cursor_path(schema: &Value) -> CursorPathSearch {
+    find_response_cursor_path_at_depth(schema, 0)
+}
+
+fn find_response_cursor_path_at_depth(schema: &Value, depth: usize) -> CursorPathSearch {
+    if depth > MAX_SCHEMA_DEPTH {
+        return CursorPathSearch::DepthExceeded;
+    }
+    let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+        return CursorPathSearch::NotFound;
+    };
+    for (name, property) in properties {
+        if is_response_cursor_property(name, property) {
+            return CursorPathSearch::Found(vec![name.clone()]);
+        }
+    }
+    let mut depth_exceeded = false;
     for (name, property) in properties {
         if !json_schema_type_contains(property, "object") {
             continue;
         }
-        if let Some(mut path) = find_response_cursor_path(property) {
-            path.insert(0, name.clone());
-            return Some(path);
+        match find_response_cursor_path_at_depth(property, depth + 1) {
+            CursorPathSearch::Found(mut path) => {
+                path.insert(0, name.clone());
+                return CursorPathSearch::Found(path);
+            }
+            CursorPathSearch::NotFound => {}
+            CursorPathSearch::DepthExceeded => {
+                depth_exceeded = true;
+            }
         }
     }
-    None
+    if depth_exceeded {
+        CursorPathSearch::DepthExceeded
+    } else {
+        CursorPathSearch::NotFound
+    }
 }
 
 fn is_response_cursor_property(name: &str, schema: &Value) -> bool {


### PR DESCRIPTION
## Summary

Closes #1306.

- Keeps MCP input `$ref` guards active across the resolved schema subtree.
- Adds a bounded MCP schema depth limit for input walking and response cursor discovery.
- Continues response cursor discovery across sibling branches after one branch exceeds the depth limit.
- Emits diagnostics only when no cursor is found before the depth cap blocks the search.

## Validation

- `make rust-checks`