### PR TITLE
feat(app): expose identity metadata validation

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -308,6 +308,24 @@ impl IdentityManagementHandle {
         self.manager.list_identities(owner).await
     }
 
+    /// Validates that an identity exists under `owner` and still matches its
+    /// installed identity spec without reading credential material.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot be read or the identity is
+    /// orphaned because its installed spec is missing, changed, or has a
+    /// different type.
+    pub async fn validate_identity_metadata(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<Option<UserOwnedIdentityRecord>, AppError> {
+        self.manager
+            .validate_identity_metadata(owner, identity_name)
+            .await
+    }
+
     /// Deletes an identity stored under `owner`.
     ///
     /// # Errors
@@ -517,6 +535,19 @@ impl UserOwnedIdentityManager {
         self.store.list_identities(owner).await
     }
 
+    async fn validate_identity_metadata(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<Option<UserOwnedIdentityRecord>, AppError> {
+        let identity_name = validate_identity_name(identity_name)?;
+        let Some(record) = self.store.load_identity(owner, &identity_name).await? else {
+            return Ok(None);
+        };
+        self.load_spec_manifest_for_record(&record)?;
+        Ok(Some(record))
+    }
+
     pub(crate) async fn list_user_owned_identities(
         &self,
         principal: &UserPrincipal,
@@ -638,6 +669,28 @@ impl UserOwnedIdentityManager {
         record: &UserOwnedIdentityRecord,
     ) -> Result<IdentitySpecRecord, AppError> {
         let spec = match self.identity_specs.get_identity_spec(&record.identity_spec) {
+            Ok(spec) => spec,
+            Err(AppError::IdentitySpecNotFound(_)) => {
+                return Err(AppError::FailedPrecondition(format!(
+                    "identity '{}' is orphaned because identity spec '{}' is not installed",
+                    record.name, record.identity_spec
+                )));
+            }
+            Err(error) => return Err(error),
+        };
+        validate_record_identity_type(record, spec.manifest.identity_type)?;
+        validate_record_identity_spec_fingerprint(record, &spec.manifest)?;
+        Ok(spec)
+    }
+
+    fn load_spec_manifest_for_record(
+        &self,
+        record: &UserOwnedIdentityRecord,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        let spec = match self
+            .identity_specs
+            .get_identity_spec_manifest(&record.identity_spec)
+        {
             Ok(spec) => spec,
             Err(AppError::IdentitySpecNotFound(_)) => {
                 return Err(AppError::FailedPrecondition(format!(
@@ -1314,6 +1367,7 @@ mod tests {
         SourceIdentityBinding, SourceIdentitySelection, SourceIdentitySelectionRequest,
         SourceIdentitySubject,
     };
+    use crate::identity_specs::{IdentitySpecRegistry, IdentitySpecRegistryRecord};
     use tempfile::TempDir;
 
     #[test]
@@ -1801,6 +1855,140 @@ oauth:
             error.contains("created before identity spec fingerprinting"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn handle_validates_identity_metadata_without_credential_material() {
+        let (_temp, manager, identity_specs) = manager_with_github_pat_spec();
+        create_github_local(&manager, "identity-token").await;
+        let owner = local_owner();
+        let record = manager
+            .store
+            .load_identity(&owner, "github_local")
+            .await
+            .expect("load identity")
+            .expect("identity");
+        manager
+            .store
+            .replace_identity(&owner, &record, &BTreeMap::new())
+            .await
+            .expect("remove credential material");
+        let handle = manager.handle();
+
+        let validated = handle
+            .validate_identity_metadata(&owner, "github_local")
+            .await
+            .expect("validate metadata")
+            .expect("identity");
+
+        assert_eq!(validated.name, "github_local");
+        identity_specs
+            .remove_identity_spec("github_pat", true)
+            .expect("force remove spec");
+        identity_specs
+            .add_identity_spec(&fixed_identity_spec_yaml_for_host("attacker.test"))
+            .expect("add changed spec");
+        let error = handle
+            .validate_identity_metadata(&owner, "github_local")
+            .await
+            .expect_err("changed identity spec should fail metadata validation");
+        assert!(
+            error
+                .to_string()
+                .contains("has changed since the identity was created"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_validates_identity_metadata_from_manifest_only_registry_path() {
+        let temp = TempDir::new().expect("tempdir");
+        let layout = test_layout(&temp);
+        let manifest_yaml = fixed_identity_spec_yaml();
+        let manifest = coral_spec::parse_identity_manifest_yaml(&manifest_yaml).expect("manifest");
+        let identity_specs = IdentitySpecManager::new_with_registry(
+            layout.clone(),
+            Arc::new(ManifestOnlyIdentitySpecRegistry { manifest_yaml }),
+            dsl_v4_features(),
+            Vec::new(),
+        );
+        let manager = UserOwnedIdentityManager::new(layout, identity_specs);
+        let owner = local_owner();
+        let record = UserOwnedIdentityRecord {
+            name: "github_local".to_string(),
+            identity_spec: manifest.name.clone(),
+            identity_spec_fingerprint: Some(
+                identity_spec_fingerprint(&manifest).expect("fingerprint"),
+            ),
+            issuer: manifest.issuer.clone(),
+            identity_type: manifest.identity_type.label().to_string(),
+            metadata: BTreeMap::new(),
+        };
+        manager
+            .store
+            .replace_identity(&owner, &record, &BTreeMap::new())
+            .await
+            .expect("store identity");
+
+        let validated = manager
+            .handle()
+            .validate_identity_metadata(&owner, "github_local")
+            .await
+            .expect("validate metadata")
+            .expect("identity");
+
+        assert_eq!(validated, record);
+    }
+
+    #[derive(Debug)]
+    struct ManifestOnlyIdentitySpecRegistry {
+        manifest_yaml: String,
+    }
+
+    impl IdentitySpecRegistry for ManifestOnlyIdentitySpecRegistry {
+        fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRegistryRecord>, AppError> {
+            Err(unexpected_manifest_only_registry_call(
+                "list identity specs",
+            ))
+        }
+
+        fn get_identity_spec(
+            &self,
+            _name: &str,
+        ) -> Result<Option<IdentitySpecRegistryRecord>, AppError> {
+            Err(unexpected_manifest_only_registry_call(
+                "hydrate identity spec input material",
+            ))
+        }
+
+        fn get_identity_spec_manifest_yaml(&self, name: &str) -> Result<Option<String>, AppError> {
+            if name != "github_pat" {
+                return Err(AppError::FailedPrecondition(format!(
+                    "unexpected identity spec lookup '{name}'"
+                )));
+            }
+            Ok(Some(self.manifest_yaml.clone()))
+        }
+
+        fn upsert_identity_spec(
+            &self,
+            _name: &str,
+            _record: IdentitySpecRegistryRecord,
+        ) -> Result<(), AppError> {
+            Err(unexpected_manifest_only_registry_call(
+                "upsert identity specs",
+            ))
+        }
+
+        fn remove_identity_spec(&self, _name: &str) -> Result<(), AppError> {
+            Err(unexpected_manifest_only_registry_call(
+                "remove identity specs",
+            ))
+        }
+    }
+
+    fn unexpected_manifest_only_registry_call(operation: &str) -> AppError {
+        AppError::FailedPrecondition(format!("metadata validation should not {operation}"))
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -113,16 +113,18 @@ pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
     fn get_identity_spec(&self, name: &str)
     -> Result<Option<IdentitySpecRegistryRecord>, AppError>;
 
-    /// Fetches one identity spec manifest by name without hydrating stored
-    /// setup input material.
+    /// Fetches one identity spec manifest by name.
+    ///
+    /// Implementations that can load manifests independently should override
+    /// this to avoid hydrating stored setup input material. The default preserves
+    /// compatibility with registries that only implement full-record lookup.
     ///
     /// # Errors
     ///
     /// Returns [`AppError`] when the registry cannot be read.
     fn get_identity_spec_manifest_yaml(&self, name: &str) -> Result<Option<String>, AppError> {
-        Err(AppError::FailedPrecondition(format!(
-            "identity spec registry does not support manifest-only lookup for '{name}'"
-        )))
+        self.get_identity_spec(name)
+            .map(|record| record.map(|record| record.manifest_yaml))
     }
 
     /// Inserts or replaces one identity spec.
@@ -905,8 +907,8 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord, IdentitySpecUsageProvider,
-        identity_spec_fingerprint,
+        IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord, IdentitySpecRegistry,
+        IdentitySpecRegistryRecord, IdentitySpecUsageProvider, identity_spec_fingerprint,
     };
     use crate::bootstrap::AppError;
     use crate::credentials::parse_env_file;
@@ -1139,6 +1141,73 @@ oauth:
                 .expect("list again")
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn manifest_lookup_default_falls_back_to_full_registry_record() {
+        let temp = TempDir::new().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout directories");
+        let manager = IdentitySpecManager::new_with_registry(
+            layout,
+            Arc::new(GetOnlyIdentitySpecRegistry {
+                record: IdentitySpecRegistryRecord {
+                    manifest_yaml: identity_yaml("github_oauth", "0.1.0"),
+                    input_material: BTreeMap::from([(
+                        "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                        "client-secret".to_string(),
+                    )]),
+                },
+            }),
+            dsl_v4_features(),
+            Vec::new(),
+        );
+
+        let record = manager
+            .get_identity_spec_manifest("github_oauth")
+            .expect("fallback manifest lookup");
+
+        assert_eq!(record.manifest.name, "github_oauth");
+        assert_eq!(record.manifest.version, "0.1.0");
+    }
+
+    #[derive(Debug)]
+    struct GetOnlyIdentitySpecRegistry {
+        record: IdentitySpecRegistryRecord,
+    }
+
+    impl IdentitySpecRegistry for GetOnlyIdentitySpecRegistry {
+        fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRegistryRecord>, AppError> {
+            Ok(vec![self.record.clone()])
+        }
+
+        fn get_identity_spec(
+            &self,
+            name: &str,
+        ) -> Result<Option<IdentitySpecRegistryRecord>, AppError> {
+            if name == "github_oauth" {
+                Ok(Some(self.record.clone()))
+            } else {
+                Ok(None)
+            }
+        }
+
+        fn upsert_identity_spec(
+            &self,
+            _name: &str,
+            _record: IdentitySpecRegistryRecord,
+        ) -> Result<(), AppError> {
+            Err(AppError::FailedPrecondition(
+                "read-only test registry".to_string(),
+            ))
+        }
+
+        fn remove_identity_spec(&self, _name: &str) -> Result<(), AppError> {
+            Err(AppError::FailedPrecondition(
+                "read-only test registry".to_string(),
+            ))
+        }
     }
 
     /// Merges the previous missing-input rejection, declared-input storage,

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -113,6 +113,18 @@ pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
     fn get_identity_spec(&self, name: &str)
     -> Result<Option<IdentitySpecRegistryRecord>, AppError>;
 
+    /// Fetches one identity spec manifest by name without hydrating stored
+    /// setup input material.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the registry cannot be read.
+    fn get_identity_spec_manifest_yaml(&self, name: &str) -> Result<Option<String>, AppError> {
+        Err(AppError::FailedPrecondition(format!(
+            "identity spec registry does not support manifest-only lookup for '{name}'"
+        )))
+    }
+
     /// Inserts or replaces one identity spec.
     ///
     /// # Errors
@@ -319,6 +331,17 @@ impl IdentitySpecManager {
         self.load_identity_spec_unlocked(&name)
     }
 
+    pub(crate) fn get_identity_spec_manifest(
+        &self,
+        name: &str,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        let span = info_span!("coral.app.identity_specs.get_manifest");
+        let _guard = span.enter();
+        let name = validate_identity_spec_name(name)?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        self.load_identity_spec_manifest_unlocked(&name)
+    }
+
     pub(crate) fn snapshot_identity_spec(
         &self,
         name: &str,
@@ -397,14 +420,32 @@ impl IdentitySpecManager {
         let Some(stored) = self.registry.get_identity_spec(&name)? else {
             return Err(AppError::IdentitySpecNotFound(name));
         };
-        let record = parse_identity_spec_record(&stored.manifest_yaml)?;
-        if record.manifest.name != name {
-            return Err(AppError::FailedPrecondition(format!(
-                "identity spec registry record '{name}' contains identity spec '{}'",
-                record.manifest.name
-            )));
+        Self::parse_identity_spec_manifest_unlocked(&name, &stored.manifest_yaml)
+    }
+
+    fn load_identity_spec_manifest_unlocked(
+        &self,
+        name: &str,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let Some(manifest_yaml) = self.registry.get_identity_spec_manifest_yaml(&name)? else {
+            return Err(AppError::IdentitySpecNotFound(name));
+        };
+        Self::parse_identity_spec_manifest_unlocked(&name, &manifest_yaml)
+    }
+
+    fn parse_identity_spec_manifest_unlocked(
+        name: &str,
+        manifest_yaml: &str,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        let record = parse_identity_spec_record(manifest_yaml)?;
+        if record.manifest.name == name {
+            return Ok(record);
         }
-        Ok(record)
+        Err(AppError::FailedPrecondition(format!(
+            "identity spec registry record '{name}' contains identity spec '{}'",
+            record.manifest.name
+        )))
     }
 
     fn count_identities_for_spec_unlocked(
@@ -606,12 +647,10 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
         &self,
         name: &str,
     ) -> Result<Option<IdentitySpecRegistryRecord>, AppError> {
-        let name = validate_identity_spec_name(name)?;
-        let path = self.layout.identity_spec_manifest_file(&name);
-        if !path.exists() {
+        let Some(manifest_yaml) = self.get_identity_spec_manifest_yaml(name)? else {
             return Ok(None);
-        }
-        let manifest_yaml = fs::read_to_string(&path)?;
+        };
+        let name = validate_identity_spec_name(name)?;
         let state = self.load_input_material_state(&name)?;
         let input_material = match state.credential_storage {
             Some(storage) => self.read_input_material(&name, storage)?,
@@ -621,6 +660,15 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
             manifest_yaml,
             input_material,
         }))
+    }
+
+    fn get_identity_spec_manifest_yaml(&self, name: &str) -> Result<Option<String>, AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let path = self.layout.identity_spec_manifest_file(&name);
+        if !path.exists() {
+            return Ok(None);
+        }
+        fs::read_to_string(&path).map(Some).map_err(Into::into)
     }
 
     fn upsert_identity_spec(

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -69,7 +69,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -528,8 +527,7 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
       "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bufbuild/protoc-gen-es": {
       "version": "2.12.0",
@@ -587,7 +585,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -609,7 +606,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -622,7 +618,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2353,7 +2348,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2438,7 +2432,6 @@
       "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.20.1.tgz",
       "integrity": "sha512-5I9RNo5uZW9tsBnqrWzJqELegOqTHBrZyDFnES0gR9gJJHBB9dom1N0bwITM9tKwBcfKrTX4a6DHVeQdJ2ubQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.9",
@@ -2609,7 +2602,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4304,7 +4296,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -4601,7 +4592,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4697,7 +4687,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4707,7 +4696,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5164,7 +5152,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5358,7 +5345,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",


### PR DESCRIPTION
## Intent

Expose a metadata-only identity validation seam from `coral-app` so product runtimes can verify that a stored user-owned identity still exists and still matches its installed DSL v4 identity spec without resolving credential material.

## What it enables

Product runtimes can validate member source identity bindings before persisting them, including stale identity-spec fingerprints, without triggering OAuth refreshes or reading user identity secrets. The identity-spec registry now has a manifest-only lookup hook; the file-backed registry implements it without hydrating setup input material, and custom registry implementations remain compatible through a full-record fallback.

## Usage examples

```rust
let owner = IdentityOwnerKey::new("user@example.com")?;
let identity = identity_management
    .validate_identity_metadata(&owner, "github-local")
    .await?;

if identity.is_none() {
    return Err(AppError::IdentityNotFound("github-local".to_string()));
}
```

## Validation

- `cargo fmt --check`
- `cargo test -p coral-app manifest_lookup_default_falls_back_to_full_registry_record --lib`
- `cargo test -p coral-app handle_validates_identity_metadata --lib`
- `make rust-checks`