### PR TITLE
feat(ui): Use dialog to confirm souce removal

### DIFF
--- a/ui/src/views/sources/source-detail.css.ts
+++ b/ui/src/views/sources/source-detail.css.ts
@@ -96,24 +96,6 @@ export const alertError = style({
   paddingInline: 12,
 })
 
-export const removeConfirm = style({
-  alignItems: 'center',
-  background: theme.pill.red.background,
-  border: `1px solid ${theme.pill.red.stroke}`,
-  borderRadius: 8,
-  display: 'flex',
-  gap: 12,
-  justifyContent: 'space-between',
-  marginBlockStart: 12,
-  padding: 12,
-  '@media': {
-    '(max-width: 520px)': {
-      alignItems: 'stretch',
-      flexDirection: 'column',
-    },
-  },
-})
-
 export const removeConfirmText = style({
   display: 'flex',
   flexDirection: 'column',

--- a/ui/src/views/sources/source-detail.tsx
+++ b/ui/src/views/sources/source-detail.tsx
@@ -276,40 +276,45 @@ function SourceDetailDialogContent({
         />
       )}
 
-      {confirmingRemove ? (
-        <RemoveConfirmation
-          deleting={deleting}
-          name={name}
-          onCancel={() => setConfirmingRemove(false)}
-          onDelete={onDelete}
-        />
-      ) : (
-        <Dialog.Actions>
+      <Dialog.Actions>
+        <ButtonContainer
+          variant="bare"
+          size="32"
+          onClick={() => setConfirmingRemove(true)}
+          disabled={saving || deleting}
+        >
+          <ButtonText>Remove</ButtonText>
+        </ButtonContainer>
+        {editable && hasChanges ? (
           <ButtonContainer
-            variant="bare"
+            variant="primary"
             size="32"
-            onClick={() => setConfirmingRemove(true)}
-            disabled={saving || deleting}
+            onClick={() => void save()}
+            disabled={saving}
           >
-            <ButtonText>Remove</ButtonText>
+            {saving ? <ButtonIcon name="Loader" /> : null}
+            <ButtonText>{saving ? 'Saving…' : 'Save changes'}</ButtonText>
           </ButtonContainer>
-          {editable && hasChanges ? (
-            <ButtonContainer
-              variant="primary"
-              size="32"
-              onClick={() => void save()}
-              disabled={saving}
-            >
-              {saving ? <ButtonIcon name="Loader" /> : null}
-              <ButtonText>{saving ? 'Saving…' : 'Save changes'}</ButtonText>
-            </ButtonContainer>
-          ) : (
-            <ButtonContainer variant="primary" size="32" onClick={onClose}>
-              <ButtonText>Close</ButtonText>
-            </ButtonContainer>
-          )}
-        </Dialog.Actions>
-      )}
+        ) : (
+          <ButtonContainer variant="primary" size="32" onClick={onClose}>
+            <ButtonText>Close</ButtonText>
+          </ButtonContainer>
+        )}
+      </Dialog.Actions>
+
+      <Dialog.Root open={confirmingRemove} onOpenChange={(open) => setConfirmingRemove(open)}>
+        <Dialog.Portal>
+          <Dialog.Backdrop />
+          <Dialog.Popup size="m">
+            <RemoveConfirmation
+              deleting={deleting}
+              name={name}
+              onCancel={() => setConfirmingRemove(false)}
+              onDelete={onDelete}
+            />
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>
     </>
   )
 }
@@ -326,15 +331,15 @@ function RemoveConfirmation({
   onDelete: () => void
 }) {
   return (
-    <section className={styles.removeConfirm} aria-live="polite">
+    <>
       <div className={styles.removeConfirmText}>
-        <Typography.BodySmallStrong variant="primary">Remove {name}?</Typography.BodySmallStrong>
-        <Typography.BodySmall variant="secondary">
+        <Dialog.Title>Remove {name}?</Dialog.Title>
+        <Dialog.Description>
           This deletes the source configuration and stored credentials from this workspace. You can
           reinstall later, but you'll need to re-supply any secrets.
-        </Typography.BodySmall>
+        </Dialog.Description>
       </div>
-      <div className={styles.removeConfirmActions}>
+      <Dialog.Actions className={styles.removeConfirmActions}>
         <ButtonContainer variant="secondary" size="32" onClick={onCancel} disabled={deleting}>
           <ButtonText>Cancel</ButtonText>
         </ButtonContainer>
@@ -347,8 +352,8 @@ function RemoveConfirmation({
           {deleting ? <ButtonIcon name="Loader" /> : null}
           <ButtonText>{deleting ? 'Removing…' : 'Remove'}</ButtonText>
         </ButtonContainer>
-      </div>
-    </section>
+      </Dialog.Actions>
+    </>
   )
 }
 

--- a/ui/tests/ui/sources.spec.ts
+++ b/ui/tests/ui/sources.spec.ts
@@ -97,20 +97,26 @@ test('installs a core source via paste, edits a binding, and removes it', async 
   await expect(detailDialog).toHaveCount(0)
   await review.pause()
 
-  await review.chapter('Remove the source', 'Confirm the remove flow inside the detail dialog')
+  await review.chapter('Remove the source', 'Confirm the remove flow in a stacked dialog')
   await page.getByRole('button', { name: /Linear/i }).click()
-  const reopenedDetailDialog = page.getByRole('dialog', { name: /Linear/i })
+  const reopenedDetailDialog = page
+    .getByRole('dialog', { includeHidden: true })
+    .filter({ hasText: 'LINEAR_API_TOKEN' })
   await expect(reopenedDetailDialog).toBeVisible()
   await reopenedDetailDialog.getByRole('button', { name: 'Remove' }).click()
 
+  const removeDialog = page.getByRole('dialog', { name: 'Remove linear?' })
+  await expect(page.getByRole('dialog', { includeHidden: true })).toHaveCount(2)
   await expect(page.getByRole('dialog')).toHaveCount(1)
-  await expect(reopenedDetailDialog.getByText('Remove linear?')).toBeVisible()
-  await reopenedDetailDialog.getByRole('button', { name: 'Cancel' }).click()
-  await expect(reopenedDetailDialog.getByText('Remove linear?')).toHaveCount(0)
+  await expect(reopenedDetailDialog).toHaveAttribute('data-nested-dialog-open', '')
+  await expect(removeDialog).toBeVisible()
+  await removeDialog.getByRole('button', { name: 'Cancel' }).click()
+  await expect(removeDialog).toHaveCount(0)
+  await expect(page.getByRole('dialog')).toHaveCount(1)
 
   await reopenedDetailDialog.getByRole('button', { name: 'Remove' }).click()
-  await expect(reopenedDetailDialog.getByText('Remove linear?')).toBeVisible()
-  await reopenedDetailDialog.getByRole('button', { name: 'Remove' }).click()
+  await expect(removeDialog).toBeVisible()
+  await removeDialog.getByRole('button', { name: 'Remove' }).click()
 
   await expect(page.getByText('Removed linear')).toBeVisible()
   await expect(page.getByRole('button', { name: /Linear/i })).toBeVisible()


### PR DESCRIPTION
## Summary

This is our pattern, not sure how the old version landed in there.

## Test plan

Trying to remove a source, see the dialog

<img width="617" height="292" alt="image" src="https://github.com/user-attachments/assets/72fef971-10f4-4595-9e5c-ef89676067c2" />


Before this PR: 

<img width="602" height="327" alt="image" src="https://github.com/user-attachments/assets/0be0ad82-13e2-4584-ba06-92f32194647c" />
