### PR TITLE
feat(recipes): add recipe lifecycle surfaces

### DIFF
--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -19,6 +19,7 @@ fn main() {
                 "proto/coral/v1/feedback.proto",
                 "proto/coral/v1/sources.proto",
                 "proto/coral/v1/query.proto",
+                "proto/coral/v1/recipes.proto",
                 "proto/coral/v1/traces.proto",
                 "proto/coral/v1/episode.proto",
             ],

--- a/crates/coral-api/proto/coral/v1/recipes.proto
+++ b/crates/coral-api/proto/coral/v1/recipes.proto
@@ -48,8 +48,8 @@ message RecipeTableFunctionPublish {
   string description = 3;
 }
 
-// One public surface requested by a recipe.
-message RecipePublish {
+// One public surface published by a recipe.
+message RecipePublishedSurface {
   // Published target.
   oneof target {
     // SQL table-function publication.
@@ -66,7 +66,7 @@ message Recipe {
   // Declared arguments.
   repeated RecipeArgument arguments = 3;
   // Published surfaces.
-  repeated RecipePublish publish = 4;
+  repeated RecipePublishedSurface publish = 4;
   // Inferred result columns.
   repeated RecipeResultColumn result_columns = 5;
   // Where the installed recipe came from.

--- a/crates/coral-api/proto/coral/v1/recipes.proto
+++ b/crates/coral-api/proto/coral/v1/recipes.proto
@@ -101,7 +101,7 @@ message ListRecipesRequest {
 
 // Installed recipes.
 message ListRecipesResponse {
-  // Recipes visible to the current workspace runtime.
+  // Installed recipe inventory, including disabled or stale recipes.
   repeated Recipe recipes = 1;
 }
 

--- a/crates/coral-api/proto/coral/v1/recipes.proto
+++ b/crates/coral-api/proto/coral/v1/recipes.proto
@@ -69,6 +69,10 @@ message Recipe {
   repeated RecipePublish publish = 4;
   // Inferred result columns.
   repeated RecipeResultColumn result_columns = 5;
+  // Where the installed recipe came from.
+  RecipeOrigin origin = 6;
+  // Whether this recipe participates in runtime publication.
+  bool enabled = 7;
 }
 
 // Installs or replaces one user recipe.

--- a/crates/coral-api/proto/coral/v1/recipes.proto
+++ b/crates/coral-api/proto/coral/v1/recipes.proto
@@ -101,20 +101,6 @@ message ListRecipesResponse {
   repeated Recipe recipes = 1;
 }
 
-// Validates one recipe without installing it.
-message ValidateRecipeRequest {
-  // Workspace that scopes installed sources and recipe collisions.
-  Workspace workspace = 1;
-  // Raw recipe YAML.
-  string yaml = 2;
-}
-
-// Validated recipe metadata.
-message ValidateRecipeResponse {
-  // Runtime-validated recipe definition.
-  Recipe recipe = 1;
-}
-
 // Removes one user recipe.
 message RemoveRecipeRequest {
   // Workspace that owns the recipe.
@@ -132,8 +118,6 @@ service RecipeService {
   rpc AddRecipe(AddRecipeRequest) returns (AddRecipeResponse);
   // Lists installed recipes without runtime validation.
   rpc ListRecipes(ListRecipesRequest) returns (ListRecipesResponse);
-  // Validates one recipe without installing it.
-  rpc ValidateRecipe(ValidateRecipeRequest) returns (ValidateRecipeResponse);
   // Removes one user recipe.
   rpc RemoveRecipe(RemoveRecipeRequest) returns (RemoveRecipeResponse);
 }

--- a/crates/coral-api/proto/coral/v1/recipes.proto
+++ b/crates/coral-api/proto/coral/v1/recipes.proto
@@ -4,16 +4,6 @@ package coral.v1;
 
 import "coral/v1/resources.proto";
 
-// Where a recipe came from.
-enum RecipeOrigin {
-  // Origin was not specified.
-  RECIPE_ORIGIN_UNSPECIFIED = 0;
-  // Recipe shipped with a bundled source.
-  RECIPE_ORIGIN_BUNDLED = 1;
-  // Recipe was installed by the user.
-  RECIPE_ORIGIN_USER = 2;
-}
-
 // One scalar recipe argument.
 message RecipeArgument {
   // Argument name.
@@ -48,13 +38,10 @@ message RecipeTableFunctionPublish {
   string description = 3;
 }
 
-// One public surface published by a recipe.
-message RecipePublishedSurface {
-  // Published target.
-  oneof target {
-    // SQL table-function publication.
-    RecipeTableFunctionPublish table_function = 1;
-  }
+// Public surfaces published by a recipe.
+message RecipePublish {
+  // SQL table-function publication.
+  RecipeTableFunctionPublish table_function = 1;
 }
 
 // Recipe definition exposed by recipe lifecycle APIs.
@@ -65,14 +52,10 @@ message Recipe {
   string description = 2;
   // Declared arguments.
   repeated RecipeArgument arguments = 3;
-  // Published surfaces.
-  repeated RecipePublishedSurface publish = 4;
+  // Published recipe surfaces.
+  RecipePublish publish = 4;
   // Inferred result columns.
   repeated RecipeResultColumn result_columns = 5;
-  // Where the installed recipe came from.
-  RecipeOrigin origin = 6;
-  // Whether this recipe participates in runtime publication.
-  bool enabled = 7;
 }
 
 // Installs or replaces one user recipe.
@@ -87,10 +70,6 @@ message AddRecipeRequest {
 message AddRecipeResponse {
   // Stable recipe name.
   string name = 1;
-  // Where the recipe came from.
-  RecipeOrigin origin = 2;
-  // Whether the recipe is enabled.
-  bool enabled = 3;
 }
 
 // Lists installed recipes in one workspace without runtime validation.
@@ -101,7 +80,7 @@ message ListRecipesRequest {
 
 // Installed recipes.
 message ListRecipesResponse {
-  // Installed recipe inventory, including disabled or stale recipes.
+  // Readable installed recipe inventory without runtime validation.
   repeated Recipe recipes = 1;
 }
 

--- a/crates/coral-api/proto/coral/v1/recipes.proto
+++ b/crates/coral-api/proto/coral/v1/recipes.proto
@@ -1,0 +1,139 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/resources.proto";
+
+// Where a recipe came from.
+enum RecipeOrigin {
+  // Origin was not specified.
+  RECIPE_ORIGIN_UNSPECIFIED = 0;
+  // Recipe shipped with a bundled source.
+  RECIPE_ORIGIN_BUNDLED = 1;
+  // Recipe was installed by the user.
+  RECIPE_ORIGIN_USER = 2;
+}
+
+// One scalar recipe argument.
+message RecipeArgument {
+  // Argument name.
+  string name = 1;
+  // Scalar argument type: string, integer, or boolean.
+  string data_type = 2;
+  // Whether callers must provide this argument.
+  bool required = 3;
+  // User-facing description.
+  string description = 4;
+}
+
+// One recipe result column.
+message RecipeResultColumn {
+  // Column name.
+  string name = 1;
+  // Arrow/DataFusion data type rendered as text.
+  string data_type = 2;
+  // Whether the column can contain null values.
+  bool nullable = 3;
+  // User-facing description.
+  string description = 4;
+}
+
+// SQL table-function publication target.
+message RecipeTableFunctionPublish {
+  // SQL schema.
+  string schema = 1;
+  // SQL table-function name.
+  string name = 2;
+  // User-facing description.
+  string description = 3;
+}
+
+// One public surface requested by a recipe.
+message RecipePublish {
+  // Published target.
+  oneof target {
+    // SQL table-function publication.
+    RecipeTableFunctionPublish table_function = 1;
+  }
+}
+
+// Recipe definition exposed by recipe lifecycle APIs.
+message Recipe {
+  // Stable recipe name.
+  string name = 1;
+  // User-facing description.
+  string description = 2;
+  // Declared arguments.
+  repeated RecipeArgument arguments = 3;
+  // Published surfaces.
+  repeated RecipePublish publish = 4;
+  // Inferred result columns.
+  repeated RecipeResultColumn result_columns = 5;
+}
+
+// Installs or replaces one user recipe.
+message AddRecipeRequest {
+  // Workspace that owns the recipe.
+  Workspace workspace = 1;
+  // Raw recipe YAML.
+  string yaml = 2;
+}
+
+// Persisted recipe install response. Runtime metadata is returned by ListRecipes.
+message AddRecipeResponse {
+  // Stable recipe name.
+  string name = 1;
+  // Where the recipe came from.
+  RecipeOrigin origin = 2;
+  // Whether the recipe is enabled.
+  bool enabled = 3;
+}
+
+// Lists installed recipes in one workspace without runtime validation.
+message ListRecipesRequest {
+  // Workspace that scopes recipes and selected sources.
+  Workspace workspace = 1;
+}
+
+// Installed recipes.
+message ListRecipesResponse {
+  // Recipes visible to the current workspace runtime.
+  repeated Recipe recipes = 1;
+}
+
+// Validates one recipe without installing it.
+message ValidateRecipeRequest {
+  // Workspace that scopes installed sources and recipe collisions.
+  Workspace workspace = 1;
+  // Raw recipe YAML.
+  string yaml = 2;
+}
+
+// Validated recipe metadata.
+message ValidateRecipeResponse {
+  // Runtime-validated recipe definition.
+  Recipe recipe = 1;
+}
+
+// Removes one user recipe.
+message RemoveRecipeRequest {
+  // Workspace that owns the recipe.
+  Workspace workspace = 1;
+  // Recipe name.
+  string name = 2;
+}
+
+// Empty remove response.
+message RemoveRecipeResponse {}
+
+// Recipe lifecycle APIs.
+service RecipeService {
+  // Installs or replaces one user recipe.
+  rpc AddRecipe(AddRecipeRequest) returns (AddRecipeResponse);
+  // Lists installed recipes without runtime validation.
+  rpc ListRecipes(ListRecipesRequest) returns (ListRecipesResponse);
+  // Validates one recipe without installing it.
+  rpc ValidateRecipe(ValidateRecipeRequest) returns (ValidateRecipeResponse);
+  // Removes one user recipe.
+  rpc RemoveRecipe(RemoveRecipeRequest) returns (RemoveRecipeResponse);
+}

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -18,6 +18,7 @@ use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::episode_service_server::EpisodeServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
+use coral_api::v1::recipe_service_server::RecipeServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
 use coral_api::v1::trace_service_server::TraceServiceServer;
 use coral_api::{
@@ -50,6 +51,7 @@ use crate::feedback::publisher::{
 use crate::feedback::service::FeedbackService;
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
+use crate::recipes::service::RecipeService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
@@ -384,6 +386,7 @@ async fn start_server(
 ) -> Result<RunningServer, AppError> {
     let source_service = SourceService::new(source_manager, query_manager.clone());
     let catalog_service = CatalogService::new(query_manager.clone());
+    let recipe_service = RecipeService::new(query_manager.recipe_manager(), query_manager.clone());
     let query_service = QueryService::new(query_manager);
     let feedback_service = FeedbackService::new(feedback_manager);
     let episode_service = EpisodeService::new(episode_store);
@@ -398,6 +401,10 @@ async fn start_server(
         .add_service(GrpcMethodAnnotatedService::new(FeedbackServiceServer::new(
             feedback_service,
         )))
+        .add_service(GrpcMethodAnnotatedService::new(
+            RecipeServiceServer::new(recipe_service)
+                .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
+        ))
         // Registered unconditionally, like `FeedbackService` above: the local
         // transport is feature-agnostic by design (effective features are resolved
         // in `coral-cli`, which gates the *consumers*, not the routes). The

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -50,6 +50,7 @@ pub mod features;
 mod feedback;
 mod identity;
 mod query;
+mod recipes;
 mod sources;
 mod state;
 mod storage;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -700,7 +700,6 @@ mod tests {
 
     use super::*;
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
-    use crate::recipes::model::RecipeOrigin;
     use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
     use crate::sources::model::SourceOrigin;
 
@@ -1233,8 +1232,6 @@ publish:
             .expect("recipes");
         assert_eq!(recipes.len(), 1);
         let recipe = recipes.first().expect("recipe");
-        assert_eq!(recipe.origin, RecipeOrigin::User);
-        assert!(recipe.enabled);
         let column = recipe
             .definition
             .result_columns

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -7,8 +7,8 @@ use std::time::Instant;
 
 use coral_engine::{
     CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, QueryExecution, QueryPlan,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RuntimeSourcePackage,
-    SourceValidationReport, StatusCode, TableInfo,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RecipeRuntimeDefinition,
+    RuntimeSourcePackage, SourceValidationReport, StatusCode, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::trace::Status as OtelStatus;
@@ -22,6 +22,7 @@ use crate::query::QueryAttribution;
 use crate::query::extensions::{
     CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
 };
+use crate::recipes::manager::RecipeManager;
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::{
@@ -47,6 +48,7 @@ pub(crate) struct ValidatedSource {
 pub(crate) struct QueryManager {
     config_store: ConfigStore,
     credential_manager: CredentialManager,
+    recipe_manager: RecipeManager,
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
@@ -60,9 +62,11 @@ impl QueryManager {
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
+        let recipe_manager = RecipeManager::new(config_store.clone(), layout.clone());
         Self {
             config_store,
             credential_manager,
+            recipe_manager,
             runtime_context,
             layout,
             engine_extensions_providers,
@@ -91,8 +95,8 @@ impl QueryManager {
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                    .runtime_config_with_recipes(workspace_name, &sources, &config)
+                    .await?;
                 CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -123,8 +127,8 @@ impl QueryManager {
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                    .runtime_config_with_recipes(workspace_name, &sources, &config)
+                    .await?;
                 CoralQuery::list_catalog(&sources, runtime, schema_filter)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -166,8 +170,8 @@ impl QueryManager {
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                    .runtime_config_with_recipes(workspace_name, &sources, &config)
+                    .await?;
                 CoralQuery::describe_table(&sources, runtime, schema_name, table_name)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -197,8 +201,8 @@ impl QueryManager {
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                    .runtime_config_with_recipes(workspace_name, &sources, &config)
+                    .await?;
                 CoralQuery::execute_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -228,8 +232,8 @@ impl QueryManager {
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                    .runtime_config_with_recipes(workspace_name, &sources, &config)
+                    .await?;
                 CoralQuery::explain_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -407,6 +411,70 @@ impl QueryManager {
         runtime.memory = config.memory_config()?;
         runtime.dependent_join = config.dependent_join_config(&selected_source_names)?;
         Ok(runtime)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "used by the recipe lifecycle API in a later stack branch"
+        )
+    )]
+    pub(crate) fn list_recipes(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<RecipeRuntimeDefinition>, QueryManagerError> {
+        self.recipe_manager
+            .list_recipes(workspace_name)
+            .map_err(QueryManagerError::App)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "used by the recipe lifecycle API in a later stack branch"
+        )
+    )]
+    pub(crate) async fn validate_recipe_yaml(
+        &self,
+        workspace_name: &WorkspaceName,
+        raw_yaml: &str,
+    ) -> Result<RecipeRuntimeDefinition, QueryManagerError> {
+        let config = self
+            .config_store
+            .load_config()
+            .map_err(QueryManagerError::App)?;
+        let sources = self
+            .load_query_sources(workspace_name, &config)
+            .map_err(QueryManagerError::App)?;
+        self.recipe_manager
+            .validate_user_recipe_yaml(
+                workspace_name,
+                &sources,
+                || self.runtime_config(workspace_name, &sources, &config),
+                raw_yaml,
+            )
+            .await
+            .map_err(QueryManagerError::App)
+    }
+
+    async fn runtime_config_with_recipes(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[QuerySource],
+        config: &AppConfig,
+    ) -> Result<QueryRuntimeConfig, QueryManagerError> {
+        let recipes = self
+            .recipe_manager
+            .load_runtime_recipes(workspace_name, selected_sources, || {
+                self.runtime_config(workspace_name, selected_sources, config)
+            })
+            .await
+            .map_err(QueryManagerError::App)?;
+        self.runtime_config(workspace_name, selected_sources, config)
+            .map(|runtime| runtime.with_recipes(recipes))
+            .map_err(QueryManagerError::App)
     }
 }
 
@@ -1046,6 +1114,129 @@ surfaces:
         assert_eq!(
             execution_to_rows(&execution),
             vec![json!({"id": 1, "title": "Generated runtime package"})]
+        );
+    }
+
+    #[tokio::test]
+    async fn user_recipe_publishes_table_function_and_executes_against_installed_source() {
+        let fake_home = tempfile::tempdir().expect("fake home");
+        let data_dir = fake_home.path().join("fixture-data");
+        std::fs::create_dir_all(&data_dir).expect("create data dir");
+        std::fs::write(
+            data_dir.join("messages.jsonl"),
+            r#"{"type":"user","text":"hello"}
+{"type":"assistant","text":"world"}
+"#,
+        )
+        .expect("write fixture");
+
+        let fixture = query_manager_with(
+            QueryRuntimeContext {
+                home_dir: Some(fake_home.path().to_path_buf()),
+                ..QueryRuntimeContext::default()
+            },
+            Vec::new(),
+        );
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_manager = SourceManager::new(
+            fixture.manager.config_store.clone(),
+            fixture.manager.credential_manager.clone(),
+            fixture.manager.layout.clone(),
+        );
+        source_manager
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: r#"
+name: recipe_demo
+version: 0.1.0
+dsl_version: 3
+backend: file
+tables:
+  - name: messages
+    description: Fixture messages
+    format: jsonl
+    source:
+      location: file://~/fixture-data/
+      glob: "**/*.jsonl"
+    columns:
+      - name: type
+        type: Utf8
+      - name: text
+        type: Utf8
+"#
+                    .to_string(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("import source");
+
+        let recipe_yaml = r"
+kind: recipe
+name: messages_by_type
+description: Messages filtered by sender type
+inputs:
+  kind:
+    type: string
+    required: true
+implementation:
+  kind: coral_sql
+  query: |
+    select text
+    from recipe_demo.messages
+    where type = $kind
+publish:
+  - table_function: recipes.messages_by_type
+";
+        let validated_recipe = fixture
+            .manager
+            .validate_recipe_yaml(&workspace_name, recipe_yaml)
+            .await
+            .expect("validate recipe");
+        fixture
+            .manager
+            .recipe_manager
+            .install_validated_user_recipe(&workspace_name, recipe_yaml, &validated_recipe)
+            .expect("install recipe");
+
+        let catalog = fixture
+            .manager
+            .list_catalog(&workspace_name, Some("recipes"))
+            .await
+            .expect("catalog");
+        let recipe_function = catalog.table_functions.first().expect("recipe function");
+        assert_eq!(recipe_function.function_name, "messages_by_type");
+        assert_eq!(
+            recipe_function
+                .result_columns
+                .first()
+                .expect("text result column")
+                .name,
+            "text"
+        );
+
+        let recipes = fixture
+            .manager
+            .list_recipes(&workspace_name)
+            .expect("recipes");
+        assert_eq!(recipes.len(), 1);
+        let recipe = recipes.first().expect("recipe");
+        let column = recipe.result_columns.first().expect("text result column");
+        assert_eq!(column.name, "text");
+
+        let execution = fixture
+            .manager
+            .execute_sql(
+                &workspace_name,
+                "select text from recipes.messages_by_type(kind => 'user')",
+                &QueryAttribution::default(),
+            )
+            .await
+            .expect("recipe query");
+        assert_eq!(
+            execution_to_rows(&execution),
+            vec![json!({"text": "hello"})]
         );
     }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -413,13 +413,6 @@ impl QueryManager {
         Ok(runtime)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "used by the recipe lifecycle API in a later stack branch"
-        )
-    )]
     pub(crate) fn list_recipes(
         &self,
         workspace_name: &WorkspaceName,
@@ -429,13 +422,10 @@ impl QueryManager {
             .map_err(QueryManagerError::App)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "used by the recipe lifecycle API in a later stack branch"
-        )
-    )]
+    pub(crate) fn recipe_manager(&self) -> RecipeManager {
+        self.recipe_manager.clone()
+    }
+
     pub(crate) async fn validate_recipe_yaml(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -112,7 +112,8 @@ impl QueryManager {
                 let sources = self
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
-                let runtime = self.runtime_config_with_recipes(workspace_name, &sources, &config)?;
+                let runtime =
+                    self.runtime_config_with_recipes(workspace_name, &sources, &config)?;
                 CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -142,7 +143,8 @@ impl QueryManager {
                 let sources = self
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
-                let runtime = self.runtime_config_with_recipes(workspace_name, &sources, &config)?;
+                let runtime =
+                    self.runtime_config_with_recipes(workspace_name, &sources, &config)?;
                 CoralQuery::list_catalog(&sources, runtime, schema_filter)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -183,7 +185,8 @@ impl QueryManager {
                 let sources = self
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
-                let runtime = self.runtime_config_with_recipes(workspace_name, &sources, &config)?;
+                let runtime =
+                    self.runtime_config_with_recipes(workspace_name, &sources, &config)?;
                 CoralQuery::describe_table(&sources, runtime, schema_name, table_name)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -1206,7 +1209,11 @@ publish:
 
         let catalog = fixture
             .manager
-            .list_catalog(&workspace_name, Some("recipes"))
+            .list_catalog(
+                &workspace_name,
+                Some("recipes"),
+                &QueryAttribution::default(),
+            )
             .await
             .expect("catalog");
         let recipe_function = catalog.table_functions.first().expect("recipe function");

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1176,8 +1176,13 @@ implementation:
     select text
     from recipe_demo.messages
     where type = $kind
+validation:
+  args:
+    kind: human
 publish:
-  - table_function: recipes.messages_by_type
+  table_function:
+    schema: recipes
+    name: messages_by_type
 ";
         let validated_recipe = fixture
             .manager

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -94,9 +94,7 @@ impl QueryManager {
                 let sources = self
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config_with_recipes(workspace_name, &sources, &config)
-                    .await?;
+                let runtime = self.runtime_config_with_recipes(workspace_name, &sources, &config)?;
                 CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -126,9 +124,7 @@ impl QueryManager {
                 let sources = self
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config_with_recipes(workspace_name, &sources, &config)
-                    .await?;
+                let runtime = self.runtime_config_with_recipes(workspace_name, &sources, &config)?;
                 CoralQuery::list_catalog(&sources, runtime, schema_filter)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -169,9 +165,7 @@ impl QueryManager {
                 let sources = self
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config_with_recipes(workspace_name, &sources, &config)
-                    .await?;
+                let runtime = self.runtime_config_with_recipes(workspace_name, &sources, &config)?;
                 CoralQuery::describe_table(&sources, runtime, schema_name, table_name)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -200,9 +194,8 @@ impl QueryManager {
                 let sources = self
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config_with_recipes(workspace_name, &sources, &config)
-                    .await?;
+                let runtime =
+                    self.runtime_config_with_recipes(workspace_name, &sources, &config)?;
                 CoralQuery::execute_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -231,9 +224,8 @@ impl QueryManager {
                 let sources = self
                     .load_query_sources(workspace_name, &config)
                     .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config_with_recipes(workspace_name, &sources, &config)
-                    .await?;
+                let runtime =
+                    self.runtime_config_with_recipes(workspace_name, &sources, &config)?;
                 CoralQuery::explain_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -449,22 +441,20 @@ impl QueryManager {
             .map_err(QueryManagerError::App)
     }
 
-    async fn runtime_config_with_recipes(
+    fn runtime_config_with_recipes(
         &self,
         workspace_name: &WorkspaceName,
         selected_sources: &[QuerySource],
         config: &AppConfig,
     ) -> Result<QueryRuntimeConfig, QueryManagerError> {
+        let runtime = self
+            .runtime_config(workspace_name, selected_sources, config)
+            .map_err(QueryManagerError::App)?;
         let recipes = self
             .recipe_manager
-            .load_runtime_recipes(workspace_name, selected_sources, || {
-                self.runtime_config(workspace_name, selected_sources, config)
-            })
-            .await
+            .load_runtime_recipes(workspace_name, selected_sources)
             .map_err(QueryManagerError::App)?;
-        self.runtime_config(workspace_name, selected_sources, config)
-            .map(|runtime| runtime.with_recipes(recipes))
-            .map_err(QueryManagerError::App)
+        Ok(runtime.with_recipes(recipes))
     }
 }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -22,7 +22,7 @@ use crate::query::QueryAttribution;
 use crate::query::extensions::{
     CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
 };
-use crate::recipes::manager::RecipeManager;
+use crate::recipes::manager::{RecipeListing, RecipeManager};
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::{
@@ -416,7 +416,7 @@ impl QueryManager {
     pub(crate) fn list_recipes(
         &self,
         workspace_name: &WorkspaceName,
-    ) -> Result<Vec<RecipeRuntimeDefinition>, QueryManagerError> {
+    ) -> Result<Vec<RecipeListing>, QueryManagerError> {
         self.recipe_manager
             .list_recipes(workspace_name)
             .map_err(QueryManagerError::App)
@@ -689,6 +689,7 @@ mod tests {
 
     use super::*;
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
+    use crate::recipes::model::RecipeOrigin;
     use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
     use crate::sources::model::SourceOrigin;
 
@@ -1217,7 +1218,13 @@ publish:
             .expect("recipes");
         assert_eq!(recipes.len(), 1);
         let recipe = recipes.first().expect("recipe");
-        let column = recipe.result_columns.first().expect("text result column");
+        assert_eq!(recipe.origin, RecipeOrigin::User);
+        assert!(recipe.enabled);
+        let column = recipe
+            .definition
+            .result_columns
+            .first()
+            .expect("text result column");
         assert_eq!(column.name, "text");
 
         let execution = fixture

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -63,6 +63,24 @@ impl QueryManager {
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
         let recipe_manager = RecipeManager::new(config_store.clone(), layout.clone());
+        Self::with_recipe_manager(
+            config_store,
+            credential_manager,
+            recipe_manager,
+            runtime_context,
+            layout,
+            engine_extensions_providers,
+        )
+    }
+
+    pub(crate) fn with_recipe_manager(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        recipe_manager: RecipeManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    ) -> Self {
         Self {
             config_store,
             credential_manager,

--- a/crates/coral-app/src/recipes/manager.rs
+++ b/crates/coral-app/src/recipes/manager.rs
@@ -5,17 +5,18 @@
     reason = "recipe manager is exposed through API/CLI surfaces in later stack branches"
 )]
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::io::ErrorKind;
 
 use coral_engine::{
     CoralQuery, QueryRuntimeConfig, QuerySource, RecipeRuntimeArgument, RecipeRuntimeArgumentType,
-    RecipeRuntimeDefinition, RecipeRuntimeImplementation, RecipeRuntimePublish,
-    RecipeRuntimeResultColumn,
+    RecipeRuntimeArgumentValue, RecipeRuntimeDefinition, RecipeRuntimeImplementation,
+    RecipeRuntimePublish, RecipeRuntimeResultColumn, RecipeRuntimeTableFunctionPublish,
 };
 use coral_spec::{
-    RecipeArgumentType, RecipeImplementationSpec, RecipePublishSpec, RecipeSpec, parse_recipe_yaml,
+    RecipeArgumentType, RecipeImplementationSpec, RecipePublishSpec, RecipeSpec,
+    RecipeValidationValue, parse_recipe_yaml,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -41,7 +42,29 @@ struct RecipeArtifact {
 #[derive(Debug, Serialize, Deserialize)]
 struct RecipeRuntimeMetadata {
     version: u32,
+    #[serde(default)]
+    validation_args: BTreeMap<String, CachedRecipeArgumentValue>,
     result_columns: Vec<CachedRecipeResultColumn>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum CachedRecipeArgumentValue {
+    String(String),
+    Integer(i64),
+    Boolean(bool),
+    Null(()),
+}
+
+impl From<&RecipeRuntimeArgumentValue> for CachedRecipeArgumentValue {
+    fn from(value: &RecipeRuntimeArgumentValue) -> Self {
+        match value {
+            RecipeRuntimeArgumentValue::String(value) => Self::String(value.clone()),
+            RecipeRuntimeArgumentValue::Integer(value) => Self::Integer(*value),
+            RecipeRuntimeArgumentValue::Boolean(value) => Self::Boolean(*value),
+            RecipeRuntimeArgumentValue::Null => Self::Null(()),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -83,18 +106,6 @@ impl RecipeManager {
         }
     }
 
-    pub(crate) fn install_user_recipe(
-        &self,
-        workspace_name: &WorkspaceName,
-        raw_yaml: &str,
-    ) -> Result<InstalledRecipe, AppError> {
-        let recipe = parse_recipe_yaml(raw_yaml).map_err(|error| {
-            AppError::InvalidInput(format!("recipe validation failed: {error}"))
-        })?;
-        let recipe_name = RecipeName::parse(recipe.name())?;
-        self.install_user_recipe_artifact(workspace_name, &recipe_name, raw_yaml, None)
-    }
-
     pub(crate) fn install_validated_user_recipe(
         &self,
         workspace_name: &WorkspaceName,
@@ -105,6 +116,7 @@ impl RecipeManager {
             AppError::InvalidInput(format!("recipe validation failed: {error}"))
         })?;
         let recipe_name = RecipeName::parse(recipe.name())?;
+        let validation_arguments = runtime_validation_arguments(&recipe);
         if recipe_name.as_str() != runtime_recipe.name {
             return Err(AppError::FailedPrecondition(format!(
                 "validated recipe '{}' does not match installed recipe '{}'",
@@ -116,6 +128,7 @@ impl RecipeManager {
             &recipe_name,
             raw_yaml,
             Some(runtime_recipe),
+            &validation_arguments,
         )
     }
 
@@ -125,6 +138,7 @@ impl RecipeManager {
         recipe_name: &RecipeName,
         raw_yaml: &str,
         runtime_recipe: Option<&RecipeRuntimeDefinition>,
+        validation_arguments: &BTreeMap<String, RecipeRuntimeArgumentValue>,
     ) -> Result<InstalledRecipe, AppError> {
         let installed = InstalledRecipe {
             name: recipe_name.clone(),
@@ -148,7 +162,11 @@ impl RecipeManager {
 
         fs::ensure_private_dir(&recipe_dir)?;
         fs::write_atomic(&recipe_file, raw_yaml.as_bytes())?;
-        if let Err(error) = write_recipe_runtime_metadata(&recipe_runtime_file, runtime_recipe) {
+        if let Err(error) = write_recipe_runtime_metadata(
+            &recipe_runtime_file,
+            runtime_recipe,
+            validation_arguments,
+        ) {
             rollback_recipe_install(
                 &recipe_dir,
                 &recipe_file,
@@ -194,7 +212,7 @@ impl RecipeManager {
             &mut publish_targets,
         )?;
         let runtime_recipe =
-            infer_runtime_recipe(selected_sources, runtime_config()?, &spec).await?;
+            validate_runtime_recipe(selected_sources, runtime_config()?, &spec).await?;
         record_publish_targets(&runtime_recipe, &mut publish_targets)?;
         Ok(runtime_recipe)
     }
@@ -261,17 +279,18 @@ impl RecipeManager {
                     continue;
                 }
             };
-            let runtime_recipe =
-                match infer_runtime_recipe(selected_sources, runtime_config()?, &spec).await {
-                    Ok(runtime_recipe) => runtime_recipe,
-                    Err(error) => {
-                        skip_recipe(
-                            &artifact,
-                            format_args!("recipe failed runtime validation: {error}"),
-                        );
-                        continue;
-                    }
-                };
+            let mut runtime_recipe = runtime_recipe_without_columns(&spec);
+            if artifact.origin == RecipeOrigin::User {
+                runtime_recipe.result_columns =
+                    self.cached_recipe_result_columns(workspace_name, &artifact.name);
+            }
+            if runtime_recipe.result_columns.is_empty() {
+                skip_recipe(
+                    &artifact,
+                    format_args!("recipe is missing cached runtime metadata; re-add the recipe"),
+                );
+                continue;
+            }
             if let Err(error) = record_publish_targets(&runtime_recipe, &mut publish_targets) {
                 skip_recipe(&artifact, format_args!("{error}"));
                 continue;
@@ -472,18 +491,40 @@ fn runtime_recipe_without_columns(spec: &RecipeSpec) -> RecipeRuntimeDefinition 
     runtime_recipe_with_result_columns(spec, Vec::new())
 }
 
-async fn infer_runtime_recipe(
+async fn validate_runtime_recipe(
     selected_sources: &[QuerySource],
     runtime_config: QueryRuntimeConfig,
     spec: &RecipeSpec,
 ) -> Result<RecipeRuntimeDefinition, AppError> {
     let runtime_recipe = runtime_recipe_without_columns(spec);
-    let schema = CoralQuery::infer_recipe_schema(selected_sources, runtime_config, runtime_recipe)
-        .await
-        .map_err(|error| {
-            AppError::FailedPrecondition(format!("recipe failed runtime validation: {error}"))
-        })?;
+    let schema = CoralQuery::validate_recipe(
+        selected_sources,
+        runtime_config,
+        runtime_recipe,
+        runtime_validation_arguments(spec),
+    )
+    .await
+    .map_err(|error| {
+        AppError::FailedPrecondition(format!("recipe failed runtime validation: {error}"))
+    })?;
     Ok(runtime_recipe_with_schema(spec, schema.as_ref()))
+}
+
+fn runtime_validation_arguments(spec: &RecipeSpec) -> BTreeMap<String, RecipeRuntimeArgumentValue> {
+    spec.validation()
+        .args
+        .iter()
+        .map(|(name, value)| (name.clone(), runtime_validation_argument_value(value)))
+        .collect()
+}
+
+fn runtime_validation_argument_value(value: &RecipeValidationValue) -> RecipeRuntimeArgumentValue {
+    match value {
+        RecipeValidationValue::String(value) => RecipeRuntimeArgumentValue::String(value.clone()),
+        RecipeValidationValue::Integer(value) => RecipeRuntimeArgumentValue::Integer(*value),
+        RecipeValidationValue::Boolean(value) => RecipeRuntimeArgumentValue::Boolean(*value),
+        RecipeValidationValue::Null(()) => RecipeRuntimeArgumentValue::Null,
+    }
 }
 
 fn runtime_recipe_with_schema(
@@ -541,22 +582,14 @@ fn runtime_implementation(spec: &RecipeImplementationSpec) -> RecipeRuntimeImple
     }
 }
 
-fn runtime_publish(specs: &[RecipePublishSpec]) -> Vec<RecipeRuntimePublish> {
-    specs
-        .iter()
-        .filter_map(|spec| match spec {
-            RecipePublishSpec::TableFunction {
-                schema,
-                name,
-                description,
-            } => Some(RecipeRuntimePublish::TableFunction {
-                schema: schema.clone(),
-                name: name.clone(),
-                description: description.clone(),
-            }),
-            RecipePublishSpec::McpTool { .. } => None,
-        })
-        .collect()
+fn runtime_publish(spec: &RecipePublishSpec) -> RecipeRuntimePublish {
+    RecipeRuntimePublish {
+        table_function: RecipeRuntimeTableFunctionPublish {
+            schema: spec.table_function.schema.clone(),
+            name: spec.table_function.name.clone(),
+            description: spec.table_function.description.clone(),
+        },
+    }
 }
 
 fn record_publish_targets(
@@ -564,18 +597,15 @@ fn record_publish_targets(
     publish_targets: &mut HashSet<PublishTarget>,
 ) -> Result<(), AppError> {
     let mut recipe_targets = HashSet::new();
-    for publish in &recipe.publish {
-        let target = match publish {
-            RecipeRuntimePublish::TableFunction { schema, name, .. } => {
-                PublishTarget::sql_relation(schema, name)
-            }
-        };
-        if publish_targets.contains(&target) || !recipe_targets.insert(target.clone()) {
-            return Err(AppError::FailedPrecondition(format!(
-                "recipe publish target '{}' is installed more than once",
-                target.display_name()
-            )));
-        }
+    let target = PublishTarget::sql_relation(
+        &recipe.publish.table_function.schema,
+        &recipe.publish.table_function.name,
+    );
+    if publish_targets.contains(&target) || !recipe_targets.insert(target.clone()) {
+        return Err(AppError::FailedPrecondition(format!(
+            "recipe publish target '{}' is installed more than once",
+            target.display_name()
+        )));
     }
     publish_targets.extend(recipe_targets);
     Ok(())
@@ -611,10 +641,15 @@ fn origin_sort_key(origin: RecipeOrigin) -> u8 {
 fn write_recipe_runtime_metadata(
     recipe_runtime_file: &std::path::Path,
     runtime_recipe: Option<&RecipeRuntimeDefinition>,
+    validation_arguments: &BTreeMap<String, RecipeRuntimeArgumentValue>,
 ) -> Result<(), AppError> {
     if let Some(runtime_recipe) = runtime_recipe {
         let metadata = RecipeRuntimeMetadata {
             version: 1,
+            validation_args: validation_arguments
+                .iter()
+                .map(|(name, value)| (name.clone(), CachedRecipeArgumentValue::from(value)))
+                .collect(),
             result_columns: runtime_recipe
                 .result_columns
                 .iter()
@@ -712,6 +747,9 @@ mod tests {
     }
 
     fn recipe_yaml_with_publish(name: &str, publish_target: &str) -> String {
+        let (schema, function) = publish_target
+            .split_once('.')
+            .expect("publish target should be schema.name");
         format!(
             r"
 kind: recipe
@@ -720,19 +758,44 @@ implementation:
   kind: coral_sql
   query: select 1 as id
 publish:
-  - table_function: {publish_target}
+  table_function:
+    schema: {schema}
+    name: {function}
 "
         )
     }
 
+    fn validated_recipe(raw_yaml: &str) -> RecipeRuntimeDefinition {
+        let spec = parse_recipe_yaml(raw_yaml).expect("recipe spec");
+        runtime_recipe_with_result_columns(
+            &spec,
+            vec![RecipeRuntimeResultColumn {
+                name: "id".to_string(),
+                data_type: "Int64".to_string(),
+                nullable: false,
+                description: String::new(),
+            }],
+        )
+    }
+
+    fn install_fixture_recipe(
+        manager: &RecipeManager,
+        workspace: &WorkspaceName,
+        raw_yaml: &str,
+    ) -> InstalledRecipe {
+        let runtime_recipe = validated_recipe(raw_yaml);
+        manager
+            .install_validated_user_recipe(workspace, raw_yaml, &runtime_recipe)
+            .expect("install recipe")
+    }
+
     #[test]
-    fn install_user_recipe_persists_yaml_and_config() {
+    fn install_validated_user_recipe_persists_yaml_and_config() {
         let (_temp, layout, manager) = fixture();
         let workspace = workspace();
+        let raw_yaml = recipe_yaml("review_queue");
 
-        let installed = manager
-            .install_user_recipe(&workspace, &recipe_yaml("review_queue"))
-            .expect("install recipe");
+        let installed = install_fixture_recipe(&manager, &workspace, &raw_yaml);
 
         assert_eq!(installed.name.as_str(), "review_queue");
         assert_eq!(installed.origin, RecipeOrigin::User);
@@ -791,9 +854,8 @@ publish:
     fn remove_user_recipe_removes_yaml_and_config() {
         let (_temp, layout, manager) = fixture();
         let workspace = workspace();
-        manager
-            .install_user_recipe(&workspace, &recipe_yaml("review_queue"))
-            .expect("install recipe");
+        let raw_yaml = recipe_yaml("review_queue");
+        install_fixture_recipe(&manager, &workspace, &raw_yaml);
         let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
 
         manager
@@ -834,10 +896,12 @@ publish:
     async fn validate_user_recipe_yaml_rejects_installed_publish_collision() {
         let (_temp, _layout, manager) = fixture();
         let workspace = workspace();
+        let existing_yaml = recipe_yaml_with_publish("existing_queue", "recipes.shared_queue");
         manager
-            .install_user_recipe(
+            .install_validated_user_recipe(
                 &workspace,
-                &recipe_yaml_with_publish("existing_queue", "recipes.shared_queue"),
+                &existing_yaml,
+                &validated_recipe(&existing_yaml),
             )
             .expect("install existing recipe");
 

--- a/crates/coral-app/src/recipes/manager.rs
+++ b/crates/coral-app/src/recipes/manager.rs
@@ -5,9 +5,17 @@
     reason = "recipe manager is exposed through API/CLI surfaces in later stack branches"
 )]
 
+use std::collections::HashSet;
 use std::io::ErrorKind;
 
-use coral_spec::parse_recipe_yaml;
+use coral_engine::{
+    CoralQuery, QueryRuntimeConfig, QuerySource, RecipeRuntimeArgument, RecipeRuntimeArgumentType,
+    RecipeRuntimeDefinition, RecipeRuntimeImplementation, RecipeRuntimePublish,
+    RecipeRuntimeResultColumn,
+};
+use coral_spec::{
+    RecipeArgumentType, RecipeImplementationSpec, RecipePublishSpec, RecipeSpec, parse_recipe_yaml,
+};
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
@@ -66,6 +74,25 @@ impl RecipeManager {
         Ok(installed)
     }
 
+    pub(crate) async fn validate_user_recipe_yaml(
+        &self,
+        _workspace_name: &WorkspaceName,
+        selected_sources: &[QuerySource],
+        mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
+        raw_yaml: &str,
+    ) -> Result<RecipeRuntimeDefinition, AppError> {
+        let spec = parse_recipe_yaml(raw_yaml).map_err(|error| {
+            AppError::InvalidInput(format!("recipe validation failed: {error}"))
+        })?;
+        RecipeName::parse(spec.name())?;
+        let mut publish_targets =
+            source_publish_targets(selected_sources, runtime_config()?).await?;
+        let runtime_recipe =
+            infer_runtime_recipe(selected_sources, runtime_config()?, &spec).await?;
+        record_publish_targets(&runtime_recipe, &mut publish_targets)?;
+        Ok(runtime_recipe)
+    }
+
     pub(crate) fn list_user_recipes(
         &self,
         workspace_name: &WorkspaceName,
@@ -115,6 +142,160 @@ impl RecipeManager {
             std::fs::remove_dir_all(&recipe_dir_backup)?;
         }
         Ok(())
+    }
+}
+
+async fn source_publish_targets(
+    selected_sources: &[QuerySource],
+    runtime_config: QueryRuntimeConfig,
+) -> Result<HashSet<PublishTarget>, AppError> {
+    let catalog = CoralQuery::list_catalog(selected_sources, runtime_config, None)
+        .await
+        .map_err(|error| {
+            AppError::FailedPrecondition(format!(
+                "failed to inspect installed source catalog for recipe publish collisions: {error}"
+            ))
+        })?;
+    let mut targets = HashSet::new();
+    targets.extend(
+        catalog
+            .tables
+            .into_iter()
+            .map(|table| PublishTarget::sql_relation(&table.schema_name, &table.table_name)),
+    );
+    targets.extend(catalog.table_functions.into_iter().map(|function| {
+        PublishTarget::sql_relation(&function.schema_name, &function.function_name)
+    }));
+    Ok(targets)
+}
+
+fn runtime_recipe_without_columns(spec: &RecipeSpec) -> RecipeRuntimeDefinition {
+    runtime_recipe_with_result_columns(spec, Vec::new())
+}
+
+async fn infer_runtime_recipe(
+    selected_sources: &[QuerySource],
+    runtime_config: QueryRuntimeConfig,
+    spec: &RecipeSpec,
+) -> Result<RecipeRuntimeDefinition, AppError> {
+    let runtime_recipe = runtime_recipe_without_columns(spec);
+    let schema = CoralQuery::infer_recipe_schema(selected_sources, runtime_config, runtime_recipe)
+        .await
+        .map_err(|error| {
+            AppError::FailedPrecondition(format!("recipe failed runtime validation: {error}"))
+        })?;
+    Ok(runtime_recipe_with_schema(spec, schema.as_ref()))
+}
+
+fn runtime_recipe_with_schema(
+    spec: &RecipeSpec,
+    schema: &arrow::datatypes::Schema,
+) -> RecipeRuntimeDefinition {
+    let result_columns = schema
+        .fields()
+        .iter()
+        .map(|field| RecipeRuntimeResultColumn {
+            name: field.name().clone(),
+            data_type: field.data_type().to_string(),
+            nullable: field.is_nullable(),
+            description: String::new(),
+        })
+        .collect();
+    runtime_recipe_with_result_columns(spec, result_columns)
+}
+
+fn runtime_recipe_with_result_columns(
+    spec: &RecipeSpec,
+    result_columns: Vec<RecipeRuntimeResultColumn>,
+) -> RecipeRuntimeDefinition {
+    RecipeRuntimeDefinition {
+        name: spec.name().to_string(),
+        description: spec.description().to_string(),
+        arguments: runtime_arguments(spec),
+        implementation: runtime_implementation(spec.implementation()),
+        publish: runtime_publish(spec.publish()),
+        result_columns,
+    }
+}
+
+fn runtime_arguments(spec: &RecipeSpec) -> Vec<RecipeRuntimeArgument> {
+    spec.arguments()
+        .iter()
+        .map(|argument| RecipeRuntimeArgument {
+            name: argument.name.clone(),
+            data_type: match argument.data_type {
+                RecipeArgumentType::String => RecipeRuntimeArgumentType::String,
+                RecipeArgumentType::Integer => RecipeRuntimeArgumentType::Integer,
+                RecipeArgumentType::Boolean => RecipeRuntimeArgumentType::Boolean,
+            },
+            required: argument.required,
+            description: argument.description.clone(),
+        })
+        .collect()
+}
+
+fn runtime_implementation(spec: &RecipeImplementationSpec) -> RecipeRuntimeImplementation {
+    match spec {
+        RecipeImplementationSpec::CoralSql { query } => RecipeRuntimeImplementation::CoralSql {
+            query: query.clone(),
+        },
+    }
+}
+
+fn runtime_publish(specs: &[RecipePublishSpec]) -> Vec<RecipeRuntimePublish> {
+    specs
+        .iter()
+        .filter_map(|spec| match spec {
+            RecipePublishSpec::TableFunction {
+                schema,
+                name,
+                description,
+            } => Some(RecipeRuntimePublish::TableFunction {
+                schema: schema.clone(),
+                name: name.clone(),
+                description: description.clone(),
+            }),
+            RecipePublishSpec::McpTool { .. } => None,
+        })
+        .collect()
+}
+
+fn record_publish_targets(
+    recipe: &RecipeRuntimeDefinition,
+    publish_targets: &mut HashSet<PublishTarget>,
+) -> Result<(), AppError> {
+    let mut recipe_targets = HashSet::new();
+    for publish in &recipe.publish {
+        let RecipeRuntimePublish::TableFunction { schema, name, .. } = publish;
+        let target = PublishTarget::sql_relation(schema, name);
+        if publish_targets.contains(&target) || !recipe_targets.insert(target.clone()) {
+            return Err(AppError::FailedPrecondition(format!(
+                "recipe publish target '{}' is installed more than once",
+                target.display_name()
+            )));
+        }
+    }
+    publish_targets.extend(recipe_targets);
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum PublishTarget {
+    SqlRelation { schema: String, name: String },
+}
+
+impl PublishTarget {
+    fn sql_relation(schema: &str, name: &str) -> Self {
+        Self::SqlRelation {
+            schema: schema.to_ascii_lowercase(),
+            name: name.to_ascii_lowercase(),
+        }
+    }
+
+    fn display_name(&self) -> String {
+        match self {
+            Self::SqlRelation { schema, name } => format!("{schema}.{name}"),
+        }
     }
 }
 
@@ -228,5 +409,26 @@ publish:
                 .expect("list recipes")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn validate_user_recipe_yaml_infers_result_columns() {
+        let (_temp, _layout, manager) = fixture();
+        let workspace = workspace();
+
+        let recipe = manager
+            .validate_user_recipe_yaml(
+                &workspace,
+                &[],
+                || Ok(QueryRuntimeConfig::default()),
+                &recipe_yaml("review_queue"),
+            )
+            .await
+            .expect("validate recipe");
+
+        assert_eq!(recipe.name, "review_queue");
+        assert_eq!(recipe.result_columns.len(), 1);
+        let column = recipe.result_columns.first().expect("id result column");
+        assert_eq!(column.name, "id");
     }
 }

--- a/crates/coral-app/src/recipes/manager.rs
+++ b/crates/coral-app/src/recipes/manager.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
 use crate::bootstrap::AppError;
-use crate::recipes::model::{InstalledRecipe, RecipeName, RecipeOrigin};
+use crate::recipes::model::{InstalledRecipe, RecipeName};
 use crate::recipes::storage::{
     ConfigRecipeRegistry, FsRecipeArtifactStore, RecipeArtifactStore, RecipeRegistry,
 };
@@ -35,8 +35,6 @@ pub(crate) struct RecipeManager {
 
 struct RecipeArtifact {
     name: RecipeName,
-    origin: RecipeOrigin,
-    enabled: bool,
     raw_yaml: String,
 }
 
@@ -44,10 +42,6 @@ struct RecipeArtifact {
 pub(crate) struct RecipeListing {
     /// Runtime definition for the recipe.
     pub(crate) definition: RecipeRuntimeDefinition,
-    /// Where this installed recipe came from.
-    pub(crate) origin: RecipeOrigin,
-    /// Whether this recipe participates in runtime publication.
-    pub(crate) enabled: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -150,7 +144,7 @@ impl RecipeManager {
             workspace_name,
             &recipe_name,
             raw_yaml,
-            Some(runtime_recipe),
+            runtime_recipe,
             &validation_arguments,
         )
     }
@@ -160,13 +154,11 @@ impl RecipeManager {
         workspace_name: &WorkspaceName,
         recipe_name: &RecipeName,
         raw_yaml: &str,
-        runtime_recipe: Option<&RecipeRuntimeDefinition>,
+        runtime_recipe: &RecipeRuntimeDefinition,
         validation_arguments: &BTreeMap<String, RecipeRuntimeArgumentValue>,
     ) -> Result<InstalledRecipe, AppError> {
         let installed = InstalledRecipe {
             name: recipe_name.clone(),
-            origin: RecipeOrigin::User,
-            enabled: true,
         };
 
         let runtime_metadata =
@@ -175,7 +167,7 @@ impl RecipeManager {
             workspace_name,
             recipe_name,
             raw_yaml,
-            runtime_metadata.as_deref(),
+            &runtime_metadata,
         )?;
         if let Err(error) = self
             .registry
@@ -225,7 +217,7 @@ impl RecipeManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<RecipeListing>, AppError> {
-        let artifacts = self.load_recipe_artifacts(workspace_name, RecipeArtifactFilter::All)?;
+        let artifacts = self.load_recipe_artifacts(workspace_name)?;
         let mut seen_names = HashSet::new();
         let mut recipes = Vec::new();
         for artifact in artifacts {
@@ -244,19 +236,13 @@ impl RecipeManager {
                 }
             };
             let mut recipe = runtime_recipe_without_columns(&spec);
-            if artifact.origin == RecipeOrigin::User {
-                recipe.result_columns = self.cached_recipe_result_columns(
-                    workspace_name,
-                    &artifact.name,
-                    &artifact.raw_yaml,
-                    &runtime_validation_arguments(&spec),
-                );
-            }
-            recipes.push(RecipeListing {
-                definition: recipe,
-                origin: artifact.origin,
-                enabled: artifact.enabled,
-            });
+            recipe.result_columns = self.cached_recipe_result_columns(
+                workspace_name,
+                &artifact.name,
+                &artifact.raw_yaml,
+                &runtime_validation_arguments(&spec),
+            );
+            recipes.push(RecipeListing { definition: recipe });
         }
         Ok(recipes)
     }
@@ -266,8 +252,7 @@ impl RecipeManager {
         workspace_name: &WorkspaceName,
         selected_sources: &[QuerySource],
     ) -> Result<Vec<RecipeRuntimeDefinition>, AppError> {
-        let artifacts =
-            self.load_recipe_artifacts(workspace_name, RecipeArtifactFilter::EnabledOnly)?;
+        let artifacts = self.load_recipe_artifacts(workspace_name)?;
         if artifacts.is_empty() {
             return Ok(Vec::new());
         }
@@ -291,14 +276,12 @@ impl RecipeManager {
                 }
             };
             let mut runtime_recipe = runtime_recipe_without_columns(&spec);
-            if artifact.origin == RecipeOrigin::User {
-                runtime_recipe.result_columns = self.cached_recipe_result_columns(
-                    workspace_name,
-                    &artifact.name,
-                    &artifact.raw_yaml,
-                    &runtime_validation_arguments(&spec),
-                );
-            }
+            runtime_recipe.result_columns = self.cached_recipe_result_columns(
+                workspace_name,
+                &artifact.name,
+                &artifact.raw_yaml,
+                &runtime_validation_arguments(&spec),
+            );
             if runtime_recipe.result_columns.is_empty() {
                 skip_recipe(
                     &artifact,
@@ -320,12 +303,7 @@ impl RecipeManager {
         workspace_name: &WorkspaceName,
         recipe_name: &RecipeName,
     ) -> Result<(), AppError> {
-        let installed = self.registry.get_recipe(workspace_name, recipe_name)?;
-        if installed.origin != RecipeOrigin::User {
-            return Err(AppError::InvalidInput(format!(
-                "recipe '{recipe_name}' is bundled and cannot be removed from workspace config"
-            )));
-        }
+        self.registry.get_recipe(workspace_name, recipe_name)?;
         let removed_artifact = self
             .artifacts
             .remove_user_recipe_artifact(workspace_name, recipe_name)?;
@@ -347,13 +325,9 @@ impl RecipeManager {
     fn load_recipe_artifacts(
         &self,
         workspace_name: &WorkspaceName,
-        filter: RecipeArtifactFilter,
     ) -> Result<Vec<RecipeArtifact>, AppError> {
         let mut artifacts = Vec::new();
         for installed in self.registry.list_workspace_recipes(workspace_name)? {
-            if filter == RecipeArtifactFilter::EnabledOnly && !installed.enabled {
-                continue;
-            }
             let raw_yaml = match self
                 .artifacts
                 .read_recipe_yaml(workspace_name, &installed.name)
@@ -377,16 +351,11 @@ impl RecipeManager {
             };
             artifacts.push(RecipeArtifact {
                 name: installed.name,
-                origin: installed.origin,
-                enabled: installed.enabled,
                 raw_yaml,
             });
         }
 
-        artifacts.sort_by(|left, right| {
-            (origin_sort_key(left.origin), left.name.as_str())
-                .cmp(&(origin_sort_key(right.origin), right.name.as_str()))
-        });
+        artifacts.sort_by(|left, right| left.name.as_str().cmp(right.name.as_str()));
         Ok(artifacts)
     }
 
@@ -397,7 +366,7 @@ impl RecipeManager {
         publish_targets: &mut HashSet<PublishTarget>,
     ) -> Result<(), AppError> {
         let mut seen_names = HashSet::new();
-        for artifact in self.load_recipe_artifacts(workspace_name, RecipeArtifactFilter::All)? {
+        for artifact in self.load_recipe_artifacts(workspace_name)? {
             if artifact.name == *replacing_recipe {
                 continue;
             }
@@ -406,9 +375,6 @@ impl RecipeManager {
                     "recipe '{}' is installed more than once",
                     artifact.name
                 )));
-            }
-            if !artifact.enabled {
-                continue;
             }
             let spec = parse_recipe_yaml(&artifact.raw_yaml).map_err(|error| {
                 AppError::FailedPrecondition(format!(
@@ -489,16 +455,9 @@ impl RecipeManager {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RecipeArtifactFilter {
-    All,
-    EnabledOnly,
-}
-
 fn skip_recipe(artifact: &RecipeArtifact, detail: fmt::Arguments<'_>) {
     tracing::warn!(
         recipe = %artifact.name,
-        origin = ?artifact.origin,
         detail = %detail,
         "skipping recipe during runtime publication"
     );
@@ -667,18 +626,16 @@ fn record_publish_targets(
     recipe: &RecipeRuntimeDefinition,
     publish_targets: &mut HashSet<PublishTarget>,
 ) -> Result<(), AppError> {
-    let mut recipe_targets = HashSet::new();
     let target = PublishTarget::sql_relation(
         &recipe.publish.table_function.schema,
         &recipe.publish.table_function.name,
     );
-    if publish_targets.contains(&target) || !recipe_targets.insert(target.clone()) {
+    if !publish_targets.insert(target.clone()) {
         return Err(AppError::FailedPrecondition(format!(
             "recipe publish target '{}' is installed more than once",
             target.display_name()
         )));
     }
-    publish_targets.extend(recipe_targets);
     Ok(())
 }
 
@@ -702,34 +659,22 @@ impl PublishTarget {
     }
 }
 
-fn origin_sort_key(origin: RecipeOrigin) -> u8 {
-    match origin {
-        RecipeOrigin::Bundled => 0,
-        RecipeOrigin::User => 1,
-    }
-}
-
 fn encode_recipe_runtime_metadata(
-    runtime_recipe: Option<&RecipeRuntimeDefinition>,
+    runtime_recipe: &RecipeRuntimeDefinition,
     raw_yaml: &str,
     validation_arguments: &BTreeMap<String, RecipeRuntimeArgumentValue>,
-) -> Result<Option<Vec<u8>>, AppError> {
-    if let Some(runtime_recipe) = runtime_recipe {
-        let metadata = RecipeRuntimeMetadata {
-            version: RECIPE_RUNTIME_METADATA_VERSION,
-            recipe_yaml_sha256: sha256_hex(raw_yaml.as_bytes()),
-            validation_args: cached_validation_arguments(validation_arguments),
-            result_columns: runtime_recipe
-                .result_columns
-                .iter()
-                .map(CachedRecipeResultColumn::from)
-                .collect(),
-        };
-        let raw = serde_json::to_vec_pretty(&metadata)?;
-        Ok(Some(raw))
-    } else {
-        Ok(None)
-    }
+) -> Result<Vec<u8>, AppError> {
+    let metadata = RecipeRuntimeMetadata {
+        version: RECIPE_RUNTIME_METADATA_VERSION,
+        recipe_yaml_sha256: sha256_hex(raw_yaml.as_bytes()),
+        validation_args: cached_validation_arguments(validation_arguments),
+        result_columns: runtime_recipe
+            .result_columns
+            .iter()
+            .map(CachedRecipeResultColumn::from)
+            .collect(),
+    };
+    serde_json::to_vec_pretty(&metadata).map_err(AppError::from)
 }
 
 fn cached_validation_arguments(
@@ -839,72 +784,6 @@ publish:
     }
 
     #[test]
-    fn install_validated_user_recipe_persists_yaml_and_config() {
-        let (_temp, layout, config_store, manager) = fixture();
-        let workspace = workspace();
-        let raw_yaml = recipe_yaml("review_queue");
-
-        let installed = install_fixture_recipe(&manager, &workspace, &raw_yaml);
-
-        assert_eq!(installed.name.as_str(), "review_queue");
-        assert_eq!(installed.origin, RecipeOrigin::User);
-        assert!(installed.enabled);
-
-        let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
-        let raw = std::fs::read_to_string(layout.recipe_file(&workspace, &recipe_name))
-            .expect("recipe file");
-        assert!(raw.contains("name: review_queue"));
-        assert_eq!(
-            config_store
-                .list_workspace_recipes(&workspace)
-                .expect("list recipes")
-                .into_iter()
-                .filter(|recipe| recipe.origin == RecipeOrigin::User)
-                .count(),
-            1
-        );
-    }
-
-    #[tokio::test]
-    async fn install_validated_user_recipe_caches_result_columns_for_list() {
-        let (_temp, layout, _config_store, manager) = fixture();
-        let workspace = workspace();
-        let raw_yaml = recipe_yaml("review_queue");
-        let runtime_recipe = manager
-            .validate_user_recipe_yaml(
-                &workspace,
-                &[],
-                || Ok(QueryRuntimeConfig::default()),
-                &raw_yaml,
-            )
-            .await
-            .expect("validate recipe");
-
-        manager
-            .install_validated_user_recipe(&workspace, &raw_yaml, &runtime_recipe)
-            .expect("install validated recipe");
-
-        let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
-        assert!(
-            layout
-                .recipe_runtime_file(&workspace, &recipe_name)
-                .exists()
-        );
-        let listed = manager.list_recipes(&workspace).expect("list recipes");
-        assert_eq!(listed.len(), 1);
-        let listed_recipe = listed.first().expect("listed recipe");
-        assert_eq!(listed_recipe.origin, RecipeOrigin::User);
-        assert!(listed_recipe.enabled);
-        assert_eq!(listed_recipe.definition.result_columns.len(), 1);
-        let column = listed_recipe
-            .definition
-            .result_columns
-            .first()
-            .expect("id result column");
-        assert_eq!(column.name, "id");
-    }
-
-    #[test]
     fn list_recipes_ignores_cached_columns_when_validation_args_change() {
         let (_temp, layout, _config_store, manager) = fixture();
         let workspace = workspace();
@@ -981,49 +860,6 @@ publish:
         );
     }
 
-    #[test]
-    fn remove_user_recipe_removes_yaml_and_config() {
-        let (_temp, layout, config_store, manager) = fixture();
-        let workspace = workspace();
-        let raw_yaml = recipe_yaml("review_queue");
-        install_fixture_recipe(&manager, &workspace, &raw_yaml);
-        let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
-
-        manager
-            .remove_user_recipe(&workspace, &recipe_name)
-            .expect("remove recipe");
-
-        assert!(!layout.recipe_dir(&workspace, &recipe_name).exists());
-        let user_recipe_count = config_store
-            .list_workspace_recipes(&workspace)
-            .expect("list recipes")
-            .into_iter()
-            .filter(|recipe| recipe.origin == RecipeOrigin::User)
-            .count();
-        assert_eq!(user_recipe_count, 0);
-    }
-
-    #[tokio::test]
-    async fn validate_user_recipe_yaml_infers_result_columns() {
-        let (_temp, _layout, _config_store, manager) = fixture();
-        let workspace = workspace();
-
-        let recipe = manager
-            .validate_user_recipe_yaml(
-                &workspace,
-                &[],
-                || Ok(QueryRuntimeConfig::default()),
-                &recipe_yaml("review_queue"),
-            )
-            .await
-            .expect("validate recipe");
-
-        assert_eq!(recipe.name, "review_queue");
-        assert_eq!(recipe.result_columns.len(), 1);
-        let column = recipe.result_columns.first().expect("id result column");
-        assert_eq!(column.name, "id");
-    }
-
     #[tokio::test]
     async fn validate_user_recipe_yaml_rejects_installed_publish_collision() {
         let (_temp, _layout, _config_store, manager) = fixture();
@@ -1053,38 +889,6 @@ publish:
         ));
     }
 
-    #[tokio::test]
-    async fn validate_user_recipe_yaml_ignores_disabled_publish_collision() {
-        let (_temp, layout, config_store, manager) = fixture();
-        let workspace = workspace();
-        let recipe_name = RecipeName::parse("existing_queue").expect("recipe name");
-        let existing_yaml = recipe_yaml_with_publish("existing_queue", "recipes.shared_queue");
-        let recipe_dir = layout.recipe_dir(&workspace, &recipe_name);
-        fs::ensure_private_dir(&recipe_dir).expect("recipe dir");
-        std::fs::write(layout.recipe_file(&workspace, &recipe_name), existing_yaml)
-            .expect("recipe yaml");
-        config_store
-            .upsert_recipe(
-                &workspace,
-                InstalledRecipe {
-                    name: recipe_name,
-                    origin: RecipeOrigin::User,
-                    enabled: false,
-                },
-            )
-            .expect("disabled installed recipe");
-
-        manager
-            .validate_user_recipe_yaml(
-                &workspace,
-                &[],
-                || Ok(QueryRuntimeConfig::default()),
-                &recipe_yaml_with_publish("new_queue", "recipes.shared_queue"),
-            )
-            .await
-            .expect("disabled recipe should not reserve publish target");
-    }
-
     #[test]
     fn artifact_restore_removes_new_yaml_when_only_runtime_metadata_existed() {
         let (_temp, layout, _config_store, _manager) = fixture();
@@ -1097,7 +901,7 @@ publish:
         std::fs::write(&recipe_runtime_file, b"previous runtime").expect("previous runtime");
         let store = FsRecipeArtifactStore::new(layout.clone());
         let previous = store
-            .write_user_recipe_artifact(&workspace, &recipe_name, "new yaml", None)
+            .write_user_recipe_artifact(&workspace, &recipe_name, "new yaml", b"new runtime")
             .expect("write new artifact");
 
         store

--- a/crates/coral-app/src/recipes/manager.rs
+++ b/crates/coral-app/src/recipes/manager.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 use std::fmt;
-use std::io::ErrorKind;
+use std::sync::Arc;
 
 use coral_engine::{
     CoralQuery, QueryRuntimeConfig, QuerySource, RecipeRuntimeArgument, RecipeRuntimeArgumentType,
@@ -15,20 +15,22 @@ use coral_spec::{
     RecipeValidationValue, parse_recipe_yaml,
 };
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
+use sha2::{Digest as _, Sha256};
 
 use crate::bootstrap::AppError;
 use crate::recipes::model::{InstalledRecipe, RecipeName, RecipeOrigin};
+use crate::recipes::storage::{
+    ConfigRecipeRegistry, FsRecipeArtifactStore, RecipeArtifactStore, RecipeRegistry,
+};
 use crate::state::{AppStateLayout, ConfigStore};
-use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 
-const RECIPE_RUNTIME_METADATA_VERSION: u32 = 1;
+const RECIPE_RUNTIME_METADATA_VERSION: u32 = 2;
 
 #[derive(Clone)]
 pub(crate) struct RecipeManager {
-    config_store: ConfigStore,
-    layout: AppStateLayout,
+    registry: Arc<dyn RecipeRegistry>,
+    artifacts: Arc<dyn RecipeArtifactStore>,
 }
 
 struct RecipeArtifact {
@@ -51,6 +53,8 @@ pub(crate) struct RecipeListing {
 #[derive(Debug, Serialize, Deserialize)]
 struct RecipeRuntimeMetadata {
     version: u32,
+    #[serde(default)]
+    recipe_yaml_sha256: String,
     #[serde(default)]
     validation_args: BTreeMap<String, CachedRecipeArgumentValue>,
     result_columns: Vec<CachedRecipeResultColumn>,
@@ -109,9 +113,19 @@ impl From<CachedRecipeResultColumn> for RecipeRuntimeResultColumn {
 
 impl RecipeManager {
     pub(crate) fn new(config_store: ConfigStore, layout: AppStateLayout) -> Self {
+        Self::with_stores(
+            Arc::new(ConfigRecipeRegistry::new(config_store)),
+            Arc::new(FsRecipeArtifactStore::new(layout)),
+        )
+    }
+
+    pub(crate) fn with_stores(
+        registry: Arc<dyn RecipeRegistry>,
+        artifacts: Arc<dyn RecipeArtifactStore>,
+    ) -> Self {
         Self {
-            config_store,
-            layout,
+            registry,
+            artifacts,
         }
     }
 
@@ -155,47 +169,29 @@ impl RecipeManager {
             enabled: true,
         };
 
-        let recipe_dir = self.layout.recipe_dir(workspace_name, recipe_name);
-        let recipe_file = self.layout.recipe_file(workspace_name, recipe_name);
-        let recipe_runtime_file = self.layout.recipe_runtime_file(workspace_name, recipe_name);
-        let previous_yaml = match std::fs::read(&recipe_file) {
-            Ok(bytes) => Some(bytes),
-            Err(error) if error.kind() == ErrorKind::NotFound => None,
-            Err(error) => return Err(error.into()),
-        };
-        let previous_runtime = match std::fs::read(&recipe_runtime_file) {
-            Ok(bytes) => Some(bytes),
-            Err(error) if error.kind() == ErrorKind::NotFound => None,
-            Err(error) => return Err(error.into()),
-        };
-
-        fs::ensure_private_dir(&recipe_dir)?;
-        fs::write_atomic(&recipe_file, raw_yaml.as_bytes())?;
-        if let Err(error) = write_recipe_runtime_metadata(
-            &recipe_runtime_file,
-            runtime_recipe,
-            validation_arguments,
-        ) {
-            rollback_recipe_install(
-                &recipe_dir,
-                &recipe_file,
-                previous_yaml.as_deref(),
-                &recipe_runtime_file,
-                previous_runtime.as_deref(),
-            );
-            return Err(error);
-        }
+        let runtime_metadata =
+            encode_recipe_runtime_metadata(runtime_recipe, raw_yaml, validation_arguments)?;
+        let previous_artifact = self.artifacts.write_user_recipe_artifact(
+            workspace_name,
+            recipe_name,
+            raw_yaml,
+            runtime_metadata.as_deref(),
+        )?;
         if let Err(error) = self
-            .config_store
+            .registry
             .upsert_recipe(workspace_name, installed.clone())
         {
-            rollback_recipe_install(
-                &recipe_dir,
-                &recipe_file,
-                previous_yaml.as_deref(),
-                &recipe_runtime_file,
-                previous_runtime.as_deref(),
-            );
+            if let Err(restore_error) = self.artifacts.restore_user_recipe_artifact(
+                workspace_name,
+                recipe_name,
+                &previous_artifact,
+            ) {
+                tracing::warn!(
+                    recipe = %recipe_name,
+                    detail = %restore_error,
+                    "failed to restore previous recipe artifact after inventory update failure"
+                );
+            }
             return Err(error);
         }
 
@@ -252,6 +248,7 @@ impl RecipeManager {
                 recipe.result_columns = self.cached_recipe_result_columns(
                     workspace_name,
                     &artifact.name,
+                    &artifact.raw_yaml,
                     &runtime_validation_arguments(&spec),
                 );
             }
@@ -298,6 +295,7 @@ impl RecipeManager {
                 runtime_recipe.result_columns = self.cached_recipe_result_columns(
                     workspace_name,
                     &artifact.name,
+                    &artifact.raw_yaml,
                     &runtime_validation_arguments(&spec),
                 );
             }
@@ -322,36 +320,26 @@ impl RecipeManager {
         workspace_name: &WorkspaceName,
         recipe_name: &RecipeName,
     ) -> Result<(), AppError> {
-        let installed = self.config_store.get_recipe(workspace_name, recipe_name)?;
+        let installed = self.registry.get_recipe(workspace_name, recipe_name)?;
         if installed.origin != RecipeOrigin::User {
             return Err(AppError::InvalidInput(format!(
                 "recipe '{recipe_name}' is bundled and cannot be removed from workspace config"
             )));
         }
-        let recipe_dir = self.layout.recipe_dir(workspace_name, recipe_name);
-        let recipe_dir_backup =
-            recipe_dir.with_file_name(format!("{recipe_name}.delete.rollback.{}", Uuid::new_v4()));
-        let had_recipe_dir = recipe_dir.exists();
-        if had_recipe_dir {
-            if recipe_dir_backup.exists() {
-                std::fs::remove_dir_all(&recipe_dir_backup)?;
-            }
-            std::fs::rename(&recipe_dir, &recipe_dir_backup)?;
-        }
-        if let Err(error) = self.config_store.remove_recipe(workspace_name, recipe_name) {
-            if had_recipe_dir
-                && recipe_dir_backup.exists()
-                && let Err(restore_error) = std::fs::rename(&recipe_dir_backup, &recipe_dir)
-            {
+        let removed_artifact = self
+            .artifacts
+            .remove_user_recipe_artifact(workspace_name, recipe_name)?;
+        if let Err(error) = self.registry.remove_recipe(workspace_name, recipe_name) {
+            if let Err(restore_error) = self.artifacts.restore_user_recipe_artifact(
+                workspace_name,
+                recipe_name,
+                &removed_artifact,
+            ) {
                 return Err(AppError::FailedPrecondition(format!(
-                    "failed to remove recipe '{recipe_name}': {error}; failed to restore recipe directory from '{}': {restore_error}",
-                    recipe_dir_backup.display()
+                    "failed to remove recipe '{recipe_name}': {error}; failed to restore recipe artifact: {restore_error}"
                 )));
             }
             return Err(error);
-        }
-        if recipe_dir_backup.exists() {
-            std::fs::remove_dir_all(&recipe_dir_backup)?;
         }
         Ok(())
     }
@@ -362,17 +350,25 @@ impl RecipeManager {
         filter: RecipeArtifactFilter,
     ) -> Result<Vec<RecipeArtifact>, AppError> {
         let mut artifacts = Vec::new();
-        for installed in self.config_store.list_workspace_recipes(workspace_name)? {
+        for installed in self.registry.list_workspace_recipes(workspace_name)? {
             if filter == RecipeArtifactFilter::EnabledOnly && !installed.enabled {
                 continue;
             }
-            let recipe_file = self.layout.recipe_file(workspace_name, &installed.name);
-            let raw_yaml = match std::fs::read_to_string(&recipe_file) {
-                Ok(raw_yaml) => raw_yaml,
+            let raw_yaml = match self
+                .artifacts
+                .read_recipe_yaml(workspace_name, &installed.name)
+            {
+                Ok(Some(raw_yaml)) => raw_yaml,
+                Ok(None) => {
+                    tracing::warn!(
+                        recipe = %installed.name,
+                        "skipping installed recipe because its recipe file is missing"
+                    );
+                    continue;
+                }
                 Err(error) => {
                     tracing::warn!(
                         recipe = %installed.name,
-                        path = %recipe_file.display(),
                         detail = %error,
                         "skipping installed recipe because its recipe file could not be read"
                     );
@@ -430,16 +426,18 @@ impl RecipeManager {
         &self,
         workspace_name: &WorkspaceName,
         recipe_name: &RecipeName,
+        raw_yaml: &str,
         validation_arguments: &BTreeMap<String, RecipeRuntimeArgumentValue>,
     ) -> Vec<RecipeRuntimeResultColumn> {
-        let metadata_file = self.layout.recipe_runtime_file(workspace_name, recipe_name);
-        let raw = match std::fs::read_to_string(&metadata_file) {
-            Ok(raw) => raw,
-            Err(error) if error.kind() == ErrorKind::NotFound => return Vec::new(),
+        let raw = match self
+            .artifacts
+            .read_runtime_metadata(workspace_name, recipe_name)
+        {
+            Ok(Some(raw)) => raw,
+            Ok(None) => return Vec::new(),
             Err(error) => {
                 tracing::warn!(
                     recipe = %recipe_name,
-                    path = %metadata_file.display(),
                     detail = %error,
                     "ignoring recipe runtime metadata because it could not be read"
                 );
@@ -448,11 +446,18 @@ impl RecipeManager {
         };
         match serde_json::from_str::<RecipeRuntimeMetadata>(&raw) {
             Ok(metadata) if metadata.version == RECIPE_RUNTIME_METADATA_VERSION => {
+                let expected_recipe_yaml_sha256 = sha256_hex(raw_yaml.as_bytes());
+                if metadata.recipe_yaml_sha256 != expected_recipe_yaml_sha256 {
+                    tracing::warn!(
+                        recipe = %recipe_name,
+                        "ignoring recipe runtime metadata because recipe YAML changed"
+                    );
+                    return Vec::new();
+                }
                 let expected_args = cached_validation_arguments(validation_arguments);
                 if metadata.validation_args != expected_args {
                     tracing::warn!(
                         recipe = %recipe_name,
-                        path = %metadata_file.display(),
                         "ignoring recipe runtime metadata because validation arguments changed"
                     );
                     return Vec::new();
@@ -466,7 +471,6 @@ impl RecipeManager {
             Ok(metadata) => {
                 tracing::warn!(
                     recipe = %recipe_name,
-                    path = %metadata_file.display(),
                     version = metadata.version,
                     supported_version = RECIPE_RUNTIME_METADATA_VERSION,
                     "ignoring recipe runtime metadata because its version is unsupported"
@@ -476,7 +480,6 @@ impl RecipeManager {
             Err(error) => {
                 tracing::warn!(
                     recipe = %recipe_name,
-                    path = %metadata_file.display(),
                     detail = %error,
                     "ignoring recipe runtime metadata because it is invalid"
                 );
@@ -706,14 +709,15 @@ fn origin_sort_key(origin: RecipeOrigin) -> u8 {
     }
 }
 
-fn write_recipe_runtime_metadata(
-    recipe_runtime_file: &std::path::Path,
+fn encode_recipe_runtime_metadata(
     runtime_recipe: Option<&RecipeRuntimeDefinition>,
+    raw_yaml: &str,
     validation_arguments: &BTreeMap<String, RecipeRuntimeArgumentValue>,
-) -> Result<(), AppError> {
+) -> Result<Option<Vec<u8>>, AppError> {
     if let Some(runtime_recipe) = runtime_recipe {
         let metadata = RecipeRuntimeMetadata {
             version: RECIPE_RUNTIME_METADATA_VERSION,
+            recipe_yaml_sha256: sha256_hex(raw_yaml.as_bytes()),
             validation_args: cached_validation_arguments(validation_arguments),
             result_columns: runtime_recipe
                 .result_columns
@@ -722,11 +726,10 @@ fn write_recipe_runtime_metadata(
                 .collect(),
         };
         let raw = serde_json::to_vec_pretty(&metadata)?;
-        fs::write_atomic(recipe_runtime_file, &raw)?;
-    } else if recipe_runtime_file.exists() {
-        std::fs::remove_file(recipe_runtime_file)?;
+        Ok(Some(raw))
+    } else {
+        Ok(None)
     }
-    Ok(())
 }
 
 fn cached_validation_arguments(
@@ -738,71 +741,10 @@ fn cached_validation_arguments(
         .collect()
 }
 
-fn rollback_recipe_install(
-    recipe_dir: &std::path::Path,
-    recipe_file: &std::path::Path,
-    previous_yaml: Option<&[u8]>,
-    recipe_runtime_file: &std::path::Path,
-    previous_runtime: Option<&[u8]>,
-) {
-    if let Some(previous_yaml) = previous_yaml {
-        if let Err(error) = fs::ensure_private_dir(recipe_dir) {
-            tracing::warn!(
-                path = %recipe_dir.display(),
-                detail = %error,
-                "failed to restore previous recipe directory after config update failure"
-            );
-            return;
-        }
-        rollback_recipe_runtime_file(recipe_runtime_file, previous_runtime);
-        if let Err(error) = fs::write_atomic(recipe_file, previous_yaml) {
-            tracing::warn!(
-                path = %recipe_file.display(),
-                detail = %error,
-                "failed to restore previous recipe file after config update failure"
-            );
-        }
-    } else if previous_runtime.is_some() {
-        rollback_recipe_runtime_file(recipe_runtime_file, previous_runtime);
-        if recipe_file.exists()
-            && let Err(error) = std::fs::remove_file(recipe_file)
-        {
-            tracing::warn!(
-                path = %recipe_file.display(),
-                detail = %error,
-                "failed to remove new recipe file after config update failure"
-            );
-        }
-    } else if let Err(error) = std::fs::remove_dir_all(recipe_dir) {
-        tracing::warn!(
-            path = %recipe_dir.display(),
-            detail = %error,
-            "failed to remove new recipe directory after config update failure"
-        );
-    }
-}
-
-fn rollback_recipe_runtime_file(
-    recipe_runtime_file: &std::path::Path,
-    previous_runtime: Option<&[u8]>,
-) {
-    if let Some(previous_runtime) = previous_runtime {
-        if let Err(error) = fs::write_atomic(recipe_runtime_file, previous_runtime) {
-            tracing::warn!(
-                path = %recipe_runtime_file.display(),
-                detail = %error,
-                "failed to restore previous recipe runtime metadata after config update failure"
-            );
-        }
-    } else if recipe_runtime_file.exists()
-        && let Err(error) = std::fs::remove_file(recipe_runtime_file)
-    {
-        tracing::warn!(
-            path = %recipe_runtime_file.display(),
-            detail = %error,
-            "failed to remove recipe runtime metadata after config update failure"
-        );
-    }
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
 }
 
 #[cfg(test)]
@@ -811,14 +753,15 @@ mod tests {
 
     use super::*;
     use crate::state::AppStateLayout;
+    use crate::storage::fs;
 
-    fn fixture() -> (TempDir, AppStateLayout, RecipeManager) {
+    fn fixture() -> (TempDir, AppStateLayout, ConfigStore, RecipeManager) {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let config_store = ConfigStore::new(layout.clone());
-        let manager = RecipeManager::new(config_store, layout.clone());
-        (temp, layout, manager)
+        let manager = RecipeManager::new(config_store.clone(), layout.clone());
+        (temp, layout, config_store, manager)
     }
 
     fn workspace() -> WorkspaceName {
@@ -897,7 +840,7 @@ publish:
 
     #[test]
     fn install_validated_user_recipe_persists_yaml_and_config() {
-        let (_temp, layout, manager) = fixture();
+        let (_temp, layout, config_store, manager) = fixture();
         let workspace = workspace();
         let raw_yaml = recipe_yaml("review_queue");
 
@@ -912,8 +855,7 @@ publish:
             .expect("recipe file");
         assert!(raw.contains("name: review_queue"));
         assert_eq!(
-            manager
-                .config_store
+            config_store
                 .list_workspace_recipes(&workspace)
                 .expect("list recipes")
                 .into_iter()
@@ -925,7 +867,7 @@ publish:
 
     #[tokio::test]
     async fn install_validated_user_recipe_caches_result_columns_for_list() {
-        let (_temp, layout, manager) = fixture();
+        let (_temp, layout, _config_store, manager) = fixture();
         let workspace = workspace();
         let raw_yaml = recipe_yaml("review_queue");
         let runtime_recipe = manager
@@ -964,7 +906,7 @@ publish:
 
     #[test]
     fn list_recipes_ignores_cached_columns_when_validation_args_change() {
-        let (_temp, layout, manager) = fixture();
+        let (_temp, layout, _config_store, manager) = fixture();
         let workspace = workspace();
         let raw_yaml = recipe_yaml_with_validation_owner("review_queue", "withcoral");
         install_fixture_recipe(&manager, &workspace, &raw_yaml);
@@ -986,8 +928,32 @@ publish:
     }
 
     #[test]
+    fn list_recipes_ignores_cached_columns_when_recipe_yaml_changes() {
+        let (_temp, layout, _config_store, manager) = fixture();
+        let workspace = workspace();
+        let raw_yaml = recipe_yaml_with_validation_owner("review_queue", "withcoral");
+        install_fixture_recipe(&manager, &workspace, &raw_yaml);
+        let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
+        let changed_yaml = raw_yaml.replace(
+            "query: select $owner as owner",
+            "query: select $owner as reviewer",
+        );
+        std::fs::write(layout.recipe_file(&workspace, &recipe_name), changed_yaml)
+            .expect("rewrite recipe yaml");
+
+        let listed = manager.list_recipes(&workspace).expect("list recipes");
+
+        assert_eq!(listed.len(), 1);
+        let listed_recipe = listed.first().expect("listed recipe");
+        assert!(
+            listed_recipe.definition.result_columns.is_empty(),
+            "cached result columns should not survive authored recipe drift"
+        );
+    }
+
+    #[test]
     fn list_recipes_ignores_unsupported_runtime_metadata_version() {
-        let (_temp, layout, manager) = fixture();
+        let (_temp, layout, _config_store, manager) = fixture();
         let workspace = workspace();
         let raw_yaml = recipe_yaml("review_queue");
         install_fixture_recipe(&manager, &workspace, &raw_yaml);
@@ -1017,7 +983,7 @@ publish:
 
     #[test]
     fn remove_user_recipe_removes_yaml_and_config() {
-        let (_temp, layout, manager) = fixture();
+        let (_temp, layout, config_store, manager) = fixture();
         let workspace = workspace();
         let raw_yaml = recipe_yaml("review_queue");
         install_fixture_recipe(&manager, &workspace, &raw_yaml);
@@ -1028,8 +994,7 @@ publish:
             .expect("remove recipe");
 
         assert!(!layout.recipe_dir(&workspace, &recipe_name).exists());
-        let user_recipe_count = manager
-            .config_store
+        let user_recipe_count = config_store
             .list_workspace_recipes(&workspace)
             .expect("list recipes")
             .into_iter()
@@ -1040,7 +1005,7 @@ publish:
 
     #[tokio::test]
     async fn validate_user_recipe_yaml_infers_result_columns() {
-        let (_temp, _layout, manager) = fixture();
+        let (_temp, _layout, _config_store, manager) = fixture();
         let workspace = workspace();
 
         let recipe = manager
@@ -1061,7 +1026,7 @@ publish:
 
     #[tokio::test]
     async fn validate_user_recipe_yaml_rejects_installed_publish_collision() {
-        let (_temp, _layout, manager) = fixture();
+        let (_temp, _layout, _config_store, manager) = fixture();
         let workspace = workspace();
         let existing_yaml = recipe_yaml_with_publish("existing_queue", "recipes.shared_queue");
         manager
@@ -1090,7 +1055,7 @@ publish:
 
     #[tokio::test]
     async fn validate_user_recipe_yaml_ignores_disabled_publish_collision() {
-        let (_temp, layout, manager) = fixture();
+        let (_temp, layout, config_store, manager) = fixture();
         let workspace = workspace();
         let recipe_name = RecipeName::parse("existing_queue").expect("recipe name");
         let existing_yaml = recipe_yaml_with_publish("existing_queue", "recipes.shared_queue");
@@ -1098,8 +1063,7 @@ publish:
         fs::ensure_private_dir(&recipe_dir).expect("recipe dir");
         std::fs::write(layout.recipe_file(&workspace, &recipe_name), existing_yaml)
             .expect("recipe yaml");
-        manager
-            .config_store
+        config_store
             .upsert_recipe(
                 &workspace,
                 InstalledRecipe {
@@ -1122,27 +1086,27 @@ publish:
     }
 
     #[test]
-    fn rollback_removes_new_yaml_when_only_runtime_metadata_existed() {
-        let (_temp, layout, _manager) = fixture();
+    fn artifact_restore_removes_new_yaml_when_only_runtime_metadata_existed() {
+        let (_temp, layout, _config_store, _manager) = fixture();
         let workspace = workspace();
         let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
         let recipe_dir = layout.recipe_dir(&workspace, &recipe_name);
         let recipe_file = layout.recipe_file(&workspace, &recipe_name);
         let recipe_runtime_file = layout.recipe_runtime_file(&workspace, &recipe_name);
         fs::ensure_private_dir(&recipe_dir).expect("recipe dir");
-        std::fs::write(&recipe_file, b"new yaml").expect("new recipe file");
+        std::fs::write(&recipe_runtime_file, b"previous runtime").expect("previous runtime");
+        let store = FsRecipeArtifactStore::new(layout.clone());
+        let previous = store
+            .write_user_recipe_artifact(&workspace, &recipe_name, "new yaml", None)
+            .expect("write new artifact");
 
-        rollback_recipe_install(
-            &recipe_dir,
-            &recipe_file,
-            None,
-            &recipe_runtime_file,
-            Some(b"previous runtime"),
-        );
+        store
+            .restore_user_recipe_artifact(&workspace, &recipe_name, &previous)
+            .expect("restore artifact");
 
         assert!(
             !recipe_file.exists(),
-            "rollback should remove newly written recipe yaml"
+            "restore should remove newly written recipe yaml"
         );
         assert_eq!(
             std::fs::read(&recipe_runtime_file).expect("restored runtime metadata"),

--- a/crates/coral-app/src/recipes/manager.rs
+++ b/crates/coral-app/src/recipes/manager.rs
@@ -8,6 +8,7 @@ use coral_engine::{
     CoralQuery, QueryRuntimeConfig, QuerySource, RecipeRuntimeArgument, RecipeRuntimeArgumentType,
     RecipeRuntimeArgumentValue, RecipeRuntimeDefinition, RecipeRuntimeImplementation,
     RecipeRuntimePublish, RecipeRuntimeResultColumn, RecipeRuntimeTableFunctionPublish,
+    RuntimeSourceComponent,
 };
 use coral_spec::{
     RecipeArgumentType, RecipeImplementationSpec, RecipePublishSpec, RecipeSpec,
@@ -55,7 +56,7 @@ struct RecipeRuntimeMetadata {
     result_columns: Vec<CachedRecipeResultColumn>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 enum CachedRecipeArgumentValue {
     String(String),
@@ -212,8 +213,7 @@ impl RecipeManager {
             AppError::InvalidInput(format!("recipe validation failed: {error}"))
         })?;
         let recipe_name = RecipeName::parse(spec.name())?;
-        let mut publish_targets =
-            source_publish_targets(selected_sources, runtime_config()?).await?;
+        let mut publish_targets = source_publish_targets(selected_sources);
         self.record_installed_recipe_publish_targets(
             workspace_name,
             &recipe_name,
@@ -249,8 +249,11 @@ impl RecipeManager {
             };
             let mut recipe = runtime_recipe_without_columns(&spec);
             if artifact.origin == RecipeOrigin::User {
-                recipe.result_columns =
-                    self.cached_recipe_result_columns(workspace_name, &artifact.name);
+                recipe.result_columns = self.cached_recipe_result_columns(
+                    workspace_name,
+                    &artifact.name,
+                    &runtime_validation_arguments(&spec),
+                );
             }
             recipes.push(RecipeListing {
                 definition: recipe,
@@ -261,11 +264,10 @@ impl RecipeManager {
         Ok(recipes)
     }
 
-    pub(crate) async fn load_runtime_recipes(
+    pub(crate) fn load_runtime_recipes(
         &self,
         workspace_name: &WorkspaceName,
         selected_sources: &[QuerySource],
-        mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
     ) -> Result<Vec<RecipeRuntimeDefinition>, AppError> {
         let artifacts =
             self.load_recipe_artifacts(workspace_name, RecipeArtifactFilter::EnabledOnly)?;
@@ -274,8 +276,7 @@ impl RecipeManager {
         }
 
         let mut seen_names = HashSet::new();
-        let mut publish_targets =
-            source_publish_targets(selected_sources, runtime_config()?).await?;
+        let mut publish_targets = source_publish_targets(selected_sources);
         let mut runtime_recipes = Vec::new();
         for artifact in artifacts {
             if !seen_names.insert(artifact.name.clone()) {
@@ -294,8 +295,11 @@ impl RecipeManager {
             };
             let mut runtime_recipe = runtime_recipe_without_columns(&spec);
             if artifact.origin == RecipeOrigin::User {
-                runtime_recipe.result_columns =
-                    self.cached_recipe_result_columns(workspace_name, &artifact.name);
+                runtime_recipe.result_columns = self.cached_recipe_result_columns(
+                    workspace_name,
+                    &artifact.name,
+                    &runtime_validation_arguments(&spec),
+                );
             }
             if runtime_recipe.result_columns.is_empty() {
                 skip_recipe(
@@ -407,6 +411,9 @@ impl RecipeManager {
                     artifact.name
                 )));
             }
+            if !artifact.enabled {
+                continue;
+            }
             let spec = parse_recipe_yaml(&artifact.raw_yaml).map_err(|error| {
                 AppError::FailedPrecondition(format!(
                     "installed recipe '{}' is invalid: {error}",
@@ -423,6 +430,7 @@ impl RecipeManager {
         &self,
         workspace_name: &WorkspaceName,
         recipe_name: &RecipeName,
+        validation_arguments: &BTreeMap<String, RecipeRuntimeArgumentValue>,
     ) -> Vec<RecipeRuntimeResultColumn> {
         let metadata_file = self.layout.recipe_runtime_file(workspace_name, recipe_name);
         let raw = match std::fs::read_to_string(&metadata_file) {
@@ -439,11 +447,22 @@ impl RecipeManager {
             }
         };
         match serde_json::from_str::<RecipeRuntimeMetadata>(&raw) {
-            Ok(metadata) if metadata.version == RECIPE_RUNTIME_METADATA_VERSION => metadata
-                .result_columns
-                .into_iter()
-                .map(RecipeRuntimeResultColumn::from)
-                .collect(),
+            Ok(metadata) if metadata.version == RECIPE_RUNTIME_METADATA_VERSION => {
+                let expected_args = cached_validation_arguments(validation_arguments);
+                if metadata.validation_args != expected_args {
+                    tracing::warn!(
+                        recipe = %recipe_name,
+                        path = %metadata_file.display(),
+                        "ignoring recipe runtime metadata because validation arguments changed"
+                    );
+                    return Vec::new();
+                }
+                metadata
+                    .result_columns
+                    .into_iter()
+                    .map(RecipeRuntimeResultColumn::from)
+                    .collect()
+            }
             Ok(metadata) => {
                 tracing::warn!(
                     recipe = %recipe_name,
@@ -482,28 +501,58 @@ fn skip_recipe(artifact: &RecipeArtifact, detail: fmt::Arguments<'_>) {
     );
 }
 
-async fn source_publish_targets(
-    selected_sources: &[QuerySource],
-    runtime_config: QueryRuntimeConfig,
-) -> Result<HashSet<PublishTarget>, AppError> {
-    let catalog = CoralQuery::list_catalog(selected_sources, runtime_config, None)
-        .await
-        .map_err(|error| {
-            AppError::FailedPrecondition(format!(
-                "failed to inspect installed source catalog for recipe publish collisions: {error}"
-            ))
-        })?;
+fn source_publish_targets(selected_sources: &[QuerySource]) -> HashSet<PublishTarget> {
     let mut targets = HashSet::new();
-    targets.extend(
-        catalog
-            .tables
-            .into_iter()
-            .map(|table| PublishTarget::sql_relation(&table.schema_name, &table.table_name)),
-    );
-    targets.extend(catalog.table_functions.into_iter().map(|function| {
-        PublishTarget::sql_relation(&function.schema_name, &function.function_name)
-    }));
-    Ok(targets)
+    for source in selected_sources {
+        for component in source.components() {
+            record_source_component_targets(component, &mut targets);
+        }
+    }
+    targets
+}
+
+fn record_source_component_targets(
+    component: &RuntimeSourceComponent,
+    targets: &mut HashSet<PublishTarget>,
+) {
+    match component {
+        RuntimeSourceComponent::Http(manifest) => {
+            for table in &manifest.tables {
+                targets.insert(PublishTarget::sql_relation(
+                    &manifest.common.name,
+                    table.name(),
+                ));
+            }
+            for function in &manifest.functions {
+                targets.insert(PublishTarget::sql_relation(
+                    &manifest.common.name,
+                    &function.name,
+                ));
+            }
+        }
+        RuntimeSourceComponent::File(manifest) => {
+            for table in &manifest.tables {
+                targets.insert(PublishTarget::sql_relation(
+                    &manifest.common.name,
+                    table.name(),
+                ));
+            }
+        }
+        RuntimeSourceComponent::Mcp(manifest) => {
+            for table in &manifest.tables {
+                targets.insert(PublishTarget::sql_relation(
+                    &manifest.common.name,
+                    &table.common.name,
+                ));
+            }
+            for function in &manifest.functions {
+                targets.insert(PublishTarget::sql_relation(
+                    &manifest.common.name,
+                    &function.common.name,
+                ));
+            }
+        }
+    }
 }
 
 fn runtime_recipe_without_columns(spec: &RecipeSpec) -> RecipeRuntimeDefinition {
@@ -665,10 +714,7 @@ fn write_recipe_runtime_metadata(
     if let Some(runtime_recipe) = runtime_recipe {
         let metadata = RecipeRuntimeMetadata {
             version: RECIPE_RUNTIME_METADATA_VERSION,
-            validation_args: validation_arguments
-                .iter()
-                .map(|(name, value)| (name.clone(), CachedRecipeArgumentValue::from(value)))
-                .collect(),
+            validation_args: cached_validation_arguments(validation_arguments),
             result_columns: runtime_recipe
                 .result_columns
                 .iter()
@@ -681,6 +727,15 @@ fn write_recipe_runtime_metadata(
         std::fs::remove_file(recipe_runtime_file)?;
     }
     Ok(())
+}
+
+fn cached_validation_arguments(
+    validation_arguments: &BTreeMap<String, RecipeRuntimeArgumentValue>,
+) -> BTreeMap<String, CachedRecipeArgumentValue> {
+    validation_arguments
+        .iter()
+        .map(|(name, value)| (name.clone(), CachedRecipeArgumentValue::from(value)))
+        .collect()
 }
 
 fn rollback_recipe_install(
@@ -709,6 +764,15 @@ fn rollback_recipe_install(
         }
     } else if previous_runtime.is_some() {
         rollback_recipe_runtime_file(recipe_runtime_file, previous_runtime);
+        if recipe_file.exists()
+            && let Err(error) = std::fs::remove_file(recipe_file)
+        {
+            tracing::warn!(
+                path = %recipe_file.display(),
+                detail = %error,
+                "failed to remove new recipe file after config update failure"
+            );
+        }
     } else if let Err(error) = std::fs::remove_dir_all(recipe_dir) {
         tracing::warn!(
             path = %recipe_dir.display(),
@@ -763,6 +827,29 @@ mod tests {
 
     fn recipe_yaml(name: &str) -> String {
         recipe_yaml_with_publish(name, &format!("recipes.{name}"))
+    }
+
+    fn recipe_yaml_with_validation_owner(name: &str, owner: &str) -> String {
+        format!(
+            r"
+kind: recipe
+name: {name}
+inputs:
+  owner:
+    type: string
+    required: true
+implementation:
+  kind: coral_sql
+  query: select $owner as owner
+validation:
+  args:
+    owner: {owner}
+publish:
+  table_function:
+    schema: recipes
+    name: {name}
+"
+        )
     }
 
     fn recipe_yaml_with_publish(name: &str, publish_target: &str) -> String {
@@ -876,6 +963,29 @@ publish:
     }
 
     #[test]
+    fn list_recipes_ignores_cached_columns_when_validation_args_change() {
+        let (_temp, layout, manager) = fixture();
+        let workspace = workspace();
+        let raw_yaml = recipe_yaml_with_validation_owner("review_queue", "withcoral");
+        install_fixture_recipe(&manager, &workspace, &raw_yaml);
+        let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
+        std::fs::write(
+            layout.recipe_file(&workspace, &recipe_name),
+            recipe_yaml_with_validation_owner("review_queue", "other_org"),
+        )
+        .expect("rewrite recipe yaml");
+
+        let listed = manager.list_recipes(&workspace).expect("list recipes");
+
+        assert_eq!(listed.len(), 1);
+        let listed_recipe = listed.first().expect("listed recipe");
+        assert!(
+            listed_recipe.definition.result_columns.is_empty(),
+            "cached result columns should not survive validation argument drift"
+        );
+    }
+
+    #[test]
     fn list_recipes_ignores_unsupported_runtime_metadata_version() {
         let (_temp, layout, manager) = fixture();
         let workspace = workspace();
@@ -976,5 +1086,67 @@ publish:
             error,
             AppError::FailedPrecondition(message) if message.contains("recipes.shared_queue")
         ));
+    }
+
+    #[tokio::test]
+    async fn validate_user_recipe_yaml_ignores_disabled_publish_collision() {
+        let (_temp, layout, manager) = fixture();
+        let workspace = workspace();
+        let recipe_name = RecipeName::parse("existing_queue").expect("recipe name");
+        let existing_yaml = recipe_yaml_with_publish("existing_queue", "recipes.shared_queue");
+        let recipe_dir = layout.recipe_dir(&workspace, &recipe_name);
+        fs::ensure_private_dir(&recipe_dir).expect("recipe dir");
+        std::fs::write(layout.recipe_file(&workspace, &recipe_name), existing_yaml)
+            .expect("recipe yaml");
+        manager
+            .config_store
+            .upsert_recipe(
+                &workspace,
+                InstalledRecipe {
+                    name: recipe_name,
+                    origin: RecipeOrigin::User,
+                    enabled: false,
+                },
+            )
+            .expect("disabled installed recipe");
+
+        manager
+            .validate_user_recipe_yaml(
+                &workspace,
+                &[],
+                || Ok(QueryRuntimeConfig::default()),
+                &recipe_yaml_with_publish("new_queue", "recipes.shared_queue"),
+            )
+            .await
+            .expect("disabled recipe should not reserve publish target");
+    }
+
+    #[test]
+    fn rollback_removes_new_yaml_when_only_runtime_metadata_existed() {
+        let (_temp, layout, _manager) = fixture();
+        let workspace = workspace();
+        let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
+        let recipe_dir = layout.recipe_dir(&workspace, &recipe_name);
+        let recipe_file = layout.recipe_file(&workspace, &recipe_name);
+        let recipe_runtime_file = layout.recipe_runtime_file(&workspace, &recipe_name);
+        fs::ensure_private_dir(&recipe_dir).expect("recipe dir");
+        std::fs::write(&recipe_file, b"new yaml").expect("new recipe file");
+
+        rollback_recipe_install(
+            &recipe_dir,
+            &recipe_file,
+            None,
+            &recipe_runtime_file,
+            Some(b"previous runtime"),
+        );
+
+        assert!(
+            !recipe_file.exists(),
+            "rollback should remove newly written recipe yaml"
+        );
+        assert_eq!(
+            std::fs::read(&recipe_runtime_file).expect("restored runtime metadata"),
+            b"previous runtime"
+        );
     }
 }

--- a/crates/coral-app/src/recipes/manager.rs
+++ b/crates/coral-app/src/recipes/manager.rs
@@ -231,6 +231,56 @@ impl RecipeManager {
         Ok(recipes)
     }
 
+    pub(crate) async fn load_runtime_recipes(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[QuerySource],
+        mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
+    ) -> Result<Vec<RecipeRuntimeDefinition>, AppError> {
+        let artifacts = self.load_recipe_artifacts(workspace_name)?;
+        if artifacts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut seen_names = HashSet::new();
+        let mut publish_targets =
+            source_publish_targets(selected_sources, runtime_config()?).await?;
+        let mut runtime_recipes = Vec::new();
+        for artifact in artifacts {
+            if !seen_names.insert(artifact.name.clone()) {
+                skip_recipe(
+                    &artifact,
+                    format_args!("recipe '{}' is installed more than once", artifact.name),
+                );
+                continue;
+            }
+            let spec = match parse_recipe_yaml(&artifact.raw_yaml) {
+                Ok(spec) => spec,
+                Err(error) => {
+                    skip_recipe(&artifact, format_args!("recipe is invalid: {error}"));
+                    continue;
+                }
+            };
+            let runtime_recipe =
+                match infer_runtime_recipe(selected_sources, runtime_config()?, &spec).await {
+                    Ok(runtime_recipe) => runtime_recipe,
+                    Err(error) => {
+                        skip_recipe(
+                            &artifact,
+                            format_args!("recipe failed runtime validation: {error}"),
+                        );
+                        continue;
+                    }
+                };
+            if let Err(error) = record_publish_targets(&runtime_recipe, &mut publish_targets) {
+                skip_recipe(&artifact, format_args!("{error}"));
+                continue;
+            }
+            runtime_recipes.push(runtime_recipe);
+        }
+        Ok(runtime_recipes)
+    }
+
     pub(crate) fn list_user_recipes(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/recipes/manager.rs
+++ b/crates/coral-app/src/recipes/manager.rs
@@ -1,10 +1,5 @@
 //! Owns user-installed recipe files and workspace inventory.
 
-#![allow(
-    dead_code,
-    reason = "recipe manager is exposed through API/CLI surfaces in later stack branches"
-)]
-
 use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::io::ErrorKind;
@@ -27,6 +22,8 @@ use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 
+const RECIPE_RUNTIME_METADATA_VERSION: u32 = 1;
+
 #[derive(Clone)]
 pub(crate) struct RecipeManager {
     config_store: ConfigStore,
@@ -36,7 +33,18 @@ pub(crate) struct RecipeManager {
 struct RecipeArtifact {
     name: RecipeName,
     origin: RecipeOrigin,
+    enabled: bool,
     raw_yaml: String,
+}
+
+/// One recipe as listed by the app inventory surface.
+pub(crate) struct RecipeListing {
+    /// Runtime definition for the recipe.
+    pub(crate) definition: RecipeRuntimeDefinition,
+    /// Where this installed recipe came from.
+    pub(crate) origin: RecipeOrigin,
+    /// Whether this recipe participates in runtime publication.
+    pub(crate) enabled: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -220,8 +228,8 @@ impl RecipeManager {
     pub(crate) fn list_recipes(
         &self,
         workspace_name: &WorkspaceName,
-    ) -> Result<Vec<RecipeRuntimeDefinition>, AppError> {
-        let artifacts = self.load_recipe_artifacts(workspace_name)?;
+    ) -> Result<Vec<RecipeListing>, AppError> {
+        let artifacts = self.load_recipe_artifacts(workspace_name, RecipeArtifactFilter::All)?;
         let mut seen_names = HashSet::new();
         let mut recipes = Vec::new();
         for artifact in artifacts {
@@ -244,7 +252,11 @@ impl RecipeManager {
                 recipe.result_columns =
                     self.cached_recipe_result_columns(workspace_name, &artifact.name);
             }
-            recipes.push(recipe);
+            recipes.push(RecipeListing {
+                definition: recipe,
+                origin: artifact.origin,
+                enabled: artifact.enabled,
+            });
         }
         Ok(recipes)
     }
@@ -255,7 +267,8 @@ impl RecipeManager {
         selected_sources: &[QuerySource],
         mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
     ) -> Result<Vec<RecipeRuntimeDefinition>, AppError> {
-        let artifacts = self.load_recipe_artifacts(workspace_name)?;
+        let artifacts =
+            self.load_recipe_artifacts(workspace_name, RecipeArtifactFilter::EnabledOnly)?;
         if artifacts.is_empty() {
             return Ok(Vec::new());
         }
@@ -300,18 +313,6 @@ impl RecipeManager {
         Ok(runtime_recipes)
     }
 
-    pub(crate) fn list_user_recipes(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<Vec<InstalledRecipe>, AppError> {
-        Ok(self
-            .config_store
-            .list_workspace_recipes(workspace_name)?
-            .into_iter()
-            .filter(|recipe| recipe.origin == RecipeOrigin::User)
-            .collect())
-    }
-
     pub(crate) fn remove_user_recipe(
         &self,
         workspace_name: &WorkspaceName,
@@ -354,10 +355,11 @@ impl RecipeManager {
     fn load_recipe_artifacts(
         &self,
         workspace_name: &WorkspaceName,
+        filter: RecipeArtifactFilter,
     ) -> Result<Vec<RecipeArtifact>, AppError> {
         let mut artifacts = Vec::new();
         for installed in self.config_store.list_workspace_recipes(workspace_name)? {
-            if !installed.enabled {
+            if filter == RecipeArtifactFilter::EnabledOnly && !installed.enabled {
                 continue;
             }
             let recipe_file = self.layout.recipe_file(workspace_name, &installed.name);
@@ -376,6 +378,7 @@ impl RecipeManager {
             artifacts.push(RecipeArtifact {
                 name: installed.name,
                 origin: installed.origin,
+                enabled: installed.enabled,
                 raw_yaml,
             });
         }
@@ -394,7 +397,7 @@ impl RecipeManager {
         publish_targets: &mut HashSet<PublishTarget>,
     ) -> Result<(), AppError> {
         let mut seen_names = HashSet::new();
-        for artifact in self.load_recipe_artifacts(workspace_name)? {
+        for artifact in self.load_recipe_artifacts(workspace_name, RecipeArtifactFilter::All)? {
             if artifact.name == *replacing_recipe {
                 continue;
             }
@@ -436,11 +439,21 @@ impl RecipeManager {
             }
         };
         match serde_json::from_str::<RecipeRuntimeMetadata>(&raw) {
-            Ok(metadata) => metadata
+            Ok(metadata) if metadata.version == RECIPE_RUNTIME_METADATA_VERSION => metadata
                 .result_columns
                 .into_iter()
                 .map(RecipeRuntimeResultColumn::from)
                 .collect(),
+            Ok(metadata) => {
+                tracing::warn!(
+                    recipe = %recipe_name,
+                    path = %metadata_file.display(),
+                    version = metadata.version,
+                    supported_version = RECIPE_RUNTIME_METADATA_VERSION,
+                    "ignoring recipe runtime metadata because its version is unsupported"
+                );
+                Vec::new()
+            }
             Err(error) => {
                 tracing::warn!(
                     recipe = %recipe_name,
@@ -452,6 +465,12 @@ impl RecipeManager {
             }
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecipeArtifactFilter {
+    All,
+    EnabledOnly,
 }
 
 fn skip_recipe(artifact: &RecipeArtifact, detail: fmt::Arguments<'_>) {
@@ -645,7 +664,7 @@ fn write_recipe_runtime_metadata(
 ) -> Result<(), AppError> {
     if let Some(runtime_recipe) = runtime_recipe {
         let metadata = RecipeRuntimeMetadata {
-            version: 1,
+            version: RECIPE_RUNTIME_METADATA_VERSION,
             validation_args: validation_arguments
                 .iter()
                 .map(|(name, value)| (name.clone(), CachedRecipeArgumentValue::from(value)))
@@ -807,9 +826,12 @@ publish:
         assert!(raw.contains("name: review_queue"));
         assert_eq!(
             manager
-                .list_user_recipes(&workspace)
+                .config_store
+                .list_workspace_recipes(&workspace)
                 .expect("list recipes")
-                .len(),
+                .into_iter()
+                .filter(|recipe| recipe.origin == RecipeOrigin::User)
+                .count(),
             1
         );
     }
@@ -842,12 +864,45 @@ publish:
         let listed = manager.list_recipes(&workspace).expect("list recipes");
         assert_eq!(listed.len(), 1);
         let listed_recipe = listed.first().expect("listed recipe");
-        assert_eq!(listed_recipe.result_columns.len(), 1);
+        assert_eq!(listed_recipe.origin, RecipeOrigin::User);
+        assert!(listed_recipe.enabled);
+        assert_eq!(listed_recipe.definition.result_columns.len(), 1);
         let column = listed_recipe
+            .definition
             .result_columns
             .first()
             .expect("id result column");
         assert_eq!(column.name, "id");
+    }
+
+    #[test]
+    fn list_recipes_ignores_unsupported_runtime_metadata_version() {
+        let (_temp, layout, manager) = fixture();
+        let workspace = workspace();
+        let raw_yaml = recipe_yaml("review_queue");
+        install_fixture_recipe(&manager, &workspace, &raw_yaml);
+        let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
+        std::fs::write(
+            layout.recipe_runtime_file(&workspace, &recipe_name),
+            r#"
+{
+  "version": 999,
+  "result_columns": [
+    {"name": "id", "data_type": "Int64", "nullable": false}
+  ]
+}
+"#,
+        )
+        .expect("write unsupported runtime metadata");
+
+        let listed = manager.list_recipes(&workspace).expect("list recipes");
+
+        assert_eq!(listed.len(), 1);
+        let listed_recipe = listed.first().expect("listed recipe");
+        assert!(
+            listed_recipe.definition.result_columns.is_empty(),
+            "unsupported cached runtime metadata should not drive list output"
+        );
     }
 
     #[test]
@@ -863,12 +918,14 @@ publish:
             .expect("remove recipe");
 
         assert!(!layout.recipe_dir(&workspace, &recipe_name).exists());
-        assert!(
-            manager
-                .list_user_recipes(&workspace)
-                .expect("list recipes")
-                .is_empty()
-        );
+        let user_recipe_count = manager
+            .config_store
+            .list_workspace_recipes(&workspace)
+            .expect("list recipes")
+            .into_iter()
+            .filter(|recipe| recipe.origin == RecipeOrigin::User)
+            .count();
+        assert_eq!(user_recipe_count, 0);
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/recipes/manager.rs
+++ b/crates/coral-app/src/recipes/manager.rs
@@ -1,0 +1,232 @@
+//! Owns user-installed recipe files and workspace inventory.
+
+#![allow(
+    dead_code,
+    reason = "recipe manager is exposed through API/CLI surfaces in later stack branches"
+)]
+
+use std::io::ErrorKind;
+
+use coral_spec::parse_recipe_yaml;
+use uuid::Uuid;
+
+use crate::bootstrap::AppError;
+use crate::recipes::model::{InstalledRecipe, RecipeName, RecipeOrigin};
+use crate::state::{AppStateLayout, ConfigStore};
+use crate::storage::fs;
+use crate::workspaces::WorkspaceName;
+
+#[derive(Clone)]
+pub(crate) struct RecipeManager {
+    config_store: ConfigStore,
+    layout: AppStateLayout,
+}
+
+impl RecipeManager {
+    pub(crate) fn new(config_store: ConfigStore, layout: AppStateLayout) -> Self {
+        Self {
+            config_store,
+            layout,
+        }
+    }
+
+    pub(crate) fn install_user_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        raw_yaml: &str,
+    ) -> Result<InstalledRecipe, AppError> {
+        let recipe = parse_recipe_yaml(raw_yaml).map_err(|error| {
+            AppError::InvalidInput(format!("recipe validation failed: {error}"))
+        })?;
+        let recipe_name = RecipeName::parse(recipe.name())?;
+        let installed = InstalledRecipe {
+            name: recipe_name.clone(),
+            origin: RecipeOrigin::User,
+            enabled: true,
+        };
+
+        let recipe_dir = self.layout.recipe_dir(workspace_name, recipe_name);
+        let recipe_file = self.layout.recipe_file(workspace_name, recipe_name);
+        let previous_yaml = match std::fs::read(&recipe_file) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+
+        fs::ensure_private_dir(&recipe_dir)?;
+        fs::write_atomic(&recipe_file, raw_yaml.as_bytes())?;
+        if let Err(error) = self
+            .config_store
+            .upsert_recipe(workspace_name, installed.clone())
+        {
+            rollback_recipe_install(&recipe_dir, &recipe_file, previous_yaml.as_deref());
+            return Err(error);
+        }
+
+        Ok(installed)
+    }
+
+    pub(crate) fn list_user_recipes(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledRecipe>, AppError> {
+        Ok(self
+            .config_store
+            .list_workspace_recipes(workspace_name)?
+            .into_iter()
+            .filter(|recipe| recipe.origin == RecipeOrigin::User)
+            .collect())
+    }
+
+    pub(crate) fn remove_user_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<(), AppError> {
+        let installed = self.config_store.get_recipe(workspace_name, recipe_name)?;
+        if installed.origin != RecipeOrigin::User {
+            return Err(AppError::InvalidInput(format!(
+                "recipe '{recipe_name}' is bundled and cannot be removed from workspace config"
+            )));
+        }
+        let recipe_dir = self.layout.recipe_dir(workspace_name, recipe_name);
+        let recipe_dir_backup =
+            recipe_dir.with_file_name(format!("{recipe_name}.delete.rollback.{}", Uuid::new_v4()));
+        let had_recipe_dir = recipe_dir.exists();
+        if had_recipe_dir {
+            if recipe_dir_backup.exists() {
+                std::fs::remove_dir_all(&recipe_dir_backup)?;
+            }
+            std::fs::rename(&recipe_dir, &recipe_dir_backup)?;
+        }
+        if let Err(error) = self.config_store.remove_recipe(workspace_name, recipe_name) {
+            if had_recipe_dir
+                && recipe_dir_backup.exists()
+                && let Err(restore_error) = std::fs::rename(&recipe_dir_backup, &recipe_dir)
+            {
+                return Err(AppError::FailedPrecondition(format!(
+                    "failed to remove recipe '{recipe_name}': {error}; failed to restore recipe directory from '{}': {restore_error}",
+                    recipe_dir_backup.display()
+                )));
+            }
+            return Err(error);
+        }
+        if recipe_dir_backup.exists() {
+            std::fs::remove_dir_all(&recipe_dir_backup)?;
+        }
+        Ok(())
+    }
+}
+
+fn rollback_recipe_install(
+    recipe_dir: &std::path::Path,
+    recipe_file: &std::path::Path,
+    previous_yaml: Option<&[u8]>,
+) {
+    if let Some(previous_yaml) = previous_yaml {
+        if let Err(error) = fs::ensure_private_dir(recipe_dir) {
+            tracing::warn!(
+                path = %recipe_dir.display(),
+                detail = %error,
+                "failed to restore previous recipe directory after config update failure"
+            );
+            return;
+        }
+        if let Err(error) = fs::write_atomic(recipe_file, previous_yaml) {
+            tracing::warn!(
+                path = %recipe_file.display(),
+                detail = %error,
+                "failed to restore previous recipe file after config update failure"
+            );
+        }
+    } else if let Err(error) = std::fs::remove_dir_all(recipe_dir) {
+        tracing::warn!(
+            path = %recipe_dir.display(),
+            detail = %error,
+            "failed to remove new recipe directory after config update failure"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::state::AppStateLayout;
+
+    fn fixture() -> (TempDir, AppStateLayout, RecipeManager) {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let manager = RecipeManager::new(config_store, layout.clone());
+        (temp, layout, manager)
+    }
+
+    fn workspace() -> WorkspaceName {
+        WorkspaceName::parse("default").expect("workspace")
+    }
+
+    fn recipe_yaml(name: &str) -> String {
+        format!(
+            r"
+kind: recipe
+name: {name}
+implementation:
+  kind: coral_sql
+  query: select 1 as id
+publish:
+  - table_function: recipes.{name}
+"
+        )
+    }
+
+    #[test]
+    fn install_user_recipe_persists_yaml_and_config() {
+        let (_temp, layout, manager) = fixture();
+        let workspace = workspace();
+
+        let installed = manager
+            .install_user_recipe(&workspace, &recipe_yaml("review_queue"))
+            .expect("install recipe");
+
+        assert_eq!(installed.name.as_str(), "review_queue");
+        assert_eq!(installed.origin, RecipeOrigin::User);
+        assert!(installed.enabled);
+
+        let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
+        let raw = std::fs::read_to_string(layout.recipe_file(&workspace, &recipe_name))
+            .expect("recipe file");
+        assert!(raw.contains("name: review_queue"));
+        assert_eq!(
+            manager
+                .list_user_recipes(&workspace)
+                .expect("list recipes")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn remove_user_recipe_removes_yaml_and_config() {
+        let (_temp, layout, manager) = fixture();
+        let workspace = workspace();
+        manager
+            .install_user_recipe(&workspace, &recipe_yaml("review_queue"))
+            .expect("install recipe");
+        let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
+
+        manager
+            .remove_user_recipe(&workspace, &recipe_name)
+            .expect("remove recipe");
+
+        assert!(!layout.recipe_dir(&workspace, &recipe_name).exists());
+        assert!(
+            manager
+                .list_user_recipes(&workspace)
+                .expect("list recipes")
+                .is_empty()
+        );
+    }
+}

--- a/crates/coral-app/src/recipes/manager.rs
+++ b/crates/coral-app/src/recipes/manager.rs
@@ -6,6 +6,7 @@
 )]
 
 use std::collections::HashSet;
+use std::fmt;
 use std::io::ErrorKind;
 
 use coral_engine::{
@@ -16,6 +17,7 @@ use coral_engine::{
 use coral_spec::{
     RecipeArgumentType, RecipeImplementationSpec, RecipePublishSpec, RecipeSpec, parse_recipe_yaml,
 };
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
@@ -28,6 +30,49 @@ use crate::workspaces::WorkspaceName;
 pub(crate) struct RecipeManager {
     config_store: ConfigStore,
     layout: AppStateLayout,
+}
+
+struct RecipeArtifact {
+    name: RecipeName,
+    origin: RecipeOrigin,
+    raw_yaml: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RecipeRuntimeMetadata {
+    version: u32,
+    result_columns: Vec<CachedRecipeResultColumn>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CachedRecipeResultColumn {
+    name: String,
+    data_type: String,
+    nullable: bool,
+    #[serde(default)]
+    description: String,
+}
+
+impl From<&RecipeRuntimeResultColumn> for CachedRecipeResultColumn {
+    fn from(column: &RecipeRuntimeResultColumn) -> Self {
+        Self {
+            name: column.name.clone(),
+            data_type: column.data_type.clone(),
+            nullable: column.nullable,
+            description: column.description.clone(),
+        }
+    }
+}
+
+impl From<CachedRecipeResultColumn> for RecipeRuntimeResultColumn {
+    fn from(column: CachedRecipeResultColumn) -> Self {
+        Self {
+            name: column.name,
+            data_type: column.data_type,
+            nullable: column.nullable,
+            description: column.description,
+        }
+    }
 }
 
 impl RecipeManager {
@@ -47,6 +92,40 @@ impl RecipeManager {
             AppError::InvalidInput(format!("recipe validation failed: {error}"))
         })?;
         let recipe_name = RecipeName::parse(recipe.name())?;
+        self.install_user_recipe_artifact(workspace_name, &recipe_name, raw_yaml, None)
+    }
+
+    pub(crate) fn install_validated_user_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        raw_yaml: &str,
+        runtime_recipe: &RecipeRuntimeDefinition,
+    ) -> Result<InstalledRecipe, AppError> {
+        let recipe = parse_recipe_yaml(raw_yaml).map_err(|error| {
+            AppError::InvalidInput(format!("recipe validation failed: {error}"))
+        })?;
+        let recipe_name = RecipeName::parse(recipe.name())?;
+        if recipe_name.as_str() != runtime_recipe.name {
+            return Err(AppError::FailedPrecondition(format!(
+                "validated recipe '{}' does not match installed recipe '{}'",
+                runtime_recipe.name, recipe_name
+            )));
+        }
+        self.install_user_recipe_artifact(
+            workspace_name,
+            &recipe_name,
+            raw_yaml,
+            Some(runtime_recipe),
+        )
+    }
+
+    fn install_user_recipe_artifact(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+        raw_yaml: &str,
+        runtime_recipe: Option<&RecipeRuntimeDefinition>,
+    ) -> Result<InstalledRecipe, AppError> {
         let installed = InstalledRecipe {
             name: recipe_name.clone(),
             origin: RecipeOrigin::User,
@@ -55,7 +134,13 @@ impl RecipeManager {
 
         let recipe_dir = self.layout.recipe_dir(workspace_name, recipe_name);
         let recipe_file = self.layout.recipe_file(workspace_name, recipe_name);
+        let recipe_runtime_file = self.layout.recipe_runtime_file(workspace_name, recipe_name);
         let previous_yaml = match std::fs::read(&recipe_file) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+        let previous_runtime = match std::fs::read(&recipe_runtime_file) {
             Ok(bytes) => Some(bytes),
             Err(error) if error.kind() == ErrorKind::NotFound => None,
             Err(error) => return Err(error.into()),
@@ -63,11 +148,27 @@ impl RecipeManager {
 
         fs::ensure_private_dir(&recipe_dir)?;
         fs::write_atomic(&recipe_file, raw_yaml.as_bytes())?;
+        if let Err(error) = write_recipe_runtime_metadata(&recipe_runtime_file, runtime_recipe) {
+            rollback_recipe_install(
+                &recipe_dir,
+                &recipe_file,
+                previous_yaml.as_deref(),
+                &recipe_runtime_file,
+                previous_runtime.as_deref(),
+            );
+            return Err(error);
+        }
         if let Err(error) = self
             .config_store
             .upsert_recipe(workspace_name, installed.clone())
         {
-            rollback_recipe_install(&recipe_dir, &recipe_file, previous_yaml.as_deref());
+            rollback_recipe_install(
+                &recipe_dir,
+                &recipe_file,
+                previous_yaml.as_deref(),
+                &recipe_runtime_file,
+                previous_runtime.as_deref(),
+            );
             return Err(error);
         }
 
@@ -76,7 +177,7 @@ impl RecipeManager {
 
     pub(crate) async fn validate_user_recipe_yaml(
         &self,
-        _workspace_name: &WorkspaceName,
+        workspace_name: &WorkspaceName,
         selected_sources: &[QuerySource],
         mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
         raw_yaml: &str,
@@ -84,13 +185,50 @@ impl RecipeManager {
         let spec = parse_recipe_yaml(raw_yaml).map_err(|error| {
             AppError::InvalidInput(format!("recipe validation failed: {error}"))
         })?;
-        RecipeName::parse(spec.name())?;
+        let recipe_name = RecipeName::parse(spec.name())?;
         let mut publish_targets =
             source_publish_targets(selected_sources, runtime_config()?).await?;
+        self.record_installed_recipe_publish_targets(
+            workspace_name,
+            &recipe_name,
+            &mut publish_targets,
+        )?;
         let runtime_recipe =
             infer_runtime_recipe(selected_sources, runtime_config()?, &spec).await?;
         record_publish_targets(&runtime_recipe, &mut publish_targets)?;
         Ok(runtime_recipe)
+    }
+
+    pub(crate) fn list_recipes(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<RecipeRuntimeDefinition>, AppError> {
+        let artifacts = self.load_recipe_artifacts(workspace_name)?;
+        let mut seen_names = HashSet::new();
+        let mut recipes = Vec::new();
+        for artifact in artifacts {
+            if !seen_names.insert(artifact.name.clone()) {
+                skip_recipe(
+                    &artifact,
+                    format_args!("recipe '{}' is installed more than once", artifact.name),
+                );
+                continue;
+            }
+            let spec = match parse_recipe_yaml(&artifact.raw_yaml) {
+                Ok(spec) => spec,
+                Err(error) => {
+                    skip_recipe(&artifact, format_args!("recipe is invalid: {error}"));
+                    continue;
+                }
+            };
+            let mut recipe = runtime_recipe_without_columns(&spec);
+            if artifact.origin == RecipeOrigin::User {
+                recipe.result_columns =
+                    self.cached_recipe_result_columns(workspace_name, &artifact.name);
+            }
+            recipes.push(recipe);
+        }
+        Ok(recipes)
     }
 
     pub(crate) fn list_user_recipes(
@@ -143,6 +281,117 @@ impl RecipeManager {
         }
         Ok(())
     }
+
+    fn load_recipe_artifacts(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<RecipeArtifact>, AppError> {
+        let mut artifacts = Vec::new();
+        for installed in self.config_store.list_workspace_recipes(workspace_name)? {
+            if !installed.enabled {
+                continue;
+            }
+            let recipe_file = self.layout.recipe_file(workspace_name, &installed.name);
+            let raw_yaml = match std::fs::read_to_string(&recipe_file) {
+                Ok(raw_yaml) => raw_yaml,
+                Err(error) => {
+                    tracing::warn!(
+                        recipe = %installed.name,
+                        path = %recipe_file.display(),
+                        detail = %error,
+                        "skipping installed recipe because its recipe file could not be read"
+                    );
+                    continue;
+                }
+            };
+            artifacts.push(RecipeArtifact {
+                name: installed.name,
+                origin: installed.origin,
+                raw_yaml,
+            });
+        }
+
+        artifacts.sort_by(|left, right| {
+            (origin_sort_key(left.origin), left.name.as_str())
+                .cmp(&(origin_sort_key(right.origin), right.name.as_str()))
+        });
+        Ok(artifacts)
+    }
+
+    fn record_installed_recipe_publish_targets(
+        &self,
+        workspace_name: &WorkspaceName,
+        replacing_recipe: &RecipeName,
+        publish_targets: &mut HashSet<PublishTarget>,
+    ) -> Result<(), AppError> {
+        let mut seen_names = HashSet::new();
+        for artifact in self.load_recipe_artifacts(workspace_name)? {
+            if artifact.name == *replacing_recipe {
+                continue;
+            }
+            if !seen_names.insert(artifact.name.clone()) {
+                return Err(AppError::FailedPrecondition(format!(
+                    "recipe '{}' is installed more than once",
+                    artifact.name
+                )));
+            }
+            let spec = parse_recipe_yaml(&artifact.raw_yaml).map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "installed recipe '{}' is invalid: {error}",
+                    artifact.name
+                ))
+            })?;
+            let runtime_recipe = runtime_recipe_without_columns(&spec);
+            record_publish_targets(&runtime_recipe, publish_targets)?;
+        }
+        Ok(())
+    }
+
+    fn cached_recipe_result_columns(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Vec<RecipeRuntimeResultColumn> {
+        let metadata_file = self.layout.recipe_runtime_file(workspace_name, recipe_name);
+        let raw = match std::fs::read_to_string(&metadata_file) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Vec::new(),
+            Err(error) => {
+                tracing::warn!(
+                    recipe = %recipe_name,
+                    path = %metadata_file.display(),
+                    detail = %error,
+                    "ignoring recipe runtime metadata because it could not be read"
+                );
+                return Vec::new();
+            }
+        };
+        match serde_json::from_str::<RecipeRuntimeMetadata>(&raw) {
+            Ok(metadata) => metadata
+                .result_columns
+                .into_iter()
+                .map(RecipeRuntimeResultColumn::from)
+                .collect(),
+            Err(error) => {
+                tracing::warn!(
+                    recipe = %recipe_name,
+                    path = %metadata_file.display(),
+                    detail = %error,
+                    "ignoring recipe runtime metadata because it is invalid"
+                );
+                Vec::new()
+            }
+        }
+    }
+}
+
+fn skip_recipe(artifact: &RecipeArtifact, detail: fmt::Arguments<'_>) {
+    tracing::warn!(
+        recipe = %artifact.name,
+        origin = ?artifact.origin,
+        detail = %detail,
+        "skipping recipe during runtime publication"
+    );
 }
 
 async fn source_publish_targets(
@@ -266,8 +515,11 @@ fn record_publish_targets(
 ) -> Result<(), AppError> {
     let mut recipe_targets = HashSet::new();
     for publish in &recipe.publish {
-        let RecipeRuntimePublish::TableFunction { schema, name, .. } = publish;
-        let target = PublishTarget::sql_relation(schema, name);
+        let target = match publish {
+            RecipeRuntimePublish::TableFunction { schema, name, .. } => {
+                PublishTarget::sql_relation(schema, name)
+            }
+        };
         if publish_targets.contains(&target) || !recipe_targets.insert(target.clone()) {
             return Err(AppError::FailedPrecondition(format!(
                 "recipe publish target '{}' is installed more than once",
@@ -299,10 +551,40 @@ impl PublishTarget {
     }
 }
 
+fn origin_sort_key(origin: RecipeOrigin) -> u8 {
+    match origin {
+        RecipeOrigin::Bundled => 0,
+        RecipeOrigin::User => 1,
+    }
+}
+
+fn write_recipe_runtime_metadata(
+    recipe_runtime_file: &std::path::Path,
+    runtime_recipe: Option<&RecipeRuntimeDefinition>,
+) -> Result<(), AppError> {
+    if let Some(runtime_recipe) = runtime_recipe {
+        let metadata = RecipeRuntimeMetadata {
+            version: 1,
+            result_columns: runtime_recipe
+                .result_columns
+                .iter()
+                .map(CachedRecipeResultColumn::from)
+                .collect(),
+        };
+        let raw = serde_json::to_vec_pretty(&metadata)?;
+        fs::write_atomic(recipe_runtime_file, &raw)?;
+    } else if recipe_runtime_file.exists() {
+        std::fs::remove_file(recipe_runtime_file)?;
+    }
+    Ok(())
+}
+
 fn rollback_recipe_install(
     recipe_dir: &std::path::Path,
     recipe_file: &std::path::Path,
     previous_yaml: Option<&[u8]>,
+    recipe_runtime_file: &std::path::Path,
+    previous_runtime: Option<&[u8]>,
 ) {
     if let Some(previous_yaml) = previous_yaml {
         if let Err(error) = fs::ensure_private_dir(recipe_dir) {
@@ -313,6 +595,7 @@ fn rollback_recipe_install(
             );
             return;
         }
+        rollback_recipe_runtime_file(recipe_runtime_file, previous_runtime);
         if let Err(error) = fs::write_atomic(recipe_file, previous_yaml) {
             tracing::warn!(
                 path = %recipe_file.display(),
@@ -320,11 +603,36 @@ fn rollback_recipe_install(
                 "failed to restore previous recipe file after config update failure"
             );
         }
+    } else if previous_runtime.is_some() {
+        rollback_recipe_runtime_file(recipe_runtime_file, previous_runtime);
     } else if let Err(error) = std::fs::remove_dir_all(recipe_dir) {
         tracing::warn!(
             path = %recipe_dir.display(),
             detail = %error,
             "failed to remove new recipe directory after config update failure"
+        );
+    }
+}
+
+fn rollback_recipe_runtime_file(
+    recipe_runtime_file: &std::path::Path,
+    previous_runtime: Option<&[u8]>,
+) {
+    if let Some(previous_runtime) = previous_runtime {
+        if let Err(error) = fs::write_atomic(recipe_runtime_file, previous_runtime) {
+            tracing::warn!(
+                path = %recipe_runtime_file.display(),
+                detail = %error,
+                "failed to restore previous recipe runtime metadata after config update failure"
+            );
+        }
+    } else if recipe_runtime_file.exists()
+        && let Err(error) = std::fs::remove_file(recipe_runtime_file)
+    {
+        tracing::warn!(
+            path = %recipe_runtime_file.display(),
+            detail = %error,
+            "failed to remove recipe runtime metadata after config update failure"
         );
     }
 }
@@ -350,6 +658,10 @@ mod tests {
     }
 
     fn recipe_yaml(name: &str) -> String {
+        recipe_yaml_with_publish(name, &format!("recipes.{name}"))
+    }
+
+    fn recipe_yaml_with_publish(name: &str, publish_target: &str) -> String {
         format!(
             r"
 kind: recipe
@@ -358,7 +670,7 @@ implementation:
   kind: coral_sql
   query: select 1 as id
 publish:
-  - table_function: recipes.{name}
+  - table_function: {publish_target}
 "
         )
     }
@@ -387,6 +699,42 @@ publish:
                 .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn install_validated_user_recipe_caches_result_columns_for_list() {
+        let (_temp, layout, manager) = fixture();
+        let workspace = workspace();
+        let raw_yaml = recipe_yaml("review_queue");
+        let runtime_recipe = manager
+            .validate_user_recipe_yaml(
+                &workspace,
+                &[],
+                || Ok(QueryRuntimeConfig::default()),
+                &raw_yaml,
+            )
+            .await
+            .expect("validate recipe");
+
+        manager
+            .install_validated_user_recipe(&workspace, &raw_yaml, &runtime_recipe)
+            .expect("install validated recipe");
+
+        let recipe_name = RecipeName::parse("review_queue").expect("recipe name");
+        assert!(
+            layout
+                .recipe_runtime_file(&workspace, &recipe_name)
+                .exists()
+        );
+        let listed = manager.list_recipes(&workspace).expect("list recipes");
+        assert_eq!(listed.len(), 1);
+        let listed_recipe = listed.first().expect("listed recipe");
+        assert_eq!(listed_recipe.result_columns.len(), 1);
+        let column = listed_recipe
+            .result_columns
+            .first()
+            .expect("id result column");
+        assert_eq!(column.name, "id");
     }
 
     #[test]
@@ -430,5 +778,32 @@ publish:
         assert_eq!(recipe.result_columns.len(), 1);
         let column = recipe.result_columns.first().expect("id result column");
         assert_eq!(column.name, "id");
+    }
+
+    #[tokio::test]
+    async fn validate_user_recipe_yaml_rejects_installed_publish_collision() {
+        let (_temp, _layout, manager) = fixture();
+        let workspace = workspace();
+        manager
+            .install_user_recipe(
+                &workspace,
+                &recipe_yaml_with_publish("existing_queue", "recipes.shared_queue"),
+            )
+            .expect("install existing recipe");
+
+        let error = manager
+            .validate_user_recipe_yaml(
+                &workspace,
+                &[],
+                || Ok(QueryRuntimeConfig::default()),
+                &recipe_yaml_with_publish("new_queue", "recipes.shared_queue"),
+            )
+            .await
+            .expect_err("collision should fail validation");
+
+        assert!(matches!(
+            error,
+            AppError::FailedPrecondition(message) if message.contains("recipes.shared_queue")
+        ));
     }
 }

--- a/crates/coral-app/src/recipes/mod.rs
+++ b/crates/coral-app/src/recipes/mod.rs
@@ -3,5 +3,6 @@
 pub(crate) mod manager;
 pub(crate) mod model;
 pub(crate) mod service;
+mod storage;
 
 pub(crate) use model::RecipeName;

--- a/crates/coral-app/src/recipes/mod.rs
+++ b/crates/coral-app/src/recipes/mod.rs
@@ -2,5 +2,6 @@
 
 pub(crate) mod manager;
 pub(crate) mod model;
+pub(crate) mod service;
 
 pub(crate) use model::RecipeName;

--- a/crates/coral-app/src/recipes/mod.rs
+++ b/crates/coral-app/src/recipes/mod.rs
@@ -1,0 +1,5 @@
+//! Recipe lifecycle and inventory workflow.
+
+pub(crate) mod model;
+
+pub(crate) use model::RecipeName;

--- a/crates/coral-app/src/recipes/mod.rs
+++ b/crates/coral-app/src/recipes/mod.rs
@@ -1,5 +1,6 @@
 //! Recipe lifecycle and inventory workflow.
 
+pub(crate) mod manager;
 pub(crate) mod model;
 
 pub(crate) use model::RecipeName;

--- a/crates/coral-app/src/recipes/model.rs
+++ b/crates/coral-app/src/recipes/model.rs
@@ -64,32 +64,4 @@ impl FromStr for RecipeName {
 pub(crate) struct InstalledRecipe {
     /// Stable recipe name.
     pub(crate) name: RecipeName,
-    /// Where this installed recipe came from.
-    pub(crate) origin: RecipeOrigin,
-    /// Whether this recipe participates in query and MCP runtime assembly.
-    #[serde(default = "default_recipe_enabled")]
-    pub(crate) enabled: bool,
-}
-
-/// Where an installed recipe came from.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum RecipeOrigin {
-    /// A recipe shipped with a bundled source package.
-    Bundled,
-    /// A recipe installed by the user.
-    User,
-}
-
-impl RecipeOrigin {
-    pub(crate) fn as_config_value(self) -> &'static str {
-        match self {
-            Self::Bundled => "bundled",
-            Self::User => "user",
-        }
-    }
-}
-
-fn default_recipe_enabled() -> bool {
-    true
 }

--- a/crates/coral-app/src/recipes/model.rs
+++ b/crates/coral-app/src/recipes/model.rs
@@ -1,0 +1,95 @@
+//! Installed-recipe domain model for the application management plane.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::bootstrap::AppError;
+use crate::identity::parse_path_segment;
+
+/// App-owned identity for one installed recipe.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RecipeName(String);
+
+impl RecipeName {
+    /// Parse and validate a recipe name for app-internal use.
+    pub(crate) fn parse(name: &str) -> Result<Self, AppError> {
+        parse_path_segment("recipe", name).map(Self)
+    }
+
+    /// Borrow the normalized recipe name at string boundaries such as paths,
+    /// config rendering, or protobuf mapping.
+    #[must_use]
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RecipeName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Serialize for RecipeName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for RecipeName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::from_str(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+impl FromStr for RecipeName {
+    type Err = AppError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+/// App-owned model for one recipe installed in a workspace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct InstalledRecipe {
+    /// Stable recipe name.
+    pub(crate) name: RecipeName,
+    /// Where this installed recipe came from.
+    pub(crate) origin: RecipeOrigin,
+    /// Whether this recipe participates in query and MCP runtime assembly.
+    #[serde(default = "default_recipe_enabled")]
+    pub(crate) enabled: bool,
+}
+
+/// Where an installed recipe came from.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RecipeOrigin {
+    /// A recipe shipped with a bundled source package.
+    Bundled,
+    /// A recipe installed by the user.
+    User,
+}
+
+impl RecipeOrigin {
+    pub(crate) fn as_config_value(self) -> &'static str {
+        match self {
+            Self::Bundled => "bundled",
+            Self::User => "user",
+        }
+    }
+}
+
+fn default_recipe_enabled() -> bool {
+    true
+}

--- a/crates/coral-app/src/recipes/service.rs
+++ b/crates/coral-app/src/recipes/service.rs
@@ -11,7 +11,7 @@ use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::query::manager::QueryManager;
-use crate::recipes::manager::RecipeManager;
+use crate::recipes::manager::{RecipeListing, RecipeManager};
 use crate::recipes::model::{RecipeName, RecipeOrigin};
 use crate::transport::{grpc_span, instrument_grpc, query_status, workspace_name_from_proto};
 
@@ -71,7 +71,7 @@ impl RecipeServiceApi for RecipeService {
                 .list_recipes(&workspace_name)
                 .map_err(query_status)?
                 .into_iter()
-                .map(runtime_recipe_to_proto)
+                .map(recipe_listing_to_proto)
                 .collect();
             Ok(Response::new(ListRecipesResponse { recipes }))
         })
@@ -97,7 +97,19 @@ impl RecipeServiceApi for RecipeService {
     }
 }
 
-fn runtime_recipe_to_proto(recipe: RecipeRuntimeDefinition) -> Recipe {
+fn recipe_listing_to_proto(listing: RecipeListing) -> Recipe {
+    runtime_recipe_to_proto(
+        listing.definition,
+        proto_recipe_origin(listing.origin),
+        listing.enabled,
+    )
+}
+
+fn runtime_recipe_to_proto(
+    recipe: RecipeRuntimeDefinition,
+    origin: ProtoRecipeOrigin,
+    enabled: bool,
+) -> Recipe {
     Recipe {
         name: recipe.name,
         description: recipe.description,
@@ -122,6 +134,8 @@ fn runtime_recipe_to_proto(recipe: RecipeRuntimeDefinition) -> Recipe {
                 description: column.description,
             })
             .collect(),
+        origin: origin as i32,
+        enabled,
     }
 }
 

--- a/crates/coral-app/src/recipes/service.rs
+++ b/crates/coral-app/src/recipes/service.rs
@@ -1,0 +1,183 @@
+//! Implements the gRPC `RecipeService`.
+
+use coral_api::v1::recipe_service_server::RecipeService as RecipeServiceApi;
+use coral_api::v1::{
+    AddRecipeRequest, AddRecipeResponse, ListRecipesRequest, ListRecipesResponse, Recipe,
+    RecipeArgument, RecipeOrigin as ProtoRecipeOrigin, RecipePublish, RecipeResultColumn,
+    RecipeTableFunctionPublish, RemoveRecipeRequest, RemoveRecipeResponse, ValidateRecipeRequest,
+    ValidateRecipeResponse, recipe_publish,
+};
+use coral_engine::{RecipeRuntimeArgumentType, RecipeRuntimeDefinition, RecipeRuntimePublish};
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::app_status;
+use crate::query::manager::QueryManager;
+use crate::recipes::manager::RecipeManager;
+use crate::recipes::model::{RecipeName, RecipeOrigin};
+use crate::transport::{grpc_span, instrument_grpc, query_status, workspace_name_from_proto};
+
+#[derive(Clone)]
+pub(crate) struct RecipeService {
+    recipes: RecipeManager,
+    queries: QueryManager,
+}
+
+impl RecipeService {
+    pub(crate) fn new(recipe_manager: RecipeManager, query_manager: QueryManager) -> Self {
+        Self {
+            recipes: recipe_manager,
+            queries: query_manager,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl RecipeServiceApi for RecipeService {
+    async fn add_recipe(
+        &self,
+        request: Request<AddRecipeRequest>,
+    ) -> Result<Response<AddRecipeResponse>, Status> {
+        let span = grpc_span(&request);
+        let recipes = self.recipes.clone();
+        let queries = self.queries.clone();
+        instrument_grpc(span, async move {
+            let inner = request.into_inner();
+            let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let runtime_recipe = queries
+                .validate_recipe_yaml(&workspace_name, &inner.yaml)
+                .await
+                .map_err(query_status)?;
+            let recipe = recipes
+                .install_validated_user_recipe(&workspace_name, &inner.yaml, &runtime_recipe)
+                .map_err(app_status)?;
+            Ok(Response::new(AddRecipeResponse {
+                name: recipe.name.as_str().to_string(),
+                origin: proto_recipe_origin(recipe.origin) as i32,
+                enabled: recipe.enabled,
+            }))
+        })
+        .await
+    }
+
+    async fn list_recipes(
+        &self,
+        request: Request<ListRecipesRequest>,
+    ) -> Result<Response<ListRecipesResponse>, Status> {
+        let span = grpc_span(&request);
+        let queries = self.queries.clone();
+        instrument_grpc(span, async move {
+            let inner = request.into_inner();
+            let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let recipes = queries
+                .list_recipes(&workspace_name)
+                .map_err(query_status)?
+                .into_iter()
+                .map(runtime_recipe_to_proto)
+                .collect();
+            Ok(Response::new(ListRecipesResponse { recipes }))
+        })
+        .await
+    }
+
+    async fn validate_recipe(
+        &self,
+        request: Request<ValidateRecipeRequest>,
+    ) -> Result<Response<ValidateRecipeResponse>, Status> {
+        let span = grpc_span(&request);
+        let queries = self.queries.clone();
+        instrument_grpc(span, async move {
+            let inner = request.into_inner();
+            let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let recipe = queries
+                .validate_recipe_yaml(&workspace_name, &inner.yaml)
+                .await
+                .map_err(query_status)?;
+            Ok(Response::new(ValidateRecipeResponse {
+                recipe: Some(runtime_recipe_to_proto(recipe)),
+            }))
+        })
+        .await
+    }
+
+    async fn remove_recipe(
+        &self,
+        request: Request<RemoveRecipeRequest>,
+    ) -> Result<Response<RemoveRecipeResponse>, Status> {
+        let span = grpc_span(&request);
+        let recipes = self.recipes.clone();
+        instrument_grpc(span, async move {
+            let inner = request.into_inner();
+            let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let recipe_name = RecipeName::parse(&inner.name).map_err(app_status)?;
+            recipes
+                .remove_user_recipe(&workspace_name, &recipe_name)
+                .map_err(app_status)?;
+            Ok(Response::new(RemoveRecipeResponse {}))
+        })
+        .await
+    }
+}
+
+fn runtime_recipe_to_proto(recipe: RecipeRuntimeDefinition) -> Recipe {
+    Recipe {
+        name: recipe.name,
+        description: recipe.description,
+        arguments: recipe
+            .arguments
+            .into_iter()
+            .map(|argument| RecipeArgument {
+                name: argument.name,
+                data_type: recipe_argument_type(argument.data_type).to_string(),
+                required: argument.required,
+                description: argument.description,
+            })
+            .collect(),
+        publish: recipe
+            .publish
+            .into_iter()
+            .map(recipe_publish_to_proto)
+            .collect(),
+        result_columns: recipe
+            .result_columns
+            .into_iter()
+            .map(|column| RecipeResultColumn {
+                name: column.name,
+                data_type: column.data_type,
+                nullable: column.nullable,
+                description: column.description,
+            })
+            .collect(),
+    }
+}
+
+fn recipe_publish_to_proto(publish: RecipeRuntimePublish) -> RecipePublish {
+    let target = match publish {
+        RecipeRuntimePublish::TableFunction {
+            schema,
+            name,
+            description,
+        } => recipe_publish::Target::TableFunction(RecipeTableFunctionPublish {
+            schema,
+            name,
+            description,
+        }),
+    };
+    RecipePublish {
+        target: Some(target),
+    }
+}
+
+fn proto_recipe_origin(origin: RecipeOrigin) -> ProtoRecipeOrigin {
+    match origin {
+        RecipeOrigin::Bundled => ProtoRecipeOrigin::Bundled,
+        RecipeOrigin::User => ProtoRecipeOrigin::User,
+    }
+}
+
+fn recipe_argument_type(data_type: RecipeRuntimeArgumentType) -> &'static str {
+    match data_type {
+        RecipeRuntimeArgumentType::String => "string",
+        RecipeRuntimeArgumentType::Integer => "integer",
+        RecipeRuntimeArgumentType::Boolean => "boolean",
+    }
+}

--- a/crates/coral-app/src/recipes/service.rs
+++ b/crates/coral-app/src/recipes/service.rs
@@ -3,8 +3,8 @@
 use coral_api::v1::recipe_service_server::RecipeService as RecipeServiceApi;
 use coral_api::v1::{
     AddRecipeRequest, AddRecipeResponse, ListRecipesRequest, ListRecipesResponse, Recipe,
-    RecipeArgument, RecipeOrigin as ProtoRecipeOrigin, RecipePublish, RecipeResultColumn,
-    RecipeTableFunctionPublish, RemoveRecipeRequest, RemoveRecipeResponse, recipe_publish,
+    RecipeArgument, RecipeOrigin as ProtoRecipeOrigin, RecipePublishedSurface, RecipeResultColumn,
+    RecipeTableFunctionPublish, RemoveRecipeRequest, RemoveRecipeResponse, recipe_published_surface,
 };
 use coral_engine::{RecipeRuntimeArgumentType, RecipeRuntimeDefinition, RecipeRuntimePublish};
 use tonic::{Request, Response, Status};
@@ -139,13 +139,13 @@ fn runtime_recipe_to_proto(
     }
 }
 
-fn recipe_publish_to_proto(publish: RecipeRuntimePublish) -> RecipePublish {
-    let target = recipe_publish::Target::TableFunction(RecipeTableFunctionPublish {
+fn recipe_publish_to_proto(publish: RecipeRuntimePublish) -> RecipePublishedSurface {
+    let target = recipe_published_surface::Target::TableFunction(RecipeTableFunctionPublish {
         schema: publish.table_function.schema,
         name: publish.table_function.name,
         description: publish.table_function.description,
     });
-    RecipePublish {
+    RecipePublishedSurface {
         target: Some(target),
     }
 }

--- a/crates/coral-app/src/recipes/service.rs
+++ b/crates/coral-app/src/recipes/service.rs
@@ -4,7 +4,8 @@ use coral_api::v1::recipe_service_server::RecipeService as RecipeServiceApi;
 use coral_api::v1::{
     AddRecipeRequest, AddRecipeResponse, ListRecipesRequest, ListRecipesResponse, Recipe,
     RecipeArgument, RecipeOrigin as ProtoRecipeOrigin, RecipePublishedSurface, RecipeResultColumn,
-    RecipeTableFunctionPublish, RemoveRecipeRequest, RemoveRecipeResponse, recipe_published_surface,
+    RecipeTableFunctionPublish, RemoveRecipeRequest, RemoveRecipeResponse,
+    recipe_published_surface,
 };
 use coral_engine::{RecipeRuntimeArgumentType, RecipeRuntimeDefinition, RecipeRuntimePublish};
 use tonic::{Request, Response, Status};

--- a/crates/coral-app/src/recipes/service.rs
+++ b/crates/coral-app/src/recipes/service.rs
@@ -4,8 +4,7 @@ use coral_api::v1::recipe_service_server::RecipeService as RecipeServiceApi;
 use coral_api::v1::{
     AddRecipeRequest, AddRecipeResponse, ListRecipesRequest, ListRecipesResponse, Recipe,
     RecipeArgument, RecipeOrigin as ProtoRecipeOrigin, RecipePublish, RecipeResultColumn,
-    RecipeTableFunctionPublish, RemoveRecipeRequest, RemoveRecipeResponse, ValidateRecipeRequest,
-    ValidateRecipeResponse, recipe_publish,
+    RecipeTableFunctionPublish, RemoveRecipeRequest, RemoveRecipeResponse, recipe_publish,
 };
 use coral_engine::{RecipeRuntimeArgumentType, RecipeRuntimeDefinition, RecipeRuntimePublish};
 use tonic::{Request, Response, Status};
@@ -79,26 +78,6 @@ impl RecipeServiceApi for RecipeService {
         .await
     }
 
-    async fn validate_recipe(
-        &self,
-        request: Request<ValidateRecipeRequest>,
-    ) -> Result<Response<ValidateRecipeResponse>, Status> {
-        let span = grpc_span(&request);
-        let queries = self.queries.clone();
-        instrument_grpc(span, async move {
-            let inner = request.into_inner();
-            let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
-            let recipe = queries
-                .validate_recipe_yaml(&workspace_name, &inner.yaml)
-                .await
-                .map_err(query_status)?;
-            Ok(Response::new(ValidateRecipeResponse {
-                recipe: Some(runtime_recipe_to_proto(recipe)),
-            }))
-        })
-        .await
-    }
-
     async fn remove_recipe(
         &self,
         request: Request<RemoveRecipeRequest>,
@@ -132,11 +111,7 @@ fn runtime_recipe_to_proto(recipe: RecipeRuntimeDefinition) -> Recipe {
                 description: argument.description,
             })
             .collect(),
-        publish: recipe
-            .publish
-            .into_iter()
-            .map(recipe_publish_to_proto)
-            .collect(),
+        publish: vec![recipe_publish_to_proto(recipe.publish)],
         result_columns: recipe
             .result_columns
             .into_iter()
@@ -151,17 +126,11 @@ fn runtime_recipe_to_proto(recipe: RecipeRuntimeDefinition) -> Recipe {
 }
 
 fn recipe_publish_to_proto(publish: RecipeRuntimePublish) -> RecipePublish {
-    let target = match publish {
-        RecipeRuntimePublish::TableFunction {
-            schema,
-            name,
-            description,
-        } => recipe_publish::Target::TableFunction(RecipeTableFunctionPublish {
-            schema,
-            name,
-            description,
-        }),
-    };
+    let target = recipe_publish::Target::TableFunction(RecipeTableFunctionPublish {
+        schema: publish.table_function.schema,
+        name: publish.table_function.name,
+        description: publish.table_function.description,
+    });
     RecipePublish {
         target: Some(target),
     }

--- a/crates/coral-app/src/recipes/service.rs
+++ b/crates/coral-app/src/recipes/service.rs
@@ -3,9 +3,8 @@
 use coral_api::v1::recipe_service_server::RecipeService as RecipeServiceApi;
 use coral_api::v1::{
     AddRecipeRequest, AddRecipeResponse, ListRecipesRequest, ListRecipesResponse, Recipe,
-    RecipeArgument, RecipeOrigin as ProtoRecipeOrigin, RecipePublishedSurface, RecipeResultColumn,
-    RecipeTableFunctionPublish, RemoveRecipeRequest, RemoveRecipeResponse,
-    recipe_published_surface,
+    RecipeArgument, RecipePublish, RecipeResultColumn, RecipeTableFunctionPublish,
+    RemoveRecipeRequest, RemoveRecipeResponse,
 };
 use coral_engine::{RecipeRuntimeArgumentType, RecipeRuntimeDefinition, RecipeRuntimePublish};
 use tonic::{Request, Response, Status};
@@ -13,7 +12,7 @@ use tonic::{Request, Response, Status};
 use crate::bootstrap::app_status;
 use crate::query::manager::QueryManager;
 use crate::recipes::manager::{RecipeListing, RecipeManager};
-use crate::recipes::model::{RecipeName, RecipeOrigin};
+use crate::recipes::model::RecipeName;
 use crate::transport::{grpc_span, instrument_grpc, query_status, workspace_name_from_proto};
 
 #[derive(Clone)]
@@ -52,8 +51,6 @@ impl RecipeServiceApi for RecipeService {
                 .map_err(app_status)?;
             Ok(Response::new(AddRecipeResponse {
                 name: recipe.name.as_str().to_string(),
-                origin: proto_recipe_origin(recipe.origin) as i32,
-                enabled: recipe.enabled,
             }))
         })
         .await
@@ -99,18 +96,10 @@ impl RecipeServiceApi for RecipeService {
 }
 
 fn recipe_listing_to_proto(listing: RecipeListing) -> Recipe {
-    runtime_recipe_to_proto(
-        listing.definition,
-        proto_recipe_origin(listing.origin),
-        listing.enabled,
-    )
+    runtime_recipe_to_proto(listing.definition)
 }
 
-fn runtime_recipe_to_proto(
-    recipe: RecipeRuntimeDefinition,
-    origin: ProtoRecipeOrigin,
-    enabled: bool,
-) -> Recipe {
+fn runtime_recipe_to_proto(recipe: RecipeRuntimeDefinition) -> Recipe {
     Recipe {
         name: recipe.name,
         description: recipe.description,
@@ -124,7 +113,7 @@ fn runtime_recipe_to_proto(
                 description: argument.description,
             })
             .collect(),
-        publish: vec![recipe_publish_to_proto(recipe.publish)],
+        publish: Some(recipe_publish_to_proto(recipe.publish)),
         result_columns: recipe
             .result_columns
             .into_iter()
@@ -135,26 +124,16 @@ fn runtime_recipe_to_proto(
                 description: column.description,
             })
             .collect(),
-        origin: origin as i32,
-        enabled,
     }
 }
 
-fn recipe_publish_to_proto(publish: RecipeRuntimePublish) -> RecipePublishedSurface {
-    let target = recipe_published_surface::Target::TableFunction(RecipeTableFunctionPublish {
-        schema: publish.table_function.schema,
-        name: publish.table_function.name,
-        description: publish.table_function.description,
-    });
-    RecipePublishedSurface {
-        target: Some(target),
-    }
-}
-
-fn proto_recipe_origin(origin: RecipeOrigin) -> ProtoRecipeOrigin {
-    match origin {
-        RecipeOrigin::Bundled => ProtoRecipeOrigin::Bundled,
-        RecipeOrigin::User => ProtoRecipeOrigin::User,
+fn recipe_publish_to_proto(publish: RecipeRuntimePublish) -> RecipePublish {
+    RecipePublish {
+        table_function: Some(RecipeTableFunctionPublish {
+            schema: publish.table_function.schema,
+            name: publish.table_function.name,
+            description: publish.table_function.description,
+        }),
     }
 }
 

--- a/crates/coral-app/src/recipes/storage.rs
+++ b/crates/coral-app/src/recipes/storage.rs
@@ -1,0 +1,277 @@
+//! Storage seams for workspace recipe inventory and artifacts.
+
+use std::io::ErrorKind;
+
+use crate::bootstrap::AppError;
+use crate::recipes::model::{InstalledRecipe, RecipeName};
+use crate::state::{AppStateLayout, ConfigStore};
+use crate::storage::fs;
+use crate::workspaces::WorkspaceName;
+
+pub(crate) trait RecipeRegistry: Send + Sync {
+    fn list_workspace_recipes(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledRecipe>, AppError>;
+
+    fn get_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<InstalledRecipe, AppError>;
+
+    fn upsert_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe: InstalledRecipe,
+    ) -> Result<(), AppError>;
+
+    fn remove_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<(), AppError>;
+}
+
+#[derive(Clone)]
+pub(crate) struct ConfigRecipeRegistry {
+    config_store: ConfigStore,
+}
+
+impl ConfigRecipeRegistry {
+    pub(crate) fn new(config_store: ConfigStore) -> Self {
+        Self { config_store }
+    }
+}
+
+impl RecipeRegistry for ConfigRecipeRegistry {
+    fn list_workspace_recipes(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledRecipe>, AppError> {
+        self.config_store.list_workspace_recipes(workspace_name)
+    }
+
+    fn get_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<InstalledRecipe, AppError> {
+        self.config_store.get_recipe(workspace_name, recipe_name)
+    }
+
+    fn upsert_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe: InstalledRecipe,
+    ) -> Result<(), AppError> {
+        self.config_store.upsert_recipe(workspace_name, recipe)
+    }
+
+    fn remove_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<(), AppError> {
+        self.config_store.remove_recipe(workspace_name, recipe_name)
+    }
+}
+
+pub(crate) trait RecipeArtifactStore: Send + Sync {
+    fn read_recipe_yaml(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<Option<String>, AppError>;
+
+    fn read_runtime_metadata(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<Option<String>, AppError>;
+
+    fn write_user_recipe_artifact(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+        raw_yaml: &str,
+        runtime_metadata: Option<&[u8]>,
+    ) -> Result<RecipeArtifactSnapshot, AppError>;
+
+    fn remove_user_recipe_artifact(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<RecipeArtifactSnapshot, AppError>;
+
+    fn restore_user_recipe_artifact(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+        snapshot: &RecipeArtifactSnapshot,
+    ) -> Result<(), AppError>;
+}
+
+#[derive(Clone)]
+pub(crate) struct FsRecipeArtifactStore {
+    layout: AppStateLayout,
+}
+
+impl FsRecipeArtifactStore {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
+    fn snapshot(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<RecipeArtifactSnapshot, AppError> {
+        Ok(RecipeArtifactSnapshot {
+            recipe_yaml: read_optional_bytes(
+                &self.layout.recipe_file(workspace_name, recipe_name),
+            )?,
+            runtime_metadata: read_optional_bytes(
+                &self.layout.recipe_runtime_file(workspace_name, recipe_name),
+            )?,
+        })
+    }
+
+    fn write_user_recipe_artifact_inner(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+        raw_yaml: &str,
+        runtime_metadata: Option<&[u8]>,
+    ) -> Result<(), AppError> {
+        let recipe_dir = self.layout.recipe_dir(workspace_name, recipe_name);
+        let recipe_file = self.layout.recipe_file(workspace_name, recipe_name);
+        let runtime_file = self.layout.recipe_runtime_file(workspace_name, recipe_name);
+
+        fs::ensure_private_dir(&recipe_dir)?;
+        fs::write_atomic(&recipe_file, raw_yaml.as_bytes())?;
+        match runtime_metadata {
+            Some(runtime_metadata) => fs::write_atomic(&runtime_file, runtime_metadata)?,
+            None if runtime_file.exists() => std::fs::remove_file(&runtime_file)?,
+            None => {}
+        }
+        Ok(())
+    }
+}
+
+impl RecipeArtifactStore for FsRecipeArtifactStore {
+    fn read_recipe_yaml(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<Option<String>, AppError> {
+        match std::fs::read_to_string(self.layout.recipe_file(workspace_name, recipe_name)) {
+            Ok(raw_yaml) => Ok(Some(raw_yaml)),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn read_runtime_metadata(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<Option<String>, AppError> {
+        match std::fs::read_to_string(self.layout.recipe_runtime_file(workspace_name, recipe_name))
+        {
+            Ok(raw_metadata) => Ok(Some(raw_metadata)),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn write_user_recipe_artifact(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+        raw_yaml: &str,
+        runtime_metadata: Option<&[u8]>,
+    ) -> Result<RecipeArtifactSnapshot, AppError> {
+        let previous = self.snapshot(workspace_name, recipe_name)?;
+        if let Err(error) = self.write_user_recipe_artifact_inner(
+            workspace_name,
+            recipe_name,
+            raw_yaml,
+            runtime_metadata,
+        ) {
+            if let Err(restore_error) =
+                self.restore_user_recipe_artifact(workspace_name, recipe_name, &previous)
+            {
+                tracing::warn!(
+                    recipe = %recipe_name,
+                    detail = %restore_error,
+                    "failed to restore previous recipe artifact after write failure"
+                );
+            }
+            return Err(error);
+        }
+        Ok(previous)
+    }
+
+    fn remove_user_recipe_artifact(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<RecipeArtifactSnapshot, AppError> {
+        let previous = self.snapshot(workspace_name, recipe_name)?;
+        let recipe_dir = self.layout.recipe_dir(workspace_name, recipe_name);
+        match std::fs::remove_dir_all(recipe_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+        Ok(previous)
+    }
+
+    fn restore_user_recipe_artifact(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+        snapshot: &RecipeArtifactSnapshot,
+    ) -> Result<(), AppError> {
+        let recipe_dir = self.layout.recipe_dir(workspace_name, recipe_name);
+        let recipe_file = self.layout.recipe_file(workspace_name, recipe_name);
+        let runtime_file = self.layout.recipe_runtime_file(workspace_name, recipe_name);
+
+        if snapshot.recipe_yaml.is_none() && snapshot.runtime_metadata.is_none() {
+            match std::fs::remove_dir_all(recipe_dir) {
+                Ok(()) => {}
+                Err(error) if error.kind() == ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+            return Ok(());
+        }
+
+        fs::ensure_private_dir(&recipe_dir)?;
+        match &snapshot.recipe_yaml {
+            Some(raw_yaml) => fs::write_atomic(&recipe_file, raw_yaml)?,
+            None if recipe_file.exists() => std::fs::remove_file(&recipe_file)?,
+            None => {}
+        }
+        match &snapshot.runtime_metadata {
+            Some(raw_metadata) => fs::write_atomic(&runtime_file, raw_metadata)?,
+            None if runtime_file.exists() => std::fs::remove_file(&runtime_file)?,
+            None => {}
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RecipeArtifactSnapshot {
+    recipe_yaml: Option<Vec<u8>>,
+    runtime_metadata: Option<Vec<u8>>,
+}
+
+fn read_optional_bytes(path: &std::path::Path) -> Result<Option<Vec<u8>>, AppError> {
+    match std::fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}

--- a/crates/coral-app/src/recipes/storage.rs
+++ b/crates/coral-app/src/recipes/storage.rs
@@ -152,8 +152,7 @@ impl FsRecipeArtifactStore {
         fs::write_atomic(&recipe_file, raw_yaml.as_bytes())?;
         match runtime_metadata {
             Some(runtime_metadata) => fs::write_atomic(&runtime_file, runtime_metadata)?,
-            None if runtime_file.exists() => std::fs::remove_file(&runtime_file)?,
-            None => {}
+            None => remove_file_if_present(&runtime_file)?,
         }
         Ok(())
     }
@@ -250,13 +249,11 @@ impl RecipeArtifactStore for FsRecipeArtifactStore {
         fs::ensure_private_dir(&recipe_dir)?;
         match &snapshot.recipe_yaml {
             Some(raw_yaml) => fs::write_atomic(&recipe_file, raw_yaml)?,
-            None if recipe_file.exists() => std::fs::remove_file(&recipe_file)?,
-            None => {}
+            None => remove_file_if_present(&recipe_file)?,
         }
         match &snapshot.runtime_metadata {
             Some(raw_metadata) => fs::write_atomic(&runtime_file, raw_metadata)?,
-            None if runtime_file.exists() => std::fs::remove_file(&runtime_file)?,
-            None => {}
+            None => remove_file_if_present(&runtime_file)?,
         }
         Ok(())
     }
@@ -272,6 +269,14 @@ fn read_optional_bytes(path: &std::path::Path) -> Result<Option<Vec<u8>>, AppErr
     match std::fs::read(path) {
         Ok(bytes) => Ok(Some(bytes)),
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn remove_file_if_present(path: &std::path::Path) -> Result<(), AppError> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error.into()),
     }
 }

--- a/crates/coral-app/src/recipes/storage.rs
+++ b/crates/coral-app/src/recipes/storage.rs
@@ -95,7 +95,7 @@ pub(crate) trait RecipeArtifactStore: Send + Sync {
         workspace_name: &WorkspaceName,
         recipe_name: &RecipeName,
         raw_yaml: &str,
-        runtime_metadata: Option<&[u8]>,
+        runtime_metadata: &[u8],
     ) -> Result<RecipeArtifactSnapshot, AppError>;
 
     fn remove_user_recipe_artifact(
@@ -142,7 +142,7 @@ impl FsRecipeArtifactStore {
         workspace_name: &WorkspaceName,
         recipe_name: &RecipeName,
         raw_yaml: &str,
-        runtime_metadata: Option<&[u8]>,
+        runtime_metadata: &[u8],
     ) -> Result<(), AppError> {
         let recipe_dir = self.layout.recipe_dir(workspace_name, recipe_name);
         let recipe_file = self.layout.recipe_file(workspace_name, recipe_name);
@@ -150,10 +150,7 @@ impl FsRecipeArtifactStore {
 
         fs::ensure_private_dir(&recipe_dir)?;
         fs::write_atomic(&recipe_file, raw_yaml.as_bytes())?;
-        match runtime_metadata {
-            Some(runtime_metadata) => fs::write_atomic(&runtime_file, runtime_metadata)?,
-            None => remove_file_if_present(&runtime_file)?,
-        }
+        fs::write_atomic(&runtime_file, runtime_metadata)?;
         Ok(())
     }
 }
@@ -189,7 +186,7 @@ impl RecipeArtifactStore for FsRecipeArtifactStore {
         workspace_name: &WorkspaceName,
         recipe_name: &RecipeName,
         raw_yaml: &str,
-        runtime_metadata: Option<&[u8]>,
+        runtime_metadata: &[u8],
     ) -> Result<RecipeArtifactSnapshot, AppError> {
         let previous = self.snapshot(workspace_name, recipe_name)?;
         if let Err(error) = self.write_user_recipe_artifact_inner(

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -9,7 +9,7 @@ use tracing::{info_span, warn};
 
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialStorageKind;
-use crate::recipes::model::{InstalledRecipe, RecipeName, RecipeOrigin};
+use crate::recipes::model::{InstalledRecipe, RecipeName};
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
@@ -178,6 +178,12 @@ pub(crate) enum RawFeatureValue {
 struct PersistedWorkspaceConfig {
     #[serde(default)]
     sources: BTreeMap<String, PersistedInstalledSource>,
+    // The persisted TOML shape is `recipes.<name> = {}` so existing workspace
+    // configs keep round-tripping even though installed recipes are membership-only.
+    #[expect(
+        clippy::zero_sized_map_values,
+        reason = "persisted recipe membership uses the existing TOML map shape"
+    )]
     #[serde(default)]
     recipes: BTreeMap<String, PersistedInstalledRecipe>,
 }
@@ -221,33 +227,18 @@ impl From<&InstalledSource> for PersistedInstalledSource {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct PersistedInstalledRecipe {
-    origin: RecipeOrigin,
-    #[serde(default = "default_persisted_recipe_enabled")]
-    enabled: bool,
-}
+struct PersistedInstalledRecipe {}
 
 impl PersistedInstalledRecipe {
-    fn into_installed_recipe(self, recipe_name: RecipeName) -> InstalledRecipe {
-        InstalledRecipe {
-            name: recipe_name,
-            origin: self.origin,
-            enabled: self.enabled,
-        }
+    fn into_installed_recipe(recipe_name: RecipeName) -> InstalledRecipe {
+        InstalledRecipe { name: recipe_name }
     }
 }
 
 impl From<&InstalledRecipe> for PersistedInstalledRecipe {
-    fn from(value: &InstalledRecipe) -> Self {
-        Self {
-            origin: value.origin,
-            enabled: value.enabled,
-        }
+    fn from(_value: &InstalledRecipe) -> Self {
+        Self {}
     }
-}
-
-fn default_persisted_recipe_enabled() -> bool {
-    true
 }
 
 #[derive(Debug, Clone, Default)]
@@ -655,7 +646,7 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
             source_item["origin"] = value(source.origin.as_config_value());
         }
 
-        for (recipe_name, recipe) in &workspace.recipes {
+        for recipe_name in workspace.recipes.keys() {
             ensure_implicit_table(&mut doc["workspaces"]);
             ensure_implicit_table(&mut doc["workspaces"][workspace_name]);
             ensure_implicit_table(&mut doc["workspaces"][workspace_name]["recipes"]);
@@ -664,9 +655,11 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
             if !recipe_item.is_table() {
                 *recipe_item = toml_edit::table();
             }
-
-            recipe_item["origin"] = value(recipe.origin.as_config_value());
-            recipe_item["enabled"] = value(recipe.enabled);
+            let recipe_table = recipe_item
+                .as_table_mut()
+                .expect("recipe config entry should be a table after initialization");
+            recipe_table.remove("origin");
+            recipe_table.remove("enabled");
         }
     }
 
@@ -749,9 +742,12 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
                 let source_name = SourceName::parse(&source_name)?;
                 catalog.upsert_source(&workspace_name, source.into_installed_source(source_name));
             }
-            for (recipe_name, recipe) in workspace_config.recipes {
+            for (recipe_name, _recipe) in workspace_config.recipes {
                 let recipe_name = RecipeName::parse(&recipe_name)?;
-                recipes.upsert_recipe(&workspace_name, recipe.into_installed_recipe(recipe_name));
+                recipes.upsert_recipe(
+                    &workspace_name,
+                    PersistedInstalledRecipe::into_installed_recipe(recipe_name),
+                );
             }
         }
         Ok(Self {
@@ -968,7 +964,7 @@ mod tests {
         load_raw_feature_overrides, render_config, set_raw_feature_override,
     };
     use crate::credentials::CredentialStorageKind;
-    use crate::recipes::model::{InstalledRecipe, RecipeName, RecipeOrigin};
+    use crate::recipes::model::{InstalledRecipe, RecipeName};
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::AppStateLayout;
@@ -995,8 +991,6 @@ mod tests {
     fn installed_recipe(name: &str) -> InstalledRecipe {
         InstalledRecipe {
             name: RecipeName::parse(name).expect("recipe"),
-            origin: RecipeOrigin::User,
-            enabled: true,
         }
     }
 
@@ -1075,8 +1069,34 @@ mod tests {
         let raw = render_config(&PersistedAppConfig::from(&config), None);
 
         assert!(raw.contains("[workspaces.default.recipes.review_queue]"));
-        assert!(raw.contains("origin = \"user\""));
-        assert!(raw.contains("enabled = true"));
+        assert!(!raw.contains("origin = \"user\""));
+        assert!(!raw.contains("enabled = true"));
+    }
+
+    #[test]
+    fn removes_legacy_recipe_origin_and_enabled_when_rendering() {
+        let existing = r#"
+version = 1
+
+[workspaces.default.recipes.review_queue]
+origin = "user"
+enabled = true
+"#;
+        let workspace_name = default_workspace();
+        let mut recipes = RecipeCatalog::default();
+        recipes.upsert_recipe(&workspace_name, installed_recipe("review_queue"));
+        let config = AppConfig {
+            version: 1,
+            engine: PersistedEngineConfig::default(),
+            catalog: SourceCatalog::default(),
+            recipes,
+        };
+
+        let raw = render_config(&PersistedAppConfig::from(&config), Some(existing));
+
+        assert!(raw.contains("[workspaces.default.recipes.review_queue]"));
+        assert!(!raw.contains("origin = \"user\""));
+        assert!(!raw.contains("enabled = true"));
     }
 
     #[test]
@@ -1133,13 +1153,11 @@ origin = "bundled"
 
     #[test]
     fn loads_recipes_from_workspace_keyed_tables() {
-        let raw = r#"
+        let raw = r"
 version = 1
 
-[workspaces.default.recipes.review_queue]
-origin = "user"
-enabled = false
-"#;
+	[workspaces.default.recipes.review_queue]
+	";
 
         let config = AppConfig::try_from(
             toml::from_str::<PersistedAppConfig>(raw).expect("workspace-keyed config should parse"),
@@ -1149,8 +1167,6 @@ enabled = false
 
         assert_eq!(recipes.len(), 1);
         assert_eq!(recipes[0].name.as_str(), "review_queue");
-        assert_eq!(recipes[0].origin, RecipeOrigin::User);
-        assert!(!recipes[0].enabled);
     }
 
     #[test]
@@ -1540,23 +1556,6 @@ max_concurrency = 0
     }
 
     #[test]
-    fn recipe_catalog_upsert_and_remove_are_workspace_scoped() {
-        let default_workspace = default_workspace();
-        let other_workspace_name = WorkspaceName::parse("other").expect("workspace");
-        let mut catalog = RecipeCatalog::default();
-        catalog.upsert_recipe(&default_workspace, installed_recipe("review_queue"));
-        catalog.upsert_recipe(&other_workspace_name, installed_recipe("review_queue"));
-
-        catalog.remove_recipe(
-            &default_workspace,
-            &RecipeName::parse("review_queue").expect("recipe"),
-        );
-
-        assert!(catalog.workspace_recipes(&default_workspace).is_empty());
-        assert_eq!(catalog.workspace_recipes(&other_workspace_name).len(), 1);
-    }
-
-    #[test]
     fn preserves_unrelated_sections_when_rendering_with_existing_config() {
         let existing = r#"
 version = 1
@@ -1677,9 +1676,8 @@ origin = "bundled"
         let invalid_recipe = r#"
 version = 1
 
-[workspaces.default.recipes."bad\\recipe"]
-origin = "user"
-"#;
+	[workspaces.default.recipes."bad\\recipe"]
+	"#;
         let error = AppConfig::try_from(
             toml::from_str::<PersistedAppConfig>(invalid_recipe)
                 .expect("quoted recipe key should parse"),

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -9,6 +9,7 @@ use tracing::{info_span, warn};
 
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialStorageKind;
+use crate::recipes::model::{InstalledRecipe, RecipeName, RecipeOrigin};
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
@@ -20,6 +21,7 @@ pub(crate) struct AppConfig {
     version: u32,
     engine: PersistedEngineConfig,
     catalog: SourceCatalog,
+    recipes: RecipeCatalog,
 }
 
 impl Default for AppConfig {
@@ -28,11 +30,20 @@ impl Default for AppConfig {
             version: default_config_version(),
             engine: PersistedEngineConfig::default(),
             catalog: SourceCatalog::default(),
+            recipes: RecipeCatalog::default(),
         }
     }
 }
 
 impl AppConfig {
+    #[allow(
+        dead_code,
+        reason = "recipe lifecycle wiring consumes inventory reads in a later stack branch"
+    )]
+    pub(crate) fn workspace_recipes(&self, workspace_name: &WorkspaceName) -> Vec<InstalledRecipe> {
+        self.recipes.workspace_recipes(workspace_name)
+    }
+
     pub(crate) fn workspace_sources(&self, workspace_name: &WorkspaceName) -> Vec<InstalledSource> {
         self.catalog.workspace_sources(workspace_name)
     }
@@ -175,6 +186,8 @@ pub(crate) enum RawFeatureValue {
 struct PersistedWorkspaceConfig {
     #[serde(default)]
     sources: BTreeMap<String, PersistedInstalledSource>,
+    #[serde(default)]
+    recipes: BTreeMap<String, PersistedInstalledRecipe>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -213,6 +226,36 @@ impl From<&InstalledSource> for PersistedInstalledSource {
             origin: value.origin,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedInstalledRecipe {
+    origin: RecipeOrigin,
+    #[serde(default = "default_persisted_recipe_enabled")]
+    enabled: bool,
+}
+
+impl PersistedInstalledRecipe {
+    fn into_installed_recipe(self, recipe_name: RecipeName) -> InstalledRecipe {
+        InstalledRecipe {
+            name: recipe_name,
+            origin: self.origin,
+            enabled: self.enabled,
+        }
+    }
+}
+
+impl From<&InstalledRecipe> for PersistedInstalledRecipe {
+    fn from(value: &InstalledRecipe) -> Self {
+        Self {
+            origin: value.origin,
+            enabled: value.enabled,
+        }
+    }
+}
+
+fn default_persisted_recipe_enabled() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Default)]
@@ -268,6 +311,65 @@ impl SourceCatalog {
             Some(sources) => {
                 removed = sources.remove(source_name);
                 sources.is_empty()
+            }
+            None => false,
+        };
+
+        if remove_workspace {
+            self.0.remove(workspace_name);
+        }
+
+        removed
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RecipeCatalog(BTreeMap<WorkspaceName, BTreeMap<RecipeName, InstalledRecipe>>);
+
+#[allow(
+    dead_code,
+    reason = "recipe lifecycle wiring consumes inventory mutation in a later stack branch"
+)]
+impl RecipeCatalog {
+    pub(crate) fn workspace_recipes(&self, workspace_name: &WorkspaceName) -> Vec<InstalledRecipe> {
+        self.0
+            .get(workspace_name)
+            .map(|recipes| recipes.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn get_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Option<InstalledRecipe> {
+        self.0
+            .get(workspace_name)
+            .and_then(|recipes| recipes.get(recipe_name))
+            .cloned()
+    }
+
+    pub(crate) fn upsert_recipe(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        recipe: InstalledRecipe,
+    ) {
+        self.0
+            .entry(workspace_name.clone())
+            .or_default()
+            .insert(recipe.name.clone(), recipe);
+    }
+
+    pub(crate) fn remove_recipe(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Option<InstalledRecipe> {
+        let mut removed = None;
+        let remove_workspace = match self.0.get_mut(workspace_name) {
+            Some(recipes) => {
+                removed = recipes.remove(recipe_name);
+                recipes.is_empty()
             }
             None => false,
         };
@@ -415,6 +517,12 @@ impl ConfigStore {
         self.load_config().map(|config| config.catalog)
     }
 
+    pub(crate) fn load_recipe_catalog(&self) -> Result<RecipeCatalog, AppError> {
+        let span = info_span!("coral.app.config.load_recipe_catalog");
+        let _guard = span.enter();
+        self.load_config().map(|config| config.recipes)
+    }
+
     fn update_catalog<T>(
         &self,
         update: impl FnOnce(&mut SourceCatalog) -> T,
@@ -422,6 +530,17 @@ impl ConfigStore {
         let _lock = self.lock_exclusive()?;
         let mut config = self.load_unlocked()?;
         let result = update(&mut config.catalog);
+        self.save_unlocked(&config)?;
+        Ok(result)
+    }
+
+    fn update_recipe_catalog<T>(
+        &self,
+        update: impl FnOnce(&mut RecipeCatalog) -> T,
+    ) -> Result<T, AppError> {
+        let _lock = self.lock_exclusive()?;
+        let mut config = self.load_unlocked()?;
+        let result = update(&mut config.recipes);
         self.save_unlocked(&config)?;
         Ok(result)
     }
@@ -459,6 +578,48 @@ impl ConfigStore {
     ) -> Result<(), AppError> {
         self.update_catalog(|catalog| {
             catalog.remove_source(workspace_name, source_name);
+        })
+    }
+}
+
+#[allow(
+    dead_code,
+    reason = "recipe lifecycle wiring consumes inventory accessors in a later stack branch"
+)]
+impl ConfigStore {
+    pub(crate) fn list_workspace_recipes(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledRecipe>, AppError> {
+        self.load_recipe_catalog()
+            .map(|catalog| catalog.workspace_recipes(workspace_name))
+    }
+
+    pub(crate) fn get_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<InstalledRecipe, AppError> {
+        self.load_recipe_catalog()?
+            .get_recipe(workspace_name, recipe_name)
+            .ok_or_else(|| AppError::InvalidInput(format!("recipe '{recipe_name}' not found")))
+    }
+
+    pub(crate) fn upsert_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe: InstalledRecipe,
+    ) -> Result<(), AppError> {
+        self.update_recipe_catalog(|catalog| catalog.upsert_recipe(workspace_name, recipe))
+    }
+
+    pub(crate) fn remove_recipe(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> Result<(), AppError> {
+        self.update_recipe_catalog(|catalog| {
+            catalog.remove_recipe(workspace_name, recipe_name);
         })
     }
 }
@@ -508,6 +669,20 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
                 source_table.remove("credential_storage");
             }
             source_item["origin"] = value(source.origin.as_config_value());
+        }
+
+        for (recipe_name, recipe) in &workspace.recipes {
+            ensure_implicit_table(&mut doc["workspaces"]);
+            ensure_implicit_table(&mut doc["workspaces"][workspace_name]);
+            ensure_implicit_table(&mut doc["workspaces"][workspace_name]["recipes"]);
+
+            let recipe_item = &mut doc["workspaces"][workspace_name]["recipes"][recipe_name];
+            if !recipe_item.is_table() {
+                *recipe_item = toml_edit::table();
+            }
+
+            recipe_item["origin"] = value(recipe.origin.as_config_value());
+            recipe_item["enabled"] = value(recipe.enabled);
         }
     }
 
@@ -583,17 +758,23 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
 
     fn try_from(value: PersistedAppConfig) -> Result<Self, Self::Error> {
         let mut catalog = SourceCatalog::default();
+        let mut recipes = RecipeCatalog::default();
         for (workspace_name, workspace_config) in value.workspaces {
             let workspace_name = WorkspaceName::parse(&workspace_name)?;
             for (source_name, source) in workspace_config.sources {
                 let source_name = SourceName::parse(&source_name)?;
                 catalog.upsert_source(&workspace_name, source.into_installed_source(source_name));
             }
+            for (recipe_name, recipe) in workspace_config.recipes {
+                let recipe_name = RecipeName::parse(&recipe_name)?;
+                recipes.upsert_recipe(&workspace_name, recipe.into_installed_recipe(recipe_name));
+            }
         }
         Ok(Self {
             version: value.version,
             engine: value.engine,
             catalog,
+            recipes,
         })
     }
 }
@@ -609,6 +790,17 @@ impl From<&AppConfig> for PersistedAppConfig {
                 workspace_config.sources.insert(
                     source.name.as_str().to_string(),
                     PersistedInstalledSource::from(source),
+                );
+            }
+        }
+        for (workspace_name, recipes) in &value.recipes.0 {
+            let workspace_config = workspaces
+                .entry(workspace_name.as_str().to_string())
+                .or_insert_with(PersistedWorkspaceConfig::default);
+            for recipe in recipes.values() {
+                workspace_config.recipes.insert(
+                    recipe.name.as_str().to_string(),
+                    PersistedInstalledRecipe::from(recipe),
                 );
             }
         }
@@ -790,8 +982,10 @@ mod tests {
         AppConfig, PersistedAppConfig, PersistedEngineConfig, PersistedMemoryConfig,
         RawFeatureContainerState, RawFeatureValue, SourceCatalog, load_raw_feature_overrides,
         render_config, set_raw_feature_override,
+        RecipeCatalog,
     };
     use crate::credentials::CredentialStorageKind;
+    use crate::recipes::model::{InstalledRecipe, RecipeName, RecipeOrigin};
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::AppStateLayout;
@@ -812,6 +1006,14 @@ mod tests {
             secrets: vec!["GITHUB_TOKEN".to_string()],
             credential_storage: None,
             origin: SourceOrigin::Imported,
+        }
+    }
+
+    fn installed_recipe(name: &str) -> InstalledRecipe {
+        InstalledRecipe {
+            name: RecipeName::parse(name).expect("recipe"),
+            origin: RecipeOrigin::User,
+            enabled: true,
         }
     }
 
@@ -862,6 +1064,7 @@ mod tests {
             version: 1,
             engine: PersistedEngineConfig::default(),
             catalog,
+            recipes: RecipeCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -872,6 +1075,25 @@ mod tests {
         assert!(!raw.contains("[[sources]]"));
         assert!(!raw.contains("workspace = { name = \"default\" }"));
         assert!(!raw.contains("manifest_file"));
+    }
+
+    #[test]
+    fn renders_recipes_under_workspace_keyed_tables() {
+        let workspace_name = default_workspace();
+        let mut recipes = RecipeCatalog::default();
+        recipes.upsert_recipe(&workspace_name, installed_recipe("review_queue"));
+        let config = AppConfig {
+            version: 1,
+            engine: PersistedEngineConfig::default(),
+            catalog: SourceCatalog::default(),
+            recipes,
+        };
+
+        let raw = render_config(&PersistedAppConfig::from(&config), None);
+
+        assert!(raw.contains("[workspaces.default.recipes.review_queue]"));
+        assert!(raw.contains("origin = \"user\""));
+        assert!(raw.contains("enabled = true"));
     }
 
     #[test]
@@ -886,6 +1108,7 @@ mod tests {
             version: 1,
             engine: PersistedEngineConfig::default(),
             catalog,
+            recipes: RecipeCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -923,6 +1146,28 @@ origin = "bundled"
             sources[0].effective_credential_storage(),
             CredentialStorageKind::File
         );
+    }
+
+    #[test]
+    fn loads_recipes_from_workspace_keyed_tables() {
+        let raw = r#"
+version = 1
+
+[workspaces.default.recipes.review_queue]
+origin = "user"
+enabled = false
+"#;
+
+        let config = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(raw).expect("workspace-keyed config should parse"),
+        )
+        .expect("config");
+        let recipes = config.workspace_recipes(&default_workspace());
+
+        assert_eq!(recipes.len(), 1);
+        assert_eq!(recipes[0].name.as_str(), "review_queue");
+        assert_eq!(recipes[0].origin, RecipeOrigin::User);
+        assert!(!recipes[0].enabled);
     }
 
     #[test]
@@ -1237,6 +1482,7 @@ max_concurrency = 0
             version: 1,
             engine: PersistedEngineConfig::default(),
             catalog,
+            recipes: RecipeCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -1308,6 +1554,23 @@ max_concurrency = 0
     }
 
     #[test]
+    fn recipe_catalog_upsert_and_remove_are_workspace_scoped() {
+        let default_workspace = default_workspace();
+        let other_workspace_name = WorkspaceName::parse("other").expect("workspace");
+        let mut catalog = RecipeCatalog::default();
+        catalog.upsert_recipe(&default_workspace, installed_recipe("review_queue"));
+        catalog.upsert_recipe(&other_workspace_name, installed_recipe("review_queue"));
+
+        catalog.remove_recipe(
+            &default_workspace,
+            &RecipeName::parse("review_queue").expect("recipe"),
+        );
+
+        assert!(catalog.workspace_recipes(&default_workspace).is_empty());
+        assert_eq!(catalog.workspace_recipes(&other_workspace_name).len(), 1);
+    }
+
+    #[test]
     fn preserves_unrelated_sections_when_rendering_with_existing_config() {
         let existing = r#"
 version = 1
@@ -1342,6 +1605,7 @@ origin = "bundled"
             version: 1,
             engine: PersistedEngineConfig::default(),
             catalog,
+            recipes: RecipeCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), Some(existing));
@@ -1423,6 +1687,19 @@ origin = "bundled"
         )
         .expect_err("invalid source key should fail");
         assert!(error.to_string().contains("source name"));
+
+        let invalid_recipe = r#"
+version = 1
+
+[workspaces.default.recipes."bad\\recipe"]
+origin = "user"
+"#;
+        let error = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(invalid_recipe)
+                .expect("quoted recipe key should parse"),
+        )
+        .expect_err("invalid recipe key should fail");
+        assert!(error.to_string().contains("recipe name"));
     }
 
     #[test]

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -964,9 +964,8 @@ mod tests {
 
     use super::{
         AppConfig, PersistedAppConfig, PersistedEngineConfig, PersistedMemoryConfig,
-        RawFeatureContainerState, RawFeatureValue, SourceCatalog, load_raw_feature_overrides,
-        render_config, set_raw_feature_override,
-        RecipeCatalog,
+        RawFeatureContainerState, RawFeatureValue, RecipeCatalog, SourceCatalog,
+        load_raw_feature_overrides, render_config, set_raw_feature_override,
     };
     use crate::credentials::CredentialStorageKind;
     use crate::recipes::model::{InstalledRecipe, RecipeName, RecipeOrigin};

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -36,14 +36,6 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
-    #[allow(
-        dead_code,
-        reason = "recipe lifecycle wiring consumes inventory reads in a later stack branch"
-    )]
-    pub(crate) fn workspace_recipes(&self, workspace_name: &WorkspaceName) -> Vec<InstalledRecipe> {
-        self.recipes.workspace_recipes(workspace_name)
-    }
-
     pub(crate) fn workspace_sources(&self, workspace_name: &WorkspaceName) -> Vec<InstalledSource> {
         self.catalog.workspace_sources(workspace_name)
     }
@@ -326,10 +318,6 @@ impl SourceCatalog {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RecipeCatalog(BTreeMap<WorkspaceName, BTreeMap<RecipeName, InstalledRecipe>>);
 
-#[allow(
-    dead_code,
-    reason = "recipe lifecycle wiring consumes inventory mutation in a later stack branch"
-)]
 impl RecipeCatalog {
     pub(crate) fn workspace_recipes(&self, workspace_name: &WorkspaceName) -> Vec<InstalledRecipe> {
         self.0
@@ -582,10 +570,6 @@ impl ConfigStore {
     }
 }
 
-#[allow(
-    dead_code,
-    reason = "recipe lifecycle wiring consumes inventory accessors in a later stack branch"
-)]
 impl ConfigStore {
     pub(crate) fn list_workspace_recipes(
         &self,
@@ -1162,7 +1146,7 @@ enabled = false
             toml::from_str::<PersistedAppConfig>(raw).expect("workspace-keyed config should parse"),
         )
         .expect("config");
-        let recipes = config.workspace_recipes(&default_workspace());
+        let recipes = config.recipes.workspace_recipes(&default_workspace());
 
         assert_eq!(recipes.len(), 1);
         assert_eq!(recipes[0].name.as_str(), "review_queue");

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -1281,6 +1281,7 @@ limit = 2147483648
                 ..PersistedEngineConfig::default()
             },
             catalog: SourceCatalog::default(),
+            recipes: RecipeCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -1306,6 +1307,7 @@ flag = true
                 ..PersistedEngineConfig::default()
             },
             catalog: SourceCatalog::default(),
+            recipes: RecipeCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), Some(existing_raw));
@@ -1331,6 +1333,7 @@ flag = true
             version: 1,
             engine: PersistedEngineConfig::default(),
             catalog: SourceCatalog::default(),
+            recipes: RecipeCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), Some(existing_raw));

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -5,11 +5,17 @@ use std::path::{Path, PathBuf};
 use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_native_strategy};
 
 use crate::bootstrap::AppError;
+use crate::recipes::RecipeName;
 use crate::sources::SourceName;
 use crate::storage::fs::ensure_dir;
 use crate::workspaces::WorkspaceName;
 
 pub(crate) const INSTALLED_MANIFEST_FILE_NAME: &str = "manifest.yaml";
+#[allow(
+    dead_code,
+    reason = "recipe lifecycle wiring consumes this path in a later stack branch"
+)]
+pub(crate) const INSTALLED_RECIPE_FILE_NAME: &str = "recipe.yaml";
 pub(crate) const INSTALLED_SECRETS_FILE_NAME: &str = "secrets.env";
 
 #[derive(Debug, Clone)]
@@ -84,6 +90,39 @@ impl AppStateLayout {
 
     pub(crate) fn feedback_reports_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.feedback_dir(workspace_name).join("reports.jsonl")
+    }
+
+    #[allow(
+        dead_code,
+        reason = "recipe lifecycle wiring consumes this path in a later stack branch"
+    )]
+    pub(crate) fn recipes_root(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.workspace_dir(workspace_name).join("recipes")
+    }
+
+    #[allow(
+        dead_code,
+        reason = "recipe lifecycle wiring consumes this path in a later stack branch"
+    )]
+    pub(crate) fn recipe_dir(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> PathBuf {
+        self.recipes_root(workspace_name).join(recipe_name.as_str())
+    }
+
+    #[allow(
+        dead_code,
+        reason = "recipe lifecycle wiring consumes this path in a later stack branch"
+    )]
+    pub(crate) fn recipe_file(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> PathBuf {
+        self.recipe_dir(workspace_name, recipe_name)
+            .join(INSTALLED_RECIPE_FILE_NAME)
     }
 
     /// Per-workspace episode log (JSONL) for experimental trajectory memory. The
@@ -196,6 +235,7 @@ impl AppStateLayout {
 #[cfg(test)]
 mod tests {
     use super::AppStateLayout;
+    use crate::recipes::RecipeName;
     use crate::sources::SourceName;
     use crate::workspaces::WorkspaceName;
     use tempfile::tempdir;
@@ -207,6 +247,7 @@ mod tests {
         let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
         let workspace_name = WorkspaceName::parse("default").expect("workspace");
         let source_name = SourceName::parse("github").expect("source");
+        let recipe_name = RecipeName::parse("review_queue").expect("recipe");
 
         assert_eq!(layout.config_file(), config_dir.join("config.toml"));
         assert_eq!(
@@ -234,6 +275,15 @@ mod tests {
                 .join("default")
                 .join("feedback")
                 .join("reports.jsonl")
+        );
+        assert_eq!(
+            layout.recipe_file(&workspace_name, &recipe_name),
+            config_dir
+                .join("workspaces")
+                .join("default")
+                .join("recipes")
+                .join("review_queue")
+                .join("recipe.yaml")
         );
         assert_eq!(
             layout.episodes_file(&workspace_name),

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -11,10 +11,6 @@ use crate::storage::fs::ensure_dir;
 use crate::workspaces::WorkspaceName;
 
 pub(crate) const INSTALLED_MANIFEST_FILE_NAME: &str = "manifest.yaml";
-#[allow(
-    dead_code,
-    reason = "recipe lifecycle wiring consumes this path in a later stack branch"
-)]
 pub(crate) const INSTALLED_RECIPE_FILE_NAME: &str = "recipe.yaml";
 pub(crate) const INSTALLED_SECRETS_FILE_NAME: &str = "secrets.env";
 
@@ -92,18 +88,10 @@ impl AppStateLayout {
         self.feedback_dir(workspace_name).join("reports.jsonl")
     }
 
-    #[allow(
-        dead_code,
-        reason = "recipe lifecycle wiring consumes this path in a later stack branch"
-    )]
     pub(crate) fn recipes_root(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.workspace_dir(workspace_name).join("recipes")
     }
 
-    #[allow(
-        dead_code,
-        reason = "recipe lifecycle wiring consumes this path in a later stack branch"
-    )]
     pub(crate) fn recipe_dir(
         &self,
         workspace_name: &WorkspaceName,
@@ -112,10 +100,6 @@ impl AppStateLayout {
         self.recipes_root(workspace_name).join(recipe_name.as_str())
     }
 
-    #[allow(
-        dead_code,
-        reason = "recipe lifecycle wiring consumes this path in a later stack branch"
-    )]
     pub(crate) fn recipe_file(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -12,6 +12,7 @@ use crate::workspaces::WorkspaceName;
 
 pub(crate) const INSTALLED_MANIFEST_FILE_NAME: &str = "manifest.yaml";
 pub(crate) const INSTALLED_RECIPE_FILE_NAME: &str = "recipe.yaml";
+pub(crate) const INSTALLED_RECIPE_RUNTIME_FILE_NAME: &str = "runtime.json";
 pub(crate) const INSTALLED_SECRETS_FILE_NAME: &str = "secrets.env";
 
 #[derive(Debug, Clone)]
@@ -107,6 +108,15 @@ impl AppStateLayout {
     ) -> PathBuf {
         self.recipe_dir(workspace_name, recipe_name)
             .join(INSTALLED_RECIPE_FILE_NAME)
+    }
+
+    pub(crate) fn recipe_runtime_file(
+        &self,
+        workspace_name: &WorkspaceName,
+        recipe_name: &RecipeName,
+    ) -> PathBuf {
+        self.recipe_dir(workspace_name, recipe_name)
+            .join(INSTALLED_RECIPE_RUNTIME_FILE_NAME)
     }
 
     /// Per-workspace episode log (JSONL) for experimental trajectory memory. The
@@ -268,6 +278,15 @@ mod tests {
                 .join("recipes")
                 .join("review_queue")
                 .join("recipe.yaml")
+        );
+        assert_eq!(
+            layout.recipe_runtime_file(&workspace_name, &recipe_name),
+            config_dir
+                .join("workspaces")
+                .join("default")
+                .join("recipes")
+                .join("review_queue")
+                .join("runtime.json")
         );
         assert_eq!(
             layout.episodes_file(&workspace_name),

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -28,8 +28,7 @@ use clap::{
 };
 use clap_complete::{Shell, generate};
 use coral_api::v1::{
-    AddRecipeRequest, ExecuteSqlRequest, ListRecipesRequest, Recipe,
-    RecipeOrigin as ProtoRecipeOrigin, RemoveRecipeRequest, recipe_published_surface,
+    AddRecipeRequest, ExecuteSqlRequest, ListRecipesRequest, Recipe, RemoveRecipeRequest,
 };
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
@@ -737,13 +736,11 @@ async fn run_recipe(app: &AppClient, args: RecipeArgs) -> Result<(), CliError> {
                 let rows = recipes.into_iter().map(|recipe| {
                     [
                         recipe.name.clone(),
-                        recipe_origin_summary(&recipe).to_string(),
-                        recipe_status_summary(&recipe).to_string(),
                         recipe_publish_summary(&recipe),
                         recipe_columns_summary(&recipe),
                     ]
                 });
-                print_text_table(["Recipe", "Origin", "Status", "Publish", "Columns"], rows);
+                print_text_table(["Recipe", "Publish", "Columns"], rows);
             }
         }
         RecipeCommand::Add { file } => {
@@ -775,37 +772,13 @@ async fn run_recipe(app: &AppClient, args: RecipeArgs) -> Result<(), CliError> {
     Ok(())
 }
 
-fn recipe_origin_summary(recipe: &Recipe) -> &'static str {
-    match ProtoRecipeOrigin::try_from(recipe.origin) {
-        Ok(ProtoRecipeOrigin::Bundled) => "bundled",
-        Ok(ProtoRecipeOrigin::User) => "user",
-        Ok(ProtoRecipeOrigin::Unspecified) | Err(_) => "unknown",
-    }
-}
-
-fn recipe_status_summary(recipe: &Recipe) -> &'static str {
-    if recipe.enabled {
-        "enabled"
-    } else {
-        "disabled"
-    }
-}
-
 fn recipe_publish_summary(recipe: &Recipe) -> String {
-    let targets = recipe
+    recipe
         .publish
-        .iter()
-        .filter_map(|publish| match publish.target.as_ref()? {
-            recipe_published_surface::Target::TableFunction(target) => {
-                Some(format!("sql: {}.{}", target.schema, target.name))
-            }
-        })
-        .collect::<Vec<_>>();
-    if targets.is_empty() {
-        "-".to_string()
-    } else {
-        targets.join(", ")
-    }
+        .as_ref()
+        .and_then(|publish| publish.table_function.as_ref())
+        .map(|target| format!("sql: {}.{}", target.schema, target.name))
+        .unwrap_or_else(|| "-".to_string())
 }
 
 fn recipe_columns_summary(recipe: &Recipe) -> String {

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -27,7 +27,10 @@ use clap::{
     Parser, Subcommand, ValueEnum,
 };
 use clap_complete::{Shell, generate};
-use coral_api::v1::ExecuteSqlRequest;
+use coral_api::v1::{
+    AddRecipeRequest, ExecuteSqlRequest, ListRecipesRequest, Recipe, RemoveRecipeRequest,
+    ValidateRecipeRequest, recipe_publish,
+};
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
 use coral_client::{
@@ -65,6 +68,8 @@ enum Command {
     Sql(SqlArgs),
     /// Manage data sources
     Source(SourceArgs),
+    /// Manage recipes
+    Recipe(RecipeArgs),
     /// Interactive wizard to set up Coral and explore use cases
     Onboard,
     /// Start the MCP server over stdio
@@ -217,6 +222,36 @@ struct FeaturesArgs {
     command: FeaturesCommand,
 }
 
+#[derive(Debug, Args)]
+/// Manage recipes
+struct RecipeArgs {
+    #[command(subcommand)]
+    command: RecipeCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum RecipeCommand {
+    /// List installed recipes
+    List,
+    /// Add or replace a user recipe
+    Add {
+        /// Path to a recipe YAML file
+        #[arg(long)]
+        file: PathBuf,
+    },
+    /// Validate a recipe without installing it
+    Validate {
+        /// Path to a recipe YAML file
+        #[arg(long)]
+        file: PathBuf,
+    },
+    /// Remove a user recipe
+    Remove {
+        /// Name of the recipe to remove
+        name: String,
+    },
+}
+
 #[derive(Debug, Subcommand)]
 enum FeaturesCommand {
     /// List experimental runtime features and their current status
@@ -358,9 +393,11 @@ impl CliError {
 impl Command {
     fn required_runtime(&self) -> RequiredRuntime {
         match self {
-            Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
-                RequiredRuntime::AppClient
-            }
+            Command::Sql(_)
+            | Command::Source(_)
+            | Command::Recipe(_)
+            | Command::Onboard
+            | Command::McpStdio(_) => RequiredRuntime::AppClient,
             Command::Features(_) | Command::Completion(_) => RequiredRuntime::None,
             #[cfg(feature = "embedded-ui")]
             Command::Ui(_) => RequiredRuntime::None,
@@ -520,7 +557,11 @@ async fn run_no_runtime_command(
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args).await.map_err(Into::into),
-        Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
+        Command::Sql(_)
+        | Command::Source(_)
+        | Command::Recipe(_)
+        | Command::Onboard
+        | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
         }
     }
@@ -555,6 +596,7 @@ async fn run_app_command(
             print_batches(result.batches(), args.format)?;
         }
         Command::Source(args) => run_source(&app, args).await?,
+        Command::Recipe(args) => run_recipe(&app, args).await?,
         Command::Onboard => {
             onboard::run(&app).await?;
         }
@@ -681,6 +723,129 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
         }
     }
     Ok(())
+}
+
+async fn run_recipe(app: &AppClient, args: RecipeArgs) -> Result<(), CliError> {
+    match args.command {
+        RecipeCommand::List => {
+            let mut client = app.recipe_client();
+            let recipes = client
+                .list_recipes(Request::new(ListRecipesRequest {
+                    workspace: Some(default_workspace()),
+                }))
+                .await
+                .map_err(anyhow::Error::from)?
+                .into_inner()
+                .recipes;
+            if recipes.is_empty() {
+                println!("No recipes configured.");
+            } else {
+                let rows = recipes.into_iter().map(|recipe| {
+                    [
+                        recipe.name.clone(),
+                        recipe_publish_summary(&recipe),
+                        recipe_columns_summary(&recipe),
+                    ]
+                });
+                print_text_table(["Recipe", "Publish", "Columns"], rows);
+            }
+        }
+        RecipeCommand::Add { file } => {
+            let yaml = std::fs::read_to_string(&file).map_err(anyhow::Error::from)?;
+            let mut client = app.recipe_client();
+            let recipe = client
+                .add_recipe(Request::new(AddRecipeRequest {
+                    workspace: Some(default_workspace()),
+                    yaml,
+                }))
+                .await
+                .map_err(anyhow::Error::from)?
+                .into_inner();
+            println!("Added recipe {}", recipe.name);
+        }
+        RecipeCommand::Validate { file } => {
+            let yaml = std::fs::read_to_string(&file).map_err(anyhow::Error::from)?;
+            let mut client = app.recipe_client();
+            let recipe = client
+                .validate_recipe(Request::new(ValidateRecipeRequest {
+                    workspace: Some(default_workspace()),
+                    yaml,
+                }))
+                .await
+                .map_err(anyhow::Error::from)?
+                .into_inner()
+                .recipe
+                .ok_or_else(|| anyhow::anyhow!("validate recipe response missing recipe"))?;
+            println!("Recipe {} is valid.", recipe.name);
+            print_text_table(
+                ["Recipe", "Publish", "Columns"],
+                [[
+                    recipe.name.clone(),
+                    recipe_publish_summary(&recipe),
+                    recipe_columns_summary(&recipe),
+                ]],
+            );
+        }
+        RecipeCommand::Remove { name } => {
+            let name = recipe_name_arg(&name)?;
+            let mut client = app.recipe_client();
+            client
+                .remove_recipe(Request::new(RemoveRecipeRequest {
+                    workspace: Some(default_workspace()),
+                    name: name.clone(),
+                }))
+                .await
+                .map_err(anyhow::Error::from)?;
+            println!("Removed recipe {name}");
+        }
+    }
+    Ok(())
+}
+
+fn recipe_publish_summary(recipe: &Recipe) -> String {
+    let targets = recipe
+        .publish
+        .iter()
+        .filter_map(|publish| match publish.target.as_ref()? {
+            recipe_publish::Target::TableFunction(target) => {
+                Some(format!("sql: {}.{}", target.schema, target.name))
+            }
+        })
+        .collect::<Vec<_>>();
+    if targets.is_empty() {
+        "-".to_string()
+    } else {
+        targets.join(", ")
+    }
+}
+
+fn recipe_columns_summary(recipe: &Recipe) -> String {
+    if recipe.result_columns.is_empty() {
+        return "-".to_string();
+    }
+    recipe
+        .result_columns
+        .iter()
+        .take(4)
+        .map(|column| column.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn recipe_name_arg(name: &str) -> Result<String, anyhow::Error> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow::anyhow!("missing recipe name"));
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(anyhow::anyhow!(
+            "recipe name must not contain '/' or '\\\\'"
+        ));
+    }
+    if trimmed == "." || trimmed == ".." {
+        return Err(anyhow::anyhow!("recipe name must not be '.' or '..'"));
+    }
+    Ok(trimmed.to_string())
 }
 
 fn print_batches(
@@ -885,6 +1050,10 @@ mod tests {
     #[test]
     fn regular_commands_use_normal_app_bootstrap() {
         let cli = Cli::try_parse_from(["coral", "source", "list"]).expect("source list parses");
+
+        assert_eq!(cli.command.required_runtime(), RequiredRuntime::AppClient);
+
+        let cli = Cli::try_parse_from(["coral", "recipe", "list"]).expect("recipe list parses");
 
         assert_eq!(cli.command.required_runtime(), RequiredRuntime::AppClient);
     }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -28,8 +28,8 @@ use clap::{
 };
 use clap_complete::{Shell, generate};
 use coral_api::v1::{
-    AddRecipeRequest, ExecuteSqlRequest, ListRecipesRequest, Recipe, RemoveRecipeRequest,
-    recipe_publish,
+    AddRecipeRequest, ExecuteSqlRequest, ListRecipesRequest, Recipe,
+    RecipeOrigin as ProtoRecipeOrigin, RemoveRecipeRequest, recipe_publish,
 };
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
@@ -737,11 +737,13 @@ async fn run_recipe(app: &AppClient, args: RecipeArgs) -> Result<(), CliError> {
                 let rows = recipes.into_iter().map(|recipe| {
                     [
                         recipe.name.clone(),
+                        recipe_origin_summary(&recipe).to_string(),
+                        recipe_status_summary(&recipe).to_string(),
                         recipe_publish_summary(&recipe),
                         recipe_columns_summary(&recipe),
                     ]
                 });
-                print_text_table(["Recipe", "Publish", "Columns"], rows);
+                print_text_table(["Recipe", "Origin", "Status", "Publish", "Columns"], rows);
             }
         }
         RecipeCommand::Add { file } => {
@@ -771,6 +773,22 @@ async fn run_recipe(app: &AppClient, args: RecipeArgs) -> Result<(), CliError> {
         }
     }
     Ok(())
+}
+
+fn recipe_origin_summary(recipe: &Recipe) -> &'static str {
+    match ProtoRecipeOrigin::try_from(recipe.origin) {
+        Ok(ProtoRecipeOrigin::Bundled) => "bundled",
+        Ok(ProtoRecipeOrigin::User) => "user",
+        Ok(ProtoRecipeOrigin::Unspecified) | Err(_) => "unknown",
+    }
+}
+
+fn recipe_status_summary(recipe: &Recipe) -> &'static str {
+    if recipe.enabled {
+        "enabled"
+    } else {
+        "disabled"
+    }
 }
 
 fn recipe_publish_summary(recipe: &Recipe) -> String {

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -29,7 +29,7 @@ use clap::{
 use clap_complete::{Shell, generate};
 use coral_api::v1::{
     AddRecipeRequest, ExecuteSqlRequest, ListRecipesRequest, Recipe,
-    RecipeOrigin as ProtoRecipeOrigin, RemoveRecipeRequest, recipe_publish,
+    RecipeOrigin as ProtoRecipeOrigin, RemoveRecipeRequest, recipe_published_surface,
 };
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
@@ -796,7 +796,7 @@ fn recipe_publish_summary(recipe: &Recipe) -> String {
         .publish
         .iter()
         .filter_map(|publish| match publish.target.as_ref()? {
-            recipe_publish::Target::TableFunction(target) => {
+            recipe_published_surface::Target::TableFunction(target) => {
                 Some(format!("sql: {}.{}", target.schema, target.name))
             }
         })

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -29,7 +29,7 @@ use clap::{
 use clap_complete::{Shell, generate};
 use coral_api::v1::{
     AddRecipeRequest, ExecuteSqlRequest, ListRecipesRequest, Recipe, RemoveRecipeRequest,
-    ValidateRecipeRequest, recipe_publish,
+    recipe_publish,
 };
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
@@ -235,12 +235,6 @@ enum RecipeCommand {
     List,
     /// Add or replace a user recipe
     Add {
-        /// Path to a recipe YAML file
-        #[arg(long)]
-        file: PathBuf,
-    },
-    /// Validate a recipe without installing it
-    Validate {
         /// Path to a recipe YAML file
         #[arg(long)]
         file: PathBuf,
@@ -762,29 +756,6 @@ async fn run_recipe(app: &AppClient, args: RecipeArgs) -> Result<(), CliError> {
                 .map_err(anyhow::Error::from)?
                 .into_inner();
             println!("Added recipe {}", recipe.name);
-        }
-        RecipeCommand::Validate { file } => {
-            let yaml = std::fs::read_to_string(&file).map_err(anyhow::Error::from)?;
-            let mut client = app.recipe_client();
-            let recipe = client
-                .validate_recipe(Request::new(ValidateRecipeRequest {
-                    workspace: Some(default_workspace()),
-                    yaml,
-                }))
-                .await
-                .map_err(anyhow::Error::from)?
-                .into_inner()
-                .recipe
-                .ok_or_else(|| anyhow::anyhow!("validate recipe response missing recipe"))?;
-            println!("Recipe {} is valid.", recipe.name);
-            print_text_table(
-                ["Recipe", "Publish", "Columns"],
-                [[
-                    recipe.name.clone(),
-                    recipe_publish_summary(&recipe),
-                    recipe_columns_summary(&recipe),
-                ]],
-            );
         }
         RecipeCommand::Remove { name } => {
             let name = recipe_name_arg(&name)?;

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -5,6 +5,7 @@ use coral_api::v1::catalog_service_client::CatalogServiceClient;
 use coral_api::v1::episode_service_client::EpisodeServiceClient;
 use coral_api::v1::feedback_service_client::FeedbackServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
+use coral_api::v1::recipe_service_client::RecipeServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
@@ -39,6 +40,9 @@ pub type CatalogClient = CatalogServiceClient<GrpcService>;
 /// Public SQL query gRPC client.
 pub type QueryClient = QueryServiceClient<GrpcService>;
 
+/// Public recipe-management gRPC client.
+pub type RecipeClient = RecipeServiceClient<GrpcService>;
+
 /// Public feedback-submission gRPC client.
 pub type FeedbackClient = FeedbackServiceClient<GrpcService>;
 
@@ -53,6 +57,7 @@ pub struct AppClient {
     source: SourceClient,
     catalog: CatalogClient,
     query: QueryClient,
+    recipe: RecipeClient,
     feedback: FeedbackClient,
     episode: EpisodeClient,
 }
@@ -76,12 +81,15 @@ impl AppClient {
             .max_decoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE);
         let query_client = QueryClient::new(grpc_service(channel.clone(), &grpc_endpoint))
             .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
+        let recipe_client = RecipeClient::new(grpc_service(channel.clone(), &grpc_endpoint))
+            .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
         let feedback_client = FeedbackClient::new(grpc_service(channel.clone(), &grpc_endpoint));
         let episode_client = EpisodeClient::new(grpc_service(channel, &grpc_endpoint));
         Ok(Self {
             source: source_client,
             catalog: catalog_client,
             query: query_client,
+            recipe: recipe_client,
             feedback: feedback_client,
             episode: episode_client,
         })
@@ -103,6 +111,12 @@ impl AppClient {
     /// Returns a cloned query client.
     pub fn query_client(&self) -> QueryClient {
         self.query.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned recipe-management client.
+    pub fn recipe_client(&self) -> RecipeClient {
+        self.recipe.clone()
     }
 
     #[must_use]

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -41,7 +41,7 @@ use serde_json::Value;
 
 pub use client::{
     AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, EpisodeClient, FeedbackClient, QueryClient,
-    SourceClient, default_workspace,
+    RecipeClient, SourceClient, default_workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use propagation::with_episode_metadata;

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -119,7 +119,7 @@ pub use parser::{
 };
 pub use recipe::{
     RecipeArgumentSpec, RecipeArgumentType, RecipeImplementationSpec, RecipePublishSpec,
-    RecipeSpec, parse_recipe_yaml,
+    RecipeSpec, RecipeValidationSpec, RecipeValidationValue, parse_recipe_yaml,
 };
 pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken};
 pub(crate) use validate::{

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -82,6 +82,7 @@ mod error;
 mod inputs;
 mod loader;
 mod parser;
+mod recipe;
 mod schema;
 mod template;
 pub mod v4;
@@ -115,6 +116,10 @@ pub use inputs::{
 pub use loader::load_manifest_path;
 pub use parser::{
     ValidatedSourceManifest, parse_source_manifest_value, parse_source_manifest_yaml,
+};
+pub use recipe::{
+    RecipeArgumentSpec, RecipeArgumentType, RecipeImplementationSpec, RecipePublishSpec,
+    RecipeSpec, parse_recipe_yaml,
 };
 pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken};
 pub(crate) use validate::{

--- a/crates/coral-spec/src/recipe.rs
+++ b/crates/coral-spec/src/recipe.rs
@@ -1,0 +1,408 @@
+//! Recipe artifact parsing and static validation.
+//!
+//! Recipes are source-neutral task capabilities. This module validates the
+//! artifact shape only; installed-source references, SQL planning, and publish
+//! collisions are checked by the app/runtime layers.
+
+use std::collections::HashSet;
+use std::fmt;
+
+use schemars::JsonSchema;
+use serde::de::{self, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::{ManifestError, Result, validate_identifier};
+
+const RESERVED_TABLE_FUNCTION_SCHEMAS: &[&str] = &["coral", "coral_admin", "__coral_recipes"];
+
+/// Validated recipe artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecipeSpec {
+    name: String,
+    description: String,
+    arguments: Vec<RecipeArgumentSpec>,
+    implementation: RecipeImplementationSpec,
+    publish: Vec<RecipePublishSpec>,
+}
+
+/// One typed recipe argument.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RecipeArgumentSpec {
+    /// Argument name used in recipe SQL placeholders and published call schemas.
+    pub name: String,
+    /// Scalar argument type.
+    #[serde(rename = "type")]
+    pub data_type: RecipeArgumentType,
+    /// Whether callers must provide this argument.
+    #[serde(default)]
+    pub required: bool,
+    /// Optional human-readable argument description.
+    #[serde(default)]
+    pub description: String,
+}
+
+/// Scalar argument types supported by v1 recipes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RecipeArgumentType {
+    /// UTF-8 string value.
+    String,
+    /// Signed 64-bit integer value.
+    Integer,
+    /// Boolean value.
+    Boolean,
+}
+
+/// The executable body behind a recipe.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RecipeImplementationSpec {
+    /// Read-only Coral SQL using `DataFusion` value parameters like `$argument`.
+    CoralSql {
+        /// SQL query executed by Coral after typed argument binding.
+        query: String,
+    },
+}
+
+/// One public surface a recipe should publish.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub enum RecipePublishSpec {
+    /// Publish the recipe as a public SQL table function.
+    TableFunction {
+        /// SQL schema where the public table function is exposed.
+        schema: String,
+        /// Public table-function name within `schema`.
+        name: String,
+        /// Optional publish-target-specific description.
+        description: String,
+    },
+    /// Publish the recipe as an MCP tool.
+    McpTool {
+        /// MCP tool name.
+        name: String,
+        /// Optional publish-target-specific description.
+        description: String,
+    },
+}
+
+/// One recipe input as authored under the `inputs` map.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RecipeInputSpec {
+    #[serde(rename = "type")]
+    data_type: RecipeArgumentType,
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    description: String,
+}
+
+impl RecipeInputSpec {
+    fn into_argument(self, name: String) -> RecipeArgumentSpec {
+        RecipeArgumentSpec {
+            name,
+            data_type: self.data_type,
+            required: self.required,
+            description: self.description,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct RawRecipeInputs(Vec<RecipeArgumentSpec>);
+
+impl<'de> Deserialize<'de> for RawRecipeInputs {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RawRecipeInputsVisitor;
+
+        impl<'de> Visitor<'de> for RawRecipeInputsVisitor {
+            type Value = RawRecipeInputs;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a mapping of input names to input specs")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut seen = HashSet::new();
+                let mut arguments = Vec::new();
+                while let Some((name, input)) = map.next_entry::<String, RecipeInputSpec>()? {
+                    if !seen.insert(name.clone()) {
+                        return Err(de::Error::custom(format!(
+                            "recipe input '{name}' is declared more than once"
+                        )));
+                    }
+                    arguments.push(input.into_argument(name));
+                }
+                Ok(RawRecipeInputs(arguments))
+            }
+        }
+
+        deserializer.deserialize_map(RawRecipeInputsVisitor)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRecipePublishSpec {
+    #[serde(default)]
+    table_function: Option<String>,
+    #[serde(default)]
+    mcp_tool: Option<String>,
+    #[serde(default)]
+    description: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRecipeSpec {
+    kind: String,
+    name: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    inputs: RawRecipeInputs,
+    implementation: RecipeImplementationSpec,
+    #[serde(default)]
+    publish: Vec<RawRecipePublishSpec>,
+}
+
+impl RecipeSpec {
+    /// Returns the stable recipe id within one workspace.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the user-facing recipe description.
+    #[must_use]
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// Returns declared recipe arguments in authored order.
+    #[must_use]
+    pub fn arguments(&self) -> &[RecipeArgumentSpec] {
+        &self.arguments
+    }
+
+    /// Returns the executable recipe implementation.
+    #[must_use]
+    pub fn implementation(&self) -> &RecipeImplementationSpec {
+        &self.implementation
+    }
+
+    /// Returns public surfaces the recipe asks Coral to publish.
+    #[must_use]
+    pub fn publish(&self) -> &[RecipePublishSpec] {
+        &self.publish
+    }
+}
+
+/// Parses and statically validates one recipe YAML document.
+///
+/// # Errors
+///
+/// Returns [`ManifestError`] when the YAML cannot be parsed, has an unsupported
+/// shape, or violates recipe-local invariants.
+pub fn parse_recipe_yaml(raw: &str) -> Result<RecipeSpec> {
+    let raw: RawRecipeSpec = serde_yaml::from_str(raw).map_err(ManifestError::parse_yaml)?;
+    validate_raw_recipe(raw)
+}
+
+fn validate_raw_recipe(raw: RawRecipeSpec) -> Result<RecipeSpec> {
+    if raw.kind != "recipe" {
+        return Err(ManifestError::validation(format!(
+            "recipe kind must be 'recipe', got '{}'",
+            raw.kind
+        )));
+    }
+    validate_lowercase_identifier(&raw.name, "recipe name")?;
+    validate_arguments(&raw.name, &raw.inputs.0)?;
+    validate_implementation(&raw.name, &raw.implementation)?;
+    let publish = raw_publish_targets(&raw.name, raw.publish)?;
+    validate_publish_targets(&raw.name, &publish)?;
+    Ok(RecipeSpec {
+        name: raw.name,
+        description: raw.description,
+        arguments: raw.inputs.0,
+        implementation: raw.implementation,
+        publish,
+    })
+}
+
+fn raw_publish_targets(
+    recipe: &str,
+    publish: Vec<RawRecipePublishSpec>,
+) -> Result<Vec<RecipePublishSpec>> {
+    publish
+        .into_iter()
+        .map(|target| raw_publish_target(recipe, target))
+        .collect()
+}
+
+fn raw_publish_target(recipe: &str, target: RawRecipePublishSpec) -> Result<RecipePublishSpec> {
+    match (target.table_function, target.mcp_tool) {
+        (Some(table_function), None) => {
+            let (schema, name) = parse_table_function_target(recipe, &table_function)?;
+            Ok(RecipePublishSpec::TableFunction {
+                schema,
+                name,
+                description: target.description,
+            })
+        }
+        (None, Some(name)) => Ok(RecipePublishSpec::McpTool {
+            name,
+            description: target.description,
+        }),
+        _ => Err(ManifestError::validation(format!(
+            "recipe '{recipe}' publish entry must set exactly one of 'table_function' or 'mcp_tool'"
+        ))),
+    }
+}
+
+fn parse_table_function_target(recipe: &str, target: &str) -> Result<(String, String)> {
+    let Some((schema, name)) = target.split_once('.') else {
+        return Err(malformed_table_function_target(recipe, target));
+    };
+    if schema.is_empty() || name.is_empty() || name.contains('.') {
+        return Err(malformed_table_function_target(recipe, target));
+    }
+    Ok((schema.to_string(), name.to_string()))
+}
+
+fn malformed_table_function_target(recipe: &str, target: &str) -> ManifestError {
+    ManifestError::validation(format!(
+        "recipe '{recipe}' table_function publish target '{target}' must be written as schema.name"
+    ))
+}
+
+fn validate_arguments(recipe: &str, arguments: &[RecipeArgumentSpec]) -> Result<()> {
+    let mut seen = HashSet::new();
+    for argument in arguments {
+        validate_lowercase_identifier(&argument.name, &format!("recipe '{recipe}' input name"))?;
+        if !seen.insert(argument.name.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "recipe '{recipe}' input '{}' is declared more than once",
+                argument.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_implementation(recipe: &str, implementation: &RecipeImplementationSpec) -> Result<()> {
+    match implementation {
+        RecipeImplementationSpec::CoralSql { query } if query.trim().is_empty() => {
+            Err(ManifestError::validation(format!(
+                "recipe '{recipe}' coral_sql query must not be empty"
+            )))
+        }
+        RecipeImplementationSpec::CoralSql { .. } => Ok(()),
+    }
+}
+
+fn validate_publish_targets(recipe: &str, publish: &[RecipePublishSpec]) -> Result<()> {
+    let mut table_functions = HashSet::new();
+    let mut mcp_tools = HashSet::new();
+    for target in publish {
+        match target {
+            RecipePublishSpec::TableFunction { schema, name, .. } => {
+                validate_lowercase_identifier(
+                    schema,
+                    &format!("recipe '{recipe}' table_function publish schema"),
+                )?;
+                validate_lowercase_identifier(
+                    name,
+                    &format!("recipe '{recipe}' table_function publish name"),
+                )?;
+                if RESERVED_TABLE_FUNCTION_SCHEMAS
+                    .iter()
+                    .any(|reserved| schema.eq_ignore_ascii_case(reserved))
+                {
+                    return Err(ManifestError::validation(format!(
+                        "recipe '{recipe}' table_function publish schema '{schema}' is reserved"
+                    )));
+                }
+                let key = (schema.as_str(), name.as_str());
+                if !table_functions.insert(key) {
+                    return Err(ManifestError::validation(format!(
+                        "recipe '{recipe}' table_function publish target '{schema}.{name}' is declared more than once"
+                    )));
+                }
+            }
+            RecipePublishSpec::McpTool { name, .. } => {
+                validate_lowercase_identifier(name, &format!("recipe '{recipe}' mcp_tool name"))?;
+                if !mcp_tools.insert(name.as_str()) {
+                    return Err(ManifestError::validation(format!(
+                        "recipe '{recipe}' mcp_tool publish target '{name}' is declared more than once"
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_lowercase_identifier(value: &str, context: &str) -> Result<()> {
+    validate_identifier(value, context)?;
+    if value != value.to_ascii_lowercase() {
+        return Err(ManifestError::validation(format!(
+            "{context} '{value}' must be lowercase"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RecipeImplementationSpec, RecipePublishSpec, parse_recipe_yaml};
+
+    fn valid_recipe() -> &'static str {
+        r"
+kind: recipe
+name: github_review_queue
+description: GitHub PR review queue
+inputs:
+  owner:
+    type: string
+    required: true
+  repo:
+    type: string
+    required: true
+implementation:
+  kind: coral_sql
+  query: |
+    select *
+    from github.pulls(owner => $owner, repo => $repo)
+publish:
+  - table_function: recipes.github_review_queue
+  - mcp_tool: github_review_queue
+"
+    }
+
+    #[test]
+    fn parse_recipe_yaml_accepts_valid_recipe() {
+        let recipe = parse_recipe_yaml(valid_recipe()).expect("recipe should parse");
+
+        assert_eq!(recipe.name(), "github_review_queue");
+        assert_eq!(recipe.arguments().len(), 2);
+        assert!(matches!(
+            recipe.implementation(),
+            RecipeImplementationSpec::CoralSql { .. }
+        ));
+        assert_eq!(recipe.publish().len(), 2);
+        assert!(matches!(
+            recipe.publish().first(),
+            Some(RecipePublishSpec::TableFunction { schema, name, .. })
+                if schema == "recipes" && name == "github_review_queue"
+        ));
+    }
+}

--- a/crates/coral-spec/src/recipe.rs
+++ b/crates/coral-spec/src/recipe.rs
@@ -405,4 +405,245 @@ publish:
                 if schema == "recipes" && name == "github_review_queue"
         ));
     }
+
+    #[test]
+    fn parse_recipe_yaml_rejects_unknown_kind() {
+        let error = parse_recipe_yaml(
+            r"
+kind: source
+name: demo
+implementation:
+  kind: coral_sql
+  query: select 1
+",
+        )
+        .expect_err("kind should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "recipe kind must be 'recipe', got 'source'"
+        );
+    }
+
+    #[test]
+    fn parse_recipe_yaml_rejects_duplicate_inputs() {
+        let error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+inputs:
+  owner:
+    type: string
+  owner:
+    type: string
+implementation:
+  kind: coral_sql
+  query: select 1
+",
+        )
+        .expect_err("duplicate input should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("recipe input 'owner' is declared more than once")
+        );
+    }
+
+    #[test]
+    fn parse_recipe_yaml_rejects_mixed_case_identifiers() {
+        let recipe_name_error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: Demo
+implementation:
+  kind: coral_sql
+  query: select 1
+",
+        )
+        .expect_err("mixed-case recipe name should fail");
+
+        assert_eq!(
+            recipe_name_error.to_string(),
+            "recipe name 'Demo' must be lowercase"
+        );
+
+        let input_name_error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+inputs:
+  Owner:
+    type: string
+implementation:
+  kind: coral_sql
+  query: select $Owner
+",
+        )
+        .expect_err("mixed-case input name should fail");
+
+        assert_eq!(
+            input_name_error.to_string(),
+            "recipe 'demo' input name 'Owner' must be lowercase"
+        );
+    }
+
+    #[test]
+    fn parse_recipe_yaml_rejects_unknown_fields() {
+        let error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+presentation: {}
+implementation:
+  kind: coral_sql
+  query: select 1
+",
+        )
+        .expect_err("unknown field should fail");
+
+        assert!(error.to_string().contains("unknown field `presentation`"));
+    }
+
+    #[test]
+    fn parse_recipe_yaml_rejects_empty_coral_sql_query() {
+        let error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+implementation:
+  kind: coral_sql
+  query: '   '
+",
+        )
+        .expect_err("empty query should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "recipe 'demo' coral_sql query must not be empty"
+        );
+    }
+
+    #[test]
+    fn parse_recipe_yaml_rejects_duplicate_publish_targets() {
+        let table_function_error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+implementation:
+  kind: coral_sql
+  query: select 1
+publish:
+  - table_function: recipes.demo
+  - table_function: recipes.demo
+",
+        )
+        .expect_err("duplicate table_function target should fail");
+
+        assert_eq!(
+            table_function_error.to_string(),
+            "recipe 'demo' table_function publish target 'recipes.demo' is declared more than once"
+        );
+
+        let mcp_tool_error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+implementation:
+  kind: coral_sql
+  query: select 1
+publish:
+  - mcp_tool: demo
+  - mcp_tool: demo
+",
+        )
+        .expect_err("duplicate mcp_tool target should fail");
+
+        assert_eq!(
+            mcp_tool_error.to_string(),
+            "recipe 'demo' mcp_tool publish target 'demo' is declared more than once"
+        );
+    }
+
+    #[test]
+    fn parse_recipe_yaml_rejects_reserved_table_function_schemas() {
+        let error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+implementation:
+  kind: coral_sql
+  query: select 1
+publish:
+  - table_function: __coral_recipes.demo
+",
+        )
+        .expect_err("reserved recipe schema should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "recipe 'demo' table_function publish schema '__coral_recipes' is reserved"
+        );
+    }
+
+    #[test]
+    fn parse_recipe_yaml_rejects_malformed_table_function_target() {
+        let error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+implementation:
+  kind: coral_sql
+  query: select 1
+publish:
+  - table_function: recipes
+",
+        )
+        .expect_err("malformed table_function target should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "recipe 'demo' table_function publish target 'recipes' must be written as schema.name"
+        );
+    }
+
+    #[test]
+    fn parse_recipe_yaml_rejects_publish_entry_with_wrong_target_count() {
+        let multiple_targets_error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+implementation:
+  kind: coral_sql
+  query: select 1
+publish:
+  - table_function: recipes.demo
+    mcp_tool: demo
+",
+        )
+        .expect_err("publish entry with two targets should fail");
+
+        assert_eq!(
+            multiple_targets_error.to_string(),
+            "recipe 'demo' publish entry must set exactly one of 'table_function' or 'mcp_tool'"
+        );
+
+        let no_targets_error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+implementation:
+  kind: coral_sql
+  query: select 1
+publish:
+  - description: Demo
+",
+        )
+        .expect_err("publish entry without target should fail");
+
+        assert_eq!(
+            no_targets_error.to_string(),
+            "recipe 'demo' publish entry must set exactly one of 'table_function' or 'mcp_tool'"
+        );
+    }
 }

--- a/crates/coral-spec/src/recipe.rs
+++ b/crates/coral-spec/src/recipe.rs
@@ -4,7 +4,7 @@
 //! artifact shape only; installed-source references, SQL planning, and publish
 //! collisions are checked by the app/runtime layers.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 
 use schemars::JsonSchema;
@@ -22,7 +22,8 @@ pub struct RecipeSpec {
     description: String,
     arguments: Vec<RecipeArgumentSpec>,
     implementation: RecipeImplementationSpec,
-    publish: Vec<RecipePublishSpec>,
+    validation: RecipeValidationSpec,
+    publish: RecipePublishSpec,
 }
 
 /// One typed recipe argument.
@@ -54,6 +55,29 @@ pub enum RecipeArgumentType {
     Boolean,
 }
 
+/// Runtime validation inputs for one recipe.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RecipeValidationSpec {
+    /// Concrete argument values Coral uses when validating the recipe at install time.
+    #[serde(default)]
+    pub args: BTreeMap<String, RecipeValidationValue>,
+}
+
+/// One scalar validation argument value.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum RecipeValidationValue {
+    /// UTF-8 string value.
+    String(String),
+    /// Signed 64-bit integer value.
+    Integer(i64),
+    /// Boolean value.
+    Boolean(bool),
+    /// Explicit null value.
+    Null(()),
+}
+
 /// The executable body behind a recipe.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
@@ -65,26 +89,25 @@ pub enum RecipeImplementationSpec {
     },
 }
 
-/// One public surface a recipe should publish.
+/// Public surfaces a recipe should publish.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub enum RecipePublishSpec {
-    /// Publish the recipe as a public SQL table function.
-    TableFunction {
-        /// SQL schema where the public table function is exposed.
-        schema: String,
-        /// Public table-function name within `schema`.
-        name: String,
-        /// Optional publish-target-specific description.
-        description: String,
-    },
-    /// Publish the recipe as an MCP tool.
-    McpTool {
-        /// MCP tool name.
-        name: String,
-        /// Optional publish-target-specific description.
-        description: String,
-    },
+pub struct RecipePublishSpec {
+    /// Required SQL table-function surface.
+    pub table_function: RecipeTableFunctionPublishSpec,
+}
+
+/// SQL table-function surface published by a recipe.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RecipeTableFunctionPublishSpec {
+    /// SQL schema where the public table function is exposed.
+    pub schema: String,
+    /// Public table-function name within `schema`.
+    pub name: String,
+    /// Optional publish-target-specific description.
+    #[serde(default)]
+    pub description: String,
 }
 
 /// One recipe input as authored under the `inputs` map.
@@ -151,17 +174,6 @@ impl<'de> Deserialize<'de> for RawRecipeInputs {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RawRecipePublishSpec {
-    #[serde(default)]
-    table_function: Option<String>,
-    #[serde(default)]
-    mcp_tool: Option<String>,
-    #[serde(default)]
-    description: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 struct RawRecipeSpec {
     kind: String,
     name: String,
@@ -171,7 +183,8 @@ struct RawRecipeSpec {
     inputs: RawRecipeInputs,
     implementation: RecipeImplementationSpec,
     #[serde(default)]
-    publish: Vec<RawRecipePublishSpec>,
+    validation: RecipeValidationSpec,
+    publish: RecipePublishSpec,
 }
 
 impl RecipeSpec {
@@ -199,9 +212,15 @@ impl RecipeSpec {
         &self.implementation
     }
 
+    /// Returns the install-time validation invocation.
+    #[must_use]
+    pub fn validation(&self) -> &RecipeValidationSpec {
+        &self.validation
+    }
+
     /// Returns public surfaces the recipe asks Coral to publish.
     #[must_use]
-    pub fn publish(&self) -> &[RecipePublishSpec] {
+    pub fn publish(&self) -> &RecipePublishSpec {
         &self.publish
     }
 }
@@ -227,61 +246,16 @@ fn validate_raw_recipe(raw: RawRecipeSpec) -> Result<RecipeSpec> {
     validate_lowercase_identifier(&raw.name, "recipe name")?;
     validate_arguments(&raw.name, &raw.inputs.0)?;
     validate_implementation(&raw.name, &raw.implementation)?;
-    let publish = raw_publish_targets(&raw.name, raw.publish)?;
-    validate_publish_targets(&raw.name, &publish)?;
+    validate_validation(&raw.name, &raw.inputs.0, &raw.validation)?;
+    validate_publish_targets(&raw.name, &raw.publish)?;
     Ok(RecipeSpec {
         name: raw.name,
         description: raw.description,
         arguments: raw.inputs.0,
         implementation: raw.implementation,
-        publish,
+        validation: raw.validation,
+        publish: raw.publish,
     })
-}
-
-fn raw_publish_targets(
-    recipe: &str,
-    publish: Vec<RawRecipePublishSpec>,
-) -> Result<Vec<RecipePublishSpec>> {
-    publish
-        .into_iter()
-        .map(|target| raw_publish_target(recipe, target))
-        .collect()
-}
-
-fn raw_publish_target(recipe: &str, target: RawRecipePublishSpec) -> Result<RecipePublishSpec> {
-    match (target.table_function, target.mcp_tool) {
-        (Some(table_function), None) => {
-            let (schema, name) = parse_table_function_target(recipe, &table_function)?;
-            Ok(RecipePublishSpec::TableFunction {
-                schema,
-                name,
-                description: target.description,
-            })
-        }
-        (None, Some(name)) => Ok(RecipePublishSpec::McpTool {
-            name,
-            description: target.description,
-        }),
-        _ => Err(ManifestError::validation(format!(
-            "recipe '{recipe}' publish entry must set exactly one of 'table_function' or 'mcp_tool'"
-        ))),
-    }
-}
-
-fn parse_table_function_target(recipe: &str, target: &str) -> Result<(String, String)> {
-    let Some((schema, name)) = target.split_once('.') else {
-        return Err(malformed_table_function_target(recipe, target));
-    };
-    if schema.is_empty() || name.is_empty() || name.contains('.') {
-        return Err(malformed_table_function_target(recipe, target));
-    }
-    Ok((schema.to_string(), name.to_string()))
-}
-
-fn malformed_table_function_target(recipe: &str, target: &str) -> ManifestError {
-    ManifestError::validation(format!(
-        "recipe '{recipe}' table_function publish target '{target}' must be written as schema.name"
-    ))
 }
 
 fn validate_arguments(recipe: &str, arguments: &[RecipeArgumentSpec]) -> Result<()> {
@@ -309,44 +283,102 @@ fn validate_implementation(recipe: &str, implementation: &RecipeImplementationSp
     }
 }
 
-fn validate_publish_targets(recipe: &str, publish: &[RecipePublishSpec]) -> Result<()> {
-    let mut table_functions = HashSet::new();
-    let mut mcp_tools = HashSet::new();
-    for target in publish {
-        match target {
-            RecipePublishSpec::TableFunction { schema, name, .. } => {
-                validate_lowercase_identifier(
-                    schema,
-                    &format!("recipe '{recipe}' table_function publish schema"),
-                )?;
-                validate_lowercase_identifier(
-                    name,
-                    &format!("recipe '{recipe}' table_function publish name"),
-                )?;
-                if RESERVED_TABLE_FUNCTION_SCHEMAS
-                    .iter()
-                    .any(|reserved| schema.eq_ignore_ascii_case(reserved))
-                {
-                    return Err(ManifestError::validation(format!(
-                        "recipe '{recipe}' table_function publish schema '{schema}' is reserved"
-                    )));
-                }
-                let key = (schema.as_str(), name.as_str());
-                if !table_functions.insert(key) {
-                    return Err(ManifestError::validation(format!(
-                        "recipe '{recipe}' table_function publish target '{schema}.{name}' is declared more than once"
-                    )));
-                }
-            }
-            RecipePublishSpec::McpTool { name, .. } => {
-                validate_lowercase_identifier(name, &format!("recipe '{recipe}' mcp_tool name"))?;
-                if !mcp_tools.insert(name.as_str()) {
-                    return Err(ManifestError::validation(format!(
-                        "recipe '{recipe}' mcp_tool publish target '{name}' is declared more than once"
-                    )));
-                }
-            }
+fn validate_validation(
+    recipe: &str,
+    arguments: &[RecipeArgumentSpec],
+    validation: &RecipeValidationSpec,
+) -> Result<()> {
+    let arguments_by_name = arguments
+        .iter()
+        .map(|argument| (argument.name.as_str(), argument))
+        .collect::<HashMap<_, _>>();
+
+    for (name, value) in &validation.args {
+        let Some(argument) = arguments_by_name.get(name.as_str()) else {
+            return Err(ManifestError::validation(format!(
+                "recipe '{recipe}' validation arg '{name}' is not declared as an input"
+            )));
+        };
+        if !validation_value_matches_argument(argument, value) {
+            return Err(ManifestError::validation(format!(
+                "recipe '{recipe}' validation arg '{name}' expected {}, got {}",
+                argument_type_name(argument.data_type),
+                validation_value_type_name(value)
+            )));
         }
+    }
+
+    for argument in arguments {
+        if argument.required
+            && !matches!(
+                validation.args.get(&argument.name),
+                Some(value) if !matches!(value, RecipeValidationValue::Null(()))
+            )
+        {
+            return Err(ManifestError::validation(format!(
+                "recipe '{recipe}' validation.args must include required input '{}'",
+                argument.name
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validation_value_matches_argument(
+    argument: &RecipeArgumentSpec,
+    value: &RecipeValidationValue,
+) -> bool {
+    matches!(
+        (argument.data_type, value),
+        (RecipeArgumentType::String, RecipeValidationValue::String(_))
+            | (
+                RecipeArgumentType::Integer,
+                RecipeValidationValue::Integer(_)
+            )
+            | (
+                RecipeArgumentType::Boolean,
+                RecipeValidationValue::Boolean(_)
+            )
+            | (_, RecipeValidationValue::Null(()))
+    )
+}
+
+fn argument_type_name(data_type: RecipeArgumentType) -> &'static str {
+    match data_type {
+        RecipeArgumentType::String => "string",
+        RecipeArgumentType::Integer => "integer",
+        RecipeArgumentType::Boolean => "boolean",
+    }
+}
+
+fn validation_value_type_name(value: &RecipeValidationValue) -> &'static str {
+    match value {
+        RecipeValidationValue::String(_) => "string",
+        RecipeValidationValue::Integer(_) => "integer",
+        RecipeValidationValue::Boolean(_) => "boolean",
+        RecipeValidationValue::Null(()) => "null",
+    }
+}
+
+fn validate_publish_targets(recipe: &str, publish: &RecipePublishSpec) -> Result<()> {
+    let table_function = &publish.table_function;
+    validate_lowercase_identifier(
+        &table_function.schema,
+        &format!("recipe '{recipe}' table_function publish schema"),
+    )?;
+    validate_lowercase_identifier(
+        &table_function.name,
+        &format!("recipe '{recipe}' table_function publish name"),
+    )?;
+    if RESERVED_TABLE_FUNCTION_SCHEMAS
+        .iter()
+        .any(|reserved| table_function.schema.eq_ignore_ascii_case(reserved))
+    {
+        return Err(ManifestError::validation(format!(
+            "recipe '{recipe}' table_function publish schema '{}' is reserved",
+            table_function.schema
+        )));
     }
     Ok(())
 }
@@ -363,7 +395,7 @@ fn validate_lowercase_identifier(value: &str, context: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{RecipeImplementationSpec, RecipePublishSpec, parse_recipe_yaml};
+    use super::{RecipeImplementationSpec, RecipeValidationValue, parse_recipe_yaml};
 
     fn valid_recipe() -> &'static str {
         r"
@@ -382,9 +414,14 @@ implementation:
   query: |
     select *
     from github.pulls(owner => $owner, repo => $repo)
+validation:
+  args:
+    owner: withcoral
+    repo: coral
 publish:
-  - table_function: recipes.github_review_queue
-  - mcp_tool: github_review_queue
+  table_function:
+    schema: recipes
+    name: github_review_queue
 "
     }
 
@@ -395,15 +432,15 @@ publish:
         assert_eq!(recipe.name(), "github_review_queue");
         assert_eq!(recipe.arguments().len(), 2);
         assert!(matches!(
+            recipe.validation().args.get("owner"),
+            Some(RecipeValidationValue::String(owner)) if owner == "withcoral"
+        ));
+        assert!(matches!(
             recipe.implementation(),
             RecipeImplementationSpec::CoralSql { .. }
         ));
-        assert_eq!(recipe.publish().len(), 2);
-        assert!(matches!(
-            recipe.publish().first(),
-            Some(RecipePublishSpec::TableFunction { schema, name, .. })
-                if schema == "recipes" && name == "github_review_queue"
-        ));
+        assert_eq!(recipe.publish().table_function.schema, "recipes");
+        assert_eq!(recipe.publish().table_function.name, "github_review_queue");
     }
 
     #[test]
@@ -415,6 +452,10 @@ name: demo
 implementation:
   kind: coral_sql
   query: select 1
+publish:
+  table_function:
+    schema: recipes
+    name: demo
 ",
         )
         .expect_err("kind should fail");
@@ -459,6 +500,10 @@ name: Demo
 implementation:
   kind: coral_sql
   query: select 1
+publish:
+  table_function:
+    schema: recipes
+    name: demo
 ",
         )
         .expect_err("mixed-case recipe name should fail");
@@ -478,6 +523,10 @@ inputs:
 implementation:
   kind: coral_sql
   query: select $Owner
+publish:
+  table_function:
+    schema: recipes
+    name: demo
 ",
         )
         .expect_err("mixed-case input name should fail");
@@ -514,6 +563,10 @@ name: demo
 implementation:
   kind: coral_sql
   query: '   '
+publish:
+  table_function:
+    schema: recipes
+    name: demo
 ",
         )
         .expect_err("empty query should fail");
@@ -525,43 +578,85 @@ implementation:
     }
 
     #[test]
-    fn parse_recipe_yaml_rejects_duplicate_publish_targets() {
-        let table_function_error = parse_recipe_yaml(
+    fn parse_recipe_yaml_rejects_missing_required_validation_arg() {
+        let error = parse_recipe_yaml(
             r"
 kind: recipe
 name: demo
+inputs:
+  owner:
+    type: string
+    required: true
 implementation:
   kind: coral_sql
-  query: select 1
+  query: select $owner
 publish:
-  - table_function: recipes.demo
-  - table_function: recipes.demo
+  table_function:
+    schema: recipes
+    name: demo
 ",
         )
-        .expect_err("duplicate table_function target should fail");
+        .expect_err("missing validation arg should fail");
 
         assert_eq!(
-            table_function_error.to_string(),
-            "recipe 'demo' table_function publish target 'recipes.demo' is declared more than once"
+            error.to_string(),
+            "recipe 'demo' validation.args must include required input 'owner'"
         );
+    }
 
-        let mcp_tool_error = parse_recipe_yaml(
+    #[test]
+    fn parse_recipe_yaml_rejects_unknown_validation_arg() {
+        let error = parse_recipe_yaml(
             r"
 kind: recipe
 name: demo
+validation:
+  args:
+    owner: withcoral
 implementation:
   kind: coral_sql
   query: select 1
 publish:
-  - mcp_tool: demo
-  - mcp_tool: demo
+  table_function:
+    schema: recipes
+    name: demo
 ",
         )
-        .expect_err("duplicate mcp_tool target should fail");
+        .expect_err("unknown validation arg should fail");
 
         assert_eq!(
-            mcp_tool_error.to_string(),
-            "recipe 'demo' mcp_tool publish target 'demo' is declared more than once"
+            error.to_string(),
+            "recipe 'demo' validation arg 'owner' is not declared as an input"
+        );
+    }
+
+    #[test]
+    fn parse_recipe_yaml_rejects_validation_arg_type_mismatch() {
+        let error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+inputs:
+  limit:
+    type: integer
+    required: true
+validation:
+  args:
+    limit: many
+implementation:
+  kind: coral_sql
+  query: select $limit
+publish:
+  table_function:
+    schema: recipes
+    name: demo
+",
+        )
+        .expect_err("validation arg type mismatch should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "recipe 'demo' validation arg 'limit' expected integer, got string"
         );
     }
 
@@ -575,7 +670,9 @@ implementation:
   kind: coral_sql
   query: select 1
 publish:
-  - table_function: __coral_recipes.demo
+  table_function:
+    schema: __coral_recipes
+    name: demo
 ",
         )
         .expect_err("reserved recipe schema should fail");
@@ -584,6 +681,22 @@ publish:
             error.to_string(),
             "recipe 'demo' table_function publish schema '__coral_recipes' is reserved"
         );
+    }
+
+    #[test]
+    fn parse_recipe_yaml_rejects_missing_publish() {
+        let error = parse_recipe_yaml(
+            r"
+kind: recipe
+name: demo
+implementation:
+  kind: coral_sql
+  query: select 1
+",
+        )
+        .expect_err("missing publish should fail");
+
+        assert!(error.to_string().contains("missing field `publish`"));
     }
 
     #[test]
@@ -596,54 +709,16 @@ implementation:
   kind: coral_sql
   query: select 1
 publish:
-  - table_function: recipes
+  table_function:
+    schema: Recipes
+    name: demo
 ",
         )
-        .expect_err("malformed table_function target should fail");
+        .expect_err("mixed-case schema should fail");
 
         assert_eq!(
             error.to_string(),
-            "recipe 'demo' table_function publish target 'recipes' must be written as schema.name"
-        );
-    }
-
-    #[test]
-    fn parse_recipe_yaml_rejects_publish_entry_with_wrong_target_count() {
-        let multiple_targets_error = parse_recipe_yaml(
-            r"
-kind: recipe
-name: demo
-implementation:
-  kind: coral_sql
-  query: select 1
-publish:
-  - table_function: recipes.demo
-    mcp_tool: demo
-",
-        )
-        .expect_err("publish entry with two targets should fail");
-
-        assert_eq!(
-            multiple_targets_error.to_string(),
-            "recipe 'demo' publish entry must set exactly one of 'table_function' or 'mcp_tool'"
-        );
-
-        let no_targets_error = parse_recipe_yaml(
-            r"
-kind: recipe
-name: demo
-implementation:
-  kind: coral_sql
-  query: select 1
-publish:
-  - description: Demo
-",
-        )
-        .expect_err("publish entry without target should fail");
-
-        assert_eq!(
-            no_targets_error.to_string(),
-            "recipe 'demo' publish entry must set exactly one of 'table_function' or 'mcp_tool'"
+            "recipe 'demo' table_function publish schema 'Recipes' must be lowercase"
         );
     }
 }

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -164,7 +164,7 @@ coral source remove github
 
 Manage workspace recipes. A recipe is a YAML artifact that defines a reusable, typed query and publishes it as a SQL table function.
 
-User-installed recipes are added to the current workspace with `coral recipe add`. Bundled or source-owned recipes can also appear when an installed source ships them; those are managed with the source package. Recipes commonly publish under `recipes.*`, while source-owned recipes may publish under their source schema.
+User-installed recipes are added to the current workspace with `coral recipe add`. Recipes commonly publish under `recipes.*`.
 
 ### `coral recipe add --file <PATH>`
 
@@ -221,7 +221,7 @@ List installed recipes.
 coral recipe list
 ```
 
-The output is inventory-only and does not re-run runtime validation, so it stays fast. Coral shows each recipe's origin, enabled status, publish target, and result columns cached during the last successful `coral recipe add --file`.
+The output is inventory-only and does not re-run runtime validation, so it stays fast. Coral shows each recipe's table-function target and result columns cached during the last successful `coral recipe add --file`.
 
 If a recipe publishes a SQL table function and declares required inputs, call it with named arguments:
 
@@ -240,7 +240,7 @@ Remove the user-installed recipe named `<NAME>`.
 coral recipe remove open_prs
 ```
 
-Only user-installed recipes are managed by this command. Bundled or source-owned recipes are managed with the source package that installed them.
+Only user-installed recipes are managed by this command.
 
 ## `coral onboard`
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -160,6 +160,82 @@ Remove an installed source.
 coral source remove github
 ```
 
+## `coral recipe`
+
+Manage user-installed recipes. A recipe is a YAML artifact that defines a reusable, typed query and can publish it as SQL under `recipes.*`.
+
+### `coral recipe add --file <PATH>`
+
+Validate, then install or replace, a user recipe from a YAML file.
+
+```shellscript
+coral recipe add --file ./my-review-queue.recipe.yaml
+```
+
+Coral validates the recipe before storing it in the current workspace. Validation checks the YAML shape, installed-source references, SQL publish target collisions, and inferred result columns. If runtime validation fails, the recipe is not installed.
+
+Example recipe:
+
+```yaml
+kind: recipe
+name: my_review_queue
+description: Pull requests ready for review
+inputs:
+  owner:
+    type: string
+    required: true
+  repo:
+    type: string
+    required: true
+implementation:
+  kind: coral_sql
+  query: |
+    select number, title, url
+    from github.pull_requests
+    where owner = $owner
+      and repo = $repo
+      and state = 'open'
+publish:
+  - table_function: recipes.my_review_queue
+```
+
+### `coral recipe validate --file <PATH>`
+
+Validate a recipe against the current workspace without installing it.
+
+```shellscript
+coral recipe validate --file ./my-review-queue.recipe.yaml
+```
+
+Use this when you want the runtime check explicitly, for example after a source changed or before sharing a recipe file.
+
+### `coral recipe list`
+
+List installed recipes.
+
+```shellscript
+coral recipe list
+```
+
+The output is inventory-only and does not re-run runtime validation, so it stays fast. For user-installed recipes, Coral shows the result columns cached during the last successful `coral recipe add --file`.
+
+If a recipe publishes SQL, call it with named arguments:
+
+```sql
+select *
+from recipes.my_review_queue(owner => 'withcoral', repo => 'coral')
+```
+
+### `coral recipe remove <NAME>`
+
+Remove a user-installed recipe.
+
+```shellscript
+coral recipe remove my_review_queue
+```
+
+Bundled recipes shipped with sources cannot be removed through workspace recipe config.
+
 ## `coral onboard`
 
 Run the guided source setup flow.

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -221,10 +221,6 @@ List installed recipes.
 coral recipe list
 ```
 
-#### Options
-
-This command has no options.
-
 The output is inventory-only and does not re-run runtime validation, so it stays fast. Coral shows each recipe's origin, enabled status, publish target, and result columns cached during the last successful `coral recipe add --file`.
 
 If a recipe publishes a SQL table function and declares required inputs, call it with named arguments:
@@ -238,21 +234,11 @@ Recipes without required inputs can be called with empty parentheses.
 
 ### `coral recipe remove <NAME>`
 
-Remove a user-installed recipe.
+Remove the user-installed recipe named `<NAME>`.
 
 ```shellscript
 coral recipe remove open_prs
 ```
-
-#### Arguments
-
-| Argument | Description                                  |
-| -------- | -------------------------------------------- |
-| `<NAME>` | Name of the user-installed recipe to remove |
-
-#### Options
-
-This command has no options.
 
 Only user-installed recipes are managed by this command. Bundled or source-owned recipes are managed with the source package that installed them.
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -162,15 +162,23 @@ coral source remove github
 
 ## `coral recipe`
 
-Manage user-installed recipes. A recipe is a YAML artifact that defines a reusable, typed query and publishes it as a SQL table function, commonly under `recipes.*`.
+Manage workspace recipes. A recipe is a YAML artifact that defines a reusable, typed query and publishes it as a SQL table function.
+
+User-installed recipes are added to the current workspace with `coral recipe add`. Bundled or source-owned recipes can also appear when an installed source ships them; those are managed with the source package. Recipes commonly publish under `recipes.*`, while source-owned recipes may publish under their source schema.
 
 ### `coral recipe add --file <PATH>`
 
-Validate, then install or replace, a user recipe from a YAML file.
+Validate, then install or replace, a user-installed recipe from a YAML file.
 
 ```shellscript
-coral recipe add --file ./my-review-queue.recipe.yaml
+coral recipe add --file ./open-prs.recipe.yaml
 ```
+
+#### Options
+
+| Option          | Type | Default  | Description                  |
+| --------------- | ---- | -------- | ---------------------------- |
+| `--file <PATH>` | path | required | Recipe YAML file to install  |
 
 Coral validates the recipe before storing it in the current workspace. Validation checks the YAML shape, installed-source references, SQL publish target collisions, inferred result columns, and one concrete validation invocation using `validation.args`. If runtime validation fails, the recipe is not installed.
 
@@ -178,8 +186,8 @@ Example recipe:
 
 ```yaml
 kind: recipe
-name: my_review_queue
-description: Pull requests ready for review
+name: open_prs
+description: All open PRs in the specified repo
 inputs:
   owner:
     type: string
@@ -202,7 +210,7 @@ validation:
 publish:
   table_function:
     schema: recipes
-    name: my_review_queue
+    name: open_prs
 ```
 
 ### `coral recipe list`
@@ -213,24 +221,40 @@ List installed recipes.
 coral recipe list
 ```
 
+#### Options
+
+This command has no options.
+
 The output is inventory-only and does not re-run runtime validation, so it stays fast. Coral shows each recipe's origin, enabled status, publish target, and result columns cached during the last successful `coral recipe add --file`.
 
-If a recipe publishes SQL, call it with named arguments:
+If a recipe publishes a SQL table function and declares required inputs, call it with named arguments:
 
 ```sql
 select *
-from recipes.my_review_queue(owner => 'withcoral', repo => 'coral')
+from recipes.open_prs(owner => 'withcoral', repo => 'coral')
 ```
+
+Recipes without required inputs can be called with empty parentheses.
 
 ### `coral recipe remove <NAME>`
 
 Remove a user-installed recipe.
 
 ```shellscript
-coral recipe remove my_review_queue
+coral recipe remove open_prs
 ```
 
-Only user-installed recipes are managed by this command.
+#### Arguments
+
+| Argument | Description                                  |
+| -------- | -------------------------------------------- |
+| `<NAME>` | Name of the user-installed recipe to remove |
+
+#### Options
+
+This command has no options.
+
+Only user-installed recipes are managed by this command. Bundled or source-owned recipes are managed with the source package that installed them.
 
 ## `coral onboard`
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -162,7 +162,7 @@ coral source remove github
 
 ## `coral recipe`
 
-Manage user-installed recipes. A recipe is a YAML artifact that defines a reusable, typed query and can publish it as SQL under `recipes.*`.
+Manage user-installed recipes. A recipe is a YAML artifact that defines a reusable, typed query and publishes it as a SQL table function, commonly under `recipes.*`.
 
 ### `coral recipe add --file <PATH>`
 
@@ -230,7 +230,7 @@ Remove a user-installed recipe.
 coral recipe remove my_review_queue
 ```
 
-Bundled recipes shipped with sources cannot be removed through workspace recipe config.
+Only user-installed recipes are managed by this command.
 
 ## `coral onboard`
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -172,7 +172,7 @@ Validate, then install or replace, a user recipe from a YAML file.
 coral recipe add --file ./my-review-queue.recipe.yaml
 ```
 
-Coral validates the recipe before storing it in the current workspace. Validation checks the YAML shape, installed-source references, SQL publish target collisions, and inferred result columns. If runtime validation fails, the recipe is not installed.
+Coral validates the recipe before storing it in the current workspace. Validation checks the YAML shape, installed-source references, SQL publish target collisions, inferred result columns, and one concrete validation invocation using `validation.args`. If runtime validation fails, the recipe is not installed.
 
 Example recipe:
 
@@ -195,19 +195,15 @@ implementation:
     where owner = $owner
       and repo = $repo
       and state = 'open'
+validation:
+  args:
+    owner: withcoral
+    repo: coral
 publish:
-  - table_function: recipes.my_review_queue
+  table_function:
+    schema: recipes
+    name: my_review_queue
 ```
-
-### `coral recipe validate --file <PATH>`
-
-Validate a recipe against the current workspace without installing it.
-
-```shellscript
-coral recipe validate --file ./my-review-queue.recipe.yaml
-```
-
-Use this when you want the runtime check explicitly, for example after a source changed or before sharing a recipe file.
 
 ### `coral recipe list`
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -191,7 +191,7 @@ implementation:
   kind: coral_sql
   query: |
     select number, title, url
-    from github.pull_requests
+    from github.pulls
     where owner = $owner
       and repo = $repo
       and state = 'open'
@@ -213,7 +213,7 @@ List installed recipes.
 coral recipe list
 ```
 
-The output is inventory-only and does not re-run runtime validation, so it stays fast. For user-installed recipes, Coral shows the result columns cached during the last successful `coral recipe add --file`.
+The output is inventory-only and does not re-run runtime validation, so it stays fast. Coral shows each recipe's origin, enabled status, publish target, and result columns cached during the last successful `coral recipe add --file`.
 
 If a recipe publishes SQL, call it with named arguments:
 


### PR DESCRIPTION
## Intent

This is the recipe lifecycle slice stacked on top of [#1298](https://github.com/withcoral/coral/pull/1298), which adds the engine runtime for published recipe table functions.

It gives Coral a user-installable recipe artifact and the app/API/CLI plumbing needed to validate, persist, list, and load those recipes into query runtimes.

## What Changed

- Adds `.recipe.yaml` parsing and validation in `coral-spec`.
- Adds app-owned recipe inventory, artifact storage, runtime validation, runtime metadata cache, and runtime loading.
- Adds recipe lifecycle RPCs in `coral-api` and thin client helpers in `coral-client`.
- Adds `coral recipe add --file`, `coral recipe list`, and `coral recipe remove`.
- Makes recipe listing read inventory plus cached result columns without rerunning runtime validation.
- Keeps installed recipe config membership-only. Runtime readiness is derived from the recipe artifact and cached runtime metadata, not persisted `origin` or `enabled` flags.

## Ownership / Boundaries

- `coral-spec` owns recipe artifact shape and static validation.
- `coral-app` owns installed recipe state, runtime validation, cached inferred metadata, and runtime package assembly.
- `coral-api` exposes lifecycle contracts only; it does not encode execution semantics.
- `coral-cli` remains an adapter over the lifecycle RPCs.
- Recipe execution remains owned by the engine PR below this one. This PR loads validated recipe runtime definitions into the query runtime; it does not add a separate execution path.

## Compatibility / User Impact

- Existing sources, tables, and table functions are unchanged.
- Recipe artifacts are new workspace-scoped state under the Coral config layout.
- `coral recipe add --file` performs runtime validation before persisting a user recipe.
- Cached recipe runtime metadata is treated as derived state. Unsupported cache versions or stale artifact fingerprints are ignored and recomputed rather than blocking startup.
- `coral recipe list` is intentionally fast: it reads inventory plus cached result columns instead of executing validation queries.

## Not in This PR

- MCP recipe tools. Those are in the next stack slice.
- Bundled out-of-the-box recipe sidecars. Those are a later stack slice.
- Automatic recipe proposal, grouping, or rollout optimisation.
- New recipe implementation kinds beyond `coral_sql`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p coral-spec recipe --all-targets`
- `cargo test --locked -p coral-app recipe --all-targets`
- `cargo test --locked -p coral-cli recipe --all-targets`
- `go run github.com/bufbuild/buf/cmd/buf@v1.69.0 lint` from `crates/coral-api`
- `make rust-checks` on the restacked top branch after this PR was updated.
- Top-of-stack real-config smoke after restack:
  - listed installed `codex`, `github`, and `linear` sources from the real Coral config
  - queried `github.pulls` against live GitHub data
  - added, listed, queried, and removed a temporary `live_recipe_smoke` recipe
  - `coral recipe list` showed SQL and MCP publish targets plus cached columns
  - queried the temporary recipe through `recipes.live_recipe_smoke(...)`
  - queried bundled `codex.recent_sessions()`