### PR TITLE
feat(api): add identity service contracts

### DIFF
--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -1,6 +1,22 @@
 //! Build script for the generated `coral-api` `protobuf` and `tonic` bindings.
 
 fn main() {
+    const PROTOS: &[&str] = &[
+        "proto/coral/v1/catalog.proto",
+        "proto/coral/v1/resources.proto",
+        "proto/coral/v1/feedback.proto",
+        "proto/coral/v1/identities.proto",
+        "proto/coral/v1/identity_specs.proto",
+        "proto/coral/v1/sources.proto",
+        "proto/coral/v1/query.proto",
+        "proto/coral/v1/traces.proto",
+        "proto/coral/v1/episode.proto",
+    ];
+    for proto in PROTOS {
+        println!("cargo:rerun-if-changed={proto}");
+    }
+    println!("cargo:rerun-if-changed=proto");
+
     let protoc = protoc_bin_vendored::protoc_bin_path().expect("vendored protoc");
     let mut config = tonic_prost_build::Config::new();
     config.protoc_executable(protoc);
@@ -11,18 +27,6 @@ fn main() {
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
-        .compile_with_config(
-            config,
-            &[
-                "proto/coral/v1/catalog.proto",
-                "proto/coral/v1/resources.proto",
-                "proto/coral/v1/feedback.proto",
-                "proto/coral/v1/sources.proto",
-                "proto/coral/v1/query.proto",
-                "proto/coral/v1/traces.proto",
-                "proto/coral/v1/episode.proto",
-            ],
-            &["proto"],
-        )
+        .compile_with_config(config, PROTOS, &["proto"])
         .expect("compile coral v1 protobuf");
 }

--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -10,6 +10,8 @@ enum IdentityOwner {
   IDENTITY_OWNER_UNSPECIFIED = 0;
   // Identity material is owned by the current Coral user principal.
   IDENTITY_OWNER_USER = 1;
+  // Identity material is owned by a workspace and independent of a user principal.
+  IDENTITY_OWNER_WORKSPACE = 2;
 }
 
 // Stored provider-facing identity instance backed by an installed identity spec.

--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -6,9 +6,6 @@ import "coral/v1/sources.proto";
 
 // Scope that owns stored provider-facing identity material.
 enum IdentityOwner {
-  reserved 2;
-  reserved "IDENTITY_OWNER_WORKSPACE";
-
   // Identity owner was not specified.
   IDENTITY_OWNER_UNSPECIFIED = 0;
   // Identity material is owned by the current Coral user principal.
@@ -23,7 +20,7 @@ message Identity {
   string identity_spec = 2;
   // Provider or issuer name copied from the identity spec.
   string issuer = 3;
-  // Identity type, such as `oauth`, `fixed_token`, or `username_password`.
+  // Identity type, such as `oauth` or `fixed_token`.
   string identity_type = 4;
   // Stored identity owner.
   IdentityOwner owner = 5;
@@ -31,38 +28,30 @@ message Identity {
   repeated CredentialMetadata metadata = 6;
 }
 
-// Creates or replaces one OAuth identity owned by the request Coral user principal.
-message CreateUserOwnedIdentityWithOAuthRequest {
-  reserved 3;
-
+// Creates or replaces one identity owned by the request Coral user principal.
+message CreateUserOwnedIdentityRequest {
   // Stable identity name used by source identity bindings.
   string name = 1;
-  // Installed OAuth identity spec name.
+  // Installed identity spec name.
   string identity_spec = 2;
-  // Legacy method-specific OAuth client values such as client ID or client
-  // secret. Inputs declared by the identity spec are owned by the installed
-  // identity spec and are supplied through AddIdentitySpecRequest instead.
-  repeated OAuthCredentialInput credential_inputs = 4;
+
+  // Type-specific setup material. OAuth identity specs do not need per-identity
+  // setup material because their setup inputs belong to the installed identity
+  // spec.
+  oneof setup {
+    // Fixed-token identity setup input.
+    FixedTokenUserOwnedIdentitySetup fixed_token = 3;
+  }
 }
 
-// Creates or replaces one fixed-token identity owned by the request Coral user principal.
-message CreateUserOwnedIdentityWithFixedTokenRequest {
-  // Stable identity name used by source identity bindings.
-  string name = 1;
-  // Installed fixed-token identity spec name.
-  string identity_spec = 2;
+// Setup payload for a fixed-token identity.
+message FixedTokenUserOwnedIdentitySetup {
   // Bearer token to store for this identity.
-  string token = 3;
+  string token = 1;
 }
 
-// Returns the created fixed-token identity.
-message CreateUserOwnedIdentityWithFixedTokenResponse {
-  // Stored identity.
-  Identity identity = 1;
-}
-
-// Streaming event emitted while creating an OAuth identity owned by a Coral user principal.
-message CreateUserOwnedIdentityWithOAuthResponse {
+// Streaming event emitted while creating a user-owned identity.
+message CreateUserOwnedIdentityResponse {
   // Creation progress or completion event.
   oneof event {
     // Identity creation completed.
@@ -85,12 +74,9 @@ message ListUserOwnedIdentitiesResponse {
 
 // Stored identity APIs.
 service IdentityService {
-  // Creates or replaces one OAuth identity owned by the request Coral user principal.
-  rpc CreateUserOwnedIdentityWithOAuth(CreateUserOwnedIdentityWithOAuthRequest)
-      returns (stream CreateUserOwnedIdentityWithOAuthResponse);
-  // Creates or replaces one fixed-token identity owned by the request Coral user principal.
-  rpc CreateUserOwnedIdentityWithFixedToken(CreateUserOwnedIdentityWithFixedTokenRequest)
-      returns (CreateUserOwnedIdentityWithFixedTokenResponse);
+  // Creates or replaces one identity owned by the request Coral user principal.
+  rpc CreateUserOwnedIdentity(CreateUserOwnedIdentityRequest)
+      returns (stream CreateUserOwnedIdentityResponse);
   // Lists user-owned identities.
   rpc ListUserOwnedIdentities(ListUserOwnedIdentitiesRequest)
       returns (ListUserOwnedIdentitiesResponse);

--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -1,0 +1,97 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/sources.proto";
+
+// Scope that owns stored provider-facing identity material.
+enum IdentityOwner {
+  reserved 2;
+  reserved "IDENTITY_OWNER_WORKSPACE";
+
+  // Identity owner was not specified.
+  IDENTITY_OWNER_UNSPECIFIED = 0;
+  // Identity material is owned by the current Coral user principal.
+  IDENTITY_OWNER_USER = 1;
+}
+
+// Stored provider-facing identity instance backed by an installed identity spec.
+message Identity {
+  // Stable identity name used by source identity bindings.
+  string name = 1;
+  // Installed identity spec name used to instantiate this identity.
+  string identity_spec = 2;
+  // Provider or issuer name copied from the identity spec.
+  string issuer = 3;
+  // Identity type, such as `oauth`, `fixed_token`, or `username_password`.
+  string identity_type = 4;
+  // Stored identity owner.
+  IdentityOwner owner = 5;
+  // Safe provider metadata, never token material.
+  repeated CredentialMetadata metadata = 6;
+}
+
+// Creates or replaces one OAuth identity owned by the request Coral user principal.
+message CreateUserOwnedIdentityWithOAuthRequest {
+  reserved 3;
+
+  // Stable identity name used by source identity bindings.
+  string name = 1;
+  // Installed OAuth identity spec name.
+  string identity_spec = 2;
+  // Legacy method-specific OAuth client values such as client ID or client
+  // secret. Inputs declared by the identity spec are owned by the installed
+  // identity spec and are supplied through AddIdentitySpecRequest instead.
+  repeated OAuthCredentialInput credential_inputs = 4;
+}
+
+// Creates or replaces one fixed-token identity owned by the request Coral user principal.
+message CreateUserOwnedIdentityWithFixedTokenRequest {
+  // Stable identity name used by source identity bindings.
+  string name = 1;
+  // Installed fixed-token identity spec name.
+  string identity_spec = 2;
+  // Bearer token to store for this identity.
+  string token = 3;
+}
+
+// Returns the created fixed-token identity.
+message CreateUserOwnedIdentityWithFixedTokenResponse {
+  // Stored identity.
+  Identity identity = 1;
+}
+
+// Streaming event emitted while creating an OAuth identity owned by a Coral user principal.
+message CreateUserOwnedIdentityWithOAuthResponse {
+  // Creation progress or completion event.
+  oneof event {
+    // Identity creation completed.
+    Identity identity = 1;
+    // OAuth authorization URL is ready.
+    OAuthCredentialAuthorization oauth_authorization = 2;
+    // OAuth credential retrieval completed.
+    OAuthCredentialCompleted oauth_completed = 3;
+  }
+}
+
+// Lists user-owned identities for the request Coral user principal.
+message ListUserOwnedIdentitiesRequest {}
+
+// Returns user-owned identities sorted by name.
+message ListUserOwnedIdentitiesResponse {
+  // Stored user-owned identities.
+  repeated Identity identities = 1;
+}
+
+// Stored identity APIs.
+service IdentityService {
+  // Creates or replaces one OAuth identity owned by the request Coral user principal.
+  rpc CreateUserOwnedIdentityWithOAuth(CreateUserOwnedIdentityWithOAuthRequest)
+      returns (stream CreateUserOwnedIdentityWithOAuthResponse);
+  // Creates or replaces one fixed-token identity owned by the request Coral user principal.
+  rpc CreateUserOwnedIdentityWithFixedToken(CreateUserOwnedIdentityWithFixedTokenRequest)
+      returns (CreateUserOwnedIdentityWithFixedTokenResponse);
+  // Lists user-owned identities.
+  rpc ListUserOwnedIdentities(ListUserOwnedIdentitiesRequest)
+      returns (ListUserOwnedIdentitiesResponse);
+}

--- a/crates/coral-api/proto/coral/v1/identity_specs.proto
+++ b/crates/coral-api/proto/coral/v1/identity_specs.proto
@@ -12,11 +12,10 @@ message IdentitySpec {
   string description = 3;
   // Provider or issuer name, such as `github`.
   string issuer = 4;
-  // Identity type, such as `oauth`, `fixed_token`, or `username_password`.
+  // Identity type, such as `oauth` or `fixed_token`.
   string identity_type = 5;
   // Canonical identity spec manifest YAML.
-  string manifest_yaml = 7;
-  reserved 6;
+  string manifest_yaml = 6;
 }
 
 // Installs one global identity spec, or replaces an unused existing spec.
@@ -25,17 +24,19 @@ message IdentitySpec {
 message AddIdentitySpecRequest {
   // Raw identity spec manifest YAML to validate and install.
   string manifest_yaml = 1;
-  // Setup input values owned by the installed identity spec. Secret values are
-  // persisted in Coral credential storage for later identity materialization.
-  repeated IdentitySpecInput inputs = 2;
+  // Setup input values owned by the installed identity spec. The server parses
+  // `manifest_yaml`, matches values by key to declared identity spec inputs,
+  // and uses the manifest-declared input kind to decide whether each value is
+  // secret material.
+  repeated IdentitySpecInputValue input_values = 2;
 }
 
 // One setup input value for an installed identity spec.
-message IdentitySpecInput {
-  // Declared identity spec input key.
+message IdentitySpecInputValue {
+  // Declared identity spec input key from AddIdentitySpecRequest.manifest_yaml.
   string key = 1;
-  // Input value. Secret values are only accepted on write requests and are not
-  // returned by identity spec read APIs.
+  // Input value. Callers do not classify values here; the identity spec
+  // manifest determines whether this value is stored as secret material.
   string value = 2;
 }
 

--- a/crates/coral-api/proto/coral/v1/identity_specs.proto
+++ b/crates/coral-api/proto/coral/v1/identity_specs.proto
@@ -1,0 +1,97 @@
+syntax = "proto3";
+
+package coral.v1;
+
+// A global identity spec installed for all Coral workspaces.
+message IdentitySpec {
+  // Stable identity spec name.
+  string name = 1;
+  // Authored identity spec version string.
+  string version = 2;
+  // Human-readable description.
+  string description = 3;
+  // Provider or issuer name, such as `github`.
+  string issuer = 4;
+  // Identity type, such as `oauth`, `fixed_token`, or `username_password`.
+  string identity_type = 5;
+  // Canonical identity spec manifest YAML.
+  string manifest_yaml = 7;
+  reserved 6;
+}
+
+// Installs one global identity spec, or replaces an unused existing spec.
+// Existing specs referenced by stored identities may only be re-added with an
+// equivalent manifest.
+message AddIdentitySpecRequest {
+  // Raw identity spec manifest YAML to validate and install.
+  string manifest_yaml = 1;
+  // Setup input values owned by the installed identity spec. Secret values are
+  // persisted in Coral credential storage for later identity materialization.
+  repeated IdentitySpecInput inputs = 2;
+}
+
+// One setup input value for an installed identity spec.
+message IdentitySpecInput {
+  // Declared identity spec input key.
+  string key = 1;
+  // Input value. Secret values are only accepted on write requests and are not
+  // returned by identity spec read APIs.
+  string value = 2;
+}
+
+// Returns the installed identity spec.
+message AddIdentitySpecResponse {
+  // The installed identity spec.
+  IdentitySpec identity_spec = 1;
+  // Whether an existing spec with the same name was replaced.
+  bool replaced = 2;
+}
+
+// Lists all globally installed identity specs.
+message ListIdentitySpecsRequest {}
+
+// Returns global identity specs.
+message ListIdentitySpecsResponse {
+  // Installed identity specs sorted by name.
+  repeated IdentitySpec identity_specs = 1;
+}
+
+// Fetches one globally installed identity spec.
+message GetIdentitySpecRequest {
+  // Identity spec name.
+  string name = 1;
+}
+
+// Returns one globally installed identity spec.
+message GetIdentitySpecResponse {
+  // The installed identity spec.
+  IdentitySpec identity_spec = 1;
+}
+
+// Deletes one globally installed identity spec.
+message DeleteIdentitySpecRequest {
+  // Identity spec name.
+  string name = 1;
+  // Required when deleting the spec would orphan stored identity instances of
+  // any owner or identity type.
+  bool force = 2;
+}
+
+// Confirms identity spec deletion.
+message DeleteIdentitySpecResponse {
+  // Number of stored identities orphaned by deletion, across identity owners
+  // and identity types visible to the app.
+  uint32 orphaned_identities = 1;
+}
+
+// Global identity spec APIs.
+service IdentitySpecService {
+  // Installs one global identity spec, or replaces an unused existing spec.
+  rpc AddIdentitySpec(AddIdentitySpecRequest) returns (AddIdentitySpecResponse);
+  // Lists globally installed identity specs.
+  rpc ListIdentitySpecs(ListIdentitySpecsRequest) returns (ListIdentitySpecsResponse);
+  // Fetches one globally installed identity spec.
+  rpc GetIdentitySpec(GetIdentitySpecRequest) returns (GetIdentitySpecResponse);
+  // Deletes one globally installed identity spec.
+  rpc DeleteIdentitySpec(DeleteIdentitySpecRequest) returns (DeleteIdentitySpecResponse);
+}

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -4,6 +4,8 @@ use coral_api::v1::Workspace;
 use coral_api::v1::catalog_service_client::CatalogServiceClient;
 use coral_api::v1::episode_service_client::EpisodeServiceClient;
 use coral_api::v1::feedback_service_client::FeedbackServiceClient;
+use coral_api::v1::identity_service_client::IdentityServiceClient;
+use coral_api::v1::identity_spec_service_client::IdentitySpecServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
 use coral_api::{
@@ -33,6 +35,12 @@ type GrpcService = InstrumentedGrpcService<RawGrpcService>;
 /// Public source-management gRPC client.
 pub type SourceClient = SourceServiceClient<GrpcService>;
 
+/// Public global identity-spec gRPC client.
+pub type IdentitySpecClient = IdentitySpecServiceClient<GrpcService>;
+
+/// Public stored-identity gRPC client.
+pub type IdentityClient = IdentityServiceClient<GrpcService>;
+
 /// Public catalog-discovery gRPC client.
 pub type CatalogClient = CatalogServiceClient<GrpcService>;
 
@@ -51,6 +59,8 @@ pub type EpisodeClient = EpisodeServiceClient<GrpcService>;
 #[derive(Clone)]
 pub struct AppClient {
     source: SourceClient,
+    identity_spec: IdentitySpecClient,
+    identity: IdentityClient,
     catalog: CatalogClient,
     query: QueryClient,
     feedback: FeedbackClient,
@@ -100,6 +110,16 @@ impl AppClient {
             &grpc_endpoint,
             static_metadata.clone(),
         ));
+        let identity_spec_client = IdentitySpecClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ));
+        let identity_client = IdentityClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ));
         let catalog_client = CatalogClient::new(grpc_service(
             channel.clone(),
             &grpc_endpoint,
@@ -121,6 +141,8 @@ impl AppClient {
             EpisodeClient::new(grpc_service(channel, &grpc_endpoint, static_metadata));
         Ok(Self {
             source: source_client,
+            identity_spec: identity_spec_client,
+            identity: identity_client,
             catalog: catalog_client,
             query: query_client,
             feedback: feedback_client,
@@ -132,6 +154,18 @@ impl AppClient {
     /// Returns a cloned source-management client.
     pub fn source_client(&self) -> SourceClient {
         self.source.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned global identity-spec client.
+    pub fn identity_spec_client(&self) -> IdentitySpecClient {
+        self.identity_spec.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned stored-identity client.
+    pub fn identity_client(&self) -> IdentityClient {
+        self.identity.clone()
     }
 
     #[must_use]

--- a/crates/coral-client/src/error.rs
+++ b/crates/coral-client/src/error.rs
@@ -6,7 +6,7 @@ pub enum ClientError {
     /// Connecting the generated gRPC client failed.
     #[error(transparent)]
     Transport(#[from] tonic::transport::Error),
-    /// Caller-supplied static gRPC metadata was invalid.
+    /// Caller-supplied request metadata was invalid.
     #[error("invalid client metadata: {0}")]
     InvalidMetadata(String),
 }

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -40,8 +40,8 @@ use coral_api::v1::ExecuteSqlResponse;
 use serde_json::Value;
 
 pub use client::{
-    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, EpisodeClient, FeedbackClient, QueryClient,
-    SourceClient, default_workspace,
+    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, EpisodeClient, FeedbackClient, IdentityClient,
+    IdentitySpecClient, QueryClient, SourceClient, default_workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use propagation::with_episode_metadata;

--- a/crates/coral-client/src/propagation.rs
+++ b/crates/coral-client/src/propagation.rs
@@ -199,18 +199,18 @@ mod tests {
 
     #[test]
     fn interceptor_injects_static_metadata() {
-        let metadata =
-            StaticClientMetadata::try_from_pairs([("x-coral-user-id", "saul")]).expect("metadata");
+        let metadata = StaticClientMetadata::try_from_pairs([("x-coral-request-user", "saul")])
+            .expect("metadata");
         let mut interceptor = ClientMetadataInterceptor::new(metadata);
 
         let request = interceptor
             .call(tonic::Request::new(()))
-            .expect("interceptor");
+            .expect("intercept request");
 
         assert_eq!(
             request
                 .metadata()
-                .get("x-coral-user-id")
+                .get("x-coral-request-user")
                 .and_then(|value| value.to_str().ok()),
             Some("saul")
         );


### PR DESCRIPTION
## Intent

Land `feat(api): add identity service contracts` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-01-manifest-metadata...sauldhernandez/dsl-v4-identity-v2-02-identity-api
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
