### PR TITLE
feat(engine): resolve DSL v4 request identities

### DIFF
--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use coral_engine::RuntimeSourceComponent;
+use coral_engine::{RuntimeHttpSourceComponent, RuntimeSourceComponent};
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::backends::mcp::{
     McpSourceManifest, McpTableFilterBinding, McpTableFunctionSpec, McpTableSpec,
@@ -31,17 +31,18 @@ pub(crate) fn runtime_components_for_v4_source(
         }
         match surface.surface_type {
             SurfaceType::OpenApi => {
-                if surface.identity_requirements.is_some() {
-                    return Err(AppError::FailedPrecondition(format!(
-                        "DSL v4 surface '{}' declares identity_requirements, but this runtime cannot resolve source identities",
-                        surface.id
-                    )));
-                }
-                components.push(RuntimeSourceComponent::Http(http_manifest_for_surface(
-                    manifest,
-                    materialized,
-                    &surface.id,
-                )?));
+                let http_manifest = http_manifest_for_surface(manifest, materialized, &surface.id)?;
+                let http_component =
+                    if let Some(identity_requirements) = surface.identity_requirements.clone() {
+                        RuntimeHttpSourceComponent::with_identity_requirements(
+                            http_manifest,
+                            surface.id.clone(),
+                            identity_requirements,
+                        )
+                    } else {
+                        RuntimeHttpSourceComponent::new(http_manifest)
+                    };
+                components.push(RuntimeSourceComponent::Http(http_component));
             }
             SurfaceType::Mcp => {
                 components.push(RuntimeSourceComponent::Mcp(mcp_manifest_for_surface(
@@ -166,7 +167,7 @@ fn http_manifest_for_surface(
         rate_limit: openapi_runtime.rate_limit.clone(),
         tables,
         functions,
-        declared_inputs: manifest.declared_inputs.clone(),
+        declared_inputs: surface.inputs.clone(),
     })
 }
 
@@ -400,19 +401,17 @@ fn validate_surface_base_url_template(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
     use std::path::PathBuf;
 
     use coral_spec::backends::http::{AuthSpec, RateLimitSpec};
     use coral_spec::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec, McpServerSpec};
     use coral_spec::v4::{
-        AcceptedIdentityRequirement, Fingerprint, IdentityRequirements, IrExecutionAttachment,
-        IrOperation, IrOperationOutput, MCP_IMPORTER_VERSION, MaterializedSurface,
-        McpExecutionAttachment, McpRuntimeConfig, OPENAPI_IMPORTER_VERSION, OpenApiRuntimeConfig,
-        PROJECTION_GENERATOR_VERSION, Projection, ProjectionCatalog, ProjectionKind,
-        ProjectionVisibility, SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceDescriptor,
-        SurfaceRuntimeConfig, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource,
-        V4SourceCommon, V4SourceManifest, V4Surface,
+        Fingerprint, IrExecutionAttachment, IrOperation, IrOperationOutput, MCP_IMPORTER_VERSION,
+        MaterializedSurface, McpExecutionAttachment, McpRuntimeConfig, OPENAPI_IMPORTER_VERSION,
+        OpenApiRuntimeConfig, PROJECTION_GENERATOR_VERSION, Projection, ProjectionCatalog,
+        ProjectionKind, ProjectionVisibility, SURFACE_IMPORTER_VERSION, SemanticIr,
+        SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION,
+        V4MaterializedSource, V4SourceCommon, V4SourceManifest, V4Surface,
     };
 
     use super::{runtime_components_for_v4_source, surface_base_url};
@@ -467,30 +466,6 @@ mod tests {
             source_document_sha256: String::new(),
             normalized_source_document_path: raw_source_document_path.clone(),
             raw_source_document_path,
-        }
-    }
-
-    fn materialized_source_with_rest_projection(
-        raw_source_document_path: PathBuf,
-    ) -> V4MaterializedSource {
-        V4MaterializedSource {
-            fingerprint: Fingerprint {
-                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
-                source_name: "demo".to_string(),
-                manifest_sha256: String::new(),
-                surfaces: Vec::new(),
-                importer_version: SURFACE_IMPORTER_VERSION.to_string(),
-                projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
-            },
-            surfaces: vec![materialized_surface(raw_source_document_path)],
-            projections: ProjectionCatalog {
-                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
-                source_name: "demo".to_string(),
-                generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
-                projections: vec![published_projection("rest", "demo", "list_issues")],
-                diagnostics: Vec::new(),
-            },
-            diagnostics: Vec::new(),
         }
     }
 
@@ -591,31 +566,6 @@ mod tests {
             detail_hints: Vec::new(),
             diagnostics: Vec::new(),
         }
-    }
-
-    #[test]
-    fn runtime_components_fail_closed_for_identity_gated_openapi_surfaces() {
-        let mut surface = surface_without_authored_base_url();
-        surface.identity_requirements = Some(IdentityRequirements {
-            accepts: vec![AcceptedIdentityRequirement {
-                id: "github".to_string(),
-                identity_specs: vec!["github_oauth".to_string()],
-                audience: BTreeMap::new(),
-            }],
-        });
-        let manifest = manifest_with_surface(surface);
-        let materialized =
-            materialized_source_with_rest_projection(PathBuf::from("/tmp/source-document.yaml"));
-
-        let error = runtime_components_for_v4_source(&manifest, &materialized)
-            .expect_err("identity-gated runtime should fail closed");
-
-        assert!(
-            error
-                .to_string()
-                .contains("cannot resolve source identities"),
-            "unexpected error: {error}"
-        );
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, OnceLock};
 
 use crate::{
-    QueryRuntimeContext, QuerySource, RequestAuthenticator, RequestIdentityResolver,
+    BoundRequestIdentityHttpAuthenticator, QueryRuntimeContext, QuerySource, RequestAuthenticator,
     SourceInputResolver,
 };
 use async_trait::async_trait;
@@ -130,7 +130,8 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) source_variables: BTreeMap<String, String>,
     pub(crate) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
     pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    pub(crate) request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    pub(crate) request_identity_http_authenticators:
+        &'a HashMap<(String, String), BoundRequestIdentityHttpAuthenticator>,
 }
 
 /// Shared resources available while registering one batch of compiled sources.

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -3,7 +3,10 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, OnceLock};
 
-use crate::{QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceInputResolver};
+use crate::{
+    QueryRuntimeContext, QuerySource, RequestAuthenticator, RequestIdentityResolver,
+    SourceInputResolver,
+};
 use async_trait::async_trait;
 use coral_spec::{
     ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
@@ -127,6 +130,7 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) source_variables: BTreeMap<String, String>,
     pub(crate) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
     pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    pub(crate) request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
 }
 
 /// Shared resources available while registering one batch of compiled sources.

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -15,8 +15,8 @@ use crate::backends::http::registration_checks::validate_source_scoped_http_conf
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::http::trace::HttpBodyCapture;
 use crate::{
-    RequestAuthenticator, RequestIdentityResolutionContext, RequestIdentityResolver,
-    SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
+    BoundRequestIdentityHttpAuthenticator, RequestAuthenticator, SourceInputResolutionContext,
+    SourceInputResolver, SourceInputResolverError,
 };
 use coral_spec::backends::http::{HttpSourceManifest, RateLimitSpec};
 use coral_spec::{AuthSpec, HeaderSpec, ParsedTemplate, RequestSpec as ManifestRequestSpec};
@@ -35,8 +35,7 @@ pub(crate) struct HttpSourceClient {
     pub(super) request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolution_context: Option<SourceInputResolutionContext>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    pub(super) identity_context: Option<RequestIdentityResolutionContext>,
-    pub(super) request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    pub(super) request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
     pub(super) rate_limit: RateLimitSpec,
     pub(super) resolved_inputs: Arc<BTreeMap<String, String>>,
     pub(super) body_capture: HttpBodyCapture,
@@ -46,8 +45,7 @@ pub(crate) struct HttpSourceClient {
 pub(crate) struct HttpSourceClientRuntime {
     source_input_resolution_context: Option<SourceInputResolutionContext>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    identity_context: Option<RequestIdentityResolutionContext>,
-    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<OtelContext>,
     http: reqwest::Client,
@@ -57,8 +55,7 @@ impl HttpSourceClientRuntime {
     pub(crate) fn new(
         source_input_resolution_context: SourceInputResolutionContext,
         source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-        identity_context: Option<RequestIdentityResolutionContext>,
-        request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+        request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
         body_capture_max_bytes: Option<usize>,
         trace_context: Option<OtelContext>,
         http: reqwest::Client,
@@ -66,8 +63,7 @@ impl HttpSourceClientRuntime {
         Self {
             source_input_resolution_context: Some(source_input_resolution_context),
             source_input_resolver,
-            identity_context,
-            request_identity_resolver,
+            request_identity_http_authenticator,
             body_capture_max_bytes,
             trace_context,
             http,
@@ -79,8 +75,7 @@ impl HttpSourceClientRuntime {
         Self {
             source_input_resolution_context: None,
             source_input_resolver: None,
-            identity_context: None,
-            request_identity_resolver: None,
+            request_identity_http_authenticator: None,
             body_capture_max_bytes,
             trace_context: None,
             http,
@@ -192,8 +187,7 @@ impl HttpSourceClient {
             request_authenticators: request_authenticators.clone(),
             source_input_resolution_context: runtime.source_input_resolution_context,
             source_input_resolver: runtime.source_input_resolver,
-            identity_context: runtime.identity_context,
-            request_identity_resolver: runtime.request_identity_resolver,
+            request_identity_http_authenticator: runtime.request_identity_http_authenticator,
             rate_limit: manifest.rate_limit.clone(),
             resolved_inputs: Arc::new(resolved_inputs),
             body_capture: HttpBodyCapture::new(runtime.body_capture_max_bytes),

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -15,8 +15,8 @@ use crate::backends::http::registration_checks::validate_source_scoped_http_conf
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::http::trace::HttpBodyCapture;
 use crate::{
-    RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver,
-    SourceInputResolverError,
+    RequestAuthenticator, RequestIdentityResolutionContext, RequestIdentityResolver,
+    SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
 };
 use coral_spec::backends::http::{HttpSourceManifest, RateLimitSpec};
 use coral_spec::{AuthSpec, HeaderSpec, ParsedTemplate, RequestSpec as ManifestRequestSpec};
@@ -35,6 +35,8 @@ pub(crate) struct HttpSourceClient {
     pub(super) request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolution_context: Option<SourceInputResolutionContext>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    pub(super) identity_context: Option<RequestIdentityResolutionContext>,
+    pub(super) request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
     pub(super) rate_limit: RateLimitSpec,
     pub(super) resolved_inputs: Arc<BTreeMap<String, String>>,
     pub(super) body_capture: HttpBodyCapture,
@@ -44,6 +46,8 @@ pub(crate) struct HttpSourceClient {
 pub(crate) struct HttpSourceClientRuntime {
     source_input_resolution_context: Option<SourceInputResolutionContext>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    identity_context: Option<RequestIdentityResolutionContext>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<OtelContext>,
     http: reqwest::Client,
@@ -53,6 +57,8 @@ impl HttpSourceClientRuntime {
     pub(crate) fn new(
         source_input_resolution_context: SourceInputResolutionContext,
         source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+        identity_context: Option<RequestIdentityResolutionContext>,
+        request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
         body_capture_max_bytes: Option<usize>,
         trace_context: Option<OtelContext>,
         http: reqwest::Client,
@@ -60,6 +66,8 @@ impl HttpSourceClientRuntime {
         Self {
             source_input_resolution_context: Some(source_input_resolution_context),
             source_input_resolver,
+            identity_context,
+            request_identity_resolver,
             body_capture_max_bytes,
             trace_context,
             http,
@@ -71,6 +79,8 @@ impl HttpSourceClientRuntime {
         Self {
             source_input_resolution_context: None,
             source_input_resolver: None,
+            identity_context: None,
+            request_identity_resolver: None,
             body_capture_max_bytes,
             trace_context: None,
             http,
@@ -182,6 +192,8 @@ impl HttpSourceClient {
             request_authenticators: request_authenticators.clone(),
             source_input_resolution_context: runtime.source_input_resolution_context,
             source_input_resolver: runtime.source_input_resolver,
+            identity_context: runtime.identity_context,
+            request_identity_resolver: runtime.request_identity_resolver,
             rate_limit: manifest.rate_limit.clone(),
             resolved_inputs: Arc::new(resolved_inputs),
             body_capture: HttpBodyCapture::new(runtime.body_capture_max_bytes),

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -160,6 +160,8 @@ pub(super) async fn fetch_rows(
                 auth: &client.auth,
                 request_headers: &client.request_headers,
                 request_authenticators: &client.request_authenticators,
+                identity_context: client.identity_context.as_ref(),
+                request_identity_resolver: client.request_identity_resolver.as_deref(),
                 trace_context: client.trace_context.as_ref(),
                 table_headers: &active_request.headers,
                 table_name: target.name(),

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -160,8 +160,9 @@ pub(super) async fn fetch_rows(
                 auth: &client.auth,
                 request_headers: &client.request_headers,
                 request_authenticators: &client.request_authenticators,
-                identity_context: client.identity_context.as_ref(),
-                request_identity_resolver: client.request_identity_resolver.as_deref(),
+                request_identity_http_authenticator: client
+                    .request_identity_http_authenticator
+                    .as_ref(),
                 trace_context: client.trace_context.as_ref(),
                 table_headers: &active_request.headers,
                 table_name: target.name(),

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -9,14 +9,19 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 use datafusion::prelude::SessionContext;
 
+#[cfg(test)]
+use crate::backends::BackendCompileRequest;
 use crate::backends::{
-    BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
-    BackendSchemaRegistration, CompiledBackendSource, RegisteredSource, RegisteredTable,
-    SourceFunctionProviderFactory, build_registered_inputs, build_registered_table,
-    build_registered_table_function, registered_columns_from_specs, required_filter_names,
+    BackendRegistration, BackendRegistrationContext, BackendSchemaRegistration,
+    CompiledBackendSource, RegisteredSource, RegisteredTable, SourceFunctionProviderFactory,
+    build_registered_inputs, build_registered_table, build_registered_table_function,
+    registered_columns_from_specs, required_filter_names,
     validate_lookup_key_filter_backend_support,
 };
-use crate::{RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver};
+use crate::{
+    RequestAuthenticator, RequestIdentityResolutionContext, RequestIdentityResolver,
+    SourceInputResolutionContext, SourceInputResolver,
+};
 use coral_spec::SourceBackend;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod auth;
@@ -50,26 +55,38 @@ struct HttpCompiledSource {
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<opentelemetry::Context>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    identity_context: Option<RequestIdentityResolutionContext>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct HttpCompileRuntime {
+    pub(crate) body_capture_max_bytes: Option<usize>,
+    pub(crate) trace_context: Option<opentelemetry::Context>,
+    pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    pub(crate) identity_context: Option<RequestIdentityResolutionContext>,
+    pub(crate) request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
 }
 
 pub(crate) fn compile_source(
     manifest: HttpSourceManifest,
     source_input_resolution: SourceInputResolutionContext,
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
-    body_capture_max_bytes: Option<usize>,
-    trace_context: Option<opentelemetry::Context>,
-    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    runtime: HttpCompileRuntime,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(HttpCompiledSource {
         manifest,
         source_input_resolution,
         request_authenticators,
-        body_capture_max_bytes,
-        trace_context,
-        source_input_resolver,
+        body_capture_max_bytes: runtime.body_capture_max_bytes,
+        trace_context: runtime.trace_context,
+        source_input_resolver: runtime.source_input_resolver,
+        identity_context: runtime.identity_context,
+        request_identity_resolver: runtime.request_identity_resolver,
     })
 }
 
+#[cfg(test)]
 pub(crate) fn compile_manifest(
     manifest: &HttpSourceManifest,
     request: &BackendCompileRequest<'_>,
@@ -78,9 +95,13 @@ pub(crate) fn compile_manifest(
         manifest.clone(),
         SourceInputResolutionContext::from_query_source(request.source),
         request.request_authenticators.clone(),
-        request.runtime_context.body_capture_max_bytes,
-        request.runtime_context.trace_context.clone(),
-        request.source_input_resolver.clone(),
+        HttpCompileRuntime {
+            body_capture_max_bytes: request.runtime_context.body_capture_max_bytes,
+            trace_context: request.runtime_context.trace_context.clone(),
+            source_input_resolver: request.source_input_resolver.clone(),
+            identity_context: None,
+            request_identity_resolver: request.request_identity_resolver.clone(),
+        },
     )
 }
 
@@ -115,6 +136,8 @@ impl CompiledBackendSource for HttpCompiledSource {
         let runtime = HttpSourceClientRuntime::new(
             self.source_input_resolution.clone(),
             self.source_input_resolver.clone(),
+            self.identity_context.clone(),
+            self.request_identity_resolver.clone(),
             self.body_capture_max_bytes,
             self.trace_context.clone(),
             http,

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -19,8 +19,8 @@ use crate::backends::{
     validate_lookup_key_filter_backend_support,
 };
 use crate::{
-    RequestAuthenticator, RequestIdentityResolutionContext, RequestIdentityResolver,
-    SourceInputResolutionContext, SourceInputResolver,
+    BoundRequestIdentityHttpAuthenticator, RequestAuthenticator, SourceInputResolutionContext,
+    SourceInputResolver,
 };
 use coral_spec::SourceBackend;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
@@ -47,7 +47,7 @@ pub(crate) use client::{HttpSourceClient, HttpSourceClientRuntime};
 pub(crate) use error::ProviderQueryError;
 pub(crate) use provider::HttpSourceTableProvider;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct HttpCompiledSource {
     manifest: HttpSourceManifest,
     source_input_resolution: SourceInputResolutionContext,
@@ -55,17 +55,15 @@ struct HttpCompiledSource {
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<opentelemetry::Context>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    identity_context: Option<RequestIdentityResolutionContext>,
-    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct HttpCompileRuntime {
     pub(crate) body_capture_max_bytes: Option<usize>,
     pub(crate) trace_context: Option<opentelemetry::Context>,
     pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    pub(crate) identity_context: Option<RequestIdentityResolutionContext>,
-    pub(crate) request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    pub(crate) request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
 }
 
 pub(crate) fn compile_source(
@@ -81,8 +79,7 @@ pub(crate) fn compile_source(
         body_capture_max_bytes: runtime.body_capture_max_bytes,
         trace_context: runtime.trace_context,
         source_input_resolver: runtime.source_input_resolver,
-        identity_context: runtime.identity_context,
-        request_identity_resolver: runtime.request_identity_resolver,
+        request_identity_http_authenticator: runtime.request_identity_http_authenticator,
     })
 }
 
@@ -99,8 +96,7 @@ pub(crate) fn compile_manifest(
             body_capture_max_bytes: request.runtime_context.body_capture_max_bytes,
             trace_context: request.runtime_context.trace_context.clone(),
             source_input_resolver: request.source_input_resolver.clone(),
-            identity_context: None,
-            request_identity_resolver: request.request_identity_resolver.clone(),
+            request_identity_http_authenticator: None,
         },
     )
 }
@@ -136,8 +132,7 @@ impl CompiledBackendSource for HttpCompiledSource {
         let runtime = HttpSourceClientRuntime::new(
             self.source_input_resolution.clone(),
             self.source_input_resolver.clone(),
-            self.identity_context.clone(),
-            self.request_identity_resolver.clone(),
+            self.request_identity_http_authenticator.clone(),
             self.body_capture_max_bytes,
             self.trace_context.clone(),
             http,

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -13,7 +13,6 @@ use tracing::Instrument as _;
 use tracing::field;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
-use crate::RequestAuthenticator;
 use crate::backends::http::ProviderQueryError;
 use crate::backends::http::auth::resolve_auth_headers;
 use crate::backends::http::error::{pagination_error, provider_error};
@@ -27,6 +26,10 @@ use crate::backends::http::trace::{
     trace_reqwest_error, trace_reqwest_error_type,
 };
 use crate::backends::shared::template::{RenderContext, resolve_value_source, value_to_string};
+use crate::{
+    RequestAuthenticator, RequestIdentityResolutionContext, RequestIdentityResolver,
+    RequestIdentityResolverError,
+};
 use coral_spec::backends::http::RateLimitSpec;
 use coral_spec::{AuthSpec, HeaderSpec, HttpMethod, ResponseBodyFormat};
 
@@ -36,6 +39,8 @@ pub(super) struct OutgoingHttpRequest<'a> {
     pub(super) auth: &'a AuthSpec,
     pub(super) request_headers: &'a [HeaderSpec],
     pub(super) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
+    pub(super) identity_context: Option<&'a RequestIdentityResolutionContext>,
+    pub(super) request_identity_resolver: Option<&'a dyn RequestIdentityResolver>,
     pub(super) trace_context: Option<&'a OtelContext>,
     pub(super) table_headers: &'a [HeaderSpec],
     pub(super) table_name: &'a str,
@@ -71,6 +76,8 @@ pub(super) async fn execute_request(
         auth,
         request_headers,
         request_authenticators,
+        identity_context,
+        request_identity_resolver,
         trace_context,
         table_headers,
         table_name,
@@ -189,7 +196,12 @@ pub(super) async fn execute_request(
         }
 
         body_capture.record_request(&request_span, request_id, body);
-        let built = match resolve_auth_headers(
+        if let (Some(identity_context), None) = (identity_context, request_identity_resolver) {
+            let error = missing_identity_resolver_error(identity_context);
+            record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
+            return Err(error);
+        }
+        let mut built = match resolve_auth_headers(
             auth,
             request,
             request_authenticators,
@@ -201,6 +213,29 @@ pub(super) async fn execute_request(
                 return Err(error);
             }
         };
+        if let (Some(identity_context), Some(resolver)) =
+            (identity_context, request_identity_resolver)
+        {
+            let identity_headers = match resolver
+                .resolve_identity_headers(identity_context, &built, render_context.resolved_inputs)
+                .await
+            {
+                Ok(headers) => headers,
+                Err(error) => {
+                    let error = identity_resolver_error(identity_context, &error);
+                    record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
+                    return Err(error);
+                }
+            };
+            for (name, value) in identity_headers {
+                if built.headers().contains_key(&name) {
+                    let error = identity_header_conflict_error(identity_context, &name);
+                    record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
+                    return Err(error);
+                }
+                built.headers_mut().insert(name, value);
+            }
+        }
         let response = match http.execute(built).instrument(request_span.clone()).await {
             Ok(response) => response,
             Err(error) => {
@@ -376,6 +411,52 @@ pub(super) async fn execute_request(
     }
 }
 
+fn identity_resolver_error(
+    identity_context: &RequestIdentityResolutionContext,
+    error: &RequestIdentityResolverError,
+) -> DataFusionError {
+    let detail = format!(
+        "request identity resolver failed for source '{}' surface '{}': {error}",
+        identity_context.source_name(),
+        identity_context.surface_id()
+    );
+    let error = match error {
+        RequestIdentityResolverError::InvalidInput(_) => {
+            RequestIdentityResolverError::invalid_input(detail)
+        }
+        RequestIdentityResolverError::FailedPrecondition(_) => {
+            RequestIdentityResolverError::failed_precondition(detail)
+        }
+    };
+    DataFusionError::External(Box::new(error))
+}
+
+fn missing_identity_resolver_error(
+    identity_context: &RequestIdentityResolutionContext,
+) -> DataFusionError {
+    DataFusionError::External(Box::new(RequestIdentityResolverError::failed_precondition(
+        format!(
+            "source '{}' surface '{}' declares identity_requirements but no request identity resolver is installed",
+            identity_context.source_name(),
+            identity_context.surface_id()
+        ),
+    )))
+}
+
+fn identity_header_conflict_error(
+    identity_context: &RequestIdentityResolutionContext,
+    name: &HeaderName,
+) -> DataFusionError {
+    DataFusionError::External(Box::new(RequestIdentityResolverError::failed_precondition(
+        format!(
+            "request identity resolver attempted to overwrite header '{}' for source '{}' surface '{}'",
+            name.as_str(),
+            identity_context.source_name(),
+            identity_context.surface_id()
+        ),
+    )))
+}
+
 fn request_error(
     source_schema: &str,
     table_name: &str,
@@ -498,6 +579,8 @@ mod tests {
                 auth: &AuthSpec::default(),
                 request_headers: &[],
                 request_authenticators: &HashMap::new(),
+                identity_context: None,
+                request_identity_resolver: None,
                 trace_context: None,
                 table_headers: &[],
                 table_name: "items",

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -27,8 +27,8 @@ use crate::backends::http::trace::{
 };
 use crate::backends::shared::template::{RenderContext, resolve_value_source, value_to_string};
 use crate::{
-    RequestAuthenticator, RequestIdentityResolutionContext, RequestIdentityResolver,
-    RequestIdentityResolverError,
+    BoundRequestIdentityHttpAuthenticator, RequestAuthenticator,
+    RequestIdentityHttpAuthenticatorError,
 };
 use coral_spec::backends::http::RateLimitSpec;
 use coral_spec::{AuthSpec, HeaderSpec, HttpMethod, ResponseBodyFormat};
@@ -39,8 +39,8 @@ pub(super) struct OutgoingHttpRequest<'a> {
     pub(super) auth: &'a AuthSpec,
     pub(super) request_headers: &'a [HeaderSpec],
     pub(super) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
-    pub(super) identity_context: Option<&'a RequestIdentityResolutionContext>,
-    pub(super) request_identity_resolver: Option<&'a dyn RequestIdentityResolver>,
+    pub(super) request_identity_http_authenticator:
+        Option<&'a BoundRequestIdentityHttpAuthenticator>,
     pub(super) trace_context: Option<&'a OtelContext>,
     pub(super) table_headers: &'a [HeaderSpec],
     pub(super) table_name: &'a str,
@@ -76,8 +76,7 @@ pub(super) async fn execute_request(
         auth,
         request_headers,
         request_authenticators,
-        identity_context,
-        request_identity_resolver,
+        request_identity_http_authenticator,
         trace_context,
         table_headers,
         table_name,
@@ -196,11 +195,6 @@ pub(super) async fn execute_request(
         }
 
         body_capture.record_request(&request_span, request_id, body);
-        if let (Some(identity_context), None) = (identity_context, request_identity_resolver) {
-            let error = missing_identity_resolver_error(identity_context);
-            record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
-            return Err(error);
-        }
         let mut built = match resolve_auth_headers(
             auth,
             request,
@@ -213,23 +207,20 @@ pub(super) async fn execute_request(
                 return Err(error);
             }
         };
-        if let (Some(identity_context), Some(resolver)) =
-            (identity_context, request_identity_resolver)
-        {
-            let identity_headers = match resolver
-                .resolve_identity_headers(identity_context, &built, render_context.resolved_inputs)
-                .await
+        if let Some(authenticator) = request_identity_http_authenticator {
+            let identity_headers = match authenticator(&built, render_context.resolved_inputs).await
             {
                 Ok(headers) => headers,
                 Err(error) => {
-                    let error = identity_resolver_error(identity_context, &error);
+                    let error =
+                        identity_http_authenticator_error(source_schema, table_name, &error);
                     record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
                     return Err(error);
                 }
             };
             for (name, value) in identity_headers {
                 if built.headers().contains_key(&name) {
-                    let error = identity_header_conflict_error(identity_context, &name);
+                    let error = identity_header_conflict_error(source_schema, table_name, &name);
                     record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
                     return Err(error);
                 }
@@ -411,50 +402,38 @@ pub(super) async fn execute_request(
     }
 }
 
-fn identity_resolver_error(
-    identity_context: &RequestIdentityResolutionContext,
-    error: &RequestIdentityResolverError,
+fn identity_http_authenticator_error(
+    source_schema: &str,
+    table_name: &str,
+    error: &RequestIdentityHttpAuthenticatorError,
 ) -> DataFusionError {
     let detail = format!(
-        "request identity resolver failed for source '{}' surface '{}': {error}",
-        identity_context.source_name(),
-        identity_context.surface_id()
+        "request identity HTTP authenticator failed for source '{source_schema}' table '{table_name}': {error}"
     );
     let error = match error {
-        RequestIdentityResolverError::InvalidInput(_) => {
-            RequestIdentityResolverError::invalid_input(detail)
+        RequestIdentityHttpAuthenticatorError::InvalidInput(_) => {
+            RequestIdentityHttpAuthenticatorError::invalid_input(detail)
         }
-        RequestIdentityResolverError::FailedPrecondition(_) => {
-            RequestIdentityResolverError::failed_precondition(detail)
+        RequestIdentityHttpAuthenticatorError::FailedPrecondition(_) => {
+            RequestIdentityHttpAuthenticatorError::failed_precondition(detail)
         }
     };
     DataFusionError::External(Box::new(error))
 }
 
-fn missing_identity_resolver_error(
-    identity_context: &RequestIdentityResolutionContext,
-) -> DataFusionError {
-    DataFusionError::External(Box::new(RequestIdentityResolverError::failed_precondition(
-        format!(
-            "source '{}' surface '{}' declares identity_requirements but no request identity resolver is installed",
-            identity_context.source_name(),
-            identity_context.surface_id()
-        ),
-    )))
-}
-
 fn identity_header_conflict_error(
-    identity_context: &RequestIdentityResolutionContext,
+    source_schema: &str,
+    table_name: &str,
     name: &HeaderName,
 ) -> DataFusionError {
-    DataFusionError::External(Box::new(RequestIdentityResolverError::failed_precondition(
-        format!(
-            "request identity resolver attempted to overwrite header '{}' for source '{}' surface '{}'",
+    DataFusionError::External(Box::new(
+        RequestIdentityHttpAuthenticatorError::failed_precondition(format!(
+            "request identity HTTP authenticator attempted to overwrite header '{}' for source '{}' table '{}'",
             name.as_str(),
-            identity_context.source_name(),
-            identity_context.surface_id()
-        ),
-    )))
+            source_schema,
+            table_name
+        )),
+    ))
 }
 
 fn request_error(
@@ -579,8 +558,7 @@ mod tests {
                 auth: &AuthSpec::default(),
                 request_headers: &[],
                 request_authenticators: &HashMap::new(),
-                identity_context: None,
-                request_identity_resolver: None,
+                request_identity_http_authenticator: None,
                 trace_context: None,
                 table_headers: &[],
                 table_name: "items",

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -71,7 +71,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::{
-    CoreError, QuerySource, RequestAuthenticator, RuntimeSourceComponent, SourceInputResolver,
+    CoreError, QuerySource, RequestAuthenticator, RequestIdentityResolver, RuntimeSourceComponent,
+    SourceInputResolutionContext, SourceInputResolver,
 };
 #[cfg(test)]
 use coral_spec::ValidatedSourceManifest;
@@ -97,6 +98,7 @@ pub(crate) fn compile_query_source(
     runtime_context: &crate::QueryRuntimeContext,
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     if source.components().is_empty() {
         return Err(CoreError::FailedPrecondition(format!(
@@ -111,6 +113,7 @@ pub(crate) fn compile_query_source(
         source_variables: source.variables().clone(),
         request_authenticators,
         source_input_resolver,
+        request_identity_resolver,
     };
     let compiled_components = source
         .components()
@@ -128,7 +131,25 @@ fn compile_component(
     request: &BackendCompileRequest<'_>,
 ) -> Box<dyn CompiledBackendSource> {
     match component {
-        RuntimeSourceComponent::Http(manifest) => http::compile_manifest(manifest, request),
+        RuntimeSourceComponent::Http(component) => {
+            let identity_context =
+                component.identity_resolution_context(request.source.source_name());
+            http::compile_source(
+                component.manifest.clone(),
+                SourceInputResolutionContext::from_query_source_with_declared_inputs(
+                    request.source,
+                    &component.manifest.declared_inputs,
+                ),
+                request.request_authenticators.clone(),
+                http::HttpCompileRuntime {
+                    body_capture_max_bytes: request.runtime_context.body_capture_max_bytes,
+                    trace_context: request.runtime_context.trace_context.clone(),
+                    source_input_resolver: request.source_input_resolver.clone(),
+                    identity_context,
+                    request_identity_resolver: request.request_identity_resolver.clone(),
+                },
+            )
+        }
         RuntimeSourceComponent::File(manifest) => file::compile_manifest(manifest, request),
         RuntimeSourceComponent::Mcp(manifest) => mcp::compile_manifest(manifest, request),
     }
@@ -156,6 +177,7 @@ pub(crate) fn compile_source_manifest(
             source_variables,
             request_authenticators: &request_authenticators,
             source_input_resolver: None,
+            request_identity_resolver: None,
         },
     )
 }

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -71,8 +71,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::{
-    CoreError, QuerySource, RequestAuthenticator, RequestIdentityResolver, RuntimeSourceComponent,
-    SourceInputResolutionContext, SourceInputResolver,
+    BoundRequestIdentityHttpAuthenticator, CoreError, QuerySource, RequestAuthenticator,
+    RuntimeSourceComponent, SourceInputResolutionContext, SourceInputResolver,
 };
 #[cfg(test)]
 use coral_spec::ValidatedSourceManifest;
@@ -98,7 +98,10 @@ pub(crate) fn compile_query_source(
     runtime_context: &crate::QueryRuntimeContext,
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    request_identity_http_authenticators: &HashMap<
+        (String, String),
+        BoundRequestIdentityHttpAuthenticator,
+    >,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     if source.components().is_empty() {
         return Err(CoreError::FailedPrecondition(format!(
@@ -113,13 +116,13 @@ pub(crate) fn compile_query_source(
         source_variables: source.variables().clone(),
         request_authenticators,
         source_input_resolver,
-        request_identity_resolver,
+        request_identity_http_authenticators,
     };
     let compiled_components = source
         .components()
         .iter()
         .map(|component| compile_component(component, &request))
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(composite::compile_source(
         source.source_name().to_string(),
         compiled_components,
@@ -129,30 +132,64 @@ pub(crate) fn compile_query_source(
 fn compile_component(
     component: &RuntimeSourceComponent,
     request: &BackendCompileRequest<'_>,
-) -> Box<dyn CompiledBackendSource> {
+) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     match component {
         RuntimeSourceComponent::Http(component) => {
-            let identity_context =
-                component.identity_resolution_context(request.source.source_name());
-            http::compile_source(
+            let request_identity_http_authenticator = component
+                .identity_requirements
+                .as_ref()
+                .map(|identity| {
+                    let key = (
+                        request.source.source_name().to_string(),
+                        identity.surface_id.clone(),
+                    );
+                    request
+                        .request_identity_http_authenticators
+                        .get(&key)
+                        .cloned()
+                        .ok_or_else(|| {
+                            CoreError::FailedPrecondition(format!(
+                                "source '{}' surface '{}' declares identity_requirements but no bound request identity HTTP authenticator is installed",
+                                request.source.source_name(),
+                                identity.surface_id
+                            ))
+                        })
+                })
+                .transpose()?;
+            Ok(http::compile_source(
                 component.manifest.clone(),
                 SourceInputResolutionContext::from_query_source_with_declared_inputs(
                     request.source,
                     &component.manifest.declared_inputs,
                 ),
-                request.request_authenticators.clone(),
+                request_authenticators_for_http_manifest(
+                    &component.manifest,
+                    request.request_authenticators,
+                ),
                 http::HttpCompileRuntime {
                     body_capture_max_bytes: request.runtime_context.body_capture_max_bytes,
                     trace_context: request.runtime_context.trace_context.clone(),
                     source_input_resolver: request.source_input_resolver.clone(),
-                    identity_context,
-                    request_identity_resolver: request.request_identity_resolver.clone(),
+                    request_identity_http_authenticator,
                 },
-            )
+            ))
         }
-        RuntimeSourceComponent::File(manifest) => file::compile_manifest(manifest, request),
-        RuntimeSourceComponent::Mcp(manifest) => mcp::compile_manifest(manifest, request),
+        RuntimeSourceComponent::File(manifest) => Ok(file::compile_manifest(manifest, request)),
+        RuntimeSourceComponent::Mcp(manifest) => Ok(mcp::compile_manifest(manifest, request)),
     }
+}
+
+fn request_authenticators_for_http_manifest(
+    manifest: &coral_spec::backends::http::HttpSourceManifest,
+    request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
+) -> HashMap<String, Arc<dyn RequestAuthenticator>> {
+    if manifest.common.dsl_version == 4 {
+        // DSL v4 must not use the engine-level CustomAuth extension registry.
+        // Identity-backed HTTP auth is already bound per surface before backend
+        // compilation, and declarative HeaderAuth needs no registry.
+        return HashMap::new();
+    }
+    request_authenticators.clone()
 }
 
 #[cfg(test)]
@@ -177,7 +214,7 @@ pub(crate) fn compile_source_manifest(
             source_variables,
             request_authenticators: &request_authenticators,
             source_input_resolver: None,
-            request_identity_resolver: None,
+            request_identity_http_authenticators: &HashMap::new(),
         },
     )
 }

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -8,9 +8,11 @@ use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use reqwest::header::{HeaderName, HeaderValue};
+use serde_json::Value;
 
 use crate::CoreError;
 use crate::contracts::QuerySource;
+use coral_spec::v4::IdentityRequirements;
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
 /// One source's table providers keyed by manifest table name.
@@ -38,105 +40,59 @@ pub enum SourceFailurePolicy {
     Abort,
 }
 
-/// Neutral error type for source-decoration failures.
-#[derive(Debug, thiserror::Error)]
-pub enum SourceDecoratorError {
-    /// The decorator was configured with invalid input.
-    #[error("{0}")]
-    InvalidInput(String),
-    /// The decorator could not proceed because a precondition was unmet.
-    #[error("{0}")]
-    FailedPrecondition(String),
+/// Defines one neutral two-variant error type for an engine extension point.
+///
+/// Every extension seam reports failures the same way, so the error shape is
+/// kept uniform on purpose: callers map `InvalidInput` to invalid-argument
+/// handling and `FailedPrecondition` to precondition handling.
+macro_rules! extension_error {
+    ($(#[$doc:meta])* $name:ident) => {
+        $(#[$doc])*
+        #[derive(Debug, thiserror::Error)]
+        pub enum $name {
+            /// The extension was configured with invalid input.
+            #[error("{0}")]
+            InvalidInput(String),
+            /// The extension could not proceed because a precondition was unmet.
+            #[error("{0}")]
+            FailedPrecondition(String),
+        }
+
+        impl $name {
+            #[must_use]
+            /// Builds an invalid-input error.
+            pub fn invalid_input(detail: impl Into<String>) -> Self {
+                Self::InvalidInput(detail.into())
+            }
+
+            #[must_use]
+            /// Builds a failed-precondition error.
+            pub fn failed_precondition(detail: impl Into<String>) -> Self {
+                Self::FailedPrecondition(detail.into())
+            }
+        }
+    };
 }
 
-impl SourceDecoratorError {
-    #[must_use]
-    /// Builds an invalid-input error.
-    pub fn invalid_input(detail: impl Into<String>) -> Self {
-        Self::InvalidInput(detail.into())
-    }
+extension_error!(
+    /// Neutral error type for source-decoration failures.
+    SourceDecoratorError
+);
 
-    #[must_use]
-    /// Builds a failed-precondition error.
-    pub fn failed_precondition(detail: impl Into<String>) -> Self {
-        Self::FailedPrecondition(detail.into())
-    }
-}
+extension_error!(
+    /// Neutral error type for query-result observer failures.
+    QueryResultObserverError
+);
 
-/// Neutral error type for query-result observer failures.
-#[derive(Debug, thiserror::Error)]
-pub enum QueryResultObserverError {
-    /// The observer was configured with invalid input.
-    #[error("{0}")]
-    InvalidInput(String),
-    /// The observer could not proceed because a precondition was unmet.
-    #[error("{0}")]
-    FailedPrecondition(String),
-}
+extension_error!(
+    /// Neutral error type for request-authenticator failures.
+    RequestAuthenticatorError
+);
 
-impl QueryResultObserverError {
-    #[must_use]
-    /// Builds an invalid-input error.
-    pub fn invalid_input(detail: impl Into<String>) -> Self {
-        Self::InvalidInput(detail.into())
-    }
-
-    #[must_use]
-    /// Builds a failed-precondition error.
-    pub fn failed_precondition(detail: impl Into<String>) -> Self {
-        Self::FailedPrecondition(detail.into())
-    }
-}
-
-/// Neutral error type for request-authenticator failures.
-#[derive(Debug, thiserror::Error)]
-pub enum RequestAuthenticatorError {
-    /// The authenticator was configured with invalid input.
-    #[error("{0}")]
-    InvalidInput(String),
-    /// The authenticator could not proceed because a precondition was unmet.
-    #[error("{0}")]
-    FailedPrecondition(String),
-}
-
-impl RequestAuthenticatorError {
-    #[must_use]
-    /// Builds an invalid-input error.
-    pub fn invalid_input(detail: impl Into<String>) -> Self {
-        Self::InvalidInput(detail.into())
-    }
-
-    #[must_use]
-    /// Builds a failed-precondition error.
-    pub fn failed_precondition(detail: impl Into<String>) -> Self {
-        Self::FailedPrecondition(detail.into())
-    }
-}
-
-/// Neutral error type for request-time source input resolution failures.
-#[derive(Debug, thiserror::Error)]
-pub enum SourceInputResolverError {
-    /// The resolver was configured with invalid input.
-    #[error("{0}")]
-    InvalidInput(String),
-    /// The resolver could not proceed because a precondition was unmet.
-    #[error("{0}")]
-    FailedPrecondition(String),
-}
-
-impl SourceInputResolverError {
-    #[must_use]
-    /// Builds an invalid-input error.
-    pub fn invalid_input(detail: impl Into<String>) -> Self {
-        Self::InvalidInput(detail.into())
-    }
-
-    #[must_use]
-    /// Builds a failed-precondition error.
-    pub fn failed_precondition(detail: impl Into<String>) -> Self {
-        Self::FailedPrecondition(detail.into())
-    }
-}
+extension_error!(
+    /// Neutral error type for request-time source input resolution failures.
+    SourceInputResolverError
+);
 
 /// Request-time source input-resolution context exposed to source input resolvers.
 ///
@@ -156,9 +112,22 @@ impl SourceInputResolutionContext {
     #[must_use]
     /// Builds request input-resolution context from one selected query source.
     pub fn from_query_source(source: &QuerySource) -> Self {
+        Self::from_query_source_with_declared_inputs(source, source.declared_inputs())
+    }
+
+    #[must_use]
+    /// Builds request input-resolution context with a narrowed input contract.
+    ///
+    /// DSL v4 compiles each surface into its own executable HTTP source, so each
+    /// synthesized surface should expose only the inputs declared by that
+    /// surface rather than the union of every surface in the manifest.
+    pub fn from_query_source_with_declared_inputs(
+        source: &QuerySource,
+        declared_inputs: &[ManifestInputSpec],
+    ) -> Self {
         Self {
             source_name: Arc::from(source.source_name()),
-            declared_inputs: Arc::from(source.declared_inputs().to_vec()),
+            declared_inputs: Arc::from(declared_inputs.to_vec()),
             variables: Arc::new(source.variables().clone()),
             secrets: Arc::new(source.secrets().clone()),
         }
@@ -210,6 +179,81 @@ impl SourceInputResolutionContext {
     }
 }
 
+/// Request-time identity-resolution context exposed to request identity resolvers.
+#[derive(Debug, Clone)]
+pub struct RequestIdentityResolutionContext {
+    source_name: Arc<str>,
+    surface_id: Arc<str>,
+    identity_requirements: Arc<IdentityRequirements>,
+}
+
+impl RequestIdentityResolutionContext {
+    #[must_use]
+    /// Builds identity-resolution context for one executable source surface.
+    pub fn new(
+        source_name: impl Into<Arc<str>>,
+        surface_id: impl Into<Arc<str>>,
+        identity_requirements: IdentityRequirements,
+    ) -> Self {
+        Self {
+            source_name: source_name.into(),
+            surface_id: surface_id.into(),
+            identity_requirements: Arc::new(identity_requirements),
+        }
+    }
+
+    #[must_use]
+    /// Returns the canonical source name. This is also the SQL schema name.
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    #[must_use]
+    /// Returns the DSL v4 surface id whose request is being executed.
+    pub fn surface_id(&self) -> &str {
+        &self.surface_id
+    }
+
+    #[must_use]
+    /// Returns the identity requirements declared by the selected surface.
+    pub fn identity_requirements(&self) -> &IdentityRequirements {
+        &self.identity_requirements
+    }
+
+    #[must_use]
+    /// Returns whether a candidate identity satisfies the selected surface's
+    /// declared requirements.
+    ///
+    /// Accepted identity entries have OR semantics: the candidate is accepted if
+    /// it satisfies any single accepted entry. Within one accepted entry, the
+    /// candidate identity's spec id must be listed in `identity_specs`, and the
+    /// declared `audience` must be a *subset* of the candidate `audience`: every
+    /// required key/value must appear in the candidate, but the candidate may
+    /// carry additional audience entries. An accepted entry with an empty
+    /// `audience` therefore imposes no audience constraint.
+    ///
+    /// Audience values are compared by exact JSON equality, type included: a
+    /// required `443` (integer) does not match a candidate `443.0` (float) or
+    /// `"443"` (string). Resolvers must construct candidate audience values
+    /// with the same JSON types the manifest declares.
+    pub fn accepts_identity(
+        &self,
+        identity_spec_id: &str,
+        audience: &BTreeMap<String, Value>,
+    ) -> bool {
+        self.identity_requirements.accepts.iter().any(|accepted| {
+            accepted
+                .identity_specs
+                .iter()
+                .any(|accepted_spec_id| accepted_spec_id == identity_spec_id)
+                && accepted
+                    .audience
+                    .iter()
+                    .all(|(key, required_value)| audience.get(key) == Some(required_value))
+        })
+    }
+}
+
 /// Request-time HTTP authenticator registered through engine extensions.
 pub trait RequestAuthenticator: Send + Sync + std::fmt::Debug {
     /// Stable authenticator name used in diagnostics and manifest dispatch.
@@ -241,6 +285,31 @@ pub trait RequestAuthenticator: Send + Sync + std::fmt::Debug {
     ) -> Result<(), RequestAuthenticatorError> {
         Ok(())
     }
+}
+
+extension_error!(
+    /// Neutral error type for request identity-resolution failures.
+    RequestIdentityResolverError
+);
+
+/// Request-time resolver for app-managed identities.
+///
+/// The engine calls this only when a DSL v4 surface declares identity
+/// requirements and an outbound request is about to be sent.
+#[async_trait]
+pub trait RequestIdentityResolver: Send + Sync + std::fmt::Debug {
+    /// Returns identity headers to append to the outbound request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RequestIdentityResolverError`] when no suitable identity is
+    /// bound, the identity is unhealthy, or identity material cannot be minted.
+    async fn resolve_identity_headers(
+        &self,
+        identity: &RequestIdentityResolutionContext,
+        request: &reqwest::Request,
+        resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError>;
 }
 
 /// Request-time resolver for source inputs owned by the app layer.
@@ -354,9 +423,29 @@ mod tests {
     use std::collections::BTreeMap;
 
     use coral_spec::parse_source_manifest_value;
-    use serde_json::json;
+    use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
+    use serde_json::{Value, json};
 
-    use crate::{QuerySource, SourceInputResolutionContext};
+    use crate::{QuerySource, RequestIdentityResolutionContext, SourceInputResolutionContext};
+
+    /// One-requirement identity context accepting `identity_specs` for the
+    /// `github-rest-read` requirement with the given audience constraints.
+    fn identity_context(
+        identity_specs: &[&str],
+        audience: BTreeMap<String, Value>,
+    ) -> RequestIdentityResolutionContext {
+        RequestIdentityResolutionContext::new(
+            "github",
+            "github_rest",
+            IdentityRequirements {
+                accepts: vec![AcceptedIdentityRequirement {
+                    id: "github-rest-read".to_string(),
+                    identity_specs: identity_specs.iter().map(ToString::to_string).collect(),
+                    audience,
+                }],
+            },
+        )
+    }
 
     #[test]
     fn source_input_resolution_context_keeps_only_request_input_contract() {
@@ -443,5 +532,56 @@ mod tests {
             Some("fresh-token")
         );
         assert!(!refreshed.secrets().contains_key("OPTIONAL_TOKEN"));
+    }
+
+    #[test]
+    fn request_identity_context_matches_candidate_by_spec_id_and_audience() {
+        let audience = BTreeMap::from([("host".to_string(), json!("github.com"))]);
+        let context = identity_context(&["github_oauth", "github_pat"], audience.clone());
+
+        assert!(context.accepts_identity("github_oauth", &audience));
+        assert!(context.accepts_identity("github_pat", &audience));
+        assert!(!context.accepts_identity("gitlab_oauth", &audience));
+    }
+
+    #[test]
+    fn request_identity_context_audience_is_subset_and_json_type_exact() {
+        let context = identity_context(
+            &["github_oauth"],
+            BTreeMap::from([("port".to_string(), json!(443))]),
+        );
+        let accepts =
+            |audience: &BTreeMap<String, Value>| context.accepts_identity("github_oauth", audience);
+
+        // Required entry present plus an extra candidate entry still matches
+        // (declared audience is a subset of the candidate audience).
+        assert!(accepts(&BTreeMap::from([
+            ("port".to_string(), json!(443)),
+            ("tenant".to_string(), json!("acme")),
+        ])));
+        // Exact JSON-type equality: float and string do not match the integer.
+        assert!(!accepts(&BTreeMap::from([(
+            "port".to_string(),
+            json!(443.0)
+        )])));
+        assert!(!accepts(&BTreeMap::from([(
+            "port".to_string(),
+            json!("443")
+        )])));
+        // Missing required key does not match.
+        assert!(!accepts(&BTreeMap::new()));
+    }
+
+    #[test]
+    fn request_identity_context_empty_audience_imposes_no_constraint() {
+        let context = identity_context(&["github_oauth"], BTreeMap::new());
+
+        // An accepted shape with no declared audience matches any candidate
+        // audience, but identity spec id still must match exactly.
+        assert!(context.accepts_identity(
+            "github_oauth",
+            &BTreeMap::from([("host".to_string(), json!("github.com"))])
+        ));
+        assert!(!context.accepts_identity("gitlab_oauth", &BTreeMap::new()));
     }
 }

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -7,6 +7,7 @@ use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
+use futures::future::BoxFuture;
 use reqwest::header::{HeaderName, HeaderValue};
 use serde_json::Value;
 
@@ -179,17 +180,17 @@ impl SourceInputResolutionContext {
     }
 }
 
-/// Request-time identity-resolution context exposed to request identity resolvers.
+/// Runtime-build identity-selection context exposed to request identity selectors.
 #[derive(Debug, Clone)]
-pub struct RequestIdentityResolutionContext {
+pub struct RequestIdentitySelectionContext {
     source_name: Arc<str>,
     surface_id: Arc<str>,
     identity_requirements: Arc<IdentityRequirements>,
 }
 
-impl RequestIdentityResolutionContext {
+impl RequestIdentitySelectionContext {
     #[must_use]
-    /// Builds identity-resolution context for one executable source surface.
+    /// Builds identity-selection context for one executable source surface.
     pub fn new(
         source_name: impl Into<Arc<str>>,
         surface_id: impl Into<Arc<str>>,
@@ -254,6 +255,48 @@ impl RequestIdentityResolutionContext {
     }
 }
 
+/// App-selected request identity for one executable source surface.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectedRequestIdentity {
+    identity_id: Arc<str>,
+    identity_spec_id: Arc<str>,
+    audience: Arc<BTreeMap<String, Value>>,
+}
+
+impl SelectedRequestIdentity {
+    #[must_use]
+    /// Builds one selected request identity.
+    pub fn new(
+        identity_id: impl Into<Arc<str>>,
+        identity_spec_id: impl Into<Arc<str>>,
+        audience: BTreeMap<String, Value>,
+    ) -> Self {
+        Self {
+            identity_id: identity_id.into(),
+            identity_spec_id: identity_spec_id.into(),
+            audience: Arc::new(audience),
+        }
+    }
+
+    #[must_use]
+    /// Returns the opaque app-owned identity handle.
+    pub fn identity_id(&self) -> &str {
+        &self.identity_id
+    }
+
+    #[must_use]
+    /// Returns the installed identity spec id for this selected identity.
+    pub fn identity_spec_id(&self) -> &str {
+        &self.identity_spec_id
+    }
+
+    #[must_use]
+    /// Returns the selected identity audience metadata.
+    pub fn audience(&self) -> &BTreeMap<String, Value> {
+        &self.audience
+    }
+}
+
 /// Request-time HTTP authenticator registered through engine extensions.
 pub trait RequestAuthenticator: Send + Sync + std::fmt::Debug {
     /// Stable authenticator name used in diagnostics and manifest dispatch.
@@ -288,28 +331,68 @@ pub trait RequestAuthenticator: Send + Sync + std::fmt::Debug {
 }
 
 extension_error!(
-    /// Neutral error type for request identity-resolution failures.
-    RequestIdentityResolverError
+    /// Neutral error type for request identity-selection failures.
+    RequestIdentitySelectionError
 );
 
-/// Request-time resolver for app-managed identities.
+extension_error!(
+    /// Neutral error type for request identity HTTP-authentication failures.
+    RequestIdentityHttpAuthenticatorError
+);
+
+/// Bound request-time HTTP authenticator for one selected identity.
+pub type BoundRequestIdentityHttpAuthenticator = Arc<
+    dyn for<'a> Fn(
+            &'a reqwest::Request,
+            &'a BTreeMap<String, String>,
+        ) -> BoxFuture<
+            'a,
+            Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError>,
+        > + Send
+        + Sync,
+>;
+
+/// Factory that binds a selected identity to a request-time HTTP authenticator.
+pub type RequestIdentityHttpAuthenticatorFactory = Arc<
+    dyn Fn(
+            SelectedRequestIdentity,
+        )
+            -> Result<BoundRequestIdentityHttpAuthenticator, RequestIdentityHttpAuthenticatorError>
+        + Send
+        + Sync,
+>;
+
+/// Runtime-build selector for app-managed identities.
 ///
-/// The engine calls this only when a DSL v4 surface declares identity
-/// requirements and an outbound request is about to be sent.
+/// The engine calls this once per selected DSL v4 surface that declares
+/// identity requirements while building the query runtime.
 #[async_trait]
-pub trait RequestIdentityResolver: Send + Sync + std::fmt::Debug {
+pub trait RequestIdentitySelector: Send + Sync + std::fmt::Debug {
+    /// Selects the app-owned identity to use for one source surface.
+    ///
+    /// # Errors
+    /// Returns [`RequestIdentitySelectionError`] when no suitable identity is
+    /// bound or the selected identity cannot be used.
+    async fn select_identity(
+        &self,
+        identity: &RequestIdentitySelectionContext,
+    ) -> Result<SelectedRequestIdentity, RequestIdentitySelectionError>;
+}
+
+/// HTTP request authenticator for one identity type.
+#[async_trait]
+pub trait RequestIdentityHttpAuthenticator: Send + Sync + std::fmt::Debug {
     /// Returns identity headers to append to the outbound request.
     ///
     /// # Errors
-    ///
-    /// Returns [`RequestIdentityResolverError`] when no suitable identity is
-    /// bound, the identity is unhealthy, or identity material cannot be minted.
-    async fn resolve_identity_headers(
+    /// Returns [`RequestIdentityHttpAuthenticatorError`] when identity material
+    /// cannot be minted or converted into HTTP headers.
+    async fn authenticate_identity_request(
         &self,
-        identity: &RequestIdentityResolutionContext,
+        identity: &SelectedRequestIdentity,
         request: &reqwest::Request,
         resolved_inputs: &BTreeMap<String, String>,
-    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError>;
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError>;
 }
 
 /// Request-time resolver for source inputs owned by the app layer.
@@ -426,15 +509,15 @@ mod tests {
     use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
     use serde_json::{Value, json};
 
-    use crate::{QuerySource, RequestIdentityResolutionContext, SourceInputResolutionContext};
+    use crate::{QuerySource, RequestIdentitySelectionContext, SourceInputResolutionContext};
 
     /// One-requirement identity context accepting `identity_specs` for the
     /// `github-rest-read` requirement with the given audience constraints.
     fn identity_context(
         identity_specs: &[&str],
         audience: BTreeMap<String, Value>,
-    ) -> RequestIdentityResolutionContext {
-        RequestIdentityResolutionContext::new(
+    ) -> RequestIdentitySelectionContext {
+        RequestIdentitySelectionContext::new(
             "github",
             "github_rest",
             IdentityRequirements {
@@ -535,7 +618,7 @@ mod tests {
     }
 
     #[test]
-    fn request_identity_context_matches_candidate_by_spec_id_and_audience() {
+    fn request_identity_selection_context_matches_candidate_by_spec_id_and_audience() {
         let audience = BTreeMap::from([("host".to_string(), json!("github.com"))]);
         let context = identity_context(&["github_oauth", "github_pat"], audience.clone());
 
@@ -545,7 +628,7 @@ mod tests {
     }
 
     #[test]
-    fn request_identity_context_audience_is_subset_and_json_type_exact() {
+    fn request_identity_selection_context_audience_is_subset_and_json_type_exact() {
         let context = identity_context(
             &["github_oauth"],
             BTreeMap::from([("port".to_string(), json!(443))]),
@@ -573,7 +656,7 @@ mod tests {
     }
 
     #[test]
-    fn request_identity_context_empty_audience_imposes_no_constraint() {
+    fn request_identity_selection_context_empty_audience_imposes_no_constraint() {
         let context = identity_context(&["github_oauth"], BTreeMap::new());
 
         // An accepted shape with no declared audience matches any candidate

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -13,8 +13,9 @@ pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
     DependentJoinConfig, DependentJoinSourceConfig, EffectiveDependentJoinConfig, MemorySize,
     QueryExecution, QueryMemoryConfig, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
-    QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
-    RuntimeSourcePackage, SourceValidationReport,
+    QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeHttpSourceComponent,
+    RuntimeIdentityRequirements, RuntimeSourceComponent, RuntimeSourcePackage,
+    SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -16,7 +16,10 @@ use coral_spec::{ManifestInputSpec, ValidatedSourceManifest};
 use opentelemetry::Context as OtelContext;
 
 use super::ColumnInfo;
-use crate::{EngineExtensions, RequestIdentityResolutionContext, RequestIdentityResolver};
+use crate::{
+    EngineExtensions, RequestIdentityHttpAuthenticatorFactory, RequestIdentitySelectionContext,
+    RequestIdentitySelector,
+};
 
 /// One managed source selected into the current query runtime.
 #[derive(Debug, Clone)]
@@ -59,12 +62,16 @@ pub enum RuntimeSourceComponent {
     Mcp(McpSourceManifest),
 }
 
-/// Backend-ready HTTP component plus optional app-owned runtime metadata.
+/// Backend-ready HTTP component shared by v3 manifests and app-assembled v4 surfaces.
+///
+/// v3 sources normalize their validated HTTP manifest into this component
+/// without identity requirements. v4 OpenAPI surfaces synthesize an HTTP
+/// runtime manifest and may attach the authored surface identity requirements.
 #[derive(Debug, Clone)]
 pub struct RuntimeHttpSourceComponent {
     /// HTTP runtime manifest executed by the engine.
     pub manifest: HttpSourceManifest,
-    /// Request identity requirements associated with this component.
+    /// DSL v4 request identity requirements associated with this component.
     pub identity_requirements: Option<RuntimeIdentityRequirements>,
 }
 
@@ -103,15 +110,15 @@ impl RuntimeHttpSourceComponent {
         }
     }
 
-    /// Builds the request-time identity-resolution context for this component,
+    /// Builds the runtime-build identity-selection context for this component,
     /// or `None` when the component declares no identity requirements.
     #[must_use]
-    pub fn identity_resolution_context(
+    pub fn identity_selection_context(
         &self,
         source_name: impl Into<Arc<str>>,
-    ) -> Option<RequestIdentityResolutionContext> {
+    ) -> Option<RequestIdentitySelectionContext> {
         self.identity_requirements.as_ref().map(|identity| {
-            RequestIdentityResolutionContext::new(
+            RequestIdentitySelectionContext::new(
                 source_name,
                 identity.surface_id.clone(),
                 identity.requirements.clone(),
@@ -442,8 +449,11 @@ pub struct QueryRuntimeConfig {
     pub extensions: EngineExtensions,
     /// Engine-wide query memory policy.
     pub memory: QueryMemoryConfig,
-    /// Request-time resolver for app-selected source identities.
-    pub request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    /// Runtime-build selector for app-owned request identities.
+    pub request_identity_selector: Option<Arc<dyn RequestIdentitySelector>>,
+    /// Factory that binds selected identities to request-time HTTP authenticators.
+    pub request_identity_http_authenticator_factory:
+        Option<RequestIdentityHttpAuthenticatorFactory>,
     /// Runtime policy for dependent predicate pushdown.
     pub dependent_join: DependentJoinConfig,
 }
@@ -456,18 +466,29 @@ impl QueryRuntimeConfig {
             context,
             extensions,
             memory: QueryMemoryConfig::default(),
-            request_identity_resolver: None,
+            request_identity_selector: None,
+            request_identity_http_authenticator_factory: None,
             dependent_join: DependentJoinConfig::default(),
         }
     }
 
-    /// Installs an app-selected request identity resolver for this runtime.
+    /// Installs the request identity selector for this runtime.
     #[must_use]
-    pub fn with_request_identity_resolver(
+    pub fn with_request_identity_selector(
         mut self,
-        resolver: Option<Arc<dyn RequestIdentityResolver>>,
+        selector: Option<Arc<dyn RequestIdentitySelector>>,
     ) -> Self {
-        self.request_identity_resolver = resolver;
+        self.request_identity_selector = selector;
+        self
+    }
+
+    /// Installs the request identity HTTP-authenticator factory for this runtime.
+    #[must_use]
+    pub fn with_request_identity_http_authenticator_factory(
+        mut self,
+        factory: Option<RequestIdentityHttpAuthenticatorFactory>,
+    ) -> Self {
+        self.request_identity_http_authenticator_factory = factory;
         self
     }
 }

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -186,6 +186,7 @@ impl QuerySource {
                     package.source_name
                 )));
             }
+            validate_runtime_component_identity_requirements(&package.source_name, component)?;
         }
         Ok(Self {
             source_name: package.source_name,
@@ -274,6 +275,38 @@ impl RuntimeSourceComponent {
             Self::Mcp(manifest) => &manifest.common.name,
         }
     }
+}
+
+fn validate_runtime_component_identity_requirements(
+    package_source_name: &str,
+    component: &RuntimeSourceComponent,
+) -> Result<(), crate::CoreError> {
+    let RuntimeSourceComponent::Http(http) = component else {
+        return Ok(());
+    };
+    let Some(identity_requirements) = &http.identity_requirements else {
+        return Ok(());
+    };
+
+    let component_name = http.manifest.common.name.as_str();
+    if http.manifest.common.dsl_version != 4 {
+        return Err(crate::CoreError::InvalidInput(format!(
+            "runtime source package '{package_source_name}' component '{component_name}' declares identity_requirements, but identity_requirements are supported only for DSL v4 HTTP components"
+        )));
+    }
+    if !is_valid_runtime_surface_id(&identity_requirements.surface_id) {
+        return Err(crate::CoreError::InvalidInput(format!(
+            "runtime source package '{package_source_name}' component '{component_name}' identity_requirements surface_id '{}' must match [a-z][a-z0-9_]*",
+            identity_requirements.surface_id
+        )));
+    }
+    Ok(())
+}
+
+fn is_valid_runtime_surface_id(surface_id: &str) -> bool {
+    let mut chars = surface_id.chars();
+    matches!(chars.next(), Some(ch) if ch.is_ascii_lowercase())
+        && chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
 }
 
 fn components_from_manifest(source_spec: &ValidatedSourceManifest) -> Vec<RuntimeSourceComponent> {
@@ -834,9 +867,17 @@ impl QueryExecution {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::str::FromStr as _;
 
-    use super::MemorySize;
+    use coral_spec::parse_source_manifest_value;
+    use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
+    use serde_json::json;
+
+    use super::{
+        MemorySize, QuerySource, RuntimeHttpSourceComponent, RuntimeSourceComponent,
+        RuntimeSourcePackage,
+    };
 
     #[test]
     fn memory_size_parses_binary_units() {
@@ -862,6 +903,106 @@ mod tests {
                 MemorySize::from_str(raw).is_err(),
                 "{raw:?} should be rejected"
             );
+        }
+    }
+
+    #[test]
+    fn runtime_source_package_rejects_empty_identity_surface_id() {
+        let mut manifest = http_manifest();
+        manifest.common.dsl_version = 4;
+
+        let error = QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: "github_v4".to_string(),
+                authored_version: None,
+                description: String::new(),
+                declared_inputs: Vec::new(),
+                test_queries: Vec::new(),
+                components: vec![RuntimeSourceComponent::Http(
+                    RuntimeHttpSourceComponent::with_identity_requirements(
+                        manifest,
+                        "",
+                        identity_requirements(),
+                    ),
+                )],
+            },
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect_err("empty identity surface id should fail runtime package validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("identity_requirements surface_id '' must match [a-z][a-z0-9_]*"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn runtime_source_package_rejects_identity_requirements_on_non_v4_http_component() {
+        let error = QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: "github".to_string(),
+                authored_version: None,
+                description: String::new(),
+                declared_inputs: Vec::new(),
+                test_queries: Vec::new(),
+                components: vec![RuntimeSourceComponent::Http(
+                    RuntimeHttpSourceComponent::with_identity_requirements(
+                        http_manifest(),
+                        "rest",
+                        identity_requirements(),
+                    ),
+                )],
+            },
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect_err("v3 HTTP component should not accept identity requirements");
+
+        assert!(
+            error.to_string().contains(
+                "declares identity_requirements, but identity_requirements are supported only for DSL v4 HTTP components"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    fn http_manifest() -> coral_spec::backends::http::HttpSourceManifest {
+        parse_source_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "github",
+            "version": "1.0.0",
+            "backend": "http",
+            "base_url": "https://api.example.com",
+            "tables": [{
+                "name": "issues",
+                "description": "Issues",
+                "request": {
+                    "method": "GET",
+                    "path": "/issues"
+                },
+                "response": {},
+                "columns": [{
+                    "name": "id",
+                    "type": "Utf8"
+                }]
+            }]
+        }))
+        .expect("manifest")
+        .as_http()
+        .expect("http manifest")
+        .clone()
+    }
+
+    fn identity_requirements() -> IdentityRequirements {
+        IdentityRequirements {
+            accepts: vec![AcceptedIdentityRequirement {
+                id: "github-rest-read".to_string(),
+                identity_specs: vec!["github_oauth".to_string()],
+                audience: BTreeMap::new(),
+            }],
         }
     }
 }

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -11,11 +11,12 @@ use arrow::record_batch::RecordBatch;
 use coral_spec::backends::file::FileSourceManifest;
 use coral_spec::backends::http::HttpSourceManifest;
 use coral_spec::backends::mcp::McpSourceManifest;
+use coral_spec::v4::IdentityRequirements;
 use coral_spec::{ManifestInputSpec, ValidatedSourceManifest};
 use opentelemetry::Context as OtelContext;
 
 use super::ColumnInfo;
-use crate::EngineExtensions;
+use crate::{EngineExtensions, RequestIdentityResolutionContext, RequestIdentityResolver};
 
 /// One managed source selected into the current query runtime.
 #[derive(Debug, Clone)]
@@ -51,11 +52,72 @@ pub struct RuntimeSourcePackage {
 #[derive(Debug, Clone)]
 pub enum RuntimeSourceComponent {
     /// HTTP-backed runtime component.
-    Http(HttpSourceManifest),
+    Http(RuntimeHttpSourceComponent),
     /// File-backed runtime component.
     File(FileSourceManifest),
     /// MCP-backed runtime component.
     Mcp(McpSourceManifest),
+}
+
+/// Backend-ready HTTP component plus optional app-owned runtime metadata.
+#[derive(Debug, Clone)]
+pub struct RuntimeHttpSourceComponent {
+    /// HTTP runtime manifest executed by the engine.
+    pub manifest: HttpSourceManifest,
+    /// Request identity requirements associated with this component.
+    pub identity_requirements: Option<RuntimeIdentityRequirements>,
+}
+
+/// Identity requirements attached to one app-assembled runtime component.
+#[derive(Debug, Clone)]
+pub struct RuntimeIdentityRequirements {
+    /// Authored DSL v4 surface id that produced this runtime component.
+    pub surface_id: String,
+    /// Accepted request identities for this runtime component.
+    pub requirements: IdentityRequirements,
+}
+
+impl RuntimeHttpSourceComponent {
+    #[must_use]
+    /// Builds an HTTP runtime component without request identity requirements.
+    pub fn new(manifest: HttpSourceManifest) -> Self {
+        Self {
+            manifest,
+            identity_requirements: None,
+        }
+    }
+
+    #[must_use]
+    /// Builds an HTTP runtime component with request identity requirements.
+    pub fn with_identity_requirements(
+        manifest: HttpSourceManifest,
+        surface_id: impl Into<String>,
+        requirements: IdentityRequirements,
+    ) -> Self {
+        Self {
+            manifest,
+            identity_requirements: Some(RuntimeIdentityRequirements {
+                surface_id: surface_id.into(),
+                requirements,
+            }),
+        }
+    }
+
+    /// Builds the request-time identity-resolution context for this component,
+    /// or `None` when the component declares no identity requirements.
+    #[must_use]
+    pub fn identity_resolution_context(
+        &self,
+        source_name: impl Into<Arc<str>>,
+    ) -> Option<RequestIdentityResolutionContext> {
+        self.identity_requirements.as_ref().map(|identity| {
+            RequestIdentityResolutionContext::new(
+                source_name,
+                identity.surface_id.clone(),
+                identity.requirements.clone(),
+            )
+        })
+    }
 }
 
 impl QuerySource {
@@ -200,7 +262,7 @@ impl RuntimeSourceComponent {
     /// Returns the runtime schema name declared by this component.
     pub fn source_name(&self) -> &str {
         match self {
-            Self::Http(manifest) => &manifest.common.name,
+            Self::Http(component) => &component.manifest.common.name,
             Self::File(manifest) => &manifest.common.name,
             Self::Mcp(manifest) => &manifest.common.name,
         }
@@ -209,7 +271,9 @@ impl RuntimeSourceComponent {
 
 fn components_from_manifest(source_spec: &ValidatedSourceManifest) -> Vec<RuntimeSourceComponent> {
     if let Some(http) = source_spec.as_http() {
-        return vec![RuntimeSourceComponent::Http(http.clone())];
+        return vec![RuntimeSourceComponent::Http(
+            RuntimeHttpSourceComponent::new(http.clone()),
+        )];
     }
     if let Some(file) = source_spec.as_file() {
         return vec![RuntimeSourceComponent::File(file.clone())];
@@ -378,6 +442,8 @@ pub struct QueryRuntimeConfig {
     pub extensions: EngineExtensions,
     /// Engine-wide query memory policy.
     pub memory: QueryMemoryConfig,
+    /// Request-time resolver for app-selected source identities.
+    pub request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
     /// Runtime policy for dependent predicate pushdown.
     pub dependent_join: DependentJoinConfig,
 }
@@ -390,8 +456,19 @@ impl QueryRuntimeConfig {
             context,
             extensions,
             memory: QueryMemoryConfig::default(),
+            request_identity_resolver: None,
             dependent_join: DependentJoinConfig::default(),
         }
+    }
+
+    /// Installs an app-selected request identity resolver for this runtime.
+    #[must_use]
+    pub fn with_request_identity_resolver(
+        mut self,
+        resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    ) -> Self {
+        self.request_identity_resolver = resolver;
+        self
     }
 }
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -65,7 +65,7 @@ pub enum RuntimeSourceComponent {
 /// Backend-ready HTTP component shared by v3 manifests and app-assembled v4 surfaces.
 ///
 /// v3 sources normalize their validated HTTP manifest into this component
-/// without identity requirements. v4 OpenAPI surfaces synthesize an HTTP
+/// without identity requirements. v4 `OpenAPI` surfaces synthesize an HTTP
 /// runtime manifest and may attach the authored surface identity requirements.
 #[derive(Debug, Clone)]
 pub struct RuntimeHttpSourceComponent {

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -62,10 +62,13 @@ mod runtime;
 
 pub use backends::mcp::discover_tool_catalog as discover_mcp_tool_catalog;
 pub use composition::{
-    EngineExtensions, QueryResultObserver, QueryResultObserverError, RequestAuthenticator,
-    RequestAuthenticatorError, RequestIdentityResolutionContext, RequestIdentityResolver,
-    RequestIdentityResolverError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
-    SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError, SourceTables,
+    BoundRequestIdentityHttpAuthenticator, EngineExtensions, QueryResultObserver,
+    QueryResultObserverError, RequestAuthenticator, RequestAuthenticatorError,
+    RequestIdentityHttpAuthenticator, RequestIdentityHttpAuthenticatorError,
+    RequestIdentityHttpAuthenticatorFactory, RequestIdentitySelectionContext,
+    RequestIdentitySelectionError, RequestIdentitySelector, SelectedRequestIdentity,
+    SourceDecorator, SourceDecoratorError, SourceFailurePolicy, SourceInputResolutionContext,
+    SourceInputResolver, SourceInputResolverError, SourceTables,
 };
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -63,16 +63,18 @@ mod runtime;
 pub use backends::mcp::discover_tool_catalog as discover_mcp_tool_catalog;
 pub use composition::{
     EngineExtensions, QueryResultObserver, QueryResultObserverError, RequestAuthenticator,
-    RequestAuthenticatorError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
+    RequestAuthenticatorError, RequestIdentityResolutionContext, RequestIdentityResolver,
+    RequestIdentityResolverError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
     SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError, SourceTables,
 };
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
     DescribeTableInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution, QueryMemoryConfig,
     QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTestFailure,
-    QueryTestResult, QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage,
-    SourceValidationReport, StatusCode, StructuredQueryError, TableFunctionArgumentInfo,
-    TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
+    QueryTestResult, QueryTestSuccess, RuntimeHttpSourceComponent, RuntimeIdentityRequirements,
+    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport, StatusCode,
+    StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
+    TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// High-level query operations for the local query engine.

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -12,8 +12,8 @@ use crate::backends::mcp::McpProviderQueryError;
 use crate::contracts::{ColumnParts, StructuredQueryError, TableRefParts};
 use crate::runtime::dependent_join::error::DependentJoinError;
 use crate::{
-    CoreError, QueryResultObserverError, RequestIdentityResolverError, SourceDecoratorError,
-    SourceInputResolverError, TableInfo,
+    CoreError, QueryResultObserverError, RequestIdentityHttpAuthenticatorError,
+    RequestIdentitySelectionError, SourceDecoratorError, SourceInputResolverError, TableInfo,
 };
 
 const DATAFUSION_DEFAULT_CATALOG: &str = "datafusion";
@@ -62,8 +62,13 @@ pub(crate) fn datafusion_to_core_with_sql_and_table_functions(
             if let Some(source_input_error) = inner.downcast_ref::<SourceInputResolverError>() {
                 return source_input_resolver_error_to_core(source_input_error);
             }
-            if let Some(identity_error) = inner.downcast_ref::<RequestIdentityResolverError>() {
-                return request_identity_resolver_error_to_core(identity_error);
+            if let Some(identity_error) = inner.downcast_ref::<RequestIdentitySelectionError>() {
+                return request_identity_selection_error_to_core(identity_error);
+            }
+            if let Some(identity_error) =
+                inner.downcast_ref::<RequestIdentityHttpAuthenticatorError>()
+            {
+                return request_identity_http_authenticator_error_to_core(identity_error);
             }
             if let Some(dependent_join_error) = inner.downcast_ref::<DependentJoinError>() {
                 return dependent_join_error.to_core_error();
@@ -103,12 +108,27 @@ fn source_input_resolver_error_to_core(error: &SourceInputResolverError) -> Core
     }
 }
 
-fn request_identity_resolver_error_to_core(error: &RequestIdentityResolverError) -> CoreError {
+pub(crate) fn request_identity_selection_error_to_core(
+    error: &RequestIdentitySelectionError,
+) -> CoreError {
     match error {
-        RequestIdentityResolverError::InvalidInput(detail) => {
+        RequestIdentitySelectionError::InvalidInput(detail) => {
             CoreError::InvalidInput(detail.clone())
         }
-        RequestIdentityResolverError::FailedPrecondition(detail) => {
+        RequestIdentitySelectionError::FailedPrecondition(detail) => {
+            CoreError::FailedPrecondition(detail.clone())
+        }
+    }
+}
+
+fn request_identity_http_authenticator_error_to_core(
+    error: &RequestIdentityHttpAuthenticatorError,
+) -> CoreError {
+    match error {
+        RequestIdentityHttpAuthenticatorError::InvalidInput(detail) => {
+            CoreError::InvalidInput(detail.clone())
+        }
+        RequestIdentityHttpAuthenticatorError::FailedPrecondition(detail) => {
             CoreError::FailedPrecondition(detail.clone())
         }
     }

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -12,7 +12,8 @@ use crate::backends::mcp::McpProviderQueryError;
 use crate::contracts::{ColumnParts, StructuredQueryError, TableRefParts};
 use crate::runtime::dependent_join::error::DependentJoinError;
 use crate::{
-    CoreError, QueryResultObserverError, SourceDecoratorError, SourceInputResolverError, TableInfo,
+    CoreError, QueryResultObserverError, RequestIdentityResolverError, SourceDecoratorError,
+    SourceInputResolverError, TableInfo,
 };
 
 const DATAFUSION_DEFAULT_CATALOG: &str = "datafusion";
@@ -61,6 +62,9 @@ pub(crate) fn datafusion_to_core_with_sql_and_table_functions(
             if let Some(source_input_error) = inner.downcast_ref::<SourceInputResolverError>() {
                 return source_input_resolver_error_to_core(source_input_error);
             }
+            if let Some(identity_error) = inner.downcast_ref::<RequestIdentityResolverError>() {
+                return request_identity_resolver_error_to_core(identity_error);
+            }
             if let Some(dependent_join_error) = inner.downcast_ref::<DependentJoinError>() {
                 return dependent_join_error.to_core_error();
             }
@@ -94,6 +98,17 @@ fn source_input_resolver_error_to_core(error: &SourceInputResolverError) -> Core
     match error {
         SourceInputResolverError::InvalidInput(detail) => CoreError::InvalidInput(detail.clone()),
         SourceInputResolverError::FailedPrecondition(detail) => {
+            CoreError::FailedPrecondition(detail.clone())
+        }
+    }
+}
+
+fn request_identity_resolver_error_to_core(error: &RequestIdentityResolverError) -> CoreError {
+    match error {
+        RequestIdentityResolverError::InvalidInput(detail) => {
+            CoreError::InvalidInput(detail.clone())
+        }
+        RequestIdentityResolverError::FailedPrecondition(detail) => {
             CoreError::FailedPrecondition(detail.clone())
         }
     }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -70,6 +70,17 @@ struct RegisteredRuntime {
     failures: Vec<SourceRegistrationFailure>,
 }
 
+struct RegisteredRuntimeBuildConfig<'a> {
+    sources: &'a [QuerySource],
+    runtime_context: &'a QueryRuntimeContext,
+    request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
+    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    source_decorators: &'a mut [Box<dyn SourceDecorator>],
+    dependent_join: &'a DependentJoinConfig,
+    memory: &'a QueryMemoryConfig,
+}
+
 enum SqlExecutionFailure {
     Planning(DataFusionError),
     Collection(DataFusionError),
@@ -116,16 +127,16 @@ async fn build_runtime_inner(
         })
     });
 
-    let primary = build_registered_runtime(
+    let primary = build_registered_runtime(RegisteredRuntimeBuildConfig {
         sources,
-        &runtime_context,
-        &request_authenticators,
+        runtime_context: &runtime_context,
+        request_authenticators: &request_authenticators,
         source_input_resolver,
         request_identity_resolver,
-        extensions.source_decorators.as_mut_slice(),
-        &dependent_join,
-        &memory,
-    )
+        source_decorators: extensions.source_decorators.as_mut_slice(),
+        dependent_join: &dependent_join,
+        memory: &memory,
+    })
     .await?;
 
     Ok(QueryRuntimeAdapter {
@@ -140,24 +151,17 @@ async fn build_runtime_inner(
 }
 
 async fn build_registered_runtime(
-    sources: &[QuerySource],
-    runtime_context: &QueryRuntimeContext,
-    request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
-    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
-    source_decorators: &mut [Box<dyn SourceDecorator>],
-    dependent_join: &DependentJoinConfig,
-    memory: &QueryMemoryConfig,
+    config: RegisteredRuntimeBuildConfig<'_>,
 ) -> Result<RegisteredRuntime, CoreError> {
-    let ctx = build_session_context(dependent_join, memory)?;
+    let ctx = build_session_context(config.dependent_join, config.memory)?;
     let registration = register_runtime_sources(
         &ctx,
-        sources,
-        runtime_context,
-        request_authenticators,
-        source_input_resolver,
-        request_identity_resolver,
-        source_decorators,
+        config.sources,
+        config.runtime_context,
+        config.request_authenticators,
+        config.source_input_resolver,
+        config.request_identity_resolver,
+        config.source_decorators,
     )
     .await?;
     catalog::register(&ctx, &registration.active_sources)
@@ -553,16 +557,17 @@ fn format_memory_limit(limit: MemorySize) -> String {
 impl FallbackRuntimeConfig {
     async fn build_without_dependent_join(&self) -> Result<RegisteredRuntime, CoreError> {
         let mut source_decorators = Vec::new();
-        build_registered_runtime(
-            &self.sources,
-            &self.runtime_context,
-            &self.request_authenticators,
-            self.source_input_resolver.clone(),
-            self.request_identity_resolver.clone(),
-            source_decorators.as_mut_slice(),
-            &self.dependent_join.without_rewrites(),
-            &self.memory,
-        )
+        let dependent_join = self.dependent_join.without_rewrites();
+        build_registered_runtime(RegisteredRuntimeBuildConfig {
+            sources: &self.sources,
+            runtime_context: &self.runtime_context,
+            request_authenticators: &self.request_authenticators,
+            source_input_resolver: self.source_input_resolver.clone(),
+            request_identity_resolver: self.request_identity_resolver.clone(),
+            source_decorators: source_decorators.as_mut_slice(),
+            dependent_join: &dependent_join,
+            memory: &self.memory,
+        })
         .await
     }
 }
@@ -710,6 +715,7 @@ mod tests {
             },
             request_authenticators: HashMap::new(),
             source_input_resolver: None,
+            request_identity_resolver: None,
         };
 
         let runtime = fallback

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -33,8 +33,8 @@ use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
     CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, MemorySize, QueryExecution,
     QueryMemoryConfig, QueryPlan, QueryResultObserver, QueryResultObserverError,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceDecorator,
-    SourceInputResolver, TableFunctionInfo, TableInfo,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RequestAuthenticator,
+    RequestIdentityResolver, SourceDecorator, SourceInputResolver, TableFunctionInfo, TableInfo,
 };
 
 pub(crate) struct QueryRuntimeAdapter {
@@ -60,6 +60,7 @@ struct FallbackRuntimeConfig {
     memory: QueryMemoryConfig,
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
 }
 
 struct RegisteredRuntime {
@@ -92,6 +93,7 @@ async fn build_runtime_inner(
         memory,
         dependent_join,
         mut extensions,
+        request_identity_resolver,
     } = runtime;
     let request_authenticators = extensions.request_authenticators.clone();
     let source_input_resolver = extensions.source_input_resolver.clone();
@@ -110,6 +112,7 @@ async fn build_runtime_inner(
             memory: memory.clone(),
             request_authenticators: request_authenticators.clone(),
             source_input_resolver: source_input_resolver.clone(),
+            request_identity_resolver: request_identity_resolver.clone(),
         })
     });
 
@@ -118,6 +121,7 @@ async fn build_runtime_inner(
         &runtime_context,
         &request_authenticators,
         source_input_resolver,
+        request_identity_resolver,
         extensions.source_decorators.as_mut_slice(),
         &dependent_join,
         &memory,
@@ -140,6 +144,7 @@ async fn build_registered_runtime(
     runtime_context: &QueryRuntimeContext,
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
     source_decorators: &mut [Box<dyn SourceDecorator>],
     dependent_join: &DependentJoinConfig,
     memory: &QueryMemoryConfig,
@@ -151,6 +156,7 @@ async fn build_registered_runtime(
         runtime_context,
         request_authenticators,
         source_input_resolver,
+        request_identity_resolver,
         source_decorators,
     )
     .await?;
@@ -239,6 +245,7 @@ async fn register_runtime_sources(
     runtime_context: &QueryRuntimeContext,
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
     source_decorators: &mut [Box<dyn SourceDecorator>],
 ) -> Result<crate::runtime::registry::SourceRegistrationResult, CoreError> {
     let mut source_candidates = Vec::new();
@@ -248,6 +255,7 @@ async fn register_runtime_sources(
             runtime_context,
             request_authenticators,
             source_input_resolver.clone(),
+            request_identity_resolver.clone(),
         ) {
             Ok(compiled) => {
                 source_candidates.push(SourceRegistrationCandidate::Compiled(
@@ -550,6 +558,7 @@ impl FallbackRuntimeConfig {
             &self.runtime_context,
             &self.request_authenticators,
             self.source_input_resolver.clone(),
+            self.request_identity_resolver.clone(),
             source_decorators.as_mut_slice(),
             &self.dependent_join.without_rewrites(),
             &self.memory,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -31,10 +31,13 @@ use crate::runtime::registry::{
 };
 use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
-    CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, MemorySize, QueryExecution,
-    QueryMemoryConfig, QueryPlan, QueryResultObserver, QueryResultObserverError,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RequestAuthenticator,
-    RequestIdentityResolver, SourceDecorator, SourceInputResolver, TableFunctionInfo, TableInfo,
+    BoundRequestIdentityHttpAuthenticator, CatalogInfo, CoreError, DependentJoinConfig,
+    DescribeTableInfo, MemorySize, QueryExecution, QueryMemoryConfig, QueryPlan,
+    QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext,
+    QuerySource, RequestAuthenticator, RequestIdentityHttpAuthenticatorError,
+    RequestIdentityHttpAuthenticatorFactory, RequestIdentitySelectionContext,
+    RequestIdentitySelectionError, RequestIdentitySelector, SelectedRequestIdentity,
+    SourceDecorator, SourceInputResolver, TableFunctionInfo, TableInfo,
 };
 
 pub(crate) struct QueryRuntimeAdapter {
@@ -46,6 +49,10 @@ pub(crate) struct QueryRuntimeAdapter {
     failures: Vec<SourceRegistrationFailure>,
     query_result_observers: Vec<Arc<dyn QueryResultObserver>>,
 }
+
+type RequestIdentitySurfaceKey = (String, String);
+type BoundRequestIdentityHttpAuthenticators =
+    HashMap<RequestIdentitySurfaceKey, BoundRequestIdentityHttpAuthenticator>;
 
 struct FallbackRuntime {
     config: FallbackRuntimeConfig,
@@ -60,7 +67,7 @@ struct FallbackRuntimeConfig {
     memory: QueryMemoryConfig,
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    request_identity_http_authenticators: BoundRequestIdentityHttpAuthenticators,
 }
 
 struct RegisteredRuntime {
@@ -75,7 +82,7 @@ struct RegisteredRuntimeBuildConfig<'a> {
     runtime_context: &'a QueryRuntimeContext,
     request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    request_identity_http_authenticators: &'a BoundRequestIdentityHttpAuthenticators,
     source_decorators: &'a mut [Box<dyn SourceDecorator>],
     dependent_join: &'a DependentJoinConfig,
     memory: &'a QueryMemoryConfig,
@@ -104,10 +111,17 @@ async fn build_runtime_inner(
         memory,
         dependent_join,
         mut extensions,
-        request_identity_resolver,
+        request_identity_selector,
+        request_identity_http_authenticator_factory,
     } = runtime;
     let request_authenticators = extensions.request_authenticators.clone();
     let source_input_resolver = extensions.source_input_resolver.clone();
+    let request_identity_http_authenticators = bind_request_identity_http_authenticators(
+        sources,
+        request_identity_selector,
+        request_identity_http_authenticator_factory,
+    )
+    .await?;
     // Resolver-row overflow can retry without the dependent-join optimizer only
     // when runtime registration is replayable. Source decorators are mutable
     // one-shot registration hooks today, so decorated runtimes keep resolver-row
@@ -123,7 +137,7 @@ async fn build_runtime_inner(
             memory: memory.clone(),
             request_authenticators: request_authenticators.clone(),
             source_input_resolver: source_input_resolver.clone(),
-            request_identity_resolver: request_identity_resolver.clone(),
+            request_identity_http_authenticators: request_identity_http_authenticators.clone(),
         })
     });
 
@@ -132,7 +146,7 @@ async fn build_runtime_inner(
         runtime_context: &runtime_context,
         request_authenticators: &request_authenticators,
         source_input_resolver,
-        request_identity_resolver,
+        request_identity_http_authenticators: &request_identity_http_authenticators,
         source_decorators: extensions.source_decorators.as_mut_slice(),
         dependent_join: &dependent_join,
         memory: &memory,
@@ -150,6 +164,108 @@ async fn build_runtime_inner(
     })
 }
 
+async fn bind_request_identity_http_authenticators(
+    sources: &[QuerySource],
+    request_identity_selector: Option<Arc<dyn RequestIdentitySelector>>,
+    request_identity_http_authenticator_factory: Option<RequestIdentityHttpAuthenticatorFactory>,
+) -> Result<BoundRequestIdentityHttpAuthenticators, CoreError> {
+    let mut authenticators = HashMap::new();
+    for source in sources {
+        for component in source.components() {
+            let crate::RuntimeSourceComponent::Http(component) = component else {
+                continue;
+            };
+            let Some(context) = component.identity_selection_context(source.source_name()) else {
+                continue;
+            };
+            let selector = request_identity_selector.as_ref().ok_or_else(|| {
+                CoreError::FailedPrecondition(format!(
+                    "source '{}' surface '{}' declares identity_requirements but no request identity selector is installed",
+                    context.source_name(),
+                    context.surface_id()
+                ))
+            })?;
+            let factory = request_identity_http_authenticator_factory
+                .as_ref()
+                .ok_or_else(|| {
+                    CoreError::FailedPrecondition(format!(
+                        "source '{}' surface '{}' declares identity_requirements but no request identity HTTP authenticator factory is installed",
+                        context.source_name(),
+                        context.surface_id()
+                    ))
+                })?;
+            let selected = selector
+                .select_identity(&context)
+                .await
+                .map_err(|error| request_identity_selection_error(&context, &error))?;
+            validate_selected_identity(&context, &selected)?;
+            let authenticator = factory(selected.clone()).map_err(|error| {
+                request_identity_http_authenticator_factory_error(&context, &selected, &error)
+            })?;
+            authenticators.insert(
+                (
+                    context.source_name().to_string(),
+                    context.surface_id().to_string(),
+                ),
+                authenticator,
+            );
+        }
+    }
+    Ok(authenticators)
+}
+
+fn validate_selected_identity(
+    context: &RequestIdentitySelectionContext,
+    selected: &SelectedRequestIdentity,
+) -> Result<(), CoreError> {
+    if context.accepts_identity(selected.identity_spec_id(), selected.audience()) {
+        return Ok(());
+    }
+    Err(CoreError::FailedPrecondition(format!(
+        "request identity selector selected identity '{}' with spec '{}' that does not satisfy identity_requirements for source '{}' surface '{}'",
+        selected.identity_id(),
+        selected.identity_spec_id(),
+        context.source_name(),
+        context.surface_id()
+    )))
+}
+
+fn request_identity_selection_error(
+    context: &RequestIdentitySelectionContext,
+    error: &RequestIdentitySelectionError,
+) -> CoreError {
+    let detail = format!(
+        "request identity selector failed for source '{}' surface '{}': {error}",
+        context.source_name(),
+        context.surface_id()
+    );
+    match error {
+        RequestIdentitySelectionError::InvalidInput(_) => CoreError::InvalidInput(detail),
+        RequestIdentitySelectionError::FailedPrecondition(_) => {
+            CoreError::FailedPrecondition(detail)
+        }
+    }
+}
+
+fn request_identity_http_authenticator_factory_error(
+    context: &RequestIdentitySelectionContext,
+    selected: &SelectedRequestIdentity,
+    error: &RequestIdentityHttpAuthenticatorError,
+) -> CoreError {
+    let detail = format!(
+        "request identity HTTP authenticator factory failed for selected identity '{}' on source '{}' surface '{}': {error}",
+        selected.identity_id(),
+        context.source_name(),
+        context.surface_id()
+    );
+    match error {
+        RequestIdentityHttpAuthenticatorError::InvalidInput(_) => CoreError::InvalidInput(detail),
+        RequestIdentityHttpAuthenticatorError::FailedPrecondition(_) => {
+            CoreError::FailedPrecondition(detail)
+        }
+    }
+}
+
 async fn build_registered_runtime(
     config: RegisteredRuntimeBuildConfig<'_>,
 ) -> Result<RegisteredRuntime, CoreError> {
@@ -160,7 +276,7 @@ async fn build_registered_runtime(
         config.runtime_context,
         config.request_authenticators,
         config.source_input_resolver,
-        config.request_identity_resolver,
+        config.request_identity_http_authenticators,
         config.source_decorators,
     )
     .await?;
@@ -249,7 +365,7 @@ async fn register_runtime_sources(
     runtime_context: &QueryRuntimeContext,
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    request_identity_resolver: Option<Arc<dyn RequestIdentityResolver>>,
+    request_identity_http_authenticators: &BoundRequestIdentityHttpAuthenticators,
     source_decorators: &mut [Box<dyn SourceDecorator>],
 ) -> Result<crate::runtime::registry::SourceRegistrationResult, CoreError> {
     let mut source_candidates = Vec::new();
@@ -259,7 +375,7 @@ async fn register_runtime_sources(
             runtime_context,
             request_authenticators,
             source_input_resolver.clone(),
-            request_identity_resolver.clone(),
+            request_identity_http_authenticators,
         ) {
             Ok(compiled) => {
                 source_candidates.push(SourceRegistrationCandidate::Compiled(
@@ -563,7 +679,7 @@ impl FallbackRuntimeConfig {
             runtime_context: &self.runtime_context,
             request_authenticators: &self.request_authenticators,
             source_input_resolver: self.source_input_resolver.clone(),
-            request_identity_resolver: self.request_identity_resolver.clone(),
+            request_identity_http_authenticators: &self.request_identity_http_authenticators,
             source_decorators: source_decorators.as_mut_slice(),
             dependent_join: &dependent_join,
             memory: &self.memory,
@@ -715,7 +831,7 @@ mod tests {
             },
             request_authenticators: HashMap::new(),
             source_input_resolver: None,
-            request_identity_resolver: None,
+            request_identity_http_authenticators: HashMap::new(),
         };
 
         let runtime = fallback

--- a/crates/coral-engine/tests/engine.rs
+++ b/crates/coral-engine/tests/engine.rs
@@ -33,3 +33,5 @@ mod query_result_observer_tests;
 mod structured_error_tests;
 #[path = "engine/test_source_tests.rs"]
 mod test_source_tests;
+#[path = "engine/v4_tests.rs"]
+mod v4_tests;

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 
-use coral_engine::{CoralQuery, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage};
+use coral_engine::{
+    CoralQuery, QuerySource, RuntimeHttpSourceComponent, RuntimeSourceComponent,
+    RuntimeSourcePackage,
+};
 use coral_spec::backends::http::HttpSourceManifest;
 use coral_spec::parse_source_manifest_yaml;
 use coral_spec::{FilterMode, FilterSpec};
@@ -38,8 +41,8 @@ async fn multi_component_source_executes_across_component_tables() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             components: vec![
-                RuntimeSourceComponent::Http(issues),
-                RuntimeSourceComponent::Http(pulls),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(issues)),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(pulls)),
             ],
         },
         BTreeMap::new(),
@@ -124,8 +127,8 @@ async fn multi_component_source_can_register_multiple_schemas() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             components: vec![
-                RuntimeSourceComponent::Http(issues),
-                RuntimeSourceComponent::Http(pulls),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(issues)),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(pulls)),
             ],
         },
         BTreeMap::new(),
@@ -162,12 +165,14 @@ async fn selected_sources_reject_runtime_schema_collisions() {
             description: "Composite GitHub runtime package".to_string(),
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
-            components: vec![RuntimeSourceComponent::Http(http_component(
-                &server.uri(),
-                "github_v4_rest",
-                "issues",
-                "/issues",
-            ))],
+            components: vec![RuntimeSourceComponent::Http(
+                RuntimeHttpSourceComponent::new(http_component(
+                    &server.uri(),
+                    "github_v4_rest",
+                    "issues",
+                    "/issues",
+                )),
+            )],
         },
         BTreeMap::new(),
         BTreeMap::new(),
@@ -180,12 +185,14 @@ async fn selected_sources_reject_runtime_schema_collisions() {
             description: "Conflicting runtime package".to_string(),
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
-            components: vec![RuntimeSourceComponent::Http(http_component(
-                &server.uri(),
-                "github_v4_rest",
-                "pulls",
-                "/pulls",
-            ))],
+            components: vec![RuntimeSourceComponent::Http(
+                RuntimeHttpSourceComponent::new(http_component(
+                    &server.uri(),
+                    "github_v4_rest",
+                    "pulls",
+                    "/pulls",
+                )),
+            )],
         },
         BTreeMap::new(),
         BTreeMap::new(),
@@ -217,8 +224,8 @@ async fn validate_source_reports_only_component_schemas_for_multi_schema_source(
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             components: vec![
-                RuntimeSourceComponent::Http(issues),
-                RuntimeSourceComponent::Http(pulls),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(issues)),
+                RuntimeSourceComponent::Http(RuntimeHttpSourceComponent::new(pulls)),
             ],
         },
         BTreeMap::new(),

--- a/crates/coral-engine/tests/engine/v4_tests.rs
+++ b/crates/coral-engine/tests/engine/v4_tests.rs
@@ -1,0 +1,362 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use coral_engine::{
+    CoralQuery, CoreError, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    RequestIdentityResolutionContext, RequestIdentityResolver, RequestIdentityResolverError,
+    RuntimeHttpSourceComponent, RuntimeSourceComponent, RuntimeSourcePackage,
+};
+use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
+use coral_spec::parse_source_manifest_yaml;
+use coral_spec::v4::{
+    IrExecutionAttachment, ProjectionKind, ProjectionVisibility, V4SourceManifest, V4Surface,
+    generate_projection_catalog, import_openapi_surface, projection_arg_specs,
+    projection_column_specs, projection_filter_specs, request_spec_for_projection,
+};
+use coral_spec::{SourceManifestCommon, SourceTableFunctionSpec, TableCommon};
+use reqwest::header::{HeaderName, HeaderValue};
+use serde_json::{Value, json};
+use wiremock::matchers::{header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::harness::{execution_to_rows, test_runtime};
+
+/// Mounts the GitHub issues endpoint returning one issue, optionally requiring
+/// an identity header on the request.
+async fn mount_issues_endpoint(
+    server: &MockServer,
+    identity_header: Option<(&str, &str)>,
+    issue: Value,
+) {
+    let mut mock = Mock::given(method("GET"))
+        .and(path("/repos/octocat/Hello-World/issues"))
+        .and(query_param("state", "open"));
+    if let Some((name, value)) = identity_header {
+        mock = mock.and(header(name, value));
+    }
+    mock.respond_with(ResponseTemplate::new(200).set_body_json(json!([issue])))
+        .mount(server)
+        .await;
+}
+
+fn issue_json(id: u64, number: u64, title: &str) -> Value {
+    json!({
+        "id": id,
+        "number": number,
+        "title": title,
+        "state": "open",
+        "html_url": format!("https://github.com/octocat/Hello-World/issues/{number}")
+    })
+}
+
+#[tokio::test]
+async fn v4_openapi_projection_executes_generated_table() {
+    let server = MockServer::start().await;
+    mount_issues_endpoint(&server, None, issue_json(1, 42, "Found it")).await;
+    let source = github_v4_source(&server.uri(), "");
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(&[source], test_runtime(), github_issues_sql())
+            .await
+            .expect("query should execute"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({"id": 1, "number": 42, "title": "Found it"})]
+    );
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ObservedIdentityResolution {
+    source_name: String,
+    surface_id: String,
+    requirement_id: String,
+    api_base: String,
+    request_path: String,
+    accepts_candidate: bool,
+}
+
+type ObservedCell = Arc<Mutex<Option<ObservedIdentityResolution>>>;
+
+#[derive(Debug)]
+struct RecordingIdentityResolver {
+    observed: ObservedCell,
+    header_name: HeaderName,
+}
+
+#[async_trait::async_trait]
+impl RequestIdentityResolver for RecordingIdentityResolver {
+    async fn resolve_identity_headers(
+        &self,
+        identity: &RequestIdentityResolutionContext,
+        request: &reqwest::Request,
+        resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
+        let audience = BTreeMap::from([("host".to_string(), json!("github.com"))]);
+        let accepts_candidate = identity.accepts_identity("github_oauth", &audience);
+        let requirement_id = identity
+            .identity_requirements()
+            .accepts
+            .first()
+            .expect("accepted identity requirement")
+            .id
+            .clone();
+        *self.observed.lock().expect("observed identity lock") = Some(ObservedIdentityResolution {
+            source_name: identity.source_name().to_string(),
+            surface_id: identity.surface_id().to_string(),
+            requirement_id,
+            api_base: resolved_inputs
+                .get("API_BASE")
+                .expect("resolved API_BASE")
+                .clone(),
+            request_path: request.url().path().to_string(),
+            accepts_candidate,
+        });
+        Ok(vec![(
+            self.header_name.clone(),
+            HeaderValue::from_static("member-token"),
+        )])
+    }
+}
+
+/// Engine runtime with a [`RecordingIdentityResolver`] writing into `observed`.
+fn recording_identity_runtime(observed: &ObservedCell) -> QueryRuntimeConfig {
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), EngineExtensions::default())
+        .with_request_identity_resolver(Some(Arc::new(RecordingIdentityResolver {
+            observed: Arc::clone(observed),
+            header_name: HeaderName::from_static("x-coral-identity"),
+        })))
+}
+
+#[tokio::test]
+async fn v4_identity_requirements_call_resolver_and_inject_headers() {
+    let server = MockServer::start().await;
+    mount_issues_endpoint(
+        &server,
+        Some(("x-coral-identity", "member-token")),
+        issue_json(7, 99, "Identity routed"),
+    )
+    .await;
+    let observed: ObservedCell = Arc::new(Mutex::new(None));
+    let runtime = recording_identity_runtime(&observed);
+    let source = github_v4_source(&server.uri(), identity_requirements_yaml());
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(&[source], runtime, github_issues_sql())
+            .await
+            .expect("identity-backed query should execute"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({"id": 7, "number": 99, "title": "Identity routed"})]
+    );
+    assert_eq!(
+        *observed.lock().expect("observed identity lock"),
+        Some(ObservedIdentityResolution {
+            source_name: "github_v4".to_string(),
+            surface_id: "rest".to_string(),
+            requirement_id: "github-rest-read".to_string(),
+            api_base: server.uri(),
+            request_path: "/repos/octocat/Hello-World/issues".to_string(),
+            accepts_candidate: true,
+        })
+    );
+}
+
+#[tokio::test]
+async fn v4_identity_requirements_fail_closed_without_resolver() {
+    let source = github_v4_source("http://127.0.0.1:1", identity_requirements_yaml());
+
+    let error = CoralQuery::execute_sql(&[source], test_runtime(), github_issues_sql())
+        .await
+        .expect_err("identity-backed query without resolver should fail");
+
+    assert!(
+        matches!(error, CoreError::FailedPrecondition(_)),
+        "expected failed precondition, got {error:?}"
+    );
+    assert!(
+        error.to_string().contains(
+            "declares identity_requirements but no request identity resolver is installed"
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn v4_identity_resolver_cannot_overwrite_existing_headers() {
+    let runtime = recording_identity_runtime(&Arc::new(Mutex::new(None)));
+    let source = github_v4_source(
+        "http://127.0.0.1:1",
+        &format!(
+            "{}    request_headers:\n      - {{name: x-coral-identity, from: literal, value: existing-token}}\n",
+            identity_requirements_yaml()
+        ),
+    );
+
+    let error = CoralQuery::execute_sql(&[source], runtime, github_issues_sql())
+        .await
+        .expect_err("identity resolver should not overwrite existing header");
+
+    assert!(
+        error
+            .to_string()
+            .contains("request identity resolver attempted to overwrite header 'x-coral-identity'"),
+        "unexpected error: {error}"
+    );
+}
+
+/// Builds an app-style v4 runtime source for the GitHub openapi fixture;
+/// `surface_extra` lines are appended under the openapi surface entry.
+fn github_v4_source(base_url: &str, surface_extra: &str) -> QuerySource {
+    let manifest = parse_source_manifest_yaml(&format!(
+        "name: github_v4\ndsl_version: 4\nsurfaces:\n  - id: rest\n    type: openapi\n    file: /tmp/github-openapi.yaml\n    sha256: 0000000000000000000000000000000000000000000000000000000000000000\n    inputs:\n      API_BASE: {{kind: variable, default: '{base_url}'}}\n    base_url: \"{{{{input.API_BASE}}}}\"\n{surface_extra}\n"
+    ))
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let (tables, functions) = published_projection_specs(v4, surface);
+    let runtime = surface
+        .openapi_runtime()
+        .expect("GitHub v4 test fixture should use OpenAPI runtime");
+
+    let http_manifest = HttpSourceManifest {
+        common: SourceManifestCommon {
+            dsl_version: v4.common.dsl_version,
+            name: v4.common.name.clone(),
+            version: String::new(),
+            description: v4.common.description.clone(),
+            test_queries: Vec::new(),
+        },
+        base_url: runtime.base_url.clone(),
+        auth: runtime.auth.clone(),
+        request_headers: runtime.request_headers.clone(),
+        rate_limit: runtime.rate_limit.clone(),
+        tables,
+        functions,
+        declared_inputs: surface.inputs.clone(),
+    };
+
+    let http_component = if let Some(identity_requirements) = surface.identity_requirements.clone()
+    {
+        RuntimeHttpSourceComponent::with_identity_requirements(
+            http_manifest,
+            surface.id.clone(),
+            identity_requirements,
+        )
+    } else {
+        RuntimeHttpSourceComponent::new(http_manifest)
+    };
+    QuerySource::from_runtime_components(
+        RuntimeSourcePackage {
+            source_name: v4.common.name.clone(),
+            authored_version: None,
+            description: v4.common.description.clone(),
+            declared_inputs: v4.declared_inputs.clone(),
+            test_queries: v4.common.test_queries.clone(),
+            components: vec![RuntimeSourceComponent::Http(http_component)],
+        },
+        BTreeMap::new(),
+        BTreeMap::new(),
+    )
+    .expect("runtime source")
+}
+
+/// Imports the GitHub openapi fixture and generates the published table and
+/// table-function specs for `surface`, mirroring app-style v4 assembly.
+fn published_projection_specs(
+    v4: &V4SourceManifest,
+    surface: &V4Surface,
+) -> (Vec<HttpTableSpec>, Vec<SourceTableFunctionSpec>) {
+    let semantic_ir = import_openapi_surface(v4, surface, github_openapi().as_bytes()).expect("ir");
+    let projections =
+        generate_projection_catalog(v4, std::slice::from_ref(&semantic_ir)).expect("projections");
+    let operations = semantic_ir
+        .operations
+        .iter()
+        .map(|operation| (operation.id.as_str(), operation))
+        .collect::<BTreeMap<_, _>>();
+    let mut tables = Vec::new();
+    let mut functions = Vec::new();
+    for projection in projections.projections.iter().filter(|projection| {
+        projection.surface_id == surface.id
+            && projection.visibility == ProjectionVisibility::Published
+    }) {
+        let operation = operations
+            .get(projection.operation_id.as_str())
+            .expect("projection operation");
+        let request = request_spec_for_projection(projection, operation).expect("request spec");
+        let columns = projection_column_specs(projection);
+        let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+            panic!("published OpenAPI projection should use REST execution");
+        };
+        match &projection.kind {
+            ProjectionKind::Table => tables.push(HttpTableSpec {
+                common: TableCommon {
+                    name: projection.name.clone(),
+                    description: projection.description.clone(),
+                    guide: projection.guide.clone(),
+                    filters: projection_filter_specs(projection),
+                    fetch_limit_default: None,
+                    search_limits: projection.search_limits.clone(),
+                    detail_hints: projection.detail_hints.clone(),
+                    columns,
+                },
+                request,
+                requests: Vec::new(),
+                response: rest.response.response.clone(),
+                pagination: projection.pagination.clone(),
+            }),
+            ProjectionKind::TableFunction { function_kind } => {
+                functions.push(SourceTableFunctionSpec {
+                    name: projection.name.clone(),
+                    kind: *function_kind,
+                    description: projection.description.clone(),
+                    fetch_limit_default: None,
+                    search_limits: projection.search_limits.clone(),
+                    detail_hints: projection.detail_hints.clone(),
+                    args: projection_arg_specs(projection),
+                    request,
+                    response: rest.response.response.clone(),
+                    pagination: projection.pagination.clone(),
+                    columns,
+                });
+            }
+        }
+    }
+    (tables, functions)
+}
+
+fn identity_requirements_yaml() -> &'static str {
+    "\n    identity_requirements:\n      accepts:\n        - id: github-rest-read\n          identity_specs: [github_oauth, github_pat]\n          audience: {host: github.com}\n"
+}
+
+fn github_issues_sql() -> &'static str {
+    "SELECT id, number, title FROM github_v4.issues WHERE owner = 'octocat' AND repo = 'Hello-World' AND state = 'open'"
+}
+
+fn github_openapi() -> &'static str {
+    r"
+openapi: 3.0.3
+paths:
+  /repos/{owner}/{repo}/issues:
+    get:
+      operationId: issues/list-for-repo
+      parameters:
+        - {name: owner, in: path, required: true, schema: {type: string}}
+        - {name: repo, in: path, required: true, schema: {type: string}}
+        - {name: state, in: query, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {type: array, items: {$ref: '#/components/schemas/issue'}}
+components:
+  schemas:
+    issue:
+      type: object
+      properties: {id: {type: integer}, number: {type: integer}, title: {type: string}, state: {type: string}, html_url: {type: string}}
+"
+}

--- a/crates/coral-engine/tests/engine/v4_tests.rs
+++ b/crates/coral-engine/tests/engine/v4_tests.rs
@@ -2,9 +2,13 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use coral_engine::{
-    CoralQuery, CoreError, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    RequestIdentityResolutionContext, RequestIdentityResolver, RequestIdentityResolverError,
+    BoundRequestIdentityHttpAuthenticator, CoralQuery, CoreError, EngineExtensions,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RequestAuthenticator,
+    RequestAuthenticatorError, RequestIdentityHttpAuthenticator,
+    RequestIdentityHttpAuthenticatorError, RequestIdentityHttpAuthenticatorFactory,
+    RequestIdentitySelectionContext, RequestIdentitySelectionError, RequestIdentitySelector,
     RuntimeHttpSourceComponent, RuntimeSourceComponent, RuntimeSourcePackage,
+    SelectedRequestIdentity,
 };
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::parse_source_manifest_yaml;
@@ -67,34 +71,94 @@ async fn v4_openapi_projection_executes_generated_table() {
     );
 }
 
+#[derive(Debug)]
+struct DisallowedV4RequestAuthenticator;
+
+impl RequestAuthenticator for DisallowedV4RequestAuthenticator {
+    fn name(&self) -> &'static str {
+        "test_signer"
+    }
+
+    fn authenticate(
+        &self,
+        _auth: &coral_spec::CustomAuthSpec,
+        _request: &reqwest::Request,
+        _resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestAuthenticatorError> {
+        Ok(Vec::new())
+    }
+}
+
+fn runtime_with_request_authenticator() -> QueryRuntimeConfig {
+    let mut extensions = EngineExtensions::default();
+    extensions.request_authenticators.insert(
+        "test_signer".to_string(),
+        Arc::new(DisallowedV4RequestAuthenticator),
+    );
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions)
+}
+
+#[tokio::test]
+async fn v4_openapi_projection_does_not_receive_request_authenticators() {
+    let source = github_v4_source(
+        "http://127.0.0.1:1",
+        "    auth:\n      type: CustomAuth\n      authenticator: test_signer\n",
+    );
+
+    let error = CoralQuery::test_source(&source, runtime_with_request_authenticator())
+        .await
+        .expect_err("v4 surfaces should not use request_authenticators");
+
+    assert!(
+        matches!(error, CoreError::FailedPrecondition(_)),
+        "expected failed precondition, got {error:?}"
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("custom authenticator 'test_signer' is not registered"),
+        "unexpected error: {error}"
+    );
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ObservedIdentityResolution {
+struct ObservedIdentitySelection {
     source_name: String,
     surface_id: String,
     requirement_id: String,
-    api_base: String,
-    request_path: String,
     accepts_candidate: bool,
 }
 
-type ObservedCell = Arc<Mutex<Option<ObservedIdentityResolution>>>;
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ObservedIdentityAuthentication {
+    identity_id: String,
+    identity_spec_id: String,
+    api_base: String,
+    request_path: String,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ObservedIdentityEvents {
+    selections: Vec<ObservedIdentitySelection>,
+    authentications: Vec<ObservedIdentityAuthentication>,
+}
+
+type ObservedCell = Arc<Mutex<ObservedIdentityEvents>>;
 
 #[derive(Debug)]
-struct RecordingIdentityResolver {
+struct RecordingIdentitySelector {
     observed: ObservedCell,
-    header_name: HeaderName,
+    identity_spec_id: String,
+    audience: BTreeMap<String, Value>,
 }
 
 #[async_trait::async_trait]
-impl RequestIdentityResolver for RecordingIdentityResolver {
-    async fn resolve_identity_headers(
+impl RequestIdentitySelector for RecordingIdentitySelector {
+    async fn select_identity(
         &self,
-        identity: &RequestIdentityResolutionContext,
-        request: &reqwest::Request,
-        resolved_inputs: &BTreeMap<String, String>,
-    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError> {
-        let audience = BTreeMap::from([("host".to_string(), json!("github.com"))]);
-        let accepts_candidate = identity.accepts_identity("github_oauth", &audience);
+        identity: &RequestIdentitySelectionContext,
+    ) -> Result<SelectedRequestIdentity, RequestIdentitySelectionError> {
+        let accepts_candidate = identity.accepts_identity(&self.identity_spec_id, &self.audience);
         let requirement_id = identity
             .identity_requirements()
             .accepts
@@ -102,17 +166,51 @@ impl RequestIdentityResolver for RecordingIdentityResolver {
             .expect("accepted identity requirement")
             .id
             .clone();
-        *self.observed.lock().expect("observed identity lock") = Some(ObservedIdentityResolution {
-            source_name: identity.source_name().to_string(),
-            surface_id: identity.surface_id().to_string(),
-            requirement_id,
-            api_base: resolved_inputs
-                .get("API_BASE")
-                .expect("resolved API_BASE")
-                .clone(),
-            request_path: request.url().path().to_string(),
-            accepts_candidate,
-        });
+        self.observed
+            .lock()
+            .expect("observed identity lock")
+            .selections
+            .push(ObservedIdentitySelection {
+                source_name: identity.source_name().to_string(),
+                surface_id: identity.surface_id().to_string(),
+                requirement_id,
+                accepts_candidate,
+            });
+        Ok(SelectedRequestIdentity::new(
+            "github-member",
+            self.identity_spec_id.clone(),
+            self.audience.clone(),
+        ))
+    }
+}
+
+#[derive(Debug)]
+struct RecordingIdentityHttpAuthenticator {
+    observed: ObservedCell,
+    header_name: HeaderName,
+}
+
+#[async_trait::async_trait]
+impl RequestIdentityHttpAuthenticator for RecordingIdentityHttpAuthenticator {
+    async fn authenticate_identity_request(
+        &self,
+        identity: &SelectedRequestIdentity,
+        request: &reqwest::Request,
+        resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError> {
+        self.observed
+            .lock()
+            .expect("observed identity lock")
+            .authentications
+            .push(ObservedIdentityAuthentication {
+                identity_id: identity.identity_id().to_string(),
+                identity_spec_id: identity.identity_spec_id().to_string(),
+                api_base: resolved_inputs
+                    .get("API_BASE")
+                    .expect("resolved API_BASE")
+                    .clone(),
+                request_path: request.url().path().to_string(),
+            });
         Ok(vec![(
             self.header_name.clone(),
             HeaderValue::from_static("member-token"),
@@ -120,17 +218,87 @@ impl RequestIdentityResolver for RecordingIdentityResolver {
     }
 }
 
-/// Engine runtime with a [`RecordingIdentityResolver`] writing into `observed`.
+/// Engine runtime with recording selector/authenticator writing into `observed`.
 fn recording_identity_runtime(observed: &ObservedCell) -> QueryRuntimeConfig {
-    QueryRuntimeConfig::new(QueryRuntimeContext::default(), EngineExtensions::default())
-        .with_request_identity_resolver(Some(Arc::new(RecordingIdentityResolver {
+    recording_identity_runtime_with_spec(observed, "github_oauth")
+}
+
+fn recording_identity_runtime_with_spec(
+    observed: &ObservedCell,
+    identity_spec_id: &str,
+) -> QueryRuntimeConfig {
+    let selector: Arc<dyn RequestIdentitySelector> = Arc::new(RecordingIdentitySelector {
+        observed: Arc::clone(observed),
+        identity_spec_id: identity_spec_id.to_string(),
+        audience: BTreeMap::from([("host".to_string(), json!("github.com"))]),
+    });
+    let http_authenticator: Arc<dyn RequestIdentityHttpAuthenticator> =
+        Arc::new(RecordingIdentityHttpAuthenticator {
             observed: Arc::clone(observed),
             header_name: HeaderName::from_static("x-coral-identity"),
-        })))
+        });
+    let factory: RequestIdentityHttpAuthenticatorFactory = Arc::new(move |selected| {
+        let http_authenticator = Arc::clone(&http_authenticator);
+        let bound: BoundRequestIdentityHttpAuthenticator = Arc::new(
+            move |request: &reqwest::Request, resolved_inputs: &BTreeMap<String, String>| {
+                let http_authenticator = Arc::clone(&http_authenticator);
+                let selected = selected.clone();
+                Box::pin(async move {
+                    http_authenticator
+                        .authenticate_identity_request(&selected, request, resolved_inputs)
+                        .await
+                })
+            },
+        );
+        Ok(bound)
+    });
+
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), EngineExtensions::default())
+        .with_request_identity_selector(Some(selector))
+        .with_request_identity_http_authenticator_factory(Some(factory))
+}
+
+fn identity_events() -> ObservedCell {
+    Arc::new(Mutex::new(ObservedIdentityEvents::default()))
+}
+
+fn selection_only_runtime(observed: &ObservedCell) -> QueryRuntimeConfig {
+    let selector: Arc<dyn RequestIdentitySelector> = Arc::new(RecordingIdentitySelector {
+        observed: Arc::clone(observed),
+        identity_spec_id: "github_oauth".to_string(),
+        audience: BTreeMap::from([("host".to_string(), json!("github.com"))]),
+    });
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), EngineExtensions::default())
+        .with_request_identity_selector(Some(selector))
 }
 
 #[tokio::test]
-async fn v4_identity_requirements_call_resolver_and_inject_headers() {
+async fn v4_identity_requirements_select_identity_during_runtime_build() {
+    let observed = identity_events();
+    let runtime = recording_identity_runtime(&observed);
+    let source = github_v4_source("http://127.0.0.1:1", identity_requirements_yaml());
+
+    let tables = CoralQuery::list_tables(&[source], runtime, Some("github_v4"), None)
+        .await
+        .expect("identity-backed catalog should build");
+
+    assert_eq!(tables.len(), 1);
+    assert_eq!(
+        *observed.lock().expect("observed identity lock"),
+        ObservedIdentityEvents {
+            selections: vec![ObservedIdentitySelection {
+                source_name: "github_v4".to_string(),
+                surface_id: "rest".to_string(),
+                requirement_id: "github-rest-read".to_string(),
+                accepts_candidate: true,
+            }],
+            authentications: Vec::new(),
+        }
+    );
+}
+
+#[tokio::test]
+async fn v4_identity_requirements_select_identity_and_inject_headers() {
     let server = MockServer::start().await;
     mount_issues_endpoint(
         &server,
@@ -138,7 +306,7 @@ async fn v4_identity_requirements_call_resolver_and_inject_headers() {
         issue_json(7, 99, "Identity routed"),
     )
     .await;
-    let observed: ObservedCell = Arc::new(Mutex::new(None));
+    let observed = identity_events();
     let runtime = recording_identity_runtime(&observed);
     let source = github_v4_source(&server.uri(), identity_requirements_yaml());
 
@@ -154,19 +322,25 @@ async fn v4_identity_requirements_call_resolver_and_inject_headers() {
     );
     assert_eq!(
         *observed.lock().expect("observed identity lock"),
-        Some(ObservedIdentityResolution {
-            source_name: "github_v4".to_string(),
-            surface_id: "rest".to_string(),
-            requirement_id: "github-rest-read".to_string(),
-            api_base: server.uri(),
-            request_path: "/repos/octocat/Hello-World/issues".to_string(),
-            accepts_candidate: true,
-        })
+        ObservedIdentityEvents {
+            selections: vec![ObservedIdentitySelection {
+                source_name: "github_v4".to_string(),
+                surface_id: "rest".to_string(),
+                requirement_id: "github-rest-read".to_string(),
+                accepts_candidate: true,
+            }],
+            authentications: vec![ObservedIdentityAuthentication {
+                identity_id: "github-member".to_string(),
+                identity_spec_id: "github_oauth".to_string(),
+                api_base: server.uri(),
+                request_path: "/repos/octocat/Hello-World/issues".to_string(),
+            }],
+        }
     );
 }
 
 #[tokio::test]
-async fn v4_identity_requirements_fail_closed_without_resolver() {
+async fn v4_identity_requirements_fail_closed_without_selector() {
     let source = github_v4_source("http://127.0.0.1:1", identity_requirements_yaml());
 
     let error = CoralQuery::execute_sql(&[source], test_runtime(), github_issues_sql())
@@ -179,15 +353,77 @@ async fn v4_identity_requirements_fail_closed_without_resolver() {
     );
     assert!(
         error.to_string().contains(
-            "declares identity_requirements but no request identity resolver is installed"
+            "declares identity_requirements but no request identity selector is installed"
         ),
         "unexpected error: {error}"
     );
 }
 
 #[tokio::test]
-async fn v4_identity_resolver_cannot_overwrite_existing_headers() {
-    let runtime = recording_identity_runtime(&Arc::new(Mutex::new(None)));
+async fn v4_identity_requirements_fail_closed_without_http_authenticator_factory() {
+    let observed = identity_events();
+    let runtime = selection_only_runtime(&observed);
+    let source = github_v4_source("http://127.0.0.1:1", identity_requirements_yaml());
+
+    let error = CoralQuery::execute_sql(&[source], runtime, github_issues_sql())
+        .await
+        .expect_err("identity-backed query without HTTP authenticator factory should fail");
+
+    assert!(
+        matches!(error, CoreError::FailedPrecondition(_)),
+        "expected failed precondition, got {error:?}"
+    );
+    assert!(
+        error.to_string().contains(
+            "declares identity_requirements but no request identity HTTP authenticator factory is installed"
+        ),
+        "unexpected error: {error}"
+    );
+    assert_eq!(
+        observed
+            .lock()
+            .expect("observed identity lock")
+            .selections
+            .len(),
+        0,
+        "factory availability should be checked before selection"
+    );
+}
+
+#[tokio::test]
+async fn v4_identity_requirements_reject_unaccepted_selected_identity() {
+    let observed = identity_events();
+    let runtime = recording_identity_runtime_with_spec(&observed, "gitlab_oauth");
+    let source = github_v4_source("http://127.0.0.1:1", identity_requirements_yaml());
+
+    let error = CoralQuery::execute_sql(&[source], runtime, github_issues_sql())
+        .await
+        .expect_err("unaccepted selected identity should fail before HTTP execution");
+
+    assert!(
+        matches!(error, CoreError::FailedPrecondition(_)),
+        "expected failed precondition, got {error:?}"
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("does not satisfy identity_requirements"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(
+        observed
+            .lock()
+            .expect("observed identity lock")
+            .authentications
+            .len(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn v4_identity_http_authenticator_cannot_overwrite_existing_headers() {
+    let observed = identity_events();
+    let runtime = recording_identity_runtime(&observed);
     let source = github_v4_source(
         "http://127.0.0.1:1",
         &format!(
@@ -198,12 +434,12 @@ async fn v4_identity_resolver_cannot_overwrite_existing_headers() {
 
     let error = CoralQuery::execute_sql(&[source], runtime, github_issues_sql())
         .await
-        .expect_err("identity resolver should not overwrite existing header");
+        .expect_err("identity HTTP authenticator should not overwrite existing header");
 
     assert!(
-        error
-            .to_string()
-            .contains("request identity resolver attempted to overwrite header 'x-coral-identity'"),
+        error.to_string().contains(
+            "request identity HTTP authenticator attempted to overwrite header 'x-coral-identity'"
+        ),
         "unexpected error: {error}"
     );
 }


### PR DESCRIPTION
## Intent

Land `feat(engine): resolve DSL v4 request identities` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-02-identity-api...sauldhernandez/dsl-v4-identity-v2-03-engine-runtime
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
