### PR TITLE
feat(app): add identity authorization seams

### DIFF
--- a/crates/coral-app/src/authorization.rs
+++ b/crates/coral-app/src/authorization.rs
@@ -10,9 +10,6 @@ pub enum AuthorizationError {
     /// The authenticated principal is not allowed to perform the operation.
     #[error("{0}")]
     Forbidden(String),
-    /// Authorization failed unexpectedly.
-    #[error("{0}")]
-    Internal(String),
 }
 
 impl AuthorizationError {
@@ -21,57 +18,82 @@ impl AuthorizationError {
     pub fn forbidden(message: impl Into<String>) -> Self {
         Self::Forbidden(message.into())
     }
-
-    /// Builds an internal authorization error.
-    #[must_use]
-    pub fn internal(message: impl Into<String>) -> Self {
-        Self::Internal(message.into())
-    }
 }
 
-/// Source mutation operation being authorized.
+/// Upsert/delete management-resource mutation operation being authorized.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SourceMutationKind {
+pub enum ResourceMutationKind {
+    /// Install, create, or replace the resource.
+    Upsert,
+    /// Remove the resource.
+    Delete,
+}
+
+/// Workspace source mutation operation being authorized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceSourceMutationKind {
     /// Install a source from Coral's bundled source catalog.
     CreateBundled,
     /// Install a bundled source while retrieving OAuth credentials.
     CreateBundledWithOAuth,
-    /// Import a source spec.
-    Import,
+    /// Install a source from an authored or imported source spec.
+    CreateFromSourceSpec,
     /// Remove an installed source from a workspace.
     Delete,
+}
+
+/// Management-plane mutation exposed by Coral's shared service surface.
+///
+/// Source specs, workspace sources, and workspace identities are separate
+/// resources: importing or updating an authored manifest mutates a source spec,
+/// adding that spec to a workspace mutates the workspace's installed source
+/// catalog, and changing workspace-owned identity material mutates a workspace
+/// identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManagementMutation<'a> {
+    /// Create, replace, or delete a global identity spec.
+    IdentitySpec {
+        /// Identity-spec operation being authorized.
+        kind: ResourceMutationKind,
+    },
+    /// Create, replace, or delete an authored source spec.
+    SourceSpec {
+        /// Source-spec operation being authorized.
+        kind: ResourceMutationKind,
+    },
+    /// Create, replace, or delete workspace-owned identity material.
+    WorkspaceIdentity {
+        /// Workspace whose identity catalog will change.
+        workspace_id: &'a str,
+        /// Workspace identity operation being authorized.
+        kind: ResourceMutationKind,
+    },
+    /// Create or delete a workspace source.
+    WorkspaceSource {
+        /// Workspace whose installed source catalog will change.
+        workspace_id: &'a str,
+        /// Workspace source operation being authorized.
+        kind: WorkspaceSourceMutationKind,
+    },
 }
 
 /// Product-provided authorization policy for management-plane mutations.
 ///
 /// OSS Coral installs [`AllowAllManagementAuthorizer`] by default to preserve
-/// local single-user behavior. Product runtimes can replace it to gate source
-/// and identity-spec mutations while reusing the shared gRPC service surface.
+/// local single-user behavior. Product runtimes can replace it to gate the
+/// management mutations exposed through the shared gRPC service surface.
 #[tonic::async_trait]
 pub trait ManagementAuthorizer: fmt::Debug + Send + Sync + 'static {
-    /// Authorizes creating or deleting global identity specs.
+    /// Authorizes one management-plane mutation.
     ///
     /// # Errors
     ///
     /// Returns [`AuthorizationError`] when the principal is not allowed to
-    /// mutate identity specs.
-    async fn authorize_identity_spec_mutation(
+    /// perform the mutation.
+    async fn authorize_management_mutation(
         &self,
         principal: &UserPrincipal,
-    ) -> Result<(), AuthorizationError>;
-
-    /// Authorizes creating, importing, or deleting a workspace source through
-    /// the shared OSS source mutation APIs.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AuthorizationError`] when the principal is not allowed to
-    /// mutate sources in the workspace.
-    async fn authorize_source_mutation(
-        &self,
-        principal: &UserPrincipal,
-        workspace_id: &str,
-        kind: SourceMutationKind,
+        mutation: ManagementMutation<'_>,
     ) -> Result<(), AuthorizationError>;
 }
 
@@ -81,18 +103,10 @@ pub struct AllowAllManagementAuthorizer;
 
 #[tonic::async_trait]
 impl ManagementAuthorizer for AllowAllManagementAuthorizer {
-    async fn authorize_identity_spec_mutation(
+    async fn authorize_management_mutation(
         &self,
         _principal: &UserPrincipal,
-    ) -> Result<(), AuthorizationError> {
-        Ok(())
-    }
-
-    async fn authorize_source_mutation(
-        &self,
-        _principal: &UserPrincipal,
-        _workspace_id: &str,
-        _kind: SourceMutationKind,
+        _mutation: ManagementMutation<'_>,
     ) -> Result<(), AuthorizationError> {
         Ok(())
     }

--- a/crates/coral-app/src/authorization.rs
+++ b/crates/coral-app/src/authorization.rs
@@ -1,0 +1,99 @@
+//! Product authorization seam for management-plane mutations.
+
+use std::fmt;
+
+use crate::identity::UserPrincipal;
+
+/// Error returned when a product runtime rejects a management-plane mutation.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthorizationError {
+    /// The authenticated principal is not allowed to perform the operation.
+    #[error("{0}")]
+    Forbidden(String),
+    /// Authorization failed unexpectedly.
+    #[error("{0}")]
+    Internal(String),
+}
+
+impl AuthorizationError {
+    /// Builds a permission-denied authorization error.
+    #[must_use]
+    pub fn forbidden(message: impl Into<String>) -> Self {
+        Self::Forbidden(message.into())
+    }
+
+    /// Builds an internal authorization error.
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+/// Source mutation operation being authorized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceMutationKind {
+    /// Install a source from Coral's bundled source catalog.
+    CreateBundled,
+    /// Install a bundled source while retrieving OAuth credentials.
+    CreateBundledWithOAuth,
+    /// Import a source spec.
+    Import,
+    /// Remove an installed source from a workspace.
+    Delete,
+}
+
+/// Product-provided authorization policy for management-plane mutations.
+///
+/// OSS Coral installs [`AllowAllManagementAuthorizer`] by default to preserve
+/// local single-user behavior. Product runtimes can replace it to gate source
+/// and identity-spec mutations while reusing the shared gRPC service surface.
+#[tonic::async_trait]
+pub trait ManagementAuthorizer: fmt::Debug + Send + Sync + 'static {
+    /// Authorizes creating or deleting global identity specs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthorizationError`] when the principal is not allowed to
+    /// mutate identity specs.
+    async fn authorize_identity_spec_mutation(
+        &self,
+        principal: &UserPrincipal,
+    ) -> Result<(), AuthorizationError>;
+
+    /// Authorizes creating, importing, or deleting a workspace source through
+    /// the shared OSS source mutation APIs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthorizationError`] when the principal is not allowed to
+    /// mutate sources in the workspace.
+    async fn authorize_source_mutation(
+        &self,
+        principal: &UserPrincipal,
+        workspace_id: &str,
+        kind: SourceMutationKind,
+    ) -> Result<(), AuthorizationError>;
+}
+
+/// Default OSS authorizer for local single-user usage.
+#[derive(Debug, Default)]
+pub struct AllowAllManagementAuthorizer;
+
+#[tonic::async_trait]
+impl ManagementAuthorizer for AllowAllManagementAuthorizer {
+    async fn authorize_identity_spec_mutation(
+        &self,
+        _principal: &UserPrincipal,
+    ) -> Result<(), AuthorizationError> {
+        Ok(())
+    }
+
+    async fn authorize_source_mutation(
+        &self,
+        _principal: &UserPrincipal,
+        _workspace_id: &str,
+        _kind: SourceMutationKind,
+    ) -> Result<(), AuthorizationError> {
+        Ok(())
+    }
+}

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
 
-use coral_engine::{RequestIdentityResolutionContext, RequestIdentityResolverError};
+use coral_engine::{RequestIdentityHttpAuthenticatorError, SelectedRequestIdentity};
 use coral_spec::v4::IdentityRequirements;
 use reqwest::header::{HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
@@ -26,16 +26,6 @@ pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppE
         return Err(AppError::InvalidInput(format!(
             "{kind} name must not be '.' or '..'"
         )));
-    }
-    Ok(trimmed.to_string())
-}
-
-fn parse_accepted_identity_id(value: &str) -> Result<String, AppError> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(AppError::InvalidInput(
-            "missing accepted identity id".to_string(),
-        ));
     }
     Ok(trimmed.to_string())
 }
@@ -141,41 +131,6 @@ impl SourceIdentityOwner {
     }
 }
 
-/// Subject used to select provider-facing source identity material.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SourceIdentitySubject {
-    /// Identity material is owned by the request user principal.
-    User(String),
-    /// Identity material is owned by the workspace, not a user principal.
-    Workspace,
-}
-
-impl SourceIdentitySubject {
-    /// Selects the runtime subject for a configured source identity owner.
-    #[must_use]
-    pub fn for_binding_owner(owner: SourceIdentityOwner, user_principal: &UserPrincipal) -> Self {
-        match owner {
-            SourceIdentityOwner::User => Self::User(user_principal.user_id().to_string()),
-            SourceIdentityOwner::Workspace => Self::Workspace,
-        }
-    }
-
-    /// Returns the selected user id for user-owned identity material.
-    #[must_use]
-    pub fn user_id(&self) -> Option<&str> {
-        match self {
-            Self::User(user_id) => Some(user_id),
-            Self::Workspace => None,
-        }
-    }
-
-    /// Returns whether identity material is workspace-owned.
-    #[must_use]
-    pub const fn is_workspace(&self) -> bool {
-        matches!(self, Self::Workspace)
-    }
-}
-
 /// Workspace config binding from one source-local surface to an identity slot.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceIdentityBinding {
@@ -188,13 +143,6 @@ pub struct SourceIdentityBinding {
     /// identity selection is per Coral user principal.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity: Option<String>,
-    /// Workspace-owned accepted identity id from the surface's
-    /// `identity_requirements`.
-    ///
-    /// User-owned bindings intentionally leave this empty because the concrete
-    /// accepted branch is per Coral user principal.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub accepted_identity: Option<String>,
 }
 
 impl SourceIdentityBinding {
@@ -204,7 +152,6 @@ impl SourceIdentityBinding {
         Self {
             owner: SourceIdentityOwner::User,
             identity: None,
-            accepted_identity: None,
         }
     }
 
@@ -213,19 +160,12 @@ impl SourceIdentityBinding {
     /// # Errors
     ///
     /// Returns [`AppError`] if the identity reference is empty or contains a
-    /// path separator, or if the accepted identity id is empty.
-    pub fn workspace_owned(
-        identity: impl Into<String>,
-        accepted_identity: Option<String>,
-    ) -> Result<Self, AppError> {
+    /// path separator.
+    pub fn workspace_owned(identity: impl Into<String>) -> Result<Self, AppError> {
         let identity = parse_path_segment("identity", &identity.into())?;
-        let accepted_identity = accepted_identity
-            .map(|accepted_identity| parse_accepted_identity_id(&accepted_identity))
-            .transpose()?;
         Ok(Self {
             owner: SourceIdentityOwner::Workspace,
             identity: Some(identity),
-            accepted_identity,
         })
     }
 
@@ -234,13 +174,13 @@ impl SourceIdentityBinding {
     /// # Errors
     ///
     /// Returns [`AppError`] if the identity reference is empty or contains a
-    /// path separator, or if the accepted identity id is empty.
+    /// path separator.
     pub fn validate(&self) -> Result<(), AppError> {
         match self.owner {
             SourceIdentityOwner::User => {
-                if self.identity.is_some() || self.accepted_identity.is_some() {
+                if self.identity.is_some() {
                     return Err(AppError::InvalidInput(
-                        "user-owned source identity bindings store only owner; identity and accepted_identity are selected per user".to_string(),
+                        "user-owned source identity bindings store only owner; identity is selected per user".to_string(),
                     ));
                 }
             }
@@ -251,9 +191,6 @@ impl SourceIdentityBinding {
                     ));
                 };
                 parse_path_segment("identity", identity)?;
-                if let Some(accepted_identity) = &self.accepted_identity {
-                    parse_accepted_identity_id(accepted_identity)?;
-                }
             }
         }
         Ok(())
@@ -265,9 +202,6 @@ impl SourceIdentityBinding {
 pub struct SourceIdentitySelection {
     /// Stable identity reference understood by installed identity providers.
     pub identity: String,
-    /// Optional accepted identity id from the surface's `identity_requirements`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub accepted_identity: Option<String>,
 }
 
 impl SourceIdentitySelection {
@@ -276,19 +210,10 @@ impl SourceIdentitySelection {
     /// # Errors
     ///
     /// Returns [`AppError`] if the identity reference is empty or contains a
-    /// path separator, or if the accepted identity id is empty.
-    pub fn new(
-        identity: impl Into<String>,
-        accepted_identity: Option<String>,
-    ) -> Result<Self, AppError> {
+    /// path separator.
+    pub fn new(identity: impl Into<String>) -> Result<Self, AppError> {
         let identity = parse_path_segment("identity", &identity.into())?;
-        let accepted_identity = accepted_identity
-            .map(|accepted_identity| parse_accepted_identity_id(&accepted_identity))
-            .transpose()?;
-        Ok(Self {
-            identity,
-            accepted_identity,
-        })
+        Ok(Self { identity })
     }
 
     /// Validates a selection loaded from storage.
@@ -296,13 +221,9 @@ impl SourceIdentitySelection {
     /// # Errors
     ///
     /// Returns [`AppError`] if the identity reference is empty or contains a
-    /// path separator, or if the accepted identity id is empty.
+    /// path separator.
     pub fn validate(&self) -> Result<(), AppError> {
-        parse_path_segment("identity", &self.identity)?;
-        if let Some(accepted_identity) = &self.accepted_identity {
-            parse_accepted_identity_id(accepted_identity)?;
-        }
-        Ok(())
+        parse_path_segment("identity", &self.identity).map(|_| ())
     }
 }
 
@@ -311,9 +232,8 @@ impl SourceIdentitySelection {
 pub struct SourceIdentitySelectionRequest {
     /// Workspace selected by the request.
     pub workspace_name: String,
-    /// Subject selected by Coral for this binding; user-owned bindings carry
-    /// the request user id (`subject.user_id()`).
-    pub subject: SourceIdentitySubject,
+    /// Request user id whose user-owned source identity selection is needed.
+    pub user_id: String,
     /// Source/schema name whose surface needs identity material.
     pub source_name: String,
     /// DSL v4 surface id.
@@ -327,12 +247,12 @@ pub struct SourceIdentitySelectionRequest {
 pub struct SourceIdentityResolutionRequest {
     /// Workspace selected by the request.
     pub workspace_name: String,
-    /// Subject selected by Coral for this binding.
+    /// Request user id selected by Coral for user-owned bindings.
     ///
-    /// User-owned bindings carry the request user id. Workspace-owned bindings
-    /// intentionally carry no request user id, so providers cannot accidentally
-    /// select user-scoped material for a workspace identity.
-    pub subject: SourceIdentitySubject,
+    /// Workspace-owned bindings intentionally carry no request user id, so
+    /// providers cannot accidentally select user-scoped material for a workspace
+    /// identity.
+    pub user_id: Option<String>,
     /// Source/schema name whose surface needs identity material.
     pub source_name: String,
     /// DSL v4 surface id.
@@ -394,21 +314,21 @@ pub trait RuntimeSourceIdentity: Send + Sync + fmt::Debug {
     ///
     /// # Errors
     ///
-    /// Returns [`RequestIdentityResolverError`] when request-scoped input is
-    /// invalid or identity material cannot satisfy the request.
+    /// Returns [`RequestIdentityHttpAuthenticatorError`] when request-scoped
+    /// input is invalid or identity material cannot satisfy the request.
     async fn resolve_headers(
         &self,
-        identity: &RequestIdentityResolutionContext,
+        identity: &SelectedRequestIdentity,
         request: &reqwest::Request,
         resolved_inputs: &BTreeMap<String, String>,
-    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError>;
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError>;
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        LOCAL_MEMBER_ID, SourceIdentityBinding, SourceIdentityOwner, SourceIdentitySelection,
-        SourceIdentitySubject, UserPrincipal, parse_path_segment,
+        LOCAL_MEMBER_ID, SourceIdentityBinding, SourceIdentitySelection, UserPrincipal,
+        parse_path_segment,
     };
 
     #[test]
@@ -470,55 +390,20 @@ mod tests {
     }
 
     #[test]
-    fn source_identity_subject_carries_user_only_for_user_owned_bindings() {
-        let user_principal = UserPrincipal::for_user("saul").expect("named user");
-
-        assert_eq!(
-            SourceIdentitySubject::for_binding_owner(SourceIdentityOwner::User, &user_principal),
-            SourceIdentitySubject::User("saul".to_string())
-        );
-        assert_eq!(
-            SourceIdentitySubject::for_binding_owner(
-                SourceIdentityOwner::Workspace,
-                &user_principal,
-            ),
-            SourceIdentitySubject::Workspace
-        );
-    }
-
-    #[test]
-    fn source_identity_binding_allows_manifest_accepted_identity_ids() {
-        let binding =
-            SourceIdentityBinding::workspace_owned("github-workspace", Some("oauth/github".into()))
-                .expect("manifest accepted identity ids are not path segments");
+    fn source_identity_binding_accepts_workspace_identity_reference() {
+        let binding = SourceIdentityBinding::workspace_owned("github-workspace")
+            .expect("workspace identity reference should validate");
 
         assert_eq!(binding.identity.as_deref(), Some("github-workspace"));
-        assert_eq!(binding.accepted_identity.as_deref(), Some("oauth/github"));
-        binding
-            .validate()
-            .expect("accepted identity id should validate");
+        binding.validate().expect("binding should validate");
     }
 
     #[test]
-    fn source_identity_selection_allows_manifest_accepted_identity_ids() {
-        let selection = SourceIdentitySelection::new("github-user", Some("oauth/github".into()))
-            .expect("manifest accepted identity ids are not path segments");
+    fn source_identity_selection_accepts_identity_reference() {
+        let selection = SourceIdentitySelection::new("github-user")
+            .expect("identity reference should validate");
 
         assert_eq!(selection.identity, "github-user");
-        assert_eq!(selection.accepted_identity.as_deref(), Some("oauth/github"));
-        selection
-            .validate()
-            .expect("accepted identity id should validate");
-    }
-
-    #[test]
-    fn source_identity_binding_rejects_empty_accepted_identity_ids() {
-        let error = SourceIdentityBinding::workspace_owned("github-workspace", Some("   ".into()))
-            .expect_err("accepted identity id should be non-empty");
-
-        assert!(
-            error.to_string().contains("missing accepted identity id"),
-            "unexpected error: {error}"
-        );
+        selection.validate().expect("selection should validate");
     }
 }

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -1,6 +1,44 @@
-//! Shared validation helpers for app-owned identifiers.
+//! App-owned identity context, binding, and runtime identity helpers.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use coral_engine::{RequestIdentityResolutionContext, RequestIdentityResolverError};
+use coral_spec::v4::IdentityRequirements;
+use reqwest::header::{HeaderName, HeaderValue};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::bootstrap::AppError;
+
+pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::InvalidInput(format!("missing {kind} name")));
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(AppError::InvalidInput(format!(
+            "{kind} name must not contain '/' or '\\\\'"
+        )));
+    }
+    if trimmed == "." || trimmed == ".." {
+        return Err(AppError::InvalidInput(format!(
+            "{kind} name must not be '.' or '..'"
+        )));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn parse_accepted_identity_id(value: &str) -> Result<String, AppError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::InvalidInput(
+            "missing accepted identity id".to_string(),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
 
 /// Stable local user used by single-user local mode.
 pub(crate) const LOCAL_MEMBER_ID: &str = "local";
@@ -82,27 +120,296 @@ impl UserPrincipalProvider for SingleUserPrincipalProvider {
     }
 }
 
-pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppError> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(AppError::InvalidInput(format!("missing {kind} name")));
+/// Scope that owns configured provider-facing source identity material.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceIdentityOwner {
+    /// Identity material is owned by the current Coral user principal.
+    User,
+    /// Identity material is owned by the workspace and independent of a user principal.
+    Workspace,
+}
+
+impl SourceIdentityOwner {
+    /// Returns the stable config representation for this owner.
+    #[must_use]
+    pub const fn as_config_value(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Workspace => "workspace",
+        }
     }
-    if trimmed.contains('/') || trimmed.contains('\\') {
-        return Err(AppError::InvalidInput(format!(
-            "{kind} name must not contain '/' or '\\\\'"
-        )));
+}
+
+/// Subject used to select provider-facing source identity material.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceIdentitySubject {
+    /// Identity material is owned by the request user principal.
+    User(String),
+    /// Identity material is owned by the workspace, not a user principal.
+    Workspace,
+}
+
+impl SourceIdentitySubject {
+    /// Selects the runtime subject for a configured source identity owner.
+    #[must_use]
+    pub fn for_binding_owner(owner: SourceIdentityOwner, user_principal: &UserPrincipal) -> Self {
+        match owner {
+            SourceIdentityOwner::User => Self::User(user_principal.user_id().to_string()),
+            SourceIdentityOwner::Workspace => Self::Workspace,
+        }
     }
-    if trimmed == "." || trimmed == ".." {
-        return Err(AppError::InvalidInput(format!(
-            "{kind} name must not be '.' or '..'"
-        )));
+
+    /// Returns the selected user id for user-owned identity material.
+    #[must_use]
+    pub fn user_id(&self) -> Option<&str> {
+        match self {
+            Self::User(user_id) => Some(user_id),
+            Self::Workspace => None,
+        }
     }
-    Ok(trimmed.to_string())
+
+    /// Returns whether identity material is workspace-owned.
+    #[must_use]
+    pub const fn is_workspace(&self) -> bool {
+        matches!(self, Self::Workspace)
+    }
+}
+
+/// Workspace config binding from one source-local surface to an identity slot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceIdentityBinding {
+    /// Whether the identity is user-specific or workspace-owned.
+    pub owner: SourceIdentityOwner,
+    /// Workspace-owned identity reference understood by installed identity
+    /// providers.
+    ///
+    /// User-owned bindings intentionally leave this empty because the concrete
+    /// identity selection is per Coral user principal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<String>,
+    /// Workspace-owned accepted identity id from the surface's
+    /// `identity_requirements`.
+    ///
+    /// User-owned bindings intentionally leave this empty because the concrete
+    /// accepted branch is per Coral user principal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_identity: Option<String>,
+}
+
+impl SourceIdentityBinding {
+    /// Builds one validated user-owned source identity slot.
+    #[must_use]
+    pub const fn user_owned() -> Self {
+        Self {
+            owner: SourceIdentityOwner::User,
+            identity: None,
+            accepted_identity: None,
+        }
+    }
+
+    /// Builds one validated workspace-owned source identity binding.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the identity reference is empty or contains a
+    /// path separator, or if the accepted identity id is empty.
+    pub fn workspace_owned(
+        identity: impl Into<String>,
+        accepted_identity: Option<String>,
+    ) -> Result<Self, AppError> {
+        let identity = parse_path_segment("identity", &identity.into())?;
+        let accepted_identity = accepted_identity
+            .map(|accepted_identity| parse_accepted_identity_id(&accepted_identity))
+            .transpose()?;
+        Ok(Self {
+            owner: SourceIdentityOwner::Workspace,
+            identity: Some(identity),
+            accepted_identity,
+        })
+    }
+
+    /// Validates a binding loaded from config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the identity reference is empty or contains a
+    /// path separator, or if the accepted identity id is empty.
+    pub fn validate(&self) -> Result<(), AppError> {
+        match self.owner {
+            SourceIdentityOwner::User => {
+                if self.identity.is_some() || self.accepted_identity.is_some() {
+                    return Err(AppError::InvalidInput(
+                        "user-owned source identity bindings store only owner; identity and accepted_identity are selected per user".to_string(),
+                    ));
+                }
+            }
+            SourceIdentityOwner::Workspace => {
+                let Some(identity) = &self.identity else {
+                    return Err(AppError::InvalidInput(
+                        "workspace-owned source identity binding is missing identity".to_string(),
+                    ));
+                };
+                parse_path_segment("identity", identity)?;
+                if let Some(accepted_identity) = &self.accepted_identity {
+                    parse_accepted_identity_id(accepted_identity)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Concrete identity selected for one source-local surface.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceIdentitySelection {
+    /// Stable identity reference understood by installed identity providers.
+    pub identity: String,
+    /// Optional accepted identity id from the surface's `identity_requirements`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_identity: Option<String>,
+}
+
+impl SourceIdentitySelection {
+    /// Builds one validated source identity selection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the identity reference is empty or contains a
+    /// path separator, or if the accepted identity id is empty.
+    pub fn new(
+        identity: impl Into<String>,
+        accepted_identity: Option<String>,
+    ) -> Result<Self, AppError> {
+        let identity = parse_path_segment("identity", &identity.into())?;
+        let accepted_identity = accepted_identity
+            .map(|accepted_identity| parse_accepted_identity_id(&accepted_identity))
+            .transpose()?;
+        Ok(Self {
+            identity,
+            accepted_identity,
+        })
+    }
+
+    /// Validates a selection loaded from storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the identity reference is empty or contains a
+    /// path separator, or if the accepted identity id is empty.
+    pub fn validate(&self) -> Result<(), AppError> {
+        parse_path_segment("identity", &self.identity)?;
+        if let Some(accepted_identity) = &self.accepted_identity {
+            parse_accepted_identity_id(accepted_identity)?;
+        }
+        Ok(())
+    }
+}
+
+/// Request to resolve a user-specific source identity selection.
+#[derive(Debug, Clone)]
+pub struct SourceIdentitySelectionRequest {
+    /// Workspace selected by the request.
+    pub workspace_name: String,
+    /// Subject selected by Coral for this binding; user-owned bindings carry
+    /// the request user id (`subject.user_id()`).
+    pub subject: SourceIdentitySubject,
+    /// Source/schema name whose surface needs identity material.
+    pub source_name: String,
+    /// DSL v4 surface id.
+    pub surface_id: String,
+    /// Workspace source-surface identity binding.
+    pub binding: SourceIdentityBinding,
+}
+
+/// Request to resolve one configured source identity binding into runtime material.
+#[derive(Debug, Clone)]
+pub struct SourceIdentityResolutionRequest {
+    /// Workspace selected by the request.
+    pub workspace_name: String,
+    /// Subject selected by Coral for this binding.
+    ///
+    /// User-owned bindings carry the request user id. Workspace-owned bindings
+    /// intentionally carry no request user id, so providers cannot accidentally
+    /// select user-scoped material for a workspace identity.
+    pub subject: SourceIdentitySubject,
+    /// Source/schema name whose surface needs identity material.
+    pub source_name: String,
+    /// DSL v4 surface id.
+    pub surface_id: String,
+    /// Configured source-surface identity binding.
+    pub binding: SourceIdentityBinding,
+    /// Concrete source-surface identity selection.
+    pub selection: SourceIdentitySelection,
+    /// The workspace binding's selected identity requirements.
+    pub identity_requirements: IdentityRequirements,
+}
+
+/// Provider that resolves configured Coral identity bindings into runtime material.
+#[tonic::async_trait]
+pub trait SourceIdentityProvider: Send + Sync + fmt::Debug {
+    /// Resolves one user-owned source identity selection.
+    ///
+    /// Providers return `Ok(None)` when they do not own the requested
+    /// selection scope. Workspace-owned bindings are resolved directly from the
+    /// workspace binding and do not call providers for selection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the provider owns the requested selection but
+    /// cannot load or validate the selected identity.
+    async fn resolve_source_identity_selection(
+        &self,
+        _request: &SourceIdentitySelectionRequest,
+    ) -> Result<Option<SourceIdentitySelection>, AppError> {
+        Ok(None)
+    }
+
+    /// Resolves one source identity binding.
+    ///
+    /// Providers return `Ok(None)` when they do not own the requested identity
+    /// reference. Coral tries providers in registration order and fails if none
+    /// can resolve a required binding.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the provider owns the requested identity but
+    /// cannot load, validate, or materialize it.
+    async fn resolve_source_identity(
+        &self,
+        request: &SourceIdentityResolutionRequest,
+    ) -> Result<Option<Arc<dyn RuntimeSourceIdentity>>, AppError>;
+}
+
+/// Runtime identity selected by Coral for one source surface.
+#[tonic::async_trait]
+pub trait RuntimeSourceIdentity: Send + Sync + fmt::Debug {
+    /// Installed identity spec id that describes this identity.
+    fn identity_spec_id(&self) -> &str;
+
+    /// Candidate audience claims for requirement matching.
+    fn audience(&self) -> &BTreeMap<String, Value>;
+
+    /// Returns headers to append to the outbound HTTP request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RequestIdentityResolverError`] when request-scoped input is
+    /// invalid or identity material cannot satisfy the request.
+    async fn resolve_headers(
+        &self,
+        identity: &RequestIdentityResolutionContext,
+        request: &reqwest::Request,
+        resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityResolverError>;
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{UserPrincipal, parse_path_segment};
+    use super::{
+        LOCAL_MEMBER_ID, SourceIdentityBinding, SourceIdentityOwner, SourceIdentitySelection,
+        SourceIdentitySubject, UserPrincipal, parse_path_segment,
+    };
 
     #[test]
     fn rejects_empty_names() {
@@ -146,5 +453,72 @@ mod tests {
         let principal = UserPrincipal::for_user("saul").expect("valid user");
 
         assert_eq!(principal.user_id(), "saul");
+    }
+
+    #[test]
+    fn user_principal_rejects_reserved_local_sentinel() {
+        let principal = UserPrincipal::for_user("saul").expect("named user");
+        assert_eq!(principal.user_id(), "saul");
+
+        let error = UserPrincipal::for_user(LOCAL_MEMBER_ID).expect_err("local id is reserved");
+        assert!(
+            error
+                .to_string()
+                .contains("reserved for single-user local mode"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn source_identity_subject_carries_user_only_for_user_owned_bindings() {
+        let user_principal = UserPrincipal::for_user("saul").expect("named user");
+
+        assert_eq!(
+            SourceIdentitySubject::for_binding_owner(SourceIdentityOwner::User, &user_principal),
+            SourceIdentitySubject::User("saul".to_string())
+        );
+        assert_eq!(
+            SourceIdentitySubject::for_binding_owner(
+                SourceIdentityOwner::Workspace,
+                &user_principal,
+            ),
+            SourceIdentitySubject::Workspace
+        );
+    }
+
+    #[test]
+    fn source_identity_binding_allows_manifest_accepted_identity_ids() {
+        let binding =
+            SourceIdentityBinding::workspace_owned("github-workspace", Some("oauth/github".into()))
+                .expect("manifest accepted identity ids are not path segments");
+
+        assert_eq!(binding.identity.as_deref(), Some("github-workspace"));
+        assert_eq!(binding.accepted_identity.as_deref(), Some("oauth/github"));
+        binding
+            .validate()
+            .expect("accepted identity id should validate");
+    }
+
+    #[test]
+    fn source_identity_selection_allows_manifest_accepted_identity_ids() {
+        let selection = SourceIdentitySelection::new("github-user", Some("oauth/github".into()))
+            .expect("manifest accepted identity ids are not path segments");
+
+        assert_eq!(selection.identity, "github-user");
+        assert_eq!(selection.accepted_identity.as_deref(), Some("oauth/github"));
+        selection
+            .validate()
+            .expect("accepted identity id should validate");
+    }
+
+    #[test]
+    fn source_identity_binding_rejects_empty_accepted_identity_ids() {
+        let error = SourceIdentityBinding::workspace_owned("github-workspace", Some("   ".into()))
+            .expect_err("accepted identity id should be non-empty");
+
+        assert!(
+            error.to_string().contains("missing accepted identity id"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -41,6 +41,7 @@
     )
 )]
 
+mod authorization;
 /// Bootstrap entrypoints and local server assembly.
 pub mod bootstrap;
 mod catalog;
@@ -59,15 +60,25 @@ pub mod telemetry;
 mod transport;
 mod workspaces;
 
+pub use authorization::{
+    AllowAllManagementAuthorizer, AuthorizationError, ManagementAuthorizer, SourceMutationKind,
+};
 pub use bootstrap::{
     AppError, RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider,
 };
-pub use coral_engine::{EngineExtensions, QuerySource};
+pub use coral_engine::{
+    EngineExtensions, QuerySource, RequestIdentityResolutionContext, RequestIdentityResolver,
+    RequestIdentityResolverError,
+};
 pub use identities::{
     IdentityOwnerKey, UserOwnedIdentityMaterialGuard, UserOwnedIdentityName,
     UserOwnedIdentityRecord, UserOwnedIdentityStore,
 };
-pub use identity::{SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider};
+pub use identity::{
+    RuntimeSourceIdentity, SingleUserPrincipalProvider, SourceIdentityBinding, SourceIdentityOwner,
+    SourceIdentityProvider, SourceIdentityResolutionRequest, SourceIdentitySelection,
+    SourceIdentitySelectionRequest, SourceIdentitySubject, UserPrincipal, UserPrincipalProvider,
+};
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -61,14 +61,17 @@ mod transport;
 mod workspaces;
 
 pub use authorization::{
-    AllowAllManagementAuthorizer, AuthorizationError, ManagementAuthorizer, SourceMutationKind,
+    AllowAllManagementAuthorizer, AuthorizationError, ManagementAuthorizer, ManagementMutation,
+    ResourceMutationKind, WorkspaceSourceMutationKind,
 };
 pub use bootstrap::{
     AppError, RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider,
 };
 pub use coral_engine::{
-    EngineExtensions, QuerySource, RequestIdentityResolutionContext, RequestIdentityResolver,
-    RequestIdentityResolverError,
+    EngineExtensions, QuerySource, RequestIdentityHttpAuthenticator,
+    RequestIdentityHttpAuthenticatorError, RequestIdentityHttpAuthenticatorFactory,
+    RequestIdentitySelectionContext, RequestIdentitySelectionError, RequestIdentitySelector,
+    SelectedRequestIdentity,
 };
 pub use identities::{
     IdentityOwnerKey, UserOwnedIdentityMaterialGuard, UserOwnedIdentityName,
@@ -77,7 +80,7 @@ pub use identities::{
 pub use identity::{
     RuntimeSourceIdentity, SingleUserPrincipalProvider, SourceIdentityBinding, SourceIdentityOwner,
     SourceIdentityProvider, SourceIdentityResolutionRequest, SourceIdentitySelection,
-    SourceIdentitySelectionRequest, SourceIdentitySubject, UserPrincipal, UserPrincipalProvider,
+    SourceIdentitySelectionRequest, UserPrincipal, UserPrincipalProvider,
 };
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,


### PR DESCRIPTION
## Intent

Land `feat(app): add identity authorization seams` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-03-engine-runtime...sauldhernandez/dsl-v4-identity-v2-04-app-seams
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
