### PR TITLE
feat(app): add identity spec management

### DIFF
--- a/crates/coral-app/src/authorization.rs
+++ b/crates/coral-app/src/authorization.rs
@@ -10,6 +10,9 @@ pub enum AuthorizationError {
     /// The authenticated principal is not allowed to perform the operation.
     #[error("{0}")]
     Forbidden(String),
+    /// The product authorization policy failed before it could make a decision.
+    #[error("{0}")]
+    Internal(String),
 }
 
 impl AuthorizationError {
@@ -17,6 +20,12 @@ impl AuthorizationError {
     #[must_use]
     pub fn forbidden(message: impl Into<String>) -> Self {
         Self::Forbidden(message.into())
+    }
+
+    /// Builds an internal authorization error.
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
     }
 }
 
@@ -114,7 +123,43 @@ impl ManagementAuthorizer for AllowAllManagementAuthorizer {
 
 pub(crate) fn authorization_status(error: AuthorizationError) -> tonic::Status {
     match error {
-        AuthorizationError::Forbidden(message) => tonic::Status::permission_denied(message),
-        AuthorizationError::Internal(message) => tonic::Status::internal(message),
+        AuthorizationError::Forbidden(message) => {
+            tonic::Status::permission_denied(bounded_status_message(message))
+        }
+        AuthorizationError::Internal(message) => {
+            tonic::Status::internal(bounded_status_message(message))
+        }
+    }
+}
+
+const MAX_AUTHORIZATION_STATUS_MESSAGE_BYTES: usize = 512;
+
+fn bounded_status_message(mut message: String) -> String {
+    const SUFFIX: &str = "...";
+
+    if message.len() <= MAX_AUTHORIZATION_STATUS_MESSAGE_BYTES {
+        return message;
+    }
+
+    let mut end = MAX_AUTHORIZATION_STATUS_MESSAGE_BYTES - SUFFIX.len();
+    while !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    message.truncate(end);
+    message.push_str(SUFFIX);
+    message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AuthorizationError, MAX_AUTHORIZATION_STATUS_MESSAGE_BYTES, authorization_status};
+
+    #[test]
+    fn authorization_status_bounds_product_messages() {
+        let status = authorization_status(AuthorizationError::forbidden("ø".repeat(1024)));
+
+        assert_eq!(status.code(), tonic::Code::PermissionDenied);
+        assert!(status.message().len() <= MAX_AUTHORIZATION_STATUS_MESSAGE_BYTES);
+        assert!(status.message().ends_with("..."));
     }
 }

--- a/crates/coral-app/src/authorization.rs
+++ b/crates/coral-app/src/authorization.rs
@@ -111,3 +111,10 @@ impl ManagementAuthorizer for AllowAllManagementAuthorizer {
         Ok(())
     }
 }
+
+pub(crate) fn authorization_status(error: AuthorizationError) -> tonic::Status {
+    match error {
+        AuthorizationError::Forbidden(message) => tonic::Status::permission_denied(message),
+        AuthorizationError::Internal(message) => tonic::Status::internal(message),
+    }
+}

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -19,6 +19,12 @@ pub enum AppError {
     /// A requested source was not found in config.
     #[error("source '{0}' not found")]
     SourceNotFound(String),
+    /// A requested identity spec was not found in global app state.
+    #[error("identity spec '{0}' not found")]
+    IdentitySpecNotFound(String),
+    /// A requested stored identity was not found in app state.
+    #[error("identity '{0}' not found")]
+    IdentityNotFound(String),
     /// Caller-supplied input was invalid.
     #[error("invalid input: {0}")]
     InvalidInput(String),
@@ -35,6 +41,10 @@ pub enum AppError {
         /// Specific materialization mismatch or missing-artifact detail.
         detail: String,
     },
+    /// A known, installed source or related setup cannot be served until the
+    /// user takes an explicit action.
+    #[error("failed precondition: {0}")]
+    SourceUnservable(String),
     /// Provider-managed credential refresh failed during active source use.
     #[error("credential refresh failed: {0}")]
     CredentialRefresh(String),
@@ -198,10 +208,13 @@ fn grpc_code(status: StatusCode) -> Code {
 fn app_code(error: &AppError) -> Code {
     match error {
         AppError::Unauthenticated(_) => Code::Unauthenticated,
-        AppError::SourceNotFound(_) => Code::NotFound,
+        AppError::SourceNotFound(_)
+        | AppError::IdentitySpecNotFound(_)
+        | AppError::IdentityNotFound(_) => Code::NotFound,
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
         | AppError::MissingOrIncompatibleV4Materialization { .. }
+        | AppError::SourceUnservable(_)
         | AppError::CredentialRefresh(_)
         | AppError::MissingConfigDir
         | AppError::Credentials(CredentialsError::Parse(_) | CredentialsError::Unavailable(_)) => {

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1055,7 +1055,7 @@ issuer: github
 type: fixed_token
 "
                 .to_string(),
-                inputs: Vec::new(),
+                input_values: Vec::new(),
             }))
             .await
             .expect("process-local dsl_v4 override should enable identity spec API");

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -410,7 +410,7 @@ impl ServerBuilder {
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
-            features.clone(),
+            features,
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
@@ -422,13 +422,12 @@ impl ServerBuilder {
             .query_runtime_context()
             .with_body_capture_max_bytes(body_capture_max_bytes);
 
-        let query_manager = QueryManager::new_with_features(
+        let query_manager = QueryManager::new(
             config_store,
             credential_manager,
             query_runtime_context,
             layout,
             self.config.engine_extensions_providers,
-            features,
         );
         let trace_service = if telemetry_config.trace_history.enabled {
             installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -848,8 +848,8 @@ mod tests {
     use crate::workspaces::WorkspaceName;
     use crate::{
         AllowAllManagementAuthorizer, AppError, AuthorizationError, AwsEngineExtensionsProvider,
-        ManagementAuthorizer, NoopEngineExtensionsProvider, SingleUserPrincipalProvider,
-        SourceMutationKind, UserPrincipal, UserPrincipalProvider,
+        ManagementAuthorizer, ManagementMutation, NoopEngineExtensionsProvider,
+        SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider,
     };
 
     fn default_workspace() -> Workspace {
@@ -894,20 +894,15 @@ enabled = false
 
     #[tonic::async_trait]
     impl ManagementAuthorizer for DenyingSourceManagementAuthorizer {
-        async fn authorize_identity_spec_mutation(
+        async fn authorize_management_mutation(
             &self,
             _principal: &UserPrincipal,
+            mutation: ManagementMutation<'_>,
         ) -> Result<(), AuthorizationError> {
+            if matches!(mutation, ManagementMutation::WorkspaceSource { .. }) {
+                return Err(AuthorizationError::forbidden("source mutation denied"));
+            }
             Ok(())
-        }
-
-        async fn authorize_source_mutation(
-            &self,
-            _principal: &UserPrincipal,
-            _workspace_id: &str,
-            _kind: SourceMutationKind,
-        ) -> Result<(), AuthorizationError> {
-            Err(AuthorizationError::forbidden("source mutation denied"))
         }
     }
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -17,6 +17,7 @@ use axum::response::Response as AxumResponse;
 use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::episode_service_server::EpisodeServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
+use coral_api::v1::identity_spec_service_server::IdentitySpecServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
 use coral_api::v1::trace_service_server::TraceServiceServer;
@@ -38,17 +39,22 @@ use tower::{Layer, Service};
 use super::env::AppEnvironment;
 use super::error::AppError;
 use crate::EngineExtensionsProvider;
+use crate::authorization::{AllowAllManagementAuthorizer, ManagementAuthorizer};
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
 use crate::credentials::{CredentialManager, CredentialStore};
 use crate::episode::service::EpisodeService;
 use crate::episode::store::EpisodeStore;
+use crate::features::FeatureOverrides;
 use crate::feedback::manager::FeedbackManager;
 use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
 use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
+use crate::identity_specs::{
+    IdentitySpecManager, IdentitySpecRegistry, IdentitySpecService, IdentitySpecUsageProvider,
+};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
@@ -83,7 +89,11 @@ pub(crate) struct ServerConfig {
     config_dir: Option<PathBuf>,
     mode: ServerMode,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    identity_spec_registry: Option<Arc<dyn IdentitySpecRegistry>>,
+    identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+    feature_overrides: FeatureOverrides,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    management_authorizer: Arc<dyn ManagementAuthorizer>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
     enable_stderr_logs: bool,
 }
@@ -100,7 +110,11 @@ impl ServerConfig {
             config_dir: None,
             mode: ServerMode::NativeGrpc,
             engine_extensions_providers: Vec::new(),
+            identity_spec_registry: None,
+            identity_spec_usage_providers: Vec::new(),
+            feature_overrides: FeatureOverrides::default(),
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
+            management_authorizer: Arc::new(AllowAllManagementAuthorizer),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
             enable_stderr_logs: false,
         }
@@ -130,6 +144,35 @@ impl ServerConfig {
         user_principal_provider: Arc<dyn UserPrincipalProvider>,
     ) -> Self {
         self.user_principal_provider = user_principal_provider;
+        self
+    }
+
+    pub(crate) fn with_management_authorizer(
+        mut self,
+        management_authorizer: Arc<dyn ManagementAuthorizer>,
+    ) -> Self {
+        self.management_authorizer = management_authorizer;
+        self
+    }
+
+    pub(crate) fn with_identity_spec_registry(
+        mut self,
+        identity_spec_registry: Arc<dyn IdentitySpecRegistry>,
+    ) -> Self {
+        self.identity_spec_registry = Some(identity_spec_registry);
+        self
+    }
+
+    pub(crate) fn add_identity_spec_usage_provider(
+        mut self,
+        usage_provider: Arc<dyn IdentitySpecUsageProvider>,
+    ) -> Self {
+        self.identity_spec_usage_providers.push(usage_provider);
+        self
+    }
+
+    pub(crate) fn with_feature_overrides(mut self, feature_overrides: FeatureOverrides) -> Self {
+        self.feature_overrides = feature_overrides;
         self
     }
 
@@ -246,6 +289,59 @@ impl ServerBuilder {
     }
 
     #[must_use]
+    /// Sets the server-side management authorizer.
+    ///
+    /// The default authorizer allows every mutation, preserving local
+    /// single-user behavior.
+    pub fn with_management_authorizer(
+        mut self,
+        management_authorizer: Arc<dyn ManagementAuthorizer>,
+    ) -> Self {
+        self.config = self
+            .config
+            .with_management_authorizer(management_authorizer);
+        self
+    }
+
+    #[must_use]
+    /// Sets the durable global identity-spec registry.
+    ///
+    /// The default registry stores identity specs under the local Coral config
+    /// directory.
+    pub fn with_identity_spec_registry(
+        mut self,
+        identity_spec_registry: Arc<dyn IdentitySpecRegistry>,
+    ) -> Self {
+        self.config = self
+            .config
+            .with_identity_spec_registry(identity_spec_registry);
+        self
+    }
+
+    #[must_use]
+    /// Adds a provider that reports stored identity usage for identity specs.
+    ///
+    /// Providers are consulted before deleting an identity spec so deletion can
+    /// reject or report orphaned identities outside the default local store.
+    pub fn add_identity_spec_usage_provider(
+        mut self,
+        usage_provider: Arc<dyn IdentitySpecUsageProvider>,
+    ) -> Self {
+        self.config = self.config.add_identity_spec_usage_provider(usage_provider);
+        self
+    }
+
+    #[must_use]
+    /// Sets process-local runtime feature overrides.
+    ///
+    /// Overrides affect this server process only; they do not persist to
+    /// `config.toml`.
+    pub fn with_feature_overrides(mut self, feature_overrides: FeatureOverrides) -> Self {
+        self.config = self.config.with_feature_overrides(feature_overrides);
+        self
+    }
+
+    #[must_use]
     /// Enables or disables local stderr log rendering for this server.
     ///
     /// `MCP` stdio adapters can enable this for diagnostics while keeping
@@ -292,11 +388,29 @@ impl ServerBuilder {
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
-        let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
+        let credential_manager = CredentialManager::new(credential_store.clone());
+        let features = crate::features::FeatureStore::new(layout.clone())
+            .load_with_overrides(&self.config.feature_overrides)?;
+        let identity_spec_manager = if let Some(registry) = self.config.identity_spec_registry {
+            IdentitySpecManager::new_with_registry(
+                layout.clone(),
+                registry,
+                features.clone(),
+                self.config.identity_spec_usage_providers,
+            )
+        } else {
+            IdentitySpecManager::new_with_credential_store(
+                layout.clone(),
+                credential_store,
+                features.clone(),
+                self.config.identity_spec_usage_providers,
+            )
+        };
+        let source_manager = SourceManager::new_with_features(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            features.clone(),
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
@@ -308,12 +422,13 @@ impl ServerBuilder {
             .query_runtime_context()
             .with_body_capture_max_bytes(body_capture_max_bytes);
 
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::new_with_features(
             config_store,
             credential_manager,
             query_runtime_context,
             layout,
             self.config.engine_extensions_providers,
+            features,
         );
         let trace_service = if telemetry_config.trace_history.enabled {
             installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))
@@ -321,16 +436,31 @@ impl ServerBuilder {
             None
         };
         start_server(
-            source_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
-            trace_service,
-            self.config.user_principal_provider,
+            ServerServices {
+                source_manager,
+                query_manager,
+                feedback_manager,
+                episode_store,
+                trace_service,
+                user_principal_provider: self.config.user_principal_provider,
+                management_authorizer: self.config.management_authorizer,
+                identity_spec_manager,
+            },
             self.config.mode,
         )
         .await
     }
+}
+
+struct ServerServices {
+    source_manager: SourceManager,
+    query_manager: QueryManager,
+    feedback_manager: FeedbackManager,
+    episode_store: EpisodeStore,
+    trace_service: Option<TraceService>,
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    management_authorizer: Arc<dyn ManagementAuthorizer>,
+    identity_spec_manager: IdentitySpecManager,
 }
 
 /// Running Coral server.
@@ -404,21 +534,33 @@ impl Drop for RunningServer {
 }
 
 async fn start_server(
-    source_manager: SourceManager,
-    query_manager: QueryManager,
-    feedback_manager: FeedbackManager,
-    episode_store: EpisodeStore,
-    trace_service: Option<TraceService>,
-    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    services: ServerServices,
     mode: ServerMode,
 ) -> Result<RunningServer, AppError> {
-    let source_service = SourceService::new(source_manager, query_manager.clone());
+    let ServerServices {
+        source_manager,
+        query_manager,
+        feedback_manager,
+        episode_store,
+        trace_service,
+        user_principal_provider,
+        management_authorizer,
+        identity_spec_manager,
+    } = services;
+    let source_service = SourceService::new(
+        source_manager,
+        query_manager.clone(),
+        Arc::clone(&management_authorizer),
+    );
     let catalog_service = CatalogService::new(query_manager.clone());
     let query_service = QueryService::new(query_manager);
     let feedback_service = FeedbackService::new(feedback_manager);
+    let identity_spec_service =
+        IdentitySpecService::new(identity_spec_manager, management_authorizer);
     let episode_service = EpisodeService::new(episode_store);
     let mut routes = Routes::default()
         .add_service(SourceServiceServer::new(source_service))
+        .add_service(IdentitySpecServiceServer::new(identity_spec_service))
         .add_service(
             CatalogServiceServer::new(catalog_service)
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
@@ -674,12 +816,15 @@ mod tests {
     use std::time::Duration;
 
     use coral_api::v1::episode_service_client::EpisodeServiceClient;
+    use coral_api::v1::identity_spec_service_client::IdentitySpecServiceClient;
     use coral_api::v1::query_service_client::QueryServiceClient;
     use coral_api::v1::source_service_client::SourceServiceClient;
     use coral_api::v1::trace_service_client::TraceServiceClient;
     use coral_api::v1::{
-        ExecuteSqlRequest, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
-        ListTracesRequest, OpenEpisodeRequest, Workspace, import_source_response,
+        AddIdentitySpecRequest, CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
+        DeleteSourceRequest, ExecuteSqlRequest, ImportSourceRequest, ImportSourceResponse,
+        ListSourcesRequest, ListTracesRequest, OpenEpisodeRequest, Workspace,
+        import_source_response,
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
@@ -688,12 +833,14 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider,
-        is_grpc_web_content_type, is_native_grpc_content_type, start_server,
+        RunningServer, ServerBuilder, ServerMode, ServerServices, StaticAsset,
+        StaticAssetsProvider, is_grpc_web_content_type, is_native_grpc_content_type, start_server,
     };
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::episode::store::EpisodeStore;
+    use crate::features::{Feature, FeatureOverrides};
     use crate::feedback::manager::FeedbackManager;
+    use crate::identity_specs::IdentitySpecManager;
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
     use crate::state::{AppStateLayout, ConfigStore};
@@ -701,12 +848,17 @@ mod tests {
     use crate::transport::workspace_to_proto;
     use crate::workspaces::WorkspaceName;
     use crate::{
-        AppError, AwsEngineExtensionsProvider, NoopEngineExtensionsProvider,
-        SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider,
+        AllowAllManagementAuthorizer, AppError, AuthorizationError, AwsEngineExtensionsProvider,
+        ManagementAuthorizer, NoopEngineExtensionsProvider, SingleUserPrincipalProvider,
+        SourceMutationKind, UserPrincipal, UserPrincipalProvider,
     };
 
     fn default_workspace() -> Workspace {
         workspace_to_proto(&WorkspaceName::default())
+    }
+
+    fn test_identity_spec_manager(layout: &AppStateLayout) -> IdentitySpecManager {
+        IdentitySpecManager::new(layout.clone())
     }
 
     fn disable_internal_tracing(config_dir: &Path) {
@@ -735,6 +887,28 @@ enabled = false
             Err(AppError::Unauthenticated(
                 "rejected user principal".to_string(),
             ))
+        }
+    }
+
+    #[derive(Debug)]
+    struct DenyingSourceManagementAuthorizer;
+
+    #[tonic::async_trait]
+    impl ManagementAuthorizer for DenyingSourceManagementAuthorizer {
+        async fn authorize_identity_spec_mutation(
+            &self,
+            _principal: &UserPrincipal,
+        ) -> Result<(), AuthorizationError> {
+            Ok(())
+        }
+
+        async fn authorize_source_mutation(
+            &self,
+            _principal: &UserPrincipal,
+            _workspace_id: &str,
+            _kind: SourceMutationKind,
+        ) -> Result<(), AuthorizationError> {
+            Err(AuthorizationError::forbidden("source mutation denied"))
         }
     }
 
@@ -786,6 +960,106 @@ enabled = false
             .expect_err("query should require a request principal");
 
         assert_eq!(status.code(), Code::Unauthenticated);
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn source_mutations_require_management_authorization() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_management_authorizer(Arc::new(DenyingSourceManagementAuthorizer))
+            .start()
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut source_client = SourceServiceClient::new(channel);
+
+        let create_status = source_client
+            .create_bundled_source(Request::new(CreateBundledSourceRequest {
+                workspace: Some(default_workspace()),
+                name: "missing_bundle".to_string(),
+                variables: Vec::new(),
+                secrets: Vec::new(),
+            }))
+            .await
+            .expect_err("bundled source creation should be authorization-gated");
+        assert_eq!(create_status.code(), Code::PermissionDenied);
+
+        let create_oauth_status = source_client
+            .create_bundled_source_with_o_auth(Request::new(CreateBundledSourceWithOAuthRequest {
+                workspace: Some(default_workspace()),
+                name: "missing_bundle".to_string(),
+                variables: Vec::new(),
+                secrets: Vec::new(),
+                oauth_credential_retrievals: Vec::new(),
+            }))
+            .await
+            .expect_err("OAuth bundled source creation should be authorization-gated");
+        assert_eq!(create_oauth_status.code(), Code::PermissionDenied);
+
+        let import_status = source_client
+            .import_source(Request::new(ImportSourceRequest {
+                workspace: Some(default_workspace()),
+                manifest_yaml: "not a manifest".to_string(),
+                variables: Vec::new(),
+                secrets: Vec::new(),
+                oauth_credential_retrievals: Vec::new(),
+            }))
+            .await
+            .expect_err("source import should be authorization-gated");
+        assert_eq!(import_status.code(), Code::PermissionDenied);
+
+        let delete_status = source_client
+            .delete_source(Request::new(DeleteSourceRequest {
+                workspace: Some(default_workspace()),
+                name: "missing_source".to_string(),
+            }))
+            .await
+            .expect_err("source deletion should be authorization-gated");
+        assert_eq!(delete_status.code(), Code::PermissionDenied);
+
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn server_feature_overrides_enable_identity_spec_api() {
+        let temp = TempDir::new().expect("temp dir");
+        let mut feature_overrides = FeatureOverrides::default();
+        feature_overrides.set(Feature::DslV4, true);
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_feature_overrides(feature_overrides)
+            .start()
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut identity_spec_client = IdentitySpecServiceClient::new(channel);
+
+        identity_spec_client
+            .add_identity_spec(Request::new(AddIdentitySpecRequest {
+                manifest_yaml: r"
+kind: identity
+spec_version: 1
+name: github_oauth
+version: 0.1.0
+issuer: github
+type: fixed_token
+"
+                .to_string(),
+                inputs: Vec::new(),
+            }))
+            .await
+            .expect("process-local dsl_v4 override should enable identity spec API");
+
         server.shutdown().await.expect("shutdown");
     }
 
@@ -933,18 +1207,23 @@ enabled = false
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
+        let identity_spec_manager = test_identity_spec_manager(&layout);
         start_server(
-            source_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
-            Some(trace_service),
-            user_principal_provider,
+            ServerServices {
+                source_manager,
+                query_manager,
+                feedback_manager,
+                episode_store,
+                trace_service: Some(trace_service),
+                user_principal_provider,
+                management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+                identity_spec_manager,
+            },
             ServerMode::NativeGrpc,
         )
         .await
@@ -1353,16 +1632,21 @@ tables:
                 home_dir: Some(fake_home.clone()),
                 ..QueryRuntimeContext::default()
             },
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
+        let identity_spec_manager = test_identity_spec_manager(&layout);
         let running = start_server(
-            source_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
-            None,
-            Arc::new(SingleUserPrincipalProvider),
+            ServerServices {
+                source_manager,
+                query_manager,
+                feedback_manager,
+                episode_store,
+                trace_service: None,
+                user_principal_provider: Arc::new(SingleUserPrincipalProvider),
+                management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+                identity_spec_manager,
+            },
             ServerMode::NativeGrpc,
         )
         .await
@@ -1455,16 +1739,21 @@ tables:
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
+        let identity_spec_manager = test_identity_spec_manager(&layout);
         let running = start_server(
-            source_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
-            None,
-            Arc::new(SingleUserPrincipalProvider),
+            ServerServices {
+                source_manager,
+                query_manager,
+                feedback_manager,
+                episode_store,
+                trace_service: None,
+                user_principal_provider: Arc::new(SingleUserPrincipalProvider),
+                management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+                identity_spec_manager,
+            },
             ServerMode::NativeGrpc,
         )
         .await
@@ -1557,16 +1846,21 @@ tables:
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
+        let identity_spec_manager = test_identity_spec_manager(&layout);
         let running = start_server(
-            source_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
-            None,
-            Arc::new(SingleUserPrincipalProvider),
+            ServerServices {
+                source_manager,
+                query_manager,
+                feedback_manager,
+                episode_store,
+                trace_service: None,
+                user_principal_provider: Arc::new(SingleUserPrincipalProvider),
+                management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+                identity_spec_manager,
+            },
             ServerMode::NativeGrpc,
         )
         .await

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -16,6 +16,8 @@ use crate::workspaces::WorkspaceName;
 
 use self::oauth::{OAuthCredentialService, RefreshOAuthCredentialRequest};
 
+#[cfg(test)]
+pub(crate) use store::parse_env_file;
 pub(crate) use store::{CredentialStore, CredentialsError};
 
 /// Opaque credential material captured for best-effort rollback.
@@ -97,6 +99,12 @@ impl CredentialSetId {
         Self(format!("source.{}", source_name.as_str()))
     }
 
+    /// Build the identity-spec-backed credential-set id used for spec-owned
+    /// input material.
+    pub(crate) fn for_identity_spec(identity_spec_name: &str) -> Self {
+        Self(format!("identity-spec.{identity_spec_name}"))
+    }
+
     pub(crate) fn source_name(&self) -> Result<SourceName, AppError> {
         let Some(source_name) = self.0.strip_prefix("source.") else {
             return Err(AppError::FailedPrecondition(format!(
@@ -105,6 +113,19 @@ impl CredentialSetId {
             )));
         };
         SourceName::parse(source_name)
+    }
+
+    pub(crate) fn identity_spec_name(&self) -> Result<&str, AppError> {
+        self.0.strip_prefix("identity-spec.").ok_or_else(|| {
+            AppError::FailedPrecondition(format!(
+                "credential set '{}' is not identity-spec-backed",
+                self.0
+            ))
+        })
+    }
+
+    pub(crate) fn is_identity_spec_backed(&self) -> bool {
+        self.0.starts_with("identity-spec.")
     }
 }
 

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -110,6 +110,14 @@ trait CredentialMaterialBackend: Send + Sync {
         material: Option<&EncodedCredentialMaterial>,
     ) -> Result<(), CredentialsError>;
 
+    fn write_unlocked(
+        &self,
+        set: &CredentialSetRef<'_>,
+        material: Option<&EncodedCredentialMaterial>,
+    ) -> Result<(), CredentialsError> {
+        self.write(set, material)
+    }
+
     fn snapshot(
         &self,
         set: &CredentialSetRef<'_>,
@@ -207,6 +215,33 @@ impl CredentialStore {
         };
         contextualize_storage_error(
             backend.write(&set, encoded.as_ref()),
+            "writing",
+            credential_set_id,
+            storage,
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn replace_material_unlocked(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
+        values: &BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        let backend = self.backend(storage);
+        tracing::trace!(%credential_set_id, %storage, "replacing credential material without taking a state lock");
+        let encoded = if values.is_empty() {
+            None
+        } else {
+            Some(encode_values(storage, values)?)
+        };
+        contextualize_storage_error(
+            backend.write_unlocked(&set, encoded.as_ref()),
             "writing",
             credential_set_id,
             storage,
@@ -328,6 +363,26 @@ impl CredentialStore {
         Ok(())
     }
 
+    pub(crate) fn remove_material_unlocked(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
+    ) -> Result<(), AppError> {
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        tracing::trace!(%credential_set_id, %storage, "removing credential material without taking a state lock");
+        contextualize_storage_error(
+            self.backend(storage).write_unlocked(&set, None),
+            "removing",
+            credential_set_id,
+            storage,
+        )?;
+        Ok(())
+    }
+
     pub(crate) fn default_write_storage(&self) -> Result<CredentialStorageKind, CredentialsError> {
         match self.preference {
             CredentialStoragePreference::File => Ok(CredentialStorageKind::File),
@@ -375,7 +430,7 @@ fn keychain_route_unavailable(
 ) -> CredentialsError {
     match error {
         CredentialsError::Unavailable(detail) => CredentialsError::Unavailable(format!(
-            "source credential set '{credential_set_id}' is configured for keychain storage, \
+            "credential set '{credential_set_id}' is configured for keychain storage, \
              but keychain is unavailable while {operation}: {detail}"
         )),
         error => error,
@@ -488,6 +543,13 @@ impl FileCredentialBackend {
         &self,
         set: &CredentialSetRef<'_>,
     ) -> Result<std::path::PathBuf, CredentialsError> {
+        if set.credential_set_id.is_identity_spec_backed() {
+            let identity_spec_name = set
+                .credential_set_id
+                .identity_spec_name()
+                .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+            return Ok(self.layout.identity_spec_material_file(identity_spec_name));
+        }
         let source_name = set
             .credential_set_id
             .source_name()
@@ -516,10 +578,16 @@ impl CredentialMaterialBackend for FileCredentialBackend {
     ) -> Result<(), CredentialsError> {
         let path = self.material_file(set)?;
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        match material {
-            Some(material) => write_file_unlocked(&path, material.bytes()),
-            None => remove_file_if_exists_unlocked(&path).map_err(Into::into),
-        }
+        Self::write_material_file_unlocked(path.as_path(), material)
+    }
+
+    fn write_unlocked(
+        &self,
+        set: &CredentialSetRef<'_>,
+        material: Option<&EncodedCredentialMaterial>,
+    ) -> Result<(), CredentialsError> {
+        let path = self.material_file(set)?;
+        Self::write_material_file_unlocked(path.as_path(), material)
     }
 
     fn snapshot(
@@ -556,6 +624,18 @@ impl CredentialMaterialBackend for FileCredentialBackend {
         match snapshot.material() {
             Some(bytes) => write_file_unlocked(&path, bytes),
             None => remove_file_if_exists_unlocked(&path).map_err(Into::into),
+        }
+    }
+}
+
+impl FileCredentialBackend {
+    fn write_material_file_unlocked(
+        path: &Path,
+        material: Option<&EncodedCredentialMaterial>,
+    ) -> Result<(), CredentialsError> {
+        match material {
+            Some(material) => write_file_unlocked(path, material.bytes()),
+            None => remove_file_if_exists_unlocked(path).map_err(Into::into),
         }
     }
 }
@@ -749,6 +829,15 @@ struct KeychainEntryAddress {
 
 impl KeychainEntryAddress {
     fn from_set(config_namespace: &CredentialConfigNamespace, set: &CredentialSetRef<'_>) -> Self {
+        if set.credential_set_id.is_identity_spec_backed() {
+            return Self {
+                service: format!(
+                    "com.withcoral.coral/{}/identity-specs",
+                    config_namespace.as_str()
+                ),
+                account: set.credential_set_id.to_string(),
+            };
+        }
         Self {
             service: format!(
                 "com.withcoral.coral/{}/workspace/{}",
@@ -924,14 +1013,14 @@ fn save_values_unlocked(
     write_file_unlocked(path, render_env_file(values).as_bytes())
 }
 
-fn write_file_unlocked(path: &Path, bytes: &[u8]) -> Result<(), CredentialsError> {
+pub(crate) fn write_file_unlocked(path: &Path, bytes: &[u8]) -> Result<(), CredentialsError> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     storage_fs::ensure_dir(parent)?;
     storage_fs::write_atomic(path, bytes)?;
     Ok(())
 }
 
-fn render_env_file(values: &BTreeMap<String, String>) -> String {
+pub(crate) fn render_env_file(values: &BTreeMap<String, String>) -> String {
     let mut output = String::new();
     for (env_var, value) in values {
         output.push_str(env_var);
@@ -942,7 +1031,7 @@ fn render_env_file(values: &BTreeMap<String, String>) -> String {
     output
 }
 
-fn remove_file_if_exists_unlocked(path: &Path) -> Result<(), io::Error> {
+pub(crate) fn remove_file_if_exists_unlocked(path: &Path) -> Result<(), io::Error> {
     match std::fs::remove_file(path) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
@@ -950,7 +1039,7 @@ fn remove_file_if_exists_unlocked(path: &Path) -> Result<(), io::Error> {
     }
 }
 
-fn parse_env_file(raw: &str) -> Result<BTreeMap<String, String>, CredentialsError> {
+pub(crate) fn parse_env_file(raw: &str) -> Result<BTreeMap<String, String>, CredentialsError> {
     let mut values = BTreeMap::new();
     for (index, line) in raw.lines().enumerate() {
         let line_number = index + 1;
@@ -1061,104 +1150,19 @@ fn encode_env_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
-    use std::sync::{Arc, Mutex};
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
 
-    use super::{CredentialMaterialBackend, CredentialSetRef, EncodedCredentialMaterial};
-    use super::{CredentialStore, decode_env_value, encode_env_value, load_file, save_file};
-    use crate::credentials::{
-        CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind,
-        CredentialStoragePreference,
+    use super::{
+        CredentialSetRef, CredentialStore, TestKeychainBackend, decode_env_value, encode_env_value,
+        load_file, save_file,
     };
+    use crate::bootstrap::AppError;
+    use crate::credentials::{CredentialSetId, CredentialStorageKind, CredentialStoragePreference};
     use crate::sources::SourceName;
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
     use tempfile::TempDir;
-
-    struct FakeKeychainBackend {
-        probe_ok: bool,
-        material: Mutex<Option<Vec<u8>>>,
-    }
-
-    impl FakeKeychainBackend {
-        fn available() -> Arc<Self> {
-            Arc::new(Self {
-                probe_ok: true,
-                material: Mutex::new(None),
-            })
-        }
-
-        fn unavailable() -> Arc<Self> {
-            Arc::new(Self {
-                probe_ok: false,
-                material: Mutex::new(None),
-            })
-        }
-
-        fn material_bytes(&self) -> Option<Vec<u8>> {
-            self.material.lock().expect("material lock").clone()
-        }
-
-        fn lock_material(
-            &self,
-        ) -> Result<std::sync::MutexGuard<'_, Option<Vec<u8>>>, super::CredentialsError> {
-            self.material.lock().map_err(|error| {
-                super::CredentialsError::Unavailable(format!(
-                    "fake keychain lock poisoned: {error}"
-                ))
-            })
-        }
-    }
-
-    impl CredentialMaterialBackend for FakeKeychainBackend {
-        fn probe(&self) -> Result<(), super::CredentialsError> {
-            if self.probe_ok {
-                Ok(())
-            } else {
-                Err(super::CredentialsError::Unavailable(
-                    "fake keychain unavailable".to_string(),
-                ))
-            }
-        }
-
-        fn read(
-            &self,
-            _set: &CredentialSetRef<'_>,
-        ) -> Result<Option<EncodedCredentialMaterial>, super::CredentialsError> {
-            self.probe()?;
-            Ok(self.lock_material()?.clone().map(EncodedCredentialMaterial))
-        }
-
-        fn write(
-            &self,
-            _set: &CredentialSetRef<'_>,
-            material: Option<&EncodedCredentialMaterial>,
-        ) -> Result<(), super::CredentialsError> {
-            self.probe()?;
-            *self.lock_material()? = material.map(|material| material.bytes().to_vec());
-            Ok(())
-        }
-
-        fn snapshot(
-            &self,
-            _set: &CredentialSetRef<'_>,
-        ) -> Result<CredentialMaterialSnapshot, super::CredentialsError> {
-            self.probe()?;
-            Ok(CredentialMaterialSnapshot::new(
-                CredentialStorageKind::Keychain,
-                self.lock_material()?.clone(),
-            ))
-        }
-
-        fn restore(
-            &self,
-            _set: &CredentialSetRef<'_>,
-            snapshot: &CredentialMaterialSnapshot,
-        ) -> Result<(), super::CredentialsError> {
-            self.probe()?;
-            *self.lock_material()? = snapshot.material().map(ToOwned::to_owned);
-            Ok(())
-        }
-    }
 
     #[test]
     fn keychain_address_namespaces_by_config_workspace_and_credential_set() {
@@ -1257,185 +1261,120 @@ mod tests {
 
     #[test]
     fn replace_material_does_not_parse_existing_file() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::new(layout.clone());
-        let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        let path = layout.secret_file(&workspace_name, &source_name);
-        std::fs::create_dir_all(path.parent().expect("secret parent")).expect("secret parent dir");
-        std::fs::write(&path, "BROKEN\n").expect("write malformed existing env file");
+        let fixture = StoreFixture::file();
+        let path = &fixture.path;
+        write_malformed_material(path);
 
         let values = BTreeMap::from([("API_TOKEN".to_string(), "secret-token".to_string())]);
-        store
-            .replace_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-                &values,
-            )
+        fixture
+            .replace(CredentialStorageKind::File, &values)
             .expect("replace malformed material");
-        assert_eq!(load_file(&path).expect("load replaced material"), values);
+        assert_eq!(load_file(path).expect("load replaced material"), values);
 
-        std::fs::write(&path, "BROKEN\n").expect("write malformed existing env file");
-        store
-            .replace_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-                &BTreeMap::new(),
-            )
+        write_malformed_material(path);
+        fixture
+            .replace(CredentialStorageKind::File, &BTreeMap::new())
             .expect("remove malformed material");
         assert!(!path.exists(), "empty replacement should remove material");
     }
 
     #[test]
     fn remove_material_treats_missing_files_as_success() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::new(layout.clone());
-        let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        let path = layout.secret_file(&workspace_name, &source_name);
+        let fixture = StoreFixture::file();
+        let path = &fixture.path;
 
-        store
-            .remove_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-            )
+        fixture
+            .remove(CredentialStorageKind::File)
             .expect("missing material should be removable");
 
-        std::fs::create_dir_all(path.parent().expect("secret parent")).expect("secret parent dir");
-        std::fs::write(&path, "BROKEN\n").expect("write malformed existing env file");
-        store
-            .remove_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-            )
+        write_malformed_material(path);
+        fixture
+            .remove(CredentialStorageKind::File)
             .expect("malformed material should be removable");
         assert!(!path.exists(), "remove should delete material");
 
-        store
-            .remove_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-            )
+        fixture
+            .remove(CredentialStorageKind::File)
             .expect("second remove should still be successful");
     }
 
     #[test]
     fn restore_material_snapshot_preserves_raw_bytes() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::new(layout.clone());
-        let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        let path = layout.secret_file(&workspace_name, &source_name);
-        std::fs::create_dir_all(path.parent().expect("secret parent")).expect("secret parent dir");
-        std::fs::write(&path, "BROKEN\n").expect("write malformed existing env file");
+        let fixture = StoreFixture::file();
+        write_malformed_material(&fixture.path);
 
-        let snapshot = store
+        let snapshot = fixture
+            .store
             .snapshot_material(
-                &workspace_name,
-                &credential_set_id,
+                &fixture.workspace_name,
+                &fixture.credential_set_id,
                 CredentialStorageKind::File,
             )
             .expect("snapshot malformed material");
         let values = BTreeMap::from([("API_TOKEN".to_string(), "secret-token".to_string())]);
-        store
-            .replace_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::File,
-                &values,
-            )
+        fixture
+            .replace(CredentialStorageKind::File, &values)
             .expect("replace material");
 
-        store
-            .restore_material(&workspace_name, &credential_set_id, &snapshot)
+        fixture
+            .store
+            .restore_material(
+                &fixture.workspace_name,
+                &fixture.credential_set_id,
+                &snapshot,
+            )
             .expect("restore malformed material");
         assert_eq!(
-            std::fs::read(&path).expect("restored bytes"),
+            std::fs::read(&fixture.path).expect("restored bytes"),
             b"BROKEN\n".to_vec()
         );
     }
 
+    /// Merges `auto_prefers_keychain_when_probe_succeeds`,
+    /// `auto_falls_back_to_file_when_keychain_probe_fails`, and
+    /// `explicit_file_uses_file_even_when_keychain_probe_fails`, whose bodies
+    /// were identical apart from the preference, the keychain probe result,
+    /// and the expected storage kind.
     #[test]
-    fn auto_prefers_keychain_when_probe_succeeds() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let keychain = FakeKeychainBackend::available();
-        let store = CredentialStore::with_keychain_backend(
-            layout,
-            CredentialStoragePreference::Auto,
-            keychain.clone(),
-        );
-        assert_eq!(
-            store.default_write_storage().expect("storage"),
-            CredentialStorageKind::Keychain
-        );
-    }
-
-    #[test]
-    fn auto_falls_back_to_file_when_keychain_probe_fails() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::with_keychain_backend(
-            layout,
-            CredentialStoragePreference::Auto,
-            FakeKeychainBackend::unavailable(),
-        );
-        assert_eq!(
-            store.default_write_storage().expect("storage"),
-            CredentialStorageKind::File
-        );
-    }
-
-    #[test]
-    fn explicit_file_uses_file_even_when_keychain_probe_fails() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::with_keychain_backend(
-            layout,
-            CredentialStoragePreference::File,
-            FakeKeychainBackend::unavailable(),
-        );
-        assert_eq!(
-            store.default_write_storage().expect("storage"),
-            CredentialStorageKind::File
-        );
+    fn default_write_storage_follows_preference_and_keychain_probe() {
+        let cases = [
+            (
+                "auto prefers keychain when probe succeeds",
+                CredentialStoragePreference::Auto,
+                TestKeychainBackend::available(),
+                CredentialStorageKind::Keychain,
+            ),
+            (
+                "auto falls back to file when keychain probe fails",
+                CredentialStoragePreference::Auto,
+                TestKeychainBackend::unavailable(),
+                CredentialStorageKind::File,
+            ),
+            (
+                "explicit file uses file even when keychain probe fails",
+                CredentialStoragePreference::File,
+                TestKeychainBackend::unavailable(),
+                CredentialStorageKind::File,
+            ),
+        ];
+        for (label, preference, keychain, expected) in cases {
+            let fixture = StoreFixture::with_keychain(preference, Arc::new(keychain));
+            assert_eq!(
+                fixture.store.default_write_storage().expect("storage"),
+                expected,
+                "{label}"
+            );
+        }
     }
 
     #[test]
     fn explicit_keychain_fails_when_probe_fails() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let store = CredentialStore::with_keychain_backend(
-            layout,
+        let fixture = StoreFixture::with_keychain(
             CredentialStoragePreference::Keychain,
-            FakeKeychainBackend::unavailable(),
+            Arc::new(TestKeychainBackend::unavailable()),
         );
-        let error = store
+        let error = fixture
+            .store
             .default_write_storage()
             .expect_err("explicit keychain should fail");
         assert!(
@@ -1450,19 +1389,9 @@ mod tests {
 
     #[test]
     fn keychain_backend_stores_one_versioned_document() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let keychain = FakeKeychainBackend::available();
-        let store = CredentialStore::with_keychain_backend(
-            layout,
-            CredentialStoragePreference::Keychain,
-            keychain.clone(),
-        );
-        let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("secured_messages").expect("source");
-        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let keychain = Arc::new(TestKeychainBackend::available());
+        let fixture =
+            StoreFixture::with_keychain(CredentialStoragePreference::Keychain, keychain.clone());
         let values = BTreeMap::from([
             ("API_TOKEN".to_string(), "secret-token".to_string()),
             (
@@ -1471,16 +1400,15 @@ mod tests {
             ),
         ]);
 
-        store
-            .replace_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::Keychain,
-                &values,
-            )
+        fixture
+            .replace(CredentialStorageKind::Keychain, &values)
             .expect("write keychain material");
 
-        let raw = keychain.material_bytes().expect("keychain blob");
+        let raw = keychain
+            .lock_material()
+            .expect("keychain lock")
+            .clone()
+            .expect("keychain blob");
         let document: serde_json::Value = serde_json::from_slice(&raw).expect("json");
         assert_eq!(document.get("version"), Some(&serde_json::json!(1)));
         assert_eq!(
@@ -1490,26 +1418,87 @@ mod tests {
             Some(&serde_json::json!("secret-token"))
         );
         assert_eq!(
-            store
+            fixture
+                .store
                 .read_material(
-                    &workspace_name,
-                    &credential_set_id,
+                    &fixture.workspace_name,
+                    &fixture.credential_set_id,
                     CredentialStorageKind::Keychain,
                 )
                 .expect("read keychain material"),
             values
         );
 
-        store
-            .remove_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::Keychain,
-            )
+        fixture
+            .remove(CredentialStorageKind::Keychain)
             .expect("remove keychain material");
         assert!(
-            keychain.material_bytes().is_none(),
+            keychain.lock_material().expect("keychain lock").is_none(),
             "remove should delete the stored keychain document"
         );
+    }
+
+    /// Store under test plus the ids of its exercised credential set:
+    /// workspace "default" and source "`secured_messages`", whose file-backend
+    /// secret file lives at `path`.
+    struct StoreFixture {
+        _temp: TempDir,
+        store: CredentialStore,
+        workspace_name: WorkspaceName,
+        credential_set_id: CredentialSetId,
+        path: PathBuf,
+    }
+
+    impl StoreFixture {
+        fn new(store: impl FnOnce(AppStateLayout) -> CredentialStore) -> Self {
+            let temp = TempDir::new().expect("temp dir");
+            let layout =
+                AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+            layout.ensure().expect("ensure layout");
+            let workspace_name = WorkspaceName::default();
+            let source_name = SourceName::parse("secured_messages").expect("source");
+            let path = layout.secret_file(&workspace_name, &source_name);
+            Self {
+                _temp: temp,
+                store: store(layout),
+                workspace_name,
+                credential_set_id: CredentialSetId::for_source(&source_name),
+                path,
+            }
+        }
+
+        fn file() -> Self {
+            Self::new(CredentialStore::new)
+        }
+
+        fn with_keychain(
+            preference: CredentialStoragePreference,
+            keychain: Arc<TestKeychainBackend>,
+        ) -> Self {
+            Self::new(|layout| CredentialStore::with_keychain_backend(layout, preference, keychain))
+        }
+
+        fn replace(
+            &self,
+            storage: CredentialStorageKind,
+            values: &BTreeMap<String, String>,
+        ) -> Result<(), AppError> {
+            self.store.replace_material(
+                &self.workspace_name,
+                &self.credential_set_id,
+                storage,
+                values,
+            )
+        }
+
+        fn remove(&self, storage: CredentialStorageKind) -> Result<(), AppError> {
+            self.store
+                .remove_material(&self.workspace_name, &self.credential_set_id, storage)
+        }
+    }
+
+    fn write_malformed_material(path: &Path) {
+        std::fs::create_dir_all(path.parent().expect("secret parent")).expect("secret parent dir");
+        std::fs::write(path, "BROKEN\n").expect("write malformed existing env file");
     }
 }

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, OnceLock};
 use sha2::{Digest as _, Sha256};
 
 use crate::bootstrap::AppError;
+use crate::identity_specs::IdentitySpecName;
 use crate::state::AppStateLayout;
 use crate::storage::fs as storage_fs;
 use crate::storage::fs::FileLock;
@@ -548,7 +549,9 @@ impl FileCredentialBackend {
                 .credential_set_id
                 .identity_spec_name()
                 .map_err(|error| CredentialsError::Parse(error.to_string()))?;
-            return Ok(self.layout.identity_spec_material_file(identity_spec_name));
+            let identity_spec_name = IdentitySpecName::parse(identity_spec_name)
+                .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+            return Ok(self.layout.identity_spec_material_file(&identity_spec_name));
         }
         let source_name = set
             .credential_set_id

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -13,6 +13,8 @@ use crate::state::{
 /// Runtime feature keys recognized by Coral.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Feature {
+    /// Enables preview DSL v4 source manifests.
+    DslV4,
     /// Expose the optional MCP `feedback` tool.
     Feedback,
     /// Experimental trajectory-memory episodes (in progress): exposes the MCP
@@ -70,6 +72,14 @@ struct FeatureSpec {
 }
 
 const FEATURE_SPECS: &[FeatureSpec] = &[
+    FeatureSpec {
+        feature: Feature::DslV4,
+        key: "dsl_v4",
+        default_enabled: false,
+        description: "Enables preview DSL v4 source manifests.",
+        enable_flag: "enable-dsl-v4",
+        disable_flag: "disable-dsl-v4",
+    },
     FeatureSpec {
         feature: Feature::Feedback,
         key: "feedback",
@@ -157,6 +167,22 @@ impl Features {
         self.enabled.get(&feature).copied().unwrap_or(false)
     }
 
+    /// Errors unless the preview DSL v4 runtime feature is enabled.
+    ///
+    /// DSL v4 sources and their identity specs cannot be installed or served
+    /// while `dsl_v4` is off, so the source-install, identity-spec-install, and
+    /// query-load paths share this single gate and its canonical remediation
+    /// message.
+    pub(crate) fn ensure_dsl_v4_enabled(&self) -> Result<(), AppError> {
+        if self.enabled(Feature::DslV4) {
+            return Ok(());
+        }
+        Err(AppError::SourceUnservable(
+            "DSL v4 sources require the 'dsl_v4' runtime feature. Run `coral features enable dsl_v4` or pass `--enable-dsl-v4` and retry."
+                .to_string(),
+        ))
+    }
+
     fn from_raw_overrides(raw: &RawFeatureOverrides) -> Self {
         let mut features = Self::default();
         for (key, value) in raw.iter() {
@@ -180,7 +206,7 @@ impl Features {
         features
     }
 
-    fn apply_overrides(&mut self, overrides: &FeatureOverrides) {
+    pub(crate) fn apply_overrides(&mut self, overrides: &FeatureOverrides) {
         for (feature, enabled) in overrides.iter() {
             self.enabled.insert(feature, enabled);
         }
@@ -199,6 +225,21 @@ impl FeatureOverrides {
         self.enabled.insert(feature, enabled);
     }
 
+    /// Returns the process-local override for a known feature, when present.
+    #[must_use]
+    pub fn get(&self, feature: Feature) -> Option<bool> {
+        self.enabled.get(&feature).copied()
+    }
+
+    /// Adds every override from `defaults` that is not already explicitly set.
+    pub fn apply_defaults_from(&mut self, defaults: &Self) {
+        for (feature, enabled) in defaults.iter() {
+            if self.get(feature).is_none() {
+                self.set(feature, enabled);
+            }
+        }
+    }
+
     fn iter(&self) -> impl Iterator<Item = (Feature, bool)> + '_ {
         self.enabled
             .iter()
@@ -213,6 +254,12 @@ pub struct FeatureStore {
 }
 
 impl FeatureStore {
+    /// Builds a feature store for an already-discovered app state layout.
+    #[must_use]
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
     /// Discovers the Coral app state layout used for runtime feature config.
     ///
     /// # Errors
@@ -329,6 +376,17 @@ fn spec_for_key(key: &str) -> Option<&'static FeatureSpec> {
     FEATURE_SPECS.iter().find(|spec| spec.key == key)
 }
 
+/// Builds a [`Features`] with the preview DSL v4 feature enabled, shared by the
+/// crate's source-install and query tests that exercise v4 sources.
+#[cfg(test)]
+pub(crate) fn dsl_v4_features() -> Features {
+    let mut overrides = FeatureOverrides::default();
+    overrides.set(Feature::DslV4, true);
+    let mut features = Features::default();
+    features.apply_overrides(&overrides);
+    features
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -340,10 +398,12 @@ mod tests {
     }
 
     #[test]
-    fn defaults_disable_feedback() {
+    fn defaults_disable_features() {
         let features = Features::default();
 
-        assert!(!features.enabled(Feature::Feedback));
+        for (label, feature) in [("feedback", Feature::Feedback), ("dsl_v4", Feature::DslV4)] {
+            assert!(!features.enabled(feature), "{label} should default off");
+        }
     }
 
     #[test]
@@ -358,19 +418,44 @@ mod tests {
     }
 
     #[test]
-    fn known_boolean_override_enables_feedback() {
-        let raw = raw([("feedback", RawFeatureValue::Bool(true))]);
-        let features = Features::from_raw_overrides(&raw);
+    fn process_override_get_reports_only_explicit_overrides() {
+        let mut overrides = FeatureOverrides::default();
 
-        assert!(features.enabled(Feature::Feedback));
+        assert_eq!(overrides.get(Feature::DslV4), None);
+
+        overrides.set(Feature::DslV4, false);
+
+        assert_eq!(overrides.get(Feature::DslV4), Some(false));
     }
 
     #[test]
-    fn known_boolean_override_disables_feedback() {
-        let raw = raw([("feedback", RawFeatureValue::Bool(false))]);
-        let features = Features::from_raw_overrides(&raw);
+    fn process_override_defaults_fill_missing_features_only() {
+        let mut overrides = FeatureOverrides::default();
+        overrides.set(Feature::DslV4, false);
+        let mut defaults = FeatureOverrides::default();
+        defaults.set(Feature::DslV4, true);
+        defaults.set(Feature::Feedback, true);
 
-        assert!(!features.enabled(Feature::Feedback));
+        overrides.apply_defaults_from(&defaults);
+
+        assert_eq!(overrides.get(Feature::DslV4), Some(false));
+        assert_eq!(overrides.get(Feature::Feedback), Some(true));
+    }
+
+    #[test]
+    fn raw_overrides_toggle_only_known_boolean_entries() {
+        use RawFeatureValue::{Bool, UnsupportedType};
+
+        for (label, key, value, on) in [
+            ("enables feedback", "feedback", Bool(true), true),
+            ("disables feedback", "feedback", Bool(false), false),
+            ("unknown key ignored", "future_flag", Bool(true), false),
+            ("unsupported type", "feedback", UnsupportedType, false),
+        ] {
+            let features = Features::from_raw_overrides(&raw([(key, value)]));
+
+            assert_eq!(features.enabled(Feature::Feedback), on, "{label}");
+        }
     }
 
     #[test]
@@ -386,31 +471,15 @@ mod tests {
     }
 
     #[test]
-    fn unknown_override_is_ignored() {
-        let raw = raw([("future_flag", RawFeatureValue::Bool(true))]);
-        let features = Features::from_raw_overrides(&raw);
-
-        assert!(!features.enabled(Feature::Feedback));
-    }
-
-    #[test]
-    fn unsupported_known_override_is_ignored() {
-        let raw = raw([("feedback", RawFeatureValue::UnsupportedType)]);
-        let features = Features::from_raw_overrides(&raw);
-
-        assert!(!features.enabled(Feature::Feedback));
-    }
-
-    #[test]
     fn statuses_report_invalid_known_value_without_enabling_feature() {
         let raw = raw([("feedback", RawFeatureValue::UnsupportedType)]);
         let features = Features::from_raw_overrides(&raw);
 
-        let statuses = FEATURE_SPECS
+        let status = FEATURE_SPECS
             .iter()
             .map(|spec| status_from_raw(spec, &raw, &features))
-            .collect::<Vec<_>>();
-        let status = statuses.first().expect("feedback status");
+            .find(|status| status.key == "feedback")
+            .expect("feedback status");
 
         assert_eq!(status.key, "feedback");
         assert_eq!(status.configured, FeatureConfiguredState::InvalidValue);

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -177,7 +177,7 @@ impl Features {
             return Ok(());
         }
         Err(AppError::SourceUnservable(
-            "DSL v4 sources require the 'dsl_v4' runtime feature. Run `coral features enable dsl_v4` or pass `--enable-dsl-v4` and retry."
+            "DSL v4 source and identity-spec management requires the 'dsl_v4' runtime feature."
                 .to_string(),
         ))
     }

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -169,10 +169,9 @@ impl Features {
 
     /// Errors unless the preview DSL v4 runtime feature is enabled.
     ///
-    /// DSL v4 sources and their identity specs cannot be installed or served
-    /// while `dsl_v4` is off, so the source-install, identity-spec-install, and
-    /// query-load paths share this single gate and its canonical remediation
-    /// message.
+    /// DSL v4 sources and their identity specs cannot be installed or managed
+    /// while `dsl_v4` is off, so source-install and identity-spec management paths
+    /// share this single gate and its canonical remediation message.
     pub(crate) fn ensure_dsl_v4_enabled(&self) -> Result<(), AppError> {
         if self.enabled(Feature::DslV4) {
             return Ok(());

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -12,6 +12,24 @@ use serde_json::Value;
 
 use crate::bootstrap::AppError;
 
+/// Collects `(key, value)` inputs into a map, validating each key as a path
+/// segment and rejecting duplicates. `label` names the input kind in errors.
+pub(crate) fn unique_input_map(
+    inputs: impl IntoIterator<Item = (String, String)>,
+    label: &str,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let mut values = BTreeMap::new();
+    for (key, value) in inputs {
+        let key = parse_path_segment(label, &key)?;
+        if values.insert(key.clone(), value).is_some() {
+            return Err(AppError::InvalidInput(format!(
+                "{label} '{key}' is repeated"
+            )));
+        }
+    }
+    Ok(values)
+}
+
 pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppError> {
     let trimmed = value.trim();
     if trimmed.is_empty() {

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -1,7 +1,9 @@
 //! Filesystem-backed global identity-spec registry.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 use std::fs;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use coral_spec::{IdentityManifest, ManifestInputKind, parse_identity_manifest_yaml};
@@ -35,6 +37,37 @@ pub(crate) struct IdentitySpecRecord {
 pub(crate) struct IdentitySpecInputValue {
     pub(crate) key: String,
     pub(crate) value: String,
+}
+
+/// Validated storage name for one installed identity spec.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct IdentitySpecName(String);
+
+impl IdentitySpecName {
+    /// Parse and validate an identity-spec name for app-internal use.
+    pub(crate) fn parse(name: &str) -> Result<Self, AppError> {
+        parse_path_segment("identity spec", name).map(Self)
+    }
+
+    /// Borrow the normalized identity-spec name at string boundaries.
+    #[must_use]
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for IdentitySpecName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for IdentitySpecName {
+    type Err = AppError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
 }
 
 /// Validated identity of one identity-spec manifest.
@@ -279,9 +312,9 @@ impl IdentitySpecManager {
         let _guard = span.enter();
         self.features.ensure_dsl_v4_enabled()?;
         let record = parse_identity_spec_record(manifest_yaml)?;
-        let name = record.manifest.name.clone();
+        let name = validate_identity_spec_name(&record.manifest.name)?;
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        let existing = self.registry.get_identity_spec(&name)?;
+        let existing = self.registry.get_identity_spec(name.as_str())?;
         let replaced = existing.is_some();
         let existing_input_material = existing
             .as_ref()
@@ -321,7 +354,7 @@ impl IdentitySpecManager {
             &provided_inputs,
         )?;
         self.registry.upsert_identity_spec(
-            &record.manifest.name,
+            name.as_str(),
             IdentitySpecRegistryRecord {
                 manifest_yaml: record.manifest_yaml.clone(),
                 input_material,
@@ -364,7 +397,7 @@ impl IdentitySpecManager {
         let _lock = FileLock::shared(self.layout.state_lock())?;
         let stored = self
             .registry
-            .get_identity_spec(&name)?
+            .get_identity_spec(name.as_str())?
             .map(|record| record.input_material)
             .unwrap_or_default();
         resolve_identity_spec_inputs_for_use(manifest, &stored)
@@ -376,8 +409,8 @@ impl IdentitySpecManager {
         self.features.ensure_dsl_v4_enabled()?;
         let name = validate_identity_spec_name(name)?;
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        if !self.registry.identity_spec_exists(&name)? {
-            return Err(AppError::IdentitySpecNotFound(name));
+        if !self.registry.identity_spec_exists(name.as_str())? {
+            return Err(AppError::IdentitySpecNotFound(name.as_str().to_string()));
         }
         let orphaned_identities = self.count_identities_for_spec_unlocked(&name)?;
         if orphaned_identities > 0 && !force {
@@ -387,20 +420,19 @@ impl IdentitySpecManager {
                 plural_pronoun(orphaned_identities)
             )));
         }
-        self.registry.remove_identity_spec(&name)?;
+        self.registry.remove_identity_spec(name.as_str())?;
         Ok(orphaned_identities)
     }
 
     fn load_identity_spec_manifest_unlocked(
         &self,
-        name: &str,
+        name: &IdentitySpecName,
     ) -> Result<IdentitySpecRecord, AppError> {
-        let name = validate_identity_spec_name(name)?;
-        let Some(manifest_yaml) = self.registry.get_identity_spec_manifest(&name)? else {
-            return Err(AppError::IdentitySpecNotFound(name));
+        let Some(manifest_yaml) = self.registry.get_identity_spec_manifest(name.as_str())? else {
+            return Err(AppError::IdentitySpecNotFound(name.as_str().to_string()));
         };
         let record = parse_identity_spec_record(&manifest_yaml)?;
-        if record.manifest.name != name {
+        if record.manifest.name != name.as_str() {
             return Err(AppError::FailedPrecondition(format!(
                 "identity spec registry record '{name}' contains identity spec '{}'",
                 record.manifest.name
@@ -411,14 +443,14 @@ impl IdentitySpecManager {
 
     fn count_identities_for_spec_unlocked(
         &self,
-        identity_spec_name: &str,
+        identity_spec_name: &IdentitySpecName,
     ) -> Result<u32, AppError> {
         let mut count = self.count_user_owned_identities_for_spec_unlocked(identity_spec_name)?;
         for provider in &self.usage_providers {
             count = checked_add_identity_count(
                 count,
-                provider.count_identities_for_spec(identity_spec_name)?,
-                identity_spec_name,
+                provider.count_identities_for_spec(identity_spec_name.as_str())?,
+                identity_spec_name.as_str(),
             )?;
         }
         Ok(count)
@@ -426,7 +458,7 @@ impl IdentitySpecManager {
 
     fn count_user_owned_identities_for_spec_unlocked(
         &self,
-        identity_spec_name: &str,
+        identity_spec_name: &IdentitySpecName,
     ) -> Result<u32, AppError> {
         let users_root = self.layout.identities_root().join("users");
         if !users_root.exists() {
@@ -449,8 +481,8 @@ impl IdentitySpecManager {
                 }
                 let raw = fs::read_to_string(&manifest_path)?;
                 let reference: UserOwnedIdentitySpecReference = serde_yaml::from_str(&raw)?;
-                if reference.identity_spec == identity_spec_name {
-                    count = checked_add_identity_count(count, 1, identity_spec_name)?;
+                if reference.identity_spec == identity_spec_name.as_str() {
+                    count = checked_add_identity_count(count, 1, identity_spec_name.as_str())?;
                 }
             }
         }
@@ -479,14 +511,14 @@ impl FileIdentitySpecRegistry {
         }
     }
 
-    fn input_material_state_file(&self, name: &str) -> std::path::PathBuf {
+    fn input_material_state_file(&self, name: &IdentitySpecName) -> std::path::PathBuf {
         self.layout
             .identity_spec_dir(name)
             .join(IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME)
     }
 
-    fn credential_set_id(name: &str) -> CredentialSetId {
-        CredentialSetId::for_identity_spec(name)
+    fn credential_set_id(name: &IdentitySpecName) -> CredentialSetId {
+        CredentialSetId::for_identity_spec(name.as_str())
     }
 
     fn input_material_workspace() -> WorkspaceName {
@@ -495,7 +527,7 @@ impl FileIdentitySpecRegistry {
 
     fn load_input_material_state(
         &self,
-        name: &str,
+        name: &IdentitySpecName,
     ) -> Result<IdentitySpecInputMaterialState, AppError> {
         let path = self.input_material_state_file(name);
         if !path.exists() {
@@ -514,7 +546,7 @@ impl FileIdentitySpecRegistry {
 
     fn write_input_material_state(
         &self,
-        name: &str,
+        name: &IdentitySpecName,
         state: &IdentitySpecInputMaterialState,
     ) -> Result<(), AppError> {
         let path = self.input_material_state_file(name);
@@ -529,7 +561,7 @@ impl FileIdentitySpecRegistry {
 
     fn read_input_material(
         &self,
-        name: &str,
+        name: &IdentitySpecName,
         storage: CredentialStorageKind,
     ) -> Result<BTreeMap<String, String>, AppError> {
         self.credential_store.read_material(
@@ -541,7 +573,7 @@ impl FileIdentitySpecRegistry {
 
     fn replace_input_material(
         &self,
-        name: &str,
+        name: &IdentitySpecName,
         existing_storage: Option<CredentialStorageKind>,
         next_storage: Option<CredentialStorageKind>,
         material: &BTreeMap<String, String>,
@@ -569,7 +601,7 @@ impl FileIdentitySpecRegistry {
 
     fn restore_after_failed_upsert(
         &self,
-        name: &str,
+        name: &IdentitySpecName,
         rollback: &IdentitySpecUpsertRollback,
     ) -> Result<(), AppError> {
         if let (Some(storage), Some(material)) = (
@@ -605,7 +637,7 @@ impl FileIdentitySpecRegistry {
         Ok(())
     }
 
-    fn remove_input_material(&self, name: &str) -> Result<(), AppError> {
+    fn remove_input_material(&self, name: &IdentitySpecName) -> Result<(), AppError> {
         let state = self.load_input_material_state(name)?;
         if let Some(storage) = state.credential_storage {
             self.credential_store.remove_material_unlocked(
@@ -759,7 +791,7 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
         if let Err(error) = result {
             if let Err(rollback_error) = self.restore_after_failed_upsert(&name, &rollback) {
                 warn!(
-                    identity_spec = name,
+                    identity_spec = %name,
                     error = %rollback_error,
                     "failed to roll back identity spec upsert"
                 );
@@ -893,10 +925,14 @@ fn merge_identity_spec_input_material(
     for input in &manifest.inputs {
         if let Some(value) = provided
             .get(&input.key)
-            .filter(|value| !value.is_empty())
-            .or_else(|| stored.get(&input.key).filter(|value| !value.is_empty()))
+            .and_then(|value| trimmed_non_empty_value(value))
+            .or_else(|| {
+                stored
+                    .get(&input.key)
+                    .and_then(|value| trimmed_non_empty_value(value))
+            })
         {
-            material.insert(input.key.clone(), value.clone());
+            material.insert(input.key.clone(), value);
         }
     }
     resolve_identity_spec_inputs_for_use(manifest, &material)?;
@@ -911,8 +947,7 @@ fn resolve_identity_spec_inputs_for_use(
     for input in &manifest.inputs {
         let value = material
             .get(&input.key)
-            .filter(|value| !value.is_empty())
-            .cloned()
+            .and_then(|value| trimmed_non_empty_value(value))
             .or_else(|| {
                 (input.kind == ManifestInputKind::Variable && !input.default_value.is_empty())
                     .then(|| input.default_value.clone())
@@ -927,6 +962,11 @@ fn resolve_identity_spec_inputs_for_use(
         }
     }
     Ok(resolved)
+}
+
+fn trimmed_non_empty_value(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
 fn remove_file_if_exists(path: &std::path::Path) -> Result<(), AppError> {
@@ -962,8 +1002,8 @@ fn normalized_manifest_yaml(manifest_yaml: &str) -> String {
     }
 }
 
-pub(crate) fn validate_identity_spec_name(name: &str) -> Result<String, AppError> {
-    parse_path_segment("identity spec", name)
+pub(crate) fn validate_identity_spec_name(name: &str) -> Result<IdentitySpecName, AppError> {
+    IdentitySpecName::parse(name)
 }
 
 #[cfg(test)]
@@ -978,7 +1018,7 @@ mod tests {
 
     use super::{
         IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME, IdentitySpecInputValue, IdentitySpecManager,
-        IdentitySpecRecord, IdentitySpecUsageProvider, identity_spec_fingerprint,
+        IdentitySpecName, IdentitySpecRecord, IdentitySpecUsageProvider, identity_spec_fingerprint,
     };
     use crate::bootstrap::AppError;
     use crate::credentials::{CredentialStoragePreference, CredentialStore, parse_env_file};
@@ -987,6 +1027,10 @@ mod tests {
 
     fn manager() -> (TempDir, IdentitySpecManager, AppStateLayout) {
         manager_with(dsl_v4_features(), Vec::new())
+    }
+
+    fn identity_spec_name(name: &str) -> IdentitySpecName {
+        IdentitySpecName::parse(name).expect("identity spec name")
     }
 
     fn manager_with(
@@ -1279,7 +1323,7 @@ oauth:
     #[test]
     fn add_identity_spec_repairs_malformed_existing_record() {
         let (_temp, manager, layout) = manager();
-        let manifest_path = layout.identity_spec_manifest_file("github_oauth");
+        let manifest_path = layout.identity_spec_manifest_file(&identity_spec_name("github_oauth"));
         fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
             .expect("create identity spec dir");
         fs::write(
@@ -1337,12 +1381,16 @@ oauth:
         assert_input(&resolved, "DEMO_TENANT", "tenant-a");
         assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "client-secret");
         assert!(
-            layout.identity_spec_material_file("demo_oauth").exists(),
+            layout
+                .identity_spec_material_file(&identity_spec_name("demo_oauth"))
+                .exists(),
             "input material belongs under the installed identity spec"
         );
         let stored = parse_env_file(
-            &fs::read_to_string(layout.identity_spec_material_file("demo_oauth"))
-                .expect("identity spec material file"),
+            &fs::read_to_string(
+                layout.identity_spec_material_file(&identity_spec_name("demo_oauth")),
+            )
+            .expect("identity spec material file"),
         )
         .expect("parse material");
         assert!(
@@ -1352,8 +1400,59 @@ oauth:
 
         remove_spec(&manager, "demo_oauth", false);
 
-        assert!(!layout.identity_spec_material_file("demo_oauth").exists());
-        assert!(!layout.identity_spec_dir("demo_oauth").exists());
+        assert!(
+            !layout
+                .identity_spec_material_file(&identity_spec_name("demo_oauth"))
+                .exists()
+        );
+        assert!(
+            !layout
+                .identity_spec_dir(&identity_spec_name("demo_oauth"))
+                .exists()
+        );
+    }
+
+    #[test]
+    fn spec_owned_input_material_is_trimmed_and_whitespace_only_is_missing() {
+        let (_temp, trimming_manager, layout) = manager();
+        let (record, _replaced) = trimming_manager
+            .add_identity_spec_with_inputs(
+                &oauth_identity_yaml_with_inputs(),
+                vec![IdentitySpecInputValue {
+                    key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                    value: "  client-secret  \n".to_string(),
+                }],
+            )
+            .expect("trimmed input should satisfy required secret");
+
+        let resolved = resolved_inputs(&trimming_manager, &record);
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "client-secret");
+        let stored = parse_env_file(
+            &fs::read_to_string(
+                layout.identity_spec_material_file(&identity_spec_name("demo_oauth")),
+            )
+            .expect("identity spec material file"),
+        )
+        .expect("parse material");
+        assert_eq!(
+            stored.get("DEMO_OAUTH_CLIENT_SECRET").map(String::as_str),
+            Some("client-secret")
+        );
+
+        let (_temp, manager, _layout) = manager();
+        let error = manager
+            .add_identity_spec_with_inputs(
+                &oauth_identity_yaml_with_inputs(),
+                vec![IdentitySpecInputValue {
+                    key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                    value: " \t\n ".to_string(),
+                }],
+            )
+            .expect_err("whitespace-only secret should be missing");
+        assert_failed_precondition(
+            &error,
+            ["missing identity spec input", "DEMO_OAUTH_CLIENT_SECRET"],
+        );
     }
 
     #[test]
@@ -1361,7 +1460,7 @@ oauth:
         let (_temp, manager, layout) = manager();
         add_spec_with_secret(&manager, &oauth_identity_yaml_with_inputs());
 
-        let material_file = layout.identity_spec_material_file("demo_oauth");
+        let material_file = layout.identity_spec_material_file(&identity_spec_name("demo_oauth"));
         fs::write(&material_file, "not env material\n").expect("write malformed material");
         let record = manager
             .get_identity_spec("demo_oauth")
@@ -1384,7 +1483,11 @@ oauth:
             !material_file.exists(),
             "malformed material should be deleted"
         );
-        assert!(!layout.identity_spec_dir("demo_oauth").exists());
+        assert!(
+            !layout
+                .identity_spec_dir(&identity_spec_name("demo_oauth"))
+                .exists()
+        );
     }
 
     #[test]
@@ -1405,9 +1508,9 @@ oauth:
         );
         add_spec_with_secret(&manager, &oauth_identity_yaml_with_inputs());
 
-        let manifest_file = layout.identity_spec_manifest_file("demo_oauth");
+        let manifest_file = layout.identity_spec_manifest_file(&identity_spec_name("demo_oauth"));
         let state_file = layout
-            .identity_spec_dir("demo_oauth")
+            .identity_spec_dir(&identity_spec_name("demo_oauth"))
             .join(IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME);
         fs::write(&state_file, "version: 1\ncredential_storage: keychain\n")
             .expect("route cleanup through unavailable keychain");
@@ -1429,7 +1532,11 @@ oauth:
         remove_spec(&manager, "demo_oauth", false);
 
         assert!(!manifest_file.exists());
-        assert!(!layout.identity_spec_dir("demo_oauth").exists());
+        assert!(
+            !layout
+                .identity_spec_dir(&identity_spec_name("demo_oauth"))
+                .exists()
+        );
     }
 
     #[test]
@@ -1438,7 +1545,7 @@ oauth:
         let (record, _replaced) =
             add_spec_with_secret_value(&manager, &oauth_identity_yaml_with_inputs(), "old-secret");
         let state_file = layout
-            .identity_spec_dir("demo_oauth")
+            .identity_spec_dir(&identity_spec_name("demo_oauth"))
             .join(IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME);
         let state_temp_file = state_file.with_file_name(format!(
             "{IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME}.tmp.{}",

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -288,15 +288,26 @@ impl IdentitySpecManager {
             .map(|record| record.input_material.clone())
             .unwrap_or_default();
         if let Some(existing) = &existing {
-            let existing = parse_identity_spec_record(&existing.manifest_yaml)?;
-            if existing.manifest != record.manifest {
-                let referencing_identities = self.count_identities_for_spec_unlocked(&name)?;
-                if referencing_identities > 0 {
-                    return Err(AppError::FailedPrecondition(format!(
-                        "identity spec '{name}' is used by {referencing_identities} stored {} and cannot be replaced with a different manifest; remove it with --force only if you intend to recreate {} against a new spec",
-                        plural_identity(referencing_identities),
-                        plural_pronoun(referencing_identities)
-                    )));
+            match parse_identity_spec_record(&existing.manifest_yaml) {
+                Ok(existing) => {
+                    if existing.manifest != record.manifest {
+                        let referencing_identities =
+                            self.count_identities_for_spec_unlocked(&name)?;
+                        if referencing_identities > 0 {
+                            return Err(AppError::FailedPrecondition(format!(
+                                "identity spec '{name}' is used by {referencing_identities} stored {} and cannot be replaced with a different manifest; remove it with --force only if you intend to recreate {} against a new spec",
+                                plural_identity(referencing_identities),
+                                plural_pronoun(referencing_identities)
+                            )));
+                        }
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        identity_spec = %name,
+                        error = %error,
+                        "replacing malformed existing identity spec record with valid manifest"
+                    );
                 }
             }
         }
@@ -963,6 +974,8 @@ mod tests {
 
     use tempfile::TempDir;
 
+    use coral_spec::ManifestInputKind;
+
     use super::{
         IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME, IdentitySpecInputValue, IdentitySpecManager,
         IdentitySpecRecord, IdentitySpecUsageProvider, identity_spec_fingerprint,
@@ -1170,6 +1183,60 @@ oauth:
         .replace("{{default_tenant}}", default_tenant)
     }
 
+    fn github_oauth_identity_yaml_with_defaulted_client_id_input() -> &'static str {
+        r"
+kind: identity
+spec_version: 1
+name: github_oauth
+version: 0.1.0
+description: GitHub OAuth access token.
+issuer: github
+type: oauth
+audience:
+  host: github.com
+inputs:
+  GITHUB_OAUTH_CLIENT_ID:
+    kind: variable
+    default: demo-client
+oauth:
+  method:
+    label: Connect with GitHub device code
+    flow:
+      type: device_code
+    endpoints:
+      device_authorization_url: https://github.com/login/device/code
+      token_url: https://github.com/login/oauth/access_token
+    client:
+      id:
+        default: demo-client
+        input: GITHUB_OAUTH_CLIENT_ID
+"
+    }
+
+    fn malformed_github_oauth_identity_yaml_missing_client_id_input() -> &'static str {
+        r"
+kind: identity
+spec_version: 1
+name: github_oauth
+version: 0.1.0
+description: Bad prior install.
+issuer: github
+type: oauth
+audience:
+  host: github.com
+oauth:
+  method:
+    flow:
+      type: device_code
+    endpoints:
+      device_authorization_url: https://github.com/login/device/code
+      token_url: https://github.com/login/oauth/access_token
+    client:
+      id:
+        input: GITHUB_OAUTH_CLIENT_ID
+"
+    }
+
     /// Merges the previous standalone replace test into the CRUD round-trip:
     /// the version 0.2.0 re-add runs over the same stored spec.
     #[test]
@@ -1206,6 +1273,43 @@ oauth:
                 .list_identity_specs()
                 .expect("list again")
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn add_identity_spec_repairs_malformed_existing_record() {
+        let (_temp, manager, layout) = manager();
+        let manifest_path = layout.identity_spec_manifest_file("github_oauth");
+        fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create identity spec dir");
+        fs::write(
+            &manifest_path,
+            malformed_github_oauth_identity_yaml_missing_client_id_input(),
+        )
+        .expect("write malformed identity spec");
+        let error = manager
+            .get_identity_spec("github_oauth")
+            .expect_err("stored spec is malformed");
+        assert!(
+            error
+                .to_string()
+                .contains("must reference a declared variable input"),
+            "unexpected error: {error}"
+        );
+
+        let (record, replaced) = add_spec(
+            &manager,
+            github_oauth_identity_yaml_with_defaulted_client_id_input(),
+        );
+
+        assert!(replaced);
+        assert_eq!(record.manifest.name, "github_oauth");
+        assert!(record.manifest.inputs.iter().any(|input| {
+            input.key == "GITHUB_OAUTH_CLIENT_ID" && input.kind == ManifestInputKind::Variable
+        }));
+        assert_eq!(
+            stored_spec(&manager, "github_oauth").manifest.inputs.len(),
+            1
         );
     }
 

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -1,0 +1,1562 @@
+//! Filesystem-backed global identity-spec registry.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::sync::Arc;
+
+use coral_spec::{IdentityManifest, ManifestInputKind, parse_identity_manifest_yaml};
+use serde::{Deserialize, Serialize};
+#[cfg(test)]
+use serde_json::Value;
+#[cfg(test)]
+use sha2::{Digest as _, Sha256};
+use tracing::{info_span, warn};
+
+use crate::bootstrap::AppError;
+use crate::credentials::{CredentialSetId, CredentialStorageKind, CredentialStore};
+use crate::features::Features;
+use crate::identity::{parse_path_segment, unique_input_map};
+use crate::state::{AppStateLayout, INSTALLED_IDENTITY_FILE_NAME};
+use crate::storage::fs::{self as storage_fs, FileLock};
+use crate::workspaces::WorkspaceName;
+
+const IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME: &str = "inputs.yaml";
+const IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION: u32 = 1;
+
+/// One installed global identity spec.
+#[derive(Debug, Clone)]
+pub(crate) struct IdentitySpecRecord {
+    pub(crate) manifest_yaml: String,
+    pub(crate) manifest: IdentityManifest,
+}
+
+/// One setup input value for a globally installed identity spec.
+#[derive(Debug, Clone)]
+pub(crate) struct IdentitySpecInputValue {
+    pub(crate) key: String,
+    pub(crate) value: String,
+}
+
+/// Validated identity of one identity-spec manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentitySpecManifestMetadata {
+    /// Stable identity-spec id declared by the manifest.
+    pub identity_spec_id: String,
+    /// Authored identity-spec version.
+    pub version: String,
+}
+
+/// Validates one identity-spec manifest and returns its registry identity.
+///
+/// # Errors
+///
+/// Returns [`AppError`] when the manifest is invalid.
+pub fn identity_spec_manifest_metadata(
+    manifest_yaml: &str,
+) -> Result<IdentitySpecManifestMetadata, AppError> {
+    let manifest = parse_identity_manifest_yaml(manifest_yaml)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    Ok(IdentitySpecManifestMetadata {
+        identity_spec_id: manifest.name,
+        version: manifest.version,
+    })
+}
+
+/// Validates identity-spec setup inputs for one manifest.
+///
+/// # Errors
+///
+/// Returns [`AppError`] when the manifest or inputs are invalid.
+pub fn identity_spec_input_material_from_manifest(
+    manifest_yaml: &str,
+    inputs: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let existing = BTreeMap::new();
+    identity_spec_input_material_from_manifest_with_existing(manifest_yaml, &existing, inputs)
+}
+
+/// Validates identity-spec setup inputs and merges them over existing material.
+///
+/// # Errors
+///
+/// Returns [`AppError`] when the manifest or inputs are invalid.
+pub fn identity_spec_input_material_from_manifest_with_existing(
+    manifest_yaml: &str,
+    existing_input_material: &BTreeMap<String, String>,
+    inputs: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let record = parse_identity_spec_record(manifest_yaml)?;
+    merge_identity_spec_input_material(&record.manifest, existing_input_material, inputs)
+}
+
+/// Durable record for one installed global identity spec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentitySpecRegistryRecord {
+    /// Raw identity-spec manifest YAML.
+    pub manifest_yaml: String,
+    /// Stored setup input material for later identity materialization.
+    pub input_material: BTreeMap<String, String>,
+}
+
+/// Durable storage backend for global identity specs.
+pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
+    /// Lists all installed identity specs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the registry cannot be read.
+    fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRegistryRecord>, AppError>;
+
+    /// Lists installed identity spec manifests without setup input material.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the registry cannot be read.
+    fn list_identity_spec_manifests(&self) -> Result<Vec<String>, AppError> {
+        Ok(self
+            .list_identity_specs()?
+            .into_iter()
+            .map(|record| record.manifest_yaml)
+            .collect())
+    }
+
+    /// Fetches one identity spec by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the registry cannot be read.
+    fn get_identity_spec(&self, name: &str)
+    -> Result<Option<IdentitySpecRegistryRecord>, AppError>;
+
+    /// Fetches one identity spec manifest without setup input material.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the registry cannot be read.
+    fn get_identity_spec_manifest(&self, name: &str) -> Result<Option<String>, AppError> {
+        Ok(self
+            .get_identity_spec(name)?
+            .map(|record| record.manifest_yaml))
+    }
+
+    /// Returns whether one identity spec manifest exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the registry cannot be inspected.
+    fn identity_spec_exists(&self, name: &str) -> Result<bool, AppError> {
+        self.get_identity_spec_manifest(name)
+            .map(|manifest| manifest.is_some())
+    }
+
+    /// Inserts or replaces one identity spec.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the record cannot be persisted.
+    fn upsert_identity_spec(
+        &self,
+        name: &str,
+        record: IdentitySpecRegistryRecord,
+    ) -> Result<(), AppError>;
+
+    /// Removes one identity spec.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the record cannot be removed.
+    fn remove_identity_spec(&self, name: &str) -> Result<(), AppError>;
+}
+
+/// Reports stored identities that reference an installed identity spec.
+///
+/// Identity ownership is orthogonal to identity type. Product runtimes that
+/// persist workspace-owned identities should install a provider so identity-spec
+/// deletion can reject or report orphaning for those identities too.
+pub trait IdentitySpecUsageProvider: Send + Sync + std::fmt::Debug + 'static {
+    /// Returns how many stored identities currently depend on `identity_spec_name`.
+    ///
+    /// The count should include every relevant identity owner and type managed
+    /// by the provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the provider cannot inspect its identity store.
+    fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError>;
+}
+
+/// Manages identity specs installed for all workspaces.
+#[derive(Clone)]
+pub(crate) struct IdentitySpecManager {
+    layout: AppStateLayout,
+    registry: Arc<dyn IdentitySpecRegistry>,
+    features: Features,
+    usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+}
+
+impl std::fmt::Debug for IdentitySpecManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IdentitySpecManager")
+            .field("layout", &self.layout)
+            .field("registry", &self.registry)
+            .field("features", &self.features)
+            .field("usage_providers", &self.usage_providers)
+            .finish_non_exhaustive()
+    }
+}
+
+impl IdentitySpecManager {
+    #[cfg(test)]
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self::new_with_usage_providers(layout, crate::features::dsl_v4_features(), Vec::new())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_usage_providers(
+        layout: AppStateLayout,
+        features: Features,
+        usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+    ) -> Self {
+        let credential_store = CredentialStore::with_preference(
+            layout.clone(),
+            crate::credentials::CredentialStoragePreference::File,
+        );
+        Self::new_with_credential_store(layout, credential_store, features, usage_providers)
+    }
+
+    pub(crate) fn new_with_credential_store(
+        layout: AppStateLayout,
+        credential_store: CredentialStore,
+        features: Features,
+        usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+    ) -> Self {
+        let registry = Arc::new(FileIdentitySpecRegistry::new(
+            layout.clone(),
+            credential_store,
+        ));
+        Self::new_with_registry(layout, registry, features, usage_providers)
+    }
+
+    pub(crate) fn new_with_registry(
+        layout: AppStateLayout,
+        registry: Arc<dyn IdentitySpecRegistry>,
+        features: Features,
+        usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+    ) -> Self {
+        Self {
+            layout,
+            registry,
+            features,
+            usage_providers,
+        }
+    }
+
+    /// Errors unless the preview DSL v4 runtime feature is enabled.
+    ///
+    /// Identity specs back DSL v4 source identities, so the whole `identity-spec`
+    /// surface is gated behind `dsl_v4`. The mutating manager methods enforce the
+    /// gate directly (and so cover the source-import bundle path); the read-only
+    /// `get_identity_spec` is also used by query-time identity resolution, so its
+    /// RPC enforces the gate from the service layer instead of the method.
+    pub(crate) fn ensure_dsl_v4_enabled(&self) -> Result<(), AppError> {
+        self.features.ensure_dsl_v4_enabled()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn add_identity_spec(
+        &self,
+        manifest_yaml: &str,
+    ) -> Result<(IdentitySpecRecord, bool), AppError> {
+        self.add_identity_spec_with_inputs(manifest_yaml, Vec::new())
+    }
+
+    pub(crate) fn add_identity_spec_with_inputs(
+        &self,
+        manifest_yaml: &str,
+        inputs: Vec<IdentitySpecInputValue>,
+    ) -> Result<(IdentitySpecRecord, bool), AppError> {
+        let span = info_span!("coral.app.identity_specs.add");
+        let _guard = span.enter();
+        self.features.ensure_dsl_v4_enabled()?;
+        let record = parse_identity_spec_record(manifest_yaml)?;
+        let name = record.manifest.name.clone();
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        let existing = self.registry.get_identity_spec(&name)?;
+        let replaced = existing.is_some();
+        let existing_input_material = existing
+            .as_ref()
+            .map(|record| record.input_material.clone())
+            .unwrap_or_default();
+        if let Some(existing) = &existing {
+            let existing = parse_identity_spec_record(&existing.manifest_yaml)?;
+            if existing.manifest != record.manifest {
+                let referencing_identities = self.count_identities_for_spec_unlocked(&name)?;
+                if referencing_identities > 0 {
+                    return Err(AppError::FailedPrecondition(format!(
+                        "identity spec '{name}' is used by {referencing_identities} stored {} and cannot be replaced with a different manifest; remove it with --force only if you intend to recreate {} against a new spec",
+                        plural_identity(referencing_identities),
+                        plural_pronoun(referencing_identities)
+                    )));
+                }
+            }
+        }
+        let provided_inputs = unique_input_map(
+            inputs.into_iter().map(|input| (input.key, input.value)),
+            "identity spec input",
+        )?;
+        let input_material = merge_identity_spec_input_material(
+            &record.manifest,
+            &existing_input_material,
+            &provided_inputs,
+        )?;
+        self.registry.upsert_identity_spec(
+            &record.manifest.name,
+            IdentitySpecRegistryRecord {
+                manifest_yaml: record.manifest_yaml.clone(),
+                input_material,
+            },
+        )?;
+        Ok((record, replaced))
+    }
+
+    pub(crate) fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRecord>, AppError> {
+        let span = info_span!("coral.app.identity_specs.list");
+        let _guard = span.enter();
+        self.features.ensure_dsl_v4_enabled()?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        let mut records = self
+            .registry
+            .list_identity_spec_manifests()?
+            .into_iter()
+            .map(|manifest_yaml| parse_identity_spec_record(&manifest_yaml))
+            .collect::<Result<Vec<_>, _>>()?;
+        records.sort_by(|left, right| left.manifest.name.cmp(&right.manifest.name));
+        Ok(records)
+    }
+
+    pub(crate) fn get_identity_spec(&self, name: &str) -> Result<IdentitySpecRecord, AppError> {
+        let span = info_span!("coral.app.identity_specs.get");
+        let _guard = span.enter();
+        let name = validate_identity_spec_name(name)?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        self.load_identity_spec_manifest_unlocked(&name)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn resolve_identity_spec_inputs(
+        &self,
+        manifest: &IdentityManifest,
+    ) -> Result<BTreeMap<String, String>, AppError> {
+        let span = info_span!("coral.app.identity_specs.resolve_inputs");
+        let _guard = span.enter();
+        let name = validate_identity_spec_name(&manifest.name)?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        let stored = self
+            .registry
+            .get_identity_spec(&name)?
+            .map(|record| record.input_material)
+            .unwrap_or_default();
+        resolve_identity_spec_inputs_for_use(manifest, &stored)
+    }
+
+    pub(crate) fn remove_identity_spec(&self, name: &str, force: bool) -> Result<u32, AppError> {
+        let span = info_span!("coral.app.identity_specs.remove");
+        let _guard = span.enter();
+        self.features.ensure_dsl_v4_enabled()?;
+        let name = validate_identity_spec_name(name)?;
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        if !self.registry.identity_spec_exists(&name)? {
+            return Err(AppError::IdentitySpecNotFound(name));
+        }
+        let orphaned_identities = self.count_identities_for_spec_unlocked(&name)?;
+        if orphaned_identities > 0 && !force {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity spec '{name}' is used by {orphaned_identities} stored {}; rerun with --force to orphan {}",
+                plural_identity(orphaned_identities),
+                plural_pronoun(orphaned_identities)
+            )));
+        }
+        self.registry.remove_identity_spec(&name)?;
+        Ok(orphaned_identities)
+    }
+
+    fn load_identity_spec_manifest_unlocked(
+        &self,
+        name: &str,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let Some(manifest_yaml) = self.registry.get_identity_spec_manifest(&name)? else {
+            return Err(AppError::IdentitySpecNotFound(name));
+        };
+        let record = parse_identity_spec_record(&manifest_yaml)?;
+        if record.manifest.name != name {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity spec registry record '{name}' contains identity spec '{}'",
+                record.manifest.name
+            )));
+        }
+        Ok(record)
+    }
+
+    fn count_identities_for_spec_unlocked(
+        &self,
+        identity_spec_name: &str,
+    ) -> Result<u32, AppError> {
+        let mut count = self.count_user_owned_identities_for_spec_unlocked(identity_spec_name)?;
+        for provider in &self.usage_providers {
+            count = checked_add_identity_count(
+                count,
+                provider.count_identities_for_spec(identity_spec_name)?,
+                identity_spec_name,
+            )?;
+        }
+        Ok(count)
+    }
+
+    fn count_user_owned_identities_for_spec_unlocked(
+        &self,
+        identity_spec_name: &str,
+    ) -> Result<u32, AppError> {
+        let users_root = self.layout.identities_root().join("users");
+        if !users_root.exists() {
+            return Ok(0);
+        }
+        let mut count = 0u32;
+        for user_entry in fs::read_dir(users_root)? {
+            let user_entry = user_entry?;
+            if !user_entry.file_type()?.is_dir() {
+                continue;
+            }
+            for identity_entry in fs::read_dir(user_entry.path())? {
+                let identity_entry = identity_entry?;
+                if !identity_entry.file_type()?.is_dir() {
+                    continue;
+                }
+                let manifest_path = identity_entry.path().join(INSTALLED_IDENTITY_FILE_NAME);
+                if !manifest_path.exists() {
+                    continue;
+                }
+                let raw = fs::read_to_string(&manifest_path)?;
+                let reference: UserOwnedIdentitySpecReference = serde_yaml::from_str(&raw)?;
+                if reference.identity_spec == identity_spec_name {
+                    count = checked_add_identity_count(count, 1, identity_spec_name)?;
+                }
+            }
+        }
+        Ok(count)
+    }
+}
+
+struct FileIdentitySpecRegistry {
+    layout: AppStateLayout,
+    credential_store: CredentialStore,
+}
+
+impl std::fmt::Debug for FileIdentitySpecRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileIdentitySpecRegistry")
+            .field("layout", &self.layout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FileIdentitySpecRegistry {
+    fn new(layout: AppStateLayout, credential_store: CredentialStore) -> Self {
+        Self {
+            layout,
+            credential_store,
+        }
+    }
+
+    fn input_material_state_file(&self, name: &str) -> std::path::PathBuf {
+        self.layout
+            .identity_spec_dir(name)
+            .join(IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME)
+    }
+
+    fn credential_set_id(name: &str) -> CredentialSetId {
+        CredentialSetId::for_identity_spec(name)
+    }
+
+    fn input_material_workspace() -> WorkspaceName {
+        WorkspaceName::default()
+    }
+
+    fn load_input_material_state(
+        &self,
+        name: &str,
+    ) -> Result<IdentitySpecInputMaterialState, AppError> {
+        let path = self.input_material_state_file(name);
+        if !path.exists() {
+            return Ok(IdentitySpecInputMaterialState::default());
+        }
+        let raw = fs::read_to_string(&path)?;
+        let state: IdentitySpecInputMaterialState = serde_yaml::from_str(&raw)?;
+        if state.version != IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity spec '{name}' input material state has unsupported version {}",
+                state.version
+            )));
+        }
+        Ok(state)
+    }
+
+    fn write_input_material_state(
+        &self,
+        name: &str,
+        state: &IdentitySpecInputMaterialState,
+    ) -> Result<(), AppError> {
+        let path = self.input_material_state_file(name);
+        if state.credential_storage.is_none() {
+            remove_file_if_exists(&path)?;
+            return Ok(());
+        }
+        let raw = serde_yaml::to_string(state)?;
+        storage_fs::write_atomic(&path, raw.as_bytes())?;
+        Ok(())
+    }
+
+    fn read_input_material(
+        &self,
+        name: &str,
+        storage: CredentialStorageKind,
+    ) -> Result<BTreeMap<String, String>, AppError> {
+        self.credential_store.read_material(
+            &Self::input_material_workspace(),
+            &Self::credential_set_id(name),
+            storage,
+        )
+    }
+
+    fn replace_input_material(
+        &self,
+        name: &str,
+        existing_storage: Option<CredentialStorageKind>,
+        next_storage: Option<CredentialStorageKind>,
+        material: &BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
+        if let Some(existing_storage) = existing_storage
+            && Some(existing_storage) != next_storage
+        {
+            self.credential_store.remove_material_unlocked(
+                &Self::input_material_workspace(),
+                &Self::credential_set_id(name),
+                existing_storage,
+            )?;
+        }
+        let Some(storage) = next_storage else {
+            remove_file_if_exists(&self.layout.identity_spec_material_file(name))?;
+            return Ok(());
+        };
+        self.credential_store.replace_material_unlocked(
+            &Self::input_material_workspace(),
+            &Self::credential_set_id(name),
+            storage,
+            material,
+        )
+    }
+
+    fn restore_after_failed_upsert(
+        &self,
+        name: &str,
+        rollback: &IdentitySpecUpsertRollback,
+    ) -> Result<(), AppError> {
+        if let (Some(storage), Some(material)) = (
+            rollback.previous_storage,
+            rollback.previous_input_material.as_ref(),
+        ) {
+            self.replace_input_material(name, None, Some(storage), material)?;
+        } else {
+            if let Some(storage) = rollback.new_storage {
+                self.credential_store.remove_material_unlocked(
+                    &Self::input_material_workspace(),
+                    &Self::credential_set_id(name),
+                    storage,
+                )?;
+            }
+            remove_file_if_exists(&self.layout.identity_spec_material_file(name))?;
+        }
+
+        match rollback.previous_material_state.as_ref() {
+            Some(state) => self.write_input_material_state(name, state)?,
+            None => remove_file_if_exists(&self.input_material_state_file(name))?,
+        }
+
+        match rollback.previous_manifest.as_ref() {
+            Some(bytes) => storage_fs::write_atomic(&rollback.manifest_path, bytes)?,
+            None => remove_file_if_exists(&rollback.manifest_path)?,
+        }
+        if rollback.previous_manifest.is_none()
+            && let Some(parent) = rollback.manifest_path.parent()
+        {
+            drop(fs::remove_dir(parent));
+        }
+        Ok(())
+    }
+
+    fn remove_input_material(&self, name: &str) -> Result<(), AppError> {
+        let state = self.load_input_material_state(name)?;
+        if let Some(storage) = state.credential_storage {
+            self.credential_store.remove_material_unlocked(
+                &Self::input_material_workspace(),
+                &Self::credential_set_id(name),
+                storage,
+            )?;
+        }
+        remove_file_if_exists(&self.input_material_state_file(name))?;
+        remove_file_if_exists(&self.layout.identity_spec_material_file(name))?;
+        Ok(())
+    }
+}
+
+impl IdentitySpecRegistry for FileIdentitySpecRegistry {
+    fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRegistryRecord>, AppError> {
+        let root = self.layout.identity_specs_root();
+        if !root.exists() {
+            return Ok(Vec::new());
+        }
+        let mut records = Vec::new();
+        for entry in fs::read_dir(root)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(ToString::to_string) else {
+                continue;
+            };
+            if let Some(record) = self.get_identity_spec(&name)? {
+                records.push(record);
+            }
+        }
+        Ok(records)
+    }
+
+    fn list_identity_spec_manifests(&self) -> Result<Vec<String>, AppError> {
+        let root = self.layout.identity_specs_root();
+        if !root.exists() {
+            return Ok(Vec::new());
+        }
+        let mut manifests = Vec::new();
+        for entry in fs::read_dir(root)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(ToString::to_string) else {
+                continue;
+            };
+            if let Some(manifest_yaml) = self.get_identity_spec_manifest(&name)? {
+                manifests.push(manifest_yaml);
+            }
+        }
+        Ok(manifests)
+    }
+
+    fn get_identity_spec(
+        &self,
+        name: &str,
+    ) -> Result<Option<IdentitySpecRegistryRecord>, AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let path = self.layout.identity_spec_manifest_file(&name);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let manifest_yaml = fs::read_to_string(&path)?;
+        let state = self.load_input_material_state(&name)?;
+        let input_material = match state.credential_storage {
+            Some(storage) => self.read_input_material(&name, storage)?,
+            None => BTreeMap::new(),
+        };
+        Ok(Some(IdentitySpecRegistryRecord {
+            manifest_yaml,
+            input_material,
+        }))
+    }
+
+    fn get_identity_spec_manifest(&self, name: &str) -> Result<Option<String>, AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let path = self.layout.identity_spec_manifest_file(&name);
+        if !path.exists() {
+            return Ok(None);
+        }
+        fs::read_to_string(&path).map(Some).map_err(Into::into)
+    }
+
+    fn identity_spec_exists(&self, name: &str) -> Result<bool, AppError> {
+        let name = validate_identity_spec_name(name)?;
+        Ok(self.layout.identity_spec_manifest_file(&name).exists())
+    }
+
+    fn upsert_identity_spec(
+        &self,
+        name: &str,
+        record: IdentitySpecRegistryRecord,
+    ) -> Result<(), AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let path = self.layout.identity_spec_manifest_file(&name);
+        let previous_manifest = match fs::read(&path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+        let previous_material_state = if previous_manifest.is_some() {
+            Some(self.load_input_material_state(&name)?)
+        } else {
+            None
+        };
+        let existing_storage = previous_material_state
+            .as_ref()
+            .and_then(|state| state.credential_storage);
+        let previous_input_material = existing_storage
+            .map(|storage| self.read_input_material(&name, storage))
+            .transpose()?;
+        let credential_storage = if record.input_material.is_empty() {
+            None
+        } else {
+            existing_storage.or(Some(self.credential_store.default_write_storage()?))
+        };
+        let rollback = IdentitySpecUpsertRollback {
+            manifest_path: path.clone(),
+            previous_manifest,
+            previous_material_state,
+            previous_storage: existing_storage,
+            previous_input_material,
+            new_storage: credential_storage,
+        };
+        if let Some(parent) = path.parent() {
+            storage_fs::ensure_private_dir(parent)?;
+        }
+        let result = self
+            .replace_input_material(
+                &name,
+                existing_storage,
+                credential_storage,
+                &record.input_material,
+            )
+            .and_then(|()| {
+                storage_fs::write_atomic(&path, record.manifest_yaml.as_bytes()).map_err(Into::into)
+            })
+            .and_then(|()| {
+                self.write_input_material_state(
+                    &name,
+                    &IdentitySpecInputMaterialState {
+                        credential_storage,
+                        version: IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION,
+                    },
+                )
+            });
+        if let Err(error) = result {
+            if let Err(rollback_error) = self.restore_after_failed_upsert(&name, &rollback) {
+                warn!(
+                    identity_spec = name,
+                    error = %rollback_error,
+                    "failed to roll back identity spec upsert"
+                );
+            }
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn remove_identity_spec(&self, name: &str) -> Result<(), AppError> {
+        let name = validate_identity_spec_name(name)?;
+        let path = self.layout.identity_spec_manifest_file(&name);
+        if !path.exists() {
+            return Ok(());
+        }
+        self.remove_input_material(&name)?;
+        remove_file_if_exists(&path)?;
+        if let Some(parent) = path.parent() {
+            drop(fs::remove_dir(parent));
+        }
+        Ok(())
+    }
+}
+
+fn checked_add_identity_count(
+    left: u32,
+    right: u32,
+    identity_spec_name: &str,
+) -> Result<u32, AppError> {
+    left.checked_add(right).ok_or_else(|| {
+        AppError::FailedPrecondition(format!(
+            "too many stored identities reference identity spec '{identity_spec_name}'"
+        ))
+    })
+}
+
+/// Hashes the parsed identity manifest so stored identities can detect when
+/// the spec they were created from has changed.
+///
+/// The manifest serializes with `serde` (struct fields in declaration order)
+/// and `canonical_json_value` sorts any free-form JSON objects (such as
+/// `audience` values), so semantically equal manifests fingerprint equally.
+#[cfg(test)]
+pub(crate) fn identity_spec_fingerprint(manifest: &IdentityManifest) -> Result<String, AppError> {
+    let encode_error = |error: &dyn std::fmt::Display| {
+        AppError::FailedPrecondition(format!(
+            "failed to encode identity spec '{}' fingerprint: {error}",
+            manifest.name
+        ))
+    };
+    let value = canonical_json_value(serde_json::to_value(manifest).map_err(|e| encode_error(&e))?);
+    let bytes = serde_json::to_vec(&value).map_err(|e| encode_error(&e))?;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+fn canonical_json_value(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut entries = map.into_iter().collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            Value::Object(
+                entries
+                    .into_iter()
+                    .map(|(key, value)| (key, canonical_json_value(value)))
+                    .collect(),
+            )
+        }
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .map(canonical_json_value)
+                .collect::<Vec<_>>(),
+        ),
+        scalar => scalar,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct UserOwnedIdentitySpecReference {
+    identity_spec: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IdentitySpecInputMaterialState {
+    version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    credential_storage: Option<CredentialStorageKind>,
+}
+
+struct IdentitySpecUpsertRollback {
+    manifest_path: std::path::PathBuf,
+    previous_manifest: Option<Vec<u8>>,
+    previous_material_state: Option<IdentitySpecInputMaterialState>,
+    previous_storage: Option<CredentialStorageKind>,
+    previous_input_material: Option<BTreeMap<String, String>>,
+    new_storage: Option<CredentialStorageKind>,
+}
+
+impl Default for IdentitySpecInputMaterialState {
+    fn default() -> Self {
+        Self {
+            version: IDENTITY_SPEC_INPUT_MATERIAL_STATE_VERSION,
+            credential_storage: None,
+        }
+    }
+}
+
+fn merge_identity_spec_input_material(
+    manifest: &IdentityManifest,
+    stored: &BTreeMap<String, String>,
+    provided: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let declared = manifest
+        .inputs
+        .iter()
+        .map(|input| input.key.as_str())
+        .collect::<BTreeSet<_>>();
+    for key in provided.keys() {
+        if !declared.contains(key.as_str()) {
+            return Err(AppError::InvalidInput(format!(
+                "unknown identity spec input '{key}' for identity spec '{}'",
+                manifest.name
+            )));
+        }
+    }
+
+    let mut material = BTreeMap::new();
+    for input in &manifest.inputs {
+        if let Some(value) = provided
+            .get(&input.key)
+            .filter(|value| !value.is_empty())
+            .or_else(|| stored.get(&input.key).filter(|value| !value.is_empty()))
+        {
+            material.insert(input.key.clone(), value.clone());
+        }
+    }
+    resolve_identity_spec_inputs_for_use(manifest, &material)?;
+    Ok(material)
+}
+
+fn resolve_identity_spec_inputs_for_use(
+    manifest: &IdentityManifest,
+    material: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let mut resolved = BTreeMap::new();
+    for input in &manifest.inputs {
+        let value = material
+            .get(&input.key)
+            .filter(|value| !value.is_empty())
+            .cloned()
+            .or_else(|| {
+                (input.kind == ManifestInputKind::Variable && !input.default_value.is_empty())
+                    .then(|| input.default_value.clone())
+            });
+        if let Some(value) = value {
+            resolved.insert(input.key.clone(), value);
+        } else if input.required {
+            return Err(AppError::FailedPrecondition(format!(
+                "missing identity spec input '{}' for identity spec '{}'",
+                input.key, manifest.name
+            )));
+        }
+    }
+    Ok(resolved)
+}
+
+fn remove_file_if_exists(path: &std::path::Path) -> Result<(), AppError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn plural_identity(count: u32) -> &'static str {
+    if count == 1 { "identity" } else { "identities" }
+}
+
+fn plural_pronoun(count: u32) -> &'static str {
+    if count == 1 { "it" } else { "them" }
+}
+
+fn parse_identity_spec_record(manifest_yaml: &str) -> Result<IdentitySpecRecord, AppError> {
+    let manifest = parse_identity_manifest_yaml(manifest_yaml)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    Ok(IdentitySpecRecord {
+        manifest_yaml: normalized_manifest_yaml(manifest_yaml),
+        manifest,
+    })
+}
+
+fn normalized_manifest_yaml(manifest_yaml: &str) -> String {
+    if manifest_yaml.ends_with('\n') {
+        manifest_yaml.to_string()
+    } else {
+        format!("{manifest_yaml}\n")
+    }
+}
+
+pub(crate) fn validate_identity_spec_name(name: &str) -> Result<String, AppError> {
+    parse_path_segment("identity spec", name)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+
+    use super::{
+        IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME, IdentitySpecInputValue, IdentitySpecManager,
+        IdentitySpecRecord, IdentitySpecUsageProvider, identity_spec_fingerprint,
+    };
+    use crate::bootstrap::AppError;
+    use crate::credentials::{CredentialStoragePreference, CredentialStore, parse_env_file};
+    use crate::features::{Features, dsl_v4_features};
+    use crate::state::AppStateLayout;
+
+    fn manager() -> (TempDir, IdentitySpecManager, AppStateLayout) {
+        manager_with(dsl_v4_features(), Vec::new())
+    }
+
+    fn manager_with(
+        features: Features,
+        usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+    ) -> (TempDir, IdentitySpecManager, AppStateLayout) {
+        let temp = TempDir::new().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout directories");
+        let manager = IdentitySpecManager::new_with_usage_providers(
+            layout.clone(),
+            features,
+            usage_providers,
+        );
+        (temp, manager, layout)
+    }
+
+    #[track_caller]
+    fn add_spec(manager: &IdentitySpecManager, yaml: &str) -> (IdentitySpecRecord, bool) {
+        manager.add_identity_spec(yaml).expect("add identity spec")
+    }
+
+    #[track_caller]
+    fn add_spec_with_secret(
+        manager: &IdentitySpecManager,
+        yaml: &str,
+    ) -> (IdentitySpecRecord, bool) {
+        add_spec_with_secret_value(manager, yaml, "client-secret")
+    }
+
+    #[track_caller]
+    fn add_spec_with_secret_value(
+        manager: &IdentitySpecManager,
+        yaml: &str,
+        value: &str,
+    ) -> (IdentitySpecRecord, bool) {
+        manager
+            .add_identity_spec_with_inputs(
+                yaml,
+                vec![IdentitySpecInputValue {
+                    key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                    value: value.to_string(),
+                }],
+            )
+            .expect("add identity spec with inputs")
+    }
+
+    #[track_caller]
+    fn remove_spec(manager: &IdentitySpecManager, name: &str, force: bool) -> u32 {
+        manager
+            .remove_identity_spec(name, force)
+            .expect("remove identity spec")
+    }
+
+    #[track_caller]
+    fn stored_spec(manager: &IdentitySpecManager, name: &str) -> IdentitySpecRecord {
+        manager.get_identity_spec(name).expect("stored spec")
+    }
+
+    #[track_caller]
+    fn resolved_inputs(
+        manager: &IdentitySpecManager,
+        record: &IdentitySpecRecord,
+    ) -> BTreeMap<String, String> {
+        manager
+            .resolve_identity_spec_inputs(&record.manifest)
+            .expect("resolve stored inputs")
+    }
+
+    #[track_caller]
+    fn assert_input(resolved: &BTreeMap<String, String>, key: &str, expected: &str) {
+        assert_eq!(resolved.get(key).map(String::as_str), Some(expected));
+    }
+
+    #[track_caller]
+    fn assert_failed_precondition(error: &AppError, fragments: [&str; 2]) {
+        match error {
+            AppError::FailedPrecondition(message) => {
+                for fragment in fragments {
+                    assert!(
+                        message.contains(fragment),
+                        "missing {fragment:?} in: {message}"
+                    );
+                }
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn identity_spec_operations_require_dsl_v4_feature() {
+        let (_temp, manager, _layout) = manager_with(Features::default(), Vec::new());
+
+        let errors = [
+            manager
+                .add_identity_spec(&identity_yaml("github_oauth", "0.1.0"))
+                .expect_err("add requires the dsl_v4 feature"),
+            manager
+                .list_identity_specs()
+                .expect_err("list requires the dsl_v4 feature"),
+            manager
+                .remove_identity_spec("github_oauth", true)
+                .expect_err("remove requires the dsl_v4 feature"),
+        ];
+
+        for error in errors {
+            assert!(
+                matches!(&error, AppError::SourceUnservable(message) if message.contains("dsl_v4")),
+                "unexpected error: {error:?}"
+            );
+        }
+    }
+
+    #[derive(Debug)]
+    struct StaticUsageProvider {
+        identity_spec_name: String,
+        count: u32,
+    }
+
+    impl IdentitySpecUsageProvider for StaticUsageProvider {
+        fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError> {
+            if identity_spec_name == self.identity_spec_name {
+                Ok(self.count)
+            } else {
+                Ok(0)
+            }
+        }
+    }
+
+    fn identity_yaml(name: &str, version: &str) -> String {
+        identity_yaml_with_audience(name, version, "github.com")
+    }
+
+    fn identity_yaml_with_audience(name: &str, version: &str, audience_host: &str) -> String {
+        identity_yaml_with_audience_block(name, version, &format!("  host: {audience_host}\n"))
+    }
+
+    fn identity_yaml_with_audience_block(name: &str, version: &str, audience: &str) -> String {
+        format!(
+            r"
+kind: identity
+spec_version: 1
+name: {name}
+version: {version}
+description: Demo identity.
+issuer: github
+type: fixed_token
+audience:
+{audience}"
+        )
+    }
+
+    fn oauth_identity_yaml_with_inputs() -> String {
+        oauth_identity_yaml_with_inputs_default("tenant-a")
+    }
+
+    fn oauth_identity_yaml_with_inputs_default(default_tenant: &str) -> String {
+        r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+description: Demo OAuth identity.
+issuer: demo
+type: oauth
+audience:
+  host: api.example.test
+inputs:
+  DEMO_TENANT:
+    kind: variable
+    required: false
+    default: {{default_tenant}}
+  DEMO_OAUTH_CLIENT_SECRET:
+    kind: secret
+    required: true
+oauth:
+  method:
+    label: Demo OAuth
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/callback
+    endpoints:
+      authorization_url: https://auth.example.test/{{input.DEMO_TENANT}}/authorize
+      token_url: https://auth.example.test/{{input.DEMO_TENANT}}/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+        transport: request_body
+"
+        .replace("{{default_tenant}}", default_tenant)
+    }
+
+    /// Merges the previous standalone replace test into the CRUD round-trip:
+    /// the version 0.2.0 re-add runs over the same stored spec.
+    #[test]
+    fn add_lists_gets_replaces_and_removes_identity_specs() {
+        let (_temp, manager, _layout) = manager();
+
+        let (record, replaced) = add_spec(&manager, &identity_yaml("github_oauth", "0.1.0"));
+        assert!(!replaced);
+        assert_eq!(record.manifest.name, "github_oauth");
+
+        let list = manager.list_identity_specs().expect("list identity specs");
+        assert_eq!(list.len(), 1);
+        assert_eq!(
+            list.first().expect("one identity spec").manifest.version,
+            "0.1.0"
+        );
+        assert_eq!(
+            stored_spec(&manager, "github_oauth").manifest.description,
+            "Demo identity."
+        );
+
+        let (record, replaced) = add_spec(&manager, &identity_yaml("github_oauth", "0.2.0"));
+        assert!(replaced);
+        assert_eq!(record.manifest.version, "0.2.0");
+        assert_eq!(
+            stored_spec(&manager, "github_oauth").manifest.version,
+            "0.2.0"
+        );
+
+        let orphaned = remove_spec(&manager, "github_oauth", false);
+        assert_eq!(orphaned, 0);
+        assert!(
+            manager
+                .list_identity_specs()
+                .expect("list again")
+                .is_empty()
+        );
+    }
+
+    /// Merges the previous missing-input rejection, declared-input storage,
+    /// and removal tests into one spec-owned input material lifecycle: the
+    /// add fails without the required secret, succeeds with it (storing the
+    /// material under the spec), and removal deletes the material with it.
+    #[test]
+    fn spec_owned_input_material_is_required_stored_on_spec_and_removed_with_it() {
+        let (_temp, manager, layout) = manager();
+
+        let error = manager
+            .add_identity_spec(&oauth_identity_yaml_with_inputs())
+            .expect_err("missing required input should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("missing identity spec input 'DEMO_OAUTH_CLIENT_SECRET'"),
+            "unexpected error: {error}"
+        );
+
+        let (record, replaced) = add_spec_with_secret(&manager, &oauth_identity_yaml_with_inputs());
+        assert!(!replaced);
+        let resolved = resolved_inputs(&manager, &record);
+        assert_input(&resolved, "DEMO_TENANT", "tenant-a");
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "client-secret");
+        assert!(
+            layout.identity_spec_material_file("demo_oauth").exists(),
+            "input material belongs under the installed identity spec"
+        );
+        let stored = parse_env_file(
+            &fs::read_to_string(layout.identity_spec_material_file("demo_oauth"))
+                .expect("identity spec material file"),
+        )
+        .expect("parse material");
+        assert!(
+            !stored.contains_key("DEMO_TENANT"),
+            "manifest defaults must not be persisted as identity-spec input material"
+        );
+
+        remove_spec(&manager, "demo_oauth", false);
+
+        assert!(!layout.identity_spec_material_file("demo_oauth").exists());
+        assert!(!layout.identity_spec_dir("demo_oauth").exists());
+    }
+
+    #[test]
+    fn remove_identity_spec_deletes_malformed_input_material() {
+        let (_temp, manager, layout) = manager();
+        add_spec_with_secret(&manager, &oauth_identity_yaml_with_inputs());
+
+        let material_file = layout.identity_spec_material_file("demo_oauth");
+        fs::write(&material_file, "not env material\n").expect("write malformed material");
+        let record = manager
+            .get_identity_spec("demo_oauth")
+            .expect("metadata reads should not parse stored material");
+        assert_eq!(record.manifest.name, "demo_oauth");
+        assert_eq!(
+            manager
+                .list_identity_specs()
+                .expect("list should not parse stored material")
+                .len(),
+            1
+        );
+        manager
+            .resolve_identity_spec_inputs(&record.manifest)
+            .expect_err("material resolution should still fail on malformed material");
+
+        remove_spec(&manager, "demo_oauth", false);
+
+        assert!(
+            !material_file.exists(),
+            "malformed material should be deleted"
+        );
+        assert!(!layout.identity_spec_dir("demo_oauth").exists());
+    }
+
+    #[test]
+    fn failed_input_material_cleanup_keeps_identity_spec_retryable() {
+        let temp = TempDir::new().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout directories");
+        let credential_store = CredentialStore::with_unavailable_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::File,
+        );
+        let manager = IdentitySpecManager::new_with_credential_store(
+            layout.clone(),
+            credential_store,
+            dsl_v4_features(),
+            Vec::new(),
+        );
+        add_spec_with_secret(&manager, &oauth_identity_yaml_with_inputs());
+
+        let manifest_file = layout.identity_spec_manifest_file("demo_oauth");
+        let state_file = layout
+            .identity_spec_dir("demo_oauth")
+            .join(IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME);
+        fs::write(&state_file, "version: 1\ncredential_storage: keychain\n")
+            .expect("route cleanup through unavailable keychain");
+
+        let error = manager
+            .remove_identity_spec("demo_oauth", false)
+            .expect_err("keychain cleanup should fail");
+        assert!(
+            error.to_string().contains("keychain is unavailable"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            manifest_file.exists(),
+            "manifest must remain so deletion can be retried"
+        );
+
+        fs::write(&state_file, "version: 1\ncredential_storage: file\n")
+            .expect("repair input material state");
+        remove_spec(&manager, "demo_oauth", false);
+
+        assert!(!manifest_file.exists());
+        assert!(!layout.identity_spec_dir("demo_oauth").exists());
+    }
+
+    #[test]
+    fn failed_identity_spec_state_write_rolls_back_input_material() {
+        let (_temp, manager, layout) = manager();
+        let (record, _replaced) =
+            add_spec_with_secret_value(&manager, &oauth_identity_yaml_with_inputs(), "old-secret");
+        let state_file = layout
+            .identity_spec_dir("demo_oauth")
+            .join(IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME);
+        let state_temp_file = state_file.with_file_name(format!(
+            "{IDENTITY_SPEC_INPUT_MATERIAL_STATE_FILE_NAME}.tmp.{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&state_temp_file).expect("block state atomic write temp path");
+
+        let error = manager
+            .add_identity_spec_with_inputs(
+                &oauth_identity_yaml_with_inputs(),
+                vec![IdentitySpecInputValue {
+                    key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                    value: "new-secret".to_string(),
+                }],
+            )
+            .expect_err("blocked state write should fail");
+        assert!(
+            error.to_string().contains("Is a directory")
+                || error.to_string().contains("is a directory"),
+            "unexpected error: {error}"
+        );
+        fs::remove_dir_all(&state_temp_file).expect("unblock state temp path");
+
+        let resolved = resolved_inputs(&manager, &record);
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "old-secret");
+        assert_eq!(
+            stored_spec(&manager, "demo_oauth").manifest.version,
+            "0.1.0"
+        );
+    }
+
+    /// Merges the previous `readding_identity_spec_preserves_existing_input_material`
+    /// coverage with the changed-default re-add: both re-adds run against the same
+    /// stored material.
+    #[test]
+    fn readding_identity_spec_preserves_material_and_uses_new_manifest_default() {
+        let (_temp, manager, _layout) = manager();
+        let (record, _replaced) = add_spec_with_secret(
+            &manager,
+            &oauth_identity_yaml_with_inputs_default("tenant-a"),
+        );
+
+        // Re-adding the identical manifest keeps the stored input material.
+        add_spec(
+            &manager,
+            &oauth_identity_yaml_with_inputs_default("tenant-a"),
+        );
+        let resolved = resolved_inputs(&manager, &record);
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "client-secret");
+
+        // Re-adding with a changed manifest default uses the new default without
+        // persisting the old one.
+        let (record, replaced) = add_spec(
+            &manager,
+            &oauth_identity_yaml_with_inputs_default("tenant-b"),
+        );
+        assert!(replaced);
+        let resolved = resolved_inputs(&manager, &record);
+        assert_input(&resolved, "DEMO_TENANT", "tenant-b");
+        assert_input(&resolved, "DEMO_OAUTH_CLIENT_SECRET", "client-secret");
+    }
+
+    /// Merges the identical-manifest and changed-manifest re-add tests over
+    /// one spec referenced by a stored identity: re-adding the identical
+    /// manifest is allowed, while a different manifest is rejected and
+    /// leaves the stored spec untouched.
+    #[test]
+    fn add_over_used_identity_spec_allows_identical_manifest_and_rejects_changes() {
+        let (_temp, manager, layout) = manager();
+        let manifest_yaml = identity_yaml_with_audience("github_oauth", "0.1.0", "github.com");
+        add_spec(&manager, &manifest_yaml);
+        write_user_owned_identity_manifest(&layout, "local", "github_local", "github_oauth");
+
+        let (record, replaced) = add_spec(&manager, &manifest_yaml);
+        assert!(replaced);
+        assert_eq!(record.manifest.version, "0.1.0");
+
+        let error = manager
+            .add_identity_spec(&identity_yaml_with_audience(
+                "github_oauth",
+                "0.1.0",
+                "attacker.test",
+            ))
+            .expect_err("used identity spec replacement should fail");
+        assert_failed_precondition(&error, ["1 stored identity", "cannot be replaced"]);
+        assert_eq!(
+            stored_spec(&manager, "github_oauth")
+                .manifest
+                .audience
+                .get("host")
+                .and_then(serde_json::Value::as_str),
+            Some("github.com")
+        );
+    }
+
+    #[test]
+    fn identity_spec_fingerprint_canonicalizes_nested_json_object_order() {
+        let left = coral_spec::parse_identity_manifest_yaml(&identity_yaml_with_audience_block(
+            "github_oauth",
+            "0.1.0",
+            "  host: github.com\n  tenant: acme\n",
+        ))
+        .expect("left manifest");
+        let right = coral_spec::parse_identity_manifest_yaml(&identity_yaml_with_audience_block(
+            "github_oauth",
+            "0.1.0",
+            "  tenant: acme\n  host: github.com\n",
+        ))
+        .expect("right manifest");
+
+        assert_eq!(left, right);
+        assert_eq!(
+            identity_spec_fingerprint(&left).expect("left fingerprint"),
+            identity_spec_fingerprint(&right).expect("right fingerprint")
+        );
+    }
+
+    #[test]
+    fn remove_missing_identity_spec_reports_not_found() {
+        let (_temp, manager, _layout) = manager();
+
+        let error = manager
+            .remove_identity_spec("missing", false)
+            .expect_err("missing identity spec");
+
+        assert!(matches!(error, AppError::IdentitySpecNotFound(_)));
+    }
+
+    #[test]
+    fn rejects_invalid_identity_manifest() {
+        let (_temp, manager, _layout) = manager();
+
+        let error = manager
+            .add_identity_spec(
+                r"
+kind: identity
+spec_version: 1
+name: github_oauth
+version: 0.1.0
+issuer: github
+type: oauth
+",
+            )
+            .expect_err("invalid identity spec");
+
+        assert!(
+            error.to_string().contains("type oauth is missing oauth"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// Merges the previous without-force rejection test and the force-removal
+    /// orphan report test into one flow over the same stored identities.
+    #[test]
+    fn remove_identity_spec_requires_force_and_reports_orphaned_user_owned_identities() {
+        let (_temp, manager, layout) = manager();
+        add_spec(&manager, &identity_yaml("github_oauth", "0.1.0"));
+        write_user_owned_identity_manifest(&layout, "local", "github_local", "github_oauth");
+
+        let error = manager
+            .remove_identity_spec("github_oauth", false)
+            .expect_err("remove should require force");
+
+        assert_failed_precondition(&error, ["1 stored identity", "--force"]);
+        manager
+            .get_identity_spec("github_oauth")
+            .expect("spec remains installed");
+
+        write_user_owned_identity_manifest(&layout, "local", "github_alt", "github_oauth");
+        write_user_owned_identity_manifest(&layout, "local", "stripe_local", "stripe_oauth");
+
+        let orphaned = remove_spec(&manager, "github_oauth", true);
+
+        assert_eq!(orphaned, 2);
+        assert!(matches!(
+            manager
+                .get_identity_spec("github_oauth")
+                .expect_err("spec removed"),
+            AppError::IdentitySpecNotFound(_)
+        ));
+    }
+
+    #[test]
+    fn remove_identity_spec_counts_external_identity_usage_provider() {
+        let (_temp, manager, _layout) = manager_with(
+            dsl_v4_features(),
+            vec![Arc::new(StaticUsageProvider {
+                identity_spec_name: "github_oauth".to_string(),
+                count: 3,
+            })],
+        );
+        add_spec(&manager, &identity_yaml("github_oauth", "0.1.0"));
+
+        let error = manager
+            .remove_identity_spec("github_oauth", false)
+            .expect_err("remove should require force");
+        assert_failed_precondition(&error, ["3 stored identities", "--force"]);
+
+        let orphaned = remove_spec(&manager, "github_oauth", true);
+        assert_eq!(orphaned, 3);
+    }
+
+    fn write_user_owned_identity_manifest(
+        layout: &AppStateLayout,
+        user_id: &str,
+        identity_name: &str,
+        identity_spec: &str,
+    ) {
+        let path = layout.user_owned_identity_manifest_file(user_id, identity_name);
+        fs::create_dir_all(path.parent().expect("identity dir")).expect("identity dir");
+        fs::write(
+            path,
+            format!(
+                r"version: 1
+name: {identity_name}
+identity_spec: {identity_spec}
+issuer: github
+identity_type: oauth
+metadata: {{}}
+"
+            ),
+        )
+        .expect("write identity manifest");
+    }
+}

--- a/crates/coral-app/src/identity_specs/mod.rs
+++ b/crates/coral-app/src/identity_specs/mod.rs
@@ -1,0 +1,12 @@
+//! Global identity-spec registry.
+
+mod manager;
+mod service;
+
+pub(crate) use manager::{IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord};
+pub use manager::{
+    IdentitySpecManifestMetadata, IdentitySpecRegistry, IdentitySpecRegistryRecord,
+    IdentitySpecUsageProvider, identity_spec_input_material_from_manifest,
+    identity_spec_input_material_from_manifest_with_existing, identity_spec_manifest_metadata,
+};
+pub(crate) use service::IdentitySpecService;

--- a/crates/coral-app/src/identity_specs/mod.rs
+++ b/crates/coral-app/src/identity_specs/mod.rs
@@ -3,7 +3,9 @@
 mod manager;
 mod service;
 
-pub(crate) use manager::{IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord};
+pub(crate) use manager::{
+    IdentitySpecInputValue, IdentitySpecManager, IdentitySpecName, IdentitySpecRecord,
+};
 pub use manager::{
     IdentitySpecManifestMetadata, IdentitySpecRegistry, IdentitySpecRegistryRecord,
     IdentitySpecUsageProvider, identity_spec_input_material_from_manifest,

--- a/crates/coral-app/src/identity_specs/service.rs
+++ b/crates/coral-app/src/identity_specs/service.rs
@@ -1,0 +1,156 @@
+//! Implements the gRPC `IdentitySpecService`.
+
+use std::sync::Arc;
+
+use coral_api::v1::identity_spec_service_server::IdentitySpecService as IdentitySpecServiceApi;
+use coral_api::v1::{
+    AddIdentitySpecRequest, AddIdentitySpecResponse, DeleteIdentitySpecRequest,
+    DeleteIdentitySpecResponse, GetIdentitySpecRequest, GetIdentitySpecResponse, IdentitySpec,
+    ListIdentitySpecsRequest, ListIdentitySpecsResponse,
+};
+use tonic::{Request, Response, Status};
+
+use crate::authorization::{ManagementAuthorizer, authorization_status};
+use crate::identity_specs::{IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord};
+use crate::request_context::RequestContext;
+use crate::transport::{grpc_span, instrument_grpc, run_blocking_operation};
+
+#[derive(Clone)]
+pub(crate) struct IdentitySpecService {
+    identity_specs: IdentitySpecManager,
+    management_authorizer: Arc<dyn ManagementAuthorizer>,
+}
+
+impl IdentitySpecService {
+    pub(crate) fn new(
+        identity_specs: IdentitySpecManager,
+        management_authorizer: Arc<dyn ManagementAuthorizer>,
+    ) -> Self {
+        Self {
+            identity_specs,
+            management_authorizer,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl IdentitySpecServiceApi for IdentitySpecService {
+    async fn add_identity_spec(
+        &self,
+        request: Request<AddIdentitySpecRequest>,
+    ) -> Result<Response<AddIdentitySpecResponse>, Status> {
+        let span = grpc_span(&request);
+        let identity_specs = self.identity_specs.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
+        instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
+            let request = request.into_inner();
+            management_authorizer
+                .authorize_identity_spec_mutation(&principal)
+                .await
+                .map_err(authorization_status)?;
+            let inputs = request
+                .inputs
+                .into_iter()
+                .map(|input| IdentitySpecInputValue {
+                    key: input.key,
+                    value: input.value,
+                })
+                .collect::<Vec<_>>();
+            let (record, replaced) = run_blocking_operation("identity spec operation", move || {
+                identity_specs.add_identity_spec_with_inputs(&request.manifest_yaml, inputs)
+            })
+            .await?;
+            Ok(Response::new(AddIdentitySpecResponse {
+                identity_spec: Some(identity_spec_record_to_proto(record)),
+                replaced,
+            }))
+        })
+        .await
+    }
+
+    async fn list_identity_specs(
+        &self,
+        request: Request<ListIdentitySpecsRequest>,
+    ) -> Result<Response<ListIdentitySpecsResponse>, Status> {
+        let span = grpc_span(&request);
+        let identity_specs = self.identity_specs.clone();
+        instrument_grpc(span, async move {
+            let _request_context = RequestContext::from_request(&request)?;
+            let _request = request.into_inner();
+            let records = run_blocking_operation("identity spec operation", move || {
+                identity_specs.list_identity_specs()
+            })
+            .await?;
+            Ok(Response::new(ListIdentitySpecsResponse {
+                identity_specs: records
+                    .into_iter()
+                    .map(identity_spec_record_to_proto)
+                    .collect(),
+            }))
+        })
+        .await
+    }
+
+    async fn get_identity_spec(
+        &self,
+        request: Request<GetIdentitySpecRequest>,
+    ) -> Result<Response<GetIdentitySpecResponse>, Status> {
+        let span = grpc_span(&request);
+        let identity_specs = self.identity_specs.clone();
+        instrument_grpc(span, async move {
+            let _request_context = RequestContext::from_request(&request)?;
+            let request = request.into_inner();
+            let record = run_blocking_operation("identity spec operation", move || {
+                // The other identity-spec RPCs gate `dsl_v4` inside the manager
+                // method, but `get_identity_spec` is shared with query-time
+                // identity resolution (which must stay ungated), so the gate is
+                // enforced here at the read RPC instead.
+                identity_specs.ensure_dsl_v4_enabled()?;
+                identity_specs.get_identity_spec(&request.name)
+            })
+            .await?;
+            Ok(Response::new(GetIdentitySpecResponse {
+                identity_spec: Some(identity_spec_record_to_proto(record)),
+            }))
+        })
+        .await
+    }
+
+    async fn delete_identity_spec(
+        &self,
+        request: Request<DeleteIdentitySpecRequest>,
+    ) -> Result<Response<DeleteIdentitySpecResponse>, Status> {
+        let span = grpc_span(&request);
+        let identity_specs = self.identity_specs.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
+        instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
+            let request = request.into_inner();
+            management_authorizer
+                .authorize_identity_spec_mutation(&principal)
+                .await
+                .map_err(authorization_status)?;
+            let orphaned_identities =
+                run_blocking_operation("identity spec operation", move || {
+                    identity_specs.remove_identity_spec(&request.name, request.force)
+                })
+                .await?;
+            Ok(Response::new(DeleteIdentitySpecResponse {
+                orphaned_identities,
+            }))
+        })
+        .await
+    }
+}
+
+fn identity_spec_record_to_proto(record: IdentitySpecRecord) -> IdentitySpec {
+    IdentitySpec {
+        name: record.manifest.name,
+        version: record.manifest.version,
+        description: record.manifest.description,
+        issuer: record.manifest.issuer,
+        identity_type: record.manifest.identity_type.label().to_string(),
+        manifest_yaml: record.manifest_yaml,
+    }
+}

--- a/crates/coral-app/src/identity_specs/service.rs
+++ b/crates/coral-app/src/identity_specs/service.rs
@@ -10,7 +10,9 @@ use coral_api::v1::{
 };
 use tonic::{Request, Response, Status};
 
-use crate::authorization::{ManagementAuthorizer, authorization_status};
+use crate::authorization::{
+    ManagementAuthorizer, ManagementMutation, ResourceMutationKind, authorization_status,
+};
 use crate::identity_specs::{IdentitySpecInputValue, IdentitySpecManager, IdentitySpecRecord};
 use crate::request_context::RequestContext;
 use crate::transport::{grpc_span, instrument_grpc, run_blocking_operation};
@@ -46,7 +48,12 @@ impl IdentitySpecServiceApi for IdentitySpecService {
             let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
             management_authorizer
-                .authorize_identity_spec_mutation(&principal)
+                .authorize_management_mutation(
+                    &principal,
+                    ManagementMutation::IdentitySpec {
+                        kind: ResourceMutationKind::Upsert,
+                    },
+                )
                 .await
                 .map_err(authorization_status)?;
             let inputs = request
@@ -128,7 +135,12 @@ impl IdentitySpecServiceApi for IdentitySpecService {
             let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
             management_authorizer
-                .authorize_identity_spec_mutation(&principal)
+                .authorize_management_mutation(
+                    &principal,
+                    ManagementMutation::IdentitySpec {
+                        kind: ResourceMutationKind::Delete,
+                    },
+                )
                 .await
                 .map_err(authorization_status)?;
             let orphaned_identities =

--- a/crates/coral-app/src/identity_specs/service.rs
+++ b/crates/coral-app/src/identity_specs/service.rs
@@ -50,7 +50,7 @@ impl IdentitySpecServiceApi for IdentitySpecService {
                 .await
                 .map_err(authorization_status)?;
             let inputs = request
-                .inputs
+                .input_values
                 .into_iter()
                 .map(|input| IdentitySpecInputValue {
                     key: input.key,

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -51,6 +51,7 @@ pub mod features;
 mod feedback;
 mod identities;
 mod identity;
+mod identity_specs;
 mod query;
 mod request_context;
 mod sources;
@@ -81,6 +82,12 @@ pub use identity::{
     RuntimeSourceIdentity, SingleUserPrincipalProvider, SourceIdentityBinding, SourceIdentityOwner,
     SourceIdentityProvider, SourceIdentityResolutionRequest, SourceIdentitySelection,
     SourceIdentitySelectionRequest, UserPrincipal, UserPrincipalProvider,
+};
+pub use identity_specs::IdentitySpecUsageProvider;
+pub use identity_specs::{
+    IdentitySpecManifestMetadata, IdentitySpecRegistry, IdentitySpecRegistryRecord,
+    identity_spec_input_material_from_manifest,
+    identity_spec_input_material_from_manifest_with_existing, identity_spec_manifest_metadata,
 };
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -18,7 +18,6 @@ use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::episode::EpisodeId;
-use crate::features::Features;
 use crate::query::QueryContext;
 use crate::query::extensions::{
     CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
@@ -51,11 +50,9 @@ pub(crate) struct QueryManager {
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-    features: Features,
 }
 
 impl QueryManager {
-    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
@@ -63,31 +60,12 @@ impl QueryManager {
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
-        Self::new_with_features(
-            config_store,
-            credential_manager,
-            runtime_context,
-            layout,
-            engine_extensions_providers,
-            Features::default(),
-        )
-    }
-
-    pub(crate) fn new_with_features(
-        config_store: ConfigStore,
-        credential_manager: CredentialManager,
-        runtime_context: QueryRuntimeContext,
-        layout: AppStateLayout,
-        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-        features: Features,
-    ) -> Self {
         Self {
             config_store,
             credential_manager,
             runtime_context,
             layout,
             engine_extensions_providers,
-            features,
         }
     }
 
@@ -333,7 +311,6 @@ impl QueryManager {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = installed.source_spec;
         let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
-            self.features.ensure_dsl_v4_enabled()?;
             let materialized = load_v4_materialization(
                 &self.layout,
                 workspace_name,
@@ -659,7 +636,7 @@ mod tests {
 
     use super::*;
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
-    use crate::features::{Features, dsl_v4_features};
+    use crate::features::dsl_v4_features;
     use crate::identity::UserPrincipal;
     use crate::query::QueryAttribution;
     use crate::request_context::RequestContext;
@@ -675,24 +652,15 @@ mod tests {
         runtime_context: QueryRuntimeContext,
         providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> QueryManagerFixture {
-        query_manager_with_features(runtime_context, providers, Features::default())
-    }
-
-    fn query_manager_with_features(
-        runtime_context: QueryRuntimeContext,
-        providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-        features: Features,
-    ) -> QueryManagerFixture {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        let manager = QueryManager::new_with_features(
+        let manager = QueryManager::new(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             runtime_context,
             layout,
             providers,
-            features,
         );
         QueryManagerFixture {
             _temp: temp,
@@ -1022,11 +990,7 @@ tables:
             .mount(&server)
             .await;
 
-        let fixture = query_manager_with_features(
-            QueryRuntimeContext::default(),
-            Vec::new(),
-            dsl_v4_features(),
-        );
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
         fixture.manager.layout.ensure().expect("ensure layout");
         let source_manager = SourceManager::new_with_features(
             fixture.manager.config_store.clone(),
@@ -1107,76 +1071,8 @@ surfaces:
     }
 
     #[test]
-    fn load_query_source_rejects_v4_when_dsl_v4_feature_is_disabled() {
-        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
-        fixture.manager.layout.ensure().expect("ensure layout");
-        let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("github_v4_disabled").expect("source name");
-        let manifest_path = fixture
-            .manager
-            .layout
-            .manifest_file(&workspace_name, &source_name);
-        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
-            .expect("create source dir");
-        std::fs::write(
-            &manifest_path,
-            r"
-name: github_v4_disabled
-dsl_version: 4
-surfaces:
-  - id: rest
-    type: openapi
-    url: https://example.com/openapi.yaml
-",
-        )
-        .expect("write manifest");
-        let source = InstalledSource {
-            name: source_name,
-            version: None,
-            variables: BTreeMap::new(),
-            secrets: Vec::new(),
-            credential_storage: None,
-            origin: SourceOrigin::Imported,
-        };
-
-        let error = fixture
-            .manager
-            .load_query_source(&workspace_name, &source)
-            .expect_err("v4 source should require feature opt-in");
-
-        assert!(
-            matches!(error, AppError::SourceUnservable(ref message) if message.contains("dsl_v4")),
-            "unexpected error: {error:#}"
-        );
-
-        fixture
-            .manager
-            .config_store
-            .upsert_source(&workspace_name, source)
-            .expect("persist v4 source");
-        let config = fixture
-            .manager
-            .config_store
-            .load_config()
-            .expect("load config");
-        let error = fixture
-            .manager
-            .load_query_sources(&workspace_name, &config)
-            .expect_err("normal query loading should fail on disabled v4 source");
-
-        assert!(
-            matches!(error, AppError::SourceUnservable(ref message) if message.contains("dsl_v4")),
-            "unexpected error: {error:#}"
-        );
-    }
-
-    #[test]
     fn load_query_sources_fails_closed_for_missing_v4_materialization() {
-        let fixture = query_manager_with_features(
-            QueryRuntimeContext::default(),
-            Vec::new(),
-            dsl_v4_features(),
-        );
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = WorkspaceName::default();
         let source_name = SourceName::parse("github_v4_missing_artifacts").expect("source name");

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -18,6 +18,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::episode::EpisodeId;
+use crate::features::Features;
 use crate::query::QueryContext;
 use crate::query::extensions::{
     CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
@@ -50,9 +51,11 @@ pub(crate) struct QueryManager {
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    features: Features,
 }
 
 impl QueryManager {
+    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
@@ -60,12 +63,31 @@ impl QueryManager {
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
+        Self::new_with_features(
+            config_store,
+            credential_manager,
+            runtime_context,
+            layout,
+            engine_extensions_providers,
+            Features::default(),
+        )
+    }
+
+    pub(crate) fn new_with_features(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        features: Features,
+    ) -> Self {
         Self {
             config_store,
             credential_manager,
             runtime_context,
             layout,
             engine_extensions_providers,
+            features,
         }
     }
 
@@ -285,7 +307,8 @@ impl QueryManager {
                 Ok((query_source, _version)) => query_sources.push(query_source),
                 Err(
                     error @ (AppError::Credentials(CredentialsError::Unavailable(_))
-                    | AppError::MissingOrIncompatibleV4Materialization { .. }),
+                    | AppError::MissingOrIncompatibleV4Materialization { .. }
+                    | AppError::SourceUnservable(_)),
                 ) => {
                     return Err(error);
                 }
@@ -310,6 +333,7 @@ impl QueryManager {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = installed.source_spec;
         let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
+            self.features.ensure_dsl_v4_enabled()?;
             let materialized = load_v4_materialization(
                 &self.layout,
                 workspace_name,
@@ -550,11 +574,14 @@ fn app_error_type(error: &AppError) -> &'static str {
     match error {
         AppError::Unauthenticated(_) => "UNAUTHENTICATED",
         AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
+        AppError::IdentitySpecNotFound(_) => "IDENTITY_SPEC_NOT_FOUND",
+        AppError::IdentityNotFound(_) => "IDENTITY_NOT_FOUND",
         AppError::InvalidInput(_) => "INVALID_INPUT",
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
         AppError::MissingOrIncompatibleV4Materialization { .. } => {
             "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION"
         }
+        AppError::SourceUnservable(_) => "SOURCE_UNSERVABLE",
         AppError::CredentialRefresh(_) => "CREDENTIAL_REFRESH",
         AppError::Unavailable(_) => "UNAVAILABLE",
         AppError::Io(_) => "IO",
@@ -632,6 +659,7 @@ mod tests {
 
     use super::*;
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
+    use crate::features::{Features, dsl_v4_features};
     use crate::identity::UserPrincipal;
     use crate::query::QueryAttribution;
     use crate::request_context::RequestContext;
@@ -647,15 +675,24 @@ mod tests {
         runtime_context: QueryRuntimeContext,
         providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> QueryManagerFixture {
+        query_manager_with_features(runtime_context, providers, Features::default())
+    }
+
+    fn query_manager_with_features(
+        runtime_context: QueryRuntimeContext,
+        providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        features: Features,
+    ) -> QueryManagerFixture {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        let manager = QueryManager::new(
+        let manager = QueryManager::new_with_features(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             runtime_context,
             layout,
             providers,
+            features,
         );
         QueryManagerFixture {
             _temp: temp,
@@ -985,12 +1022,17 @@ tables:
             .mount(&server)
             .await;
 
-        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        let fixture = query_manager_with_features(
+            QueryRuntimeContext::default(),
+            Vec::new(),
+            dsl_v4_features(),
+        );
         fixture.manager.layout.ensure().expect("ensure layout");
-        let source_manager = SourceManager::new(
+        let source_manager = SourceManager::new_with_features(
             fixture.manager.config_store.clone(),
             fixture.manager.credential_manager.clone(),
             fixture.manager.layout.clone(),
+            dsl_v4_features(),
         );
         let workspace_name = WorkspaceName::default();
         let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
@@ -1065,8 +1107,76 @@ surfaces:
     }
 
     #[test]
-    fn load_query_sources_fails_closed_for_missing_v4_materialization() {
+    fn load_query_source_rejects_v4_when_dsl_v4_feature_is_disabled() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("github_v4_disabled").expect("source name");
+        let manifest_path = fixture
+            .manager
+            .layout
+            .manifest_file(&workspace_name, &source_name);
+        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create source dir");
+        std::fs::write(
+            &manifest_path,
+            r"
+name: github_v4_disabled
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/openapi.yaml
+",
+        )
+        .expect("write manifest");
+        let source = InstalledSource {
+            name: source_name,
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            origin: SourceOrigin::Imported,
+        };
+
+        let error = fixture
+            .manager
+            .load_query_source(&workspace_name, &source)
+            .expect_err("v4 source should require feature opt-in");
+
+        assert!(
+            matches!(error, AppError::SourceUnservable(ref message) if message.contains("dsl_v4")),
+            "unexpected error: {error:#}"
+        );
+
+        fixture
+            .manager
+            .config_store
+            .upsert_source(&workspace_name, source)
+            .expect("persist v4 source");
+        let config = fixture
+            .manager
+            .config_store
+            .load_config()
+            .expect("load config");
+        let error = fixture
+            .manager
+            .load_query_sources(&workspace_name, &config)
+            .expect_err("normal query loading should fail on disabled v4 source");
+
+        assert!(
+            matches!(error, AppError::SourceUnservable(ref message) if message.contains("dsl_v4")),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_query_sources_fails_closed_for_missing_v4_materialization() {
+        let fixture = query_manager_with_features(
+            QueryRuntimeContext::default(),
+            Vec::new(),
+            dsl_v4_features(),
+        );
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = WorkspaceName::default();
         let source_name = SourceName::parse("github_v4_missing_artifacts").expect("source name");

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -15,6 +15,7 @@ use crate::credentials::{
     CORAL_INTERNAL_KEY_PREFIX, CredentialManager, CredentialMaterialGuard,
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialsError,
 };
+use crate::features::Features;
 use crate::sources::SourceName;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
@@ -40,6 +41,7 @@ pub(crate) struct SourceManager {
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
     layout: AppStateLayout,
+    features: Features,
 }
 
 pub(crate) struct CreateBundledSourceCommand {
@@ -169,16 +171,32 @@ fn materialization_inputs_from_bindings(
 }
 
 impl SourceManager {
+    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
         layout: AppStateLayout,
+    ) -> Self {
+        Self::new_with_features(
+            config_store,
+            credential_manager,
+            layout,
+            Features::default(),
+        )
+    }
+
+    pub(crate) fn new_with_features(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+        features: Features,
     ) -> Self {
         Self {
             config_store,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
             layout,
+            features,
         }
     }
 
@@ -301,6 +319,7 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_enabled_for_manifest(&manifest)?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
@@ -322,6 +341,7 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_enabled_for_manifest(&manifest)?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
@@ -351,6 +371,7 @@ impl SourceManager {
         materialization_manifest_yaml: &str,
         origin: SourceOrigin,
     ) -> Result<InstalledSource, AppError> {
+        self.ensure_dsl_v4_enabled_for_manifest_yaml(materialization_manifest_yaml)?;
         self.validate_runtime_schema_names_available(
             workspace_name,
             &candidate.name,
@@ -412,6 +433,7 @@ impl SourceManager {
         materialization_manifest_yaml: &str,
         origin: SourceOrigin,
     ) -> Result<InstalledSource, AppError> {
+        self.ensure_dsl_v4_enabled_for_manifest_yaml(materialization_manifest_yaml)?;
         self.validate_runtime_schema_names_available(
             workspace_name,
             &candidate.name,
@@ -726,6 +748,7 @@ impl SourceManager {
         let Some(v4) = manifest.as_v4() else {
             return Ok(None);
         };
+        self.features.ensure_dsl_v4_enabled()?;
         if matches!(origin, SourceOrigin::Bundled)
             && v4.surfaces.iter().any(|surface| {
                 matches!(
@@ -749,6 +772,22 @@ impl SourceManager {
             &new_materialization_suffix(suffix_prefix),
         )
         .map(Some)
+    }
+
+    fn ensure_dsl_v4_enabled_for_manifest(
+        &self,
+        manifest: &ValidatedSourceManifest,
+    ) -> Result<(), AppError> {
+        if manifest.as_v4().is_some() {
+            self.features.ensure_dsl_v4_enabled()?;
+        }
+        Ok(())
+    }
+
+    fn ensure_dsl_v4_enabled_for_manifest_yaml(&self, manifest_yaml: &str) -> Result<(), AppError> {
+        let manifest = parse_source_manifest_yaml(manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        self.ensure_dsl_v4_enabled_for_manifest(&manifest)
     }
 
     fn validate_runtime_schema_names_available(
@@ -1490,15 +1529,30 @@ mod tests {
         materialization_inputs_from_bindings, normalize_binding_key,
         source_needs_stored_material_for_validation,
     };
+    use crate::bootstrap::AppError;
     use crate::credentials::{
         CredentialManager, CredentialSetId, CredentialStorageKind, CredentialStoragePreference,
         CredentialStore,
     };
+    use crate::features::dsl_v4_features;
     use crate::sources::SourceName;
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::WorkspaceName;
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
+
+    fn source_manager_with_dsl_v4(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+    ) -> SourceManager {
+        SourceManager::new_with_features(
+            config_store,
+            credential_manager,
+            layout,
+            dsl_v4_features(),
+        )
+    }
 
     fn default_workspace() -> WorkspaceName {
         WorkspaceName::default()
@@ -1935,6 +1989,83 @@ tables:
     }
 
     #[test]
+    fn import_v4_source_requires_dsl_v4_feature() {
+        let temp = TempDir::new().expect("temp dir");
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+
+        let error = manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_v4_with_file_descriptor(&openapi_file),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect_err("v4 source import should require feature opt-in");
+
+        assert!(
+            matches!(error, AppError::SourceUnservable(ref message) if message.contains("dsl_v4")),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            manager
+                .list_workspace_sources(&default_workspace())
+                .expect("list sources")
+                .is_empty(),
+            "rejected source should not be persisted"
+        );
+    }
+
+    #[tokio::test]
+    async fn import_v4_source_with_oauth_requires_dsl_v4_before_retrieval() {
+        let temp = TempDir::new().expect("temp dir");
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager = SourceManager::new(config_store, credential_manager, layout);
+        let (event_tx, mut event_rx) = import_event_channel();
+
+        let error = manager
+            .import_source_with_credentials(
+                &default_workspace(),
+                ImportSourceWithCredentialsCommand {
+                    manifest_yaml: manifest_v4_with_file_descriptor(&openapi_file),
+                    bindings: SourceBindings::default(),
+                    oauth_credential_retrievals: vec![SourceOAuthCredentialRetrieval {
+                        input_key: "API_TOKEN".to_string(),
+                        method_index: 0,
+                        credential_inputs: Vec::new(),
+                    }],
+                },
+                event_tx,
+            )
+            .await
+            .expect_err("v4 OAuth import should require feature opt-in");
+
+        assert!(
+            matches!(error, AppError::SourceUnservable(ref message) if message.contains("dsl_v4")),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            event_rx.try_recv().is_err(),
+            "feature gate should fail before OAuth retrieval emits events"
+        );
+    }
+
+    #[test]
     fn import_v4_source_writes_materialized_artifacts() {
         let temp = TempDir::new().expect("temp dir");
         let descriptor_temp = TempDir::new().expect("descriptor temp dir");
@@ -1946,7 +2077,7 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let manager = source_manager_with_dsl_v4(config_store, credential_manager, layout.clone());
 
         let installed = manager
             .import_source(
@@ -1986,7 +2117,7 @@ tables:
         layout.ensure().expect("ensure layout");
         let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
         std::fs::write(&openapi_file, v4_openapi_fixture()).expect("write fixture");
-        let manager = SourceManager::new(
+        let manager = source_manager_with_dsl_v4(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout.clone(),
@@ -2048,7 +2179,7 @@ tables:
             v4_openapi_fixture_with_defaulted_input_server_url(),
         )
         .expect("write fixture");
-        let manager = SourceManager::new(
+        let manager = source_manager_with_dsl_v4(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout.clone(),
@@ -2086,7 +2217,7 @@ tables:
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         layout.ensure().expect("ensure layout");
-        let manager = SourceManager::new(
+        let manager = source_manager_with_dsl_v4(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout,
@@ -2119,7 +2250,7 @@ tables:
         layout.ensure().expect("ensure layout");
         let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
         std::fs::write(&openapi_file, v4_openapi_fixture_with_metadata()).expect("write fixture");
-        let manager = SourceManager::new(
+        let manager = source_manager_with_dsl_v4(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout.clone(),

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -2,6 +2,7 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use coral_api::v1::source_service_server::SourceService as SourceServiceApi;
@@ -31,9 +32,11 @@ use coral_spec::{
 };
 use tonic::{Request, Response, Status};
 
+use crate::authorization::{ManagementAuthorizer, SourceMutationKind, authorization_status};
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
 use crate::query::manager::QueryManager;
+use crate::request_context::RequestContext;
 use crate::sources::SourceName;
 use crate::sources::manager::{
     CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
@@ -56,13 +59,19 @@ use tokio_stream::StreamExt as _;
 pub(crate) struct SourceService {
     sources: SourceManager,
     queries: QueryManager,
+    management_authorizer: Arc<dyn ManagementAuthorizer>,
 }
 
 impl SourceService {
-    pub(crate) fn new(source_manager: SourceManager, query_manager: QueryManager) -> Self {
+    pub(crate) fn new(
+        source_manager: SourceManager,
+        query_manager: QueryManager,
+        management_authorizer: Arc<dyn ManagementAuthorizer>,
+    ) -> Self {
         Self {
             sources: source_manager,
             queries: query_manager,
+            management_authorizer,
         }
     }
 }
@@ -158,9 +167,19 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<CreateBundledSourceResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            management_authorizer
+                .authorize_source_mutation(
+                    &principal,
+                    workspace_name.as_str(),
+                    SourceMutationKind::CreateBundled,
+                )
+                .await
+                .map_err(authorization_status)?;
             let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
             let command = CreateBundledSourceCommand {
                 name: bundled_name,
@@ -187,9 +206,19 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_grpc(span.clone(), async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            management_authorizer
+                .authorize_source_mutation(
+                    &principal,
+                    workspace_name.as_str(),
+                    SourceMutationKind::CreateBundledWithOAuth,
+                )
+                .await
+                .map_err(authorization_status)?;
             let response_workspace_name = workspace_name.clone();
             let command = CreateBundledSourceWithOAuthCommand {
                 name: SourceName::parse(&request.name).map_err(app_status)?,
@@ -228,9 +257,19 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Self::ImportSourceStream>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_grpc(span.clone(), async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            management_authorizer
+                .authorize_source_mutation(
+                    &principal,
+                    workspace_name.as_str(),
+                    SourceMutationKind::Import,
+                )
+                .await
+                .map_err(authorization_status)?;
             let response_workspace_name = workspace_name.clone();
             if request.oauth_credential_retrievals.is_empty() {
                 let command = ImportSourceCommand {
@@ -280,9 +319,19 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<DeleteSourceResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let management_authorizer = Arc::clone(&self.management_authorizer);
         instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            management_authorizer
+                .authorize_source_mutation(
+                    &principal,
+                    workspace_name.as_str(),
+                    SourceMutationKind::Delete,
+                )
+                .await
+                .map_err(authorization_status)?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             run_blocking_source_operation(move || {
                 sources.delete_source(&workspace_name, &source_name)

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -32,7 +32,9 @@ use coral_spec::{
 };
 use tonic::{Request, Response, Status};
 
-use crate::authorization::{ManagementAuthorizer, SourceMutationKind, authorization_status};
+use crate::authorization::{
+    ManagementAuthorizer, ManagementMutation, WorkspaceSourceMutationKind, authorization_status,
+};
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
 use crate::query::manager::QueryManager;
@@ -173,10 +175,12 @@ impl SourceServiceApi for SourceService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             management_authorizer
-                .authorize_source_mutation(
+                .authorize_management_mutation(
                     &principal,
-                    workspace_name.as_str(),
-                    SourceMutationKind::CreateBundled,
+                    ManagementMutation::WorkspaceSource {
+                        workspace_id: workspace_name.as_str(),
+                        kind: WorkspaceSourceMutationKind::CreateBundled,
+                    },
                 )
                 .await
                 .map_err(authorization_status)?;
@@ -212,10 +216,12 @@ impl SourceServiceApi for SourceService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             management_authorizer
-                .authorize_source_mutation(
+                .authorize_management_mutation(
                     &principal,
-                    workspace_name.as_str(),
-                    SourceMutationKind::CreateBundledWithOAuth,
+                    ManagementMutation::WorkspaceSource {
+                        workspace_id: workspace_name.as_str(),
+                        kind: WorkspaceSourceMutationKind::CreateBundledWithOAuth,
+                    },
                 )
                 .await
                 .map_err(authorization_status)?;
@@ -263,10 +269,12 @@ impl SourceServiceApi for SourceService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             management_authorizer
-                .authorize_source_mutation(
+                .authorize_management_mutation(
                     &principal,
-                    workspace_name.as_str(),
-                    SourceMutationKind::Import,
+                    ManagementMutation::WorkspaceSource {
+                        workspace_id: workspace_name.as_str(),
+                        kind: WorkspaceSourceMutationKind::CreateFromSourceSpec,
+                    },
                 )
                 .await
                 .map_err(authorization_status)?;
@@ -325,10 +333,12 @@ impl SourceServiceApi for SourceService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             management_authorizer
-                .authorize_source_mutation(
+                .authorize_management_mutation(
                     &principal,
-                    workspace_name.as_str(),
-                    SourceMutationKind::Delete,
+                    ManagementMutation::WorkspaceSource {
+                        workspace_id: workspace_name.as_str(),
+                        kind: WorkspaceSourceMutationKind::Delete,
+                    },
                 )
                 .await
                 .map_err(authorization_status)?;

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -11,6 +11,7 @@ use crate::workspaces::WorkspaceName;
 
 pub(crate) const INSTALLED_MANIFEST_FILE_NAME: &str = "manifest.yaml";
 pub(crate) const INSTALLED_SECRETS_FILE_NAME: &str = "secrets.env";
+pub(crate) const INSTALLED_IDENTITY_FILE_NAME: &str = "identity.yaml";
 
 #[derive(Debug, Clone)]
 pub(crate) struct AppStateLayout {
@@ -93,6 +94,41 @@ impl AppStateLayout {
         self.workspace_dir(workspace_name)
             .join("episodes")
             .join("episodes.jsonl")
+    }
+
+    pub(crate) fn identity_specs_root(&self) -> PathBuf {
+        self.config_dir.join("identity-specs")
+    }
+
+    pub(crate) fn identity_spec_dir(&self, identity_spec_name: &str) -> PathBuf {
+        self.identity_specs_root().join(identity_spec_name)
+    }
+
+    pub(crate) fn identity_spec_manifest_file(&self, identity_spec_name: &str) -> PathBuf {
+        self.identity_spec_dir(identity_spec_name)
+            .join(INSTALLED_MANIFEST_FILE_NAME)
+    }
+
+    pub(crate) fn identity_spec_material_file(&self, identity_spec_name: &str) -> PathBuf {
+        self.identity_spec_dir(identity_spec_name)
+            .join(INSTALLED_SECRETS_FILE_NAME)
+    }
+
+    pub(crate) fn identities_root(&self) -> PathBuf {
+        self.config_dir.join("identities")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn user_owned_identity_manifest_file(
+        &self,
+        user_id: &str,
+        identity_name: &str,
+    ) -> PathBuf {
+        self.identities_root()
+            .join("users")
+            .join(user_id)
+            .join(identity_name)
+            .join(INSTALLED_IDENTITY_FILE_NAME)
     }
 
     pub(crate) fn source_dir(

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_native_strategy};
 
 use crate::bootstrap::AppError;
+use crate::identity_specs::IdentitySpecName;
 use crate::sources::SourceName;
 use crate::storage::fs::ensure_dir;
 use crate::workspaces::WorkspaceName;
@@ -100,16 +101,22 @@ impl AppStateLayout {
         self.config_dir.join("identity-specs")
     }
 
-    pub(crate) fn identity_spec_dir(&self, identity_spec_name: &str) -> PathBuf {
-        self.identity_specs_root().join(identity_spec_name)
+    pub(crate) fn identity_spec_dir(&self, identity_spec_name: &IdentitySpecName) -> PathBuf {
+        self.identity_specs_root().join(identity_spec_name.as_str())
     }
 
-    pub(crate) fn identity_spec_manifest_file(&self, identity_spec_name: &str) -> PathBuf {
+    pub(crate) fn identity_spec_manifest_file(
+        &self,
+        identity_spec_name: &IdentitySpecName,
+    ) -> PathBuf {
         self.identity_spec_dir(identity_spec_name)
             .join(INSTALLED_MANIFEST_FILE_NAME)
     }
 
-    pub(crate) fn identity_spec_material_file(&self, identity_spec_name: &str) -> PathBuf {
+    pub(crate) fn identity_spec_material_file(
+        &self,
+        identity_spec_name: &IdentitySpecName,
+    ) -> PathBuf {
         self.identity_spec_dir(identity_spec_name)
             .join(INSTALLED_SECRETS_FILE_NAME)
     }

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -8,4 +8,4 @@ pub(crate) use config::{
     RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue, load_raw_feature_overrides,
     set_raw_feature_override,
 };
-pub(crate) use layout::AppStateLayout;
+pub(crate) use layout::{AppStateLayout, INSTALLED_IDENTITY_FILE_NAME};

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -4,6 +4,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use tokio::task;
+
 use coral_api::{
     CORAL_EPISODE_ID_METADATA_KEY, CORAL_ERROR_DOMAIN, grpc_response_status_code,
     v1::{
@@ -287,6 +289,20 @@ where
     })
 }
 
+/// Runs a blocking `operation` on the blocking thread pool while preserving the
+/// current tracing span, mapping a join failure or [`AppError`] to a [`Status`].
+/// `label` names the operation in the join-failure message.
+pub(crate) async fn run_blocking_operation<T, F>(label: &str, operation: F) -> Result<T, Status>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, AppError> + Send + 'static,
+{
+    let span = tracing::Span::current();
+    task::spawn_blocking(move || span.in_scope(operation))
+        .await
+        .map_err(|error| Status::internal(format!("{label} task failed: {error}")))?
+        .map_err(app_status)
+}
 fn record_grpc_status(span: &tracing::Span, code: Code, status: Option<&Status>) {
     let response_status_code = grpc_response_status_code(code);
     span.record("grpc.status_code", code as i64);

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -9,6 +9,8 @@
 mod catalog_discovery_tests;
 #[path = "grpc/harness.rs"]
 mod harness;
+#[path = "grpc/identity_spec_tests.rs"]
+mod identity_spec_tests;
 #[path = "grpc/oauth_refresh_tests.rs"]
 mod oauth_refresh_tests;
 #[path = "grpc/resilience_tests.rs"]

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -7,7 +7,7 @@ use coral_api::v1::{
     ValidateSourceResponse, catalog_item, import_source_response,
 };
 use coral_client::{
-    AppClient, CatalogClient, QueryClient, SourceClient, batches_to_json_rows,
+    AppClient, CatalogClient, IdentitySpecClient, QueryClient, SourceClient, batches_to_json_rows,
     decode_execute_sql_response, default_workspace,
     local::{RunningServer, ServerBuilder},
 };
@@ -67,6 +67,10 @@ impl GrpcHarness {
 
     pub(crate) fn source_client(&self) -> SourceClient {
         self.app.source_client()
+    }
+
+    pub(crate) fn identity_spec_client(&self) -> IdentitySpecClient {
+        self.app.identity_spec_client()
     }
 
     pub(crate) fn catalog_client(&self) -> CatalogClient {

--- a/crates/coral-app/tests/grpc/identity_spec_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_spec_tests.rs
@@ -1,0 +1,130 @@
+use std::fs;
+
+use coral_api::v1::{
+    AddIdentitySpecRequest, DeleteIdentitySpecRequest, GetIdentitySpecRequest, IdentitySpecInput,
+    ListIdentitySpecsRequest,
+};
+use tempfile::TempDir;
+use tonic::Request;
+
+use crate::harness::GrpcHarness;
+
+#[tokio::test]
+async fn identity_spec_service_installs_lists_gets_and_deletes_spec() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[features]\ndsl_v4 = true\n",
+    )
+    .expect("write feature config");
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+
+    let mut client = harness.identity_spec_client();
+    let added = client
+        .add_identity_spec(Request::new(AddIdentitySpecRequest {
+            manifest_yaml: identity_spec_yaml(),
+            inputs: vec![IdentitySpecInput {
+                key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                value: "secret-value".to_string(),
+            }],
+        }))
+        .await
+        .expect("add identity spec")
+        .into_inner();
+    let identity_spec = added.identity_spec.expect("added identity spec");
+    assert_eq!(identity_spec.name, "demo_oauth");
+    assert_eq!(identity_spec.version, "0.1.0");
+    assert!(!added.replaced);
+
+    let listed = client
+        .list_identity_specs(Request::new(ListIdentitySpecsRequest {}))
+        .await
+        .expect("list identity specs")
+        .into_inner()
+        .identity_specs;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(
+        listed.first().expect("listed identity spec").name,
+        "demo_oauth"
+    );
+
+    let fetched = client
+        .get_identity_spec(Request::new(GetIdentitySpecRequest {
+            name: "demo_oauth".to_string(),
+        }))
+        .await
+        .expect("get identity spec")
+        .into_inner()
+        .identity_spec
+        .expect("fetched identity spec");
+    assert_eq!(fetched.manifest_yaml, identity_spec.manifest_yaml);
+
+    let material_file = config_dir
+        .join("identity-specs")
+        .join("demo_oauth")
+        .join("secrets.env");
+    assert!(
+        fs::read_to_string(&material_file)
+            .expect("identity spec material")
+            .contains("DEMO_OAUTH_CLIENT_SECRET=secret-value")
+    );
+
+    let deleted = client
+        .delete_identity_spec(Request::new(DeleteIdentitySpecRequest {
+            name: "demo_oauth".to_string(),
+            force: false,
+        }))
+        .await
+        .expect("delete identity spec")
+        .into_inner();
+    assert_eq!(deleted.orphaned_identities, 0);
+    assert!(!material_file.exists());
+
+    let listed = client
+        .list_identity_specs(Request::new(ListIdentitySpecsRequest {}))
+        .await
+        .expect("list identity specs after delete")
+        .into_inner()
+        .identity_specs;
+    assert!(listed.is_empty());
+}
+
+fn identity_spec_yaml() -> String {
+    r"kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+description: Demo OAuth identity
+issuer: demo
+type: oauth
+audience:
+  host: api.example.test
+inputs:
+  DEMO_TENANT:
+    kind: variable
+    required: false
+    default: tenant-a
+  DEMO_OAUTH_CLIENT_SECRET:
+    kind: secret
+    required: true
+oauth:
+  method:
+    label: Demo OAuth
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/callback
+    endpoints:
+      authorization_url: https://auth.example.test/{{input.DEMO_TENANT}}/authorize
+      token_url: https://auth.example.test/{{input.DEMO_TENANT}}/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+        transport: request_body
+"
+    .to_string()
+}

--- a/crates/coral-app/tests/grpc/identity_spec_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_spec_tests.rs
@@ -27,7 +27,7 @@ async fn identity_spec_service_installs_lists_gets_and_deletes_spec() {
             manifest_yaml: identity_spec_yaml(),
             input_values: vec![IdentitySpecInputValue {
                 key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
-                value: "secret-value".to_string(),
+                value: " secret-value ".to_string(),
             }],
         }))
         .await
@@ -65,10 +65,9 @@ async fn identity_spec_service_installs_lists_gets_and_deletes_spec() {
         .join("identity-specs")
         .join("demo_oauth")
         .join("secrets.env");
-    assert!(
-        fs::read_to_string(&material_file)
-            .expect("identity spec material")
-            .contains("DEMO_OAUTH_CLIENT_SECRET=secret-value")
+    assert_eq!(
+        fs::read_to_string(&material_file).expect("identity spec material"),
+        "DEMO_OAUTH_CLIENT_SECRET=secret-value\n"
     );
 
     let deleted = client

--- a/crates/coral-app/tests/grpc/identity_spec_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_spec_tests.rs
@@ -1,8 +1,8 @@
 use std::fs;
 
 use coral_api::v1::{
-    AddIdentitySpecRequest, DeleteIdentitySpecRequest, GetIdentitySpecRequest, IdentitySpecInput,
-    ListIdentitySpecsRequest,
+    AddIdentitySpecRequest, DeleteIdentitySpecRequest, GetIdentitySpecRequest,
+    IdentitySpecInputValue, ListIdentitySpecsRequest,
 };
 use tempfile::TempDir;
 use tonic::Request;
@@ -25,7 +25,7 @@ async fn identity_spec_service_installs_lists_gets_and_deletes_spec() {
     let added = client
         .add_identity_spec(Request::new(AddIdentitySpecRequest {
             manifest_yaml: identity_spec_yaml(),
-            inputs: vec![IdentitySpecInput {
+            input_values: vec![IdentitySpecInputValue {
                 key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
                 value: "secret-value".to_string(),
             }],

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -11,9 +11,10 @@ pub(crate) struct Bootstrap {
     server: Option<RunningServer>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct BootstrapOptions {
     pub(crate) enable_stderr_logs: bool,
+    pub(crate) feature_overrides: coral_app::features::FeatureOverrides,
 }
 
 impl Bootstrap {
@@ -51,10 +52,16 @@ pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, Bo
 }
 
 #[cfg(feature = "embedded-ui")]
-pub(crate) async fn start_ui_server(port: u16) -> Result<RunningServer, BootstrapError> {
+pub(crate) async fn start_ui_server(
+    port: u16,
+    feature_overrides: coral_app::features::FeatureOverrides,
+) -> Result<RunningServer, BootstrapError> {
     let server = configure_server_builder(
         ServerBuilder::embedded_ui_loopback(port, crate::embedded_ui_assets()),
-        BootstrapOptions::default(),
+        BootstrapOptions {
+            enable_stderr_logs: false,
+            feature_overrides,
+        },
     )
     .start()
     .await?;
@@ -64,6 +71,7 @@ pub(crate) async fn start_ui_server(port: u16) -> Result<RunningServer, Bootstra
 fn configure_server_builder(builder: ServerBuilder, options: BootstrapOptions) -> ServerBuilder {
     builder
         .with_stderr_logs(options.enable_stderr_logs)
+        .with_feature_overrides(options.feature_overrides)
         .add_engine_extensions_provider(Arc::new(AwsEngineExtensionsProvider))
 }
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -437,6 +437,7 @@ pub async fn run_from_env() -> Result<(), CliError> {
             let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
             let bootstrap = bootstrap::bootstrap(bootstrap::BootstrapOptions {
                 enable_stderr_logs: command.enables_stderr_logs(),
+                feature_overrides: feature_overrides.clone(),
             })
             .await
             .map_err(anyhow::Error::from)?;
@@ -481,8 +482,11 @@ pub fn open_url(url: &str) -> Result<(), std::io::Error> {
 }
 
 #[cfg(feature = "embedded-ui")]
-async fn run_ui(args: UiArgs) -> Result<(), anyhow::Error> {
-    let server = bootstrap::start_ui_server(args.port).await?;
+async fn run_ui(
+    args: UiArgs,
+    feature_overrides: &coral_app::features::FeatureOverrides,
+) -> Result<(), anyhow::Error> {
+    let server = bootstrap::start_ui_server(args.port, feature_overrides.clone()).await?;
     let endpoint = server.endpoint_uri().to_string();
 
     println!("Coral UI listening on {endpoint}");
@@ -519,7 +523,7 @@ async fn run_no_runtime_command(
         }
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
-        Command::Ui(args) => run_ui(args).await.map_err(Into::into),
+        Command::Ui(args) => run_ui(args, feature_overrides).await.map_err(Into::into),
         Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
         }


### PR DESCRIPTION
## Intent

Land `feat(app): add identity spec management` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-04-app-seams...sauldhernandez/dsl-v4-identity-v2-05-identity-specs
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
