### PR TITLE
feat(app): add user-owned identity storage

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -17,6 +17,7 @@ use axum::response::Response as AxumResponse;
 use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::episode_service_server::EpisodeServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
+use coral_api::v1::identity_service_server::IdentityServiceServer;
 use coral_api::v1::identity_spec_service_server::IdentitySpecServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
@@ -51,6 +52,9 @@ use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
+use crate::identities::{
+    IdentityManagementHandle, IdentityService, UserOwnedIdentityManager, UserOwnedIdentityStore,
+};
 use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
 use crate::identity_specs::{
     IdentitySpecManager, IdentitySpecRegistry, IdentitySpecService, IdentitySpecUsageProvider,
@@ -59,7 +63,7 @@ use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
-use crate::state::ConfigStore;
+use crate::state::{AppStateLayout, ConfigStore};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcRequestContextLayer;
@@ -92,6 +96,7 @@ pub(crate) struct ServerConfig {
     identity_spec_registry: Option<Arc<dyn IdentitySpecRegistry>>,
     identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
     feature_overrides: FeatureOverrides,
+    user_owned_identity_store: Option<Arc<dyn UserOwnedIdentityStore>>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
@@ -113,6 +118,7 @@ impl ServerConfig {
             identity_spec_registry: None,
             identity_spec_usage_providers: Vec::new(),
             feature_overrides: FeatureOverrides::default(),
+            user_owned_identity_store: None,
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             management_authorizer: Arc::new(AllowAllManagementAuthorizer),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
@@ -173,6 +179,14 @@ impl ServerConfig {
 
     pub(crate) fn with_feature_overrides(mut self, feature_overrides: FeatureOverrides) -> Self {
         self.feature_overrides = feature_overrides;
+        self
+    }
+
+    pub(crate) fn with_user_owned_identity_store(
+        mut self,
+        user_owned_identity_store: Arc<dyn UserOwnedIdentityStore>,
+    ) -> Self {
+        self.user_owned_identity_store = Some(user_owned_identity_store);
         self
     }
 
@@ -342,6 +356,21 @@ impl ServerBuilder {
     }
 
     #[must_use]
+    /// Sets the durable user-owned identity store.
+    ///
+    /// The default store persists identities under the local Coral config
+    /// directory.
+    pub fn with_user_owned_identity_store(
+        mut self,
+        user_owned_identity_store: Arc<dyn UserOwnedIdentityStore>,
+    ) -> Self {
+        self.config = self
+            .config
+            .with_user_owned_identity_store(user_owned_identity_store);
+        self
+    }
+
+    #[must_use]
     /// Enables or disables local stderr log rendering for this server.
     ///
     /// `MCP` stdio adapters can enable this for diagnostics while keeping
@@ -406,6 +435,11 @@ impl ServerBuilder {
                 self.config.identity_spec_usage_providers,
             )
         };
+        let user_owned_identity_manager = user_owned_identity_manager_for_server(
+            layout.clone(),
+            identity_spec_manager.clone(),
+            self.config.user_owned_identity_store,
+        );
         let source_manager = SourceManager::new_with_features(
             config_store.clone(),
             credential_manager.clone(),
@@ -444,10 +478,22 @@ impl ServerBuilder {
                 user_principal_provider: self.config.user_principal_provider,
                 management_authorizer: self.config.management_authorizer,
                 identity_spec_manager,
+                user_owned_identity_manager,
             },
             self.config.mode,
         )
         .await
+    }
+}
+
+fn user_owned_identity_manager_for_server(
+    layout: AppStateLayout,
+    identity_spec_manager: IdentitySpecManager,
+    store: Option<Arc<dyn UserOwnedIdentityStore>>,
+) -> UserOwnedIdentityManager {
+    match store {
+        Some(store) => UserOwnedIdentityManager::new_with_store(identity_spec_manager, store),
+        None => UserOwnedIdentityManager::new(layout, identity_spec_manager),
     }
 }
 
@@ -460,6 +506,7 @@ struct ServerServices {
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
     identity_spec_manager: IdentitySpecManager,
+    user_owned_identity_manager: UserOwnedIdentityManager,
 }
 
 /// Running Coral server.
@@ -469,6 +516,7 @@ struct ServerServices {
 /// does not wait for the task to finish.
 pub struct RunningServer {
     endpoint_uri: String,
+    identity_management: IdentityManagementHandle,
     shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
     task: Mutex<Option<JoinHandle<Result<(), tonic::transport::Error>>>>,
 }
@@ -482,6 +530,12 @@ impl RunningServer {
     /// over server configuration.
     pub fn endpoint_uri(&self) -> &str {
         &self.endpoint_uri
+    }
+
+    #[must_use]
+    /// Returns the identity management handle used by this server.
+    pub fn identity_management(&self) -> &IdentityManagementHandle {
+        &self.identity_management
     }
 
     /// Shuts the server down and waits for the background task to finish.
@@ -545,6 +599,7 @@ async fn start_server(
         user_principal_provider,
         management_authorizer,
         identity_spec_manager,
+        user_owned_identity_manager,
     } = services;
     let source_service = SourceService::new(
         source_manager,
@@ -556,10 +611,13 @@ async fn start_server(
     let feedback_service = FeedbackService::new(feedback_manager);
     let identity_spec_service =
         IdentitySpecService::new(identity_spec_manager, management_authorizer);
+    let identity_management = user_owned_identity_manager.handle();
+    let identity_service = IdentityService::new(user_owned_identity_manager);
     let episode_service = EpisodeService::new(episode_store);
     let mut routes = Routes::default()
         .add_service(SourceServiceServer::new(source_service))
         .add_service(IdentitySpecServiceServer::new(identity_spec_service))
+        .add_service(IdentityServiceServer::new(identity_service))
         .add_service(
             CatalogServiceServer::new(catalog_service)
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
@@ -606,6 +664,7 @@ async fn start_server(
 
     Ok(RunningServer {
         endpoint_uri,
+        identity_management,
         shutdown_tx: Mutex::new(Some(shutdown_tx)),
         task: Mutex::new(Some(task)),
     })
@@ -839,6 +898,7 @@ mod tests {
     use crate::episode::store::EpisodeStore;
     use crate::features::{Feature, FeatureOverrides};
     use crate::feedback::manager::FeedbackManager;
+    use crate::identities::UserOwnedIdentityManager;
     use crate::identity_specs::IdentitySpecManager;
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
@@ -858,6 +918,13 @@ mod tests {
 
     fn test_identity_spec_manager(layout: &AppStateLayout) -> IdentitySpecManager {
         IdentitySpecManager::new(layout.clone())
+    }
+
+    fn test_user_owned_identity_manager(
+        layout: &AppStateLayout,
+        identity_specs: &IdentitySpecManager,
+    ) -> UserOwnedIdentityManager {
+        UserOwnedIdentityManager::new(layout.clone(), identity_specs.clone())
     }
 
     fn disable_internal_tracing(config_dir: &Path) {
@@ -1207,6 +1274,8 @@ type: fixed_token
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
         let identity_spec_manager = test_identity_spec_manager(&layout);
+        let user_owned_identity_manager =
+            test_user_owned_identity_manager(&layout, &identity_spec_manager);
         start_server(
             ServerServices {
                 source_manager,
@@ -1217,6 +1286,7 @@ type: fixed_token
                 user_principal_provider,
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
+                user_owned_identity_manager,
             },
             ServerMode::NativeGrpc,
         )
@@ -1630,6 +1700,8 @@ tables:
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
+        let user_owned_identity_manager =
+            test_user_owned_identity_manager(&layout, &identity_spec_manager);
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -1640,6 +1712,7 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
+                user_owned_identity_manager,
             },
             ServerMode::NativeGrpc,
         )
@@ -1737,6 +1810,8 @@ tables:
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
+        let user_owned_identity_manager =
+            test_user_owned_identity_manager(&layout, &identity_spec_manager);
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -1747,6 +1822,7 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
+                user_owned_identity_manager,
             },
             ServerMode::NativeGrpc,
         )
@@ -1844,6 +1920,8 @@ tables:
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
+        let user_owned_identity_manager =
+            test_user_owned_identity_manager(&layout, &identity_spec_manager);
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -1854,6 +1932,7 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
+                user_owned_identity_manager,
             },
             ServerMode::NativeGrpc,
         )

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -53,7 +53,7 @@ use crate::feedback::publisher::{
 };
 use crate::feedback::service::FeedbackService;
 use crate::identities::{
-    IdentityManagementHandle, IdentityService, UserOwnedIdentityManager, UserOwnedIdentityStore,
+    IdentityInstanceManager, IdentityInstanceStore, IdentityManagementHandle, IdentityService,
 };
 use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
 use crate::identity_specs::{
@@ -96,7 +96,7 @@ pub(crate) struct ServerConfig {
     identity_spec_registry: Option<Arc<dyn IdentitySpecRegistry>>,
     identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
     feature_overrides: FeatureOverrides,
-    user_owned_identity_store: Option<Arc<dyn UserOwnedIdentityStore>>,
+    identity_instance_store: Option<Arc<dyn IdentityInstanceStore>>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
@@ -118,7 +118,7 @@ impl ServerConfig {
             identity_spec_registry: None,
             identity_spec_usage_providers: Vec::new(),
             feature_overrides: FeatureOverrides::default(),
-            user_owned_identity_store: None,
+            identity_instance_store: None,
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             management_authorizer: Arc::new(AllowAllManagementAuthorizer),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
@@ -182,11 +182,11 @@ impl ServerConfig {
         self
     }
 
-    pub(crate) fn with_user_owned_identity_store(
+    pub(crate) fn with_identity_instance_store(
         mut self,
-        user_owned_identity_store: Arc<dyn UserOwnedIdentityStore>,
+        identity_instance_store: Arc<dyn IdentityInstanceStore>,
     ) -> Self {
-        self.user_owned_identity_store = Some(user_owned_identity_store);
+        self.identity_instance_store = Some(identity_instance_store);
         self
     }
 
@@ -356,17 +356,17 @@ impl ServerBuilder {
     }
 
     #[must_use]
-    /// Sets the durable user-owned identity store.
+    /// Sets the durable identity-instance store.
     ///
-    /// The default store persists identities under the local Coral config
-    /// directory.
-    pub fn with_user_owned_identity_store(
+    /// The default store persists identity instances under the local Coral
+    /// config directory's user-owned identity layout.
+    pub fn with_identity_instance_store(
         mut self,
-        user_owned_identity_store: Arc<dyn UserOwnedIdentityStore>,
+        identity_instance_store: Arc<dyn IdentityInstanceStore>,
     ) -> Self {
         self.config = self
             .config
-            .with_user_owned_identity_store(user_owned_identity_store);
+            .with_identity_instance_store(identity_instance_store);
         self
     }
 
@@ -435,10 +435,10 @@ impl ServerBuilder {
                 self.config.identity_spec_usage_providers,
             )
         };
-        let user_owned_identity_manager = user_owned_identity_manager_for_server(
+        let identity_instance_manager = identity_instance_manager_for_server(
             layout.clone(),
             identity_spec_manager.clone(),
-            self.config.user_owned_identity_store,
+            self.config.identity_instance_store,
         );
         let source_manager = SourceManager::new_with_features(
             config_store.clone(),
@@ -478,7 +478,7 @@ impl ServerBuilder {
                 user_principal_provider: self.config.user_principal_provider,
                 management_authorizer: self.config.management_authorizer,
                 identity_spec_manager,
-                user_owned_identity_manager,
+                identity_instance_manager,
             },
             self.config.mode,
         )
@@ -486,14 +486,14 @@ impl ServerBuilder {
     }
 }
 
-fn user_owned_identity_manager_for_server(
+fn identity_instance_manager_for_server(
     layout: AppStateLayout,
     identity_spec_manager: IdentitySpecManager,
-    store: Option<Arc<dyn UserOwnedIdentityStore>>,
-) -> UserOwnedIdentityManager {
+    store: Option<Arc<dyn IdentityInstanceStore>>,
+) -> IdentityInstanceManager {
     match store {
-        Some(store) => UserOwnedIdentityManager::new_with_store(identity_spec_manager, store),
-        None => UserOwnedIdentityManager::new(layout, identity_spec_manager),
+        Some(store) => IdentityInstanceManager::new_with_store(identity_spec_manager, store),
+        None => IdentityInstanceManager::new(layout, identity_spec_manager),
     }
 }
 
@@ -506,7 +506,7 @@ struct ServerServices {
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
     identity_spec_manager: IdentitySpecManager,
-    user_owned_identity_manager: UserOwnedIdentityManager,
+    identity_instance_manager: IdentityInstanceManager,
 }
 
 /// Running Coral server.
@@ -599,7 +599,7 @@ async fn start_server(
         user_principal_provider,
         management_authorizer,
         identity_spec_manager,
-        user_owned_identity_manager,
+        identity_instance_manager,
     } = services;
     let source_service = SourceService::new(
         source_manager,
@@ -611,8 +611,8 @@ async fn start_server(
     let feedback_service = FeedbackService::new(feedback_manager);
     let identity_spec_service =
         IdentitySpecService::new(identity_spec_manager, management_authorizer);
-    let identity_management = user_owned_identity_manager.handle();
-    let identity_service = IdentityService::new(user_owned_identity_manager);
+    let identity_management = identity_instance_manager.handle();
+    let identity_service = IdentityService::new(identity_instance_manager);
     let episode_service = EpisodeService::new(episode_store);
     let mut routes = Routes::default()
         .add_service(SourceServiceServer::new(source_service))
@@ -898,7 +898,7 @@ mod tests {
     use crate::episode::store::EpisodeStore;
     use crate::features::{Feature, FeatureOverrides};
     use crate::feedback::manager::FeedbackManager;
-    use crate::identities::UserOwnedIdentityManager;
+    use crate::identities::IdentityInstanceManager;
     use crate::identity_specs::IdentitySpecManager;
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
@@ -920,11 +920,11 @@ mod tests {
         IdentitySpecManager::new(layout.clone())
     }
 
-    fn test_user_owned_identity_manager(
+    fn test_identity_instance_manager(
         layout: &AppStateLayout,
         identity_specs: &IdentitySpecManager,
-    ) -> UserOwnedIdentityManager {
-        UserOwnedIdentityManager::new(layout.clone(), identity_specs.clone())
+    ) -> IdentityInstanceManager {
+        IdentityInstanceManager::new(layout.clone(), identity_specs.clone())
     }
 
     fn disable_internal_tracing(config_dir: &Path) {
@@ -966,10 +966,12 @@ enabled = false
             _principal: &UserPrincipal,
             mutation: ManagementMutation<'_>,
         ) -> Result<(), AuthorizationError> {
-            if matches!(mutation, ManagementMutation::WorkspaceSource { .. }) {
-                return Err(AuthorizationError::forbidden("source mutation denied"));
+            match mutation {
+                ManagementMutation::WorkspaceSource { .. } => {
+                    Err(AuthorizationError::forbidden("source mutation denied"))
+                }
+                _ => Ok(()),
             }
-            Ok(())
         }
     }
 
@@ -1274,8 +1276,8 @@ type: fixed_token
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
         let identity_spec_manager = test_identity_spec_manager(&layout);
-        let user_owned_identity_manager =
-            test_user_owned_identity_manager(&layout, &identity_spec_manager);
+        let identity_instance_manager =
+            test_identity_instance_manager(&layout, &identity_spec_manager);
         start_server(
             ServerServices {
                 source_manager,
@@ -1286,7 +1288,7 @@ type: fixed_token
                 user_principal_provider,
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                user_owned_identity_manager,
+                identity_instance_manager,
             },
             ServerMode::NativeGrpc,
         )
@@ -1700,8 +1702,8 @@ tables:
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
-        let user_owned_identity_manager =
-            test_user_owned_identity_manager(&layout, &identity_spec_manager);
+        let identity_instance_manager =
+            test_identity_instance_manager(&layout, &identity_spec_manager);
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -1712,7 +1714,7 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                user_owned_identity_manager,
+                identity_instance_manager,
             },
             ServerMode::NativeGrpc,
         )
@@ -1810,8 +1812,8 @@ tables:
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
-        let user_owned_identity_manager =
-            test_user_owned_identity_manager(&layout, &identity_spec_manager);
+        let identity_instance_manager =
+            test_identity_instance_manager(&layout, &identity_spec_manager);
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -1822,7 +1824,7 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                user_owned_identity_manager,
+                identity_instance_manager,
             },
             ServerMode::NativeGrpc,
         )
@@ -1920,8 +1922,8 @@ tables:
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
-        let user_owned_identity_manager =
-            test_user_owned_identity_manager(&layout, &identity_spec_manager);
+        let identity_instance_manager =
+            test_identity_instance_manager(&layout, &identity_spec_manager);
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -1932,7 +1934,7 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                user_owned_identity_manager,
+                identity_instance_manager,
             },
             ServerMode::NativeGrpc,
         )

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -420,25 +420,32 @@ impl ServerBuilder {
         let credential_manager = CredentialManager::new(credential_store.clone());
         let features = crate::features::FeatureStore::new(layout.clone())
             .load_with_overrides(&self.config.feature_overrides)?;
+        let identity_instance_store = self.config.identity_instance_store;
+        let mut identity_spec_usage_providers = self.config.identity_spec_usage_providers;
+        if let Some(store) = identity_instance_store.as_ref() {
+            identity_spec_usage_providers.push(Arc::new(IdentityInstanceStoreUsageProvider {
+                store: Arc::clone(store),
+            }));
+        }
         let identity_spec_manager = if let Some(registry) = self.config.identity_spec_registry {
             IdentitySpecManager::new_with_registry(
                 layout.clone(),
                 registry,
                 features.clone(),
-                self.config.identity_spec_usage_providers,
+                identity_spec_usage_providers,
             )
         } else {
             IdentitySpecManager::new_with_credential_store(
                 layout.clone(),
                 credential_store,
                 features.clone(),
-                self.config.identity_spec_usage_providers,
+                identity_spec_usage_providers,
             )
         };
         let identity_instance_manager = identity_instance_manager_for_server(
             layout.clone(),
             identity_spec_manager.clone(),
-            self.config.identity_instance_store,
+            identity_instance_store,
         );
         let source_manager = SourceManager::new_with_features(
             config_store.clone(),
@@ -494,6 +501,17 @@ fn identity_instance_manager_for_server(
     match store {
         Some(store) => IdentityInstanceManager::new_with_store(identity_spec_manager, store),
         None => IdentityInstanceManager::new(layout, identity_spec_manager),
+    }
+}
+
+#[derive(Debug)]
+struct IdentityInstanceStoreUsageProvider {
+    store: Arc<dyn IdentityInstanceStore>,
+}
+
+impl IdentitySpecUsageProvider for IdentityInstanceStoreUsageProvider {
+    fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError> {
+        self.store.count_identities_for_spec(identity_spec_name)
     }
 }
 
@@ -868,6 +886,7 @@ mod tests {
     )]
 
     use std::borrow::Cow;
+    use std::collections::BTreeMap;
     use std::net::{Ipv4Addr, TcpListener};
     use std::path::Path;
     use std::sync::Arc;
@@ -880,8 +899,8 @@ mod tests {
     use coral_api::v1::trace_service_client::TraceServiceClient;
     use coral_api::v1::{
         AddIdentitySpecRequest, CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
-        DeleteSourceRequest, ExecuteSqlRequest, ImportSourceRequest, ImportSourceResponse,
-        ListSourcesRequest, ListTracesRequest, OpenEpisodeRequest, Workspace,
+        DeleteIdentitySpecRequest, DeleteSourceRequest, ExecuteSqlRequest, ImportSourceRequest,
+        ImportSourceResponse, ListSourcesRequest, ListTracesRequest, OpenEpisodeRequest, Workspace,
         import_source_response,
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
@@ -898,7 +917,10 @@ mod tests {
     use crate::episode::store::EpisodeStore;
     use crate::features::{Feature, FeatureOverrides};
     use crate::feedback::manager::FeedbackManager;
-    use crate::identities::IdentityInstanceManager;
+    use crate::identities::{
+        IdentityInstanceManager, IdentityInstanceMaterialGuard, IdentityInstanceName,
+        IdentityInstanceRecord, IdentityInstanceStore, IdentityOwnerKey,
+    };
     use crate::identity_specs::IdentitySpecManager;
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
@@ -971,6 +993,67 @@ enabled = false
                     Err(AuthorizationError::forbidden("source mutation denied"))
                 }
                 _ => Ok(()),
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingIdentityInstanceStore {
+        identity_spec_name: String,
+        count: u32,
+    }
+
+    #[tonic::async_trait]
+    impl IdentityInstanceStore for CountingIdentityInstanceStore {
+        async fn list_identities(
+            &self,
+            _owner: &IdentityOwnerKey,
+        ) -> Result<Vec<IdentityInstanceRecord>, AppError> {
+            Ok(Vec::new())
+        }
+
+        async fn load_identity(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _identity_name: &IdentityInstanceName,
+        ) -> Result<Option<IdentityInstanceRecord>, AppError> {
+            Ok(None)
+        }
+
+        async fn replace_identity(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _record: &IdentityInstanceRecord,
+            _material: &BTreeMap<String, String>,
+        ) -> Result<(), AppError> {
+            Err(AppError::FailedPrecondition(
+                "test identity store is read-only".to_string(),
+            ))
+        }
+
+        async fn delete_identity(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _identity_name: &IdentityInstanceName,
+        ) -> Result<bool, AppError> {
+            Ok(false)
+        }
+
+        async fn material_guard(
+            &self,
+            _owner: &IdentityOwnerKey,
+            _identity_name: &IdentityInstanceName,
+        ) -> Result<Box<dyn IdentityInstanceMaterialGuard>, AppError> {
+            Err(AppError::FailedPrecondition(
+                "test identity store has no material".to_string(),
+            ))
+        }
+
+        fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError> {
+            if identity_spec_name == self.identity_spec_name {
+                Ok(self.count)
+            } else {
+                Ok(0)
             }
         }
     }
@@ -1123,6 +1206,60 @@ type: fixed_token
             .await
             .expect("process-local dsl_v4 override should enable identity spec API");
 
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn identity_instance_store_reports_identity_spec_usage() {
+        let temp = TempDir::new().expect("temp dir");
+        let mut feature_overrides = FeatureOverrides::default();
+        feature_overrides.set(Feature::DslV4, true);
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_feature_overrides(feature_overrides)
+            .with_identity_instance_store(Arc::new(CountingIdentityInstanceStore {
+                identity_spec_name: "github_pat".to_string(),
+                count: 1,
+            }))
+            .start()
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut identity_spec_client = IdentitySpecServiceClient::new(channel);
+
+        identity_spec_client
+            .add_identity_spec(Request::new(AddIdentitySpecRequest {
+                manifest_yaml: r"
+kind: identity
+spec_version: 1
+name: github_pat
+version: 0.1.0
+issuer: github
+type: fixed_token
+"
+                .to_string(),
+                input_values: Vec::new(),
+            }))
+            .await
+            .expect("add identity spec");
+
+        let status = identity_spec_client
+            .delete_identity_spec(Request::new(DeleteIdentitySpecRequest {
+                name: "github_pat".to_string(),
+                force: false,
+            }))
+            .await
+            .expect_err("delete should respect injected identity store usage");
+
+        assert_eq!(status.code(), Code::FailedPrecondition);
+        assert!(
+            status.message().contains("1 stored identity"),
+            "unexpected status: {status:?}"
+        );
         server.shutdown().await.expect("shutdown");
     }
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -53,7 +53,7 @@ use crate::feedback::publisher::{
 };
 use crate::feedback::service::FeedbackService;
 use crate::identities::{
-    IdentityInstanceManager, IdentityInstanceStore, IdentityManagementHandle, IdentityService,
+    IdentityManagementHandle, IdentityManager, IdentityService, IdentityStore,
 };
 use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
 use crate::identity_specs::{
@@ -96,7 +96,7 @@ pub(crate) struct ServerConfig {
     identity_spec_registry: Option<Arc<dyn IdentitySpecRegistry>>,
     identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
     feature_overrides: FeatureOverrides,
-    identity_instance_store: Option<Arc<dyn IdentityInstanceStore>>,
+    identity_store: Option<Arc<dyn IdentityStore>>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
@@ -118,7 +118,7 @@ impl ServerConfig {
             identity_spec_registry: None,
             identity_spec_usage_providers: Vec::new(),
             feature_overrides: FeatureOverrides::default(),
-            identity_instance_store: None,
+            identity_store: None,
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             management_authorizer: Arc::new(AllowAllManagementAuthorizer),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
@@ -182,11 +182,8 @@ impl ServerConfig {
         self
     }
 
-    pub(crate) fn with_identity_instance_store(
-        mut self,
-        identity_instance_store: Arc<dyn IdentityInstanceStore>,
-    ) -> Self {
-        self.identity_instance_store = Some(identity_instance_store);
+    pub(crate) fn with_identity_store(mut self, identity_store: Arc<dyn IdentityStore>) -> Self {
+        self.identity_store = Some(identity_store);
         self
     }
 
@@ -356,17 +353,12 @@ impl ServerBuilder {
     }
 
     #[must_use]
-    /// Sets the durable identity-instance store.
+    /// Sets the durable identity store.
     ///
-    /// The default store persists identity instances under the local Coral
-    /// config directory's user-owned identity layout.
-    pub fn with_identity_instance_store(
-        mut self,
-        identity_instance_store: Arc<dyn IdentityInstanceStore>,
-    ) -> Self {
-        self.config = self
-            .config
-            .with_identity_instance_store(identity_instance_store);
+    /// The default store persists identities under the local Coral config
+    /// directory, partitioned by owner kind and owner key.
+    pub fn with_identity_store(mut self, identity_store: Arc<dyn IdentityStore>) -> Self {
+        self.config = self.config.with_identity_store(identity_store);
         self
     }
 
@@ -420,10 +412,10 @@ impl ServerBuilder {
         let credential_manager = CredentialManager::new(credential_store.clone());
         let features = crate::features::FeatureStore::new(layout.clone())
             .load_with_overrides(&self.config.feature_overrides)?;
-        let identity_instance_store = self.config.identity_instance_store;
+        let identity_store = self.config.identity_store;
         let mut identity_spec_usage_providers = self.config.identity_spec_usage_providers;
-        if let Some(store) = identity_instance_store.as_ref() {
-            identity_spec_usage_providers.push(Arc::new(IdentityInstanceStoreUsageProvider {
+        if let Some(store) = identity_store.as_ref() {
+            identity_spec_usage_providers.push(Arc::new(IdentityStoreUsageProvider {
                 store: Arc::clone(store),
             }));
         }
@@ -442,10 +434,10 @@ impl ServerBuilder {
                 identity_spec_usage_providers,
             )
         };
-        let identity_instance_manager = identity_instance_manager_for_server(
+        let identity_manager = identity_manager_for_server(
             layout.clone(),
             identity_spec_manager.clone(),
-            identity_instance_store,
+            identity_store,
         );
         let source_manager = SourceManager::new_with_features(
             config_store.clone(),
@@ -485,7 +477,7 @@ impl ServerBuilder {
                 user_principal_provider: self.config.user_principal_provider,
                 management_authorizer: self.config.management_authorizer,
                 identity_spec_manager,
-                identity_instance_manager,
+                identity_manager,
             },
             self.config.mode,
         )
@@ -493,23 +485,23 @@ impl ServerBuilder {
     }
 }
 
-fn identity_instance_manager_for_server(
+fn identity_manager_for_server(
     layout: AppStateLayout,
     identity_spec_manager: IdentitySpecManager,
-    store: Option<Arc<dyn IdentityInstanceStore>>,
-) -> IdentityInstanceManager {
+    store: Option<Arc<dyn IdentityStore>>,
+) -> IdentityManager {
     match store {
-        Some(store) => IdentityInstanceManager::new_with_store(identity_spec_manager, store),
-        None => IdentityInstanceManager::new(layout, identity_spec_manager),
+        Some(store) => IdentityManager::new_with_store(identity_spec_manager, store),
+        None => IdentityManager::new(layout, identity_spec_manager),
     }
 }
 
 #[derive(Debug)]
-struct IdentityInstanceStoreUsageProvider {
-    store: Arc<dyn IdentityInstanceStore>,
+struct IdentityStoreUsageProvider {
+    store: Arc<dyn IdentityStore>,
 }
 
-impl IdentitySpecUsageProvider for IdentityInstanceStoreUsageProvider {
+impl IdentitySpecUsageProvider for IdentityStoreUsageProvider {
     fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError> {
         self.store.count_identities_for_spec(identity_spec_name)
     }
@@ -524,7 +516,7 @@ struct ServerServices {
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
     identity_spec_manager: IdentitySpecManager,
-    identity_instance_manager: IdentityInstanceManager,
+    identity_manager: IdentityManager,
 }
 
 /// Running Coral server.
@@ -617,7 +609,7 @@ async fn start_server(
         user_principal_provider,
         management_authorizer,
         identity_spec_manager,
-        identity_instance_manager,
+        identity_manager,
     } = services;
     let source_service = SourceService::new(
         source_manager,
@@ -629,8 +621,8 @@ async fn start_server(
     let feedback_service = FeedbackService::new(feedback_manager);
     let identity_spec_service =
         IdentitySpecService::new(identity_spec_manager, management_authorizer);
-    let identity_management = identity_instance_manager.handle();
-    let identity_service = IdentityService::new(identity_instance_manager);
+    let identity_management = identity_manager.handle();
+    let identity_service = IdentityService::new(identity_manager);
     let episode_service = EpisodeService::new(episode_store);
     let mut routes = Routes::default()
         .add_service(SourceServiceServer::new(source_service))
@@ -918,8 +910,8 @@ mod tests {
     use crate::features::{Feature, FeatureOverrides};
     use crate::feedback::manager::FeedbackManager;
     use crate::identities::{
-        IdentityInstanceManager, IdentityInstanceMaterialGuard, IdentityInstanceName,
-        IdentityInstanceRecord, IdentityInstanceStore, IdentityOwnerKey,
+        IdentityManager, IdentityMaterialGuard, IdentityName, IdentityOwner, IdentityRecord,
+        IdentityStore,
     };
     use crate::identity_specs::IdentitySpecManager;
     use crate::query::manager::QueryManager;
@@ -942,11 +934,11 @@ mod tests {
         IdentitySpecManager::new(layout.clone())
     }
 
-    fn test_identity_instance_manager(
+    fn test_identity_manager(
         layout: &AppStateLayout,
         identity_specs: &IdentitySpecManager,
-    ) -> IdentityInstanceManager {
-        IdentityInstanceManager::new(layout.clone(), identity_specs.clone())
+    ) -> IdentityManager {
+        IdentityManager::new(layout.clone(), identity_specs.clone())
     }
 
     fn disable_internal_tracing(config_dir: &Path) {
@@ -998,32 +990,31 @@ enabled = false
     }
 
     #[derive(Debug)]
-    struct CountingIdentityInstanceStore {
+    struct CountingIdentityStore {
         identity_spec_name: String,
         count: u32,
     }
 
     #[tonic::async_trait]
-    impl IdentityInstanceStore for CountingIdentityInstanceStore {
+    impl IdentityStore for CountingIdentityStore {
         async fn list_identities(
             &self,
-            _owner: &IdentityOwnerKey,
-        ) -> Result<Vec<IdentityInstanceRecord>, AppError> {
+            _owner: &IdentityOwner,
+        ) -> Result<Vec<IdentityRecord>, AppError> {
             Ok(Vec::new())
         }
 
         async fn load_identity(
             &self,
-            _owner: &IdentityOwnerKey,
-            _identity_name: &IdentityInstanceName,
-        ) -> Result<Option<IdentityInstanceRecord>, AppError> {
+            _owner: &IdentityOwner,
+            _identity_name: &IdentityName,
+        ) -> Result<Option<IdentityRecord>, AppError> {
             Ok(None)
         }
 
         async fn replace_identity(
             &self,
-            _owner: &IdentityOwnerKey,
-            _record: &IdentityInstanceRecord,
+            _record: &IdentityRecord,
             _material: &BTreeMap<String, String>,
         ) -> Result<(), AppError> {
             Err(AppError::FailedPrecondition(
@@ -1033,17 +1024,17 @@ enabled = false
 
         async fn delete_identity(
             &self,
-            _owner: &IdentityOwnerKey,
-            _identity_name: &IdentityInstanceName,
+            _owner: &IdentityOwner,
+            _identity_name: &IdentityName,
         ) -> Result<bool, AppError> {
             Ok(false)
         }
 
         async fn material_guard(
             &self,
-            _owner: &IdentityOwnerKey,
-            _identity_name: &IdentityInstanceName,
-        ) -> Result<Box<dyn IdentityInstanceMaterialGuard>, AppError> {
+            _owner: &IdentityOwner,
+            _identity_name: &IdentityName,
+        ) -> Result<Box<dyn IdentityMaterialGuard>, AppError> {
             Err(AppError::FailedPrecondition(
                 "test identity store has no material".to_string(),
             ))
@@ -1210,14 +1201,14 @@ type: fixed_token
     }
 
     #[tokio::test]
-    async fn identity_instance_store_reports_identity_spec_usage() {
+    async fn identity_store_reports_identity_spec_usage() {
         let temp = TempDir::new().expect("temp dir");
         let mut feature_overrides = FeatureOverrides::default();
         feature_overrides.set(Feature::DslV4, true);
         let server = ServerBuilder::new()
             .with_config_dir(temp.path().join("coral-config"))
             .with_feature_overrides(feature_overrides)
-            .with_identity_instance_store(Arc::new(CountingIdentityInstanceStore {
+            .with_identity_store(Arc::new(CountingIdentityStore {
                 identity_spec_name: "github_pat".to_string(),
                 count: 1,
             }))
@@ -1413,8 +1404,7 @@ type: fixed_token
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
         let identity_spec_manager = test_identity_spec_manager(&layout);
-        let identity_instance_manager =
-            test_identity_instance_manager(&layout, &identity_spec_manager);
+        let identity_manager = test_identity_manager(&layout, &identity_spec_manager);
         start_server(
             ServerServices {
                 source_manager,
@@ -1425,7 +1415,7 @@ type: fixed_token
                 user_principal_provider,
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                identity_instance_manager,
+                identity_manager,
             },
             ServerMode::NativeGrpc,
         )
@@ -1839,8 +1829,7 @@ tables:
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
-        let identity_instance_manager =
-            test_identity_instance_manager(&layout, &identity_spec_manager);
+        let identity_manager = test_identity_manager(&layout, &identity_spec_manager);
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -1851,7 +1840,7 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                identity_instance_manager,
+                identity_manager,
             },
             ServerMode::NativeGrpc,
         )
@@ -1949,8 +1938,7 @@ tables:
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
-        let identity_instance_manager =
-            test_identity_instance_manager(&layout, &identity_spec_manager);
+        let identity_manager = test_identity_manager(&layout, &identity_spec_manager);
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -1961,7 +1949,7 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                identity_instance_manager,
+                identity_manager,
             },
             ServerMode::NativeGrpc,
         )
@@ -2059,8 +2047,7 @@ tables:
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
-        let identity_instance_manager =
-            test_identity_instance_manager(&layout, &identity_spec_manager);
+        let identity_manager = test_identity_manager(&layout, &identity_spec_manager);
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -2071,7 +2058,7 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                identity_instance_manager,
+                identity_manager,
             },
             ServerMode::NativeGrpc,
         )

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -16,9 +16,10 @@ use crate::workspaces::WorkspaceName;
 
 use self::oauth::{OAuthCredentialService, RefreshOAuthCredentialRequest};
 
-#[cfg(test)]
-pub(crate) use store::parse_env_file;
 pub(crate) use store::{CredentialStore, CredentialsError};
+pub(crate) use store::{
+    parse_env_file, remove_file_if_exists_unlocked, render_env_file, write_file_unlocked,
+};
 
 /// Opaque credential material captured for best-effort rollback.
 #[derive(Clone)]

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -17,9 +17,6 @@ use crate::workspaces::WorkspaceName;
 use self::oauth::{OAuthCredentialService, RefreshOAuthCredentialRequest};
 
 pub(crate) use store::{CredentialStore, CredentialsError};
-pub(crate) use store::{
-    parse_env_file, remove_file_if_exists_unlocked, render_env_file, write_file_unlocked,
-};
 
 /// Opaque credential material captured for best-effort rollback.
 #[derive(Clone)]

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -11,6 +11,7 @@ use sha2::{Digest as _, Sha256};
 use crate::bootstrap::AppError;
 use crate::identity_specs::IdentitySpecName;
 use crate::state::AppStateLayout;
+use crate::storage::env_file::{parse_env_file, render_env_file};
 use crate::storage::fs as storage_fs;
 use crate::storage::fs::FileLock;
 use crate::workspaces::WorkspaceName;
@@ -33,6 +34,12 @@ pub enum CredentialsError {
         snapshot: &'static str,
         requested: &'static str,
     },
+}
+
+impl From<crate::storage::env_file::EnvFileError> for CredentialsError {
+    fn from(error: crate::storage::env_file::EnvFileError) -> Self {
+        Self::Parse(error.to_string())
+    }
 }
 
 #[derive(Clone)]
@@ -968,7 +975,7 @@ fn decode_values(
         CredentialStorageKind::File => {
             let raw = std::str::from_utf8(bytes)
                 .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
-            parse_env_file(raw)
+            parse_env_file(raw).map_err(Into::into)
         }
         CredentialStorageKind::Keychain => {
             let document: KeychainMaterialDocument = serde_json::from_slice(bytes)
@@ -990,7 +997,7 @@ fn load_file(path: &Path) -> Result<BTreeMap<String, String>, CredentialsError> 
         return Ok(BTreeMap::new());
     }
 
-    parse_env_file(&std::fs::read_to_string(path)?)
+    parse_env_file(&std::fs::read_to_string(path)?).map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -1023,17 +1030,6 @@ pub(crate) fn write_file_unlocked(path: &Path, bytes: &[u8]) -> Result<(), Crede
     Ok(())
 }
 
-pub(crate) fn render_env_file(values: &BTreeMap<String, String>) -> String {
-    let mut output = String::new();
-    for (env_var, value) in values {
-        output.push_str(env_var);
-        output.push('=');
-        output.push_str(&encode_env_value(value));
-        output.push('\n');
-    }
-    output
-}
-
 pub(crate) fn remove_file_if_exists_unlocked(path: &Path) -> Result<(), io::Error> {
     match std::fs::remove_file(path) {
         Ok(()) => Ok(()),
@@ -1042,128 +1038,18 @@ pub(crate) fn remove_file_if_exists_unlocked(path: &Path) -> Result<(), io::Erro
     }
 }
 
-pub(crate) fn parse_env_file(raw: &str) -> Result<BTreeMap<String, String>, CredentialsError> {
-    let mut values = BTreeMap::new();
-    for (index, line) in raw.lines().enumerate() {
-        let line_number = index + 1;
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-
-        let Some((env_var, raw_value)) = line.split_once('=') else {
-            return Err(CredentialsError::Parse(format!(
-                "line {line_number} is missing '='"
-            )));
-        };
-        let env_var = env_var.trim();
-        if env_var.is_empty() {
-            return Err(CredentialsError::Parse(format!(
-                "line {line_number} has an empty variable name"
-            )));
-        }
-        if values.contains_key(env_var) {
-            return Err(CredentialsError::Parse(format!(
-                "line {line_number} redefines '{env_var}'"
-            )));
-        }
-
-        let value = decode_env_value(raw_value.trim(), line_number)?;
-        values.insert(env_var.to_string(), value);
-    }
-    Ok(values)
-}
-
-fn decode_env_value(raw: &str, line_number: usize) -> Result<String, CredentialsError> {
-    if let Some(inner) = raw.strip_prefix('"') {
-        let Some(inner) = inner.strip_suffix('"') else {
-            return Err(CredentialsError::Parse(format!(
-                "line {line_number} has an unterminated quoted value"
-            )));
-        };
-        return decode_quoted_env_value(inner, line_number);
-    }
-
-    if let Some(inner) = raw.strip_prefix('\'') {
-        let Some(inner) = inner.strip_suffix('\'') else {
-            return Err(CredentialsError::Parse(format!(
-                "line {line_number} has an unterminated single-quoted value"
-            )));
-        };
-        return Ok(inner.to_string());
-    }
-
-    Ok(raw.to_string())
-}
-
-fn decode_quoted_env_value(raw: &str, line_number: usize) -> Result<String, CredentialsError> {
-    let mut decoded = String::with_capacity(raw.len());
-    let mut chars = raw.chars();
-    while let Some(ch) = chars.next() {
-        if ch != '\\' {
-            decoded.push(ch);
-            continue;
-        }
-
-        let Some(escaped) = chars.next() else {
-            return Err(CredentialsError::Parse(format!(
-                "line {line_number} ends with a dangling escape"
-            )));
-        };
-        match escaped {
-            '\\' => decoded.push('\\'),
-            '"' => decoded.push('"'),
-            'n' => decoded.push('\n'),
-            'r' => decoded.push('\r'),
-            't' => decoded.push('\t'),
-            other => {
-                return Err(CredentialsError::Parse(format!(
-                    "line {line_number} uses unsupported escape '\\{other}'"
-                )));
-            }
-        }
-    }
-    Ok(decoded)
-}
-
-fn encode_env_value(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/' | ':' | '@'))
-    {
-        return value.to_string();
-    }
-
-    let mut encoded = String::with_capacity(value.len() + 2);
-    encoded.push('"');
-    for ch in value.chars() {
-        match ch {
-            '\\' => encoded.push_str("\\\\"),
-            '"' => encoded.push_str("\\\""),
-            '\n' => encoded.push_str("\\n"),
-            '\r' => encoded.push_str("\\r"),
-            '\t' => encoded.push_str("\\t"),
-            other => encoded.push(other),
-        }
-    }
-    encoded.push('"');
-    encoded
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
-    use super::{
-        CredentialSetRef, CredentialStore, TestKeychainBackend, decode_env_value, encode_env_value,
-        load_file, save_file,
-    };
+    use super::{CredentialSetRef, CredentialStore, TestKeychainBackend, load_file, save_file};
     use crate::bootstrap::AppError;
     use crate::credentials::{CredentialSetId, CredentialStorageKind, CredentialStoragePreference};
     use crate::sources::SourceName;
     use crate::state::AppStateLayout;
+    use crate::storage::env_file::{decode_env_value, encode_env_value};
     use crate::workspaces::WorkspaceName;
     use tempfile::TempDir;
 

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fs;
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -11,14 +12,12 @@ use serde::{Deserialize, Serialize};
 use tracing::info_span;
 
 use crate::bootstrap::AppError;
-use crate::credentials::{
-    parse_env_file, remove_file_if_exists_unlocked, render_env_file, write_file_unlocked,
-};
 use crate::identity::{UserPrincipal, parse_path_segment};
 use crate::identity_specs::{
     IdentitySpecManager, IdentitySpecRecord, identity_spec_fingerprint, validate_identity_spec_name,
 };
 use crate::state::AppStateLayout;
+use crate::storage::env_file::{parse_env_file, render_env_file};
 use crate::storage::fs::{self as storage_fs, FileLock};
 
 const IDENTITY_INSTANCE_DOCUMENT_VERSION: u32 = 1;
@@ -221,6 +220,13 @@ pub trait IdentityInstanceStore: Send + Sync + std::fmt::Debug + 'static {
         owner: &IdentityOwnerKey,
         identity_name: &IdentityInstanceName,
     ) -> Result<Box<dyn IdentityInstanceMaterialGuard>, AppError>;
+
+    /// Counts identities that reference `identity_spec_name`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot inspect its records.
+    fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError>;
 }
 
 /// Manages provider-facing identity instances keyed by an opaque owner.
@@ -316,7 +322,9 @@ impl IdentityInstanceManager {
         self.identity_specs.ensure_dsl_v4_enabled()?;
         let name = validate_identity_name(name)?;
         let identity_spec_name = validate_identity_spec_name(identity_spec)?;
-        let spec = self.identity_specs.get_identity_spec(&identity_spec_name)?;
+        let spec = self
+            .identity_specs
+            .get_identity_spec(identity_spec_name.as_str())?;
         if spec.manifest.identity_type != expected {
             return Err(AppError::InvalidInput(format!(
                 "identity spec '{identity_spec_name}' has type '{}'; expected {}",
@@ -340,7 +348,8 @@ impl IdentityInstanceManager {
             &command.identity_spec,
             IdentitySpecType::FixedToken,
         )?;
-        if command.token.is_empty() {
+        let token = command.token.trim().to_string();
+        if token.is_empty() {
             return Err(AppError::InvalidInput(
                 "fixed token identity token must not be empty".to_string(),
             ));
@@ -353,7 +362,7 @@ impl IdentityInstanceManager {
             identity_type: spec.manifest.identity_type.label().to_string(),
             metadata: BTreeMap::new(),
         };
-        let material = BTreeMap::from([(FIXED_TOKEN_MATERIAL_KEY.to_string(), command.token)]);
+        let material = BTreeMap::from([(FIXED_TOKEN_MATERIAL_KEY.to_string(), token)]);
         self.store
             .replace_identity(&owner, &record, &material)
             .await?;
@@ -412,31 +421,60 @@ impl FileIdentityInstanceStore {
 
     fn load_identity_unlocked(
         &self,
-        owner_key: &str,
-        name: &str,
+        owner: &IdentityOwnerKey,
+        name: &IdentityInstanceName,
     ) -> Result<IdentityInstanceRecord, AppError> {
-        let owner_key = validate_identity_owner_key(owner_key)?;
-        let name = validate_identity_name(name)?;
-        let path = self
-            .layout
-            .user_owned_identity_manifest_file(&owner_key, name.as_str());
+        let path = self.layout.user_owned_identity_manifest_file(owner, name);
         if !path.exists() {
             return Err(AppError::IdentityNotFound(name.to_string()));
         }
         let raw = fs::read_to_string(&path)?;
         let document: IdentityInstanceDocument = serde_yaml::from_str(&raw)?;
-        document.into_record(&name)
+        document.into_record(name)
     }
 
     fn material_lock_for_layout(
         layout: &AppStateLayout,
-        owner_key: &str,
+        owner: &IdentityOwnerKey,
         identity_name: &IdentityInstanceName,
     ) -> Result<FileLock, AppError> {
-        FileLock::exclusive(
-            &layout.user_owned_identity_refresh_lock_file(owner_key, identity_name.as_str()),
-        )
-        .map_err(Into::into)
+        FileLock::exclusive(&layout.user_owned_identity_refresh_lock_file(owner, identity_name))
+            .map_err(Into::into)
+    }
+
+    fn count_identity_spec_references_unlocked(
+        layout: &AppStateLayout,
+        identity_spec_name: &str,
+    ) -> Result<u32, AppError> {
+        let users_root = layout.identities_root().join("users");
+        if !users_root.exists() {
+            return Ok(0);
+        }
+        let mut count = 0u32;
+        for user_entry in fs::read_dir(users_root)? {
+            let user_entry = user_entry?;
+            if !user_entry.file_type()?.is_dir() {
+                continue;
+            }
+            for identity_entry in fs::read_dir(user_entry.path())? {
+                let identity_entry = identity_entry?;
+                if !identity_entry.file_type()?.is_dir() {
+                    continue;
+                }
+                let manifest_path = identity_entry
+                    .path()
+                    .join(crate::state::INSTALLED_IDENTITY_FILE_NAME);
+                if !manifest_path.exists() {
+                    continue;
+                }
+                let raw = fs::read_to_string(&manifest_path)?;
+                let reference: IdentitySpecReference = serde_yaml::from_str(&raw)?;
+                if reference.identity_spec == identity_spec_name {
+                    count = checked_add_identity_count(count, 1, identity_spec_name)?;
+                }
+            }
+        }
+        Ok(count)
     }
 }
 
@@ -447,11 +485,10 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
         owner: &IdentityOwnerKey,
     ) -> Result<Vec<IdentityInstanceRecord>, AppError> {
         let store = self.clone();
-        let owner_key = owner.as_str().to_string();
+        let owner = owner.clone();
         tokio::task::spawn_blocking(move || {
-            let owner_key = validate_identity_owner_key(&owner_key)?;
             let _lock = FileLock::shared(store.layout.state_lock())?;
-            let root = store.layout.user_owned_identities_root(&owner_key);
+            let root = store.layout.user_owned_identities_root(&owner);
             if !root.exists() {
                 return Ok(Vec::new());
             }
@@ -464,7 +501,8 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
                 let Some(name) = entry.file_name().to_str().map(ToString::to_string) else {
                     continue;
                 };
-                records.push(store.load_identity_unlocked(&owner_key, &name)?);
+                let name = validate_identity_name(&name)?;
+                records.push(store.load_identity_unlocked(&owner, &name)?);
             }
             records.sort_by(|left, right| left.name.cmp(&right.name));
             Ok(records)
@@ -478,11 +516,11 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
         identity_name: &IdentityInstanceName,
     ) -> Result<Option<IdentityInstanceRecord>, AppError> {
         let store = self.clone();
-        let owner_key = owner.as_str().to_string();
+        let owner = owner.clone();
         let identity_name = identity_name.clone();
         tokio::task::spawn_blocking(move || {
             let _lock = FileLock::shared(store.layout.state_lock())?;
-            match store.load_identity_unlocked(&owner_key, identity_name.as_str()) {
+            match store.load_identity_unlocked(&owner, &identity_name) {
                 Ok(record) => Ok(Some(record)),
                 Err(AppError::IdentityNotFound(_)) => Ok(None),
                 Err(error) => Err(error),
@@ -498,20 +536,19 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
         material: &BTreeMap<String, String>,
     ) -> Result<(), AppError> {
         let store = self.clone();
-        let owner_key = owner.as_str().to_string();
+        let owner = owner.clone();
         let record = record.clone();
         let material = material.clone();
         tokio::task::spawn_blocking(move || {
-            let owner_key = validate_identity_owner_key(&owner_key)?;
             let _material_lock =
-                Self::material_lock_for_layout(&store.layout, &owner_key, &record.name)?;
+                Self::material_lock_for_layout(&store.layout, &owner, &record.name)?;
             let _state_lock = FileLock::exclusive(store.layout.state_lock())?;
             let manifest_path = store
                 .layout
-                .user_owned_identity_manifest_file(&owner_key, record.name.as_str());
+                .user_owned_identity_manifest_file(&owner, &record.name);
             let material_path = store
                 .layout
-                .user_owned_identity_material_file(&owner_key, record.name.as_str());
+                .user_owned_identity_material_file(&owner, &record.name);
             if let Some(parent) = manifest_path.parent() {
                 storage_fs::ensure_private_dir(parent)?;
             }
@@ -532,27 +569,24 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
         identity_name: &IdentityInstanceName,
     ) -> Result<bool, AppError> {
         let store = self.clone();
-        let owner_key = owner.as_str().to_string();
+        let owner = owner.clone();
         let identity_name = identity_name.clone();
         tokio::task::spawn_blocking(move || {
-            let owner_key = validate_identity_owner_key(&owner_key)?;
             let _material_lock =
-                Self::material_lock_for_layout(&store.layout, &owner_key, &identity_name)?;
+                Self::material_lock_for_layout(&store.layout, &owner, &identity_name)?;
             let _state_lock = FileLock::exclusive(store.layout.state_lock())?;
             let manifest_path = store
                 .layout
-                .user_owned_identity_manifest_file(&owner_key, identity_name.as_str());
+                .user_owned_identity_manifest_file(&owner, &identity_name);
             let material_path = store
                 .layout
-                .user_owned_identity_material_file(&owner_key, identity_name.as_str());
+                .user_owned_identity_material_file(&owner, &identity_name);
             if !manifest_path.exists() {
                 return Ok(false);
             }
             remove_file_if_exists_unlocked(&material_path)?;
             remove_file_if_exists_unlocked(&manifest_path)?;
-            let identity_dir = store
-                .layout
-                .user_owned_identity_dir(&owner_key, identity_name.as_str());
+            let identity_dir = store.layout.user_owned_identity_dir(&owner, &identity_name);
             if identity_dir.exists() {
                 match fs::remove_dir(&identity_dir) {
                     Ok(()) => {}
@@ -572,25 +606,29 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
         identity_name: &IdentityInstanceName,
     ) -> Result<Box<dyn IdentityInstanceMaterialGuard>, AppError> {
         let layout = self.layout.clone();
-        let owner_key = owner.as_str().to_string();
+        let owner = owner.clone();
         let identity_name = identity_name.clone();
         tokio::task::spawn_blocking(move || {
-            let owner_key = validate_identity_owner_key(&owner_key)?;
-            let lock = Self::material_lock_for_layout(&layout, &owner_key, &identity_name)?;
+            let lock = Self::material_lock_for_layout(&layout, &owner, &identity_name)?;
             Ok(Box::new(FileIdentityInstanceMaterialGuard {
                 layout,
-                owner_key,
+                owner,
                 identity_name,
                 _lock: lock,
             }) as Box<dyn IdentityInstanceMaterialGuard>)
         })
         .await?
     }
+
+    fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError> {
+        let identity_spec_name = validate_identity_spec_name(identity_spec_name)?;
+        Self::count_identity_spec_references_unlocked(&self.layout, identity_spec_name.as_str())
+    }
 }
 
 struct FileIdentityInstanceMaterialGuard {
     layout: AppStateLayout,
-    owner_key: String,
+    owner: IdentityOwnerKey,
     identity_name: IdentityInstanceName,
     _lock: FileLock,
 }
@@ -600,10 +638,12 @@ impl IdentityInstanceMaterialGuard for FileIdentityInstanceMaterialGuard {
     async fn read_material(&self) -> Result<BTreeMap<String, String>, AppError> {
         let path = self
             .layout
-            .user_owned_identity_material_file(&self.owner_key, self.identity_name.as_str());
+            .user_owned_identity_material_file(&self.owner, &self.identity_name);
         let identity_name = self.identity_name.to_string();
         tokio::task::spawn_blocking(move || match fs::read_to_string(path) {
-            Ok(raw) => parse_env_file(&raw).map_err(Into::into),
+            Ok(raw) => parse_env_file(&raw).map_err(|error| {
+                AppError::Credentials(crate::credentials::CredentialsError::from(error))
+            }),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 Err(AppError::FailedPrecondition(format!(
                     "identity '{identity_name}' is missing credential material"
@@ -616,18 +656,17 @@ impl IdentityInstanceMaterialGuard for FileIdentityInstanceMaterialGuard {
 
     async fn write_material(&self, material: &BTreeMap<String, String>) -> Result<(), AppError> {
         let layout = self.layout.clone();
-        let owner_key = self.owner_key.clone();
+        let owner = self.owner.clone();
         let identity_name = self.identity_name.clone();
         let material = material.clone();
         tokio::task::spawn_blocking(move || {
-            let path = layout.user_owned_identity_material_file(&owner_key, identity_name.as_str());
+            let path = layout.user_owned_identity_material_file(&owner, &identity_name);
             let _state_lock = FileLock::exclusive(layout.state_lock())?;
-            let manifest_path =
-                layout.user_owned_identity_manifest_file(&owner_key, identity_name.as_str());
+            let manifest_path = layout.user_owned_identity_manifest_file(&owner, &identity_name);
             if !manifest_path.exists() {
                 return Err(AppError::IdentityNotFound(identity_name.to_string()));
             }
-            write_file_unlocked(&path, render_env_file(&material).as_bytes()).map_err(Into::into)
+            write_file_unlocked(&path, render_env_file(&material).as_bytes())
         })
         .await?
     }
@@ -678,7 +717,7 @@ impl IdentityInstanceDocument {
         }
         Ok(IdentityInstanceRecord {
             name,
-            identity_spec: validate_identity_spec_name(&self.identity_spec)?,
+            identity_spec: validate_identity_spec_name(&self.identity_spec)?.to_string(),
             identity_spec_fingerprint: self.identity_spec_fingerprint,
             issuer: self.issuer,
             identity_type: self.identity_type,
@@ -687,8 +726,9 @@ impl IdentityInstanceDocument {
     }
 }
 
-fn validate_identity_owner_key(owner: &str) -> Result<String, AppError> {
-    parse_path_segment("identity owner", owner)
+#[derive(Debug, Deserialize)]
+struct IdentitySpecReference {
+    identity_spec: String,
 }
 
 fn validate_identity_name(name: &str) -> Result<IdentityInstanceName, AppError> {
@@ -712,6 +752,18 @@ fn validate_identity_spec_reference_unlocked(
         )));
     }
     Ok(())
+}
+
+fn checked_add_identity_count(
+    current: u32,
+    additional: u32,
+    identity_spec_name: &str,
+) -> Result<u32, AppError> {
+    current.checked_add(additional).ok_or_else(|| {
+        AppError::FailedPrecondition(format!(
+            "too many stored identities reference identity spec '{identity_spec_name}'"
+        ))
+    })
 }
 
 /// Snapshots `paths`, runs `write`, and restores every file to its prior
@@ -746,8 +798,23 @@ fn restore_file_unlocked(
     snapshot: Option<Vec<u8>>,
 ) -> Result<(), AppError> {
     match snapshot {
-        Some(bytes) => write_file_unlocked(path, &bytes).map_err(Into::into),
+        Some(bytes) => write_file_unlocked(path, &bytes),
         None => remove_file_if_exists_unlocked(path).map_err(Into::into),
+    }
+}
+
+fn write_file_unlocked(path: &Path, bytes: &[u8]) -> Result<(), AppError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    storage_fs::ensure_dir(parent)?;
+    storage_fs::write_atomic(path, bytes)?;
+    Ok(())
+}
+
+fn remove_file_if_exists_unlocked(path: &Path) -> Result<(), std::io::Error> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
     }
 }
 
@@ -896,7 +963,7 @@ audience:
         let record = manager
             .create_user_owned_fixed_token_identity(
                 &UserPrincipal::local(),
-                github_local_command("ghp_token"),
+                github_local_command("  ghp_token  "),
             )
             .await
             .expect("create identity");
@@ -912,14 +979,35 @@ audience:
         assert!(record.metadata.is_empty());
 
         let layout = test_layout(&temp);
-        let raw =
-            fs::read_to_string(layout.user_owned_identity_manifest_file("local", "github_local"))
-                .expect("identity manifest");
+        let raw = fs::read_to_string(
+            layout.user_owned_identity_manifest_file(&local_owner(), &github_local_name()),
+        )
+        .expect("identity manifest");
         assert!(raw.contains("identity_spec: github_pat"));
-        let material =
-            fs::read_to_string(layout.user_owned_identity_material_file("local", "github_local"))
-                .expect("identity material");
+        let material = fs::read_to_string(
+            layout.user_owned_identity_material_file(&local_owner(), &github_local_name()),
+        )
+        .expect("identity material");
         assert!(material.contains("TOKEN=ghp_token"));
+        assert!(!material.contains("  ghp_token  "));
+    }
+
+    #[tokio::test]
+    async fn create_user_owned_fixed_token_identity_rejects_whitespace_token() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+
+        let error = manager
+            .create_user_owned_fixed_token_identity(
+                &UserPrincipal::local(),
+                github_local_command("   "),
+            )
+            .await
+            .expect_err("whitespace-only token should be rejected");
+
+        assert!(
+            matches!(error, AppError::InvalidInput(ref message) if message.contains("must not be empty")),
+            "unexpected error: {error:?}"
+        );
     }
 
     #[tokio::test]
@@ -995,13 +1083,13 @@ audience:
         let layout = test_layout(&temp);
         assert!(
             !layout
-                .user_owned_identity_manifest_file("local", "github_local")
+                .user_owned_identity_manifest_file(&local_owner(), &github_local_name())
                 .exists(),
             "rejected stale identity should not create a manifest"
         );
         assert!(
             !layout
-                .user_owned_identity_material_file("local", "github_local")
+                .user_owned_identity_material_file(&local_owner(), &github_local_name())
                 .exists(),
             "rejected stale identity should not create material"
         );
@@ -1098,7 +1186,7 @@ audience:
             .await
             .expect("create identity");
         let layout = test_layout(&temp);
-        fs::remove_dir_all(layout.user_owned_identity_dir("local", "github_local"))
+        fs::remove_dir_all(layout.user_owned_identity_dir(&local_owner(), &github_local_name()))
             .expect("delete identity");
 
         let error = manager
@@ -1113,7 +1201,7 @@ audience:
         assert!(matches!(error, AppError::IdentityNotFound(name) if name == "github_local"));
         assert!(
             !layout
-                .user_owned_identity_material_file("local", "github_local")
+                .user_owned_identity_material_file(&local_owner(), &github_local_name())
                 .exists(),
             "deleted identity material should stay deleted"
         );

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1,4 +1,4 @@
-//! Storage seam types and traits for user-owned provider identity material.
+//! Storage seam types and traits for provider identity instances.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -21,14 +21,14 @@ use crate::identity_specs::{
 use crate::state::AppStateLayout;
 use crate::storage::fs::{self as storage_fs, FileLock};
 
-const USER_OWNED_IDENTITY_DOCUMENT_VERSION: u32 = 1;
+const IDENTITY_INSTANCE_DOCUMENT_VERSION: u32 = 1;
 const FIXED_TOKEN_MATERIAL_KEY: &str = "TOKEN";
 
-/// One stored user-owned identity.
+/// One stored provider identity instance.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UserOwnedIdentityRecord {
+pub struct IdentityInstanceRecord {
     /// Stable identity name used by source identity bindings.
-    pub name: UserOwnedIdentityName,
+    pub name: IdentityInstanceName,
     /// Installed identity spec used to instantiate this identity.
     pub identity_spec: String,
     /// Fingerprint of the identity spec at creation time.
@@ -41,11 +41,11 @@ pub struct UserOwnedIdentityRecord {
     pub metadata: BTreeMap<String, String>,
 }
 
-/// Validated storage name for one user-owned identity.
+/// Validated storage name for one provider identity instance.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct UserOwnedIdentityName(String);
+pub struct IdentityInstanceName(String);
 
-impl UserOwnedIdentityName {
+impl IdentityInstanceName {
     /// Builds an identity name from a storage-safe string.
     ///
     /// # Errors
@@ -62,13 +62,13 @@ impl UserOwnedIdentityName {
     }
 }
 
-impl fmt::Display for UserOwnedIdentityName {
+impl fmt::Display for IdentityInstanceName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl FromStr for UserOwnedIdentityName {
+impl FromStr for IdentityInstanceName {
     type Err = AppError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
@@ -76,7 +76,7 @@ impl FromStr for UserOwnedIdentityName {
     }
 }
 
-impl TryFrom<String> for UserOwnedIdentityName {
+impl TryFrom<String> for IdentityInstanceName {
     type Error = AppError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
@@ -146,9 +146,9 @@ pub struct CreateFixedTokenIdentityCommand {
     pub token: String,
 }
 
-/// Locked access to credential material for one user-owned identity.
+/// Locked access to credential material for one provider identity instance.
 #[tonic::async_trait]
-pub trait UserOwnedIdentityMaterialGuard: Send {
+pub trait IdentityInstanceMaterialGuard: Send {
     /// Reads the identity's credential material.
     ///
     /// # Errors
@@ -164,9 +164,9 @@ pub trait UserOwnedIdentityMaterialGuard: Send {
     async fn write_material(&self, material: &BTreeMap<String, String>) -> Result<(), AppError>;
 }
 
-/// Durable storage backend for user-owned identities.
+/// Durable storage backend for provider identity instances.
 #[tonic::async_trait]
-pub trait UserOwnedIdentityStore: Send + Sync + std::fmt::Debug + 'static {
+pub trait IdentityInstanceStore: Send + Sync + std::fmt::Debug + 'static {
     /// Lists identities owned by one opaque owner key.
     ///
     /// # Errors
@@ -175,7 +175,7 @@ pub trait UserOwnedIdentityStore: Send + Sync + std::fmt::Debug + 'static {
     async fn list_identities(
         &self,
         owner: &IdentityOwnerKey,
-    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError>;
+    ) -> Result<Vec<IdentityInstanceRecord>, AppError>;
 
     /// Loads one identity owned by one opaque owner key.
     ///
@@ -185,8 +185,8 @@ pub trait UserOwnedIdentityStore: Send + Sync + std::fmt::Debug + 'static {
     async fn load_identity(
         &self,
         owner: &IdentityOwnerKey,
-        identity_name: &UserOwnedIdentityName,
-    ) -> Result<Option<UserOwnedIdentityRecord>, AppError>;
+        identity_name: &IdentityInstanceName,
+    ) -> Result<Option<IdentityInstanceRecord>, AppError>;
 
     /// Replaces one identity and its credential material atomically.
     ///
@@ -196,7 +196,7 @@ pub trait UserOwnedIdentityStore: Send + Sync + std::fmt::Debug + 'static {
     async fn replace_identity(
         &self,
         owner: &IdentityOwnerKey,
-        record: &UserOwnedIdentityRecord,
+        record: &IdentityInstanceRecord,
         material: &BTreeMap<String, String>,
     ) -> Result<(), AppError>;
 
@@ -208,7 +208,7 @@ pub trait UserOwnedIdentityStore: Send + Sync + std::fmt::Debug + 'static {
     async fn delete_identity(
         &self,
         owner: &IdentityOwnerKey,
-        identity_name: &UserOwnedIdentityName,
+        identity_name: &IdentityInstanceName,
     ) -> Result<bool, AppError>;
 
     /// Returns locked access to one identity's credential material.
@@ -219,15 +219,15 @@ pub trait UserOwnedIdentityStore: Send + Sync + std::fmt::Debug + 'static {
     async fn material_guard(
         &self,
         owner: &IdentityOwnerKey,
-        identity_name: &UserOwnedIdentityName,
-    ) -> Result<Box<dyn UserOwnedIdentityMaterialGuard>, AppError>;
+        identity_name: &IdentityInstanceName,
+    ) -> Result<Box<dyn IdentityInstanceMaterialGuard>, AppError>;
 }
 
-/// Manages provider-facing identities owned by Coral user principals.
+/// Manages provider-facing identity instances keyed by an opaque owner.
 #[derive(Debug, Clone)]
-pub(crate) struct UserOwnedIdentityManager {
+pub(crate) struct IdentityInstanceManager {
     identity_specs: IdentitySpecManager,
-    store: Arc<dyn UserOwnedIdentityStore>,
+    store: Arc<dyn IdentityInstanceStore>,
 }
 
 /// Product-facing handle for stored provider identity management.
@@ -237,7 +237,7 @@ pub(crate) struct UserOwnedIdentityManager {
 /// metadata into stable keys.
 #[derive(Debug, Clone)]
 pub struct IdentityManagementHandle {
-    manager: UserOwnedIdentityManager,
+    manager: IdentityInstanceManager,
 }
 
 impl IdentityManagementHandle {
@@ -250,7 +250,7 @@ impl IdentityManagementHandle {
         &self,
         owner: &IdentityOwnerKey,
         command: CreateFixedTokenIdentityCommand,
-    ) -> Result<UserOwnedIdentityRecord, AppError> {
+    ) -> Result<IdentityInstanceRecord, AppError> {
         self.manager
             .create_fixed_token_identity(owner, command)
             .await
@@ -264,7 +264,7 @@ impl IdentityManagementHandle {
     pub async fn list_identities(
         &self,
         owner: &IdentityOwnerKey,
-    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+    ) -> Result<Vec<IdentityInstanceRecord>, AppError> {
         self.manager.list_identities(owner).await
     }
 
@@ -282,17 +282,17 @@ impl IdentityManagementHandle {
     }
 }
 
-impl UserOwnedIdentityManager {
+impl IdentityInstanceManager {
     pub(crate) fn new(layout: AppStateLayout, identity_specs: IdentitySpecManager) -> Self {
         Self::new_with_store(
             identity_specs.clone(),
-            Arc::new(FileUserOwnedIdentityStore::new(layout, identity_specs)),
+            Arc::new(FileIdentityInstanceStore::new(layout, identity_specs)),
         )
     }
 
     pub(crate) fn new_with_store(
         identity_specs: IdentitySpecManager,
-        store: Arc<dyn UserOwnedIdentityStore>,
+        store: Arc<dyn IdentityInstanceStore>,
     ) -> Self {
         Self {
             identity_specs,
@@ -312,7 +312,7 @@ impl UserOwnedIdentityManager {
         name: &str,
         identity_spec: &str,
         expected: IdentitySpecType,
-    ) -> Result<(IdentityOwnerKey, UserOwnedIdentityName, IdentitySpecRecord), AppError> {
+    ) -> Result<(IdentityOwnerKey, IdentityInstanceName, IdentitySpecRecord), AppError> {
         self.identity_specs.ensure_dsl_v4_enabled()?;
         let name = validate_identity_name(name)?;
         let identity_spec_name = validate_identity_spec_name(identity_spec)?;
@@ -331,7 +331,7 @@ impl UserOwnedIdentityManager {
         &self,
         owner: &IdentityOwnerKey,
         command: CreateFixedTokenIdentityCommand,
-    ) -> Result<UserOwnedIdentityRecord, AppError> {
+    ) -> Result<IdentityInstanceRecord, AppError> {
         let span = info_span!("coral.app.identities.create_fixed_token");
         let _guard = span.enter();
         let (owner, name, spec) = self.prepare_identity_creation(
@@ -345,7 +345,7 @@ impl UserOwnedIdentityManager {
                 "fixed token identity token must not be empty".to_string(),
             ));
         }
-        let record = UserOwnedIdentityRecord {
+        let record = IdentityInstanceRecord {
             name,
             identity_spec: spec.manifest.name.clone(),
             identity_spec_fingerprint: Some(identity_spec_fingerprint(&spec.manifest)?),
@@ -364,7 +364,7 @@ impl UserOwnedIdentityManager {
         &self,
         principal: &UserPrincipal,
         command: CreateFixedTokenIdentityCommand,
-    ) -> Result<UserOwnedIdentityRecord, AppError> {
+    ) -> Result<IdentityInstanceRecord, AppError> {
         let owner = IdentityOwnerKey::for_user_principal(principal)?;
         self.create_fixed_token_identity(&owner, command).await
     }
@@ -372,14 +372,14 @@ impl UserOwnedIdentityManager {
     async fn list_identities(
         &self,
         owner: &IdentityOwnerKey,
-    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+    ) -> Result<Vec<IdentityInstanceRecord>, AppError> {
         self.store.list_identities(owner).await
     }
 
     pub(crate) async fn list_user_owned_identities(
         &self,
         principal: &UserPrincipal,
-    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+    ) -> Result<Vec<IdentityInstanceRecord>, AppError> {
         let span = info_span!("coral.app.identities.list_user_owned");
         let _guard = span.enter();
         let owner = IdentityOwnerKey::for_user_principal(principal)?;
@@ -397,12 +397,12 @@ impl UserOwnedIdentityManager {
 }
 
 #[derive(Debug, Clone)]
-struct FileUserOwnedIdentityStore {
+struct FileIdentityInstanceStore {
     layout: AppStateLayout,
     identity_specs: IdentitySpecManager,
 }
 
-impl FileUserOwnedIdentityStore {
+impl FileIdentityInstanceStore {
     fn new(layout: AppStateLayout, identity_specs: IdentitySpecManager) -> Self {
         Self {
             layout,
@@ -414,7 +414,7 @@ impl FileUserOwnedIdentityStore {
         &self,
         owner_key: &str,
         name: &str,
-    ) -> Result<UserOwnedIdentityRecord, AppError> {
+    ) -> Result<IdentityInstanceRecord, AppError> {
         let owner_key = validate_identity_owner_key(owner_key)?;
         let name = validate_identity_name(name)?;
         let path = self
@@ -424,14 +424,14 @@ impl FileUserOwnedIdentityStore {
             return Err(AppError::IdentityNotFound(name.to_string()));
         }
         let raw = fs::read_to_string(&path)?;
-        let document: UserOwnedIdentityDocument = serde_yaml::from_str(&raw)?;
+        let document: IdentityInstanceDocument = serde_yaml::from_str(&raw)?;
         document.into_record(&name)
     }
 
     fn material_lock_for_layout(
         layout: &AppStateLayout,
         owner_key: &str,
-        identity_name: &UserOwnedIdentityName,
+        identity_name: &IdentityInstanceName,
     ) -> Result<FileLock, AppError> {
         FileLock::exclusive(
             &layout.user_owned_identity_refresh_lock_file(owner_key, identity_name.as_str()),
@@ -441,11 +441,11 @@ impl FileUserOwnedIdentityStore {
 }
 
 #[tonic::async_trait]
-impl UserOwnedIdentityStore for FileUserOwnedIdentityStore {
+impl IdentityInstanceStore for FileIdentityInstanceStore {
     async fn list_identities(
         &self,
         owner: &IdentityOwnerKey,
-    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+    ) -> Result<Vec<IdentityInstanceRecord>, AppError> {
         let store = self.clone();
         let owner_key = owner.as_str().to_string();
         tokio::task::spawn_blocking(move || {
@@ -475,8 +475,8 @@ impl UserOwnedIdentityStore for FileUserOwnedIdentityStore {
     async fn load_identity(
         &self,
         owner: &IdentityOwnerKey,
-        identity_name: &UserOwnedIdentityName,
-    ) -> Result<Option<UserOwnedIdentityRecord>, AppError> {
+        identity_name: &IdentityInstanceName,
+    ) -> Result<Option<IdentityInstanceRecord>, AppError> {
         let store = self.clone();
         let owner_key = owner.as_str().to_string();
         let identity_name = identity_name.clone();
@@ -494,7 +494,7 @@ impl UserOwnedIdentityStore for FileUserOwnedIdentityStore {
     async fn replace_identity(
         &self,
         owner: &IdentityOwnerKey,
-        record: &UserOwnedIdentityRecord,
+        record: &IdentityInstanceRecord,
         material: &BTreeMap<String, String>,
     ) -> Result<(), AppError> {
         let store = self.clone();
@@ -517,7 +517,7 @@ impl UserOwnedIdentityStore for FileUserOwnedIdentityStore {
             }
             validate_identity_spec_reference_unlocked(&store.identity_specs, &record)?;
             write_files_transactionally(&[&manifest_path, &material_path], || {
-                let document = UserOwnedIdentityDocument::from_record(&record);
+                let document = IdentityInstanceDocument::from_record(&record);
                 write_file_unlocked(&manifest_path, serde_yaml::to_string(&document)?.as_bytes())?;
                 write_file_unlocked(&material_path, render_env_file(&material).as_bytes())?;
                 Ok(())
@@ -529,7 +529,7 @@ impl UserOwnedIdentityStore for FileUserOwnedIdentityStore {
     async fn delete_identity(
         &self,
         owner: &IdentityOwnerKey,
-        identity_name: &UserOwnedIdentityName,
+        identity_name: &IdentityInstanceName,
     ) -> Result<bool, AppError> {
         let store = self.clone();
         let owner_key = owner.as_str().to_string();
@@ -569,34 +569,34 @@ impl UserOwnedIdentityStore for FileUserOwnedIdentityStore {
     async fn material_guard(
         &self,
         owner: &IdentityOwnerKey,
-        identity_name: &UserOwnedIdentityName,
-    ) -> Result<Box<dyn UserOwnedIdentityMaterialGuard>, AppError> {
+        identity_name: &IdentityInstanceName,
+    ) -> Result<Box<dyn IdentityInstanceMaterialGuard>, AppError> {
         let layout = self.layout.clone();
         let owner_key = owner.as_str().to_string();
         let identity_name = identity_name.clone();
         tokio::task::spawn_blocking(move || {
             let owner_key = validate_identity_owner_key(&owner_key)?;
             let lock = Self::material_lock_for_layout(&layout, &owner_key, &identity_name)?;
-            Ok(Box::new(FileUserOwnedIdentityMaterialGuard {
+            Ok(Box::new(FileIdentityInstanceMaterialGuard {
                 layout,
                 owner_key,
                 identity_name,
                 _lock: lock,
-            }) as Box<dyn UserOwnedIdentityMaterialGuard>)
+            }) as Box<dyn IdentityInstanceMaterialGuard>)
         })
         .await?
     }
 }
 
-struct FileUserOwnedIdentityMaterialGuard {
+struct FileIdentityInstanceMaterialGuard {
     layout: AppStateLayout,
     owner_key: String,
-    identity_name: UserOwnedIdentityName,
+    identity_name: IdentityInstanceName,
     _lock: FileLock,
 }
 
 #[tonic::async_trait]
-impl UserOwnedIdentityMaterialGuard for FileUserOwnedIdentityMaterialGuard {
+impl IdentityInstanceMaterialGuard for FileIdentityInstanceMaterialGuard {
     async fn read_material(&self) -> Result<BTreeMap<String, String>, AppError> {
         let path = self
             .layout
@@ -635,7 +635,7 @@ impl UserOwnedIdentityMaterialGuard for FileUserOwnedIdentityMaterialGuard {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct UserOwnedIdentityDocument {
+struct IdentityInstanceDocument {
     version: u32,
     name: String,
     identity_spec: String,
@@ -647,10 +647,10 @@ struct UserOwnedIdentityDocument {
     metadata: BTreeMap<String, String>,
 }
 
-impl UserOwnedIdentityDocument {
-    fn from_record(record: &UserOwnedIdentityRecord) -> Self {
+impl IdentityInstanceDocument {
+    fn from_record(record: &IdentityInstanceRecord) -> Self {
         Self {
-            version: USER_OWNED_IDENTITY_DOCUMENT_VERSION,
+            version: IDENTITY_INSTANCE_DOCUMENT_VERSION,
             name: record.name.to_string(),
             identity_spec: record.identity_spec.clone(),
             identity_spec_fingerprint: record.identity_spec_fingerprint.clone(),
@@ -662,12 +662,12 @@ impl UserOwnedIdentityDocument {
 
     fn into_record(
         self,
-        expected_name: &UserOwnedIdentityName,
-    ) -> Result<UserOwnedIdentityRecord, AppError> {
-        if self.version != USER_OWNED_IDENTITY_DOCUMENT_VERSION {
+        expected_name: &IdentityInstanceName,
+    ) -> Result<IdentityInstanceRecord, AppError> {
+        if self.version != IDENTITY_INSTANCE_DOCUMENT_VERSION {
             return Err(AppError::FailedPrecondition(format!(
                 "identity '{}' has unsupported document version {}; expected {}",
-                self.name, self.version, USER_OWNED_IDENTITY_DOCUMENT_VERSION
+                self.name, self.version, IDENTITY_INSTANCE_DOCUMENT_VERSION
             )));
         }
         let name = validate_identity_name(&self.name)?;
@@ -676,7 +676,7 @@ impl UserOwnedIdentityDocument {
                 "identity file for '{expected_name}' contains identity '{name}'"
             )));
         }
-        Ok(UserOwnedIdentityRecord {
+        Ok(IdentityInstanceRecord {
             name,
             identity_spec: validate_identity_spec_name(&self.identity_spec)?,
             identity_spec_fingerprint: self.identity_spec_fingerprint,
@@ -691,13 +691,13 @@ fn validate_identity_owner_key(owner: &str) -> Result<String, AppError> {
     parse_path_segment("identity owner", owner)
 }
 
-fn validate_identity_name(name: &str) -> Result<UserOwnedIdentityName, AppError> {
-    UserOwnedIdentityName::new(name)
+fn validate_identity_name(name: &str) -> Result<IdentityInstanceName, AppError> {
+    IdentityInstanceName::new(name)
 }
 
 fn validate_identity_spec_reference_unlocked(
     identity_specs: &IdentitySpecManager,
-    record: &UserOwnedIdentityRecord,
+    record: &IdentityInstanceRecord,
 ) -> Result<(), AppError> {
     let spec = identity_specs
         .load_identity_spec_manifest_unlocked_for_state_lock(&record.identity_spec)?;
@@ -779,21 +779,21 @@ mod tests {
 
     #[test]
     fn identity_name_rejects_storage_unsafe_values() {
-        UserOwnedIdentityName::new(" ").unwrap_err();
-        UserOwnedIdentityName::new("a/b").unwrap_err();
-        UserOwnedIdentityName::new("a\\b").unwrap_err();
-        UserOwnedIdentityName::new("..").unwrap_err();
+        IdentityInstanceName::new(" ").unwrap_err();
+        IdentityInstanceName::new("a/b").unwrap_err();
+        IdentityInstanceName::new("a\\b").unwrap_err();
+        IdentityInstanceName::new("..").unwrap_err();
     }
 
     #[test]
     fn identity_name_round_trips_storage_name() {
-        let identity_name = UserOwnedIdentityName::new("github-primary").expect("identity name");
+        let identity_name = IdentityInstanceName::new("github-primary").expect("identity name");
 
         assert_eq!(identity_name.as_str(), "github-primary");
         assert_eq!(identity_name.to_string(), "github-primary");
         assert_eq!(
             "github-primary"
-                .parse::<UserOwnedIdentityName>()
+                .parse::<IdentityInstanceName>()
                 .expect("parse"),
             identity_name
         );
@@ -806,25 +806,25 @@ mod tests {
         layout
     }
 
-    fn manager() -> (TempDir, UserOwnedIdentityManager, IdentitySpecManager) {
+    fn manager() -> (TempDir, IdentityInstanceManager, IdentitySpecManager) {
         manager_with_features(dsl_v4_features())
     }
 
     fn manager_with_features(
         features: Features,
-    ) -> (TempDir, UserOwnedIdentityManager, IdentitySpecManager) {
+    ) -> (TempDir, IdentityInstanceManager, IdentitySpecManager) {
         let temp = TempDir::new().expect("tempdir");
         let layout = test_layout(&temp);
         let identity_specs =
             IdentitySpecManager::new_with_usage_providers(layout.clone(), features, Vec::new());
         (
             temp,
-            UserOwnedIdentityManager::new(layout, identity_specs.clone()),
+            IdentityInstanceManager::new(layout, identity_specs.clone()),
             identity_specs,
         )
     }
 
-    fn manager_with_github_pat_spec() -> (TempDir, UserOwnedIdentityManager, IdentitySpecManager) {
+    fn manager_with_github_pat_spec() -> (TempDir, IdentityInstanceManager, IdentitySpecManager) {
         let (temp, manager, identity_specs) = manager();
         identity_specs
             .add_identity_spec(&fixed_identity_spec_yaml())
@@ -859,8 +859,8 @@ audience:
         }
     }
 
-    fn github_local_name() -> UserOwnedIdentityName {
-        UserOwnedIdentityName::new("github_local").expect("github_local identity name")
+    fn github_local_name() -> IdentityInstanceName {
+        IdentityInstanceName::new("github_local").expect("github_local identity name")
     }
 
     fn local_owner() -> IdentityOwnerKey {
@@ -928,7 +928,7 @@ audience:
         let original_spec = identity_specs
             .get_identity_spec("github_pat")
             .expect("original identity spec");
-        let record = UserOwnedIdentityRecord {
+        let record = IdentityInstanceRecord {
             name: github_local_name(),
             identity_spec: "github_pat".to_string(),
             identity_spec_fingerprint: Some(
@@ -961,7 +961,7 @@ audience:
         let original_spec = identity_specs
             .get_identity_spec("github_pat")
             .expect("original identity spec");
-        let record = UserOwnedIdentityRecord {
+        let record = IdentityInstanceRecord {
             name: github_local_name(),
             identity_spec: "github_pat".to_string(),
             identity_spec_fingerprint: Some(

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -2,10 +2,27 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
+use std::fs;
 use std::str::FromStr;
+use std::sync::Arc;
+
+use coral_spec::IdentitySpecType;
+use serde::{Deserialize, Serialize};
+use tracing::info_span;
 
 use crate::bootstrap::AppError;
-use crate::identity::parse_path_segment;
+use crate::credentials::{
+    parse_env_file, remove_file_if_exists_unlocked, render_env_file, write_file_unlocked,
+};
+use crate::identity::{UserPrincipal, parse_path_segment};
+use crate::identity_specs::{
+    IdentitySpecManager, IdentitySpecRecord, identity_spec_fingerprint, validate_identity_spec_name,
+};
+use crate::state::AppStateLayout;
+use crate::storage::fs::{self as storage_fs, FileLock};
+
+const USER_OWNED_IDENTITY_DOCUMENT_VERSION: u32 = 1;
+const FIXED_TOKEN_MATERIAL_KEY: &str = "TOKEN";
 
 /// One stored user-owned identity.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,9 +86,9 @@ impl TryFrom<String> for UserOwnedIdentityName {
 
 /// Opaque durable owner key for stored provider-facing identity material.
 ///
-/// OSS Coral only constructs this from the request user principal. Product
-/// runtimes can use their own stable owner keys without adding product-specific
-/// ownership concepts to OSS identity management.
+/// OSS Coral constructs this from the request user principal. Other runtimes can
+/// use their own stable owner keys without adding their ownership model to OSS
+/// identity management.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IdentityOwnerKey(String);
 
@@ -83,6 +100,10 @@ impl IdentityOwnerKey {
     /// Returns [`AppError`] when the key is empty or contains path separators.
     pub fn new(value: impl Into<String>) -> Result<Self, AppError> {
         parse_path_segment("identity owner", &value.into()).map(Self)
+    }
+
+    pub(crate) fn for_user_principal(principal: &UserPrincipal) -> Result<Self, AppError> {
+        Self::new(principal.user_id())
     }
 
     /// Returns the storage key string.
@@ -112,6 +133,17 @@ impl TryFrom<String> for IdentityOwnerKey {
     fn try_from(value: String) -> Result<Self, Self::Error> {
         Self::new(value)
     }
+}
+
+/// Request to create or replace a fixed-token identity.
+#[derive(Debug, Clone)]
+pub struct CreateFixedTokenIdentityCommand {
+    /// Stable identity name used by source identity bindings.
+    pub name: String,
+    /// Installed fixed-token identity spec name.
+    pub identity_spec: String,
+    /// Bearer token to store.
+    pub token: String,
 }
 
 /// Locked access to credential material for one user-owned identity.
@@ -191,9 +223,539 @@ pub trait UserOwnedIdentityStore: Send + Sync + std::fmt::Debug + 'static {
     ) -> Result<Box<dyn UserOwnedIdentityMaterialGuard>, AppError>;
 }
 
+/// Manages provider-facing identities owned by Coral user principals.
+#[derive(Debug, Clone)]
+pub(crate) struct UserOwnedIdentityManager {
+    identity_specs: IdentitySpecManager,
+    store: Arc<dyn UserOwnedIdentityStore>,
+}
+
+/// Product-facing handle for stored provider identity management.
+///
+/// The handle intentionally deals only in opaque owner keys. OSS callers keep
+/// using user-owned gRPC methods, while other runtimes can map their owner
+/// metadata into stable keys.
+#[derive(Debug, Clone)]
+pub struct IdentityManagementHandle {
+    manager: UserOwnedIdentityManager,
+}
+
+impl IdentityManagementHandle {
+    /// Creates or replaces a fixed-token identity under `owner`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when validation or storage fails.
+    pub async fn create_fixed_token_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        command: CreateFixedTokenIdentityCommand,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        self.manager
+            .create_fixed_token_identity(owner, command)
+            .await
+    }
+
+    /// Lists identities stored under `owner`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot be read.
+    pub async fn list_identities(
+        &self,
+        owner: &IdentityOwnerKey,
+    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+        self.manager.list_identities(owner).await
+    }
+
+    /// Deletes an identity stored under `owner`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot be written.
+    pub async fn delete_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<bool, AppError> {
+        self.manager.delete_identity(owner, identity_name).await
+    }
+}
+
+impl UserOwnedIdentityManager {
+    pub(crate) fn new(layout: AppStateLayout, identity_specs: IdentitySpecManager) -> Self {
+        Self::new_with_store(
+            identity_specs.clone(),
+            Arc::new(FileUserOwnedIdentityStore::new(layout, identity_specs)),
+        )
+    }
+
+    pub(crate) fn new_with_store(
+        identity_specs: IdentitySpecManager,
+        store: Arc<dyn UserOwnedIdentityStore>,
+    ) -> Self {
+        Self {
+            identity_specs,
+            store,
+        }
+    }
+
+    pub(crate) fn handle(&self) -> IdentityManagementHandle {
+        IdentityManagementHandle {
+            manager: self.clone(),
+        }
+    }
+
+    fn prepare_identity_creation(
+        &self,
+        owner: &IdentityOwnerKey,
+        name: &str,
+        identity_spec: &str,
+        expected: IdentitySpecType,
+    ) -> Result<(IdentityOwnerKey, UserOwnedIdentityName, IdentitySpecRecord), AppError> {
+        self.identity_specs.ensure_dsl_v4_enabled()?;
+        let name = validate_identity_name(name)?;
+        let identity_spec_name = validate_identity_spec_name(identity_spec)?;
+        let spec = self.identity_specs.get_identity_spec(&identity_spec_name)?;
+        if spec.manifest.identity_type != expected {
+            return Err(AppError::InvalidInput(format!(
+                "identity spec '{identity_spec_name}' has type '{}'; expected {}",
+                spec.manifest.identity_type.label(),
+                expected.label()
+            )));
+        }
+        Ok((owner.clone(), name, spec))
+    }
+
+    async fn create_fixed_token_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        command: CreateFixedTokenIdentityCommand,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        let span = info_span!("coral.app.identities.create_fixed_token");
+        let _guard = span.enter();
+        let (owner, name, spec) = self.prepare_identity_creation(
+            owner,
+            &command.name,
+            &command.identity_spec,
+            IdentitySpecType::FixedToken,
+        )?;
+        if command.token.is_empty() {
+            return Err(AppError::InvalidInput(
+                "fixed token identity token must not be empty".to_string(),
+            ));
+        }
+        let record = UserOwnedIdentityRecord {
+            name,
+            identity_spec: spec.manifest.name.clone(),
+            identity_spec_fingerprint: Some(identity_spec_fingerprint(&spec.manifest)?),
+            issuer: spec.manifest.issuer,
+            identity_type: spec.manifest.identity_type.label().to_string(),
+            metadata: BTreeMap::new(),
+        };
+        let material = BTreeMap::from([(FIXED_TOKEN_MATERIAL_KEY.to_string(), command.token)]);
+        self.store
+            .replace_identity(&owner, &record, &material)
+            .await?;
+        Ok(record)
+    }
+
+    pub(crate) async fn create_user_owned_fixed_token_identity(
+        &self,
+        principal: &UserPrincipal,
+        command: CreateFixedTokenIdentityCommand,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+        self.create_fixed_token_identity(&owner, command).await
+    }
+
+    async fn list_identities(
+        &self,
+        owner: &IdentityOwnerKey,
+    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+        self.store.list_identities(owner).await
+    }
+
+    pub(crate) async fn list_user_owned_identities(
+        &self,
+        principal: &UserPrincipal,
+    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+        let span = info_span!("coral.app.identities.list_user_owned");
+        let _guard = span.enter();
+        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+        self.list_identities(&owner).await
+    }
+
+    async fn delete_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &str,
+    ) -> Result<bool, AppError> {
+        let identity_name = validate_identity_name(identity_name)?;
+        self.store.delete_identity(owner, &identity_name).await
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FileUserOwnedIdentityStore {
+    layout: AppStateLayout,
+    identity_specs: IdentitySpecManager,
+}
+
+impl FileUserOwnedIdentityStore {
+    fn new(layout: AppStateLayout, identity_specs: IdentitySpecManager) -> Self {
+        Self {
+            layout,
+            identity_specs,
+        }
+    }
+
+    fn load_identity_unlocked(
+        &self,
+        owner_key: &str,
+        name: &str,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        let owner_key = validate_identity_owner_key(owner_key)?;
+        let name = validate_identity_name(name)?;
+        let path = self
+            .layout
+            .user_owned_identity_manifest_file(&owner_key, name.as_str());
+        if !path.exists() {
+            return Err(AppError::IdentityNotFound(name.to_string()));
+        }
+        let raw = fs::read_to_string(&path)?;
+        let document: UserOwnedIdentityDocument = serde_yaml::from_str(&raw)?;
+        document.into_record(&name)
+    }
+
+    fn material_lock_for_layout(
+        layout: &AppStateLayout,
+        owner_key: &str,
+        identity_name: &UserOwnedIdentityName,
+    ) -> Result<FileLock, AppError> {
+        FileLock::exclusive(
+            &layout.user_owned_identity_refresh_lock_file(owner_key, identity_name.as_str()),
+        )
+        .map_err(Into::into)
+    }
+}
+
+#[tonic::async_trait]
+impl UserOwnedIdentityStore for FileUserOwnedIdentityStore {
+    async fn list_identities(
+        &self,
+        owner: &IdentityOwnerKey,
+    ) -> Result<Vec<UserOwnedIdentityRecord>, AppError> {
+        let store = self.clone();
+        let owner_key = owner.as_str().to_string();
+        tokio::task::spawn_blocking(move || {
+            let owner_key = validate_identity_owner_key(&owner_key)?;
+            let _lock = FileLock::shared(store.layout.state_lock())?;
+            let root = store.layout.user_owned_identities_root(&owner_key);
+            if !root.exists() {
+                return Ok(Vec::new());
+            }
+            let mut records = Vec::new();
+            for entry in fs::read_dir(root)? {
+                let entry = entry?;
+                if !entry.file_type()?.is_dir() {
+                    continue;
+                }
+                let Some(name) = entry.file_name().to_str().map(ToString::to_string) else {
+                    continue;
+                };
+                records.push(store.load_identity_unlocked(&owner_key, &name)?);
+            }
+            records.sort_by(|left, right| left.name.cmp(&right.name));
+            Ok(records)
+        })
+        .await?
+    }
+
+    async fn load_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &UserOwnedIdentityName,
+    ) -> Result<Option<UserOwnedIdentityRecord>, AppError> {
+        let store = self.clone();
+        let owner_key = owner.as_str().to_string();
+        let identity_name = identity_name.clone();
+        tokio::task::spawn_blocking(move || {
+            let _lock = FileLock::shared(store.layout.state_lock())?;
+            match store.load_identity_unlocked(&owner_key, identity_name.as_str()) {
+                Ok(record) => Ok(Some(record)),
+                Err(AppError::IdentityNotFound(_)) => Ok(None),
+                Err(error) => Err(error),
+            }
+        })
+        .await?
+    }
+
+    async fn replace_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        record: &UserOwnedIdentityRecord,
+        material: &BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
+        let store = self.clone();
+        let owner_key = owner.as_str().to_string();
+        let record = record.clone();
+        let material = material.clone();
+        tokio::task::spawn_blocking(move || {
+            let owner_key = validate_identity_owner_key(&owner_key)?;
+            let _material_lock =
+                Self::material_lock_for_layout(&store.layout, &owner_key, &record.name)?;
+            let _state_lock = FileLock::exclusive(store.layout.state_lock())?;
+            let manifest_path = store
+                .layout
+                .user_owned_identity_manifest_file(&owner_key, record.name.as_str());
+            let material_path = store
+                .layout
+                .user_owned_identity_material_file(&owner_key, record.name.as_str());
+            if let Some(parent) = manifest_path.parent() {
+                storage_fs::ensure_private_dir(parent)?;
+            }
+            validate_identity_spec_reference_unlocked(&store.identity_specs, &record)?;
+            write_files_transactionally(&[&manifest_path, &material_path], || {
+                let document = UserOwnedIdentityDocument::from_record(&record);
+                write_file_unlocked(&manifest_path, serde_yaml::to_string(&document)?.as_bytes())?;
+                write_file_unlocked(&material_path, render_env_file(&material).as_bytes())?;
+                Ok(())
+            })
+        })
+        .await?
+    }
+
+    async fn delete_identity(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &UserOwnedIdentityName,
+    ) -> Result<bool, AppError> {
+        let store = self.clone();
+        let owner_key = owner.as_str().to_string();
+        let identity_name = identity_name.clone();
+        tokio::task::spawn_blocking(move || {
+            let owner_key = validate_identity_owner_key(&owner_key)?;
+            let _material_lock =
+                Self::material_lock_for_layout(&store.layout, &owner_key, &identity_name)?;
+            let _state_lock = FileLock::exclusive(store.layout.state_lock())?;
+            let manifest_path = store
+                .layout
+                .user_owned_identity_manifest_file(&owner_key, identity_name.as_str());
+            let material_path = store
+                .layout
+                .user_owned_identity_material_file(&owner_key, identity_name.as_str());
+            if !manifest_path.exists() {
+                return Ok(false);
+            }
+            remove_file_if_exists_unlocked(&material_path)?;
+            remove_file_if_exists_unlocked(&manifest_path)?;
+            let identity_dir = store
+                .layout
+                .user_owned_identity_dir(&owner_key, identity_name.as_str());
+            if identity_dir.exists() {
+                match fs::remove_dir(&identity_dir) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => {}
+                    Err(error) => return Err(error.into()),
+                }
+            }
+            Ok(true)
+        })
+        .await?
+    }
+
+    async fn material_guard(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &UserOwnedIdentityName,
+    ) -> Result<Box<dyn UserOwnedIdentityMaterialGuard>, AppError> {
+        let layout = self.layout.clone();
+        let owner_key = owner.as_str().to_string();
+        let identity_name = identity_name.clone();
+        tokio::task::spawn_blocking(move || {
+            let owner_key = validate_identity_owner_key(&owner_key)?;
+            let lock = Self::material_lock_for_layout(&layout, &owner_key, &identity_name)?;
+            Ok(Box::new(FileUserOwnedIdentityMaterialGuard {
+                layout,
+                owner_key,
+                identity_name,
+                _lock: lock,
+            }) as Box<dyn UserOwnedIdentityMaterialGuard>)
+        })
+        .await?
+    }
+}
+
+struct FileUserOwnedIdentityMaterialGuard {
+    layout: AppStateLayout,
+    owner_key: String,
+    identity_name: UserOwnedIdentityName,
+    _lock: FileLock,
+}
+
+#[tonic::async_trait]
+impl UserOwnedIdentityMaterialGuard for FileUserOwnedIdentityMaterialGuard {
+    async fn read_material(&self) -> Result<BTreeMap<String, String>, AppError> {
+        let path = self
+            .layout
+            .user_owned_identity_material_file(&self.owner_key, self.identity_name.as_str());
+        let identity_name = self.identity_name.to_string();
+        tokio::task::spawn_blocking(move || match fs::read_to_string(path) {
+            Ok(raw) => parse_env_file(&raw).map_err(Into::into),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                Err(AppError::FailedPrecondition(format!(
+                    "identity '{identity_name}' is missing credential material"
+                )))
+            }
+            Err(error) => Err(error.into()),
+        })
+        .await?
+    }
+
+    async fn write_material(&self, material: &BTreeMap<String, String>) -> Result<(), AppError> {
+        let layout = self.layout.clone();
+        let owner_key = self.owner_key.clone();
+        let identity_name = self.identity_name.clone();
+        let material = material.clone();
+        tokio::task::spawn_blocking(move || {
+            let path = layout.user_owned_identity_material_file(&owner_key, identity_name.as_str());
+            let _state_lock = FileLock::exclusive(layout.state_lock())?;
+            let manifest_path =
+                layout.user_owned_identity_manifest_file(&owner_key, identity_name.as_str());
+            if !manifest_path.exists() {
+                return Err(AppError::IdentityNotFound(identity_name.to_string()));
+            }
+            write_file_unlocked(&path, render_env_file(&material).as_bytes()).map_err(Into::into)
+        })
+        .await?
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UserOwnedIdentityDocument {
+    version: u32,
+    name: String,
+    identity_spec: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    identity_spec_fingerprint: Option<String>,
+    issuer: String,
+    identity_type: String,
+    #[serde(default)]
+    metadata: BTreeMap<String, String>,
+}
+
+impl UserOwnedIdentityDocument {
+    fn from_record(record: &UserOwnedIdentityRecord) -> Self {
+        Self {
+            version: USER_OWNED_IDENTITY_DOCUMENT_VERSION,
+            name: record.name.to_string(),
+            identity_spec: record.identity_spec.clone(),
+            identity_spec_fingerprint: record.identity_spec_fingerprint.clone(),
+            issuer: record.issuer.clone(),
+            identity_type: record.identity_type.clone(),
+            metadata: record.metadata.clone(),
+        }
+    }
+
+    fn into_record(
+        self,
+        expected_name: &UserOwnedIdentityName,
+    ) -> Result<UserOwnedIdentityRecord, AppError> {
+        if self.version != USER_OWNED_IDENTITY_DOCUMENT_VERSION {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity '{}' has unsupported document version {}; expected {}",
+                self.name, self.version, USER_OWNED_IDENTITY_DOCUMENT_VERSION
+            )));
+        }
+        let name = validate_identity_name(&self.name)?;
+        if &name != expected_name {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity file for '{expected_name}' contains identity '{name}'"
+            )));
+        }
+        Ok(UserOwnedIdentityRecord {
+            name,
+            identity_spec: validate_identity_spec_name(&self.identity_spec)?,
+            identity_spec_fingerprint: self.identity_spec_fingerprint,
+            issuer: self.issuer,
+            identity_type: self.identity_type,
+            metadata: self.metadata,
+        })
+    }
+}
+
+fn validate_identity_owner_key(owner: &str) -> Result<String, AppError> {
+    parse_path_segment("identity owner", owner)
+}
+
+fn validate_identity_name(name: &str) -> Result<UserOwnedIdentityName, AppError> {
+    UserOwnedIdentityName::new(name)
+}
+
+fn validate_identity_spec_reference_unlocked(
+    identity_specs: &IdentitySpecManager,
+    record: &UserOwnedIdentityRecord,
+) -> Result<(), AppError> {
+    let spec = identity_specs
+        .load_identity_spec_manifest_unlocked_for_state_lock(&record.identity_spec)?;
+    let fingerprint = identity_spec_fingerprint(&spec.manifest)?;
+    if spec.manifest.issuer != record.issuer
+        || spec.manifest.identity_type.label() != record.identity_type.as_str()
+        || record.identity_spec_fingerprint.as_deref() != Some(fingerprint.as_str())
+    {
+        return Err(AppError::FailedPrecondition(format!(
+            "identity '{}' references identity spec '{}' that changed before the identity could be stored",
+            record.name, record.identity_spec
+        )));
+    }
+    Ok(())
+}
+
+/// Snapshots `paths`, runs `write`, and restores every file to its prior
+/// contents if `write` fails, so a partial write never leaves files mutated.
+fn write_files_transactionally(
+    paths: &[&std::path::Path],
+    write: impl FnOnce() -> Result<(), AppError>,
+) -> Result<(), AppError> {
+    let snapshots = paths
+        .iter()
+        .map(|&path| snapshot_file_unlocked(path))
+        .collect::<Result<Vec<_>, _>>()?;
+    let result = write();
+    if result.is_err() {
+        for (&path, snapshot) in paths.iter().zip(snapshots) {
+            restore_file_unlocked(path, snapshot)?;
+        }
+    }
+    result
+}
+
+fn snapshot_file_unlocked(path: &std::path::Path) -> Result<Option<Vec<u8>>, AppError> {
+    match fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn restore_file_unlocked(
+    path: &std::path::Path,
+    snapshot: Option<Vec<u8>>,
+) -> Result<(), AppError> {
+    match snapshot {
+        Some(bytes) => write_file_unlocked(path, &bytes).map_err(Into::into),
+        None => remove_file_if_exists_unlocked(path).map_err(Into::into),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{IdentityOwnerKey, UserOwnedIdentityName};
+    use super::*;
+    use crate::features::{Features, dsl_v4_features};
+    use tempfile::TempDir;
 
     #[test]
     fn owner_key_rejects_storage_unsafe_values() {
@@ -234,6 +796,326 @@ mod tests {
                 .parse::<UserOwnedIdentityName>()
                 .expect("parse"),
             identity_name
+        );
+    }
+
+    fn test_layout(temp: &TempDir) -> AppStateLayout {
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout directories");
+        layout
+    }
+
+    fn manager() -> (TempDir, UserOwnedIdentityManager, IdentitySpecManager) {
+        manager_with_features(dsl_v4_features())
+    }
+
+    fn manager_with_features(
+        features: Features,
+    ) -> (TempDir, UserOwnedIdentityManager, IdentitySpecManager) {
+        let temp = TempDir::new().expect("tempdir");
+        let layout = test_layout(&temp);
+        let identity_specs =
+            IdentitySpecManager::new_with_usage_providers(layout.clone(), features, Vec::new());
+        (
+            temp,
+            UserOwnedIdentityManager::new(layout, identity_specs.clone()),
+            identity_specs,
+        )
+    }
+
+    fn manager_with_github_pat_spec() -> (TempDir, UserOwnedIdentityManager, IdentitySpecManager) {
+        let (temp, manager, identity_specs) = manager();
+        identity_specs
+            .add_identity_spec(&fixed_identity_spec_yaml())
+            .expect("add identity spec");
+        (temp, manager, identity_specs)
+    }
+
+    fn fixed_identity_spec_yaml() -> String {
+        fixed_identity_spec_yaml_with_issuer("github")
+    }
+
+    fn fixed_identity_spec_yaml_with_issuer(issuer: &str) -> String {
+        format!(
+            r"
+kind: identity
+spec_version: 1
+name: github_pat
+version: 0.1.0
+issuer: {issuer}
+type: fixed_token
+audience:
+  host: github.com
+"
+        )
+    }
+
+    fn github_local_command(token: &str) -> CreateFixedTokenIdentityCommand {
+        CreateFixedTokenIdentityCommand {
+            name: "github_local".to_string(),
+            identity_spec: "github_pat".to_string(),
+            token: token.to_string(),
+        }
+    }
+
+    fn github_local_name() -> UserOwnedIdentityName {
+        UserOwnedIdentityName::new("github_local").expect("github_local identity name")
+    }
+
+    fn local_owner() -> IdentityOwnerKey {
+        IdentityOwnerKey::new("local").expect("local owner")
+    }
+
+    fn material(key: &str, value: &str) -> BTreeMap<String, String> {
+        BTreeMap::from([(key.to_string(), value.to_string())])
+    }
+
+    #[tokio::test]
+    async fn create_user_owned_identity_requires_dsl_v4_feature() {
+        let (_temp, manager, _identity_specs) = manager_with_features(Features::default());
+
+        let error = manager
+            .create_user_owned_fixed_token_identity(
+                &UserPrincipal::local(),
+                github_local_command("token"),
+            )
+            .await
+            .expect_err("identity creation requires the dsl_v4 feature");
+
+        assert!(
+            matches!(&error, AppError::SourceUnservable(message) if message.contains("dsl_v4")),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_user_owned_fixed_token_identity_stores_record_and_material() {
+        let (temp, manager, _identity_specs) = manager_with_github_pat_spec();
+
+        let record = manager
+            .create_user_owned_fixed_token_identity(
+                &UserPrincipal::local(),
+                github_local_command("ghp_token"),
+            )
+            .await
+            .expect("create identity");
+
+        assert_eq!(record.name.as_str(), "github_local");
+        assert_eq!(record.identity_spec, "github_pat");
+        assert_eq!(record.issuer, "github");
+        assert_eq!(record.identity_type, "fixed_token");
+        assert!(
+            record.identity_spec_fingerprint.is_some(),
+            "identity should pin the identity spec fingerprint"
+        );
+        assert!(record.metadata.is_empty());
+
+        let layout = test_layout(&temp);
+        let raw =
+            fs::read_to_string(layout.user_owned_identity_manifest_file("local", "github_local"))
+                .expect("identity manifest");
+        assert!(raw.contains("identity_spec: github_pat"));
+        let material =
+            fs::read_to_string(layout.user_owned_identity_material_file("local", "github_local"))
+                .expect("identity material");
+        assert!(material.contains("TOKEN=ghp_token"));
+    }
+
+    #[tokio::test]
+    async fn identity_write_rejects_identity_spec_deleted_after_validation() {
+        let (_temp, manager, identity_specs) = manager_with_github_pat_spec();
+        let original_spec = identity_specs
+            .get_identity_spec("github_pat")
+            .expect("original identity spec");
+        let record = UserOwnedIdentityRecord {
+            name: github_local_name(),
+            identity_spec: "github_pat".to_string(),
+            identity_spec_fingerprint: Some(
+                identity_spec_fingerprint(&original_spec.manifest).expect("fingerprint"),
+            ),
+            issuer: "github".to_string(),
+            identity_type: IdentitySpecType::FixedToken.label().to_string(),
+            metadata: BTreeMap::new(),
+        };
+        identity_specs
+            .remove_identity_spec("github_pat", true)
+            .expect("remove original spec");
+
+        let error = manager
+            .store
+            .replace_identity(
+                &local_owner(),
+                &record,
+                &material(FIXED_TOKEN_MATERIAL_KEY, "ghp_token"),
+            )
+            .await
+            .expect_err("deleted identity spec reference must be rejected");
+
+        assert!(matches!(error, AppError::IdentitySpecNotFound(name) if name == "github_pat"));
+    }
+
+    #[tokio::test]
+    async fn identity_write_rejects_identity_spec_changed_after_validation() {
+        let (temp, manager, identity_specs) = manager_with_github_pat_spec();
+        let original_spec = identity_specs
+            .get_identity_spec("github_pat")
+            .expect("original identity spec");
+        let record = UserOwnedIdentityRecord {
+            name: github_local_name(),
+            identity_spec: "github_pat".to_string(),
+            identity_spec_fingerprint: Some(
+                identity_spec_fingerprint(&original_spec.manifest).expect("fingerprint"),
+            ),
+            issuer: "github".to_string(),
+            identity_type: IdentitySpecType::FixedToken.label().to_string(),
+            metadata: BTreeMap::new(),
+        };
+        identity_specs
+            .remove_identity_spec("github_pat", true)
+            .expect("remove original spec");
+        identity_specs
+            .add_identity_spec(&fixed_identity_spec_yaml_with_issuer("github_enterprise"))
+            .expect("replace with changed spec");
+
+        let error = manager
+            .store
+            .replace_identity(
+                &local_owner(),
+                &record,
+                &material(FIXED_TOKEN_MATERIAL_KEY, "ghp_token"),
+            )
+            .await
+            .expect_err("stale identity spec reference must be rejected");
+
+        assert!(
+            matches!(error, AppError::FailedPrecondition(ref message) if message.contains("changed before the identity could be stored")),
+            "unexpected error: {error:?}"
+        );
+        let layout = test_layout(&temp);
+        assert!(
+            !layout
+                .user_owned_identity_manifest_file("local", "github_local")
+                .exists(),
+            "rejected stale identity should not create a manifest"
+        );
+        assert!(
+            !layout
+                .user_owned_identity_material_file("local", "github_local")
+                .exists(),
+            "rejected stale identity should not create material"
+        );
+    }
+
+    #[tokio::test]
+    async fn lists_user_owned_identity_records() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        let principal = UserPrincipal::local();
+        manager
+            .create_user_owned_fixed_token_identity(&principal, github_local_command("ghp_token"))
+            .await
+            .expect("create identity");
+
+        let listed = manager
+            .list_user_owned_identities(&principal)
+            .await
+            .expect("list identities");
+
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed.first().expect("listed identity").name.as_str(),
+            "github_local"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_replacement_waits_for_in_flight_material_refresh() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        manager
+            .create_user_owned_fixed_token_identity(
+                &UserPrincipal::local(),
+                github_local_command("old-token"),
+            )
+            .await
+            .expect("create identity");
+
+        let refresh_guard = manager
+            .store
+            .material_guard(&local_owner(), &github_local_name())
+            .await
+            .expect("hold refresh lock");
+        let replacement_manager = manager.clone();
+        let mut replacement = tokio::spawn(async move {
+            replacement_manager
+                .create_user_owned_fixed_token_identity(
+                    &UserPrincipal::local(),
+                    github_local_command("replacement-token"),
+                )
+                .await
+        });
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(200), &mut replacement)
+                .await
+                .is_err(),
+            "identity replacement must wait behind an in-flight material refresh"
+        );
+        refresh_guard
+            .write_material(&material(FIXED_TOKEN_MATERIAL_KEY, "stale-refreshed-token"))
+            .await
+            .expect("write stale refreshed material while refresh lock is held");
+        drop(refresh_guard);
+        replacement
+            .await
+            .expect("replacement task")
+            .expect("replacement should succeed");
+
+        let final_material = manager
+            .store
+            .material_guard(&local_owner(), &github_local_name())
+            .await
+            .expect("open final material guard")
+            .read_material()
+            .await
+            .expect("read final material");
+        assert_eq!(
+            final_material
+                .get(FIXED_TOKEN_MATERIAL_KEY)
+                .map(String::as_str),
+            Some("replacement-token"),
+            "replacement material should win over stale in-flight refresh material"
+        );
+    }
+
+    #[tokio::test]
+    async fn refreshed_material_write_rejects_deleted_identity() {
+        let (temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        manager
+            .create_user_owned_fixed_token_identity(
+                &UserPrincipal::local(),
+                github_local_command("old-token"),
+            )
+            .await
+            .expect("create identity");
+        let layout = test_layout(&temp);
+        fs::remove_dir_all(layout.user_owned_identity_dir("local", "github_local"))
+            .expect("delete identity");
+
+        let error = manager
+            .store
+            .material_guard(&local_owner(), &github_local_name())
+            .await
+            .expect("open material guard")
+            .write_material(&material(FIXED_TOKEN_MATERIAL_KEY, "new-token"))
+            .await
+            .expect_err("deleted identity material must not be recreated");
+
+        assert!(matches!(error, AppError::IdentityNotFound(name) if name == "github_local"));
+        assert!(
+            !layout
+                .user_owned_identity_material_file("local", "github_local")
+                .exists(),
+            "deleted identity material should stay deleted"
         );
     }
 }

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1,4 +1,4 @@
-//! Storage seam types and traits for provider identity instances.
+//! Storage seam types and traits for provider identities.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info_span;
 
 use crate::bootstrap::AppError;
-use crate::identity::{UserPrincipal, parse_path_segment};
+use crate::identity::{IdentityOwnerKind, UserPrincipal, parse_path_segment};
 use crate::identity_specs::{
     IdentitySpecManager, IdentitySpecRecord, identity_spec_fingerprint, validate_identity_spec_name,
 };
@@ -20,14 +20,16 @@ use crate::state::AppStateLayout;
 use crate::storage::env_file::{parse_env_file, render_env_file};
 use crate::storage::fs::{self as storage_fs, FileLock};
 
-const IDENTITY_INSTANCE_DOCUMENT_VERSION: u32 = 1;
+const IDENTITY_DOCUMENT_VERSION: u32 = 1;
 const FIXED_TOKEN_MATERIAL_KEY: &str = "TOKEN";
 
-/// One stored provider identity instance.
+/// One stored provider identity.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IdentityInstanceRecord {
+pub struct IdentityRecord {
+    /// Principal or workspace that owns this identity.
+    pub owner: IdentityOwner,
     /// Stable identity name used by source identity bindings.
-    pub name: IdentityInstanceName,
+    pub name: IdentityName,
     /// Installed identity spec used to instantiate this identity.
     pub identity_spec: String,
     /// Fingerprint of the identity spec at creation time.
@@ -40,11 +42,11 @@ pub struct IdentityInstanceRecord {
     pub metadata: BTreeMap<String, String>,
 }
 
-/// Validated storage name for one provider identity instance.
+/// Validated storage name for one provider identity.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct IdentityInstanceName(String);
+pub struct IdentityName(String);
 
-impl IdentityInstanceName {
+impl IdentityName {
     /// Builds an identity name from a storage-safe string.
     ///
     /// # Errors
@@ -61,13 +63,13 @@ impl IdentityInstanceName {
     }
 }
 
-impl fmt::Display for IdentityInstanceName {
+impl fmt::Display for IdentityName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl FromStr for IdentityInstanceName {
+impl FromStr for IdentityName {
     type Err = AppError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
@@ -75,7 +77,7 @@ impl FromStr for IdentityInstanceName {
     }
 }
 
-impl TryFrom<String> for IdentityInstanceName {
+impl TryFrom<String> for IdentityName {
     type Error = AppError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
@@ -83,54 +85,68 @@ impl TryFrom<String> for IdentityInstanceName {
     }
 }
 
-/// Opaque durable owner key for stored provider-facing identity material.
-///
-/// OSS Coral constructs this from the request user principal. Other runtimes can
-/// use their own stable owner keys without adding their ownership model to OSS
-/// identity management.
+/// Explicit owner of stored provider-facing identity material.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct IdentityOwnerKey(String);
+pub struct IdentityOwner {
+    kind: IdentityOwnerKind,
+    key: String,
+}
 
-impl IdentityOwnerKey {
-    /// Builds an owner key from a storage-safe string.
+impl IdentityOwner {
+    /// Builds an owner from its explicit kind and storage-safe key.
     ///
     /// # Errors
     ///
     /// Returns [`AppError`] when the key is empty or contains path separators.
-    pub fn new(value: impl Into<String>) -> Result<Self, AppError> {
-        parse_path_segment("identity owner", &value.into()).map(Self)
+    pub fn new(kind: IdentityOwnerKind, key: impl Into<String>) -> Result<Self, AppError> {
+        parse_path_segment("identity owner", &key.into()).map(|key| Self { kind, key })
+    }
+
+    /// Builds a user-owned identity owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the key is empty or contains path separators.
+    pub fn user(key: impl Into<String>) -> Result<Self, AppError> {
+        Self::new(IdentityOwnerKind::User, key)
+    }
+
+    /// Builds a workspace-owned identity owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the key is empty or contains path separators.
+    pub fn workspace(key: impl Into<String>) -> Result<Self, AppError> {
+        Self::new(IdentityOwnerKind::Workspace, key)
     }
 
     pub(crate) fn for_user_principal(principal: &UserPrincipal) -> Result<Self, AppError> {
-        Self::new(principal.user_id())
+        Self::user(principal.user_id())
+    }
+
+    /// Returns the explicit owner kind.
+    #[must_use]
+    pub const fn kind(&self) -> IdentityOwnerKind {
+        self.kind
     }
 
     /// Returns the storage key string.
     #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub(crate) const fn storage_segment(&self) -> &'static str {
+        match self.kind {
+            IdentityOwnerKind::User => "users",
+            IdentityOwnerKind::Workspace => "workspaces",
+        }
     }
 }
 
-impl fmt::Display for IdentityOwnerKey {
+impl fmt::Display for IdentityOwner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl FromStr for IdentityOwnerKey {
-    type Err = AppError;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Self::new(value)
-    }
-}
-
-impl TryFrom<String> for IdentityOwnerKey {
-    type Error = AppError;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::new(value)
+        write!(f, "{}:{}", self.kind.as_config_value(), self.key)
     }
 }
 
@@ -145,9 +161,9 @@ pub struct CreateFixedTokenIdentityCommand {
     pub token: String,
 }
 
-/// Locked access to credential material for one provider identity instance.
+/// Locked access to credential material for one provider identity.
 #[tonic::async_trait]
-pub trait IdentityInstanceMaterialGuard: Send {
+pub trait IdentityMaterialGuard: Send {
     /// Reads the identity's credential material.
     ///
     /// # Errors
@@ -163,29 +179,27 @@ pub trait IdentityInstanceMaterialGuard: Send {
     async fn write_material(&self, material: &BTreeMap<String, String>) -> Result<(), AppError>;
 }
 
-/// Durable storage backend for provider identity instances.
+/// Durable storage backend for provider identities.
 #[tonic::async_trait]
-pub trait IdentityInstanceStore: Send + Sync + std::fmt::Debug + 'static {
-    /// Lists identities owned by one opaque owner key.
+pub trait IdentityStore: Send + Sync + std::fmt::Debug + 'static {
+    /// Lists identities owned by one owner.
     ///
     /// # Errors
     ///
     /// Returns [`AppError`] when the store cannot be read.
-    async fn list_identities(
-        &self,
-        owner: &IdentityOwnerKey,
-    ) -> Result<Vec<IdentityInstanceRecord>, AppError>;
+    async fn list_identities(&self, owner: &IdentityOwner)
+    -> Result<Vec<IdentityRecord>, AppError>;
 
-    /// Loads one identity owned by one opaque owner key.
+    /// Loads one identity owned by one owner.
     ///
     /// # Errors
     ///
     /// Returns [`AppError`] when the store cannot be read.
     async fn load_identity(
         &self,
-        owner: &IdentityOwnerKey,
-        identity_name: &IdentityInstanceName,
-    ) -> Result<Option<IdentityInstanceRecord>, AppError>;
+        owner: &IdentityOwner,
+        identity_name: &IdentityName,
+    ) -> Result<Option<IdentityRecord>, AppError>;
 
     /// Replaces one identity and its credential material atomically.
     ///
@@ -194,8 +208,7 @@ pub trait IdentityInstanceStore: Send + Sync + std::fmt::Debug + 'static {
     /// Returns [`AppError`] when the store cannot be written.
     async fn replace_identity(
         &self,
-        owner: &IdentityOwnerKey,
-        record: &IdentityInstanceRecord,
+        record: &IdentityRecord,
         material: &BTreeMap<String, String>,
     ) -> Result<(), AppError>;
 
@@ -206,8 +219,8 @@ pub trait IdentityInstanceStore: Send + Sync + std::fmt::Debug + 'static {
     /// Returns [`AppError`] when the store cannot be written.
     async fn delete_identity(
         &self,
-        owner: &IdentityOwnerKey,
-        identity_name: &IdentityInstanceName,
+        owner: &IdentityOwner,
+        identity_name: &IdentityName,
     ) -> Result<bool, AppError>;
 
     /// Returns locked access to one identity's credential material.
@@ -217,9 +230,9 @@ pub trait IdentityInstanceStore: Send + Sync + std::fmt::Debug + 'static {
     /// Returns [`AppError`] when the material lock cannot be acquired.
     async fn material_guard(
         &self,
-        owner: &IdentityOwnerKey,
-        identity_name: &IdentityInstanceName,
-    ) -> Result<Box<dyn IdentityInstanceMaterialGuard>, AppError>;
+        owner: &IdentityOwner,
+        identity_name: &IdentityName,
+    ) -> Result<Box<dyn IdentityMaterialGuard>, AppError>;
 
     /// Counts identities that reference `identity_spec_name`.
     ///
@@ -229,21 +242,20 @@ pub trait IdentityInstanceStore: Send + Sync + std::fmt::Debug + 'static {
     fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError>;
 }
 
-/// Manages provider-facing identity instances keyed by an opaque owner.
+/// Manages provider-facing identities keyed by their explicit owner.
 #[derive(Debug, Clone)]
-pub(crate) struct IdentityInstanceManager {
+pub(crate) struct IdentityManager {
     identity_specs: IdentitySpecManager,
-    store: Arc<dyn IdentityInstanceStore>,
+    store: Arc<dyn IdentityStore>,
 }
 
 /// Product-facing handle for stored provider identity management.
 ///
-/// The handle intentionally deals only in opaque owner keys. OSS callers keep
-/// using user-owned gRPC methods, while other runtimes can map their owner
-/// metadata into stable keys.
+/// OSS callers keep using user-owned gRPC methods, while other runtimes can
+/// pass explicit workspace or user owners.
 #[derive(Debug, Clone)]
 pub struct IdentityManagementHandle {
-    manager: IdentityInstanceManager,
+    manager: IdentityManager,
 }
 
 impl IdentityManagementHandle {
@@ -254,9 +266,9 @@ impl IdentityManagementHandle {
     /// Returns [`AppError`] when validation or storage fails.
     pub async fn create_fixed_token_identity(
         &self,
-        owner: &IdentityOwnerKey,
+        owner: &IdentityOwner,
         command: CreateFixedTokenIdentityCommand,
-    ) -> Result<IdentityInstanceRecord, AppError> {
+    ) -> Result<IdentityRecord, AppError> {
         self.manager
             .create_fixed_token_identity(owner, command)
             .await
@@ -269,8 +281,8 @@ impl IdentityManagementHandle {
     /// Returns [`AppError`] when the store cannot be read.
     pub async fn list_identities(
         &self,
-        owner: &IdentityOwnerKey,
-    ) -> Result<Vec<IdentityInstanceRecord>, AppError> {
+        owner: &IdentityOwner,
+    ) -> Result<Vec<IdentityRecord>, AppError> {
         self.manager.list_identities(owner).await
     }
 
@@ -281,24 +293,24 @@ impl IdentityManagementHandle {
     /// Returns [`AppError`] when the store cannot be written.
     pub async fn delete_identity(
         &self,
-        owner: &IdentityOwnerKey,
+        owner: &IdentityOwner,
         identity_name: &str,
     ) -> Result<bool, AppError> {
         self.manager.delete_identity(owner, identity_name).await
     }
 }
 
-impl IdentityInstanceManager {
+impl IdentityManager {
     pub(crate) fn new(layout: AppStateLayout, identity_specs: IdentitySpecManager) -> Self {
         Self::new_with_store(
             identity_specs.clone(),
-            Arc::new(FileIdentityInstanceStore::new(layout, identity_specs)),
+            Arc::new(FileIdentityStore::new(layout, identity_specs)),
         )
     }
 
     pub(crate) fn new_with_store(
         identity_specs: IdentitySpecManager,
-        store: Arc<dyn IdentityInstanceStore>,
+        store: Arc<dyn IdentityStore>,
     ) -> Self {
         Self {
             identity_specs,
@@ -314,11 +326,11 @@ impl IdentityInstanceManager {
 
     fn prepare_identity_creation(
         &self,
-        owner: &IdentityOwnerKey,
+        owner: &IdentityOwner,
         name: &str,
         identity_spec: &str,
         expected: IdentitySpecType,
-    ) -> Result<(IdentityOwnerKey, IdentityInstanceName, IdentitySpecRecord), AppError> {
+    ) -> Result<(IdentityOwner, IdentityName, IdentitySpecRecord), AppError> {
         self.identity_specs.ensure_dsl_v4_enabled()?;
         let name = validate_identity_name(name)?;
         let identity_spec_name = validate_identity_spec_name(identity_spec)?;
@@ -337,9 +349,9 @@ impl IdentityInstanceManager {
 
     async fn create_fixed_token_identity(
         &self,
-        owner: &IdentityOwnerKey,
+        owner: &IdentityOwner,
         command: CreateFixedTokenIdentityCommand,
-    ) -> Result<IdentityInstanceRecord, AppError> {
+    ) -> Result<IdentityRecord, AppError> {
         let span = info_span!("coral.app.identities.create_fixed_token");
         let _guard = span.enter();
         let (owner, name, spec) = self.prepare_identity_creation(
@@ -354,7 +366,8 @@ impl IdentityInstanceManager {
                 "fixed token identity token must not be empty".to_string(),
             ));
         }
-        let record = IdentityInstanceRecord {
+        let record = IdentityRecord {
+            owner,
             name,
             identity_spec: spec.manifest.name.clone(),
             identity_spec_fingerprint: Some(identity_spec_fingerprint(&spec.manifest)?),
@@ -363,9 +376,7 @@ impl IdentityInstanceManager {
             metadata: BTreeMap::new(),
         };
         let material = BTreeMap::from([(FIXED_TOKEN_MATERIAL_KEY.to_string(), token)]);
-        self.store
-            .replace_identity(&owner, &record, &material)
-            .await?;
+        self.store.replace_identity(&record, &material).await?;
         Ok(record)
     }
 
@@ -373,31 +384,31 @@ impl IdentityInstanceManager {
         &self,
         principal: &UserPrincipal,
         command: CreateFixedTokenIdentityCommand,
-    ) -> Result<IdentityInstanceRecord, AppError> {
-        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+    ) -> Result<IdentityRecord, AppError> {
+        let owner = IdentityOwner::for_user_principal(principal)?;
         self.create_fixed_token_identity(&owner, command).await
     }
 
     async fn list_identities(
         &self,
-        owner: &IdentityOwnerKey,
-    ) -> Result<Vec<IdentityInstanceRecord>, AppError> {
+        owner: &IdentityOwner,
+    ) -> Result<Vec<IdentityRecord>, AppError> {
         self.store.list_identities(owner).await
     }
 
     pub(crate) async fn list_user_owned_identities(
         &self,
         principal: &UserPrincipal,
-    ) -> Result<Vec<IdentityInstanceRecord>, AppError> {
+    ) -> Result<Vec<IdentityRecord>, AppError> {
         let span = info_span!("coral.app.identities.list_user_owned");
         let _guard = span.enter();
-        let owner = IdentityOwnerKey::for_user_principal(principal)?;
+        let owner = IdentityOwner::for_user_principal(principal)?;
         self.list_identities(&owner).await
     }
 
     async fn delete_identity(
         &self,
-        owner: &IdentityOwnerKey,
+        owner: &IdentityOwner,
         identity_name: &str,
     ) -> Result<bool, AppError> {
         let identity_name = validate_identity_name(identity_name)?;
@@ -406,12 +417,12 @@ impl IdentityInstanceManager {
 }
 
 #[derive(Debug, Clone)]
-struct FileIdentityInstanceStore {
+struct FileIdentityStore {
     layout: AppStateLayout,
     identity_specs: IdentitySpecManager,
 }
 
-impl FileIdentityInstanceStore {
+impl FileIdentityStore {
     fn new(layout: AppStateLayout, identity_specs: IdentitySpecManager) -> Self {
         Self {
             layout,
@@ -421,24 +432,24 @@ impl FileIdentityInstanceStore {
 
     fn load_identity_unlocked(
         &self,
-        owner: &IdentityOwnerKey,
-        name: &IdentityInstanceName,
-    ) -> Result<IdentityInstanceRecord, AppError> {
-        let path = self.layout.user_owned_identity_manifest_file(owner, name);
+        owner: &IdentityOwner,
+        name: &IdentityName,
+    ) -> Result<IdentityRecord, AppError> {
+        let path = self.layout.identity_manifest_file(owner, name);
         if !path.exists() {
             return Err(AppError::IdentityNotFound(name.to_string()));
         }
         let raw = fs::read_to_string(&path)?;
-        let document: IdentityInstanceDocument = serde_yaml::from_str(&raw)?;
-        document.into_record(name)
+        let document: IdentityDocument = serde_yaml::from_str(&raw)?;
+        document.into_record(owner, name)
     }
 
     fn material_lock_for_layout(
         layout: &AppStateLayout,
-        owner: &IdentityOwnerKey,
-        identity_name: &IdentityInstanceName,
+        owner: &IdentityOwner,
+        identity_name: &IdentityName,
     ) -> Result<FileLock, AppError> {
-        FileLock::exclusive(&layout.user_owned_identity_refresh_lock_file(owner, identity_name))
+        FileLock::exclusive(&layout.identity_refresh_lock_file(owner, identity_name))
             .map_err(Into::into)
     }
 
@@ -446,31 +457,37 @@ impl FileIdentityInstanceStore {
         layout: &AppStateLayout,
         identity_spec_name: &str,
     ) -> Result<u32, AppError> {
-        let users_root = layout.identities_root().join("users");
-        if !users_root.exists() {
+        let identities_root = layout.identities_root();
+        if !identities_root.exists() {
             return Ok(0);
         }
         let mut count = 0u32;
-        for user_entry in fs::read_dir(users_root)? {
-            let user_entry = user_entry?;
-            if !user_entry.file_type()?.is_dir() {
+        for owner_kind_entry in fs::read_dir(identities_root)? {
+            let owner_kind_entry = owner_kind_entry?;
+            if !owner_kind_entry.file_type()?.is_dir() {
                 continue;
             }
-            for identity_entry in fs::read_dir(user_entry.path())? {
-                let identity_entry = identity_entry?;
-                if !identity_entry.file_type()?.is_dir() {
+            for owner_entry in fs::read_dir(owner_kind_entry.path())? {
+                let owner_entry = owner_entry?;
+                if !owner_entry.file_type()?.is_dir() {
                     continue;
                 }
-                let manifest_path = identity_entry
-                    .path()
-                    .join(crate::state::INSTALLED_IDENTITY_FILE_NAME);
-                if !manifest_path.exists() {
-                    continue;
-                }
-                let raw = fs::read_to_string(&manifest_path)?;
-                let reference: IdentitySpecReference = serde_yaml::from_str(&raw)?;
-                if reference.identity_spec == identity_spec_name {
-                    count = checked_add_identity_count(count, 1, identity_spec_name)?;
+                for identity_entry in fs::read_dir(owner_entry.path())? {
+                    let identity_entry = identity_entry?;
+                    if !identity_entry.file_type()?.is_dir() {
+                        continue;
+                    }
+                    let manifest_path = identity_entry
+                        .path()
+                        .join(crate::state::INSTALLED_IDENTITY_FILE_NAME);
+                    if !manifest_path.exists() {
+                        continue;
+                    }
+                    let raw = fs::read_to_string(&manifest_path)?;
+                    let reference: IdentitySpecReference = serde_yaml::from_str(&raw)?;
+                    if reference.identity_spec == identity_spec_name {
+                        count = checked_add_identity_count(count, 1, identity_spec_name)?;
+                    }
                 }
             }
         }
@@ -479,16 +496,16 @@ impl FileIdentityInstanceStore {
 }
 
 #[tonic::async_trait]
-impl IdentityInstanceStore for FileIdentityInstanceStore {
+impl IdentityStore for FileIdentityStore {
     async fn list_identities(
         &self,
-        owner: &IdentityOwnerKey,
-    ) -> Result<Vec<IdentityInstanceRecord>, AppError> {
+        owner: &IdentityOwner,
+    ) -> Result<Vec<IdentityRecord>, AppError> {
         let store = self.clone();
         let owner = owner.clone();
         tokio::task::spawn_blocking(move || {
             let _lock = FileLock::shared(store.layout.state_lock())?;
-            let root = store.layout.user_owned_identities_root(&owner);
+            let root = store.layout.identity_owner_root(&owner);
             if !root.exists() {
                 return Ok(Vec::new());
             }
@@ -512,9 +529,9 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
 
     async fn load_identity(
         &self,
-        owner: &IdentityOwnerKey,
-        identity_name: &IdentityInstanceName,
-    ) -> Result<Option<IdentityInstanceRecord>, AppError> {
+        owner: &IdentityOwner,
+        identity_name: &IdentityName,
+    ) -> Result<Option<IdentityRecord>, AppError> {
         let store = self.clone();
         let owner = owner.clone();
         let identity_name = identity_name.clone();
@@ -531,30 +548,25 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
 
     async fn replace_identity(
         &self,
-        owner: &IdentityOwnerKey,
-        record: &IdentityInstanceRecord,
+        record: &IdentityRecord,
         material: &BTreeMap<String, String>,
     ) -> Result<(), AppError> {
         let store = self.clone();
-        let owner = owner.clone();
         let record = record.clone();
         let material = material.clone();
         tokio::task::spawn_blocking(move || {
+            let owner = record.owner.clone();
             let _material_lock =
                 Self::material_lock_for_layout(&store.layout, &owner, &record.name)?;
             let _state_lock = FileLock::exclusive(store.layout.state_lock())?;
-            let manifest_path = store
-                .layout
-                .user_owned_identity_manifest_file(&owner, &record.name);
-            let material_path = store
-                .layout
-                .user_owned_identity_material_file(&owner, &record.name);
+            let manifest_path = store.layout.identity_manifest_file(&owner, &record.name);
+            let material_path = store.layout.identity_material_file(&owner, &record.name);
             if let Some(parent) = manifest_path.parent() {
                 storage_fs::ensure_private_dir(parent)?;
             }
             validate_identity_spec_reference_unlocked(&store.identity_specs, &record)?;
             write_files_transactionally(&[&manifest_path, &material_path], || {
-                let document = IdentityInstanceDocument::from_record(&record);
+                let document = IdentityDocument::from_record(&record);
                 write_file_unlocked(&manifest_path, serde_yaml::to_string(&document)?.as_bytes())?;
                 write_file_unlocked(&material_path, render_env_file(&material).as_bytes())?;
                 Ok(())
@@ -565,8 +577,8 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
 
     async fn delete_identity(
         &self,
-        owner: &IdentityOwnerKey,
-        identity_name: &IdentityInstanceName,
+        owner: &IdentityOwner,
+        identity_name: &IdentityName,
     ) -> Result<bool, AppError> {
         let store = self.clone();
         let owner = owner.clone();
@@ -575,18 +587,14 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
             let _material_lock =
                 Self::material_lock_for_layout(&store.layout, &owner, &identity_name)?;
             let _state_lock = FileLock::exclusive(store.layout.state_lock())?;
-            let manifest_path = store
-                .layout
-                .user_owned_identity_manifest_file(&owner, &identity_name);
-            let material_path = store
-                .layout
-                .user_owned_identity_material_file(&owner, &identity_name);
+            let manifest_path = store.layout.identity_manifest_file(&owner, &identity_name);
+            let material_path = store.layout.identity_material_file(&owner, &identity_name);
             if !manifest_path.exists() {
                 return Ok(false);
             }
             remove_file_if_exists_unlocked(&material_path)?;
             remove_file_if_exists_unlocked(&manifest_path)?;
-            let identity_dir = store.layout.user_owned_identity_dir(&owner, &identity_name);
+            let identity_dir = store.layout.identity_dir(&owner, &identity_name);
             if identity_dir.exists() {
                 match fs::remove_dir(&identity_dir) {
                     Ok(()) => {}
@@ -602,20 +610,20 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
 
     async fn material_guard(
         &self,
-        owner: &IdentityOwnerKey,
-        identity_name: &IdentityInstanceName,
-    ) -> Result<Box<dyn IdentityInstanceMaterialGuard>, AppError> {
+        owner: &IdentityOwner,
+        identity_name: &IdentityName,
+    ) -> Result<Box<dyn IdentityMaterialGuard>, AppError> {
         let layout = self.layout.clone();
         let owner = owner.clone();
         let identity_name = identity_name.clone();
         tokio::task::spawn_blocking(move || {
             let lock = Self::material_lock_for_layout(&layout, &owner, &identity_name)?;
-            Ok(Box::new(FileIdentityInstanceMaterialGuard {
+            Ok(Box::new(FileIdentityMaterialGuard {
                 layout,
                 owner,
                 identity_name,
                 _lock: lock,
-            }) as Box<dyn IdentityInstanceMaterialGuard>)
+            }) as Box<dyn IdentityMaterialGuard>)
         })
         .await?
     }
@@ -626,19 +634,19 @@ impl IdentityInstanceStore for FileIdentityInstanceStore {
     }
 }
 
-struct FileIdentityInstanceMaterialGuard {
+struct FileIdentityMaterialGuard {
     layout: AppStateLayout,
-    owner: IdentityOwnerKey,
-    identity_name: IdentityInstanceName,
+    owner: IdentityOwner,
+    identity_name: IdentityName,
     _lock: FileLock,
 }
 
 #[tonic::async_trait]
-impl IdentityInstanceMaterialGuard for FileIdentityInstanceMaterialGuard {
+impl IdentityMaterialGuard for FileIdentityMaterialGuard {
     async fn read_material(&self) -> Result<BTreeMap<String, String>, AppError> {
         let path = self
             .layout
-            .user_owned_identity_material_file(&self.owner, &self.identity_name);
+            .identity_material_file(&self.owner, &self.identity_name);
         let identity_name = self.identity_name.to_string();
         tokio::task::spawn_blocking(move || match fs::read_to_string(path) {
             Ok(raw) => parse_env_file(&raw).map_err(|error| {
@@ -660,9 +668,9 @@ impl IdentityInstanceMaterialGuard for FileIdentityInstanceMaterialGuard {
         let identity_name = self.identity_name.clone();
         let material = material.clone();
         tokio::task::spawn_blocking(move || {
-            let path = layout.user_owned_identity_material_file(&owner, &identity_name);
+            let path = layout.identity_material_file(&owner, &identity_name);
             let _state_lock = FileLock::exclusive(layout.state_lock())?;
-            let manifest_path = layout.user_owned_identity_manifest_file(&owner, &identity_name);
+            let manifest_path = layout.identity_manifest_file(&owner, &identity_name);
             if !manifest_path.exists() {
                 return Err(AppError::IdentityNotFound(identity_name.to_string()));
             }
@@ -674,8 +682,10 @@ impl IdentityInstanceMaterialGuard for FileIdentityInstanceMaterialGuard {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct IdentityInstanceDocument {
+struct IdentityDocument {
     version: u32,
+    #[serde(default = "default_identity_owner_kind")]
+    owner: IdentityOwnerKind,
     name: String,
     identity_spec: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -686,10 +696,11 @@ struct IdentityInstanceDocument {
     metadata: BTreeMap<String, String>,
 }
 
-impl IdentityInstanceDocument {
-    fn from_record(record: &IdentityInstanceRecord) -> Self {
+impl IdentityDocument {
+    fn from_record(record: &IdentityRecord) -> Self {
         Self {
-            version: IDENTITY_INSTANCE_DOCUMENT_VERSION,
+            version: IDENTITY_DOCUMENT_VERSION,
+            owner: record.owner.kind(),
             name: record.name.to_string(),
             identity_spec: record.identity_spec.clone(),
             identity_spec_fingerprint: record.identity_spec_fingerprint.clone(),
@@ -701,12 +712,13 @@ impl IdentityInstanceDocument {
 
     fn into_record(
         self,
-        expected_name: &IdentityInstanceName,
-    ) -> Result<IdentityInstanceRecord, AppError> {
-        if self.version != IDENTITY_INSTANCE_DOCUMENT_VERSION {
+        expected_owner: &IdentityOwner,
+        expected_name: &IdentityName,
+    ) -> Result<IdentityRecord, AppError> {
+        if self.version != IDENTITY_DOCUMENT_VERSION {
             return Err(AppError::FailedPrecondition(format!(
                 "identity '{}' has unsupported document version {}; expected {}",
-                self.name, self.version, IDENTITY_INSTANCE_DOCUMENT_VERSION
+                self.name, self.version, IDENTITY_DOCUMENT_VERSION
             )));
         }
         let name = validate_identity_name(&self.name)?;
@@ -715,7 +727,15 @@ impl IdentityInstanceDocument {
                 "identity file for '{expected_name}' contains identity '{name}'"
             )));
         }
-        Ok(IdentityInstanceRecord {
+        if self.owner != expected_owner.kind() {
+            return Err(AppError::FailedPrecondition(format!(
+                "identity file for '{expected_name}' is owned by '{}', but storage path is for '{}'",
+                self.owner.as_config_value(),
+                expected_owner.kind().as_config_value()
+            )));
+        }
+        Ok(IdentityRecord {
+            owner: expected_owner.clone(),
             name,
             identity_spec: validate_identity_spec_name(&self.identity_spec)?.to_string(),
             identity_spec_fingerprint: self.identity_spec_fingerprint,
@@ -726,18 +746,22 @@ impl IdentityInstanceDocument {
     }
 }
 
+const fn default_identity_owner_kind() -> IdentityOwnerKind {
+    IdentityOwnerKind::User
+}
+
 #[derive(Debug, Deserialize)]
 struct IdentitySpecReference {
     identity_spec: String,
 }
 
-fn validate_identity_name(name: &str) -> Result<IdentityInstanceName, AppError> {
-    IdentityInstanceName::new(name)
+fn validate_identity_name(name: &str) -> Result<IdentityName, AppError> {
+    IdentityName::new(name)
 }
 
 fn validate_identity_spec_reference_unlocked(
     identity_specs: &IdentitySpecManager,
-    record: &IdentityInstanceRecord,
+    record: &IdentityRecord,
 ) -> Result<(), AppError> {
     let spec = identity_specs
         .load_identity_spec_manifest_unlocked_for_state_lock(&record.identity_spec)?;
@@ -825,43 +849,38 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn owner_key_rejects_storage_unsafe_values() {
-        IdentityOwnerKey::new(" ").unwrap_err();
-        IdentityOwnerKey::new("a/b").unwrap_err();
-        IdentityOwnerKey::new("a\\b").unwrap_err();
-        IdentityOwnerKey::new("..").unwrap_err();
+    fn identity_owner_rejects_storage_unsafe_keys() {
+        IdentityOwner::user(" ").unwrap_err();
+        IdentityOwner::user("a/b").unwrap_err();
+        IdentityOwner::user("a\\b").unwrap_err();
+        IdentityOwner::user("..").unwrap_err();
     }
 
     #[test]
-    fn owner_key_round_trips_storage_key() {
-        let owner = IdentityOwnerKey::new("member-123").expect("owner key");
+    fn identity_owner_exposes_kind_and_storage_key() {
+        let owner = IdentityOwner::user("member-123").expect("owner");
 
-        assert_eq!(owner.as_str(), "member-123");
-        assert_eq!(owner.to_string(), "member-123");
-        assert_eq!(
-            "member-123".parse::<IdentityOwnerKey>().expect("parse"),
-            owner
-        );
+        assert_eq!(owner.kind(), IdentityOwnerKind::User);
+        assert_eq!(owner.key(), "member-123");
+        assert_eq!(owner.to_string(), "user:member-123");
     }
 
     #[test]
     fn identity_name_rejects_storage_unsafe_values() {
-        IdentityInstanceName::new(" ").unwrap_err();
-        IdentityInstanceName::new("a/b").unwrap_err();
-        IdentityInstanceName::new("a\\b").unwrap_err();
-        IdentityInstanceName::new("..").unwrap_err();
+        IdentityName::new(" ").unwrap_err();
+        IdentityName::new("a/b").unwrap_err();
+        IdentityName::new("a\\b").unwrap_err();
+        IdentityName::new("..").unwrap_err();
     }
 
     #[test]
     fn identity_name_round_trips_storage_name() {
-        let identity_name = IdentityInstanceName::new("github-primary").expect("identity name");
+        let identity_name = IdentityName::new("github-primary").expect("identity name");
 
         assert_eq!(identity_name.as_str(), "github-primary");
         assert_eq!(identity_name.to_string(), "github-primary");
         assert_eq!(
-            "github-primary"
-                .parse::<IdentityInstanceName>()
-                .expect("parse"),
+            "github-primary".parse::<IdentityName>().expect("parse"),
             identity_name
         );
     }
@@ -873,25 +892,25 @@ mod tests {
         layout
     }
 
-    fn manager() -> (TempDir, IdentityInstanceManager, IdentitySpecManager) {
+    fn manager() -> (TempDir, IdentityManager, IdentitySpecManager) {
         manager_with_features(dsl_v4_features())
     }
 
     fn manager_with_features(
         features: Features,
-    ) -> (TempDir, IdentityInstanceManager, IdentitySpecManager) {
+    ) -> (TempDir, IdentityManager, IdentitySpecManager) {
         let temp = TempDir::new().expect("tempdir");
         let layout = test_layout(&temp);
         let identity_specs =
             IdentitySpecManager::new_with_usage_providers(layout.clone(), features, Vec::new());
         (
             temp,
-            IdentityInstanceManager::new(layout, identity_specs.clone()),
+            IdentityManager::new(layout, identity_specs.clone()),
             identity_specs,
         )
     }
 
-    fn manager_with_github_pat_spec() -> (TempDir, IdentityInstanceManager, IdentitySpecManager) {
+    fn manager_with_github_pat_spec() -> (TempDir, IdentityManager, IdentitySpecManager) {
         let (temp, manager, identity_specs) = manager();
         identity_specs
             .add_identity_spec(&fixed_identity_spec_yaml())
@@ -926,12 +945,16 @@ audience:
         }
     }
 
-    fn github_local_name() -> IdentityInstanceName {
-        IdentityInstanceName::new("github_local").expect("github_local identity name")
+    fn github_local_name() -> IdentityName {
+        IdentityName::new("github_local").expect("github_local identity name")
     }
 
-    fn local_owner() -> IdentityOwnerKey {
-        IdentityOwnerKey::new("local").expect("local owner")
+    fn local_owner() -> IdentityOwner {
+        IdentityOwner::user("local").expect("local owner")
+    }
+
+    fn default_workspace_owner() -> IdentityOwner {
+        IdentityOwner::workspace("default").expect("workspace owner")
     }
 
     fn material(key: &str, value: &str) -> BTreeMap<String, String> {
@@ -977,19 +1000,51 @@ audience:
             "identity should pin the identity spec fingerprint"
         );
         assert!(record.metadata.is_empty());
+        assert_eq!(record.owner, local_owner());
+
+        let layout = test_layout(&temp);
+        let raw =
+            fs::read_to_string(layout.identity_manifest_file(&local_owner(), &github_local_name()))
+                .expect("identity manifest");
+        assert!(raw.contains("identity_spec: github_pat"));
+        assert!(raw.contains("owner: user"));
+        let material =
+            fs::read_to_string(layout.identity_material_file(&local_owner(), &github_local_name()))
+                .expect("identity material");
+        assert!(material.contains("TOKEN=ghp_token"));
+        assert!(!material.contains("  ghp_token  "));
+    }
+
+    #[tokio::test]
+    async fn create_workspace_fixed_token_identity_stores_record_and_material() {
+        let (temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        let owner = default_workspace_owner();
+
+        let record = manager
+            .create_fixed_token_identity(&owner, github_local_command("workspace-token"))
+            .await
+            .expect("create workspace identity");
+
+        assert_eq!(record.owner, owner);
+        assert_eq!(record.name.as_str(), "github_local");
 
         let layout = test_layout(&temp);
         let raw = fs::read_to_string(
-            layout.user_owned_identity_manifest_file(&local_owner(), &github_local_name()),
+            layout.identity_manifest_file(&default_workspace_owner(), &github_local_name()),
         )
-        .expect("identity manifest");
-        assert!(raw.contains("identity_spec: github_pat"));
+        .expect("workspace identity manifest");
+        assert!(raw.contains("owner: workspace"));
         let material = fs::read_to_string(
-            layout.user_owned_identity_material_file(&local_owner(), &github_local_name()),
+            layout.identity_material_file(&default_workspace_owner(), &github_local_name()),
         )
-        .expect("identity material");
-        assert!(material.contains("TOKEN=ghp_token"));
-        assert!(!material.contains("  ghp_token  "));
+        .expect("workspace identity material");
+        assert!(material.contains("TOKEN=workspace-token"));
+        assert!(
+            !layout
+                .identity_manifest_file(&local_owner(), &github_local_name())
+                .exists(),
+            "workspace identity should not be stored in the user bucket"
+        );
     }
 
     #[tokio::test]
@@ -1016,7 +1071,8 @@ audience:
         let original_spec = identity_specs
             .get_identity_spec("github_pat")
             .expect("original identity spec");
-        let record = IdentityInstanceRecord {
+        let record = IdentityRecord {
+            owner: local_owner(),
             name: github_local_name(),
             identity_spec: "github_pat".to_string(),
             identity_spec_fingerprint: Some(
@@ -1032,11 +1088,7 @@ audience:
 
         let error = manager
             .store
-            .replace_identity(
-                &local_owner(),
-                &record,
-                &material(FIXED_TOKEN_MATERIAL_KEY, "ghp_token"),
-            )
+            .replace_identity(&record, &material(FIXED_TOKEN_MATERIAL_KEY, "ghp_token"))
             .await
             .expect_err("deleted identity spec reference must be rejected");
 
@@ -1049,7 +1101,8 @@ audience:
         let original_spec = identity_specs
             .get_identity_spec("github_pat")
             .expect("original identity spec");
-        let record = IdentityInstanceRecord {
+        let record = IdentityRecord {
+            owner: local_owner(),
             name: github_local_name(),
             identity_spec: "github_pat".to_string(),
             identity_spec_fingerprint: Some(
@@ -1068,11 +1121,7 @@ audience:
 
         let error = manager
             .store
-            .replace_identity(
-                &local_owner(),
-                &record,
-                &material(FIXED_TOKEN_MATERIAL_KEY, "ghp_token"),
-            )
+            .replace_identity(&record, &material(FIXED_TOKEN_MATERIAL_KEY, "ghp_token"))
             .await
             .expect_err("stale identity spec reference must be rejected");
 
@@ -1083,13 +1132,13 @@ audience:
         let layout = test_layout(&temp);
         assert!(
             !layout
-                .user_owned_identity_manifest_file(&local_owner(), &github_local_name())
+                .identity_manifest_file(&local_owner(), &github_local_name())
                 .exists(),
             "rejected stale identity should not create a manifest"
         );
         assert!(
             !layout
-                .user_owned_identity_material_file(&local_owner(), &github_local_name())
+                .identity_material_file(&local_owner(), &github_local_name())
                 .exists(),
             "rejected stale identity should not create material"
         );
@@ -1186,7 +1235,7 @@ audience:
             .await
             .expect("create identity");
         let layout = test_layout(&temp);
-        fs::remove_dir_all(layout.user_owned_identity_dir(&local_owner(), &github_local_name()))
+        fs::remove_dir_all(layout.identity_dir(&local_owner(), &github_local_name()))
             .expect("delete identity");
 
         let error = manager
@@ -1201,7 +1250,7 @@ audience:
         assert!(matches!(error, AppError::IdentityNotFound(name) if name == "github_local"));
         assert!(
             !layout
-                .user_owned_identity_material_file(&local_owner(), &github_local_name())
+                .identity_material_file(&local_owner(), &github_local_name())
                 .exists(),
             "deleted identity material should stay deleted"
         );

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -1,12 +1,11 @@
-//! Stored user-owned provider identity registry and APIs.
+//! Stored provider identity-instance registry and user-owned gRPC APIs.
 
 mod manager;
 mod service;
 
-pub(crate) use manager::UserOwnedIdentityManager;
+pub(crate) use manager::IdentityInstanceManager;
 pub use manager::{
-    CreateFixedTokenIdentityCommand, IdentityManagementHandle, IdentityOwnerKey,
-    UserOwnedIdentityMaterialGuard, UserOwnedIdentityName, UserOwnedIdentityRecord,
-    UserOwnedIdentityStore,
+    CreateFixedTokenIdentityCommand, IdentityInstanceMaterialGuard, IdentityInstanceName,
+    IdentityInstanceRecord, IdentityInstanceStore, IdentityManagementHandle, IdentityOwnerKey,
 };
 pub(crate) use service::IdentityService;

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -1,11 +1,11 @@
-//! Stored provider identity-instance registry and user-owned gRPC APIs.
+//! Stored provider identity registry and user-owned gRPC APIs.
 
 mod manager;
 mod service;
 
-pub(crate) use manager::IdentityInstanceManager;
+pub(crate) use manager::IdentityManager;
 pub use manager::{
-    CreateFixedTokenIdentityCommand, IdentityInstanceMaterialGuard, IdentityInstanceName,
-    IdentityInstanceRecord, IdentityInstanceStore, IdentityManagementHandle, IdentityOwnerKey,
+    CreateFixedTokenIdentityCommand, IdentityManagementHandle, IdentityMaterialGuard, IdentityName,
+    IdentityOwner, IdentityRecord, IdentityStore,
 };
 pub(crate) use service::IdentityService;

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -1,8 +1,12 @@
-//! Stored user-owned provider identity storage seams.
+//! Stored user-owned provider identity registry and APIs.
 
 mod manager;
+mod service;
 
+pub(crate) use manager::UserOwnedIdentityManager;
 pub use manager::{
-    IdentityOwnerKey, UserOwnedIdentityMaterialGuard, UserOwnedIdentityName,
-    UserOwnedIdentityRecord, UserOwnedIdentityStore,
+    CreateFixedTokenIdentityCommand, IdentityManagementHandle, IdentityOwnerKey,
+    UserOwnedIdentityMaterialGuard, UserOwnedIdentityName, UserOwnedIdentityRecord,
+    UserOwnedIdentityStore,
 };
+pub(crate) use service::IdentityService;

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -4,10 +4,10 @@ use std::pin::Pin;
 
 use coral_api::v1::identity_service_server::IdentityService as IdentityServiceApi;
 use coral_api::v1::{
-    CreateUserOwnedIdentityWithFixedTokenRequest, CreateUserOwnedIdentityWithFixedTokenResponse,
-    CreateUserOwnedIdentityWithOAuthRequest, CreateUserOwnedIdentityWithOAuthResponse,
-    CredentialMetadata, Identity, IdentityOwner, ListUserOwnedIdentitiesRequest,
-    ListUserOwnedIdentitiesResponse,
+    CreateUserOwnedIdentityRequest, CreateUserOwnedIdentityResponse, CredentialMetadata,
+    FixedTokenUserOwnedIdentitySetup, Identity, IdentityOwner, ListUserOwnedIdentitiesRequest,
+    ListUserOwnedIdentitiesResponse, create_user_owned_identity_request,
+    create_user_owned_identity_response,
 };
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
@@ -32,42 +32,43 @@ impl IdentityService {
 
 #[tonic::async_trait]
 impl IdentityServiceApi for IdentityService {
-    type CreateUserOwnedIdentityWithOAuthStream = CreateUserOwnedIdentityResponseStreamBox;
+    type CreateUserOwnedIdentityStream = CreateUserOwnedIdentityResponseStreamBox;
 
-    async fn create_user_owned_identity_with_o_auth(
+    async fn create_user_owned_identity(
         &self,
-        _request: Request<CreateUserOwnedIdentityWithOAuthRequest>,
-    ) -> Result<Response<Self::CreateUserOwnedIdentityWithOAuthStream>, Status> {
-        Err(Status::unimplemented(
-            "OAuth identity creation is not enabled by this server",
-        ))
-    }
-
-    async fn create_user_owned_identity_with_fixed_token(
-        &self,
-        request: Request<CreateUserOwnedIdentityWithFixedTokenRequest>,
-    ) -> Result<Response<CreateUserOwnedIdentityWithFixedTokenResponse>, Status> {
+        request: Request<CreateUserOwnedIdentityRequest>,
+    ) -> Result<Response<Self::CreateUserOwnedIdentityStream>, Status> {
         let span = grpc_span(&request);
         let identities = self.identities.clone();
         instrument_grpc(span, async move {
             let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
+            let Some(create_user_owned_identity_request::Setup::FixedToken(
+                FixedTokenUserOwnedIdentitySetup { token },
+            )) = request.setup
+            else {
+                return Err(Status::unimplemented(
+                    "OAuth identity creation is not enabled by this server",
+                ));
+            };
             let record = identities
                 .create_user_owned_fixed_token_identity(
                     &principal,
                     CreateFixedTokenIdentityCommand {
                         name: request.name,
                         identity_spec: request.identity_spec,
-                        token: request.token,
+                        token,
                     },
                 )
                 .await
                 .map_err(app_status)?;
-            Ok(Response::new(
-                CreateUserOwnedIdentityWithFixedTokenResponse {
-                    identity: Some(identity_record_to_proto(record)),
-                },
-            ))
+            let response = CreateUserOwnedIdentityResponse {
+                event: Some(create_user_owned_identity_response::Event::Identity(
+                    identity_record_to_proto(record),
+                )),
+            };
+            let stream = Box::pin(tokio_stream::iter([Ok(response)]));
+            Ok(Response::new(stream as CreateUserOwnedIdentityResponseStreamBox))
         })
         .await
     }
@@ -94,7 +95,7 @@ impl IdentityServiceApi for IdentityService {
 }
 
 type CreateUserOwnedIdentityResponseStreamBox =
-    Pin<Box<dyn Stream<Item = Result<CreateUserOwnedIdentityWithOAuthResponse, Status>> + Send>>;
+    Pin<Box<dyn Stream<Item = Result<CreateUserOwnedIdentityResponse, Status>> + Send>>;
 
 fn identity_record_to_proto(record: UserOwnedIdentityRecord) -> Identity {
     Identity {

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -1,0 +1,112 @@
+//! Implements the gRPC `IdentityService`.
+
+use std::pin::Pin;
+
+use coral_api::v1::identity_service_server::IdentityService as IdentityServiceApi;
+use coral_api::v1::{
+    CreateUserOwnedIdentityWithFixedTokenRequest, CreateUserOwnedIdentityWithFixedTokenResponse,
+    CreateUserOwnedIdentityWithOAuthRequest, CreateUserOwnedIdentityWithOAuthResponse,
+    CredentialMetadata, Identity, IdentityOwner, ListUserOwnedIdentitiesRequest,
+    ListUserOwnedIdentitiesResponse,
+};
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::app_status;
+use crate::identities::{
+    CreateFixedTokenIdentityCommand, UserOwnedIdentityManager, UserOwnedIdentityRecord,
+};
+use crate::request_context::RequestContext;
+use crate::transport::{grpc_span, instrument_grpc};
+
+#[derive(Clone)]
+pub(crate) struct IdentityService {
+    identities: UserOwnedIdentityManager,
+}
+
+impl IdentityService {
+    pub(crate) fn new(identities: UserOwnedIdentityManager) -> Self {
+        Self { identities }
+    }
+}
+
+#[tonic::async_trait]
+impl IdentityServiceApi for IdentityService {
+    type CreateUserOwnedIdentityWithOAuthStream = CreateUserOwnedIdentityResponseStreamBox;
+
+    async fn create_user_owned_identity_with_o_auth(
+        &self,
+        _request: Request<CreateUserOwnedIdentityWithOAuthRequest>,
+    ) -> Result<Response<Self::CreateUserOwnedIdentityWithOAuthStream>, Status> {
+        Err(Status::unimplemented(
+            "OAuth identity creation is not enabled by this server",
+        ))
+    }
+
+    async fn create_user_owned_identity_with_fixed_token(
+        &self,
+        request: Request<CreateUserOwnedIdentityWithFixedTokenRequest>,
+    ) -> Result<Response<CreateUserOwnedIdentityWithFixedTokenResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
+            let request = request.into_inner();
+            let record = identities
+                .create_user_owned_fixed_token_identity(
+                    &principal,
+                    CreateFixedTokenIdentityCommand {
+                        name: request.name,
+                        identity_spec: request.identity_spec,
+                        token: request.token,
+                    },
+                )
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(
+                CreateUserOwnedIdentityWithFixedTokenResponse {
+                    identity: Some(identity_record_to_proto(record)),
+                },
+            ))
+        })
+        .await
+    }
+
+    async fn list_user_owned_identities(
+        &self,
+        request: Request<ListUserOwnedIdentitiesRequest>,
+    ) -> Result<Response<ListUserOwnedIdentitiesResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
+            let _request = request.into_inner();
+            let records = identities
+                .list_user_owned_identities(&principal)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(ListUserOwnedIdentitiesResponse {
+                identities: records.into_iter().map(identity_record_to_proto).collect(),
+            }))
+        })
+        .await
+    }
+}
+
+type CreateUserOwnedIdentityResponseStreamBox =
+    Pin<Box<dyn Stream<Item = Result<CreateUserOwnedIdentityWithOAuthResponse, Status>> + Send>>;
+
+fn identity_record_to_proto(record: UserOwnedIdentityRecord) -> Identity {
+    Identity {
+        name: record.name.to_string(),
+        identity_spec: record.identity_spec,
+        issuer: record.issuer,
+        identity_type: record.identity_type,
+        owner: IdentityOwner::User as i32,
+        metadata: record
+            .metadata
+            .into_iter()
+            .map(|(key, value)| CredentialMetadata { key, value })
+            .collect(),
+    }
+}

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -5,27 +5,26 @@ use std::pin::Pin;
 use coral_api::v1::identity_service_server::IdentityService as IdentityServiceApi;
 use coral_api::v1::{
     CreateUserOwnedIdentityRequest, CreateUserOwnedIdentityResponse, CredentialMetadata,
-    FixedTokenUserOwnedIdentitySetup, Identity, IdentityOwner, ListUserOwnedIdentitiesRequest,
-    ListUserOwnedIdentitiesResponse, create_user_owned_identity_request,
-    create_user_owned_identity_response,
+    FixedTokenUserOwnedIdentitySetup, Identity, IdentityOwner as ProtoIdentityOwner,
+    ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
+    create_user_owned_identity_request, create_user_owned_identity_response,
 };
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
-use crate::identities::{
-    CreateFixedTokenIdentityCommand, IdentityInstanceManager, IdentityInstanceRecord,
-};
+use crate::identities::{CreateFixedTokenIdentityCommand, IdentityManager, IdentityRecord};
+use crate::identity::IdentityOwnerKind;
 use crate::request_context::RequestContext;
 use crate::transport::{grpc_span, instrument_grpc};
 
 #[derive(Clone)]
 pub(crate) struct IdentityService {
-    identities: IdentityInstanceManager,
+    identities: IdentityManager,
 }
 
 impl IdentityService {
-    pub(crate) fn new(identities: IdentityInstanceManager) -> Self {
+    pub(crate) fn new(identities: IdentityManager) -> Self {
         Self { identities }
     }
 }
@@ -64,7 +63,7 @@ impl IdentityServiceApi for IdentityService {
                 .map_err(app_status)?;
             let response = CreateUserOwnedIdentityResponse {
                 event: Some(create_user_owned_identity_response::Event::Identity(
-                    identity_record_to_proto(record),
+                    user_owned_identity_record_to_proto(record),
                 )),
             };
             let stream = Box::pin(tokio_stream::iter([Ok(response)]));
@@ -89,7 +88,10 @@ impl IdentityServiceApi for IdentityService {
                 .await
                 .map_err(app_status)?;
             Ok(Response::new(ListUserOwnedIdentitiesResponse {
-                identities: records.into_iter().map(identity_record_to_proto).collect(),
+                identities: records
+                    .into_iter()
+                    .map(user_owned_identity_record_to_proto)
+                    .collect(),
             }))
         })
         .await
@@ -99,13 +101,14 @@ impl IdentityServiceApi for IdentityService {
 type CreateUserOwnedIdentityResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<CreateUserOwnedIdentityResponse, Status>> + Send>>;
 
-fn identity_record_to_proto(record: IdentityInstanceRecord) -> Identity {
+fn user_owned_identity_record_to_proto(record: IdentityRecord) -> Identity {
+    debug_assert_eq!(record.owner.kind(), IdentityOwnerKind::User);
     Identity {
         name: record.name.to_string(),
         identity_spec: record.identity_spec,
         issuer: record.issuer,
         identity_type: record.identity_type,
-        owner: IdentityOwner::User as i32,
+        owner: ProtoIdentityOwner::User as i32,
         metadata: record
             .metadata
             .into_iter()

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -14,18 +14,18 @@ use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::identities::{
-    CreateFixedTokenIdentityCommand, UserOwnedIdentityManager, UserOwnedIdentityRecord,
+    CreateFixedTokenIdentityCommand, IdentityInstanceManager, IdentityInstanceRecord,
 };
 use crate::request_context::RequestContext;
 use crate::transport::{grpc_span, instrument_grpc};
 
 #[derive(Clone)]
 pub(crate) struct IdentityService {
-    identities: UserOwnedIdentityManager,
+    identities: IdentityInstanceManager,
 }
 
 impl IdentityService {
-    pub(crate) fn new(identities: UserOwnedIdentityManager) -> Self {
+    pub(crate) fn new(identities: IdentityInstanceManager) -> Self {
         Self { identities }
     }
 }
@@ -68,7 +68,9 @@ impl IdentityServiceApi for IdentityService {
                 )),
             };
             let stream = Box::pin(tokio_stream::iter([Ok(response)]));
-            Ok(Response::new(stream as CreateUserOwnedIdentityResponseStreamBox))
+            Ok(Response::new(
+                stream as CreateUserOwnedIdentityResponseStreamBox,
+            ))
         })
         .await
     }
@@ -97,7 +99,7 @@ impl IdentityServiceApi for IdentityService {
 type CreateUserOwnedIdentityResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<CreateUserOwnedIdentityResponse, Status>> + Send>>;
 
-fn identity_record_to_proto(record: UserOwnedIdentityRecord) -> Identity {
+fn identity_record_to_proto(record: IdentityInstanceRecord) -> Identity {
     Identity {
         name: record.name.to_string(),
         identity_spec: record.identity_spec,

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -129,16 +129,16 @@ impl UserPrincipalProvider for SingleUserPrincipalProvider {
 }
 
 /// Scope that owns configured provider-facing source identity material.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "snake_case")]
-pub enum SourceIdentityOwner {
+pub enum IdentityOwnerKind {
     /// Identity material is owned by the current Coral user principal.
     User,
     /// Identity material is owned by the workspace and independent of a user principal.
     Workspace,
 }
 
-impl SourceIdentityOwner {
+impl IdentityOwnerKind {
     /// Returns the stable config representation for this owner.
     #[must_use]
     pub const fn as_config_value(self) -> &'static str {
@@ -153,7 +153,7 @@ impl SourceIdentityOwner {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceIdentityBinding {
     /// Whether the identity is user-specific or workspace-owned.
-    pub owner: SourceIdentityOwner,
+    pub owner: IdentityOwnerKind,
     /// Workspace-owned identity reference understood by installed identity
     /// providers.
     ///
@@ -168,7 +168,7 @@ impl SourceIdentityBinding {
     #[must_use]
     pub const fn user_owned() -> Self {
         Self {
-            owner: SourceIdentityOwner::User,
+            owner: IdentityOwnerKind::User,
             identity: None,
         }
     }
@@ -182,7 +182,7 @@ impl SourceIdentityBinding {
     pub fn workspace_owned(identity: impl Into<String>) -> Result<Self, AppError> {
         let identity = parse_path_segment("identity", &identity.into())?;
         Ok(Self {
-            owner: SourceIdentityOwner::Workspace,
+            owner: IdentityOwnerKind::Workspace,
             identity: Some(identity),
         })
     }
@@ -195,14 +195,14 @@ impl SourceIdentityBinding {
     /// path separator.
     pub fn validate(&self) -> Result<(), AppError> {
         match self.owner {
-            SourceIdentityOwner::User => {
+            IdentityOwnerKind::User => {
                 if self.identity.is_some() {
                     return Err(AppError::InvalidInput(
                         "user-owned source identity bindings store only owner; identity is selected per user".to_string(),
                     ));
                 }
             }
-            SourceIdentityOwner::Workspace => {
+            IdentityOwnerKind::Workspace => {
                 let Some(identity) = &self.identity else {
                     return Err(AppError::InvalidInput(
                         "workspace-owned source identity binding is missing identity".to_string(),

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -388,7 +388,8 @@ impl IdentitySpecManager {
         &self,
         name: &str,
     ) -> Result<IdentitySpecRecord, AppError> {
-        self.load_identity_spec_manifest_unlocked(name)
+        let name = validate_identity_spec_name(name)?;
+        self.load_identity_spec_manifest_unlocked(&name)
     }
 
     #[cfg(test)]
@@ -1024,9 +1025,11 @@ mod tests {
         IdentitySpecName, IdentitySpecRecord, IdentitySpecUsageProvider, identity_spec_fingerprint,
     };
     use crate::bootstrap::AppError;
-    use crate::credentials::{CredentialStoragePreference, CredentialStore, parse_env_file};
+    use crate::credentials::{CredentialStoragePreference, CredentialStore};
     use crate::features::{Features, dsl_v4_features};
+    use crate::identities::{IdentityInstanceName, IdentityOwnerKey};
     use crate::state::AppStateLayout;
+    use crate::storage::env_file::parse_env_file;
 
     fn manager() -> (TempDir, IdentitySpecManager, AppStateLayout) {
         manager_with(dsl_v4_features(), Vec::new())
@@ -1757,7 +1760,9 @@ type: oauth
         identity_name: &str,
         identity_spec: &str,
     ) {
-        let path = layout.user_owned_identity_manifest_file(user_id, identity_name);
+        let owner = IdentityOwnerKey::new(user_id).expect("identity owner");
+        let identity_name = IdentityInstanceName::new(identity_name).expect("identity name");
+        let path = layout.user_owned_identity_manifest_file(&owner, &identity_name);
         fs::create_dir_all(path.parent().expect("identity dir")).expect("identity dir");
         fs::write(
             path,

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -8,9 +8,7 @@ use std::sync::Arc;
 
 use coral_spec::{IdentityManifest, ManifestInputKind, parse_identity_manifest_yaml};
 use serde::{Deserialize, Serialize};
-#[cfg(test)]
 use serde_json::Value;
-#[cfg(test)]
 use sha2::{Digest as _, Sha256};
 use tracing::{info_span, warn};
 
@@ -384,6 +382,13 @@ impl IdentitySpecManager {
         let name = validate_identity_spec_name(name)?;
         let _lock = FileLock::shared(self.layout.state_lock())?;
         self.load_identity_spec_manifest_unlocked(&name)
+    }
+
+    pub(crate) fn load_identity_spec_manifest_unlocked_for_state_lock(
+        &self,
+        name: &str,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        self.load_identity_spec_manifest_unlocked(name)
     }
 
     #[cfg(test)]
@@ -834,7 +839,6 @@ fn checked_add_identity_count(
 /// The manifest serializes with `serde` (struct fields in declaration order)
 /// and `canonical_json_value` sorts any free-form JSON objects (such as
 /// `audience` values), so semantically equal manifests fingerprint equally.
-#[cfg(test)]
 pub(crate) fn identity_spec_fingerprint(manifest: &IdentityManifest) -> Result<String, AppError> {
     let encode_error = |error: &dyn std::fmt::Display| {
         AppError::FailedPrecondition(format!(
@@ -849,7 +853,6 @@ pub(crate) fn identity_spec_fingerprint(manifest: &IdentityManifest) -> Result<S
     Ok(format!("{:x}", hasher.finalize()))
 }
 
-#[cfg(test)]
 fn canonical_json_value(value: Value) -> Value {
     match value {
         Value::Object(map) => {

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -451,7 +451,7 @@ impl IdentitySpecManager {
         &self,
         identity_spec_name: &IdentitySpecName,
     ) -> Result<u32, AppError> {
-        let mut count = self.count_user_owned_identities_for_spec_unlocked(identity_spec_name)?;
+        let mut count = self.count_stored_identities_for_spec_unlocked(identity_spec_name)?;
         for provider in &self.usage_providers {
             count = checked_add_identity_count(
                 count,
@@ -462,33 +462,39 @@ impl IdentitySpecManager {
         Ok(count)
     }
 
-    fn count_user_owned_identities_for_spec_unlocked(
+    fn count_stored_identities_for_spec_unlocked(
         &self,
         identity_spec_name: &IdentitySpecName,
     ) -> Result<u32, AppError> {
-        let users_root = self.layout.identities_root().join("users");
-        if !users_root.exists() {
+        let identities_root = self.layout.identities_root();
+        if !identities_root.exists() {
             return Ok(0);
         }
         let mut count = 0u32;
-        for user_entry in fs::read_dir(users_root)? {
-            let user_entry = user_entry?;
-            if !user_entry.file_type()?.is_dir() {
+        for owner_kind_entry in fs::read_dir(identities_root)? {
+            let owner_kind_entry = owner_kind_entry?;
+            if !owner_kind_entry.file_type()?.is_dir() {
                 continue;
             }
-            for identity_entry in fs::read_dir(user_entry.path())? {
-                let identity_entry = identity_entry?;
-                if !identity_entry.file_type()?.is_dir() {
+            for owner_entry in fs::read_dir(owner_kind_entry.path())? {
+                let owner_entry = owner_entry?;
+                if !owner_entry.file_type()?.is_dir() {
                     continue;
                 }
-                let manifest_path = identity_entry.path().join(INSTALLED_IDENTITY_FILE_NAME);
-                if !manifest_path.exists() {
-                    continue;
-                }
-                let raw = fs::read_to_string(&manifest_path)?;
-                let reference: UserOwnedIdentitySpecReference = serde_yaml::from_str(&raw)?;
-                if reference.identity_spec == identity_spec_name.as_str() {
-                    count = checked_add_identity_count(count, 1, identity_spec_name.as_str())?;
+                for identity_entry in fs::read_dir(owner_entry.path())? {
+                    let identity_entry = identity_entry?;
+                    if !identity_entry.file_type()?.is_dir() {
+                        continue;
+                    }
+                    let manifest_path = identity_entry.path().join(INSTALLED_IDENTITY_FILE_NAME);
+                    if !manifest_path.exists() {
+                        continue;
+                    }
+                    let raw = fs::read_to_string(&manifest_path)?;
+                    let reference: StoredIdentitySpecReference = serde_yaml::from_str(&raw)?;
+                    if reference.identity_spec == identity_spec_name.as_str() {
+                        count = checked_add_identity_count(count, 1, identity_spec_name.as_str())?;
+                    }
                 }
             }
         }
@@ -877,7 +883,7 @@ fn canonical_json_value(value: Value) -> Value {
 }
 
 #[derive(Debug, Deserialize)]
-struct UserOwnedIdentitySpecReference {
+struct StoredIdentitySpecReference {
     identity_spec: String,
 }
 
@@ -1027,7 +1033,7 @@ mod tests {
     use crate::bootstrap::AppError;
     use crate::credentials::{CredentialStoragePreference, CredentialStore};
     use crate::features::{Features, dsl_v4_features};
-    use crate::identities::{IdentityInstanceName, IdentityOwnerKey};
+    use crate::identities::{IdentityName, IdentityOwner};
     use crate::state::AppStateLayout;
     use crate::storage::env_file::parse_env_file;
 
@@ -1623,7 +1629,7 @@ oauth:
         let (_temp, manager, layout) = manager();
         let manifest_yaml = identity_yaml_with_audience("github_oauth", "0.1.0", "github.com");
         add_spec(&manager, &manifest_yaml);
-        write_user_owned_identity_manifest(&layout, "local", "github_local", "github_oauth");
+        write_identity_manifest(&layout, &local_user_owner(), "github_local", "github_oauth");
 
         let (record, replaced) = add_spec(&manager, &manifest_yaml);
         assert!(replaced);
@@ -1706,10 +1712,10 @@ type: oauth
     /// Merges the previous without-force rejection test and the force-removal
     /// orphan report test into one flow over the same stored identities.
     #[test]
-    fn remove_identity_spec_requires_force_and_reports_orphaned_user_owned_identities() {
+    fn remove_identity_spec_requires_force_and_reports_orphaned_identities() {
         let (_temp, manager, layout) = manager();
         add_spec(&manager, &identity_yaml("github_oauth", "0.1.0"));
-        write_user_owned_identity_manifest(&layout, "local", "github_local", "github_oauth");
+        write_identity_manifest(&layout, &local_user_owner(), "github_local", "github_oauth");
 
         let error = manager
             .remove_identity_spec("github_oauth", false)
@@ -1720,8 +1726,13 @@ type: oauth
             .get_identity_spec("github_oauth")
             .expect("spec remains installed");
 
-        write_user_owned_identity_manifest(&layout, "local", "github_alt", "github_oauth");
-        write_user_owned_identity_manifest(&layout, "local", "stripe_local", "stripe_oauth");
+        write_identity_manifest(
+            &layout,
+            &default_workspace_owner(),
+            "github_alt",
+            "github_oauth",
+        );
+        write_identity_manifest(&layout, &local_user_owner(), "stripe_local", "stripe_oauth");
 
         let orphaned = remove_spec(&manager, "github_oauth", true);
 
@@ -1754,26 +1765,35 @@ type: oauth
         assert_eq!(orphaned, 3);
     }
 
-    fn write_user_owned_identity_manifest(
+    fn local_user_owner() -> IdentityOwner {
+        IdentityOwner::user("local").expect("identity owner")
+    }
+
+    fn default_workspace_owner() -> IdentityOwner {
+        IdentityOwner::workspace("default").expect("identity owner")
+    }
+
+    fn write_identity_manifest(
         layout: &AppStateLayout,
-        user_id: &str,
+        owner: &IdentityOwner,
         identity_name: &str,
         identity_spec: &str,
     ) {
-        let owner = IdentityOwnerKey::new(user_id).expect("identity owner");
-        let identity_name = IdentityInstanceName::new(identity_name).expect("identity name");
-        let path = layout.user_owned_identity_manifest_file(&owner, &identity_name);
+        let identity_name = IdentityName::new(identity_name).expect("identity name");
+        let path = layout.identity_manifest_file(owner, &identity_name);
         fs::create_dir_all(path.parent().expect("identity dir")).expect("identity dir");
         fs::write(
             path,
             format!(
                 r"version: 1
+owner: {}
 name: {identity_name}
 identity_spec: {identity_spec}
 issuer: github
 identity_type: oauth
 metadata: {{}}
-"
+",
+                owner.kind().as_config_value()
             ),
         )
         .expect("write identity manifest");

--- a/crates/coral-app/src/identity_specs/mod.rs
+++ b/crates/coral-app/src/identity_specs/mod.rs
@@ -11,4 +11,5 @@ pub use manager::{
     IdentitySpecUsageProvider, identity_spec_input_material_from_manifest,
     identity_spec_input_material_from_manifest_with_existing, identity_spec_manifest_metadata,
 };
+pub(crate) use manager::{identity_spec_fingerprint, validate_identity_spec_name};
 pub(crate) use service::IdentitySpecService;

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -75,9 +75,8 @@ pub use coral_engine::{
     SelectedRequestIdentity,
 };
 pub use identities::{
-    CreateFixedTokenIdentityCommand, IdentityManagementHandle, IdentityOwnerKey,
-    UserOwnedIdentityMaterialGuard, UserOwnedIdentityName, UserOwnedIdentityRecord,
-    UserOwnedIdentityStore,
+    CreateFixedTokenIdentityCommand, IdentityInstanceMaterialGuard, IdentityInstanceName,
+    IdentityInstanceRecord, IdentityInstanceStore, IdentityManagementHandle, IdentityOwnerKey,
 };
 pub use identity::{
     RuntimeSourceIdentity, SingleUserPrincipalProvider, SourceIdentityBinding, SourceIdentityOwner,

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -75,11 +75,11 @@ pub use coral_engine::{
     SelectedRequestIdentity,
 };
 pub use identities::{
-    CreateFixedTokenIdentityCommand, IdentityInstanceMaterialGuard, IdentityInstanceName,
-    IdentityInstanceRecord, IdentityInstanceStore, IdentityManagementHandle, IdentityOwnerKey,
+    CreateFixedTokenIdentityCommand, IdentityManagementHandle, IdentityMaterialGuard, IdentityName,
+    IdentityOwner, IdentityRecord, IdentityStore,
 };
 pub use identity::{
-    RuntimeSourceIdentity, SingleUserPrincipalProvider, SourceIdentityBinding, SourceIdentityOwner,
+    IdentityOwnerKind, RuntimeSourceIdentity, SingleUserPrincipalProvider, SourceIdentityBinding,
     SourceIdentityProvider, SourceIdentityResolutionRequest, SourceIdentitySelection,
     SourceIdentitySelectionRequest, UserPrincipal, UserPrincipalProvider,
 };

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -75,8 +75,9 @@ pub use coral_engine::{
     SelectedRequestIdentity,
 };
 pub use identities::{
-    IdentityOwnerKey, UserOwnedIdentityMaterialGuard, UserOwnedIdentityName,
-    UserOwnedIdentityRecord, UserOwnedIdentityStore,
+    CreateFixedTokenIdentityCommand, IdentityManagementHandle, IdentityOwnerKey,
+    UserOwnedIdentityMaterialGuard, UserOwnedIdentityName, UserOwnedIdentityRecord,
+    UserOwnedIdentityStore,
 };
 pub use identity::{
     RuntimeSourceIdentity, SingleUserPrincipalProvider, SourceIdentityBinding, SourceIdentityOwner,

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -125,17 +125,43 @@ impl AppStateLayout {
         self.config_dir.join("identities")
     }
 
-    #[cfg(test)]
+    pub(crate) fn user_owned_identities_root(&self, user_id: &str) -> PathBuf {
+        self.identities_root().join("users").join(user_id)
+    }
+
+    pub(crate) fn user_owned_identity_dir(&self, user_id: &str, identity_name: &str) -> PathBuf {
+        self.user_owned_identities_root(user_id).join(identity_name)
+    }
+
     pub(crate) fn user_owned_identity_manifest_file(
         &self,
         user_id: &str,
         identity_name: &str,
     ) -> PathBuf {
-        self.identities_root()
+        self.user_owned_identity_dir(user_id, identity_name)
+            .join(INSTALLED_IDENTITY_FILE_NAME)
+    }
+
+    pub(crate) fn user_owned_identity_material_file(
+        &self,
+        user_id: &str,
+        identity_name: &str,
+    ) -> PathBuf {
+        self.user_owned_identity_dir(user_id, identity_name)
+            .join(INSTALLED_SECRETS_FILE_NAME)
+    }
+
+    pub(crate) fn user_owned_identity_refresh_lock_file(
+        &self,
+        user_id: &str,
+        identity_name: &str,
+    ) -> PathBuf {
+        self.config_dir
+            .join("locks")
+            .join("identities")
             .join("users")
             .join(user_id)
-            .join(identity_name)
-            .join(INSTALLED_IDENTITY_FILE_NAME)
+            .join(format!("{identity_name}.refresh.lock"))
     }
 
     pub(crate) fn source_dir(

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_native_strategy};
 
 use crate::bootstrap::AppError;
+use crate::identities::{IdentityInstanceName, IdentityOwnerKey};
 use crate::identity_specs::IdentitySpecName;
 use crate::sources::SourceName;
 use crate::storage::fs::ensure_dir;
@@ -125,43 +126,48 @@ impl AppStateLayout {
         self.config_dir.join("identities")
     }
 
-    pub(crate) fn user_owned_identities_root(&self, user_id: &str) -> PathBuf {
-        self.identities_root().join("users").join(user_id)
+    pub(crate) fn user_owned_identities_root(&self, owner: &IdentityOwnerKey) -> PathBuf {
+        self.identities_root().join("users").join(owner.as_str())
     }
 
-    pub(crate) fn user_owned_identity_dir(&self, user_id: &str, identity_name: &str) -> PathBuf {
-        self.user_owned_identities_root(user_id).join(identity_name)
+    pub(crate) fn user_owned_identity_dir(
+        &self,
+        owner: &IdentityOwnerKey,
+        identity_name: &IdentityInstanceName,
+    ) -> PathBuf {
+        self.user_owned_identities_root(owner)
+            .join(identity_name.as_str())
     }
 
     pub(crate) fn user_owned_identity_manifest_file(
         &self,
-        user_id: &str,
-        identity_name: &str,
+        owner: &IdentityOwnerKey,
+        identity_name: &IdentityInstanceName,
     ) -> PathBuf {
-        self.user_owned_identity_dir(user_id, identity_name)
+        self.user_owned_identity_dir(owner, identity_name)
             .join(INSTALLED_IDENTITY_FILE_NAME)
     }
 
     pub(crate) fn user_owned_identity_material_file(
         &self,
-        user_id: &str,
-        identity_name: &str,
+        owner: &IdentityOwnerKey,
+        identity_name: &IdentityInstanceName,
     ) -> PathBuf {
-        self.user_owned_identity_dir(user_id, identity_name)
+        self.user_owned_identity_dir(owner, identity_name)
             .join(INSTALLED_SECRETS_FILE_NAME)
     }
 
     pub(crate) fn user_owned_identity_refresh_lock_file(
         &self,
-        user_id: &str,
-        identity_name: &str,
+        owner: &IdentityOwnerKey,
+        identity_name: &IdentityInstanceName,
     ) -> PathBuf {
         self.config_dir
             .join("locks")
             .join("identities")
             .join("users")
-            .join(user_id)
-            .join(format!("{identity_name}.refresh.lock"))
+            .join(owner.as_str())
+            .join(format!("{}.refresh.lock", identity_name.as_str()))
     }
 
     pub(crate) fn source_dir(

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_native_strategy};
 
 use crate::bootstrap::AppError;
-use crate::identities::{IdentityInstanceName, IdentityOwnerKey};
+use crate::identities::{IdentityName, IdentityOwner};
 use crate::identity_specs::IdentitySpecName;
 use crate::sources::SourceName;
 use crate::storage::fs::ensure_dir;
@@ -126,47 +126,48 @@ impl AppStateLayout {
         self.config_dir.join("identities")
     }
 
-    pub(crate) fn user_owned_identities_root(&self, owner: &IdentityOwnerKey) -> PathBuf {
-        self.identities_root().join("users").join(owner.as_str())
+    pub(crate) fn identity_owner_root(&self, owner: &IdentityOwner) -> PathBuf {
+        self.identities_root()
+            .join(owner.storage_segment())
+            .join(owner.key())
     }
 
-    pub(crate) fn user_owned_identity_dir(
+    pub(crate) fn identity_dir(
         &self,
-        owner: &IdentityOwnerKey,
-        identity_name: &IdentityInstanceName,
+        owner: &IdentityOwner,
+        identity_name: &IdentityName,
     ) -> PathBuf {
-        self.user_owned_identities_root(owner)
-            .join(identity_name.as_str())
+        self.identity_owner_root(owner).join(identity_name.as_str())
     }
 
-    pub(crate) fn user_owned_identity_manifest_file(
+    pub(crate) fn identity_manifest_file(
         &self,
-        owner: &IdentityOwnerKey,
-        identity_name: &IdentityInstanceName,
+        owner: &IdentityOwner,
+        identity_name: &IdentityName,
     ) -> PathBuf {
-        self.user_owned_identity_dir(owner, identity_name)
+        self.identity_dir(owner, identity_name)
             .join(INSTALLED_IDENTITY_FILE_NAME)
     }
 
-    pub(crate) fn user_owned_identity_material_file(
+    pub(crate) fn identity_material_file(
         &self,
-        owner: &IdentityOwnerKey,
-        identity_name: &IdentityInstanceName,
+        owner: &IdentityOwner,
+        identity_name: &IdentityName,
     ) -> PathBuf {
-        self.user_owned_identity_dir(owner, identity_name)
+        self.identity_dir(owner, identity_name)
             .join(INSTALLED_SECRETS_FILE_NAME)
     }
 
-    pub(crate) fn user_owned_identity_refresh_lock_file(
+    pub(crate) fn identity_refresh_lock_file(
         &self,
-        owner: &IdentityOwnerKey,
-        identity_name: &IdentityInstanceName,
+        owner: &IdentityOwner,
+        identity_name: &IdentityName,
     ) -> PathBuf {
         self.config_dir
             .join("locks")
             .join("identities")
-            .join("users")
-            .join(owner.as_str())
+            .join(owner.storage_segment())
+            .join(owner.key())
             .join(format!("{}.refresh.lock", identity_name.as_str()))
     }
 

--- a/crates/coral-app/src/storage/env_file.rs
+++ b/crates/coral-app/src/storage/env_file.rs
@@ -1,0 +1,127 @@
+//! `.env`-style material encoding helpers shared by app-owned stores.
+
+use std::collections::BTreeMap;
+
+/// Errors returned while parsing `.env`-style material.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub(crate) struct EnvFileError(String);
+
+/// Renders key/value material as a deterministic `.env`-style file.
+pub(crate) fn render_env_file(values: &BTreeMap<String, String>) -> String {
+    let mut output = String::new();
+    for (env_var, value) in values {
+        output.push_str(env_var);
+        output.push('=');
+        output.push_str(&encode_env_value(value));
+        output.push('\n');
+    }
+    output
+}
+
+/// Parses key/value material from a `.env`-style file.
+pub(crate) fn parse_env_file(raw: &str) -> Result<BTreeMap<String, String>, EnvFileError> {
+    let mut values = BTreeMap::new();
+    for (index, line) in raw.lines().enumerate() {
+        let line_number = index + 1;
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let Some((env_var, raw_value)) = line.split_once('=') else {
+            return Err(EnvFileError(format!("line {line_number} is missing '='")));
+        };
+        let env_var = env_var.trim();
+        if env_var.is_empty() {
+            return Err(EnvFileError(format!(
+                "line {line_number} has an empty variable name"
+            )));
+        }
+        if values.contains_key(env_var) {
+            return Err(EnvFileError(format!(
+                "line {line_number} redefines '{env_var}'"
+            )));
+        }
+
+        let value = decode_env_value(raw_value.trim(), line_number)?;
+        values.insert(env_var.to_string(), value);
+    }
+    Ok(values)
+}
+
+pub(crate) fn decode_env_value(raw: &str, line_number: usize) -> Result<String, EnvFileError> {
+    if let Some(inner) = raw.strip_prefix('"') {
+        let Some(inner) = inner.strip_suffix('"') else {
+            return Err(EnvFileError(format!(
+                "line {line_number} has an unterminated quoted value"
+            )));
+        };
+        return decode_quoted_env_value(inner, line_number);
+    }
+
+    if let Some(inner) = raw.strip_prefix('\'') {
+        let Some(inner) = inner.strip_suffix('\'') else {
+            return Err(EnvFileError(format!(
+                "line {line_number} has an unterminated single-quoted value"
+            )));
+        };
+        return Ok(inner.to_string());
+    }
+
+    Ok(raw.to_string())
+}
+
+fn decode_quoted_env_value(raw: &str, line_number: usize) -> Result<String, EnvFileError> {
+    let mut decoded = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            decoded.push(ch);
+            continue;
+        }
+
+        let Some(escaped) = chars.next() else {
+            return Err(EnvFileError(format!(
+                "line {line_number} ends with a dangling escape"
+            )));
+        };
+        match escaped {
+            '\\' => decoded.push('\\'),
+            '"' => decoded.push('"'),
+            'n' => decoded.push('\n'),
+            'r' => decoded.push('\r'),
+            't' => decoded.push('\t'),
+            other => {
+                return Err(EnvFileError(format!(
+                    "line {line_number} uses unsupported escape '\\{other}'"
+                )));
+            }
+        }
+    }
+    Ok(decoded)
+}
+
+pub(crate) fn encode_env_value(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/' | ':' | '@'))
+    {
+        return value.to_string();
+    }
+
+    let mut encoded = String::with_capacity(value.len() + 2);
+    encoded.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => encoded.push_str("\\\\"),
+            '"' => encoded.push_str("\\\""),
+            '\n' => encoded.push_str("\\n"),
+            '\r' => encoded.push_str("\\r"),
+            '\t' => encoded.push_str("\\t"),
+            other => encoded.push(other),
+        }
+    }
+    encoded.push('"');
+    encoded
+}

--- a/crates/coral-app/src/storage/mod.rs
+++ b/crates/coral-app/src/storage/mod.rs
@@ -1,3 +1,4 @@
 //! Shared filesystem helpers for local persistence.
 
+pub(crate) mod env_file;
 pub(crate) mod fs;

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -11,6 +11,8 @@ mod catalog_discovery_tests;
 mod harness;
 #[path = "grpc/identity_spec_tests.rs"]
 mod identity_spec_tests;
+#[path = "grpc/identity_tests.rs"]
+mod identity_tests;
 #[path = "grpc/oauth_refresh_tests.rs"]
 mod oauth_refresh_tests;
 #[path = "grpc/resilience_tests.rs"]

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -7,8 +7,8 @@ use coral_api::v1::{
     ValidateSourceResponse, catalog_item, import_source_response,
 };
 use coral_client::{
-    AppClient, CatalogClient, IdentitySpecClient, QueryClient, SourceClient, batches_to_json_rows,
-    decode_execute_sql_response, default_workspace,
+    AppClient, CatalogClient, IdentityClient, IdentitySpecClient, QueryClient, SourceClient,
+    batches_to_json_rows, decode_execute_sql_response, default_workspace,
     local::{RunningServer, ServerBuilder},
 };
 use serde_json::{Value, json};
@@ -71,6 +71,10 @@ impl GrpcHarness {
 
     pub(crate) fn identity_spec_client(&self) -> IdentitySpecClient {
         self.app.identity_spec_client()
+    }
+
+    pub(crate) fn identity_client(&self) -> IdentityClient {
+        self.app.identity_client()
     }
 
     pub(crate) fn catalog_client(&self) -> CatalogClient {

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -1,0 +1,90 @@
+use std::fs;
+
+use coral_api::v1::{
+    AddIdentitySpecRequest, CreateUserOwnedIdentityWithFixedTokenRequest,
+    ListUserOwnedIdentitiesRequest,
+};
+use tempfile::TempDir;
+use tonic::Request;
+
+use crate::harness::GrpcHarness;
+
+#[tokio::test]
+async fn identity_service_creates_and_lists_user_fixed_token_identity() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[features]\ndsl_v4 = true\n",
+    )
+    .expect("write feature config");
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+
+    harness
+        .identity_spec_client()
+        .add_identity_spec(Request::new(AddIdentitySpecRequest {
+            manifest_yaml: fixed_token_identity_spec_yaml(),
+            inputs: Vec::new(),
+        }))
+        .await
+        .expect("add identity spec");
+
+    let created = harness
+        .identity_client()
+        .create_user_owned_identity_with_fixed_token(Request::new(
+            CreateUserOwnedIdentityWithFixedTokenRequest {
+                name: "github_local".to_string(),
+                identity_spec: "github_pat".to_string(),
+                token: "ghp_secret".to_string(),
+            },
+        ))
+        .await
+        .expect("create fixed-token identity")
+        .into_inner()
+        .identity
+        .expect("created identity");
+    assert_eq!(created.name, "github_local");
+    assert_eq!(created.identity_spec, "github_pat");
+    assert_eq!(created.issuer, "github");
+    assert_eq!(created.identity_type, "fixed_token");
+    assert!(created.metadata.is_empty());
+
+    let listed = harness
+        .identity_client()
+        .list_user_owned_identities(Request::new(ListUserOwnedIdentitiesRequest {}))
+        .await
+        .expect("list identities")
+        .into_inner()
+        .identities;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(
+        listed.first().expect("listed identity").name,
+        "github_local"
+    );
+
+    let material_file = config_dir
+        .join("identities")
+        .join("users")
+        .join("local")
+        .join("github_local")
+        .join("secrets.env");
+    assert!(
+        fs::read_to_string(&material_file)
+            .expect("identity material")
+            .contains("TOKEN=ghp_secret")
+    );
+}
+
+fn fixed_token_identity_spec_yaml() -> String {
+    r"kind: identity
+spec_version: 1
+name: github_pat
+version: 0.1.0
+issuer: github
+type: fixed_token
+audience:
+  host: github.com
+"
+    .to_string()
+}

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -1,8 +1,9 @@
 use std::fs;
 
 use coral_api::v1::{
-    AddIdentitySpecRequest, CreateUserOwnedIdentityWithFixedTokenRequest,
-    ListUserOwnedIdentitiesRequest,
+    AddIdentitySpecRequest, CreateUserOwnedIdentityRequest, FixedTokenUserOwnedIdentitySetup,
+    ListUserOwnedIdentitiesRequest, create_user_owned_identity_request,
+    create_user_owned_identity_response,
 };
 use tempfile::TempDir;
 use tonic::Request;
@@ -25,25 +26,36 @@ async fn identity_service_creates_and_lists_user_fixed_token_identity() {
         .identity_spec_client()
         .add_identity_spec(Request::new(AddIdentitySpecRequest {
             manifest_yaml: fixed_token_identity_spec_yaml(),
-            inputs: Vec::new(),
+            input_values: Vec::new(),
         }))
         .await
         .expect("add identity spec");
 
-    let created = harness
+    let mut stream = harness
         .identity_client()
-        .create_user_owned_identity_with_fixed_token(Request::new(
-            CreateUserOwnedIdentityWithFixedTokenRequest {
-                name: "github_local".to_string(),
-                identity_spec: "github_pat".to_string(),
-                token: "ghp_secret".to_string(),
-            },
-        ))
+        .create_user_owned_identity(Request::new(CreateUserOwnedIdentityRequest {
+            name: "github_local".to_string(),
+            identity_spec: "github_pat".to_string(),
+            setup: Some(create_user_owned_identity_request::Setup::FixedToken(
+                FixedTokenUserOwnedIdentitySetup {
+                    token: "ghp_secret".to_string(),
+                },
+            )),
+        }))
         .await
         .expect("create fixed-token identity")
-        .into_inner()
-        .identity
-        .expect("created identity");
+        .into_inner();
+    let created = match stream
+        .message()
+        .await
+        .expect("identity creation event")
+        .expect("created identity event")
+        .event
+        .expect("identity creation event payload")
+    {
+        create_user_owned_identity_response::Event::Identity(identity) => identity,
+        event => panic!("expected identity event, got {event:?}"),
+    };
     assert_eq!(created.name, "github_local");
     assert_eq!(created.identity_spec, "github_pat");
     assert_eq!(created.issuer, "github");

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -38,7 +38,7 @@ async fn identity_service_creates_and_lists_user_fixed_token_identity() {
             identity_spec: "github_pat".to_string(),
             setup: Some(create_user_owned_identity_request::Setup::FixedToken(
                 FixedTokenUserOwnedIdentitySetup {
-                    token: "ghp_secret".to_string(),
+                    token: "  ghp_secret  ".to_string(),
                 },
             )),
         }))
@@ -85,6 +85,11 @@ async fn identity_service_creates_and_lists_user_fixed_token_identity() {
         fs::read_to_string(&material_file)
             .expect("identity material")
             .contains("TOKEN=ghp_secret")
+    );
+    assert!(
+        !fs::read_to_string(&material_file)
+            .expect("identity material")
+            .contains("  ghp_secret  ")
     );
 }
 


### PR DESCRIPTION
## Intent

Land `feat(app): add user-owned identity storage` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-05-identity-specs...sauldhernandez/dsl-v4-identity-v2-06-user-owned-identity-store
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
