### PR TITLE
feat(app): add OAuth identity runtime

### DIFF
--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -20,7 +20,7 @@ use serde_json::Value;
 use sha2::{Digest as _, Sha256};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::TcpListener;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use url::{Url, form_urlencoded};
 use uuid::Uuid;
 
@@ -35,7 +35,7 @@ const MAX_CALLBACK_BYTES: usize = 8 * 1024;
 const REFRESH_EXPIRY_SKEW_SECONDS: i64 = 60;
 const TOKEN_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct OAuthCredentialService {
     http: reqwest::Client,
 }
@@ -45,23 +45,155 @@ pub(crate) struct StartOAuthCredentialRequest<'a> {
     pub(crate) oauth: &'a ManifestOAuthCredentialSpec,
     pub(crate) source_inputs: &'a BTreeMap<String, String>,
     pub(crate) credential_inputs: Vec<(String, String)>,
+    pub(crate) client_material_persistence: OAuthClientMaterialPersistence,
 }
 
-pub(super) struct RefreshOAuthCredentialRequest<'a> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OAuthClientMaterialPersistence {
+    None,
+    ClientCredentials {
+        client_id: bool,
+        client_secret: bool,
+    },
+    All,
+}
+
+/// Progress event emitted while an OAuth credential authorization runs.
+#[derive(Debug, Clone)]
+pub enum OAuthProgressEvent {
+    /// An OAuth flow is waiting for the user to authorize the credential.
+    OAuthAuthorization {
+        /// Source or identity input key whose credential is being authorized.
+        input_key: String,
+        /// Authorization URL the user should open.
+        authorization_url: String,
+        /// Number of seconds before the authorization request expires.
+        expires_in_seconds: u64,
+        /// Optional device-code user code, when the provider returns one.
+        user_code: Option<String>,
+        /// Optional device-code verification URL.
+        verification_uri: Option<String>,
+        /// Optional complete device-code verification URL.
+        verification_uri_complete: Option<String>,
+    },
+    /// The OAuth flow completed and produced safe credential metadata.
+    OAuthCompleted {
+        /// Source or identity input key whose credential was authorized.
+        input_key: String,
+        /// Safe metadata about the credential, never token material.
+        metadata: BTreeMap<String, String>,
+    },
+}
+
+/// Acknowledged progress-event sink bridging an OAuth-driven manager operation
+/// to its gRPC response stream.
+#[derive(Clone)]
+pub struct OAuthProgressEventSender {
+    tx: mpsc::Sender<PendingOAuthProgressEvent>,
+    closed_message: &'static str,
+}
+
+pub(crate) struct PendingOAuthProgressEvent {
+    event: OAuthProgressEvent,
+    delivered: oneshot::Sender<()>,
+}
+
+impl OAuthProgressEventSender {
+    pub(crate) fn new(
+        tx: mpsc::Sender<PendingOAuthProgressEvent>,
+        closed_message: &'static str,
+    ) -> Self {
+        Self { tx, closed_message }
+    }
+
+    /// Sends one progress event and waits until the response stream dequeues it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the response stream has closed.
+    pub async fn send(&self, event: OAuthProgressEvent) -> Result<(), AppError> {
+        let (delivered, delivered_rx) = oneshot::channel();
+        self.tx
+            .send(PendingOAuthProgressEvent { event, delivered })
+            .await
+            .map_err(|_closed| AppError::FailedPrecondition(self.closed_message.to_string()))?;
+        delivered_rx
+            .await
+            .map_err(|_closed| AppError::FailedPrecondition(self.closed_message.to_string()))
+    }
+}
+
+impl PendingOAuthProgressEvent {
+    pub(crate) fn into_event(self) -> OAuthProgressEvent {
+        if self.delivered.send(()).is_err() {
+            // The sender side is best-effort; the operation will observe stream
+            // closure through the next progress send.
+        }
+        self.event
+    }
+}
+
+impl OAuthClientMaterialPersistence {
+    fn stores_client_id(self) -> bool {
+        matches!(
+            self,
+            Self::All
+                | Self::ClientCredentials {
+                    client_id: true,
+                    ..
+                }
+        )
+    }
+
+    fn stores_client_secret(self) -> bool {
+        matches!(
+            self,
+            Self::All
+                | Self::ClientCredentials {
+                    client_secret: true,
+                    ..
+                }
+        )
+    }
+}
+
+pub(crate) struct RefreshOAuthCredentialRequest<'a> {
     access_token_material_key: &'a str,
+    material_label: String,
+    reconnect_label: &'static str,
     metadata_prefix: String,
     oauth: &'a ManifestOAuthCredentialSpec,
+    resolved_inputs: Option<&'a BTreeMap<String, String>>,
 }
 
 impl<'a> RefreshOAuthCredentialRequest<'a> {
-    pub(super) fn for_source_input(
+    pub(crate) fn for_source_input(
         input_key: &'a str,
         oauth: &'a ManifestOAuthCredentialSpec,
     ) -> Self {
         Self {
             access_token_material_key: input_key,
+            material_label: format!("source secret '{input_key}'"),
+            reconnect_label: "reconnect the source",
             metadata_prefix: oauth_metadata_prefix(input_key),
             oauth,
+            resolved_inputs: None,
+        }
+    }
+
+    pub(crate) fn for_identity(
+        identity_name: &str,
+        access_token_material_key: &'a str,
+        oauth: &'a ManifestOAuthCredentialSpec,
+        resolved_inputs: &'a BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            access_token_material_key,
+            material_label: format!("identity '{identity_name}'"),
+            reconnect_label: "reconnect the identity",
+            metadata_prefix: oauth_metadata_prefix(access_token_material_key),
+            oauth,
+            resolved_inputs: Some(resolved_inputs),
         }
     }
 }
@@ -88,6 +220,7 @@ struct OAuthSessionCommon {
     endpoints: ManifestOAuthEndpointUrls,
     client_id: String,
     client_secret: Option<String>,
+    client_material_persistence: OAuthClientMaterialPersistence,
 }
 
 struct AuthorizationCodeSessionConfig {
@@ -165,6 +298,39 @@ impl OAuthCredentialService {
         }
     }
 
+    /// Runs [`Self::authorize`] while reporting progress on `events`, keying
+    /// emitted events by `event_key`.
+    pub(crate) async fn authorize_with_progress(
+        &self,
+        request: StartOAuthCredentialRequest<'_>,
+        event_key: String,
+        events: &OAuthProgressEventSender,
+    ) -> Result<OAuthCredentialMaterial, AppError> {
+        let authorization_events = events.clone();
+        let authorization_key = event_key.clone();
+        let material = self
+            .authorize(request, move |authorization| async move {
+                authorization_events
+                    .send(OAuthProgressEvent::OAuthAuthorization {
+                        input_key: authorization_key,
+                        authorization_url: authorization.authorization_url,
+                        expires_in_seconds: authorization.expires_in_seconds,
+                        user_code: authorization.user_code,
+                        verification_uri: authorization.verification_uri,
+                        verification_uri_complete: authorization.verification_uri_complete,
+                    })
+                    .await
+            })
+            .await?;
+        events
+            .send(OAuthProgressEvent::OAuthCompleted {
+                input_key: event_key,
+                metadata: material.safe_metadata.clone(),
+            })
+            .await?;
+        Ok(material)
+    }
+
     pub(crate) async fn authorize<F, Fut>(
         &self,
         request: StartOAuthCredentialRequest<'_>,
@@ -180,39 +346,29 @@ impl OAuthCredentialService {
         reject_unknown_credential_inputs(&oauth, &credential_inputs)?;
         let client_id = resolve_client_id(&oauth, &credential_inputs)?;
         let client_secret = resolve_client_secret(&oauth, &credential_inputs)?;
-        match oauth.flow.kind {
+        let flow_kind = oauth.flow.kind;
+        let common = OAuthSessionCommon {
+            input_key: request.input_key.to_string(),
+            oauth,
+            endpoints,
+            client_id,
+            client_secret,
+            client_material_persistence: request.client_material_persistence,
+        };
+        match flow_kind {
             ManifestOAuthFlowKind::AuthorizationCode => {
-                self.authorize_authorization_code(
-                    request.input_key.to_string(),
-                    oauth,
-                    endpoints,
-                    client_id,
-                    client_secret,
-                    on_authorization,
-                )
-                .await
+                self.authorize_authorization_code(common, on_authorization)
+                    .await
             }
             ManifestOAuthFlowKind::DeviceCode => {
-                self.authorize_device_code(
-                    request.input_key.to_string(),
-                    oauth,
-                    endpoints,
-                    client_id,
-                    client_secret,
-                    on_authorization,
-                )
-                .await
+                self.authorize_device_code(common, on_authorization).await
             }
         }
     }
 
     async fn authorize_authorization_code<F, Fut>(
         &self,
-        input_key: String,
-        oauth: ManifestOAuthCredentialSpec,
-        endpoints: ManifestOAuthEndpointUrls,
-        client_id: String,
-        client_secret: Option<String>,
+        common: OAuthSessionCommon,
         on_authorization: F,
     ) -> Result<OAuthCredentialMaterial, AppError>
     where
@@ -220,25 +376,18 @@ impl OAuthCredentialService {
         Fut: Future<Output = Result<(), AppError>>,
     {
         let (listener, callback_path, provider_redirect_uri) =
-            bind_redirect_listener(&oauth).await?;
+            bind_redirect_listener(&common.oauth).await?;
         let state = random_token();
-        let code_verifier = pkce_code_verifier(&oauth);
+        let code_verifier = pkce_code_verifier(&common.oauth);
         let authorization_url = build_authorization_url(
-            &oauth,
-            &endpoints,
+            &common.oauth,
+            &common.endpoints,
             &provider_redirect_uri,
-            &client_id,
+            &common.client_id,
             &state,
             code_verifier.as_deref(),
         )?;
         let expires_at = Instant::now() + SESSION_TTL;
-        let common = OAuthSessionCommon {
-            input_key,
-            oauth,
-            endpoints,
-            client_id,
-            client_secret,
-        };
         let session = AuthorizationCodeSessionConfig {
             common,
             state,
@@ -298,15 +447,17 @@ impl OAuthCredentialService {
 
     /// Uses persisted credential material as both the refresh input
     /// (expiry, refresh token, client metadata) and output (new token values).
-    pub(super) async fn refresh_if_needed(
+    pub(crate) async fn refresh_if_needed(
         &self,
         request: RefreshOAuthCredentialRequest<'_>,
         credential_material: &mut BTreeMap<String, String>,
     ) -> Result<bool, AppError> {
         let Some(refresh) = oauth_refresh_config(
-            request.access_token_material_key,
+            request.material_label.as_str(),
+            request.reconnect_label,
             request.metadata_prefix.as_str(),
             request.oauth,
+            request.resolved_inputs,
             credential_material,
         )?
         else {
@@ -324,27 +475,23 @@ impl OAuthCredentialService {
 
     async fn authorize_device_code<F, Fut>(
         &self,
-        input_key: String,
-        oauth: ManifestOAuthCredentialSpec,
-        endpoints: ManifestOAuthEndpointUrls,
-        client_id: String,
-        client_secret: Option<String>,
+        common: OAuthSessionCommon,
         on_authorization: F,
     ) -> Result<OAuthCredentialMaterial, AppError>
     where
         F: FnOnce(OAuthAuthorization) -> Fut,
         Fut: Future<Output = Result<(), AppError>>,
     {
-        if client_secret.is_some() {
+        if common.client_secret.is_some() {
             return Err(AppError::InvalidInput(
                 "device_code OAuth methods must not declare a client secret".to_string(),
             ));
         }
         let device = request_device_code(
             &self.http,
-            &oauth,
-            &endpoints,
-            &client_id,
+            &common.oauth,
+            &common.endpoints,
+            &common.client_id,
             DEVICE_CODE_REQUEST_TIMEOUT,
         )
         .await?;
@@ -356,13 +503,6 @@ impl OAuthCredentialService {
         let verification_uri = device.verification_uri.clone();
         let verification_uri_complete = device.verification_uri_complete.clone();
         let expires_in = device.expires_in;
-        let common = OAuthSessionCommon {
-            input_key,
-            oauth,
-            endpoints,
-            client_id,
-            client_secret: None,
-        };
         let session = DeviceCodeSessionConfig {
             common,
             device_code: device.device_code,
@@ -602,6 +742,7 @@ fn build_authorization_url(
     let mut url = Url::parse(authorization_url).map_err(|error| {
         AppError::InvalidInput(format!("invalid OAuth authorization URL: {error}"))
     })?;
+    ensure_oauth_url_uses_credential_safe_transport("OAuth authorization URL", &url)?;
     {
         let mut query = url.query_pairs_mut();
         query
@@ -622,6 +763,36 @@ fn build_authorization_url(
         }
     }
     Ok(url.to_string())
+}
+
+fn ensure_oauth_endpoint_uses_credential_safe_transport(
+    label: &str,
+    endpoint_url: &str,
+) -> Result<(), AppError> {
+    let url = Url::parse(endpoint_url)
+        .map_err(|error| AppError::InvalidInput(format!("{label} is invalid: {error}")))?;
+    ensure_oauth_url_uses_credential_safe_transport(label, &url)
+}
+
+fn ensure_oauth_url_uses_credential_safe_transport(label: &str, url: &Url) -> Result<(), AppError> {
+    if url.scheme() == "https" || is_loopback_http_url(url) {
+        return Ok(());
+    }
+    let host = url.host_str().unwrap_or("<missing>");
+    Err(AppError::InvalidInput(format!(
+        "{label} must use https or loopback http, got {}://{host}",
+        url.scheme()
+    )))
+}
+
+fn is_loopback_http_url(url: &Url) -> bool {
+    url.scheme() == "http"
+        && url.host_str().is_some_and(|host| {
+            host.eq_ignore_ascii_case("localhost")
+                || host
+                    .parse::<IpAddr>()
+                    .is_ok_and(|address| address.is_loopback())
+        })
 }
 
 fn join_scope_values(delimiter: ManifestOAuthScopeDelimiter, values: &[String]) -> String {
@@ -878,6 +1049,10 @@ async fn request_device_code(
                     "device_code OAuth method is missing device_authorization_url".to_string(),
                 )
             })?;
+    ensure_oauth_endpoint_uses_credential_safe_transport(
+        "OAuth device authorization URL",
+        device_authorization_url,
+    )?;
     let mut form = vec![("client_id", client_id.to_string())];
     if let Some(scopes) = oauth.scopes.as_ref() {
         form.push((
@@ -961,6 +1136,10 @@ async fn poll_device_token(
     http: &reqwest::Client,
     session: &DeviceCodeSessionConfig,
 ) -> Result<TokenResponse, AppError> {
+    ensure_oauth_endpoint_uses_credential_safe_transport(
+        "OAuth device token URL",
+        &session.common.endpoints.token_url,
+    )?;
     let deadline = Instant::now() + session.expires_in;
     let mut interval = session.interval;
     loop {
@@ -1038,6 +1217,10 @@ async fn exchange_authorization_code(
     session: &AuthorizationCodeSessionConfig,
     code: &str,
 ) -> Result<TokenResponse, AppError> {
+    ensure_oauth_endpoint_uses_credential_safe_transport(
+        "OAuth token exchange URL",
+        &session.common.endpoints.token_url,
+    )?;
     let mut form = vec![
         ("grant_type", "authorization_code".to_string()),
         ("code", code.to_string()),
@@ -1069,6 +1252,10 @@ async fn refresh_access_token(
     http: &reqwest::Client,
     refresh: &OAuthRefreshConfig,
 ) -> Result<TokenResponse, AppError> {
+    ensure_oauth_endpoint_uses_credential_safe_transport(
+        "OAuth token refresh URL",
+        &refresh.token_url,
+    )?;
     let mut form = vec![
         ("grant_type", "refresh_token".to_string()),
         ("refresh_token", refresh.refresh_token.clone()),
@@ -1248,19 +1435,25 @@ fn oauth_credential_material(
     if let Some(scope) = token.scope.as_deref() {
         internal_metadata.insert(format!("{prefix}scope"), scope.to_string());
     }
-    internal_metadata.insert(format!("{prefix}client_id"), session.client_id.clone());
-    internal_metadata.insert(
-        format!("{prefix}token_url"),
-        session.endpoints.token_url.clone(),
-    );
-    if let Some(secret) = session.oauth.client.secret.as_ref() {
+    if session.client_material_persistence.stores_client_id() {
+        internal_metadata.insert(format!("{prefix}client_id"), session.client_id.clone());
+    }
+    if session.client_material_persistence == OAuthClientMaterialPersistence::All {
         internal_metadata.insert(
-            format!("{prefix}client_secret_transport"),
-            secret.transport.label().to_string(),
+            format!("{prefix}token_url"),
+            session.endpoints.token_url.clone(),
         );
     }
-    if let Some(client_secret) = session.client_secret.as_deref() {
-        internal_metadata.insert(format!("{prefix}client_secret"), client_secret.to_string());
+    if session.client_material_persistence.stores_client_secret() {
+        if let Some(secret) = session.oauth.client.secret.as_ref() {
+            internal_metadata.insert(
+                format!("{prefix}client_secret_transport"),
+                secret.transport.label().to_string(),
+            );
+        }
+        if let Some(client_secret) = session.client_secret.as_deref() {
+            internal_metadata.insert(format!("{prefix}client_secret"), client_secret.to_string());
+        }
     }
     OAuthCredentialMaterial {
         input_key: session.input_key.clone(),
@@ -1282,11 +1475,15 @@ fn oauth_metadata_prefix(input_key: &str) -> String {
 }
 
 fn oauth_refresh_config(
-    access_token_material_key: &str,
+    material_label: &str,
+    reconnect_label: &str,
     metadata_prefix: &str,
     oauth: &ManifestOAuthCredentialSpec,
+    resolved_inputs: Option<&BTreeMap<String, String>>,
     material: &BTreeMap<String, String>,
 ) -> Result<Option<OAuthRefreshConfig>, AppError> {
+    let empty_resolved_inputs = BTreeMap::new();
+    let resolved_inputs = resolved_inputs.unwrap_or(&empty_resolved_inputs);
     if material
         .get(&format!("{metadata_prefix}method"))
         .map(String::as_str)
@@ -1301,7 +1498,7 @@ fn oauth_refresh_config(
     let expires_at = DateTime::parse_from_rfc3339(expires_at)
         .map_err(|error| {
             AppError::FailedPrecondition(format!(
-                "stored OAuth access token expiry for source secret '{access_token_material_key}' is invalid: {error}"
+                "stored OAuth access token expiry for {material_label} is invalid: {error}"
             ))
         })?
         .with_timezone(&Utc);
@@ -1318,43 +1515,33 @@ fn oauth_refresh_config(
             return Ok(None);
         }
         return Err(AppError::FailedPrecondition(format!(
-            "OAuth access token for source secret '{access_token_material_key}' expired and cannot be refreshed because no refresh token is stored; reconnect the source"
+            "OAuth access token for {material_label} expired and cannot be refreshed because no refresh token is stored; {reconnect_label}"
         )));
     };
-    let client_id = material
-        .get(&format!("{metadata_prefix}client_id"))
-        .filter(|value| !value.is_empty())
-        .cloned()
-        .or_else(|| oauth.client.id.default.clone())
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            AppError::FailedPrecondition(format!(
-                "OAuth access token for source secret '{access_token_material_key}' expired and cannot be refreshed because client ID metadata is missing"
-            ))
-        })?;
-    let token_url = material
-        .get(&format!("{metadata_prefix}token_url"))
-        .filter(|value| !value.is_empty())
-        .cloned()
-        .unwrap_or_else(|| oauth.token_url.clone());
+    let client_id = oauth_refresh_client_id(
+        material_label,
+        metadata_prefix,
+        oauth,
+        resolved_inputs,
+        material,
+    )?;
+    let token_url = oauth_refresh_token_url(metadata_prefix, oauth, resolved_inputs, material)?;
     let client_secret_transport = material
         .get(&format!("{metadata_prefix}client_secret_transport"))
         .map(|value| {
             ManifestOAuthClientSecretTransport::from_label(value).ok_or_else(|| {
                 AppError::FailedPrecondition(format!(
-                    "stored OAuth client secret transport for source secret '{access_token_material_key}' is invalid: {value}"
+                    "stored OAuth client secret transport for {material_label} is invalid: {value}"
                 ))
             })
         })
         .transpose()?
         .or_else(|| oauth.client.secret.as_ref().map(|secret| secret.transport));
-    let client_secret = material
-        .get(&format!("{metadata_prefix}client_secret"))
-        .filter(|value| !value.is_empty())
-        .cloned();
+    let client_secret =
+        oauth_refresh_client_secret(metadata_prefix, oauth, resolved_inputs, material);
     if client_secret_transport.is_some() && client_secret.is_none() {
         return Err(AppError::FailedPrecondition(format!(
-            "OAuth access token for source secret '{access_token_material_key}' expired and cannot be refreshed because client secret metadata is missing"
+            "OAuth access token for {material_label} expired and cannot be refreshed because client secret metadata is missing"
         )));
     }
     Ok(Some(OAuthRefreshConfig {
@@ -1364,6 +1551,77 @@ fn oauth_refresh_config(
         client_secret_transport,
         refresh_token,
     }))
+}
+
+fn oauth_refresh_client_id(
+    material_label: &str,
+    metadata_prefix: &str,
+    oauth: &ManifestOAuthCredentialSpec,
+    resolved_inputs: &BTreeMap<String, String>,
+    material: &BTreeMap<String, String>,
+) -> Result<String, AppError> {
+    material
+        .get(&format!("{metadata_prefix}client_id"))
+        .filter(|value| !value.is_empty())
+        .cloned()
+        .or_else(|| {
+            oauth.client
+                .id
+                .input
+                .as_deref()
+                .and_then(|input| resolved_inputs.get(input))
+                .filter(|value| !value.is_empty())
+                .cloned()
+        })
+        .or_else(|| oauth.client.id.default.clone())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            AppError::FailedPrecondition(format!(
+                "OAuth access token for {material_label} expired and cannot be refreshed because client ID metadata is missing"
+            ))
+        })
+}
+
+fn oauth_refresh_token_url(
+    metadata_prefix: &str,
+    oauth: &ManifestOAuthCredentialSpec,
+    resolved_inputs: &BTreeMap<String, String>,
+    material: &BTreeMap<String, String>,
+) -> Result<String, AppError> {
+    material
+        .get(&format!("{metadata_prefix}token_url"))
+        .filter(|value| !value.is_empty())
+        .cloned()
+        .map_or_else(
+            || {
+                oauth
+                    .endpoint_urls(resolved_inputs)
+                    .map(|endpoints| endpoints.token_url)
+                    .map_err(|error| AppError::FailedPrecondition(error.to_string()))
+            },
+            Ok,
+        )
+}
+
+fn oauth_refresh_client_secret(
+    metadata_prefix: &str,
+    oauth: &ManifestOAuthCredentialSpec,
+    resolved_inputs: &BTreeMap<String, String>,
+    material: &BTreeMap<String, String>,
+) -> Option<String> {
+    material
+        .get(&format!("{metadata_prefix}client_secret"))
+        .filter(|value| !value.is_empty())
+        .cloned()
+        .or_else(|| {
+            oauth
+                .client
+                .secret
+                .as_ref()
+                .and_then(|secret| resolved_inputs.get(&secret.input))
+                .filter(|value| !value.is_empty())
+                .cloned()
+        })
 }
 
 fn apply_refreshed_token(
@@ -1449,10 +1707,11 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        AuthorizationCodeSessionConfig, OAuthCredentialService, OAuthSessionCommon,
-        RefreshOAuthCredentialRequest, StartOAuthCredentialRequest, basic_client_authorization,
-        join_scope_values, material_key_belongs_to_input, oauth_metadata_prefix,
-        parse_token_response, pkce_challenge, receive_callback, request_device_code,
+        AuthorizationCodeSessionConfig, OAuthClientMaterialPersistence, OAuthCredentialService,
+        OAuthSessionCommon, RefreshOAuthCredentialRequest, StartOAuthCredentialRequest,
+        basic_client_authorization, join_scope_values, material_key_belongs_to_input,
+        oauth_metadata_prefix, parse_token_response, pkce_challenge, receive_callback,
+        request_device_code,
     };
     use coral_spec::{
         ManifestOAuthClientIdSpec, ManifestOAuthClientSecretSpec,
@@ -1583,6 +1842,56 @@ mod tests {
             Some("rotated-refresh-token")
         );
         assert!(captured.authorization.is_none());
+    }
+
+    #[tokio::test]
+    async fn expired_oauth_material_rejects_non_https_non_loopback_refresh_url() {
+        let token_url = "http://provider.example.test/access_token";
+        let oauth = oauth_spec(
+            token_url,
+            free_loopback_port(),
+            ManifestOAuthPkceMode::Disabled,
+            ManifestOAuthClientSpec {
+                id: ManifestOAuthClientIdSpec {
+                    default: Some("default-client".to_string()),
+                    input: None,
+                },
+                secret: None,
+            },
+        );
+        let prefix = oauth_metadata_prefix("API_TOKEN");
+        let mut material = BTreeMap::from([
+            ("API_TOKEN".to_string(), "expired-token".to_string()),
+            (format!("{prefix}method"), "oauth".to_string()),
+            (
+                format!("{prefix}access_token_expires_at"),
+                (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
+            ),
+            (
+                format!("{prefix}refresh_token"),
+                "stored-refresh-token".to_string(),
+            ),
+            (format!("{prefix}client_id"), "stored-client".to_string()),
+            (format!("{prefix}token_url"), token_url.to_string()),
+        ]);
+        let service = OAuthCredentialService::new();
+
+        let error = service
+            .refresh_if_needed(
+                RefreshOAuthCredentialRequest::for_source_input("API_TOKEN", &oauth),
+                &mut material,
+            )
+            .await
+            .expect_err("non-https non-loopback refresh URL should fail before request");
+
+        assert!(
+            error.to_string().contains("must use https"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            material.get("API_TOKEN").map(String::as_str),
+            Some("expired-token")
+        );
     }
 
     #[tokio::test]
@@ -1823,6 +2132,7 @@ mod tests {
                     "OAUTH_CLIENT_ID".to_string(),
                     "override-client".to_string(),
                 )],
+                client_material_persistence: OAuthClientMaterialPersistence::All,
             },
             move |authorization| async move {
                 authorization_tx
@@ -1865,6 +2175,7 @@ mod tests {
         let (completed, ()) = tokio::join!(authorize, callback);
         let completed = completed.expect("authorize oauth");
         let captured = fixture.token_server.await.expect("token server");
+        let metadata_prefix = oauth_metadata_prefix("API_TOKEN");
 
         assert_eq!(completed.input_key, "API_TOKEN");
         assert_eq!(completed.access_token, "access-token");
@@ -1882,17 +2193,14 @@ mod tests {
         assert_eq!(
             completed
                 .internal_metadata
-                .get(&format!(
-                    "{}refresh_token",
-                    oauth_metadata_prefix("API_TOKEN")
-                ))
+                .get(&format!("{metadata_prefix}refresh_token"))
                 .map(String::as_str),
             Some("refresh-token")
         );
         assert_eq!(
             completed
                 .internal_metadata
-                .get(&format!("{}client_id", oauth_metadata_prefix("API_TOKEN")))
+                .get(&format!("{metadata_prefix}client_id"))
                 .map(String::as_str),
             Some("override-client")
         );
@@ -1918,6 +2226,7 @@ mod tests {
                     "OAUTH_CLIENT_ID".to_string(),
                     "device-client".to_string(),
                 )],
+                client_material_persistence: OAuthClientMaterialPersistence::All,
             },
             move |authorization| async move {
                 authorization_tx.send(authorization).map_err(|_error| {
@@ -1998,6 +2307,7 @@ mod tests {
                     "OAUTH_CLIENT_ID".to_string(),
                     "device-client".to_string(),
                 )],
+                client_material_persistence: OAuthClientMaterialPersistence::All,
             },
             |_authorization| async { Ok(()) },
         );
@@ -2083,6 +2393,7 @@ mod tests {
                     ("OAUTH_CLIENT_ID".to_string(), "client".to_string()),
                     ("OAUTH_CLIENT_SECRET".to_string(), "secret".to_string()),
                 ],
+                client_material_persistence: OAuthClientMaterialPersistence::All,
             },
             move |authorization| async move {
                 authorization_tx
@@ -2150,6 +2461,7 @@ mod tests {
                 endpoints,
                 client_id: "client".to_string(),
                 client_secret: None,
+                client_material_persistence: OAuthClientMaterialPersistence::All,
             },
             state: "expected-state".to_string(),
             code_verifier: None,
@@ -2217,6 +2529,7 @@ mod tests {
                 endpoints,
                 client_id: "client".to_string(),
                 client_secret: None,
+                client_material_persistence: OAuthClientMaterialPersistence::All,
             },
             state: "expected-state".to_string(),
             code_verifier: None,
@@ -2278,6 +2591,7 @@ mod tests {
                     ("OAUTH_CLIENT_ID".to_string(), "client".to_string()),
                     ("OAUTH_CLIENT_SECRET".to_string(), "secret".to_string()),
                 ],
+                client_material_persistence: OAuthClientMaterialPersistence::All,
             },
             move |authorization| async move {
                 authorization_tx
@@ -2329,6 +2643,7 @@ mod tests {
                 oauth: &oauth,
                 source_inputs: &EMPTY_SOURCE_INPUTS,
                 credential_inputs: Vec::new(),
+                client_material_persistence: OAuthClientMaterialPersistence::All,
             },
             move |authorization| async move {
                 authorization_tx
@@ -2389,6 +2704,7 @@ mod tests {
                 oauth: &oauth,
                 source_inputs: &EMPTY_SOURCE_INPUTS,
                 credential_inputs: Vec::new(),
+                client_material_persistence: OAuthClientMaterialPersistence::All,
             },
             move |authorization| async move {
                 authorization_tx

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -579,12 +579,16 @@ fn normalize_credential_inputs(
     inputs: Vec<(String, String)>,
 ) -> Result<BTreeMap<String, String>, AppError> {
     let mut normalized = BTreeMap::new();
+    let mut seen = BTreeSet::new();
     for (key, value) in inputs {
         let key = normalize_credential_input_key(&key)?;
-        if normalized.insert(key.clone(), value).is_some() {
+        if !seen.insert(key.clone()) {
             return Err(AppError::InvalidInput(format!(
                 "credential input '{key}' is repeated"
             )));
+        }
+        if let Some(value) = trimmed_non_empty(value.as_str()) {
+            normalized.insert(key, value.to_string());
         }
     }
     Ok(normalized)
@@ -621,6 +625,11 @@ fn normalize_credential_input_key(value: &str) -> Result<String, AppError> {
     Ok(trimmed.to_string())
 }
 
+fn trimmed_non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
 fn reject_unknown_credential_inputs(
     oauth: &ManifestOAuthCredentialSpec,
     inputs: &BTreeMap<String, String>,
@@ -648,12 +657,12 @@ fn resolve_client_id(
 ) -> Result<String, AppError> {
     if let Some(input_key) = oauth.client.id.input.as_deref()
         && let Some(value) = inputs.get(input_key)
-        && !value.is_empty()
+        && let Some(value) = trimmed_non_empty(value)
     {
-        return Ok(value.clone());
+        return Ok(value.to_string());
     }
     if let Some(default) = oauth.client.id.default.as_deref()
-        && !default.is_empty()
+        && let Some(default) = trimmed_non_empty(default)
     {
         return Ok(default.to_string());
     }
@@ -677,13 +686,16 @@ fn resolve_client_secret(
     let Some(secret) = oauth.client.secret.as_ref() else {
         return Ok(None);
     };
-    let Some(value) = inputs.get(&secret.input).filter(|value| !value.is_empty()) else {
+    let Some(value) = inputs
+        .get(&secret.input)
+        .and_then(|value| trimmed_non_empty(value))
+    else {
         return Err(AppError::FailedPrecondition(format!(
             "missing OAuth client secret input '{}'",
             secret.input
         )));
     };
-    Ok(Some(value.clone()))
+    Ok(Some(value.to_string()))
 }
 
 async fn bind_redirect_listener(
@@ -1124,7 +1136,7 @@ fn parse_device_authorization_response(
     let verification_uri_complete = body
         .get("verification_uri_complete")
         .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
+        .and_then(trimmed_non_empty)
         .map(ToString::to_string);
     let expires_in = Duration::from_secs(json_u64_field(&body, "expires_in")?.max(1));
     let interval = Duration::from_secs(
@@ -1354,7 +1366,7 @@ fn parse_token_response_value(body: &Value) -> Result<TokenResponse, AppError> {
     let access_token = body
         .get("access_token")
         .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
+        .and_then(trimmed_non_empty)
         .ok_or_else(|| {
             AppError::FailedPrecondition(
                 "OAuth token response did not include access_token".to_string(),
@@ -1364,17 +1376,17 @@ fn parse_token_response_value(body: &Value) -> Result<TokenResponse, AppError> {
     let refresh_token = body
         .get("refresh_token")
         .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
+        .and_then(trimmed_non_empty)
         .map(ToString::to_string);
     let token_type = body
         .get("token_type")
         .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
+        .and_then(trimmed_non_empty)
         .map(ToString::to_string);
     let scope = body
         .get("scope")
         .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
+        .and_then(trimmed_non_empty)
         .map(ToString::to_string);
     let expires_at = body
         .get("expires_in")
@@ -1393,7 +1405,7 @@ fn parse_token_response_value(body: &Value) -> Result<TokenResponse, AppError> {
 fn json_string_field<'a>(body: &'a Value, field: &str) -> Result<&'a str, AppError> {
     body.get(field)
         .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
+        .and_then(trimmed_non_empty)
         .ok_or_else(|| {
             AppError::FailedPrecondition(format!("OAuth response did not include {field}"))
         })
@@ -1416,7 +1428,7 @@ fn oauth_error_message(body: &Value) -> Option<String> {
         .get("error_description")
         .or_else(|| body.get("error_description_uri"))
         .and_then(Value::as_str)
-        .filter(|value| !value.is_empty());
+        .and_then(trimmed_non_empty);
     Some(match description {
         Some(description) => format!("{error}: {description}"),
         None => error.to_string(),
@@ -1461,7 +1473,7 @@ fn oauth_credential_material(
                 secret.transport.label().to_string(),
             );
         }
-        if let Some(client_secret) = session.client_secret.as_deref() {
+        if let Some(client_secret) = session.client_secret.as_deref().and_then(trimmed_non_empty) {
             internal_metadata.insert(format!("{prefix}client_secret"), client_secret.to_string());
         }
     }
@@ -1518,8 +1530,8 @@ fn oauth_refresh_config(
     }
     let Some(refresh_token) = material
         .get(&format!("{metadata_prefix}refresh_token"))
-        .filter(|value| !value.is_empty())
-        .cloned()
+        .and_then(|value| trimmed_non_empty(value))
+        .map(ToString::to_string)
     else {
         if expires_at > now {
             return Ok(None);
@@ -1572,19 +1584,25 @@ fn oauth_refresh_client_id(
 ) -> Result<String, AppError> {
     material
         .get(&format!("{metadata_prefix}client_id"))
-        .filter(|value| !value.is_empty())
-        .cloned()
+        .and_then(|value| trimmed_non_empty(value))
+        .map(ToString::to_string)
         .or_else(|| {
             oauth.client
                 .id
                 .input
                 .as_deref()
                 .and_then(|input| resolved_inputs.get(input))
-                .filter(|value| !value.is_empty())
-                .cloned()
+                .and_then(|value| trimmed_non_empty(value))
+                .map(ToString::to_string)
         })
-        .or_else(|| oauth.client.id.default.clone())
-        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            oauth.client
+                .id
+                .default
+                .as_deref()
+                .and_then(trimmed_non_empty)
+                .map(ToString::to_string)
+        })
         .ok_or_else(|| {
             AppError::FailedPrecondition(format!(
                 "OAuth access token for {material_label} expired and cannot be refreshed because client ID metadata is missing"
@@ -1600,8 +1618,8 @@ fn oauth_refresh_token_url(
 ) -> Result<String, AppError> {
     material
         .get(&format!("{metadata_prefix}token_url"))
-        .filter(|value| !value.is_empty())
-        .cloned()
+        .and_then(|value| trimmed_non_empty(value))
+        .map(ToString::to_string)
         .map_or_else(
             || {
                 oauth
@@ -1621,16 +1639,16 @@ fn oauth_refresh_client_secret(
 ) -> Option<String> {
     material
         .get(&format!("{metadata_prefix}client_secret"))
-        .filter(|value| !value.is_empty())
-        .cloned()
+        .and_then(|value| trimmed_non_empty(value))
+        .map(ToString::to_string)
         .or_else(|| {
             oauth
                 .client
                 .secret
                 .as_ref()
                 .and_then(|secret| resolved_inputs.get(&secret.input))
-                .filter(|value| !value.is_empty())
-                .cloned()
+                .and_then(|value| trimmed_non_empty(value))
+                .map(ToString::to_string)
         })
 }
 
@@ -1775,6 +1793,33 @@ mod tests {
     }
 
     #[test]
+    fn whitespace_only_oauth_credential_input_is_treated_as_missing() {
+        let oauth = oauth_spec(
+            "https://provider.example.com/oauth/token",
+            free_loopback_port(),
+            ManifestOAuthPkceMode::Disabled,
+            confidential_client(ManifestOAuthClientSecretTransport::RequestBody),
+        );
+
+        let error = OAuthCredentialService::validate_credential_inputs(
+            &oauth,
+            &EMPTY_SOURCE_INPUTS,
+            vec![
+                (" OAUTH_CLIENT_ID ".to_string(), " client ".to_string()),
+                ("OAUTH_CLIENT_SECRET".to_string(), "   ".to_string()),
+            ],
+        )
+        .expect_err("blank client secret should be missing");
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing OAuth client secret input 'OAUTH_CLIENT_SECRET'"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
     fn token_response_ignores_unrepresentable_expires_in() {
         let token = parse_token_response(
             r#"{"access_token":"access-token","expires_in":9223372036854775807}"#,
@@ -1783,6 +1828,20 @@ mod tests {
 
         assert_eq!(token.access_token, "access-token");
         assert!(token.expires_at.is_none());
+    }
+
+    #[test]
+    fn token_response_rejects_whitespace_only_access_token() {
+        let Err(error) = parse_token_response(r#"{"access_token":"   "}"#) else {
+            panic!("blank access token should be missing");
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("OAuth token response did not include access_token"),
+            "unexpected error: {error:#}"
+        );
     }
 
     #[tokio::test]
@@ -2082,7 +2141,7 @@ mod tests {
             (format!("{prefix}client_id"), "stored-client".to_string()),
             (
                 format!("{prefix}client_secret"),
-                "stored-secret".to_string(),
+                " stored-secret ".to_string(),
             ),
             (
                 format!("{prefix}client_secret_transport"),
@@ -2403,8 +2462,8 @@ mod tests {
                 oauth: &oauth,
                 source_inputs: &EMPTY_SOURCE_INPUTS,
                 credential_inputs: vec![
-                    ("OAUTH_CLIENT_ID".to_string(), "client".to_string()),
-                    ("OAUTH_CLIENT_SECRET".to_string(), "secret".to_string()),
+                    (" OAUTH_CLIENT_ID ".to_string(), " client ".to_string()),
+                    ("OAUTH_CLIENT_SECRET".to_string(), " secret ".to_string()),
                 ],
                 refresh_material_persistence:
                     OAuthRefreshMaterialPersistence::CompleteRefreshContext,

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -169,8 +169,8 @@ impl OAuthRefreshMaterialPersistence {
 
 pub(crate) struct RefreshOAuthCredentialRequest<'a> {
     access_token_material_key: &'a str,
-    material_label: String,
-    reconnect_label: &'static str,
+    error_subject: String,
+    reconnect_hint: &'static str,
     metadata_prefix: String,
     oauth: &'a ManifestOAuthCredentialSpec,
     resolved_inputs: Option<&'a BTreeMap<String, String>>,
@@ -183,8 +183,8 @@ impl<'a> RefreshOAuthCredentialRequest<'a> {
     ) -> Self {
         Self {
             access_token_material_key: input_key,
-            material_label: format!("source secret '{input_key}'"),
-            reconnect_label: "reconnect the source",
+            error_subject: format!("source secret '{input_key}'"),
+            reconnect_hint: "reconnect the source",
             metadata_prefix: oauth_metadata_prefix(input_key),
             oauth,
             resolved_inputs: None,
@@ -199,8 +199,8 @@ impl<'a> RefreshOAuthCredentialRequest<'a> {
     ) -> Self {
         Self {
             access_token_material_key,
-            material_label: format!("identity '{identity_name}'"),
-            reconnect_label: "reconnect the identity",
+            error_subject: format!("identity '{identity_name}'"),
+            reconnect_hint: "reconnect the identity",
             metadata_prefix: oauth_metadata_prefix(access_token_material_key),
             oauth,
             resolved_inputs: Some(resolved_inputs),
@@ -463,8 +463,8 @@ impl OAuthCredentialService {
         credential_material: &mut BTreeMap<String, String>,
     ) -> Result<bool, AppError> {
         let Some(refresh) = oauth_refresh_config(
-            request.material_label.as_str(),
-            request.reconnect_label,
+            request.error_subject.as_str(),
+            request.reconnect_hint,
             request.metadata_prefix.as_str(),
             request.oauth,
             request.resolved_inputs,
@@ -1497,8 +1497,8 @@ fn oauth_metadata_prefix(input_key: &str) -> String {
 }
 
 fn oauth_refresh_config(
-    material_label: &str,
-    reconnect_label: &str,
+    error_subject: &str,
+    reconnect_hint: &str,
     metadata_prefix: &str,
     oauth: &ManifestOAuthCredentialSpec,
     resolved_inputs: Option<&BTreeMap<String, String>>,
@@ -1520,7 +1520,7 @@ fn oauth_refresh_config(
     let expires_at = DateTime::parse_from_rfc3339(expires_at)
         .map_err(|error| {
             AppError::FailedPrecondition(format!(
-                "stored OAuth access token expiry for {material_label} is invalid: {error}"
+                "stored OAuth access token expiry for {error_subject} is invalid: {error}"
             ))
         })?
         .with_timezone(&Utc);
@@ -1537,11 +1537,11 @@ fn oauth_refresh_config(
             return Ok(None);
         }
         return Err(AppError::FailedPrecondition(format!(
-            "OAuth access token for {material_label} expired and cannot be refreshed because no refresh token is stored; {reconnect_label}"
+            "OAuth access token for {error_subject} expired and cannot be refreshed because no refresh token is stored; {reconnect_hint}"
         )));
     };
     let client_id = oauth_refresh_client_id(
-        material_label,
+        error_subject,
         metadata_prefix,
         oauth,
         resolved_inputs,
@@ -1553,7 +1553,7 @@ fn oauth_refresh_config(
         .map(|value| {
             ManifestOAuthClientSecretTransport::from_label(value).ok_or_else(|| {
                 AppError::FailedPrecondition(format!(
-                    "stored OAuth client secret transport for {material_label} is invalid: {value}"
+                    "stored OAuth client secret transport for {error_subject} is invalid: {value}"
                 ))
             })
         })
@@ -1563,7 +1563,7 @@ fn oauth_refresh_config(
         oauth_refresh_client_secret(metadata_prefix, oauth, resolved_inputs, material);
     if client_secret_transport.is_some() && client_secret.is_none() {
         return Err(AppError::FailedPrecondition(format!(
-            "OAuth access token for {material_label} expired and cannot be refreshed because client secret metadata is missing"
+            "OAuth access token for {error_subject} expired and cannot be refreshed because client secret metadata is missing"
         )));
     }
     Ok(Some(OAuthRefreshConfig {
@@ -1576,7 +1576,7 @@ fn oauth_refresh_config(
 }
 
 fn oauth_refresh_client_id(
-    material_label: &str,
+    error_subject: &str,
     metadata_prefix: &str,
     oauth: &ManifestOAuthCredentialSpec,
     resolved_inputs: &BTreeMap<String, String>,
@@ -1605,7 +1605,7 @@ fn oauth_refresh_client_id(
         })
         .ok_or_else(|| {
             AppError::FailedPrecondition(format!(
-                "OAuth access token for {material_label} expired and cannot be refreshed because client ID metadata is missing"
+                "OAuth access token for {error_subject} expired and cannot be refreshed because client ID metadata is missing"
             ))
         })
 }

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -45,17 +45,23 @@ pub(crate) struct StartOAuthCredentialRequest<'a> {
     pub(crate) oauth: &'a ManifestOAuthCredentialSpec,
     pub(crate) source_inputs: &'a BTreeMap<String, String>,
     pub(crate) credential_inputs: Vec<(String, String)>,
-    pub(crate) client_material_persistence: OAuthClientMaterialPersistence,
+    pub(crate) refresh_material_persistence: OAuthRefreshMaterialPersistence,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum OAuthClientMaterialPersistence {
+pub(crate) enum OAuthRefreshMaterialPersistence {
+    /// Do not persist OAuth refresh context that can be derived later from the
+    /// source or identity spec.
     None,
-    ClientCredentials {
+    /// Persist only refresh context values that were supplied directly for this
+    /// credential and will not be available from spec-level input material.
+    PartialRefreshContext {
         client_id: bool,
         client_secret: bool,
     },
-    All,
+    /// Persist every non-token value required to refresh standalone credential
+    /// material without resolved source or identity-spec input context.
+    CompleteRefreshContext,
 }
 
 /// Progress event emitted while an OAuth credential authorization runs.
@@ -133,12 +139,12 @@ impl PendingOAuthProgressEvent {
     }
 }
 
-impl OAuthClientMaterialPersistence {
+impl OAuthRefreshMaterialPersistence {
     fn stores_client_id(self) -> bool {
         matches!(
             self,
-            Self::All
-                | Self::ClientCredentials {
+            Self::CompleteRefreshContext
+                | Self::PartialRefreshContext {
                     client_id: true,
                     ..
                 }
@@ -148,12 +154,16 @@ impl OAuthClientMaterialPersistence {
     fn stores_client_secret(self) -> bool {
         matches!(
             self,
-            Self::All
-                | Self::ClientCredentials {
+            Self::CompleteRefreshContext
+                | Self::PartialRefreshContext {
                     client_secret: true,
                     ..
                 }
         )
+    }
+
+    fn stores_token_url(self) -> bool {
+        matches!(self, Self::CompleteRefreshContext)
     }
 }
 
@@ -220,7 +230,7 @@ struct OAuthSessionCommon {
     endpoints: ManifestOAuthEndpointUrls,
     client_id: String,
     client_secret: Option<String>,
-    client_material_persistence: OAuthClientMaterialPersistence,
+    refresh_material_persistence: OAuthRefreshMaterialPersistence,
 }
 
 struct AuthorizationCodeSessionConfig {
@@ -353,7 +363,7 @@ impl OAuthCredentialService {
             endpoints,
             client_id,
             client_secret,
-            client_material_persistence: request.client_material_persistence,
+            refresh_material_persistence: request.refresh_material_persistence,
         };
         match flow_kind {
             ManifestOAuthFlowKind::AuthorizationCode => {
@@ -1435,16 +1445,16 @@ fn oauth_credential_material(
     if let Some(scope) = token.scope.as_deref() {
         internal_metadata.insert(format!("{prefix}scope"), scope.to_string());
     }
-    if session.client_material_persistence.stores_client_id() {
+    if session.refresh_material_persistence.stores_client_id() {
         internal_metadata.insert(format!("{prefix}client_id"), session.client_id.clone());
     }
-    if session.client_material_persistence == OAuthClientMaterialPersistence::All {
+    if session.refresh_material_persistence.stores_token_url() {
         internal_metadata.insert(
             format!("{prefix}token_url"),
             session.endpoints.token_url.clone(),
         );
     }
-    if session.client_material_persistence.stores_client_secret() {
+    if session.refresh_material_persistence.stores_client_secret() {
         if let Some(secret) = session.oauth.client.secret.as_ref() {
             internal_metadata.insert(
                 format!("{prefix}client_secret_transport"),
@@ -1707,7 +1717,7 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        AuthorizationCodeSessionConfig, OAuthClientMaterialPersistence, OAuthCredentialService,
+        AuthorizationCodeSessionConfig, OAuthCredentialService, OAuthRefreshMaterialPersistence,
         OAuthSessionCommon, RefreshOAuthCredentialRequest, StartOAuthCredentialRequest,
         basic_client_authorization, join_scope_values, material_key_belongs_to_input,
         oauth_metadata_prefix, parse_token_response, pkce_challenge, receive_callback,
@@ -2132,7 +2142,8 @@ mod tests {
                     "OAUTH_CLIENT_ID".to_string(),
                     "override-client".to_string(),
                 )],
-                client_material_persistence: OAuthClientMaterialPersistence::All,
+                refresh_material_persistence:
+                    OAuthRefreshMaterialPersistence::CompleteRefreshContext,
             },
             move |authorization| async move {
                 authorization_tx
@@ -2226,7 +2237,8 @@ mod tests {
                     "OAUTH_CLIENT_ID".to_string(),
                     "device-client".to_string(),
                 )],
-                client_material_persistence: OAuthClientMaterialPersistence::All,
+                refresh_material_persistence:
+                    OAuthRefreshMaterialPersistence::CompleteRefreshContext,
             },
             move |authorization| async move {
                 authorization_tx.send(authorization).map_err(|_error| {
@@ -2307,7 +2319,8 @@ mod tests {
                     "OAUTH_CLIENT_ID".to_string(),
                     "device-client".to_string(),
                 )],
-                client_material_persistence: OAuthClientMaterialPersistence::All,
+                refresh_material_persistence:
+                    OAuthRefreshMaterialPersistence::CompleteRefreshContext,
             },
             |_authorization| async { Ok(()) },
         );
@@ -2393,7 +2406,8 @@ mod tests {
                     ("OAUTH_CLIENT_ID".to_string(), "client".to_string()),
                     ("OAUTH_CLIENT_SECRET".to_string(), "secret".to_string()),
                 ],
-                client_material_persistence: OAuthClientMaterialPersistence::All,
+                refresh_material_persistence:
+                    OAuthRefreshMaterialPersistence::CompleteRefreshContext,
             },
             move |authorization| async move {
                 authorization_tx
@@ -2461,7 +2475,8 @@ mod tests {
                 endpoints,
                 client_id: "client".to_string(),
                 client_secret: None,
-                client_material_persistence: OAuthClientMaterialPersistence::All,
+                refresh_material_persistence:
+                    OAuthRefreshMaterialPersistence::CompleteRefreshContext,
             },
             state: "expected-state".to_string(),
             code_verifier: None,
@@ -2529,7 +2544,8 @@ mod tests {
                 endpoints,
                 client_id: "client".to_string(),
                 client_secret: None,
-                client_material_persistence: OAuthClientMaterialPersistence::All,
+                refresh_material_persistence:
+                    OAuthRefreshMaterialPersistence::CompleteRefreshContext,
             },
             state: "expected-state".to_string(),
             code_verifier: None,
@@ -2591,7 +2607,8 @@ mod tests {
                     ("OAUTH_CLIENT_ID".to_string(), "client".to_string()),
                     ("OAUTH_CLIENT_SECRET".to_string(), "secret".to_string()),
                 ],
-                client_material_persistence: OAuthClientMaterialPersistence::All,
+                refresh_material_persistence:
+                    OAuthRefreshMaterialPersistence::CompleteRefreshContext,
             },
             move |authorization| async move {
                 authorization_tx
@@ -2643,7 +2660,8 @@ mod tests {
                 oauth: &oauth,
                 source_inputs: &EMPTY_SOURCE_INPUTS,
                 credential_inputs: Vec::new(),
-                client_material_persistence: OAuthClientMaterialPersistence::All,
+                refresh_material_persistence:
+                    OAuthRefreshMaterialPersistence::CompleteRefreshContext,
             },
             move |authorization| async move {
                 authorization_tx
@@ -2704,7 +2722,8 @@ mod tests {
                 oauth: &oauth,
                 source_inputs: &EMPTY_SOURCE_INPUTS,
                 credential_inputs: Vec::new(),
-                client_material_persistence: OAuthClientMaterialPersistence::All,
+                refresh_material_persistence:
+                    OAuthRefreshMaterialPersistence::CompleteRefreshContext,
             },
             move |authorization| async move {
                 authorization_tx

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -15,8 +15,8 @@ use tracing::info_span;
 
 use crate::bootstrap::AppError;
 use crate::credentials::oauth::{
-    OAuthClientMaterialPersistence, OAuthCredentialMaterial, OAuthCredentialService,
-    OAuthProgressEventSender, StartOAuthCredentialRequest,
+    OAuthCredentialMaterial, OAuthCredentialService, OAuthProgressEventSender,
+    OAuthRefreshMaterialPersistence, StartOAuthCredentialRequest,
 };
 use crate::identities::runtime::{
     FIXED_TOKEN_MATERIAL_KEY, IdentityRuntimeServices, OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
@@ -454,8 +454,8 @@ impl IdentityManager {
             credential_inputs.clone(),
         )?;
 
-        let client_material_persistence =
-            oauth_client_material_persistence_for_identity(oauth, &provided_inputs);
+        let refresh_material_persistence =
+            oauth_refresh_material_persistence_for_identity(oauth, &provided_inputs);
         let material = self
             .oauth_credential_service
             .authorize_with_progress(
@@ -464,7 +464,7 @@ impl IdentityManager {
                     oauth,
                     source_inputs: &identity_inputs,
                     credential_inputs,
-                    client_material_persistence,
+                    refresh_material_persistence,
                 },
                 name.to_string(),
                 &events,
@@ -1073,10 +1073,10 @@ fn oauth_credential_inputs_from_identity_inputs(
     values
 }
 
-fn oauth_client_material_persistence_for_identity(
+fn oauth_refresh_material_persistence_for_identity(
     oauth: &ManifestOAuthCredentialSpec,
     provided: &BTreeMap<String, String>,
-) -> OAuthClientMaterialPersistence {
+) -> OAuthRefreshMaterialPersistence {
     let client_id = oauth
         .client
         .id
@@ -1089,12 +1089,12 @@ fn oauth_client_material_persistence_for_identity(
         .as_ref()
         .is_some_and(|secret| provided.contains_key(&secret.input));
     if client_id || client_secret {
-        OAuthClientMaterialPersistence::ClientCredentials {
+        OAuthRefreshMaterialPersistence::PartialRefreshContext {
             client_id,
             client_secret,
         }
     } else {
-        OAuthClientMaterialPersistence::None
+        OAuthRefreshMaterialPersistence::None
     }
 }
 

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1,18 +1,30 @@
 //! Storage seam types and traits for provider identities.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use coral_spec::IdentitySpecType;
+use coral_spec::{
+    IdentityManifest, IdentitySpecConfig, IdentitySpecType, ManifestOAuthCredentialSpec,
+};
 use serde::{Deserialize, Serialize};
 use tracing::info_span;
 
 use crate::bootstrap::AppError;
-use crate::identity::{IdentityOwnerKind, UserPrincipal, parse_path_segment};
+use crate::credentials::oauth::{
+    OAuthClientMaterialPersistence, OAuthCredentialMaterial, OAuthCredentialService,
+    OAuthProgressEventSender, StartOAuthCredentialRequest,
+};
+use crate::identities::runtime::{
+    FIXED_TOKEN_MATERIAL_KEY, IdentityRuntimeServices, OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
+    StoredIdentityRuntimeData,
+};
+use crate::identity::{
+    IdentityOwnerKind, RuntimeSourceIdentity, UserPrincipal, parse_path_segment, unique_input_map,
+};
 use crate::identity_specs::{
     IdentitySpecManager, IdentitySpecRecord, identity_spec_fingerprint, validate_identity_spec_name,
 };
@@ -21,7 +33,6 @@ use crate::storage::env_file::{parse_env_file, render_env_file};
 use crate::storage::fs::{self as storage_fs, FileLock};
 
 const IDENTITY_DOCUMENT_VERSION: u32 = 1;
-const FIXED_TOKEN_MATERIAL_KEY: &str = "TOKEN";
 
 /// One stored provider identity.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -150,6 +161,17 @@ impl fmt::Display for IdentityOwner {
     }
 }
 
+/// Request to create or replace an OAuth identity.
+#[derive(Debug, Clone)]
+pub struct CreateOAuthIdentityCommand {
+    /// Stable identity name used by source identity bindings.
+    pub name: String,
+    /// Installed OAuth identity spec name.
+    pub identity_spec: String,
+    /// Method-specific OAuth credential inputs.
+    pub credential_inputs: Vec<IdentityCredentialInput>,
+}
+
 /// Request to create or replace a fixed-token identity.
 #[derive(Debug, Clone)]
 pub struct CreateFixedTokenIdentityCommand {
@@ -159,6 +181,16 @@ pub struct CreateFixedTokenIdentityCommand {
     pub identity_spec: String,
     /// Bearer token to store.
     pub token: String,
+}
+
+/// Locked access to credential material for one provider identity.
+/// OAuth method input supplied while creating an identity.
+#[derive(Debug, Clone)]
+pub struct IdentityCredentialInput {
+    /// Input key.
+    pub key: String,
+    /// Input value.
+    pub value: String,
 }
 
 /// Locked access to credential material for one provider identity.
@@ -246,6 +278,7 @@ pub trait IdentityStore: Send + Sync + std::fmt::Debug + 'static {
 #[derive(Debug, Clone)]
 pub(crate) struct IdentityManager {
     identity_specs: IdentitySpecManager,
+    oauth_credential_service: OAuthCredentialService,
     store: Arc<dyn IdentityStore>,
 }
 
@@ -259,6 +292,23 @@ pub struct IdentityManagementHandle {
 }
 
 impl IdentityManagementHandle {
+    /// Creates or replaces an OAuth identity under `owner`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the identity spec is invalid, OAuth
+    /// authorization fails, or credential material cannot be stored.
+    pub async fn create_oauth_identity(
+        &self,
+        owner: &IdentityOwner,
+        command: CreateOAuthIdentityCommand,
+        events: OAuthProgressEventSender,
+    ) -> Result<IdentityRecord, AppError> {
+        self.manager
+            .create_oauth_identity(owner, command, events)
+            .await
+    }
+
     /// Creates or replaces a fixed-token identity under `owner`.
     ///
     /// # Errors
@@ -298,6 +348,21 @@ impl IdentityManagementHandle {
     ) -> Result<bool, AppError> {
         self.manager.delete_identity(owner, identity_name).await
     }
+
+    /// Resolves an identity under `owner` into runtime credential material,
+    /// refreshing OAuth material if necessary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the stored identity is invalid or refresh
+    /// fails.
+    pub async fn resolve_identity(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<Option<Arc<dyn RuntimeSourceIdentity>>, AppError> {
+        self.manager.resolve_identity(owner, identity_name).await
+    }
 }
 
 impl IdentityManager {
@@ -314,6 +379,7 @@ impl IdentityManager {
     ) -> Self {
         Self {
             identity_specs,
+            oauth_credential_service: OAuthCredentialService::new(),
             store,
         }
     }
@@ -345,6 +411,78 @@ impl IdentityManager {
             )));
         }
         Ok((owner.clone(), name, spec))
+    }
+
+    async fn create_oauth_identity(
+        &self,
+        owner: &IdentityOwner,
+        command: CreateOAuthIdentityCommand,
+        events: OAuthProgressEventSender,
+    ) -> Result<IdentityRecord, AppError> {
+        let span = info_span!("coral.app.identities.create_oauth");
+        let _guard = span.enter();
+        let (owner, name, spec) = self.prepare_identity_creation(
+            owner,
+            &command.name,
+            &command.identity_spec,
+            IdentitySpecType::OAuth,
+        )?;
+        let identity_spec_name = spec.manifest.name.clone();
+        let oauth = oauth_method(&identity_spec_name, &spec.manifest.config)?;
+        let provided_inputs = unique_input_map(
+            command
+                .credential_inputs
+                .into_iter()
+                .map(|input| (input.key, input.value)),
+            "credential input",
+        )?;
+        reject_identity_owned_inputs(
+            name.as_str(),
+            &identity_spec_name,
+            &spec.manifest,
+            oauth,
+            &provided_inputs,
+        )?;
+        let identity_inputs = self
+            .identity_specs
+            .resolve_identity_spec_inputs(&spec.manifest)?;
+        let credential_inputs =
+            oauth_credential_inputs_from_identity_inputs(oauth, &identity_inputs, &provided_inputs);
+        OAuthCredentialService::validate_credential_inputs(
+            oauth,
+            &identity_inputs,
+            credential_inputs.clone(),
+        )?;
+
+        let client_material_persistence =
+            oauth_client_material_persistence_for_identity(oauth, &provided_inputs);
+        let material = self
+            .oauth_credential_service
+            .authorize_with_progress(
+                StartOAuthCredentialRequest {
+                    input_key: OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
+                    oauth,
+                    source_inputs: &identity_inputs,
+                    credential_inputs,
+                    client_material_persistence,
+                },
+                name.to_string(),
+                &events,
+            )
+            .await?;
+
+        let record = IdentityRecord {
+            owner,
+            name,
+            identity_spec: identity_spec_name,
+            identity_spec_fingerprint: Some(identity_spec_fingerprint(&spec.manifest)?),
+            issuer: spec.manifest.issuer,
+            identity_type: spec.manifest.identity_type.label().to_string(),
+            metadata: material.safe_metadata.clone(),
+        };
+        let material = material_values(material);
+        self.store.replace_identity(&record, &material).await?;
+        Ok(record)
     }
 
     async fn create_fixed_token_identity(
@@ -380,6 +518,16 @@ impl IdentityManager {
         Ok(record)
     }
 
+    pub(crate) async fn create_user_owned_oauth_identity(
+        &self,
+        principal: &UserPrincipal,
+        command: CreateOAuthIdentityCommand,
+        events: OAuthProgressEventSender,
+    ) -> Result<IdentityRecord, AppError> {
+        let owner = IdentityOwner::for_user_principal(principal)?;
+        self.create_oauth_identity(&owner, command, events).await
+    }
+
     pub(crate) async fn create_user_owned_fixed_token_identity(
         &self,
         principal: &UserPrincipal,
@@ -413,6 +561,59 @@ impl IdentityManager {
     ) -> Result<bool, AppError> {
         let identity_name = validate_identity_name(identity_name)?;
         self.store.delete_identity(owner, &identity_name).await
+    }
+
+    /// Loads the installed identity spec backing `record`, reporting orphaned
+    /// identities and rejecting records that no longer match the spec.
+    fn load_spec_for_record(
+        &self,
+        record: &IdentityRecord,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        let spec = match self.identity_specs.get_identity_spec(&record.identity_spec) {
+            Ok(spec) => spec,
+            Err(AppError::IdentitySpecNotFound(_)) => {
+                return Err(AppError::FailedPrecondition(format!(
+                    "identity '{}' is orphaned because identity spec '{}' is not installed",
+                    record.name, record.identity_spec
+                )));
+            }
+            Err(error) => return Err(error),
+        };
+        validate_record_identity_type(record, spec.manifest.identity_type)?;
+        validate_record_identity_spec_fingerprint(record, &spec.manifest)?;
+        Ok(spec)
+    }
+
+    async fn resolve_identity(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<Option<Arc<dyn RuntimeSourceIdentity>>, AppError> {
+        let identity_name = validate_identity_name(identity_name)?;
+        let material_guard = self.store.material_guard(owner, &identity_name).await?;
+        let record = self.store.load_identity(owner, &identity_name).await?;
+        let Some(record) = record else {
+            return Ok(None);
+        };
+        let spec = self.load_spec_for_record(&record)?;
+        let identity_inputs = self
+            .identity_specs
+            .resolve_identity_spec_inputs(&spec.manifest)?;
+        let material = material_guard.read_material().await?;
+        let prepared = StoredIdentityRuntimeData::new(
+            record.name.to_string(),
+            spec.manifest,
+            identity_inputs,
+            material,
+        )
+        .prepare(IdentityRuntimeServices {
+            oauth_credential_service: &self.oauth_credential_service,
+        })
+        .await?;
+        if let Some(updated_material) = prepared.updated_material {
+            material_guard.write_material(&updated_material).await?;
+        }
+        Ok(Some(prepared.identity))
     }
 }
 
@@ -753,6 +954,148 @@ const fn default_identity_owner_kind() -> IdentityOwnerKind {
 #[derive(Debug, Deserialize)]
 struct IdentitySpecReference {
     identity_spec: String,
+}
+
+fn oauth_method<'a>(
+    identity_spec_name: &str,
+    config: &'a IdentitySpecConfig,
+) -> Result<&'a ManifestOAuthCredentialSpec, AppError> {
+    let IdentitySpecConfig::OAuth(oauth) = config else {
+        return Err(AppError::InvalidInput(format!(
+            "identity spec '{identity_spec_name}' is not oauth"
+        )));
+    };
+    Ok(&oauth.method.oauth)
+}
+
+fn material_values(material: OAuthCredentialMaterial) -> BTreeMap<String, String> {
+    let mut values = material.internal_metadata;
+    values.insert(
+        OAUTH_ACCESS_TOKEN_MATERIAL_KEY.to_string(),
+        material.access_token,
+    );
+    values
+}
+
+fn validate_record_identity_type(
+    record: &IdentityRecord,
+    identity_spec_type: IdentitySpecType,
+) -> Result<(), AppError> {
+    let expected = identity_spec_type.label();
+    if record.identity_type == expected {
+        return Ok(());
+    }
+    Err(AppError::FailedPrecondition(format!(
+        "identity '{}' is orphaned because identity spec '{}' has type '{}', but the stored identity has type '{}'",
+        record.name, record.identity_spec, expected, record.identity_type
+    )))
+}
+
+fn validate_record_identity_spec_fingerprint(
+    record: &IdentityRecord,
+    identity_spec: &IdentityManifest,
+) -> Result<(), AppError> {
+    let Some(stored_fingerprint) = record.identity_spec_fingerprint.as_deref() else {
+        return Err(AppError::FailedPrecondition(format!(
+            "identity '{}' is orphaned because it was created before identity spec fingerprinting; recreate it from identity spec '{}'",
+            record.name, record.identity_spec
+        )));
+    };
+    let current_fingerprint = identity_spec_fingerprint(identity_spec)?;
+    if stored_fingerprint == current_fingerprint {
+        return Ok(());
+    }
+    Err(AppError::FailedPrecondition(format!(
+        "identity '{}' is orphaned because identity spec '{}' has changed since the identity was created; recreate the identity from the current spec",
+        record.name, record.identity_spec
+    )))
+}
+
+fn reject_identity_owned_inputs(
+    identity_name: &str,
+    identity_spec_name: &str,
+    manifest: &IdentityManifest,
+    oauth: &ManifestOAuthCredentialSpec,
+    provided: &BTreeMap<String, String>,
+) -> Result<(), AppError> {
+    let declared = manifest
+        .inputs
+        .iter()
+        .map(|input| input.key.as_str())
+        .collect::<BTreeSet<_>>();
+    for key in provided.keys() {
+        if declared.contains(key.as_str()) {
+            return Err(AppError::InvalidInput(format!(
+                "identity input '{key}' belongs to identity spec '{identity_spec_name}', not identity '{identity_name}'; provide it when installing the identity spec"
+            )));
+        }
+        if legacy_oauth_client_input(oauth, key) {
+            continue;
+        }
+        return Err(AppError::InvalidInput(format!(
+            "unknown OAuth credential input '{key}' for identity '{identity_name}'"
+        )));
+    }
+    Ok(())
+}
+
+fn legacy_oauth_client_input(oauth: &ManifestOAuthCredentialSpec, key: &str) -> bool {
+    oauth.client.id.input.as_deref() == Some(key)
+        || oauth
+            .client
+            .secret
+            .as_ref()
+            .is_some_and(|secret| secret.input == key)
+}
+
+fn oauth_credential_inputs_from_identity_inputs(
+    oauth: &ManifestOAuthCredentialSpec,
+    identity_inputs: &BTreeMap<String, String>,
+    provided: &BTreeMap<String, String>,
+) -> Vec<(String, String)> {
+    let mut values = Vec::new();
+    if let Some(input_key) = oauth.client.id.input.as_deref()
+        && let Some(value) = identity_inputs
+            .get(input_key)
+            .or_else(|| provided.get(input_key))
+            .filter(|value| !value.is_empty())
+    {
+        values.push((input_key.to_string(), value.clone()));
+    }
+    if let Some(secret) = oauth.client.secret.as_ref()
+        && let Some(value) = identity_inputs
+            .get(&secret.input)
+            .or_else(|| provided.get(&secret.input))
+            .filter(|value| !value.is_empty())
+    {
+        values.push((secret.input.clone(), value.clone()));
+    }
+    values
+}
+
+fn oauth_client_material_persistence_for_identity(
+    oauth: &ManifestOAuthCredentialSpec,
+    provided: &BTreeMap<String, String>,
+) -> OAuthClientMaterialPersistence {
+    let client_id = oauth
+        .client
+        .id
+        .input
+        .as_deref()
+        .is_some_and(|input| provided.contains_key(input));
+    let client_secret = oauth
+        .client
+        .secret
+        .as_ref()
+        .is_some_and(|secret| provided.contains_key(&secret.input));
+    if client_id || client_secret {
+        OAuthClientMaterialPersistence::ClientCredentials {
+            client_id,
+            client_secret,
+        }
+    } else {
+        OAuthClientMaterialPersistence::None
+    }
 }
 
 fn validate_identity_name(name: &str) -> Result<IdentityName, AppError> {
@@ -1141,6 +1484,47 @@ audience:
                 .identity_material_file(&local_owner(), &github_local_name())
                 .exists(),
             "rejected stale identity should not create material"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_management_handle_resolves_fixed_token_identity() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        let principal = UserPrincipal::local();
+        manager
+            .create_user_owned_fixed_token_identity(&principal, github_local_command("ghp_token"))
+            .await
+            .expect("create identity");
+
+        let identity = manager
+            .handle()
+            .resolve_identity(&local_owner(), "github_local")
+            .await
+            .expect("resolve identity")
+            .expect("identity exists");
+        let request = reqwest::Request::new(
+            reqwest::Method::GET,
+            "https://api.github.com/user".parse().expect("request url"),
+        );
+        let headers = identity
+            .resolve_headers(
+                &coral_engine::SelectedRequestIdentity::new(
+                    "github_local".to_string(),
+                    identity.identity_spec_id().to_string(),
+                    identity.audience().clone(),
+                ),
+                &request,
+                &BTreeMap::new(),
+            )
+            .await
+            .expect("identity headers");
+
+        assert_eq!(
+            headers,
+            vec![(
+                reqwest::header::AUTHORIZATION,
+                reqwest::header::HeaderValue::from_static("Bearer ghp_token")
+            )]
         );
     }
 

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -1,11 +1,13 @@
 //! Stored provider identity registry and user-owned gRPC APIs.
 
 mod manager;
+mod runtime;
 mod service;
 
 pub(crate) use manager::IdentityManager;
 pub use manager::{
-    CreateFixedTokenIdentityCommand, IdentityManagementHandle, IdentityMaterialGuard, IdentityName,
-    IdentityOwner, IdentityRecord, IdentityStore,
+    CreateFixedTokenIdentityCommand, CreateOAuthIdentityCommand, IdentityCredentialInput,
+    IdentityManagementHandle, IdentityMaterialGuard, IdentityName, IdentityOwner, IdentityRecord,
+    IdentityStore,
 };
 pub(crate) use service::IdentityService;

--- a/crates/coral-app/src/identities/runtime.rs
+++ b/crates/coral-app/src/identities/runtime.rs
@@ -148,8 +148,8 @@ fn required_material<'a>(
 ) -> Result<&'a str, RequestIdentityHttpAuthenticatorError> {
     data.material
         .get(key)
+        .map(|value| value.trim())
         .filter(|value| !value.is_empty())
-        .map(String::as_str)
         .ok_or_else(|| {
             RequestIdentityHttpAuthenticatorError::failed_precondition(format!(
                 "identity '{}' is missing {label} material key '{key}'",
@@ -393,6 +393,23 @@ audience:
             "Bearer fixed-token",
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn identity_headers_reject_whitespace_only_material() {
+        let prepared =
+            prepared_identity(fixed_token_identity_spec(), FIXED_TOKEN_MATERIAL_KEY, "   ").await;
+
+        let error = resolve_headers(&prepared, "api.example.test")
+            .await
+            .expect_err("blank material should not produce identity headers");
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing fixed token material key 'TOKEN'"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/identities/runtime.rs
+++ b/crates/coral-app/src/identities/runtime.rs
@@ -1,0 +1,471 @@
+//! Runtime HTTP injection for stored provider identities.
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use coral_engine::{RequestIdentityHttpAuthenticatorError, SelectedRequestIdentity};
+use coral_spec::{
+    IdentityManifest, IdentitySpecConfig, IdentitySpecType, ManifestOAuthCredentialSpec,
+};
+use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
+use serde_json::Value;
+
+use crate::bootstrap::AppError;
+use crate::credentials::oauth::{OAuthCredentialService, RefreshOAuthCredentialRequest};
+use crate::identity::RuntimeSourceIdentity;
+
+pub(super) const OAUTH_ACCESS_TOKEN_MATERIAL_KEY: &str = "ACCESS_TOKEN";
+pub(super) const FIXED_TOKEN_MATERIAL_KEY: &str = "TOKEN";
+
+/// Services type-specific identity runtimes may need while preparing material.
+pub(super) struct IdentityRuntimeServices<'a> {
+    pub(super) oauth_credential_service: &'a OAuthCredentialService,
+}
+
+/// Parsed identity spec plus stored secret material for one concrete identity.
+#[derive(Debug)]
+pub(super) struct StoredIdentityRuntimeData {
+    identity_name: String,
+    identity_spec: IdentityManifest,
+    identity_inputs: BTreeMap<String, String>,
+    material: BTreeMap<String, String>,
+}
+
+impl StoredIdentityRuntimeData {
+    pub(super) fn new(
+        identity_name: String,
+        identity_spec: IdentityManifest,
+        identity_inputs: BTreeMap<String, String>,
+        material: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            identity_name,
+            identity_spec,
+            identity_inputs,
+            material,
+        }
+    }
+
+    pub(super) async fn prepare(
+        mut self,
+        services: IdentityRuntimeServices<'_>,
+    ) -> Result<PreparedRuntimeIdentity, AppError> {
+        let (material_key, label, updated_material) = match self.identity_spec.identity_type {
+            IdentitySpecType::OAuth => {
+                let oauth = oauth_method(&self.identity_spec)?;
+                let refreshed = services
+                    .oauth_credential_service
+                    .refresh_if_needed(
+                        RefreshOAuthCredentialRequest::for_identity(
+                            &self.identity_name,
+                            OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
+                            oauth,
+                            &self.identity_inputs,
+                        ),
+                        &mut self.material,
+                    )
+                    .await?;
+                let updated_material = refreshed.then(|| self.material.clone());
+                (
+                    OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
+                    "OAuth access token",
+                    updated_material,
+                )
+            }
+            IdentitySpecType::FixedToken => (FIXED_TOKEN_MATERIAL_KEY, "fixed token", None),
+        };
+        Ok(PreparedRuntimeIdentity {
+            identity: Arc::new(BearerTokenRuntimeIdentity {
+                data: self,
+                material_key,
+                label,
+            }),
+            updated_material,
+        })
+    }
+
+    fn identity_spec_id(&self) -> &str {
+        &self.identity_spec.name
+    }
+
+    fn audience(&self) -> &BTreeMap<String, Value> {
+        &self.identity_spec.audience
+    }
+}
+
+pub(super) struct PreparedRuntimeIdentity {
+    pub(super) identity: Arc<dyn RuntimeSourceIdentity>,
+    pub(super) updated_material: Option<BTreeMap<String, String>>,
+}
+
+/// Runtime identity that injects `Authorization: Bearer <token>` from one
+/// stored material key after enforcing the identity's audience host.
+#[derive(Debug)]
+struct BearerTokenRuntimeIdentity {
+    data: StoredIdentityRuntimeData,
+    material_key: &'static str,
+    label: &'static str,
+}
+
+#[tonic::async_trait]
+impl RuntimeSourceIdentity for BearerTokenRuntimeIdentity {
+    fn identity_spec_id(&self) -> &str {
+        self.data.identity_spec_id()
+    }
+
+    fn audience(&self) -> &BTreeMap<String, Value> {
+        self.data.audience()
+    }
+
+    async fn resolve_headers(
+        &self,
+        _identity: &SelectedRequestIdentity,
+        request: &reqwest::Request,
+        _resolved_inputs: &BTreeMap<String, String>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError> {
+        ensure_request_uses_credential_safe_transport(&self.data, request)?;
+        ensure_request_matches_identity_audience(&self.data, request)?;
+        let token = required_material(&self.data, self.material_key, self.label)?;
+        bearer_authorization_header(&self.data, token, self.label)
+    }
+}
+
+fn oauth_method(spec: &IdentityManifest) -> Result<&ManifestOAuthCredentialSpec, AppError> {
+    let IdentitySpecConfig::OAuth(oauth) = &spec.config else {
+        return Err(AppError::FailedPrecondition(format!(
+            "identity spec '{}' has type oauth but no OAuth runtime config",
+            spec.name
+        )));
+    };
+    Ok(&oauth.method.oauth)
+}
+
+fn required_material<'a>(
+    data: &'a StoredIdentityRuntimeData,
+    key: &str,
+    label: &str,
+) -> Result<&'a str, RequestIdentityHttpAuthenticatorError> {
+    data.material
+        .get(key)
+        .filter(|value| !value.is_empty())
+        .map(String::as_str)
+        .ok_or_else(|| {
+            RequestIdentityHttpAuthenticatorError::failed_precondition(format!(
+                "identity '{}' is missing {label} material key '{key}'",
+                data.identity_name
+            ))
+        })
+}
+
+fn bearer_authorization_header(
+    data: &StoredIdentityRuntimeData,
+    token: &str,
+    label: &str,
+) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError> {
+    authorization_header(data, "Bearer", token, label)
+}
+
+fn authorization_header(
+    data: &StoredIdentityRuntimeData,
+    scheme: &str,
+    credential: &str,
+    label: &str,
+) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError> {
+    let value = HeaderValue::from_str(&format!("{scheme} {credential}")).map_err(|error| {
+        RequestIdentityHttpAuthenticatorError::failed_precondition(format!(
+            "identity '{}' {label} material could not be encoded as an Authorization header: {error}",
+            data.identity_name
+        ))
+    })?;
+    Ok(vec![(AUTHORIZATION, value)])
+}
+
+fn ensure_request_matches_identity_audience(
+    data: &StoredIdentityRuntimeData,
+    request: &reqwest::Request,
+) -> Result<(), RequestIdentityHttpAuthenticatorError> {
+    let audience_host = data
+        .identity_spec
+        .audience
+        .get("host")
+        .and_then(Value::as_str)
+        .filter(|host| !host.trim().is_empty())
+        .ok_or_else(|| {
+            RequestIdentityHttpAuthenticatorError::failed_precondition(format!(
+                "identity spec '{}' must declare string audience.host before identity '{}' can inject Authorization headers",
+                data.identity_spec.name, data.identity_name
+            ))
+        })?;
+    let request_host = request.url().host_str().ok_or_else(|| {
+        RequestIdentityHttpAuthenticatorError::failed_precondition(format!(
+            "identity '{}' cannot inject Authorization headers for URL without a host",
+            data.identity_name
+        ))
+    })?;
+    if host_matches_audience(request_host, audience_host) {
+        return Ok(());
+    }
+    Err(RequestIdentityHttpAuthenticatorError::failed_precondition(
+        format!(
+            "identity '{}' audience host '{}' does not match request host '{}'",
+            data.identity_name, audience_host, request_host
+        ),
+    ))
+}
+
+fn ensure_request_uses_credential_safe_transport(
+    data: &StoredIdentityRuntimeData,
+    request: &reqwest::Request,
+) -> Result<(), RequestIdentityHttpAuthenticatorError> {
+    let url = request.url();
+    if url.scheme() == "https" || is_loopback_http_url(url) {
+        return Ok(());
+    }
+    let host = url.host_str().unwrap_or("<missing>");
+    Err(RequestIdentityHttpAuthenticatorError::failed_precondition(
+        format!(
+            "identity '{}' cannot inject Authorization headers over {}://{host}; provider identity requests must use https or loopback http",
+            data.identity_name,
+            url.scheme()
+        ),
+    ))
+}
+
+fn is_loopback_http_url(url: &reqwest::Url) -> bool {
+    url.scheme() == "http"
+        && url.host_str().is_some_and(|host| {
+            host.eq_ignore_ascii_case("localhost")
+                || host
+                    .parse::<IpAddr>()
+                    .is_ok_and(|address| address.is_loopback())
+        })
+}
+
+fn host_matches_audience(request_host: &str, audience_host: &str) -> bool {
+    let request_host = request_host
+        .trim()
+        .trim_end_matches('.')
+        .to_ascii_lowercase();
+    let audience_host = audience_host
+        .trim()
+        .trim_end_matches('.')
+        .to_ascii_lowercase();
+    !audience_host.is_empty()
+        && (request_host == audience_host
+            || request_host
+                .strip_suffix(&audience_host)
+                .is_some_and(|prefix| prefix.ends_with('.')))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coral_spec::parse_identity_manifest_yaml;
+
+    async fn prepared_identity(
+        identity_spec: IdentityManifest,
+        material_key: &str,
+        token: &str,
+    ) -> PreparedRuntimeIdentity {
+        StoredIdentityRuntimeData::new(
+            "demo_local".to_string(),
+            identity_spec,
+            BTreeMap::new(),
+            BTreeMap::from([(material_key.to_string(), token.to_string())]),
+        )
+        .prepare(IdentityRuntimeServices {
+            oauth_credential_service: &OAuthCredentialService::new(),
+        })
+        .await
+        .expect("prepare identity")
+    }
+
+    async fn resolve_headers(
+        prepared: &PreparedRuntimeIdentity,
+        host: &str,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError> {
+        resolve_headers_for_url(prepared, &format!("https://{host}/user")).await
+    }
+
+    async fn resolve_headers_for_url(
+        prepared: &PreparedRuntimeIdentity,
+        url: &str,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError> {
+        let context = SelectedRequestIdentity::new(
+            "demo".to_string(),
+            prepared.identity.identity_spec_id().to_string(),
+            prepared.identity.audience().clone(),
+        );
+        let request = reqwest::Request::new(reqwest::Method::GET, url.parse().expect("url"));
+        prepared
+            .identity
+            .resolve_headers(&context, &request, &BTreeMap::new())
+            .await
+    }
+
+    async fn assert_identity_injects_bearer_token(
+        identity_spec: IdentityManifest,
+        material_key: &str,
+        token: &str,
+        expected_header: &'static str,
+    ) {
+        let prepared = prepared_identity(identity_spec, material_key, token).await;
+
+        let headers = resolve_headers(&prepared, "api.example.test")
+            .await
+            .expect("headers");
+
+        assert_eq!(
+            headers,
+            vec![(AUTHORIZATION, HeaderValue::from_static(expected_header))]
+        );
+        assert!(prepared.updated_material.is_none());
+    }
+
+    fn oauth_identity_spec() -> IdentityManifest {
+        parse_identity_manifest_yaml(
+            r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+issuer: demo
+type: oauth
+audience:
+  host: example.test
+oauth:
+  method:
+    flow:
+      type: device_code
+    endpoints:
+      device_authorization_url: https://example.test/device
+      token_url: https://example.test/token
+    client:
+      id:
+        default: demo-client
+",
+        )
+        .expect("identity spec")
+    }
+
+    fn fixed_token_identity_spec() -> IdentityManifest {
+        fixed_token_identity_spec_with_audience("host: example.test")
+    }
+
+    fn fixed_token_identity_spec_without_audience_host() -> IdentityManifest {
+        fixed_token_identity_spec_with_audience("tenant: demo")
+    }
+
+    fn fixed_token_identity_spec_with_audience(audience: &str) -> IdentityManifest {
+        parse_identity_manifest_yaml(&format!(
+            r"
+kind: identity
+spec_version: 1
+name: demo_token
+version: 0.1.0
+issuer: demo
+type: fixed_token
+audience:
+  {audience}
+"
+        ))
+        .expect("identity spec")
+    }
+
+    #[tokio::test]
+    async fn oauth_identity_injects_bearer_access_token_from_material() {
+        assert_identity_injects_bearer_token(
+            oauth_identity_spec(),
+            OAUTH_ACCESS_TOKEN_MATERIAL_KEY,
+            "oauth-token",
+            "Bearer oauth-token",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn fixed_token_identity_injects_bearer_token_from_material() {
+        assert_identity_injects_bearer_token(
+            fixed_token_identity_spec(),
+            FIXED_TOKEN_MATERIAL_KEY,
+            "fixed-token",
+            "Bearer fixed-token",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn identity_headers_reject_request_host_outside_audience() {
+        let prepared = prepared_identity(
+            fixed_token_identity_spec(),
+            FIXED_TOKEN_MATERIAL_KEY,
+            "token",
+        )
+        .await;
+
+        let error = resolve_headers(&prepared, "api.example.test.attacker.test")
+            .await
+            .expect_err("mismatched host should not receive identity headers");
+
+        assert!(
+            error.to_string().contains("does not match request host"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_headers_reject_non_https_provider_requests() {
+        let prepared = prepared_identity(
+            fixed_token_identity_spec(),
+            FIXED_TOKEN_MATERIAL_KEY,
+            "token",
+        )
+        .await;
+
+        let error = resolve_headers_for_url(&prepared, "http://api.example.test/user")
+            .await
+            .expect_err("non-https provider request should not receive identity headers");
+
+        assert!(
+            error.to_string().contains("must use https"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_headers_require_audience_host() {
+        let prepared = prepared_identity(
+            fixed_token_identity_spec_without_audience_host(),
+            FIXED_TOKEN_MATERIAL_KEY,
+            "token",
+        )
+        .await;
+
+        let error = resolve_headers(&prepared, "api.example.test")
+            .await
+            .expect_err("missing audience host should fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("must declare string audience.host"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn audience_host_matching_allows_only_exact_or_subdomain_hosts() {
+        assert!(host_matches_audience("example.test", "example.test"));
+        assert!(host_matches_audience("api.example.test", "example.test"));
+        assert!(host_matches_audience("API.EXAMPLE.TEST", "example.test"));
+        assert!(host_matches_audience("api.example.test.", "example.test."));
+        assert!(!host_matches_audience("badexample.test", "example.test"));
+        assert!(!host_matches_audience(
+            "example.test.attacker.test",
+            "example.test"
+        ));
+        assert!(!host_matches_audience("github.com.evil.test", "github.com"));
+        assert!(!host_matches_audience("example.test", ""));
+    }
+}

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -13,10 +13,15 @@ use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
-use crate::identities::{CreateFixedTokenIdentityCommand, IdentityManager, IdentityRecord};
+use crate::credentials::oauth::OAuthProgressEvent;
+use crate::identities::{
+    CreateFixedTokenIdentityCommand, CreateOAuthIdentityCommand, IdentityManager, IdentityRecord,
+};
 use crate::identity::IdentityOwnerKind;
 use crate::request_context::RequestContext;
-use crate::transport::{grpc_span, instrument_grpc};
+use crate::transport::{
+    OAuthProgressProto, grpc_span, instrument_grpc, oauth_operation_response_stream,
+};
 
 #[derive(Clone)]
 pub(crate) struct IdentityService {
@@ -39,37 +44,54 @@ impl IdentityServiceApi for IdentityService {
     ) -> Result<Response<Self::CreateUserOwnedIdentityStream>, Status> {
         let span = grpc_span(&request);
         let identities = self.identities.clone();
-        instrument_grpc(span, async move {
+        instrument_grpc(span.clone(), async move {
             let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
-            let Some(create_user_owned_identity_request::Setup::FixedToken(
+            if let Some(create_user_owned_identity_request::Setup::FixedToken(
                 FixedTokenUserOwnedIdentitySetup { token },
             )) = request.setup
-            else {
-                return Err(Status::unimplemented(
-                    "OAuth identity creation is not enabled by this server",
+            {
+                let record = identities
+                    .create_user_owned_fixed_token_identity(
+                        &principal,
+                        CreateFixedTokenIdentityCommand {
+                            name: request.name,
+                            identity_spec: request.identity_spec,
+                            token,
+                        },
+                    )
+                    .await
+                    .map_err(app_status)?;
+                let response = CreateUserOwnedIdentityResponse {
+                    event: Some(create_user_owned_identity_response::Event::Identity(
+                        identity_record_to_proto(record),
+                    )),
+                };
+                let stream = Box::pin(tokio_stream::iter([Ok(response)]));
+                return Ok(Response::new(
+                    stream as CreateUserOwnedIdentityResponseStreamBox,
                 ));
-            };
-            let record = identities
-                .create_user_owned_fixed_token_identity(
-                    &principal,
-                    CreateFixedTokenIdentityCommand {
-                        name: request.name,
-                        identity_spec: request.identity_spec,
-                        token,
-                    },
-                )
-                .await
-                .map_err(app_status)?;
-            let response = CreateUserOwnedIdentityResponse {
-                event: Some(create_user_owned_identity_response::Event::Identity(
-                    user_owned_identity_record_to_proto(record),
-                )),
-            };
-            let stream = Box::pin(tokio_stream::iter([Ok(response)]));
-            Ok(Response::new(
-                stream as CreateUserOwnedIdentityResponseStreamBox,
-            ))
+            }
+
+            let command = create_user_owned_oauth_command_from_proto(request);
+            let stream = oauth_operation_response_stream(
+                "identity OAuth stream closed before creation completed",
+                move |event_sender| {
+                    instrument_grpc(span, async move {
+                        identities
+                            .create_user_owned_oauth_identity(&principal, command, event_sender)
+                            .await
+                            .map_err(app_status)
+                    })
+                },
+                identity_event_to_proto,
+                |identity| CreateUserOwnedIdentityResponse {
+                    event: Some(create_user_owned_identity_response::Event::Identity(
+                        identity_record_to_proto(identity),
+                    )),
+                },
+            );
+            Ok(Response::new(stream))
         })
         .await
     }
@@ -88,10 +110,7 @@ impl IdentityServiceApi for IdentityService {
                 .await
                 .map_err(app_status)?;
             Ok(Response::new(ListUserOwnedIdentitiesResponse {
-                identities: records
-                    .into_iter()
-                    .map(user_owned_identity_record_to_proto)
-                    .collect(),
+                identities: records.into_iter().map(identity_record_to_proto).collect(),
             }))
         })
         .await
@@ -101,18 +120,45 @@ impl IdentityServiceApi for IdentityService {
 type CreateUserOwnedIdentityResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<CreateUserOwnedIdentityResponse, Status>> + Send>>;
 
-fn user_owned_identity_record_to_proto(record: IdentityRecord) -> Identity {
-    debug_assert_eq!(record.owner.kind(), IdentityOwnerKind::User);
+fn create_user_owned_oauth_command_from_proto(
+    request: CreateUserOwnedIdentityRequest,
+) -> CreateOAuthIdentityCommand {
+    CreateOAuthIdentityCommand {
+        name: request.name,
+        identity_spec: request.identity_spec,
+        credential_inputs: Vec::new(),
+    }
+}
+
+fn identity_event_to_proto(event: OAuthProgressEvent) -> CreateUserOwnedIdentityResponse {
+    use create_user_owned_identity_response::Event;
+    let event = match OAuthProgressProto::from(event) {
+        OAuthProgressProto::Authorization(authorization) => {
+            Event::OauthAuthorization(authorization)
+        }
+        OAuthProgressProto::Completed(completed) => Event::OauthCompleted(completed),
+    };
+    CreateUserOwnedIdentityResponse { event: Some(event) }
+}
+
+fn identity_record_to_proto(record: IdentityRecord) -> Identity {
     Identity {
         name: record.name.to_string(),
         identity_spec: record.identity_spec,
         issuer: record.issuer,
         identity_type: record.identity_type,
-        owner: ProtoIdentityOwner::User as i32,
+        owner: proto_identity_owner(record.owner.kind()) as i32,
         metadata: record
             .metadata
             .into_iter()
             .map(|(key, value)| CredentialMetadata { key, value })
             .collect(),
+    }
+}
+
+fn proto_identity_owner(owner: IdentityOwnerKind) -> ProtoIdentityOwner {
+    match owner {
+        IdentityOwnerKind::User => ProtoIdentityOwner::User,
+        IdentityOwnerKind::Workspace => ProtoIdentityOwner::Workspace,
     }
 }

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -392,7 +392,6 @@ impl IdentitySpecManager {
         self.load_identity_spec_manifest_unlocked(&name)
     }
 
-    #[cfg(test)]
     pub(crate) fn resolve_identity_spec_inputs(
         &self,
         manifest: &IdentityManifest,

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -74,9 +74,11 @@ pub use coral_engine::{
     RequestIdentitySelectionContext, RequestIdentitySelectionError, RequestIdentitySelector,
     SelectedRequestIdentity,
 };
+pub use credentials::oauth::{OAuthProgressEvent, OAuthProgressEventSender};
 pub use identities::{
-    CreateFixedTokenIdentityCommand, IdentityManagementHandle, IdentityMaterialGuard, IdentityName,
-    IdentityOwner, IdentityRecord, IdentityStore,
+    CreateFixedTokenIdentityCommand, CreateOAuthIdentityCommand, IdentityCredentialInput,
+    IdentityManagementHandle, IdentityMaterialGuard, IdentityName, IdentityOwner, IdentityRecord,
+    IdentityStore,
 };
 pub use identity::{
     IdentityOwnerKind, RuntimeSourceIdentity, SingleUserPrincipalProvider, SourceIdentityBinding,
@@ -93,4 +95,5 @@ pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };
 pub use telemetry::{RunContext, RunErrorTelemetry, run_with_context, shutdown_tracing};
+pub use transport::oauth_operation_response_stream;
 pub use workspaces::DEFAULT_WORKSPACE_ID;

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -8,7 +8,7 @@ use serde_yaml::Value as YamlValue;
 
 use crate::bootstrap::AppError;
 use crate::credentials::oauth::{
-    OAuthClientMaterialPersistence, OAuthCredentialMaterial, OAuthCredentialService,
+    OAuthCredentialMaterial, OAuthCredentialService, OAuthRefreshMaterialPersistence,
     StartOAuthCredentialRequest, material_key_belongs_to_input,
 };
 use crate::credentials::{
@@ -998,7 +998,8 @@ impl SourceManager {
                         oauth: config.oauth,
                         source_inputs,
                         credential_inputs,
-                        client_material_persistence: OAuthClientMaterialPersistence::All,
+                        refresh_material_persistence:
+                            OAuthRefreshMaterialPersistence::CompleteRefreshContext,
                     },
                     move |authorization| {
                         let events = authorization_events;

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -8,8 +8,8 @@ use serde_yaml::Value as YamlValue;
 
 use crate::bootstrap::AppError;
 use crate::credentials::oauth::{
-    OAuthCredentialMaterial, OAuthCredentialService, StartOAuthCredentialRequest,
-    material_key_belongs_to_input,
+    OAuthClientMaterialPersistence, OAuthCredentialMaterial, OAuthCredentialService,
+    StartOAuthCredentialRequest, material_key_belongs_to_input,
 };
 use crate::credentials::{
     CORAL_INTERNAL_KEY_PREFIX, CredentialManager, CredentialMaterialGuard,
@@ -998,6 +998,7 @@ impl SourceManager {
                         oauth: config.oauth,
                         source_inputs,
                         credential_inputs,
+                        client_material_persistence: OAuthClientMaterialPersistence::All,
                     },
                     move |authorization| {
                         let events = authorization_events;

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -3,8 +3,11 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
+use tokio::sync::mpsc;
 use tokio::task;
+use tokio_stream::Stream;
 
 use coral_api::{
     CORAL_EPISODE_ID_METADATA_KEY, CORAL_ERROR_DOMAIN, grpc_response_status_code,
@@ -31,6 +34,9 @@ use crate::bootstrap::{AppError, app_status, core_status};
 use crate::catalog::discovery::{
     CatalogItem, CatalogMetadataField, CatalogSearchResult, ColumnMetadataField,
     ColumnSearchResult, DescribeTableResult,
+};
+use crate::credentials::oauth::{
+    OAuthProgressEvent, OAuthProgressEventSender, PendingOAuthProgressEvent,
 };
 use crate::episode::EpisodeId;
 use crate::identity::UserPrincipalProvider;
@@ -346,6 +352,124 @@ fn decode_grpc_error(status: &Status) -> GrpcErrorTelemetry {
     GrpcErrorTelemetry {
         error_type: grpc_response_status_code(status.code()).to_string(),
         message: status.message().to_string(),
+    }
+}
+
+/// One OAuth progress event mapped onto the shared credential proto pair.
+pub(crate) enum OAuthProgressProto {
+    /// Authorization-in-progress response payload.
+    Authorization(coral_api::v1::OAuthCredentialAuthorization),
+    /// Authorization-completed response payload.
+    Completed(coral_api::v1::OAuthCredentialCompleted),
+}
+
+impl From<OAuthProgressEvent> for OAuthProgressProto {
+    fn from(event: OAuthProgressEvent) -> Self {
+        match event {
+            OAuthProgressEvent::OAuthAuthorization {
+                input_key,
+                authorization_url,
+                expires_in_seconds,
+                user_code,
+                verification_uri,
+                verification_uri_complete,
+            } => Self::Authorization(coral_api::v1::OAuthCredentialAuthorization {
+                input_key,
+                authorization_url,
+                expires_in_seconds,
+                user_code: user_code.unwrap_or_default(),
+                verification_uri: verification_uri.unwrap_or_default(),
+                verification_uri_complete: verification_uri_complete.unwrap_or_default(),
+            }),
+            OAuthProgressEvent::OAuthCompleted {
+                input_key,
+                metadata,
+            } => Self::Completed(coral_api::v1::OAuthCredentialCompleted {
+                input_key,
+                metadata: metadata
+                    .into_iter()
+                    .map(|(key, value)| coral_api::v1::CredentialMetadata { key, value })
+                    .collect(),
+            }),
+        }
+    }
+}
+
+/// Builds a gRPC response stream that forwards acknowledged OAuth progress
+/// events while `operation` runs, then yields the operation's mapped result.
+pub fn oauth_operation_response_stream<T, R, F, Fut>(
+    closed_message: &'static str,
+    operation: F,
+    event_to_response: fn(OAuthProgressEvent) -> R,
+    operation_to_response: impl FnOnce(T) -> R + Send + 'static,
+) -> Pin<Box<dyn Stream<Item = Result<R, Status>> + Send>>
+where
+    T: 'static,
+    R: Send + Unpin + 'static,
+    F: FnOnce(OAuthProgressEventSender) -> Fut,
+    Fut: Future<Output = Result<T, Status>> + Send + 'static,
+{
+    let (event_tx, event_rx) = mpsc::channel(8);
+    let sender = OAuthProgressEventSender::new(event_tx, closed_message);
+    Box::pin(OAuthOperationResponseStream {
+        events: event_rx,
+        operation: Some((
+            Box::pin(operation(sender)) as Pin<Box<dyn Future<Output = _> + Send>>,
+            Box::new(operation_to_response),
+        )),
+        completion: None,
+        event_to_response,
+    })
+}
+
+struct OAuthOperationResponseStream<T, R> {
+    events: mpsc::Receiver<PendingOAuthProgressEvent>,
+    #[expect(clippy::type_complexity, reason = "private one-shot operation slot")]
+    operation: Option<(
+        Pin<Box<dyn Future<Output = Result<T, Status>> + Send>>,
+        Box<dyn FnOnce(T) -> R + Send>,
+    )>,
+    completion: Option<Result<R, Status>>,
+    event_to_response: fn(OAuthProgressEvent) -> R,
+}
+
+impl<T, R> OAuthOperationResponseStream<T, R> {
+    fn poll_event(&mut self, cx: &mut Context<'_>) -> Poll<Option<R>> {
+        Pin::new(&mut self.events)
+            .poll_recv(cx)
+            .map(|event| event.map(|event| (self.event_to_response)(event.into_event())))
+    }
+}
+
+impl<T, R: Unpin> Stream for OAuthOperationResponseStream<T, R> {
+    type Item = Result<R, Status>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            if let Poll::Ready(Some(event)) = this.poll_event(cx) {
+                return Poll::Ready(Some(Ok(event)));
+            }
+            if let Some(completion) = this.completion.take() {
+                return Poll::Ready(Some(completion));
+            }
+            let Some((operation, _)) = this.operation.as_mut() else {
+                return Poll::Ready(None);
+            };
+            match operation.as_mut().poll(cx) {
+                Poll::Ready(result) => {
+                    if let Some((_, operation_to_response)) = this.operation.take() {
+                        this.completion = Some(result.map(operation_to_response));
+                    }
+                }
+                Poll::Pending => {
+                    return match this.poll_event(cx) {
+                        Poll::Ready(Some(event)) => Poll::Ready(Some(Ok(event))),
+                        Poll::Ready(None) | Poll::Pending => Poll::Pending,
+                    };
+                }
+            }
+        }
     }
 }
 

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -1,25 +1,26 @@
 use std::fs;
+use std::path::PathBuf;
 
 use coral_api::v1::{
     AddIdentitySpecRequest, CreateUserOwnedIdentityRequest, FixedTokenUserOwnedIdentitySetup,
-    ListUserOwnedIdentitiesRequest, create_user_owned_identity_request,
+    IdentitySpecInputValue, ListUserOwnedIdentitiesRequest, create_user_owned_identity_request,
     create_user_owned_identity_response,
 };
 use tempfile::TempDir;
 use tonic::Request;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::harness::GrpcHarness;
+
+struct OAuthFixture {
+    server: MockServer,
+}
 
 #[tokio::test]
 async fn identity_service_creates_and_lists_user_fixed_token_identity() {
     let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    fs::create_dir_all(&config_dir).expect("create config dir");
-    fs::write(
-        config_dir.join("config.toml"),
-        "[features]\ndsl_v4 = true\n",
-    )
-    .expect("write feature config");
+    let config_dir = dsl_v4_config_dir(&temp);
     let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
 
     harness
@@ -93,6 +94,66 @@ async fn identity_service_creates_and_lists_user_fixed_token_identity() {
     );
 }
 
+#[tokio::test]
+async fn identity_service_creates_and_lists_user_oauth_identity() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = dsl_v4_config_dir(&temp);
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+    let oauth = OAuthFixture::start().await;
+
+    harness
+        .identity_spec_client()
+        .add_identity_spec(Request::new(AddIdentitySpecRequest {
+            manifest_yaml: oauth.identity_spec_yaml("github_oauth"),
+            input_values: vec![IdentitySpecInputValue {
+                key: "GITHUB_OAUTH_CLIENT_ID".to_string(),
+                value: "test-client".to_string(),
+            }],
+        }))
+        .await
+        .expect("add identity spec");
+
+    let identity = create_github_oauth_identity(&harness, &oauth).await;
+    assert_eq!(identity.name, "github_local");
+    assert_eq!(identity.identity_spec, "github_oauth");
+    assert_eq!(identity.issuer, "github");
+    assert_eq!(identity.identity_type, "oauth");
+
+    let material_file = config_dir
+        .join("identities")
+        .join("users")
+        .join("local")
+        .join("github_local")
+        .join("secrets.env");
+    let material = fs::read_to_string(&material_file).expect("identity material");
+    assert!(material.contains("ACCESS_TOKEN=identity-access-token"));
+    assert!(material.contains("refresh_token=identity-refresh-token"));
+
+    let listed = harness
+        .identity_client()
+        .list_user_owned_identities(Request::new(ListUserOwnedIdentitiesRequest {}))
+        .await
+        .expect("list identities")
+        .into_inner()
+        .identities;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(
+        listed.first().expect("listed identity").name,
+        "github_local"
+    );
+}
+
+fn dsl_v4_config_dir(temp: &TempDir) -> PathBuf {
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[features]\ndsl_v4 = true\n",
+    )
+    .expect("write feature config");
+    config_dir
+}
+
 fn fixed_token_identity_spec_yaml() -> String {
     r"kind: identity
 spec_version: 1
@@ -104,4 +165,127 @@ audience:
   host: github.com
 "
     .to_string()
+}
+
+impl OAuthFixture {
+    async fn start() -> Self {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/device"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "device_code": "device-code",
+                "user_code": "ABCD-EFGH",
+                "verification_uri": format!("{}/verify", server.uri()),
+                "expires_in": 600,
+                "interval": 1
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "identity-access-token",
+                "refresh_token": "identity-refresh-token",
+                "token_type": "Bearer",
+                "scope": "repo",
+                "expires_in": 3600
+            })))
+            .mount(&server)
+            .await;
+        Self { server }
+    }
+
+    fn verify_url(&self) -> String {
+        format!("{}/verify", self.server.uri())
+    }
+
+    fn identity_spec_yaml(&self, name: &str) -> String {
+        format!(
+            r"
+kind: identity
+spec_version: 1
+name: {name}
+version: 0.1.0
+description: GitHub OAuth test identity.
+issuer: github
+type: oauth
+audience:
+  host: github.com
+inputs:
+  GITHUB_OAUTH_CLIENT_ID:
+    kind: variable
+    required: true
+oauth:
+  method:
+    label: Test device flow
+    flow:
+      type: device_code
+    endpoints:
+      device_authorization_url: {}/device
+      token_url: {}/token
+    client:
+      id:
+        input: GITHUB_OAUTH_CLIENT_ID
+    scopes:
+      scope:
+        delimiter: space
+        values:
+          - repo
+",
+            self.server.uri(),
+            self.server.uri()
+        )
+    }
+}
+
+async fn create_github_oauth_identity(
+    harness: &GrpcHarness,
+    oauth: &OAuthFixture,
+) -> coral_api::v1::Identity {
+    let mut stream = harness
+        .identity_client()
+        .create_user_owned_identity(Request::new(CreateUserOwnedIdentityRequest {
+            name: "github_local".to_string(),
+            identity_spec: "github_oauth".to_string(),
+            setup: None,
+        }))
+        .await
+        .expect("create identity")
+        .into_inner();
+
+    let authorization = stream
+        .message()
+        .await
+        .expect("authorization response")
+        .expect("authorization event");
+    match authorization.event.expect("authorization event body") {
+        create_user_owned_identity_response::Event::OauthAuthorization(authorization) => {
+            assert_eq!(authorization.input_key, "github_local");
+            assert_eq!(authorization.user_code, "ABCD-EFGH");
+            assert_eq!(authorization.authorization_url, oauth.verify_url());
+        }
+        other => panic!("unexpected first event: {other:?}"),
+    }
+
+    let completed = stream
+        .message()
+        .await
+        .expect("completed response")
+        .expect("completed event");
+    assert!(matches!(
+        completed.event,
+        Some(create_user_owned_identity_response::Event::OauthCompleted(
+            _
+        ))
+    ));
+
+    let created = stream
+        .message()
+        .await
+        .expect("created response")
+        .expect("created event");
+    match created.event.expect("created event body") {
+        create_user_owned_identity_response::Event::Identity(identity) => identity,
+        other => panic!("unexpected created event: {other:?}"),
+    }
 }


### PR DESCRIPTION
## Intent

Land `feat(app): add OAuth identity runtime` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-06-user-owned-identity-store...sauldhernandez/dsl-v4-identity-v2-07-oauth-identity-runtime
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
