### PR TITLE
feat(app): resolve source identities at query time

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -55,11 +55,11 @@ use crate::feedback::service::FeedbackService;
 use crate::identities::{
     IdentityManagementHandle, IdentityManager, IdentityService, IdentityStore,
 };
-use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
+use crate::identity::{SingleUserPrincipalProvider, SourceIdentityProvider, UserPrincipalProvider};
 use crate::identity_specs::{
     IdentitySpecManager, IdentitySpecRegistry, IdentitySpecService, IdentitySpecUsageProvider,
 };
-use crate::query::manager::QueryManager;
+use crate::query::manager::{QueryManager, QueryManagerOptions};
 use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
@@ -97,6 +97,7 @@ pub(crate) struct ServerConfig {
     identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
     feature_overrides: FeatureOverrides,
     identity_store: Option<Arc<dyn IdentityStore>>,
+    source_identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
@@ -119,6 +120,7 @@ impl ServerConfig {
             identity_spec_usage_providers: Vec::new(),
             feature_overrides: FeatureOverrides::default(),
             identity_store: None,
+            source_identity_providers: Vec::new(),
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             management_authorizer: Arc::new(AllowAllManagementAuthorizer),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
@@ -184,6 +186,15 @@ impl ServerConfig {
 
     pub(crate) fn with_identity_store(mut self, identity_store: Arc<dyn IdentityStore>) -> Self {
         self.identity_store = Some(identity_store);
+        self
+    }
+
+    pub(crate) fn add_source_identity_provider(
+        mut self,
+        source_identity_provider: Arc<dyn SourceIdentityProvider>,
+    ) -> Self {
+        self.source_identity_providers
+            .push(source_identity_provider);
         self
     }
 
@@ -363,6 +374,21 @@ impl ServerBuilder {
     }
 
     #[must_use]
+    /// Adds a source identity provider for query-time identity resolution.
+    ///
+    /// Providers are evaluated in call order before the built-in identity
+    /// provider.
+    pub fn add_source_identity_provider(
+        mut self,
+        source_identity_provider: Arc<dyn SourceIdentityProvider>,
+    ) -> Self {
+        self.config = self
+            .config
+            .add_source_identity_provider(source_identity_provider);
+        self
+    }
+
+    #[must_use]
     /// Enables or disables local stderr log rendering for this server.
     ///
     /// `MCP` stdio adapters can enable this for diagnostics while keeping
@@ -443,8 +469,10 @@ impl ServerBuilder {
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
-            features,
+            features.clone(),
         );
+        let mut source_identity_providers = self.config.source_identity_providers;
+        source_identity_providers.push(Arc::new(identity_manager.clone()));
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
         let episode_store = EpisodeStore::new(layout.clone());
@@ -455,12 +483,16 @@ impl ServerBuilder {
             .query_runtime_context()
             .with_body_capture_max_bytes(body_capture_max_bytes);
 
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::new_with_options(
             config_store,
             credential_manager,
             query_runtime_context,
             layout,
             self.config.engine_extensions_providers,
+            QueryManagerOptions {
+                features,
+                source_identity_providers,
+            },
         );
         let trace_service = if telemetry_config.trace_history.enabled {
             installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -378,6 +378,7 @@ impl IdentityManager {
         }
         for provider in self.providers.iter() {
             if let Some(selection) = provider.resolve_source_identity_selection(&request).await? {
+                selection.validate()?;
                 return Ok(selection);
             }
         }
@@ -413,9 +414,14 @@ impl fmt::Debug for IdentityManager {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use crate::bootstrap::AppError;
+
     use super::{
-        LOCAL_MEMBER_ID, SourceIdentityBinding, SourceIdentitySelection, UserPrincipal,
-        parse_path_segment,
+        IdentityManager, LOCAL_MEMBER_ID, RuntimeSourceIdentity, SourceIdentityBinding,
+        SourceIdentityProvider, SourceIdentityResolutionRequest, SourceIdentitySelection,
+        SourceIdentitySelectionRequest, UserPrincipal, parse_path_segment,
     };
 
     #[test]
@@ -492,5 +498,50 @@ mod tests {
 
         assert_eq!(selection.identity, "github-user");
         selection.validate().expect("selection should validate");
+    }
+
+    #[derive(Debug)]
+    struct InvalidSelectionProvider;
+
+    #[tonic::async_trait]
+    impl SourceIdentityProvider for InvalidSelectionProvider {
+        async fn resolve_source_identity_selection(
+            &self,
+            _request: &SourceIdentitySelectionRequest,
+        ) -> Result<Option<SourceIdentitySelection>, AppError> {
+            Ok(Some(SourceIdentitySelection {
+                identity: "../github".to_string(),
+            }))
+        }
+
+        async fn resolve_source_identity(
+            &self,
+            _request: &SourceIdentityResolutionRequest,
+        ) -> Result<Option<Arc<dyn RuntimeSourceIdentity>>, AppError> {
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn identity_manager_rejects_invalid_provider_selection() {
+        let manager = IdentityManager::new(vec![Arc::new(InvalidSelectionProvider)]);
+
+        let error = manager
+            .resolve_source_identity_selection(SourceIdentitySelectionRequest {
+                workspace_name: "default".to_string(),
+                user_id: "saul".to_string(),
+                source_name: "github_v4".to_string(),
+                surface_id: "rest".to_string(),
+                binding: SourceIdentityBinding::user_owned(),
+            })
+            .await
+            .expect_err("invalid provider selection should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("identity name must not contain '/' or '\\\\'"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -213,6 +213,19 @@ impl SourceIdentityBinding {
         }
         Ok(())
     }
+
+    fn workspace_selection(&self) -> Result<SourceIdentitySelection, AppError> {
+        if self.owner != IdentityOwnerKind::Workspace {
+            return Err(AppError::InvalidInput(
+                "user-owned source identity selection must be resolved per user".to_string(),
+            ));
+        }
+        SourceIdentitySelection::new(self.identity.clone().ok_or_else(|| {
+            AppError::InvalidInput(
+                "workspace-owned source identity binding is missing identity".to_string(),
+            )
+        })?)
+    }
 }
 
 /// Concrete identity selected for one source-local surface.
@@ -340,6 +353,62 @@ pub trait RuntimeSourceIdentity: Send + Sync + fmt::Debug {
         request: &reqwest::Request,
         resolved_inputs: &BTreeMap<String, String>,
     ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError>;
+}
+
+/// App-owned source identity manager. It owns binding resolution policy;
+/// providers only supply material for an already-selected binding.
+#[derive(Clone, Default)]
+pub(crate) struct IdentityManager {
+    providers: Arc<Vec<Arc<dyn SourceIdentityProvider>>>,
+}
+
+impl IdentityManager {
+    pub(crate) fn new(providers: Vec<Arc<dyn SourceIdentityProvider>>) -> Self {
+        Self {
+            providers: Arc::new(providers),
+        }
+    }
+
+    pub(crate) async fn resolve_source_identity_selection(
+        &self,
+        request: SourceIdentitySelectionRequest,
+    ) -> Result<SourceIdentitySelection, AppError> {
+        if request.binding.owner == IdentityOwnerKind::Workspace {
+            return request.binding.workspace_selection();
+        }
+        for provider in self.providers.iter() {
+            if let Some(selection) = provider.resolve_source_identity_selection(&request).await? {
+                return Ok(selection);
+            }
+        }
+        Err(AppError::FailedPrecondition(format!(
+            "no source identity provider resolved user-owned selection for source '{}' surface '{}' and user '{}'",
+            request.source_name, request.surface_id, request.user_id
+        )))
+    }
+
+    pub(crate) async fn resolve_source_identity(
+        &self,
+        request: SourceIdentityResolutionRequest,
+    ) -> Result<Arc<dyn RuntimeSourceIdentity>, AppError> {
+        for provider in self.providers.iter() {
+            if let Some(identity) = provider.resolve_source_identity(&request).await? {
+                return Ok(identity);
+            }
+        }
+        Err(AppError::FailedPrecondition(format!(
+            "no source identity provider resolved identity '{}' for source '{}' surface '{}'",
+            request.selection.identity, request.source_name, request.surface_id
+        )))
+    }
+}
+
+impl fmt::Debug for IdentityManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IdentityManager")
+            .field("provider_count", &self.providers.len())
+            .finish()
+    }
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/query/context.rs
+++ b/crates/coral-app/src/query/context.rs
@@ -35,13 +35,6 @@ impl QueryContext {
         &self.workspace_name
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "QueryContext intentionally carries principal state before query authorization consumes it."
-        )
-    )]
     pub(crate) fn principal(&self) -> &UserPrincipal {
         self.request_context.principal()
     }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1,14 +1,18 @@
 //! Query-time loading, validation, and execution over installed sources.
 
 use std::collections::BTreeMap;
+use std::fmt;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
 
 use coral_engine::{
-    CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, QueryExecution, QueryPlan,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RuntimeSourcePackage,
-    SourceValidationReport, StatusCode, TableInfo,
+    BoundRequestIdentityHttpAuthenticator, CatalogInfo, CoralQuery, CoreError, DescribeTableInfo,
+    QueryExecution, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    RequestIdentityHttpAuthenticatorError, RequestIdentityHttpAuthenticatorFactory,
+    RequestIdentitySelectionContext, RequestIdentitySelectionError, RequestIdentitySelector,
+    RuntimeIdentityRequirements, RuntimeSourceComponent, RuntimeSourcePackage,
+    SelectedRequestIdentity, SourceValidationReport, StatusCode, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::trace::Status as OtelStatus;
@@ -18,6 +22,12 @@ use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::episode::EpisodeId;
+use crate::features::Features;
+use crate::identity::{
+    IdentityManager, IdentityOwnerKind, SourceIdentityBinding, SourceIdentityProvider,
+    SourceIdentityResolutionRequest, SourceIdentitySelection, SourceIdentitySelectionRequest,
+    UserPrincipal,
+};
 use crate::query::QueryContext;
 use crate::query::extensions::{
     CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
@@ -43,6 +53,21 @@ pub(crate) struct ValidatedSource {
     pub(crate) report: SourceValidationReport,
 }
 
+type SourceIdentityBindingsSnapshot = BTreeMap<String, BTreeMap<String, SourceIdentityBinding>>;
+
+#[derive(Debug)]
+struct LoadedQuerySource {
+    query_source: QuerySource,
+    version: Option<String>,
+    identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+}
+
+#[derive(Default)]
+pub(crate) struct QueryManagerOptions {
+    pub(crate) features: Features,
+    pub(crate) source_identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
+}
+
 #[derive(Clone)]
 pub(crate) struct QueryManager {
     config_store: ConfigStore,
@@ -50,9 +75,12 @@ pub(crate) struct QueryManager {
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    features: Features,
+    identity_manager: IdentityManager,
 }
 
 impl QueryManager {
+    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
@@ -60,13 +88,59 @@ impl QueryManager {
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
+        Self::new_with_options(
+            config_store,
+            credential_manager,
+            runtime_context,
+            layout,
+            engine_extensions_providers,
+            QueryManagerOptions::default(),
+        )
+    }
+
+    pub(crate) fn new_with_options(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        options: QueryManagerOptions,
+    ) -> Self {
         Self {
             config_store,
             credential_manager,
             runtime_context,
             layout,
             engine_extensions_providers,
+            features: options.features,
+            identity_manager: IdentityManager::new(options.source_identity_providers),
         }
+    }
+
+    fn load_query_runtime(
+        &self,
+        context: &QueryContext,
+    ) -> Result<(Vec<QuerySource>, QueryRuntimeConfig), QueryManagerError> {
+        let workspace_name = context.workspace_name();
+        let config = self
+            .config_store
+            .load_config()
+            .map_err(QueryManagerError::App)?;
+        let loaded_sources = self
+            .load_query_sources(workspace_name, &config)
+            .map_err(QueryManagerError::App)?;
+        let identity_bindings = identity_binding_snapshot_for_sources(&loaded_sources);
+        let sources = query_sources_from_loaded(loaded_sources);
+        let runtime = self
+            .runtime_config(
+                workspace_name,
+                context.principal(),
+                &sources,
+                identity_bindings,
+                &config,
+            )
+            .map_err(QueryManagerError::App)?;
+        Ok((sources, runtime))
     }
 
     pub(crate) async fn list_tables(
@@ -83,16 +157,7 @@ impl QueryManager {
             &trace_sql,
             context.episode_id(),
             async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name, &config)
-                    .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                let (sources, runtime) = self.load_query_runtime(context)?;
                 CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -115,16 +180,7 @@ impl QueryManager {
             &trace_sql,
             context.episode_id(),
             async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name, &config)
-                    .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                let (sources, runtime) = self.load_query_runtime(context)?;
                 CoralQuery::list_catalog(&sources, runtime, schema_filter)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -158,16 +214,7 @@ impl QueryManager {
             &trace_sql,
             context.episode_id(),
             async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name, &config)
-                    .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                let (sources, runtime) = self.load_query_runtime(context)?;
                 CoralQuery::describe_table(&sources, runtime, schema_name, table_name)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -189,16 +236,7 @@ impl QueryManager {
             sql,
             context.episode_id(),
             async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name, &config)
-                    .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                let (sources, runtime) = self.load_query_runtime(context)?;
                 CoralQuery::execute_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -220,16 +258,7 @@ impl QueryManager {
             sql,
             context.episode_id(),
             async {
-                let config = self
-                    .config_store
-                    .load_config()
-                    .map_err(QueryManagerError::App)?;
-                let sources = self
-                    .load_query_sources(workspace_name, &config)
-                    .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config(workspace_name, &sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                let (sources, runtime) = self.load_query_runtime(context)?;
                 CoralQuery::explain_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -241,9 +270,10 @@ impl QueryManager {
 
     pub(crate) async fn validate_source(
         &self,
-        workspace_name: &WorkspaceName,
+        context: &QueryContext,
         source_name: &SourceName,
     ) -> Result<ValidatedSource, QueryManagerError> {
+        let workspace_name = context.workspace_name();
         let config = self
             .config_store
             .load_config()
@@ -252,18 +282,32 @@ impl QueryManager {
             .get_source(workspace_name, source_name)
             .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
             .map_err(QueryManagerError::App)?;
-        let (query_source, version) = self
+        let loaded_source = self
             .load_query_source(workspace_name, &source)
             .map_err(QueryManagerError::App)?;
-        let runtime = self
-            .runtime_config(workspace_name, std::slice::from_ref(&query_source), &config)
+        self.validate_source_identity_bindings(workspace_name, context.principal(), &loaded_source)
+            .await
             .map_err(QueryManagerError::App)?;
-        let report =
-            CoralQuery::validate_source(&query_source, runtime, query_source.test_queries())
-                .await
-                .map_err(QueryManagerError::Core)?;
+        let identity_bindings =
+            identity_binding_snapshot_for_sources(std::slice::from_ref(&loaded_source));
+        let runtime = self
+            .runtime_config(
+                workspace_name,
+                context.principal(),
+                std::slice::from_ref(&loaded_source.query_source),
+                identity_bindings,
+                &config,
+            )
+            .map_err(QueryManagerError::App)?;
+        let report = CoralQuery::validate_source(
+            &loaded_source.query_source,
+            runtime,
+            loaded_source.query_source.test_queries(),
+        )
+        .await
+        .map_err(QueryManagerError::Core)?;
         let mut source = source;
-        source.version = version;
+        source.version = loaded_source.version;
 
         Ok(ValidatedSource { source, report })
     }
@@ -272,7 +316,7 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         config: &AppConfig,
-    ) -> Result<Vec<QuerySource>, AppError> {
+    ) -> Result<Vec<LoadedQuerySource>, AppError> {
         let span = tracing::info_span!(
             "coral.app.query_sources.load",
             workspace = %workspace_name,
@@ -282,7 +326,7 @@ impl QueryManager {
         let mut query_sources = Vec::new();
         for source in config.workspace_sources(workspace_name) {
             match self.load_query_source(workspace_name, &source) {
-                Ok((query_source, _version)) => query_sources.push(query_source),
+                Ok(query_source) => query_sources.push(query_source),
                 Err(
                     error @ (AppError::Credentials(CredentialsError::Unavailable(_))
                     | AppError::MissingOrIncompatibleV4Materialization { .. }
@@ -307,10 +351,11 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
-    ) -> Result<(QuerySource, Option<String>), AppError> {
+    ) -> Result<LoadedQuerySource, AppError> {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = installed.source_spec;
         let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
+            self.features.ensure_dsl_v4_enabled()?;
             let materialized = load_v4_materialization(
                 &self.layout,
                 workspace_name,
@@ -380,13 +425,80 @@ impl QueryManager {
         } else {
             QuerySource::from_manifest(&source_spec, source.variables.clone(), resolved_secrets)
         };
-        Ok((query_source, installed.candidate.version))
+        Ok(LoadedQuerySource {
+            query_source,
+            version: installed.candidate.version,
+            identity_bindings: source.identity_bindings.clone(),
+        })
+    }
+
+    fn request_identity_selector_and_factory(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+        selected_sources: &[QuerySource],
+        identity_bindings: SourceIdentityBindingsSnapshot,
+    ) -> (
+        Option<Arc<dyn RequestIdentitySelector>>,
+        Option<RequestIdentityHttpAuthenticatorFactory>,
+    ) {
+        if !selected_sources
+            .iter()
+            .any(|source| identity_requirements_for_source(source).next().is_some())
+        {
+            return (None, None);
+        }
+        let selector = Arc::new(LazyRuntimeIdentitySelector {
+            workspace_name: workspace_name.clone(),
+            request_principal: request_principal.clone(),
+            source_identity_bindings: Arc::new(identity_bindings),
+            identity_manager: self.identity_manager.clone(),
+            selected_identities: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
+        });
+        let authenticator_selector = Arc::clone(&selector);
+        let factory: RequestIdentityHttpAuthenticatorFactory =
+            Arc::new(move |selected| authenticator_selector.bound_authenticator_for(selected));
+        (Some(selector), Some(factory))
+    }
+
+    async fn validate_source_identity_bindings(
+        &self,
+        workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
+        loaded_source: &LoadedQuerySource,
+    ) -> Result<(), AppError> {
+        let mut source_identity_bindings = BTreeMap::new();
+        source_identity_bindings.insert(
+            loaded_source.query_source.source_name().to_string(),
+            loaded_source.identity_bindings.clone(),
+        );
+        let resolver = LazyRuntimeIdentitySelector {
+            workspace_name: workspace_name.clone(),
+            request_principal: request_principal.clone(),
+            source_identity_bindings: Arc::new(source_identity_bindings),
+            identity_manager: self.identity_manager.clone(),
+            selected_identities: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
+        };
+        for requirements in identity_requirements_for_source(&loaded_source.query_source) {
+            let context = RequestIdentitySelectionContext::new(
+                loaded_source.query_source.source_name().to_string(),
+                requirements.surface_id,
+                requirements.requirements,
+            );
+            resolver
+                .select_identity(&context)
+                .await
+                .map_err(identity_selection_error_to_app_error)?;
+        }
+        Ok(())
     }
 
     fn runtime_config(
         &self,
         workspace_name: &WorkspaceName,
+        request_principal: &UserPrincipal,
         selected_sources: &[QuerySource],
+        identity_bindings: SourceIdentityBindingsSnapshot,
         config: &AppConfig,
     ) -> Result<QueryRuntimeConfig, AppError> {
         let mut extensions =
@@ -398,9 +510,20 @@ impl QueryManager {
             self.credential_manager.clone(),
             provider_input_resolver,
         )));
+        let (request_identity_selector, request_identity_http_authenticator_factory) = self
+            .request_identity_selector_and_factory(
+                workspace_name,
+                request_principal,
+                selected_sources,
+                identity_bindings,
+            );
         let mut runtime_context = self.runtime_context.clone();
         runtime_context.trace_context = Some(tracing::Span::current().context());
-        let mut runtime = QueryRuntimeConfig::new(runtime_context, extensions);
+        let mut runtime = QueryRuntimeConfig::new(runtime_context, extensions)
+            .with_request_identity_selector(request_identity_selector)
+            .with_request_identity_http_authenticator_factory(
+                request_identity_http_authenticator_factory,
+            );
         let selected_source_names = selected_sources
             .iter()
             .map(|source| source.source_name().to_string())
@@ -408,6 +531,204 @@ impl QueryManager {
         runtime.memory = config.memory_config()?;
         runtime.dependent_join = config.dependent_join_config(&selected_source_names)?;
         Ok(runtime)
+    }
+}
+
+fn query_sources_from_loaded(loaded_sources: Vec<LoadedQuerySource>) -> Vec<QuerySource> {
+    loaded_sources
+        .into_iter()
+        .map(|loaded| loaded.query_source)
+        .collect()
+}
+
+fn identity_binding_snapshot_for_sources(
+    loaded_sources: &[LoadedQuerySource],
+) -> SourceIdentityBindingsSnapshot {
+    loaded_sources
+        .iter()
+        .map(|loaded| {
+            (
+                loaded.query_source.source_name().to_string(),
+                loaded.identity_bindings.clone(),
+            )
+        })
+        .collect()
+}
+
+#[derive(Clone)]
+struct LazyRuntimeIdentitySelector {
+    workspace_name: WorkspaceName,
+    request_principal: UserPrincipal,
+    source_identity_bindings: Arc<SourceIdentityBindingsSnapshot>,
+    identity_manager: IdentityManager,
+    selected_identities:
+        Arc<std::sync::Mutex<BTreeMap<String, Arc<dyn crate::identity::RuntimeSourceIdentity>>>>,
+}
+
+impl fmt::Debug for LazyRuntimeIdentitySelector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LazyRuntimeIdentitySelector")
+            .field("workspace_name", &self.workspace_name)
+            .field("source_identity_bindings", &self.source_identity_bindings)
+            .field("identity_manager", &self.identity_manager)
+            .finish_non_exhaustive()
+    }
+}
+
+impl LazyRuntimeIdentitySelector {
+    async fn resolve_runtime_identity(
+        &self,
+        identity: &RequestIdentitySelectionContext,
+    ) -> Result<
+        (
+            SourceIdentitySelection,
+            Arc<dyn crate::identity::RuntimeSourceIdentity>,
+        ),
+        AppError,
+    > {
+        SourceName::parse(identity.source_name())
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        let binding = identity_binding_for_surface(
+            &self.source_identity_bindings,
+            identity.source_name(),
+            identity.surface_id(),
+        )?;
+        let selection = self
+            .identity_manager
+            .resolve_source_identity_selection(SourceIdentitySelectionRequest {
+                workspace_name: self.workspace_name.as_str().to_string(),
+                user_id: self.request_principal.user_id().to_string(),
+                source_name: identity.source_name().to_string(),
+                surface_id: identity.surface_id().to_string(),
+                binding: binding.clone(),
+            })
+            .await?;
+        let user_id = (binding.owner == IdentityOwnerKind::User)
+            .then(|| self.request_principal.user_id().to_string());
+        let runtime_identity = self
+            .identity_manager
+            .resolve_source_identity(SourceIdentityResolutionRequest {
+                workspace_name: self.workspace_name.as_str().to_string(),
+                user_id,
+                source_name: identity.source_name().to_string(),
+                surface_id: identity.surface_id().to_string(),
+                binding,
+                selection: selection.clone(),
+                identity_requirements: identity.identity_requirements().clone(),
+            })
+            .await?;
+        if !identity.accepts_identity(
+            runtime_identity.identity_spec_id(),
+            runtime_identity.audience(),
+        ) {
+            return Err(AppError::FailedPrecondition(format!(
+                "resolved identity does not satisfy identity_requirements for source '{}' surface '{}'",
+                identity.source_name(),
+                identity.surface_id()
+            )));
+        }
+        Ok((selection, runtime_identity))
+    }
+
+    fn bound_authenticator_for(
+        &self,
+        selected: SelectedRequestIdentity,
+    ) -> Result<BoundRequestIdentityHttpAuthenticator, RequestIdentityHttpAuthenticatorError> {
+        let runtime_identity = self
+            .selected_identities
+            .lock()
+            .expect("selected identity cache lock")
+            .get(selected.identity_id())
+            .cloned()
+            .ok_or_else(|| {
+                RequestIdentityHttpAuthenticatorError::failed_precondition(format!(
+                    "selected identity '{}' was not resolved during identity selection",
+                    selected.identity_id()
+                ))
+            })?;
+        let bound: BoundRequestIdentityHttpAuthenticator = Arc::new(
+            move |request: &reqwest::Request, resolved_inputs: &BTreeMap<String, String>| {
+                let runtime_identity = Arc::clone(&runtime_identity);
+                let selected = selected.clone();
+                Box::pin(async move {
+                    runtime_identity
+                        .resolve_headers(&selected, request, resolved_inputs)
+                        .await
+                })
+            },
+        );
+        Ok(bound)
+    }
+}
+
+#[tonic::async_trait]
+impl RequestIdentitySelector for LazyRuntimeIdentitySelector {
+    async fn select_identity(
+        &self,
+        identity: &RequestIdentitySelectionContext,
+    ) -> Result<SelectedRequestIdentity, RequestIdentitySelectionError> {
+        let (selection, runtime_identity) = self
+            .resolve_runtime_identity(identity)
+            .await
+            .map_err(|error| app_error_to_identity_selection_error(&error))?;
+        let selected = SelectedRequestIdentity::new(
+            selection.identity,
+            runtime_identity.identity_spec_id().to_string(),
+            runtime_identity.audience().clone(),
+        );
+        self.selected_identities
+            .lock()
+            .expect("selected identity cache lock")
+            .insert(
+                selected.identity_id().to_string(),
+                Arc::clone(&runtime_identity),
+            );
+        Ok(selected)
+    }
+}
+
+fn identity_requirements_for_source(
+    source: &QuerySource,
+) -> impl Iterator<Item = RuntimeIdentityRequirements> + '_ {
+    source
+        .components()
+        .iter()
+        .filter_map(|component| match component {
+            RuntimeSourceComponent::Http(component) => component.identity_requirements.clone(),
+            RuntimeSourceComponent::File(_) | RuntimeSourceComponent::Mcp(_) => None,
+        })
+}
+
+fn identity_binding_for_surface(
+    source_identity_bindings: &SourceIdentityBindingsSnapshot,
+    source_name: &str,
+    surface_id: &str,
+) -> Result<SourceIdentityBinding, AppError> {
+    source_identity_bindings
+        .get(source_name)
+        .and_then(|bindings| bindings.get(surface_id))
+        .cloned()
+        .ok_or_else(|| {
+            AppError::FailedPrecondition(format!(
+                "source '{source_name}' surface '{surface_id}' declares identity_requirements but has no workspace identity binding"
+            ))
+        })
+}
+
+fn app_error_to_identity_selection_error(error: &AppError) -> RequestIdentitySelectionError {
+    let detail = error.to_string();
+    match error {
+        AppError::InvalidInput(_) => RequestIdentitySelectionError::invalid_input(detail),
+        _ => RequestIdentitySelectionError::failed_precondition(detail),
+    }
+}
+
+fn identity_selection_error_to_app_error(error: RequestIdentitySelectionError) -> AppError {
+    match error {
+        RequestIdentitySelectionError::InvalidInput(detail) => AppError::InvalidInput(detail),
+        RequestIdentitySelectionError::FailedPrecondition(detail) => {
+            AppError::FailedPrecondition(detail)
+        }
     }
 }
 
@@ -625,10 +946,11 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use coral_engine::{
-        EngineExtensions, QueryExecution, SourceInputResolutionContext, SourceInputResolver,
-        SourceInputResolverError,
+        EngineExtensions, QueryExecution, RuntimeHttpSourceComponent, SourceInputResolutionContext,
+        SourceInputResolver, SourceInputResolverError,
     };
     use coral_spec::parse_source_manifest_yaml;
+    use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
     use serde_json::{Value, json};
     use tempfile::TempDir;
     use wiremock::matchers::{method, path};
@@ -636,7 +958,7 @@ mod tests {
 
     use super::*;
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
-    use crate::features::dsl_v4_features;
+    use crate::features::{Features, dsl_v4_features};
     use crate::identity::UserPrincipal;
     use crate::query::QueryAttribution;
     use crate::request_context::RequestContext;
@@ -652,15 +974,49 @@ mod tests {
         runtime_context: QueryRuntimeContext,
         providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> QueryManagerFixture {
+        query_manager_with_options(runtime_context, providers, Features::default(), Vec::new())
+    }
+
+    fn query_manager_with_features(
+        runtime_context: QueryRuntimeContext,
+        providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        features: Features,
+    ) -> QueryManagerFixture {
+        query_manager_with_options(runtime_context, providers, features, Vec::new())
+    }
+
+    fn query_manager_with_identity_providers(
+        runtime_context: QueryRuntimeContext,
+        providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
+    ) -> QueryManagerFixture {
+        query_manager_with_options(
+            runtime_context,
+            providers,
+            Features::default(),
+            identity_providers,
+        )
+    }
+
+    fn query_manager_with_options(
+        runtime_context: QueryRuntimeContext,
+        providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        features: Features,
+        identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
+    ) -> QueryManagerFixture {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        let manager = QueryManager::new(
+        let manager = QueryManager::new_with_options(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             runtime_context,
             layout,
             providers,
+            QueryManagerOptions {
+                features,
+                source_identity_providers: identity_providers,
+            },
         );
         QueryManagerFixture {
             _temp: temp,
@@ -680,7 +1036,7 @@ mod tests {
         use crate::query::service::QueryService;
 
         // Capture finished spans into memory via a scoped subscriber so the
-        // assertion exercises the request context -> manager -> span path end to end.
+        // assertion exercises the real metadata -> manager -> span path end to end.
         let exporter = InMemorySpanExporter::default();
         let provider = SdkTracerProvider::builder()
             .with_simple_exporter(exporter.clone())
@@ -699,7 +1055,7 @@ mod tests {
             }),
             sql: "SELECT 1".to_string(),
         });
-        let episode_id = EpisodeId::parse("ep_trace_1").expect("episode id");
+        let episode_id = crate::episode::EpisodeId::parse("ep_trace_1").expect("episode id");
         request
             .extensions_mut()
             .insert(RequestContext::with_attribution(
@@ -886,7 +1242,13 @@ mod tests {
 
         let runtime = fixture
             .manager
-            .runtime_config(&WorkspaceName::default(), &[], &AppConfig::default())
+            .runtime_config(
+                &WorkspaceName::default(),
+                &UserPrincipal::local(),
+                &[],
+                BTreeMap::new(),
+                &AppConfig::default(),
+            )
             .expect("runtime config");
 
         let config = runtime
@@ -896,9 +1258,212 @@ mod tests {
         assert_eq!(config, 42);
     }
 
+    #[derive(Debug)]
+    struct TestRuntimeIdentity {
+        identity_spec_id: String,
+        audience: BTreeMap<String, Value>,
+    }
+
+    #[tonic::async_trait]
+    impl crate::identity::RuntimeSourceIdentity for TestRuntimeIdentity {
+        fn identity_spec_id(&self) -> &str {
+            &self.identity_spec_id
+        }
+
+        fn audience(&self) -> &BTreeMap<String, Value> {
+            &self.audience
+        }
+
+        async fn resolve_headers(
+            &self,
+            _identity: &SelectedRequestIdentity,
+            _request: &reqwest::Request,
+            _resolved_inputs: &BTreeMap<String, String>,
+        ) -> Result<
+            Vec<(reqwest::header::HeaderName, reqwest::header::HeaderValue)>,
+            RequestIdentityHttpAuthenticatorError,
+        > {
+            Ok(vec![(
+                reqwest::header::AUTHORIZATION,
+                reqwest::header::HeaderValue::from_static("Bearer selected-token"),
+            )])
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestSourceIdentityProvider {
+        selection_user_ids: Arc<Mutex<Vec<String>>>,
+        resolution_user_ids: Arc<Mutex<Vec<Option<String>>>>,
+    }
+
+    #[tonic::async_trait]
+    impl SourceIdentityProvider for TestSourceIdentityProvider {
+        async fn resolve_source_identity_selection(
+            &self,
+            request: &SourceIdentitySelectionRequest,
+        ) -> Result<Option<SourceIdentitySelection>, AppError> {
+            self.selection_user_ids
+                .lock()
+                .expect("selection lock")
+                .push(request.user_id.clone());
+            Ok(Some(
+                SourceIdentitySelection::new("github_saul").expect("selection"),
+            ))
+        }
+
+        async fn resolve_source_identity(
+            &self,
+            request: &SourceIdentityResolutionRequest,
+        ) -> Result<Option<Arc<dyn crate::identity::RuntimeSourceIdentity>>, AppError> {
+            self.resolution_user_ids
+                .lock()
+                .expect("resolution lock")
+                .push(request.user_id.clone());
+            let selected_requirement = request
+                .identity_requirements
+                .accepts
+                .first()
+                .expect("selected identity requirement");
+            assert_eq!(request.selection.identity, "github_saul");
+            assert_eq!(request.identity_requirements.accepts.len(), 1);
+            assert_eq!(selected_requirement.id, "github-rest-read");
+            Ok(Some(Arc::new(TestRuntimeIdentity {
+                identity_spec_id: "github_pat".to_string(),
+                audience: BTreeMap::from([("host".to_string(), json!("api.example.test"))]),
+            })))
+        }
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "This integration-style unit test sets up source, binding, provider, and resolver state."
+    )]
+    #[tokio::test]
+    async fn runtime_config_resolves_user_source_identity_for_request_principal() {
+        let selection_user_ids = Arc::new(Mutex::new(Vec::new()));
+        let resolution_user_ids = Arc::new(Mutex::new(Vec::new()));
+        let fixture = query_manager_with_identity_providers(
+            QueryRuntimeContext::default(),
+            Vec::new(),
+            vec![Arc::new(TestSourceIdentityProvider {
+                selection_user_ids: Arc::clone(&selection_user_ids),
+                resolution_user_ids: Arc::clone(&resolution_user_ids),
+            })],
+        );
+        let requirements = IdentityRequirements {
+            accepts: vec![AcceptedIdentityRequirement {
+                id: "github-rest-read".to_string(),
+                identity_specs: vec!["github_pat".to_string()],
+                audience: BTreeMap::from([("host".to_string(), json!("api.example.test"))]),
+            }],
+        };
+        let mut http_manifest = parse_source_manifest_yaml(
+            r"
+name: github_v4_query
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://api.example.test
+tables:
+  - name: issues
+    description: Issues
+    request:
+      method: GET
+      path: /issues
+    response: {}
+    columns:
+      - name: id
+        type: Int64
+",
+        )
+        .expect("parse manifest")
+        .as_http()
+        .expect("http manifest")
+        .clone();
+        http_manifest.common.dsl_version = 4;
+        let source = QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: "github_v4_query".to_string(),
+                authored_version: None,
+                description: "GitHub".to_string(),
+                declared_inputs: Vec::new(),
+                test_queries: Vec::new(),
+                components: vec![RuntimeSourceComponent::Http(
+                    RuntimeHttpSourceComponent::with_identity_requirements(
+                        http_manifest,
+                        "rest",
+                        requirements.clone(),
+                    ),
+                )],
+            },
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect("runtime source");
+        let runtime = fixture
+            .manager
+            .runtime_config(
+                &WorkspaceName::default(),
+                &UserPrincipal::for_user("saul").expect("request principal"),
+                std::slice::from_ref(&source),
+                BTreeMap::from([(
+                    "github_v4_query".to_string(),
+                    BTreeMap::from([("rest".to_string(), SourceIdentityBinding::user_owned())]),
+                )]),
+                &AppConfig::default(),
+            )
+            .expect("runtime config");
+        let selector = runtime
+            .request_identity_selector
+            .expect("identity selector installed");
+        let factory = runtime
+            .request_identity_http_authenticator_factory
+            .expect("identity authenticator factory installed");
+        let selected = selector
+            .select_identity(&RequestIdentitySelectionContext::new(
+                "github_v4_query".to_string(),
+                "rest".to_string(),
+                requirements,
+            ))
+            .await
+            .expect("identity selected");
+        assert_eq!(selected.identity_id(), "github_saul");
+        assert_eq!(selected.identity_spec_id(), "github_pat");
+        let authenticator = factory(selected).expect("identity authenticator");
+        let request = reqwest::Request::new(
+            reqwest::Method::GET,
+            "https://api.example.test/issues".parse().expect("url"),
+        );
+        let headers = authenticator.as_ref()(&request, &BTreeMap::new())
+            .await
+            .expect("identity headers");
+
+        assert_eq!(
+            selection_user_ids
+                .lock()
+                .expect("selection lock")
+                .as_slice(),
+            &["saul".to_string()]
+        );
+        assert_eq!(
+            resolution_user_ids
+                .lock()
+                .expect("resolution lock")
+                .as_slice(),
+            &[Some("saul".to_string())]
+        );
+        let authorization = headers.first().expect("authorization header");
+        assert_eq!(authorization.0, reqwest::header::AUTHORIZATION);
+        assert_eq!(authorization.1, "Bearer selected-token");
+    }
+
     #[test]
     fn load_query_source_passes_present_optional_secrets_to_runtime() {
-        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        let fixture = query_manager_with_features(
+            QueryRuntimeContext::default(),
+            Vec::new(),
+            dsl_v4_features(),
+        );
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = WorkspaceName::default();
         let source_name = SourceName::parse("optional_auth").expect("source name");
@@ -950,6 +1515,7 @@ tables:
             variables: BTreeMap::new(),
             secrets: vec!["API_KEY".to_string(), "OAUTH_TOKEN".to_string()],
             credential_storage: Some(CredentialStorageKind::File),
+            identity_bindings: BTreeMap::new(),
             origin: SourceOrigin::Imported,
         };
         fixture
@@ -968,13 +1534,13 @@ tables:
             )
             .expect("persist secret material");
 
-        let (query_source, _) = fixture
+        let loaded_source = fixture
             .manager
             .load_query_source(&workspace_name, &source)
             .expect("optional secret should load when present");
 
         assert_eq!(
-            query_source.secrets(),
+            loaded_source.query_source.secrets(),
             &BTreeMap::from([("OAUTH_TOKEN".to_string(), "oauth-token".to_string())])
         );
     }
@@ -990,7 +1556,11 @@ tables:
             .mount(&server)
             .await;
 
-        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        let fixture = query_manager_with_features(
+            QueryRuntimeContext::default(),
+            Vec::new(),
+            dsl_v4_features(),
+        );
         fixture.manager.layout.ensure().expect("ensure layout");
         let source_manager = SourceManager::new_with_features(
             fixture.manager.config_store.clone(),
@@ -1046,6 +1616,8 @@ surfaces:
                         openapi_file.display()
                     ),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("import v4 source");
@@ -1071,8 +1643,77 @@ surfaces:
     }
 
     #[test]
-    fn load_query_sources_fails_closed_for_missing_v4_materialization() {
+    fn load_query_source_rejects_v4_when_dsl_v4_feature_is_disabled() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("github_v4_disabled").expect("source name");
+        let manifest_path = fixture
+            .manager
+            .layout
+            .manifest_file(&workspace_name, &source_name);
+        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create source dir");
+        std::fs::write(
+            &manifest_path,
+            r"
+name: github_v4_disabled
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/openapi.yaml
+",
+        )
+        .expect("write manifest");
+        let source = InstalledSource {
+            name: source_name,
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            origin: SourceOrigin::Imported,
+            identity_bindings: BTreeMap::new(),
+        };
+
+        let error = fixture
+            .manager
+            .load_query_source(&workspace_name, &source)
+            .expect_err("v4 source should require feature opt-in");
+
+        assert!(
+            matches!(error, AppError::SourceUnservable(ref message) if message.contains("dsl_v4")),
+            "unexpected error: {error:#}"
+        );
+
+        fixture
+            .manager
+            .config_store
+            .upsert_source(&workspace_name, source)
+            .expect("persist v4 source");
+        let config = fixture
+            .manager
+            .config_store
+            .load_config()
+            .expect("load config");
+        let error = fixture
+            .manager
+            .load_query_sources(&workspace_name, &config)
+            .expect_err("normal query loading should fail on disabled v4 source");
+
+        assert!(
+            matches!(error, AppError::SourceUnservable(ref message) if message.contains("dsl_v4")),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_query_sources_fails_closed_for_missing_v4_materialization() {
+        let fixture = query_manager_with_features(
+            QueryRuntimeContext::default(),
+            Vec::new(),
+            dsl_v4_features(),
+        );
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = WorkspaceName::default();
         let source_name = SourceName::parse("github_v4_missing_artifacts").expect("source name");
@@ -1105,6 +1746,7 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: Vec::new(),
                     credential_storage: None,
+                    identity_bindings: BTreeMap::new(),
                     origin: SourceOrigin::Imported,
                 },
             )
@@ -1147,6 +1789,7 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: vec!["GITHUB_TOKEN".to_string()],
                     credential_storage: Some(CredentialStorageKind::Keychain),
+                    identity_bindings: BTreeMap::new(),
                     origin: SourceOrigin::Bundled,
                 },
             )
@@ -1222,6 +1865,10 @@ surfaces:
         }
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "This integration-style unit test sets up persisted credentials and resolver composition."
+    )]
     #[tokio::test]
     async fn runtime_config_composes_provider_input_resolver_with_refreshed_inputs() {
         let calls = Arc::new(AtomicUsize::new(0));
@@ -1247,6 +1894,7 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: vec!["API_TOKEN".to_string()],
                     credential_storage: Some(CredentialStorageKind::File),
+                    identity_bindings: BTreeMap::new(),
                     origin: SourceOrigin::Bundled,
                 },
             )
@@ -1292,7 +1940,9 @@ tables:
             .manager
             .runtime_config(
                 &workspace_name,
+                &UserPrincipal::local(),
                 std::slice::from_ref(&source),
+                BTreeMap::new(),
                 &AppConfig::default(),
             )
             .expect("runtime config");

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -637,7 +637,11 @@ impl LazyRuntimeIdentitySelector {
         let runtime_identity = self
             .selected_identities
             .lock()
-            .expect("selected identity cache lock")
+            .map_err(|_error| {
+                RequestIdentityHttpAuthenticatorError::failed_precondition(
+                    "selected identity cache lock was poisoned",
+                )
+            })?
             .get(selected.identity_id())
             .cloned()
             .ok_or_else(|| {
@@ -678,7 +682,11 @@ impl RequestIdentitySelector for LazyRuntimeIdentitySelector {
         );
         self.selected_identities
             .lock()
-            .expect("selected identity cache lock")
+            .map_err(|_error| {
+                RequestIdentitySelectionError::failed_precondition(
+                    "selected identity cache lock was poisoned",
+                )
+            })?
             .insert(
                 selected.identity_id().to_string(),
                 Arc::clone(&runtime_identity),

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1055,7 +1055,7 @@ mod tests {
             }),
             sql: "SELECT 1".to_string(),
         });
-        let episode_id = crate::episode::EpisodeId::parse("ep_trace_1").expect("episode id");
+        let episode_id = EpisodeId::parse("ep_trace_1").expect("episode id");
         request
             .extensions_mut()
             .insert(RequestContext::with_attribution(

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -2155,7 +2155,7 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = source_manager_with_dsl_v4(config_store, credential_manager, layout);
+        let manager = SourceManager::new(config_store, credential_manager, layout);
         let (event_tx, mut event_rx) = import_event_channel();
 
         let error = manager

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -16,6 +16,7 @@ use crate::credentials::{
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialsError,
 };
 use crate::features::Features;
+use crate::identity::SourceIdentityBinding;
 use crate::sources::SourceName;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
@@ -58,12 +59,16 @@ pub(crate) struct CreateBundledSourceWithOAuthCommand {
 pub(crate) struct ImportSourceCommand {
     pub(crate) manifest_yaml: String,
     pub(crate) bindings: SourceBindings,
+    pub(crate) identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+    pub(crate) replace_identity_bindings: bool,
 }
 
 pub(crate) struct ImportSourceWithCredentialsCommand {
     pub(crate) manifest_yaml: String,
     pub(crate) bindings: SourceBindings,
     pub(crate) oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
+    pub(crate) identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+    pub(crate) replace_identity_bindings: bool,
 }
 
 #[derive(Default)]
@@ -147,6 +152,7 @@ struct PersistSourceRequest<'a> {
     candidate: &'a CandidateSource,
     manifest_yaml: Option<&'a str>,
     bindings: ValidatedBindings,
+    identity_bindings: BTreeMap<String, SourceIdentityBinding>,
     origin: SourceOrigin,
     credential_storage: Option<CredentialStorageKind>,
     materialization_tmp: Option<PathBuf>,
@@ -285,6 +291,7 @@ impl SourceManager {
             workspace_name,
             &candidate,
             &command.bindings,
+            BTreeMap::new(),
             None,
             &bundled.manifest_yaml,
             SourceOrigin::Bundled,
@@ -305,6 +312,7 @@ impl SourceManager {
             &command.bindings,
             command.oauth_credential_retrievals,
             events,
+            BTreeMap::new(),
             None,
             &bundled.manifest_yaml,
             SourceOrigin::Bundled,
@@ -323,10 +331,18 @@ impl SourceManager {
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        let identity_bindings = self.effective_source_identity_bindings(
+            workspace_name,
+            &candidate.name,
+            &command.identity_bindings,
+            command.replace_identity_bindings,
+        )?;
+        validate_import_identity_bindings(&manifest, &identity_bindings)?;
         self.install_validated_source(
             workspace_name,
             &candidate,
             &command.bindings,
+            identity_bindings,
             Some(&manifest_yaml),
             &manifest_yaml,
             SourceOrigin::Imported,
@@ -345,12 +361,20 @@ impl SourceManager {
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        let identity_bindings = self.effective_source_identity_bindings(
+            workspace_name,
+            &candidate.name,
+            &command.identity_bindings,
+            command.replace_identity_bindings,
+        )?;
+        validate_import_identity_bindings(&manifest, &identity_bindings)?;
         self.install_source_with_oauth(
             workspace_name,
             &candidate,
             &command.bindings,
             command.oauth_credential_retrievals,
             events,
+            identity_bindings,
             Some(&manifest_yaml),
             &manifest_yaml,
             SourceOrigin::Imported,
@@ -362,11 +386,16 @@ impl SourceManager {
     /// the source. Shared tail of the non-OAuth install entry points; the
     /// caller supplies the resolved `candidate` plus the per-origin
     /// `manifest_yaml`/`origin`.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Shared non-OAuth install tail for the source-lifecycle entry points; the parameters are the irreducible per-call inputs and match the OAuth tail below."
+    )]
     fn install_validated_source(
         &self,
         workspace_name: &WorkspaceName,
         candidate: &CandidateSource,
         bindings: &SourceBindings,
+        identity_bindings: BTreeMap<String, SourceIdentityBinding>,
         manifest_yaml: Option<&str>,
         materialization_manifest_yaml: &str,
         origin: SourceOrigin,
@@ -398,6 +427,7 @@ impl SourceManager {
                 candidate,
                 manifest_yaml,
                 bindings,
+                identity_bindings,
                 origin,
                 credential_storage,
                 materialization_tmp: self
@@ -429,6 +459,7 @@ impl SourceManager {
         bindings: &SourceBindings,
         oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
         events: ImportSourceEventSender,
+        identity_bindings: BTreeMap<String, SourceIdentityBinding>,
         manifest_yaml: Option<&str>,
         materialization_manifest_yaml: &str,
         origin: SourceOrigin,
@@ -474,6 +505,7 @@ impl SourceManager {
                 candidate,
                 manifest_yaml,
                 bindings,
+                identity_bindings,
                 origin,
                 credential_storage,
                 materialization_tmp: self
@@ -702,6 +734,7 @@ impl SourceManager {
             variables,
             secrets: visible_secret_keys,
             credential_storage,
+            identity_bindings: request.identity_bindings,
             origin: request.origin,
         };
         if let Err(error) = self
@@ -828,6 +861,23 @@ impl SourceManager {
             .config_store
             .load_catalog()?
             .contains(workspace_name, source_name))
+    }
+
+    fn effective_source_identity_bindings(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        requested: &BTreeMap<String, SourceIdentityBinding>,
+        replace_identity_bindings: bool,
+    ) -> Result<BTreeMap<String, SourceIdentityBinding>, AppError> {
+        if replace_identity_bindings || !requested.is_empty() {
+            return Ok(requested.clone());
+        }
+        match self.config_store.get_source(workspace_name, source_name) {
+            Ok(source) => Ok(source.identity_bindings),
+            Err(AppError::SourceNotFound(_)) => Ok(BTreeMap::new()),
+            Err(error) => Err(error),
+        }
     }
 
     fn read_source_material(
@@ -1270,6 +1320,51 @@ fn validate_bindings(
     })
 }
 
+fn validate_import_identity_bindings(
+    manifest: &ValidatedSourceManifest,
+    bindings: &BTreeMap<String, SourceIdentityBinding>,
+) -> Result<(), AppError> {
+    let Some(v4) = manifest.as_v4() else {
+        if bindings.is_empty() {
+            return Ok(());
+        }
+        return Err(AppError::InvalidInput(
+            "source identity bindings can only be configured for DSL v4 sources".to_string(),
+        ));
+    };
+
+    for surface in v4
+        .surfaces
+        .iter()
+        .filter(|surface| surface.identity_requirements.is_some())
+    {
+        if !bindings.contains_key(&surface.id) {
+            return Err(AppError::InvalidInput(format!(
+                "source '{}' surface '{}' declares identity_requirements but no identity binding was provided",
+                manifest.schema_name(),
+                surface.id
+            )));
+        }
+    }
+
+    for (surface_id, binding) in bindings {
+        binding.validate()?;
+        let surface = v4.surface(surface_id).ok_or_else(|| {
+            AppError::InvalidInput(format!(
+                "source '{}' identity binding targets unknown surface '{surface_id}'",
+                manifest.schema_name()
+            ))
+        })?;
+        surface.identity_requirements.as_ref().ok_or_else(|| {
+            AppError::InvalidInput(format!(
+                "source '{}' surface '{surface_id}' does not declare identity_requirements",
+                manifest.schema_name()
+            ))
+        })?;
+    }
+    Ok(())
+}
+
 fn source_needs_stored_material_for_validation(
     candidate: &CandidateSource,
     bindings: &SourceBindings,
@@ -1537,6 +1632,7 @@ mod tests {
         CredentialStore,
     };
     use crate::features::dsl_v4_features;
+    use crate::identity::{IdentityOwnerKind, SourceIdentityBinding};
     use crate::sources::SourceName;
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
     use crate::state::{AppStateLayout, ConfigStore};
@@ -1699,6 +1795,25 @@ surfaces:
         default: http://127.0.0.1:1
     base_url: "{{{{input.API_BASE}}}}"
 "#,
+            openapi_file.display()
+        )
+    }
+
+    fn manifest_v4_with_identity_requirement(openapi_file: &std::path::Path) -> String {
+        format!(
+            r"
+name: github_v4_identity
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          identity_specs: [github_pat]
+          audience: {{host: api.example.test}}
+",
             openapi_file.display()
         )
     }
@@ -1937,6 +2052,7 @@ tables:
                     variables: BTreeMap::new(),
                     secrets: vec!["OTHER_TOKEN".to_string()],
                     credential_storage: Some(CredentialStorageKind::Keychain),
+                    identity_bindings: BTreeMap::new(),
                     origin: SourceOrigin::Imported,
                 },
             )
@@ -2009,6 +2125,8 @@ tables:
                 &ImportSourceCommand {
                     manifest_yaml: manifest_v4_with_file_descriptor(&openapi_file),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect_err("v4 source import should require feature opt-in");
@@ -2037,7 +2155,7 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout);
+        let manager = source_manager_with_dsl_v4(config_store, credential_manager, layout);
         let (event_tx, mut event_rx) = import_event_channel();
 
         let error = manager
@@ -2046,6 +2164,8 @@ tables:
                 ImportSourceWithCredentialsCommand {
                     manifest_yaml: manifest_v4_with_file_descriptor(&openapi_file),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                     oauth_credential_retrievals: vec![SourceOAuthCredentialRetrieval {
                         input_key: "API_TOKEN".to_string(),
                         method_index: 0,
@@ -2087,6 +2207,8 @@ tables:
                 &ImportSourceCommand {
                     manifest_yaml: manifest_v4_with_file_descriptor(&openapi_file),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("import v4 source");
@@ -2111,6 +2233,47 @@ tables:
     }
 
     #[test]
+    fn import_v4_source_persists_identity_bindings() {
+        let temp = TempDir::new().expect("temp dir");
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
+        std::fs::write(&openapi_file, v4_openapi_fixture()).expect("write fixture");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager = source_manager_with_dsl_v4(config_store, credential_manager, layout);
+        let mut identity_bindings = BTreeMap::new();
+        identity_bindings.insert("rest".to_string(), SourceIdentityBinding::user_owned());
+
+        let installed = manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_v4_with_identity_requirement(&openapi_file),
+                    bindings: SourceBindings::default(),
+                    identity_bindings,
+                    replace_identity_bindings: false,
+                },
+            )
+            .expect("import v4 source with identity binding");
+
+        let binding = installed
+            .identity_bindings
+            .get("rest")
+            .expect("rest identity binding");
+        assert_eq!(binding.owner, IdentityOwnerKind::User);
+        assert_eq!(binding.identity, None);
+        let source_name = SourceName::parse("github_v4_identity").expect("source");
+        let stored = manager
+            .get_source(&default_workspace(), &source_name)
+            .expect("stored source");
+        assert_eq!(stored.identity_bindings, installed.identity_bindings);
+    }
+
+    #[test]
     fn import_v4_source_rejects_runtime_schema_collision_before_persistence() {
         let temp = TempDir::new().expect("temp dir");
         let descriptor_temp = TempDir::new().expect("descriptor temp dir");
@@ -2132,6 +2295,8 @@ tables:
                     manifest_yaml: manifest_without_secrets()
                         .replace("public_messages", "github_v4_rest"),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("install existing source");
@@ -2146,6 +2311,8 @@ tables:
                         "rest",
                     ),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect_err("surface namespace should collide with installed source schema");
@@ -2193,6 +2360,8 @@ tables:
                 &ImportSourceCommand {
                     manifest_yaml: manifest_v4_with_input_and_derived_base_url(&openapi_file),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect_err("source add should reject derived base_url input token defaults");
@@ -2231,6 +2400,8 @@ tables:
                 &ImportSourceCommand {
                     manifest_yaml: manifest_v4_with_file_descriptor(Path::new("openapi.yaml")),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect_err("raw relative descriptors should fail in app import");
@@ -2264,6 +2435,8 @@ tables:
                 &ImportSourceCommand {
                     manifest_yaml: manifest_v4_without_description_or_base_url(&openapi_file),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("import v4 source");
@@ -2314,6 +2487,8 @@ tables:
                             value: "secret-token".to_string(),
                         }],
                     },
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect_err("secret persistence should fail");
@@ -2407,6 +2582,8 @@ tables:
                             value: "secret-token".to_string(),
                         }],
                     },
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("import source");
@@ -2445,6 +2622,8 @@ tables:
                             value: "secret-token".to_string(),
                         }],
                     },
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("import source");
@@ -2508,6 +2687,8 @@ tables:
                 &ImportSourceCommand {
                     manifest_yaml: manifest_without_secrets(),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("import source");
@@ -2548,6 +2729,8 @@ tables:
                 &ImportSourceCommand {
                     manifest_yaml: manifest_with_secret(),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect_err("missing required secret should fail validation");
@@ -2584,6 +2767,8 @@ tables:
                             value: "old-token".to_string(),
                         }],
                     },
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("initial import");
@@ -2603,6 +2788,8 @@ tables:
                             value: "new-token".to_string(),
                         }],
                     },
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("replace malformed credential material");
@@ -2637,6 +2824,8 @@ tables:
                             value: "secret-token".to_string(),
                         }],
                     },
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("initial import");
@@ -2694,6 +2883,8 @@ tables:
                 &ImportSourceCommand {
                     manifest_yaml: manifest_with_secret(),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("import source");
@@ -2738,6 +2929,8 @@ tables:
                 &ImportSourceCommand {
                     manifest_yaml: manifest_with_secret(),
                     bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect_err("stored material I/O error should fail import");
@@ -2796,6 +2989,8 @@ tables:
                             value: "manual-token".to_string(),
                         }],
                     },
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("import source");
@@ -2844,6 +3039,8 @@ tables:
                             value: "old-token".to_string(),
                         }],
                     },
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("install source");
@@ -2870,6 +3067,8 @@ tables:
                             value: "manual-token".to_string(),
                         }],
                     },
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
         });
@@ -2950,6 +3149,8 @@ tables:
                     method_index: 0,
                     credential_inputs: Vec::new(),
                 }],
+                identity_bindings: BTreeMap::new(),
+                replace_identity_bindings: false,
             },
             event_tx,
         );
@@ -3039,6 +3240,8 @@ tables:
                             value: "old-token".to_string(),
                         }],
                     },
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
             )
             .expect("install source");
@@ -3060,6 +3263,8 @@ tables:
                         method_index: 0,
                         credential_inputs: Vec::new(),
                     }],
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
                 event_tx,
             )
@@ -3127,6 +3332,8 @@ tables:
                         method_index: 0,
                         credential_inputs: Vec::new(),
                     }],
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 },
                 event_tx,
             )

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -6,6 +6,7 @@ use coral_spec::ManifestInputSpec;
 use serde::{Deserialize, Serialize};
 
 use crate::credentials::CredentialStorageKind;
+use crate::identity::SourceIdentityBinding;
 use crate::sources::SourceName;
 
 /// App-owned description of a source candidate that can be installed.
@@ -43,6 +44,9 @@ pub(crate) struct InstalledSource {
     /// storage until the source is removed and re-added.
     #[serde(default)]
     pub(crate) credential_storage: Option<CredentialStorageKind>,
+    /// Source-local DSL v4 surface identity bindings for this workspace.
+    #[serde(default)]
+    pub(crate) identity_bindings: BTreeMap<String, SourceIdentityBinding>,
     /// Where this installed source came from.
     pub(crate) origin: SourceOrigin,
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -1,5 +1,6 @@
 //! Implements the gRPC `SourceService` for source lifecycle APIs.
 
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -37,6 +38,7 @@ use crate::authorization::{
 };
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
+use crate::query::QueryContext;
 use crate::query::manager::QueryManager;
 use crate::request_context::RequestContext;
 use crate::sources::SourceName;
@@ -283,6 +285,8 @@ impl SourceServiceApi for SourceService {
                 let command = ImportSourceCommand {
                     manifest_yaml: request.manifest_yaml,
                     bindings: source_bindings_from_proto(request.variables, request.secrets),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
                 };
                 let installed = run_blocking_source_operation(move || {
                     sources.import_source(&workspace_name, &command)
@@ -306,6 +310,8 @@ impl SourceServiceApi for SourceService {
                     .map(oauth_credential_retrieval_from_proto)
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(app_status)?,
+                identity_bindings: BTreeMap::new(),
+                replace_identity_bindings: false,
             };
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
@@ -359,18 +365,19 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
         instrument_grpc(span, async move {
+            let workspace_name = workspace_name_from_proto(request.get_ref().workspace.as_ref())?;
+            let context = QueryContext::from_request(workspace_name, &request)?;
             let request = request.into_inner();
-            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             let result = queries
-                .validate_source(&workspace_name, &source_name)
+                .validate_source(&context, &source_name)
                 .await
                 .map_err(query_status)?;
             let crate::query::manager::ValidatedSource { source, report } = result;
-            let source = installed_source_to_proto(&workspace_name, source);
+            let source = installed_source_to_proto(context.workspace_name(), source);
             Ok(Response::new(validate_source_response_to_proto(
                 source,
-                &workspace_name,
+                context.workspace_name(),
                 report,
             )))
         })

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -9,6 +9,7 @@ use tracing::{info_span, warn};
 
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialStorageKind;
+use crate::identity::SourceIdentityBinding;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
@@ -187,19 +188,23 @@ struct PersistedInstalledSource {
     secrets: Vec<String>,
     #[serde(default)]
     credential_storage: Option<CredentialStorageKind>,
+    #[serde(default)]
+    identity_bindings: BTreeMap<String, SourceIdentityBinding>,
     origin: SourceOrigin,
 }
 
 impl PersistedInstalledSource {
-    fn into_installed_source(self, source_name: SourceName) -> InstalledSource {
-        InstalledSource {
+    fn into_installed_source(self, source_name: SourceName) -> Result<InstalledSource, AppError> {
+        validate_identity_bindings(source_name.as_str(), &self.identity_bindings)?;
+        Ok(InstalledSource {
             name: source_name,
             version: self.version,
             variables: self.variables,
             secrets: self.secrets,
             credential_storage: self.credential_storage,
+            identity_bindings: self.identity_bindings,
             origin: self.origin,
-        }
+        })
     }
 }
 
@@ -210,6 +215,7 @@ impl From<&InstalledSource> for PersistedInstalledSource {
             variables: value.variables.clone(),
             secrets: value.secrets.clone(),
             credential_storage: value.credential_storage,
+            identity_bindings: value.identity_bindings.clone(),
             origin: value.origin,
         }
     }
@@ -527,6 +533,15 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
                     .expect("source config entry should be a table after initialization");
                 source_table.remove("credential_storage");
             }
+            if source.identity_bindings.is_empty() {
+                let source_table = source_item
+                    .as_table_mut()
+                    .expect("source config entry should be a table after initialization");
+                source_table.remove("identity_bindings");
+            } else {
+                source_item["identity_bindings"] =
+                    Item::Value(render_identity_bindings(&source.identity_bindings));
+            }
             source_item["origin"] = value(source.origin.as_config_value());
         }
     }
@@ -607,7 +622,7 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
             let workspace_name = WorkspaceName::parse(&workspace_name)?;
             for (source_name, source) in workspace_config.sources {
                 let source_name = SourceName::parse(&source_name)?;
-                catalog.upsert_source(&workspace_name, source.into_installed_source(source_name));
+                catalog.upsert_source(&workspace_name, source.into_installed_source(source_name)?);
             }
         }
         Ok(Self {
@@ -781,6 +796,42 @@ fn positive_optional(field: &str, value: Option<usize>) -> Result<Option<usize>,
     }
 }
 
+fn validate_identity_bindings(
+    source_name: &str,
+    bindings: &BTreeMap<String, SourceIdentityBinding>,
+) -> Result<(), AppError> {
+    for (surface_id, binding) in bindings {
+        validate_surface_id(surface_id).map_err(|error| {
+            AppError::InvalidInput(format!(
+                "source '{source_name}' identity binding surface '{surface_id}' is invalid: {error}"
+            ))
+        })?;
+        binding.validate()?;
+    }
+    Ok(())
+}
+
+fn validate_surface_id(surface_id: &str) -> Result<(), AppError> {
+    if surface_id.is_empty() {
+        return Err(AppError::InvalidInput("missing surface id".to_string()));
+    }
+    let mut chars = surface_id.chars();
+    let Some(first) = chars.next() else {
+        return Err(AppError::InvalidInput("missing surface id".to_string()));
+    };
+    if !first.is_ascii_lowercase() {
+        return Err(AppError::InvalidInput(
+            "surface id must start with a lowercase ASCII letter".to_string(),
+        ));
+    }
+    if chars.any(|ch| !(ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')) {
+        return Err(AppError::InvalidInput(
+            "surface id must contain only lowercase ASCII letters, digits, or '_'".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn render_inline_table(values: &BTreeMap<String, String>) -> Value {
     let mut table = InlineTable::new();
     for (key, value) in values {
@@ -792,6 +843,21 @@ fn render_inline_table(values: &BTreeMap<String, String>) -> Value {
 
 fn render_string_array(values: &[String]) -> Value {
     values.iter().cloned().collect()
+}
+
+fn render_identity_bindings(values: &BTreeMap<String, SourceIdentityBinding>) -> Value {
+    let mut table = InlineTable::new();
+    for (surface_id, binding) in values {
+        let mut binding_table = InlineTable::new();
+        binding_table.insert("owner", Value::from(binding.owner.as_config_value()));
+        if let Some(identity) = &binding.identity {
+            binding_table.insert("identity", Value::from(identity.clone()));
+        }
+        binding_table.fmt();
+        table.insert(surface_id, Value::InlineTable(binding_table));
+    }
+    table.fmt();
+    Value::InlineTable(table)
 }
 
 #[cfg(test)]
@@ -831,6 +897,7 @@ mod tests {
             )]),
             secrets: vec!["GITHUB_TOKEN".to_string()],
             credential_storage: None,
+            identity_bindings: BTreeMap::new(),
             origin: SourceOrigin::Imported,
         }
     }

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 
 use coral_engine::{DependentJoinConfig, DependentJoinSourceConfig, MemorySize, QueryMemoryConfig};
+use coral_spec::v4::validate_surface_id;
 use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, InlineTable, Item, Value, value};
 use tracing::{info_span, warn};
@@ -811,27 +812,6 @@ fn validate_identity_bindings(
     Ok(())
 }
 
-fn validate_surface_id(surface_id: &str) -> Result<(), AppError> {
-    if surface_id.is_empty() {
-        return Err(AppError::InvalidInput("missing surface id".to_string()));
-    }
-    let mut chars = surface_id.chars();
-    let Some(first) = chars.next() else {
-        return Err(AppError::InvalidInput("missing surface id".to_string()));
-    };
-    if !first.is_ascii_lowercase() {
-        return Err(AppError::InvalidInput(
-            "surface id must start with a lowercase ASCII letter".to_string(),
-        ));
-    }
-    if chars.any(|ch| !(ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')) {
-        return Err(AppError::InvalidInput(
-            "surface id must contain only lowercase ASCII letters, digits, or '_'".to_string(),
-        ));
-    }
-    Ok(())
-}
-
 fn render_inline_table(values: &BTreeMap<String, String>) -> Value {
     let mut table = InlineTable::new();
     for (key, value) in values {
@@ -1009,6 +989,29 @@ origin = "bundled"
         assert_eq!(
             sources[0].effective_credential_storage(),
             CredentialStorageKind::File
+        );
+    }
+
+    #[test]
+    fn rejects_identity_binding_surface_ids_using_spec_rule() {
+        let raw = r#"
+version = 1
+
+[workspaces.default.sources.github_v4]
+origin = "imported"
+identity_bindings = { Rest = { owner = "user" } }
+"#;
+
+        let error = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(raw).expect("config should parse"),
+        )
+        .expect_err("invalid identity binding surface id should fail");
+
+        assert!(
+            error.to_string().contains(
+                "source 'github_v4' identity binding surface 'Rest' is invalid: surface id 'Rest' must match [a-z][a-z0-9_]*"
+            ),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/coral-spec/src/v4/manifest.rs
+++ b/crates/coral-spec/src/v4/manifest.rs
@@ -240,7 +240,7 @@ impl V4SourceManifest {
             let surface_value = surface_values.get(index).ok_or_else(|| {
                 ManifestError::validation(format!("source '{name}' surface[{index}] is missing"))
             })?;
-            validate_surface_id(&name, &raw_surface.id)?;
+            validate_manifest_surface_id(&name, &raw_surface.id)?;
             if !seen_surface_ids.insert(raw_surface.id.clone()) {
                 return Err(ManifestError::validation(format!(
                     "source '{name}' has duplicate surface id '{}'",
@@ -518,7 +518,7 @@ fn mcp_server_location(server: &McpServerSpec) -> String {
     }
 }
 
-fn validate_surface_id(source_name: &str, id: &str) -> Result<()> {
+pub fn validate_surface_id(id: &str) -> Result<()> {
     let mut chars = id.chars();
     let valid = matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
         && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
@@ -526,9 +526,17 @@ fn validate_surface_id(source_name: &str, id: &str) -> Result<()> {
         Ok(())
     } else {
         Err(ManifestError::validation(format!(
-            "source '{source_name}' surface id '{id}' must match [a-z][a-z0-9_]*"
+            "surface id '{id}' must match [a-z][a-z0-9_]*"
         )))
     }
+}
+
+fn validate_manifest_surface_id(source_name: &str, id: &str) -> Result<()> {
+    validate_surface_id(id).map_err(|_error| {
+        ManifestError::validation(format!(
+            "source '{source_name}' surface id '{id}' must match [a-z][a-z0-9_]*"
+        ))
+    })
 }
 
 fn surface_relation_namespace(

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -41,7 +41,7 @@ pub use ir::{
 pub use manifest::{
     AcceptedIdentityRequirement, IdentityRequirements, McpRuntimeConfig, OpenApiRuntimeConfig,
     SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType, V4SourceCommon, V4SourceManifest,
-    V4Surface, validate_openapi_base_url_template,
+    V4Surface, validate_openapi_base_url_template, validate_surface_id,
 };
 pub use naming::normalize_identifier;
 pub use projections::{


### PR DESCRIPTION
## Intent

Land `feat(app): resolve source identities at query time` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-08-source-identity-bindings...sauldhernandez/dsl-v4-identity-v2-09-query-identity-resolution
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
