### PR TITLE
feat(source): import identity specs with sources

### DIFF
--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package coral.v1;
 
 import "coral/v1/catalog.proto";
+import "coral/v1/identity_specs.proto";
 import "coral/v1/resources.proto";
 
 // How one installed source entered Coral ownership.
@@ -344,6 +345,10 @@ message ImportSourceRequest {
   repeated SourceSecret secrets = 4;
   // OAuth credential retrievals the app should run before validation and import.
   repeated OAuthCredentialRetrieval oauth_credential_retrievals = 5;
+  // Global identity specs authored in the same import bundle as this source.
+  // The app installs these specs before importing the source manifest. They do
+  // not create identity instances or source bindings.
+  repeated string identity_spec_manifest_yamls = 6;
   // Source-surface identity bindings to persist with the imported source.
   //
   // Workspace-owned bindings use identity as the workspace identity name.
@@ -362,6 +367,18 @@ message ImportSourceRequest {
   // compatibility with callers that cannot distinguish omitted and empty
   // repeated fields.
   bool replace_identity_bindings = 9;
+  // Setup input values for identity specs imported with this source. Values are
+  // grouped by identity spec name and stored as identity-spec-owned material,
+  // not as source or identity instance material.
+  repeated IdentitySpecImportInputs identity_spec_inputs = 10;
+}
+
+// Setup inputs for one identity spec imported with a source bundle.
+message IdentitySpecImportInputs {
+  // Identity spec name matching one identity_spec_manifest_yamls entry.
+  string identity_spec_name = 1;
+  // Setup input values owned by the installed identity spec.
+  repeated IdentitySpecInputValue input_values = 2;
 }
 
 // Streaming event emitted while importing a source.

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -646,6 +646,7 @@ async fn start_server(
     let source_service = SourceService::new(
         source_manager,
         query_manager.clone(),
+        identity_spec_manager.clone(),
         identity_manager.clone(),
         Arc::clone(&management_authorizer),
     );
@@ -956,7 +957,7 @@ mod tests {
     use crate::{
         AllowAllManagementAuthorizer, AppError, AuthorizationError, AwsEngineExtensionsProvider,
         ManagementAuthorizer, ManagementMutation, NoopEngineExtensionsProvider,
-        SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider,
+        ResourceMutationKind, SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider,
     };
 
     fn default_workspace() -> Workspace {
@@ -1082,6 +1083,27 @@ enabled = false
         }
     }
 
+    #[derive(Debug)]
+    struct DenyingIdentitySpecManagementAuthorizer;
+
+    #[tonic::async_trait]
+    impl ManagementAuthorizer for DenyingIdentitySpecManagementAuthorizer {
+        async fn authorize_management_mutation(
+            &self,
+            _principal: &UserPrincipal,
+            mutation: ManagementMutation<'_>,
+        ) -> Result<(), AuthorizationError> {
+            match mutation {
+                ManagementMutation::IdentitySpec {
+                    kind: ResourceMutationKind::Upsert,
+                } => Err(AuthorizationError::forbidden(
+                    "identity spec mutation denied",
+                )),
+                _ => Ok(()),
+            }
+        }
+    }
+
     #[tokio::test]
     async fn grpc_services_reject_unauthenticated_requests() {
         let temp = TempDir::new().expect("temp dir");
@@ -1181,6 +1203,8 @@ enabled = false
                 oauth_credential_retrievals: Vec::new(),
                 identity_bindings: Vec::new(),
                 replace_identity_bindings: false,
+                identity_spec_manifest_yamls: Vec::new(),
+                identity_spec_inputs: Vec::new(),
             }))
             .await
             .expect_err("source import should be authorization-gated");
@@ -1194,6 +1218,42 @@ enabled = false
             .await
             .expect_err("source deletion should be authorization-gated");
         assert_eq!(delete_status.code(), Code::PermissionDenied);
+
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn import_source_identity_spec_bundle_requires_identity_spec_authorization() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_management_authorizer(Arc::new(DenyingIdentitySpecManagementAuthorizer))
+            .start()
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut source_client = SourceServiceClient::new(channel);
+
+        let status = source_client
+            .import_source(Request::new(ImportSourceRequest {
+                workspace: Some(default_workspace()),
+                manifest_yaml: "not a manifest".to_string(),
+                variables: Vec::new(),
+                secrets: Vec::new(),
+                oauth_credential_retrievals: Vec::new(),
+                identity_bindings: Vec::new(),
+                replace_identity_bindings: false,
+                identity_spec_manifest_yamls: vec!["not an identity spec".to_string()],
+                identity_spec_inputs: Vec::new(),
+            }))
+            .await
+            .expect_err("identity spec bundle import should be authorization-gated");
+        assert_eq!(status.code(), Code::PermissionDenied);
+        assert_eq!(status.message(), "identity spec mutation denied");
 
         server.shutdown().await.expect("shutdown");
     }
@@ -1616,6 +1676,8 @@ tables:
                 variables: Vec::new(),
                 secrets: Vec::new(),
                 oauth_credential_retrievals: Vec::new(),
+                identity_spec_manifest_yamls: Vec::new(),
+                identity_spec_inputs: Vec::new(),
                 identity_bindings: Vec::new(),
                 replace_identity_bindings: false,
             }))
@@ -1918,6 +1980,8 @@ tables:
                 variables: Vec::new(),
                 secrets: Vec::new(),
                 oauth_credential_retrievals: Vec::new(),
+                identity_spec_manifest_yamls: Vec::new(),
+                identity_spec_inputs: Vec::new(),
                 identity_bindings: Vec::new(),
                 replace_identity_bindings: false,
             }))
@@ -2120,6 +2184,8 @@ tables:
                 variables: Vec::new(),
                 secrets: Vec::new(),
                 oauth_credential_retrievals: Vec::new(),
+                identity_spec_manifest_yamls: Vec::new(),
+                identity_spec_inputs: Vec::new(),
                 identity_bindings: Vec::new(),
                 replace_identity_bindings: false,
             }))

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -129,6 +129,13 @@ pub struct IdentitySpecRegistryRecord {
     pub input_material: BTreeMap<String, String>,
 }
 
+/// Complete rollback snapshot for one installed global identity spec.
+#[derive(Debug, Clone)]
+pub(crate) struct IdentitySpecSnapshot {
+    record: IdentitySpecRecord,
+    input_material: BTreeMap<String, String>,
+}
+
 /// Durable storage backend for global identity specs.
 pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
     /// Lists all installed identity specs.
@@ -390,6 +397,52 @@ impl IdentitySpecManager {
     ) -> Result<IdentitySpecRecord, AppError> {
         let name = validate_identity_spec_name(name)?;
         self.load_identity_spec_manifest_unlocked(&name)
+    }
+
+    pub(crate) fn snapshot_identity_spec(
+        &self,
+        name: &str,
+    ) -> Result<Option<IdentitySpecSnapshot>, AppError> {
+        self.features.ensure_dsl_v4_enabled()?;
+        let name = validate_identity_spec_name(name)?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        let Some(stored) = self.registry.get_identity_spec(name.as_str())? else {
+            return Ok(None);
+        };
+        let record = parse_identity_spec_record(&stored.manifest_yaml)?;
+        Ok(Some(IdentitySpecSnapshot {
+            record,
+            input_material: stored.input_material,
+        }))
+    }
+
+    pub(crate) fn rollback_identity_spec_snapshot_if_current_matches(
+        &self,
+        installed: &IdentitySpecSnapshot,
+        previous: Option<&IdentitySpecSnapshot>,
+    ) -> Result<bool, AppError> {
+        self.features.ensure_dsl_v4_enabled()?;
+        let name = validate_identity_spec_name(&installed.record.manifest.name)?;
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        let Some(current) = self.registry.get_identity_spec(name.as_str())? else {
+            return Ok(false);
+        };
+        if current.manifest_yaml != installed.record.manifest_yaml
+            || current.input_material != installed.input_material
+        {
+            return Ok(false);
+        }
+        match previous {
+            Some(previous) => self.registry.upsert_identity_spec(
+                name.as_str(),
+                IdentitySpecRegistryRecord {
+                    manifest_yaml: previous.record.manifest_yaml.clone(),
+                    input_material: previous.input_material.clone(),
+                },
+            )?,
+            None => self.registry.remove_identity_spec(name.as_str())?,
+        }
+        Ok(true)
     }
 
     pub(crate) fn resolve_identity_spec_inputs(
@@ -1671,6 +1724,60 @@ oauth:
         assert_eq!(
             identity_spec_fingerprint(&left).expect("left fingerprint"),
             identity_spec_fingerprint(&right).expect("right fingerprint")
+        );
+    }
+
+    #[test]
+    fn conditional_identity_spec_rollback_removes_matching_import() {
+        let (_temp, manager, _layout) = manager();
+        add_spec(
+            &manager,
+            &identity_yaml_with_audience("github_oauth", "0.1.0", "github.com"),
+        );
+        let installed = manager
+            .snapshot_identity_spec("github_oauth")
+            .expect("snapshot")
+            .expect("installed spec");
+
+        let rolled_back = manager
+            .rollback_identity_spec_snapshot_if_current_matches(&installed, None)
+            .expect("rollback");
+
+        assert!(rolled_back);
+        assert!(matches!(
+            manager.get_identity_spec("github_oauth"),
+            Err(AppError::IdentitySpecNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn conditional_identity_spec_rollback_skips_concurrent_update() {
+        let (_temp, manager, _layout) = manager();
+        add_spec(
+            &manager,
+            &identity_yaml_with_audience("github_oauth", "0.1.0", "github.com"),
+        );
+        let installed = manager
+            .snapshot_identity_spec("github_oauth")
+            .expect("snapshot")
+            .expect("installed spec");
+        add_spec(
+            &manager,
+            &identity_yaml_with_audience("github_oauth", "0.1.0", "api.github.com"),
+        );
+
+        let rolled_back = manager
+            .rollback_identity_spec_snapshot_if_current_matches(&installed, None)
+            .expect("rollback");
+
+        assert!(!rolled_back);
+        assert_eq!(
+            stored_spec(&manager, "github_oauth")
+                .manifest
+                .audience
+                .get("host")
+                .and_then(serde_json::Value::as_str),
+            Some("api.github.com")
         );
     }
 

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -409,7 +409,7 @@ impl IdentitySpecManager {
         let Some(stored) = self.registry.get_identity_spec(name.as_str())? else {
             return Ok(None);
         };
-        let record = parse_identity_spec_record(&stored.manifest_yaml)?;
+        let record = parse_identity_spec_record_for_name(&name, &stored.manifest_yaml)?;
         Ok(Some(IdentitySpecSnapshot {
             record,
             input_material: stored.input_material,
@@ -489,14 +489,7 @@ impl IdentitySpecManager {
         let Some(manifest_yaml) = self.registry.get_identity_spec_manifest(name.as_str())? else {
             return Err(AppError::IdentitySpecNotFound(name.as_str().to_string()));
         };
-        let record = parse_identity_spec_record(&manifest_yaml)?;
-        if record.manifest.name != name.as_str() {
-            return Err(AppError::FailedPrecondition(format!(
-                "identity spec registry record '{name}' contains identity spec '{}'",
-                record.manifest.name
-            )));
-        }
-        Ok(record)
+        parse_identity_spec_record_for_name(name, &manifest_yaml)
     }
 
     fn count_identities_for_spec_unlocked(
@@ -1066,6 +1059,20 @@ fn normalized_manifest_yaml(manifest_yaml: &str) -> String {
 
 pub(crate) fn validate_identity_spec_name(name: &str) -> Result<IdentitySpecName, AppError> {
     IdentitySpecName::parse(name)
+}
+
+fn parse_identity_spec_record_for_name(
+    name: &IdentitySpecName,
+    manifest_yaml: &str,
+) -> Result<IdentitySpecRecord, AppError> {
+    let record = parse_identity_spec_record(manifest_yaml)?;
+    if record.manifest.name != name.as_str() {
+        return Err(AppError::FailedPrecondition(format!(
+            "identity spec registry record '{name}' contains identity spec '{}'",
+            record.manifest.name
+        )));
+    }
+    Ok(record)
 }
 
 #[cfg(test)]
@@ -1779,6 +1786,21 @@ oauth:
                 .and_then(serde_json::Value::as_str),
             Some("api.github.com")
         );
+    }
+
+    #[test]
+    fn identity_spec_snapshot_rejects_mismatched_registry_record_name() {
+        let (_temp, manager, layout) = manager();
+        add_spec(&manager, &identity_yaml("github_oauth", "0.1.0"));
+        let manifest_file = layout.identity_spec_manifest_file(&identity_spec_name("github_oauth"));
+        fs::write(&manifest_file, identity_yaml("stripe_oauth", "0.1.0"))
+            .expect("corrupt stored identity spec manifest");
+
+        let error = manager
+            .snapshot_identity_spec("github_oauth")
+            .expect_err("snapshot should reject mismatched registry record");
+
+        assert_failed_precondition(&error, ["github_oauth", "stripe_oauth"]);
     }
 
     #[test]

--- a/crates/coral-app/src/identity_specs/mod.rs
+++ b/crates/coral-app/src/identity_specs/mod.rs
@@ -5,6 +5,7 @@ mod service;
 
 pub(crate) use manager::{
     IdentitySpecInputValue, IdentitySpecManager, IdentitySpecName, IdentitySpecRecord,
+    IdentitySpecSnapshot,
 };
 pub use manager::{
     IdentitySpecManifestMetadata, IdentitySpecRegistry, IdentitySpecRegistryRecord,

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -164,6 +164,11 @@ struct SourceRollbackState {
     credential_material: Option<CredentialMaterialSnapshot>,
 }
 
+pub(crate) struct SourceImportRollback {
+    source_name: SourceName,
+    previous: Option<SourceRollbackState>,
+}
+
 fn materialization_inputs_from_bindings(
     bindings: &ValidatedBindings,
     stored_material: &BTreeMap<String, String>,
@@ -606,6 +611,65 @@ impl SourceManager {
             self.layout.workspace_dir(workspace_name).parent(),
         );
         Ok(removed)
+    }
+
+    pub(crate) fn snapshot_source_import_rollback(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<SourceImportRollback, AppError> {
+        let credential_set_id = CredentialSetId::for_source(source_name);
+        let credential_guard = self
+            .credential_manager
+            .material_guard(workspace_name, &credential_set_id)?;
+        let previous =
+            self.load_source_rollback_state(workspace_name, source_name, &credential_guard)?;
+        Ok(SourceImportRollback {
+            source_name: source_name.clone(),
+            previous,
+        })
+    }
+
+    pub(crate) fn rollback_source_import(
+        &self,
+        workspace_name: &WorkspaceName,
+        rollback: SourceImportRollback,
+    ) -> Result<(), AppError> {
+        let SourceImportRollback {
+            source_name,
+            previous,
+        } = rollback;
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let credential_guard = self
+            .credential_manager
+            .material_guard(workspace_name, &credential_set_id)?;
+        let current_source = match self.config_store.get_source(workspace_name, &source_name) {
+            Ok(source) => Some(source),
+            Err(AppError::SourceNotFound(_)) => None,
+            Err(error) => return Err(error),
+        };
+        let new_material_storage = current_source
+            .as_ref()
+            .and_then(InstalledSource::credential_storage_for_material);
+        let remove_result = if previous.is_none() {
+            match self
+                .config_store
+                .remove_source(workspace_name, &source_name)
+            {
+                Ok(()) | Err(AppError::SourceNotFound(_)) => Ok(()),
+                Err(error) => Err(error),
+            }
+        } else {
+            Ok(())
+        };
+        self.restore_source_rollback_state(
+            workspace_name,
+            &source_name,
+            previous,
+            new_material_storage,
+            &credential_guard,
+        );
+        remove_result
     }
 
     fn describe_bundled_source(

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -1,6 +1,6 @@
 //! Implements the gRPC `SourceService` for source lifecycle APIs.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -12,11 +12,11 @@ use coral_api::v1::{
     CreateBundledSourceWithOAuthResponse, CredentialMetadata, DeleteSourceRequest,
     DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
     GetSourceInfoResponse, GetSourceRequest, GetSourceResponse,
-    IdentityOwner as ProtoIdentityOwner, ImportSourceRequest, ImportSourceResponse,
-    ListSourcesRequest, ListSourcesResponse, OAuthCredentialAuthorization, OAuthCredentialClient,
-    OAuthCredentialClientId, OAuthCredentialClientSecret, OAuthCredentialCompleted,
-    OAuthCredentialEndpoints, OAuthCredentialInput, OAuthCredentialMethod,
-    OAuthCredentialRetrieval, OAuthCredentialScope, OAuthCredentialScopes,
+    IdentityOwner as ProtoIdentityOwner, IdentitySpecImportInputs, ImportSourceRequest,
+    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, OAuthCredentialAuthorization,
+    OAuthCredentialClient, OAuthCredentialClientId, OAuthCredentialClientSecret,
+    OAuthCredentialCompleted, OAuthCredentialEndpoints, OAuthCredentialInput,
+    OAuthCredentialMethod, OAuthCredentialRetrieval, OAuthCredentialScope, OAuthCredentialScopes,
     OauthCredentialClientSecretTransport, OauthCredentialFlowType, OauthCredentialPkceMode,
     OauthCredentialRedirectUriPortMode, OauthCredentialScopeDelimiter, Source,
     SourceConfigCredentialMethod, SourceCredential, SourceCredentialMethod,
@@ -32,12 +32,13 @@ use coral_spec::{
     ManifestCredentialMethodKind, ManifestCredentialSpec, ManifestInputKind, ManifestInputSpec,
     ManifestOAuthClientSecretTransport, ManifestOAuthCredentialSpec, ManifestOAuthFlowKind,
     ManifestOAuthPkceMode, ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter,
-    parse_source_manifest_yaml,
+    parse_identity_manifest_yaml, parse_source_manifest_yaml,
 };
 use tonic::{Request, Response, Status};
 
 use crate::authorization::{
-    ManagementAuthorizer, ManagementMutation, WorkspaceSourceMutationKind, authorization_status,
+    ManagementAuthorizer, ManagementMutation, ResourceMutationKind, WorkspaceSourceMutationKind,
+    authorization_status,
 };
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
@@ -46,6 +47,7 @@ use crate::identity::{
     IdentityOwnerKind as AppSourceIdentityOwner, SourceIdentityBinding as AppSourceIdentityBinding,
     SourceIdentitySelection as AppSourceIdentitySelection, UserPrincipal,
 };
+use crate::identity_specs::{IdentitySpecInputValue, IdentitySpecManager, IdentitySpecSnapshot};
 use crate::query::QueryContext;
 use crate::query::manager::QueryManager;
 use crate::request_context::RequestContext;
@@ -53,8 +55,8 @@ use crate::sources::SourceName;
 use crate::sources::manager::{
     CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
     ImportSourceEventSender, ImportSourceWithCredentialsCommand, ImportSourceWithCredentialsEvent,
-    PendingImportSourceWithCredentialsEvent, SourceBinding, SourceBindings, SourceManager,
-    SourceOAuthCredentialRetrieval,
+    PendingImportSourceWithCredentialsEvent, SourceBinding, SourceBindings, SourceImportRollback,
+    SourceManager, SourceOAuthCredentialRetrieval,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::transport::{
@@ -71,6 +73,7 @@ use tokio_stream::StreamExt as _;
 pub(crate) struct SourceService {
     sources: SourceManager,
     queries: QueryManager,
+    identity_specs: IdentitySpecManager,
     identity_instances: IdentityManager,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
 }
@@ -79,12 +82,14 @@ impl SourceService {
     pub(crate) fn new(
         source_manager: SourceManager,
         query_manager: QueryManager,
+        identity_spec_manager: IdentitySpecManager,
         identity_instance_manager: IdentityManager,
         management_authorizer: Arc<dyn ManagementAuthorizer>,
     ) -> Self {
         Self {
             sources: source_manager,
             queries: query_manager,
+            identity_specs: identity_spec_manager,
             identity_instances: identity_instance_manager,
             management_authorizer,
         }
@@ -277,6 +282,7 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let management_authorizer = Arc::clone(&self.management_authorizer);
+        let identity_specs = self.identity_specs.clone();
         let identity_instances = self.identity_instances.clone();
         instrument_grpc(span, async move {
             let principal = RequestContext::from_request(&request)?.principal().clone();
@@ -292,7 +298,25 @@ impl SourceServiceApi for SourceService {
                 )
                 .await
                 .map_err(authorization_status)?;
-            handle_import_source(sources, identity_instances, principal, request).await
+            if !request.identity_spec_manifest_yamls.is_empty() {
+                management_authorizer
+                    .authorize_management_mutation(
+                        &principal,
+                        ManagementMutation::IdentitySpec {
+                            kind: ResourceMutationKind::Upsert,
+                        },
+                    )
+                    .await
+                    .map_err(authorization_status)?;
+            }
+            handle_import_source(
+                sources,
+                identity_specs,
+                identity_instances,
+                principal,
+                request,
+            )
+            .await
         })
         .await
     }
@@ -357,30 +381,40 @@ impl SourceServiceApi for SourceService {
 
 async fn handle_import_source(
     sources: SourceManager,
+    identity_specs: IdentitySpecManager,
     identity_instances: IdentityManager,
     principal: UserPrincipal,
     request: ImportSourceRequest,
 ) -> Result<Response<ImportSourceResponseStreamBox>, Status> {
     let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
     let response_workspace_name = workspace_name.clone();
-    let identity_bindings = import_source_identity_bindings_from_proto(request.identity_bindings)
+    let ParsedImportSourceIdentityBindings {
+        source_bindings,
+        user_selections,
+    } = import_source_identity_bindings_from_proto(request.identity_bindings)
         .map_err(app_status)?;
-    let user_principal = (!identity_bindings.user_selections.is_empty()).then_some(principal);
+    let identity_context = ImportSourceIdentityContext {
+        identity_specs,
+        identity_instances,
+        identity_spec_manifest_yamls: request.identity_spec_manifest_yamls,
+        identity_spec_inputs: identity_spec_import_inputs_from_proto(request.identity_spec_inputs)
+            .map_err(app_status)?,
+        user_principal: (!user_selections.is_empty()).then_some(principal),
+        user_identity_bindings: user_selections,
+    };
     if request.oauth_credential_retrievals.is_empty() {
         let command = ImportSourceCommand {
             manifest_yaml: request.manifest_yaml,
             bindings: source_bindings_from_proto(request.variables, request.secrets),
-            identity_bindings: identity_bindings.source_bindings,
+            identity_bindings: source_bindings,
             replace_identity_bindings: request.replace_identity_bindings,
         };
         return handle_import_source_without_credentials(
             sources,
-            identity_instances,
-            user_principal,
+            identity_context,
             workspace_name,
             response_workspace_name,
             command,
-            identity_bindings.user_selections,
         )
         .await;
     }
@@ -394,61 +428,84 @@ async fn handle_import_source(
             .map(oauth_credential_retrieval_from_proto)
             .collect::<Result<Vec<_>, _>>()
             .map_err(app_status)?,
-        identity_bindings: identity_bindings.source_bindings,
+        identity_bindings: source_bindings,
         replace_identity_bindings: request.replace_identity_bindings,
     };
     handle_import_source_with_credentials(
         sources,
-        identity_instances,
-        user_principal,
+        identity_context,
         workspace_name,
         response_workspace_name,
         command,
-        identity_bindings.user_selections,
     )
     .await
 }
 
+struct ImportSourceIdentityContext {
+    identity_specs: IdentitySpecManager,
+    identity_instances: IdentityManager,
+    identity_spec_manifest_yamls: Vec<String>,
+    identity_spec_inputs: Vec<IdentitySpecImportInputValues>,
+    user_principal: Option<UserPrincipal>,
+    user_identity_bindings: BTreeMap<String, AppSourceIdentitySelection>,
+}
+
 async fn handle_import_source_without_credentials(
     sources: SourceManager,
-    identity_instances: IdentityManager,
-    user_principal: Option<UserPrincipal>,
+    identity_context: ImportSourceIdentityContext,
     workspace_name: WorkspaceName,
     response_workspace_name: WorkspaceName,
     command: ImportSourceCommand,
-    user_identity_bindings: BTreeMap<String, AppSourceIdentitySelection>,
 ) -> Result<Response<ImportSourceResponseStreamBox>, Status> {
     let source_name = source_name_from_manifest_yaml(&command.manifest_yaml).map_err(app_status)?;
+    let identity_spec_guard = install_identity_specs_for_import_or_status(&identity_context)?;
     let prepared_user_bindings =
         prepare_user_source_identity_bindings_for_import(ValidateUserSourceIdentityImport {
             sources: &sources,
-            identities: &identity_instances,
-            principal: user_principal.as_ref(),
+            identities: &identity_context.identity_instances,
+            principal: identity_context.user_principal.as_ref(),
             workspace_name: &workspace_name,
             manifest_yaml: &command.manifest_yaml,
             requested_identity_bindings: &command.identity_bindings,
             replace_identity_bindings: command.replace_identity_bindings,
-            user_identity_bindings: &user_identity_bindings,
+            user_identity_bindings: &identity_context.user_identity_bindings,
         })
         .await?;
-    let import_workspace_name = workspace_name.clone();
-    let import_result = run_blocking_source_operation(move || {
-        sources.import_source(&import_workspace_name, &command)
-    })
-    .await;
-    let installed = match import_result {
-        Ok(installed) => installed,
-        Err(error) => return Err(error),
-    };
-    persist_user_source_identity_bindings_for_import(
-        &identity_instances,
-        user_principal.as_ref(),
+    let user_binding_guard = persist_user_source_identity_bindings_for_import(
+        &identity_context.identity_instances,
+        identity_context.user_principal.as_ref(),
         &workspace_name,
         &source_name,
         &prepared_user_bindings,
-        &user_identity_bindings,
+        &identity_context.user_identity_bindings,
     )
     .await?;
+    let source_rollback = sources
+        .snapshot_source_import_rollback(&workspace_name, &source_name)
+        .map_err(app_status)?;
+    let import_workspace_name = workspace_name.clone();
+    let import_sources = sources.clone();
+    let mut import_task = PendingBlockingSourceImport::spawn(
+        BlockingSourceImportCleanup {
+            sources,
+            workspace_name: workspace_name.clone(),
+            rollback: source_rollback,
+        },
+        move || import_sources.import_source(&import_workspace_name, &command),
+    );
+    let import_result = import_task.await_result().await;
+    let installed = match import_result {
+        Ok(installed) => installed,
+        Err(error) => {
+            return Err(restore_user_source_identity_bindings_after_import_error(
+                user_binding_guard,
+                error,
+            )
+            .await);
+        }
+    };
+    user_binding_guard.commit();
+    identity_spec_guard.commit();
     let response = ImportSourceResponse {
         event: Some(import_source_response::Event::Source(
             installed_source_to_proto(&response_workspace_name, installed),
@@ -459,47 +516,53 @@ async fn handle_import_source_without_credentials(
 
 async fn handle_import_source_with_credentials(
     sources: SourceManager,
-    identity_instances: IdentityManager,
-    user_principal: Option<UserPrincipal>,
+    identity_context: ImportSourceIdentityContext,
     workspace_name: WorkspaceName,
     response_workspace_name: WorkspaceName,
     command: ImportSourceWithCredentialsCommand,
-    user_identity_bindings: BTreeMap<String, AppSourceIdentitySelection>,
 ) -> Result<Response<ImportSourceResponseStreamBox>, Status> {
     let span = tracing::Span::current();
     let source_name = source_name_from_manifest_yaml(&command.manifest_yaml).map_err(app_status)?;
+    let identity_spec_guard = install_identity_specs_for_import_or_status(&identity_context)?;
     let prepared_user_bindings =
         prepare_user_source_identity_bindings_for_import(ValidateUserSourceIdentityImport {
             sources: &sources,
-            identities: &identity_instances,
-            principal: user_principal.as_ref(),
+            identities: &identity_context.identity_instances,
+            principal: identity_context.user_principal.as_ref(),
             workspace_name: &workspace_name,
             manifest_yaml: &command.manifest_yaml,
             requested_identity_bindings: &command.identity_bindings,
             replace_identity_bindings: command.replace_identity_bindings,
-            user_identity_bindings: &user_identity_bindings,
+            user_identity_bindings: &identity_context.user_identity_bindings,
         })
         .await?;
     let stream = import_source_response_stream(response_workspace_name, move |event_sender| {
         instrument_grpc(span, async move {
+            let identity_spec_guard = identity_spec_guard;
+            let user_binding_guard = persist_user_source_identity_bindings_for_import(
+                &identity_context.identity_instances,
+                identity_context.user_principal.as_ref(),
+                &workspace_name,
+                &source_name,
+                &prepared_user_bindings,
+                &identity_context.user_identity_bindings,
+            )
+            .await?;
             let import_result = sources
                 .import_source_with_credentials(&workspace_name, command, event_sender)
                 .await
                 .map_err(app_status);
             match import_result {
                 Ok(installed) => {
-                    persist_user_source_identity_bindings_for_import(
-                        &identity_instances,
-                        user_principal.as_ref(),
-                        &workspace_name,
-                        &source_name,
-                        &prepared_user_bindings,
-                        &user_identity_bindings,
-                    )
-                    .await?;
+                    user_binding_guard.commit();
+                    identity_spec_guard.commit();
                     Ok(installed)
                 }
-                Err(error) => Err(error),
+                Err(error) => Err(restore_user_source_identity_bindings_after_import_error(
+                    user_binding_guard,
+                    error,
+                )
+                .await),
             }
         })
     });
@@ -522,6 +585,91 @@ where
         .await
         .map_err(|error| Status::internal(format!("source operation task failed: {error}")))?
         .map_err(app_status)
+}
+
+struct BlockingSourceImportCleanup {
+    sources: SourceManager,
+    workspace_name: WorkspaceName,
+    rollback: SourceImportRollback,
+}
+
+impl BlockingSourceImportCleanup {
+    fn rollback(self) {
+        if let Err(error) = self
+            .sources
+            .rollback_source_import(&self.workspace_name, self.rollback)
+        {
+            tracing::warn!(
+                workspace = %self.workspace_name,
+                error = %error,
+                "failed to roll back cancelled source import"
+            );
+        }
+    }
+}
+
+struct PendingBlockingSourceImport {
+    handle: Option<task::JoinHandle<Result<InstalledSource, AppError>>>,
+    cleanup: Option<BlockingSourceImportCleanup>,
+}
+
+impl PendingBlockingSourceImport {
+    fn spawn<F>(cleanup: BlockingSourceImportCleanup, operation: F) -> Self
+    where
+        F: FnOnce() -> Result<InstalledSource, AppError> + Send + 'static,
+    {
+        let span = tracing::Span::current();
+        let handle = task::spawn_blocking(move || span.in_scope(operation));
+        Self {
+            handle: Some(handle),
+            cleanup: Some(cleanup),
+        }
+    }
+
+    async fn await_result(&mut self) -> Result<InstalledSource, Status> {
+        let handle = self
+            .handle
+            .take()
+            .expect("pending blocking source import must have a join handle");
+        match handle.await {
+            Ok(result) => {
+                self.cleanup = None;
+                result.map_err(app_status)
+            }
+            Err(error) => {
+                if let Some(cleanup) = self.cleanup.take() {
+                    cleanup.rollback();
+                }
+                Err(Status::internal(format!(
+                    "source operation task failed: {error}"
+                )))
+            }
+        }
+    }
+}
+
+impl Drop for PendingBlockingSourceImport {
+    fn drop(&mut self) {
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        let Some(cleanup) = self.cleanup.take() else {
+            return;
+        };
+        task::spawn(async move {
+            match handle.await {
+                Ok(Ok(_installed)) => cleanup.rollback(),
+                Ok(Err(_error)) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        "cancelled source import task failed before rollback cleanup"
+                    );
+                    cleanup.rollback();
+                }
+            }
+        });
+    }
 }
 
 fn import_source_response_stream<F, Fut>(
@@ -674,6 +822,179 @@ fn source_name_from_manifest_yaml(manifest_yaml: &str) -> Result<SourceName, App
     SourceName::parse(manifest.schema_name())
 }
 
+#[derive(Debug, Clone)]
+struct IdentitySpecImportRollback {
+    name: String,
+    previous: Option<IdentitySpecSnapshot>,
+    installed: IdentitySpecSnapshot,
+}
+
+struct IdentitySpecImportGuard {
+    identity_specs: IdentitySpecManager,
+    rollback: Option<Vec<IdentitySpecImportRollback>>,
+}
+
+impl IdentitySpecImportGuard {
+    fn new(identity_specs: IdentitySpecManager, rollback: Vec<IdentitySpecImportRollback>) -> Self {
+        Self {
+            identity_specs,
+            rollback: Some(rollback),
+        }
+    }
+
+    fn commit(mut self) {
+        self.rollback = None;
+    }
+}
+
+impl Drop for IdentitySpecImportGuard {
+    fn drop(&mut self) {
+        if let Some(rollback) = self.rollback.take() {
+            rollback_identity_specs_for_import(&self.identity_specs, rollback);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct IdentitySpecImportInputValues {
+    identity_spec_name: String,
+    inputs: Vec<IdentitySpecInputValue>,
+}
+
+fn identity_spec_import_inputs_from_proto(
+    inputs: Vec<IdentitySpecImportInputs>,
+) -> Result<Vec<IdentitySpecImportInputValues>, AppError> {
+    let mut seen = BTreeSet::new();
+    let mut values = Vec::new();
+    for input_group in inputs {
+        if !seen.insert(input_group.identity_spec_name.clone()) {
+            return Err(AppError::InvalidInput(format!(
+                "identity spec inputs for '{}' are repeated",
+                input_group.identity_spec_name
+            )));
+        }
+        values.push(IdentitySpecImportInputValues {
+            identity_spec_name: input_group.identity_spec_name,
+            inputs: input_group
+                .input_values
+                .into_iter()
+                .map(|input| IdentitySpecInputValue {
+                    key: input.key,
+                    value: input.value,
+                })
+                .collect(),
+        });
+    }
+    Ok(values)
+}
+
+fn install_identity_specs_for_import_or_status(
+    context: &ImportSourceIdentityContext,
+) -> Result<IdentitySpecImportGuard, Status> {
+    install_identity_specs_for_import(
+        &context.identity_specs,
+        &context.identity_spec_manifest_yamls,
+        &context.identity_spec_inputs,
+    )
+    .map(|rollback| IdentitySpecImportGuard::new(context.identity_specs.clone(), rollback))
+    .map_err(app_status)
+}
+
+fn install_identity_specs_for_import(
+    identity_specs: &IdentitySpecManager,
+    manifest_yamls: &[String],
+    input_groups: &[IdentitySpecImportInputValues],
+) -> Result<Vec<IdentitySpecImportRollback>, AppError> {
+    let mut parsed = Vec::new();
+    let mut parsed_names = BTreeSet::new();
+    for manifest_yaml in manifest_yamls {
+        let manifest = parse_identity_manifest_yaml(manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        let name = manifest.name.clone();
+        if !parsed_names.insert(name.clone()) {
+            return Err(AppError::InvalidInput(format!(
+                "identity spec '{name}' is repeated in the source import"
+            )));
+        }
+        parsed.push((manifest_yaml, name));
+    }
+
+    if let Some(unknown_name) = input_groups
+        .iter()
+        .map(|input_group| input_group.identity_spec_name.as_str())
+        .find(|name| !parsed_names.contains(*name))
+    {
+        return Err(AppError::InvalidInput(format!(
+            "identity spec inputs were provided for '{unknown_name}', but no matching identity spec was included in the source import"
+        )));
+    }
+
+    let mut inputs_by_spec = input_groups
+        .iter()
+        .map(|input_group| {
+            (
+                input_group.identity_spec_name.as_str(),
+                input_group.inputs.clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut rollback = Vec::new();
+    for (manifest_yaml, name) in parsed {
+        let previous = match identity_specs.snapshot_identity_spec(&name) {
+            Ok(previous) => previous,
+            Err(error) => {
+                rollback_identity_specs_for_import(identity_specs, rollback);
+                return Err(error);
+            }
+        };
+        let inputs = inputs_by_spec.remove(name.as_str()).unwrap_or_default();
+        if let Err(error) = identity_specs.add_identity_spec_with_inputs(manifest_yaml, inputs) {
+            rollback_identity_specs_for_import(identity_specs, rollback);
+            return Err(error);
+        }
+        let installed = identity_specs
+            .snapshot_identity_spec(&name)?
+            .ok_or_else(|| {
+                AppError::FailedPrecondition(format!(
+                    "identity spec '{name}' was not stored after source import installation"
+                ))
+            })?;
+        rollback.push(IdentitySpecImportRollback {
+            name,
+            previous,
+            installed,
+        });
+    }
+    Ok(rollback)
+}
+
+fn rollback_identity_specs_for_import(
+    identity_specs: &IdentitySpecManager,
+    rollback: Vec<IdentitySpecImportRollback>,
+) {
+    for item in rollback.into_iter().rev() {
+        match identity_specs.rollback_identity_spec_snapshot_if_current_matches(
+            &item.installed,
+            item.previous.as_ref(),
+        ) {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::warn!(
+                    identity_spec = item.name,
+                    "skipped identity spec import rollback because the current spec no longer matches the imported spec"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    identity_spec = item.name,
+                    error = %error,
+                    "failed to roll back identity spec import"
+                );
+            }
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 struct ValidateUserSourceIdentityImport<'a> {
     sources: &'a SourceManager,
@@ -813,6 +1134,64 @@ struct PreparedUserSourceIdentityBindings {
     effective_identity_bindings: BTreeMap<String, AppSourceIdentityBinding>,
 }
 
+struct UserSourceIdentityBindingImportGuard {
+    identities: IdentityManager,
+    principal: Option<UserPrincipal>,
+    workspace_name: WorkspaceName,
+    source_name: SourceName,
+    snapshot: Option<UserSourceIdentityBindingSnapshot>,
+}
+
+impl UserSourceIdentityBindingImportGuard {
+    fn commit(mut self) {
+        self.snapshot = None;
+    }
+
+    async fn rollback(mut self) -> Result<(), AppError> {
+        let Some(snapshot) = self.snapshot.take() else {
+            return Ok(());
+        };
+        restore_user_source_identity_bindings(
+            &self.identities,
+            self.principal.as_ref(),
+            &self.workspace_name,
+            &self.source_name,
+            snapshot,
+        )
+        .await
+    }
+}
+
+impl Drop for UserSourceIdentityBindingImportGuard {
+    fn drop(&mut self) {
+        let Some(snapshot) = self.snapshot.take() else {
+            return;
+        };
+        let identities = self.identities.clone();
+        let principal = self.principal.clone();
+        let workspace_name = self.workspace_name.clone();
+        let source_name = self.source_name.clone();
+        tokio::spawn(async move {
+            if let Err(error) = restore_user_source_identity_bindings(
+                &identities,
+                principal.as_ref(),
+                &workspace_name,
+                &source_name,
+                snapshot,
+            )
+            .await
+            {
+                tracing::warn!(
+                    workspace = %workspace_name,
+                    source = %source_name,
+                    error = %error,
+                    "failed to roll back user-owned source identity bindings after import cancellation"
+                );
+            }
+        });
+    }
+}
+
 async fn prepare_user_source_identity_bindings_for_import(
     request: ValidateUserSourceIdentityImport<'_>,
 ) -> Result<PreparedUserSourceIdentityBindings, Status> {
@@ -831,7 +1210,7 @@ async fn persist_user_source_identity_bindings_for_import(
     source_name: &SourceName,
     prepared: &PreparedUserSourceIdentityBindings,
     user_identity_bindings: &BTreeMap<String, AppSourceIdentitySelection>,
-) -> Result<(), Status> {
+) -> Result<UserSourceIdentityBindingImportGuard, Status> {
     let snapshot = snapshot_user_source_identity_bindings(
         identities,
         principal,
@@ -866,7 +1245,25 @@ async fn persist_user_source_identity_bindings_for_import(
         }
         return Err(app_status(error));
     }
-    Ok(())
+    Ok(UserSourceIdentityBindingImportGuard {
+        identities: identities.clone(),
+        principal: principal.cloned(),
+        workspace_name: workspace_name.clone(),
+        source_name: source_name.clone(),
+        snapshot: Some(snapshot),
+    })
+}
+
+async fn restore_user_source_identity_bindings_after_import_error(
+    guard: UserSourceIdentityBindingImportGuard,
+    import_error: Status,
+) -> Status {
+    if let Err(restore_error) = guard.rollback().await {
+        return app_status(AppError::FailedPrecondition(format!(
+            "source import failed: {import_error}; failed to restore previous user-owned source identity bindings: {restore_error}"
+        )));
+    }
+    import_error
 }
 
 async fn snapshot_user_source_identity_bindings(
@@ -1280,6 +1677,57 @@ mod tests {
         ManifestOAuthFlowKind, ManifestOAuthFlowSpec, ManifestOAuthPkceMode,
         ManifestOAuthRedirectUriPortMode,
     };
+    use tempfile::TempDir;
+
+    use crate::features::dsl_v4_features;
+    use crate::state::AppStateLayout;
+
+    fn test_identity_spec_manager() -> (TempDir, IdentitySpecManager) {
+        let temp = TempDir::new().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout");
+        (
+            temp,
+            IdentitySpecManager::new_with_usage_providers(layout, dsl_v4_features(), Vec::new()),
+        )
+    }
+
+    fn test_fixed_identity_spec_yaml() -> String {
+        r"
+kind: identity
+spec_version: 1
+name: github_pat
+version: 0.1.0
+issuer: github
+type: fixed_token
+audience:
+  host: github.com
+"
+        .to_string()
+    }
+
+    #[test]
+    fn identity_spec_import_guard_rolls_back_on_drop() {
+        let (_temp, identity_specs) = test_identity_spec_manager();
+        let rollback = install_identity_specs_for_import(
+            &identity_specs,
+            &[test_fixed_identity_spec_yaml()],
+            &[],
+        )
+        .expect("install identity spec");
+        let guard = IdentitySpecImportGuard::new(identity_specs.clone(), rollback);
+        identity_specs
+            .get_identity_spec("github_pat")
+            .expect("installed identity spec");
+
+        drop(guard);
+
+        assert!(matches!(
+            identity_specs.get_identity_spec("github_pat"),
+            Err(AppError::IdentitySpecNotFound(_))
+        ));
+    }
 
     #[test]
     fn converts_credential_methods_to_source_input_spec() {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -117,6 +117,8 @@ impl GrpcHarness {
                 variables,
                 secrets,
                 oauth_credential_retrievals: Vec::new(),
+                identity_spec_manifest_yamls: Vec::new(),
+                identity_spec_inputs: Vec::new(),
                 identity_bindings: Vec::new(),
                 replace_identity_bindings: false,
             }))

--- a/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
+++ b/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
@@ -409,6 +409,8 @@ async fn manual_credential_replacement_waits_for_in_flight_refresh() {
                     value: "manual-token".to_string(),
                 }],
                 oauth_credential_retrievals: Vec::new(),
+                identity_spec_manifest_yamls: Vec::new(),
+                identity_spec_inputs: Vec::new(),
                 identity_bindings: Vec::new(),
                 replace_identity_bindings: false,
             }))

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -9,7 +9,8 @@ use std::{fs, path::PathBuf};
 use coral_api::v1::{
     AddIdentitySpecRequest, CreateBundledSourceRequest, CreateUserOwnedIdentityRequest,
     DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest, ExplainSqlRequest,
-    FixedTokenUserOwnedIdentitySetup, GetSourceInfoRequest, GetSourceRequest, IdentityOwner,
+    FixedTokenUserOwnedIdentitySetup, GetIdentitySpecRequest, GetSourceInfoRequest,
+    GetSourceRequest, IdentityOwner, IdentitySpecImportInputs, IdentitySpecInputValue,
     ImportSourceRequest, ListCatalogRequest, ListUserOwnedIdentitiesRequest,
     OauthCredentialFlowType, OauthCredentialScopeDelimiter, PaginationRequest, QueryTestFailure,
     QueryTestSuccess, Source, SourceCredentialStorage, SourceIdentityBinding, SourceOrigin,
@@ -41,6 +42,34 @@ issuer: test
 type: fixed_token
 audience:
   host: 127.0.0.1
+"
+    .to_string()
+}
+
+fn oauth_identity_spec_with_required_input_yaml() -> String {
+    r"kind: identity
+spec_version: 1
+name: test_oauth
+version: 0.1.0
+issuer: test
+type: oauth
+audience:
+  host: 127.0.0.1
+inputs:
+  TEST_OAUTH_CLIENT_ID:
+    kind: variable
+    required: true
+oauth:
+  method:
+    label: Test OAuth
+    flow:
+      type: device_code
+    endpoints:
+      device_authorization_url: https://auth.example.test/device
+      token_url: https://auth.example.test/token
+    client:
+      id:
+        input: TEST_OAUTH_CLIENT_ID
 "
     .to_string()
 }
@@ -106,6 +135,41 @@ surfaces:
         - id: github-rest-read
           identity_specs: [test_pat]
           audience: {{host: 127.0.0.1}}
+"#,
+        descriptor_path.display()
+    )
+}
+
+fn plain_v4_source_manifest_yaml(descriptor_path: &std::path::Path, base_url: &str) -> String {
+    format!(
+        r"
+name: identity_github
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    base_url: {base_url}
+",
+        descriptor_path.display()
+    )
+}
+
+fn plain_v4_source_manifest_with_required_variable_yaml(
+    descriptor_path: &std::path::Path,
+) -> String {
+    format!(
+        r#"
+name: identity_github
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    inputs:
+      API_BASE:
+        kind: variable
+    base_url: "{{{{input.API_BASE}}}}"
 "#,
         descriptor_path.display()
     )
@@ -225,6 +289,63 @@ async fn create_and_assert_scoped_fixed_token_identity(
     assert!(material.contains(&format!("TOKEN={token}")));
 }
 
+fn import_request_with_user_identity_binding(manifest_yaml: String) -> ImportSourceRequest {
+    ImportSourceRequest {
+        workspace: Some(default_workspace()),
+        manifest_yaml,
+        variables: Vec::new(),
+        secrets: Vec::new(),
+        oauth_credential_retrievals: Vec::new(),
+        identity_spec_manifest_yamls: Vec::new(),
+        identity_spec_inputs: Vec::new(),
+        identity_bindings: vec![SourceIdentityBinding {
+            surface_id: "rest".to_string(),
+            identity: "test_local".to_string(),
+            owner: IdentityOwner::User as i32,
+        }],
+        replace_identity_bindings: false,
+    }
+}
+
+fn import_request_without_identity_bindings(
+    manifest_yaml: String,
+    replace_identity_bindings: bool,
+) -> ImportSourceRequest {
+    ImportSourceRequest {
+        workspace: Some(default_workspace()),
+        manifest_yaml,
+        variables: Vec::new(),
+        secrets: Vec::new(),
+        oauth_credential_retrievals: Vec::new(),
+        identity_spec_manifest_yamls: Vec::new(),
+        identity_spec_inputs: Vec::new(),
+        identity_bindings: Vec::new(),
+        replace_identity_bindings,
+    }
+}
+
+async fn import_source_and_read_source_event(
+    harness: &GrpcHarness,
+    request: ImportSourceRequest,
+    label: &str,
+) -> Source {
+    let mut stream = harness
+        .source_client()
+        .import_source(Request::new(request))
+        .await
+        .unwrap_or_else(|error| panic!("{label}: import failed: {error}"))
+        .into_inner();
+    stream
+        .message()
+        .await
+        .unwrap_or_else(|error| panic!("{label}: import stream failed: {error}"))
+        .and_then(|response| match response.event {
+            Some(import_source_response::Event::Source(source)) => Some(source),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("{label}: import response missing source"))
+}
+
 #[tokio::test]
 async fn import_source_persists_and_lists() {
     let harness = GrpcHarness::new().await;
@@ -293,6 +414,8 @@ async fn import_source_persists_user_identity_binding_for_queries() {
             variables: Vec::new(),
             secrets: Vec::new(),
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: vec![SourceIdentityBinding {
                 surface_id: "rest".to_string(),
                 identity: "test_local".to_string(),
@@ -387,6 +510,8 @@ async fn user_identity_source_bindings_are_scoped_to_request_principal() {
                 variables: Vec::new(),
                 secrets: Vec::new(),
                 oauth_credential_retrievals: Vec::new(),
+                identity_spec_manifest_yamls: Vec::new(),
+                identity_spec_inputs: Vec::new(),
                 identity_bindings: vec![SourceIdentityBinding {
                     surface_id: "rest".to_string(),
                     identity: "test_local".to_string(),
@@ -439,6 +564,224 @@ async fn user_identity_source_bindings_are_scoped_to_request_principal() {
 }
 
 #[tokio::test]
+async fn reimport_preserves_or_clears_identity_bindings_by_replace_flag() {
+    let fixture = identity_source_fixture();
+    let server = MockServer::start().await;
+    let harness = GrpcHarness::start_with_config_dir(fixture.config_dir.clone()).await;
+    install_test_fixed_token_identity(&harness).await;
+
+    import_source_and_read_source_event(
+        &harness,
+        import_request_with_user_identity_binding(identity_source_manifest_yaml(
+            &fixture.descriptor_path,
+            &server.uri(),
+        )),
+        "initial import",
+    )
+    .await;
+
+    import_source_and_read_source_event(
+        &harness,
+        import_request_without_identity_bindings(
+            identity_source_manifest_yaml(&fixture.descriptor_path, &server.uri()),
+            false,
+        ),
+        "reimport preserving identity bindings",
+    )
+    .await;
+
+    let fetched = harness
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "identity_github".to_string(),
+        }))
+        .await
+        .expect("get preserved source")
+        .into_inner()
+        .source
+        .expect("source");
+    assert_user_owned_rest_identity_binding(&fetched);
+
+    import_source_and_read_source_event(
+        &harness,
+        import_request_without_identity_bindings(
+            plain_v4_source_manifest_yaml(&fixture.descriptor_path, &server.uri()),
+            true,
+        ),
+        "reimport clearing identity bindings",
+    )
+    .await;
+
+    let fetched = harness
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "identity_github".to_string(),
+        }))
+        .await
+        .expect("get cleared source")
+        .into_inner()
+        .source
+        .expect("source");
+    assert!(fetched.identity_bindings.is_empty());
+}
+
+#[tokio::test]
+async fn import_source_installs_identity_specs_from_request_bundle() {
+    let fixture = identity_source_fixture();
+    let harness = GrpcHarness::start_with_config_dir(fixture.config_dir.clone()).await;
+
+    let mut stream = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: plain_v4_source_manifest_yaml(
+                &fixture.descriptor_path,
+                "http://127.0.0.1:1",
+            ),
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: vec![fixed_token_identity_spec_yaml()],
+            identity_spec_inputs: Vec::new(),
+            identity_bindings: Vec::new(),
+            replace_identity_bindings: false,
+        }))
+        .await
+        .expect("import source")
+        .into_inner();
+    stream
+        .message()
+        .await
+        .expect("import stream")
+        .expect("import response");
+
+    let identity_spec = harness
+        .identity_spec_client()
+        .get_identity_spec(Request::new(GetIdentitySpecRequest {
+            name: "test_pat".to_string(),
+        }))
+        .await
+        .expect("get imported identity spec")
+        .into_inner()
+        .identity_spec
+        .expect("identity spec");
+    assert_eq!(identity_spec.name, "test_pat");
+}
+
+#[tokio::test]
+async fn import_source_installs_identity_spec_inputs_from_request_bundle() {
+    let fixture = identity_source_fixture();
+    let harness = GrpcHarness::start_with_config_dir(fixture.config_dir.clone()).await;
+
+    let mut stream = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: plain_v4_source_manifest_yaml(
+                &fixture.descriptor_path,
+                "http://127.0.0.1:1",
+            ),
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: vec![oauth_identity_spec_with_required_input_yaml()],
+            identity_spec_inputs: vec![IdentitySpecImportInputs {
+                identity_spec_name: "test_oauth".to_string(),
+                input_values: vec![IdentitySpecInputValue {
+                    key: "TEST_OAUTH_CLIENT_ID".to_string(),
+                    value: "test-client-id".to_string(),
+                }],
+            }],
+            identity_bindings: Vec::new(),
+            replace_identity_bindings: false,
+        }))
+        .await
+        .expect("import source")
+        .into_inner();
+    stream
+        .message()
+        .await
+        .expect("import stream")
+        .expect("import response");
+
+    let material_file = fixture
+        .config_dir
+        .join("identity-specs")
+        .join("test_oauth")
+        .join("secrets.env");
+    let material = fs::read_to_string(material_file).expect("identity spec material");
+    assert!(material.contains("TEST_OAUTH_CLIENT_ID=test-client-id"));
+}
+
+#[tokio::test]
+async fn import_source_rolls_back_identity_specs_when_source_import_fails() {
+    let fixture = identity_source_fixture();
+    let harness = GrpcHarness::start_with_config_dir(fixture.config_dir.clone()).await;
+
+    let error = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: plain_v4_source_manifest_with_required_variable_yaml(
+                &fixture.descriptor_path,
+            ),
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: vec![fixed_token_identity_spec_yaml()],
+            identity_spec_inputs: Vec::new(),
+            identity_bindings: Vec::new(),
+            replace_identity_bindings: false,
+        }))
+        .await
+        .expect_err("missing source variable should fail");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+
+    let error = harness
+        .identity_spec_client()
+        .get_identity_spec(Request::new(GetIdentitySpecRequest {
+            name: "test_pat".to_string(),
+        }))
+        .await
+        .expect_err("identity spec import should roll back");
+    assert_eq!(error.code(), tonic::Code::NotFound);
+}
+
+#[tokio::test]
+async fn import_source_rejects_inputs_without_matching_identity_spec() {
+    let fixture = identity_source_fixture();
+    let harness = GrpcHarness::start_with_config_dir(fixture.config_dir.clone()).await;
+
+    let error = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: plain_v4_source_manifest_yaml(
+                &fixture.descriptor_path,
+                "http://127.0.0.1:1",
+            ),
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: vec![IdentitySpecImportInputs {
+                identity_spec_name: "missing_spec".to_string(),
+                input_values: vec![IdentitySpecInputValue {
+                    key: "TOKEN".to_string(),
+                    value: "secret".to_string(),
+                }],
+            }],
+            identity_bindings: Vec::new(),
+            replace_identity_bindings: false,
+        }))
+        .await
+        .expect_err("inputs without matching identity spec should fail");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+}
+
+#[tokio::test]
 async fn import_source_rolls_back_user_identity_binding_when_import_fails() {
     let fixture = identity_source_fixture();
     let binding_path = fixture
@@ -457,6 +800,8 @@ async fn import_source_rolls_back_user_identity_binding_when_import_fails() {
             variables: Vec::new(),
             secrets: Vec::new(),
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: vec![SourceIdentityBinding {
                 surface_id: "rest".to_string(),
                 identity: "test_local".to_string(),
@@ -488,6 +833,8 @@ async fn import_source_rejects_user_owned_identity_binding_without_user_selectio
             variables: Vec::new(),
             secrets: Vec::new(),
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: vec![SourceIdentityBinding {
                 surface_id: "rest".to_string(),
                 identity: String::new(),
@@ -563,6 +910,8 @@ async fn import_duplicate_source_overwrites_existing_source() {
             variables: Vec::new(),
             secrets: Vec::new(),
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: Vec::new(),
             replace_identity_bindings: false,
         }))
@@ -606,6 +955,8 @@ async fn import_invalid_manifest_returns_invalid_argument() {
             variables: Vec::new(),
             secrets: Vec::new(),
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: Vec::new(),
             replace_identity_bindings: false,
         }))
@@ -1024,6 +1375,8 @@ async fn import_source_missing_required_secret_returns_invalid_argument() {
             }],
             secrets: Vec::new(),
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: Vec::new(),
             replace_identity_bindings: false,
         }))
@@ -1052,6 +1405,8 @@ async fn import_source_missing_required_variable_returns_invalid_argument() {
                 value: "secret-token".to_string(),
             }],
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: Vec::new(),
             replace_identity_bindings: false,
         }))
@@ -1083,6 +1438,8 @@ async fn import_source_unknown_variable_returns_invalid_argument() {
                 value: "secret-token".to_string(),
             }],
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: Vec::new(),
             replace_identity_bindings: false,
         }))
@@ -1116,6 +1473,8 @@ async fn import_source_unknown_secret_returns_invalid_argument() {
                 },
             ],
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: Vec::new(),
             replace_identity_bindings: false,
         }))
@@ -1153,6 +1512,8 @@ async fn import_source_repeated_variable_returns_invalid_argument() {
                 value: "secret-token".to_string(),
             }],
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: Vec::new(),
             replace_identity_bindings: false,
         }))
@@ -1190,6 +1551,8 @@ async fn import_source_repeated_secret_returns_invalid_argument() {
                 },
             ],
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: Vec::new(),
             replace_identity_bindings: false,
         }))
@@ -1827,6 +2190,8 @@ async fn import_rolls_back_on_config_write_failure() {
                 value: "secret-token".to_string(),
             }],
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: Vec::new(),
             replace_identity_bindings: false,
         }))

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -129,6 +129,8 @@ pub(crate) async fn import_source(
             variables,
             secrets,
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: identity_bindings.source_bindings,
             replace_identity_bindings: identity_bindings.replace_existing,
         }))
@@ -222,6 +224,8 @@ pub(crate) async fn import_source_with_credentials(
             variables: inputs.variables,
             secrets: inputs.secrets,
             oauth_credential_retrievals: inputs.oauth_credential_retrievals,
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: identity_bindings.source_bindings,
             replace_identity_bindings: identity_bindings.replace_existing,
         }))

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -175,6 +175,8 @@ async fn add_demo_source(source_client: &mut SourceClient, manifest_yaml: String
             variables: Vec::new(),
             secrets: Vec::new(),
             oauth_credential_retrievals: Vec::new(),
+            identity_spec_manifest_yamls: Vec::new(),
+            identity_spec_inputs: Vec::new(),
             identity_bindings: Vec::new(),
             replace_identity_bindings: false,
         }))

--- a/ui/buf.gen.yaml
+++ b/ui/buf.gen.yaml
@@ -11,5 +11,6 @@ inputs:
       - ../crates/coral-api/proto/coral/v1/resources.proto
       - ../crates/coral-api/proto/coral/v1/catalog.proto
       - ../crates/coral-api/proto/coral/v1/query.proto
+      - ../crates/coral-api/proto/coral/v1/identity_specs.proto
       - ../crates/coral-api/proto/coral/v1/sources.proto
       - ../crates/coral-api/proto/coral/v1/traces.proto


### PR DESCRIPTION
## Intent

Land `feat(source): import identity specs with sources` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-10-source-identity-import-api...sauldhernandez/dsl-v4-identity-v2-11-source-identity-spec-import
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
