### PR TITLE
feat(cli): expose reusable runtime entrypoints

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -925,9 +925,9 @@ mod tests {
     use coral_api::v1::trace_service_client::TraceServiceClient;
     use coral_api::v1::{
         AddIdentitySpecRequest, CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
-        DeleteIdentitySpecRequest, DeleteSourceRequest, ExecuteSqlRequest, ImportSourceRequest,
-        ImportSourceResponse, ListSourcesRequest, ListTracesRequest, OpenEpisodeRequest, Workspace,
-        import_source_response,
+        DeleteIdentitySpecRequest, DeleteSourceRequest, ExecuteSqlRequest, IdentitySpecInputValue,
+        ImportSourceRequest, ImportSourceResponse, ListSourcesRequest, ListTracesRequest,
+        OpenEpisodeRequest, Workspace, import_source_response,
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
@@ -962,6 +962,44 @@ mod tests {
 
     fn default_workspace() -> Workspace {
         workspace_to_proto(&WorkspaceName::default())
+    }
+
+    fn test_identity_spec_yaml() -> String {
+        r"kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+description: Demo OAuth identity
+issuer: demo
+type: oauth
+audience:
+  host: api.example.test
+inputs:
+  DEMO_TENANT:
+    kind: variable
+    required: false
+    default: tenant-a
+  DEMO_OAUTH_CLIENT_SECRET:
+    kind: secret
+    required: true
+oauth:
+  method:
+    label: Demo OAuth
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/callback
+    endpoints:
+      authorization_url: https://auth.example.test/{{input.DEMO_TENANT}}/authorize
+      token_url: https://auth.example.test/{{input.DEMO_TENANT}}/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+        transport: request_body
+"
+        .to_string()
     }
 
     fn test_identity_spec_manager(layout: &AppStateLayout) -> IdentitySpecManager {
@@ -1375,6 +1413,45 @@ type: fixed_token
             .expect_err("trace service should be disabled");
 
         assert_eq!(status.code(), Code::Unimplemented);
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn server_builder_applies_process_feature_overrides() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        disable_internal_tracing(&config_dir);
+        let mut feature_overrides = FeatureOverrides::default();
+        feature_overrides.set(Feature::DslV4, true);
+        let server = ServerBuilder::new()
+            .with_config_dir(config_dir)
+            .with_feature_overrides(feature_overrides)
+            .start()
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut identity_specs = IdentitySpecServiceClient::new(channel);
+
+        let added = identity_specs
+            .add_identity_spec(Request::new(AddIdentitySpecRequest {
+                manifest_yaml: test_identity_spec_yaml(),
+                input_values: vec![IdentitySpecInputValue {
+                    key: "DEMO_OAUTH_CLIENT_SECRET".to_string(),
+                    value: "secret-value".to_string(),
+                }],
+            }))
+            .await
+            .expect("process feature overrides should enable DSL v4 identity specs")
+            .into_inner();
+
+        assert_eq!(
+            added.identity_spec.expect("added identity spec").name,
+            "demo_oauth"
+        );
         server.shutdown().await.expect("shutdown");
     }
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -18,6 +18,7 @@ mod query_error;
 mod source_ops;
 
 use std::borrow::Cow;
+use std::future::Future;
 use std::path::PathBuf;
 #[cfg(feature = "embedded-ui")]
 use std::sync::Arc;
@@ -27,7 +28,7 @@ use clap::{
     Parser, Subcommand, ValueEnum,
 };
 use clap_complete::{Shell, generate};
-use coral_api::v1::ExecuteSqlRequest;
+use coral_api::v1::{ExecuteSqlRequest, ExecuteSqlResponse, Workspace};
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
 use coral_client::{
@@ -83,6 +84,26 @@ enum Command {
 enum RequiredRuntime {
     AppClient,
     None,
+}
+
+/// Runtime options parsed from the shared CLI surface before an app client is
+/// needed.
+#[derive(Debug, Clone)]
+pub struct SuppliedRuntimeOptions {
+    /// Whether the supplied server should render logs to stderr for this
+    /// invocation.
+    pub enable_stderr_logs: bool,
+    /// Process-local runtime feature overrides parsed from global CLI flags.
+    pub feature_overrides: coral_app::features::FeatureOverrides,
+}
+
+/// Product-specific defaults used by a sibling binary that supplies the app
+/// runtime.
+#[derive(Debug, Clone, Default)]
+pub struct AppRuntimeConfig {
+    /// Baseline process-local feature overrides. Explicit global CLI feature
+    /// flags still take precedence.
+    pub feature_overrides: coral_app::features::FeatureOverrides,
 }
 
 #[cfg(feature = "embedded-ui")]
@@ -305,9 +326,12 @@ enum SourceCommand {
     },
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
-enum OutputFormat {
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+/// Output format for rendered SQL query results.
+pub enum OutputFormat {
+    /// Render query results as an aligned terminal table.
     Table,
+    /// Render query results as JSON.
     Json,
 }
 
@@ -478,6 +502,112 @@ pub async fn run_from_env() -> Result<(), CliError> {
     }
 }
 
+/// Parses CLI arguments and runs them against an app runtime supplied by a
+/// sibling binary.
+///
+/// This keeps shared command parsing, feature override handling, output
+/// rendering, and telemetry classification in `coral-cli` while allowing a
+/// product-specific binary to own server startup and extension composition.
+/// The runtime factory is called only for commands that need an app client, and
+/// receives parsed runtime options before the app client is constructed.
+///
+/// # Errors
+///
+/// Returns an error if runtime startup, command execution, or output formatting
+/// fails.
+pub async fn run_with_app_runtime<Start, StartFuture, RuntimeGuard>(
+    ctx: coral_app::RunContext,
+    start_runtime: Start,
+) -> Result<(), CliError>
+where
+    Start: FnOnce(SuppliedRuntimeOptions) -> StartFuture,
+    StartFuture: Future<Output = Result<(AppClient, RuntimeGuard), anyhow::Error>>,
+{
+    run_with_app_runtime_config(ctx, AppRuntimeConfig::default(), start_runtime).await
+}
+
+/// Parses CLI arguments and runs them against an app runtime supplied by a
+/// sibling binary, applying product-specific runtime defaults before command
+/// execution.
+///
+/// Explicit global CLI feature flags override `config` defaults. This lets a
+/// sibling binary keep no-runtime commands such as `features list` aligned with
+/// the runtime it would supply for app-backed commands.
+///
+/// # Errors
+///
+/// Returns an error if runtime startup, command execution, or output formatting
+/// fails.
+pub async fn run_with_app_runtime_config<Start, StartFuture, RuntimeGuard>(
+    ctx: coral_app::RunContext,
+    config: AppRuntimeConfig,
+    start_runtime: Start,
+) -> Result<(), CliError>
+where
+    Start: FnOnce(SuppliedRuntimeOptions) -> StartFuture,
+    StartFuture: Future<Output = Result<(AppClient, RuntimeGuard), anyhow::Error>>,
+{
+    let Cli {
+        feature_overrides,
+        command,
+    } = Cli::parse();
+    let feature_overrides =
+        feature_overrides_with_defaults(feature_overrides.into_overrides(), &config);
+
+    match command.required_runtime() {
+        RequiredRuntime::AppClient => {
+            let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
+            let (app, _runtime_guard) = start_runtime(SuppliedRuntimeOptions {
+                enable_stderr_logs: command.enables_stderr_logs(),
+                feature_overrides: feature_overrides.clone(),
+            })
+            .await?;
+            if is_mcp_stdio {
+                run_app_command(app, command, Some(&ctx), &feature_overrides).await
+            } else {
+                coral_app::run_with_context(
+                    &ctx,
+                    Box::pin(run_app_command(app, command, None, &feature_overrides)),
+                )
+                .await
+            }
+        }
+        RequiredRuntime::None => {
+            coral_app::run_with_context(
+                &ctx,
+                Box::pin(run_no_runtime_command(command, &feature_overrides)),
+            )
+            .await
+        }
+    }
+}
+
+fn feature_overrides_with_defaults(
+    mut feature_overrides: coral_app::features::FeatureOverrides,
+    config: &AppRuntimeConfig,
+) -> coral_app::features::FeatureOverrides {
+    feature_overrides.apply_defaults_from(&config.feature_overrides);
+    feature_overrides
+}
+
+/// Parses CLI arguments and runs them against an already-configured app client.
+///
+/// Use [`run_with_app_runtime`] instead when parsed feature overrides or stderr
+/// log settings must affect the server that backs the client.
+///
+/// # Errors
+///
+/// Returns an error if command execution or output formatting fails.
+pub async fn run(app: AppClient, ctx: coral_app::RunContext) -> Result<(), CliError> {
+    run_with_app_runtime(ctx, |_| async move { Ok((app, ())) }).await
+}
+
+/// Returns the shared Coral CLI command definition.
+#[must_use]
+pub fn command() -> clap::Command {
+    Cli::command()
+}
+
 /// Returns the embedded Coral UI assets for the local server to serve.
 #[cfg(feature = "embedded-ui")]
 #[must_use]
@@ -552,25 +682,7 @@ async fn run_app_command(
 ) -> Result<(), CliError> {
     match command {
         Command::Sql(args) => {
-            let response = match app
-                .query_client()
-                .execute_sql(Request::new(ExecuteSqlRequest {
-                    workspace: Some(default_workspace()),
-                    sql: args.sql,
-                }))
-                .await
-            {
-                Ok(response) => response.into_inner(),
-                Err(status) => {
-                    return Err(CliError::Query {
-                        error_message: query_error::telemetry_error_message(&status),
-                        error_type: query_error::telemetry_error_type(&status),
-                        rendered_stderr: query_error::render_query_error(&status),
-                    });
-                }
-            };
-            let result = decode_execute_sql_response(&response).map_err(anyhow::Error::from)?;
-            print_batches(result.batches(), args.format)?;
+            run_sql(&app, default_workspace(), args.sql, args.format).await?;
         }
         Command::Source(args) => run_source(&app, args).await?,
         Command::Onboard => {
@@ -709,6 +821,75 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
         }
     }
     Ok(())
+}
+
+/// Build a workspace selector for shared CLI query helpers.
+#[must_use]
+pub fn workspace_with_name(name: impl Into<String>) -> Workspace {
+    Workspace { name: name.into() }
+}
+
+/// Execute a SQL query against the given workspace and return the raw response.
+///
+/// # Errors
+///
+/// Returns the gRPC status from query execution when the server rejects or fails
+/// the request.
+pub async fn execute_sql(
+    app: &AppClient,
+    workspace: Workspace,
+    sql: String,
+) -> Result<ExecuteSqlResponse, tonic::Status> {
+    app.query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(workspace),
+            sql,
+        }))
+        .await
+        .map(tonic::Response::into_inner)
+}
+
+/// Render a SQL response in the same format used by the shared CLI.
+///
+/// # Errors
+///
+/// Returns an error when the response payload cannot be decoded or formatted.
+pub fn print_sql_response(
+    response: &ExecuteSqlResponse,
+    format: OutputFormat,
+) -> Result<(), anyhow::Error> {
+    let result = decode_execute_sql_response(response).map_err(anyhow::Error::from)?;
+    print_batches(result.batches(), format)
+}
+
+/// Execute and render a SQL query using the shared CLI's query diagnostics.
+///
+/// # Errors
+///
+/// Returns [`CliError::Query`] when the server rejects query execution, or
+/// [`CliError::Internal`] when the successful response cannot be decoded or
+/// rendered.
+pub async fn run_sql(
+    app: &AppClient,
+    workspace: Workspace,
+    sql: String,
+    format: OutputFormat,
+) -> Result<(), CliError> {
+    let response = execute_sql(app, workspace, sql)
+        .await
+        .map_err(|status| sql_status_to_cli_error(&status))?;
+    print_sql_response(&response, format)?;
+    Ok(())
+}
+
+/// Convert a query status into the shared CLI's structured query diagnostic.
+#[must_use]
+pub fn sql_status_to_cli_error(status: &tonic::Status) -> CliError {
+    CliError::Query {
+        error_message: query_error::telemetry_error_message(status),
+        error_type: query_error::telemetry_error_type(status),
+        rendered_stderr: query_error::render_query_error(status),
+    }
 }
 
 fn print_batches(
@@ -887,8 +1068,12 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
 #[cfg(test)]
 mod tests {
     use clap::{CommandFactory, Parser};
+    use coral_app::features::{Feature, FeatureOverrides};
 
-    use super::{Cli, RequiredRuntime, command_enables_stderr_logs};
+    use super::{
+        AppRuntimeConfig, Cli, RequiredRuntime, command_enables_stderr_logs,
+        feature_overrides_with_defaults,
+    };
 
     #[test]
     fn server_command_is_not_available() {
@@ -989,6 +1174,36 @@ mod tests {
         .expect_err("conflicting feature overrides should fail");
 
         assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    fn dsl_v4_overrides(enabled: bool) -> FeatureOverrides {
+        let mut overrides = FeatureOverrides::default();
+        overrides.set(Feature::DslV4, enabled);
+        overrides
+    }
+
+    #[test]
+    fn runtime_config_feature_overrides_apply_as_defaults() {
+        let merged = feature_overrides_with_defaults(
+            FeatureOverrides::default(),
+            &AppRuntimeConfig {
+                feature_overrides: dsl_v4_overrides(true),
+            },
+        );
+
+        assert_eq!(merged.get(Feature::DslV4), Some(true));
+    }
+
+    #[test]
+    fn cli_feature_overrides_win_over_runtime_config_defaults() {
+        let merged = feature_overrides_with_defaults(
+            dsl_v4_overrides(false),
+            &AppRuntimeConfig {
+                feature_overrides: dsl_v4_overrides(true),
+            },
+        );
+
+        assert_eq!(merged.get(Feature::DslV4), Some(false));
     }
 
     #[test]


### PR DESCRIPTION
## Intent

Land `feat(cli): expose reusable runtime entrypoints` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-12-https-app-client...sauldhernandez/dsl-v4-identity-v2-13-cli-runtime-entrypoints
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
