### PR TITLE
feat(app): expose server extension factories

### DIFF
--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -15,7 +15,10 @@ pub(crate) use error::MAX_STATUS_DETAIL_BYTES;
 pub(crate) use error::{app_status, core_status};
 
 pub use error::AppError;
-pub use server::{RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider};
+pub use server::{
+    RunningServer, ServerBuilder, ServerExtensionContext, ServerMode, StaticAsset,
+    StaticAssetsProvider,
+};
 
 pub(crate) fn discover_app_state_layout(
     config_dir_override: Option<PathBuf>,

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -122,7 +122,6 @@ pub(crate) struct ServerConfig {
     identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
     feature_overrides: FeatureOverrides,
     identity_store: Option<Arc<dyn IdentityStore>>,
-    source_identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
     source_identity_provider_factories: Vec<SourceIdentityProviderFactory>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
@@ -147,7 +146,6 @@ impl ServerConfig {
             identity_spec_usage_providers: Vec::new(),
             feature_overrides: FeatureOverrides::default(),
             identity_store: None,
-            source_identity_providers: Vec::new(),
             source_identity_provider_factories: Vec::new(),
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             management_authorizer: Arc::new(AllowAllManagementAuthorizer),
@@ -222,8 +220,10 @@ impl ServerConfig {
         mut self,
         source_identity_provider: Arc<dyn SourceIdentityProvider>,
     ) -> Self {
-        self.source_identity_providers
-            .push(source_identity_provider);
+        self.source_identity_provider_factories
+            .push(Arc::new(move |_context| {
+                Arc::clone(&source_identity_provider)
+            }));
         self
     }
 
@@ -569,7 +569,6 @@ impl ServerBuilder {
         );
         let extension_context = ServerExtensionContext::new(identity_manager.handle());
         let source_identity_providers = source_identity_providers_for_server(
-            self.config.source_identity_providers,
             self.config.source_identity_provider_factories,
             &extension_context,
             &identity_manager,
@@ -669,16 +668,14 @@ fn identity_spec_manager_for_server(
 }
 
 fn source_identity_providers_for_server(
-    mut providers: Vec<Arc<dyn SourceIdentityProvider>>,
     factories: Vec<SourceIdentityProviderFactory>,
     extension_context: &ServerExtensionContext,
     identity_manager: &IdentityManager,
 ) -> Vec<Arc<dyn SourceIdentityProvider>> {
-    providers.extend(
-        factories
-            .into_iter()
-            .map(|factory| factory(extension_context)),
-    );
+    let mut providers: Vec<_> = factories
+        .into_iter()
+        .map(|factory| factory(extension_context))
+        .collect();
     providers.push(Arc::new(identity_manager.clone()));
     providers
 }
@@ -1095,9 +1092,9 @@ mod tests {
     use tonic::{Code, Request, Response, Status};
 
     use super::{
-        RunningServer, ServerBuilder, ServerExtensionContext, ServerMode, ServerServices,
-        StaticAsset, StaticAssetsProvider, is_grpc_web_content_type, is_native_grpc_content_type,
-        start_server,
+        RunningServer, ServerBuilder, ServerConfig, ServerExtensionContext, ServerMode,
+        ServerServices, StaticAsset, StaticAssetsProvider, is_grpc_web_content_type,
+        is_native_grpc_content_type, source_identity_providers_for_server, start_server,
     };
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::episode::store::EpisodeStore;
@@ -1315,6 +1312,43 @@ enabled = false
         ) -> Result<Option<Arc<dyn RuntimeSourceIdentity>>, AppError> {
             Ok(None)
         }
+    }
+
+    #[test]
+    fn source_identity_providers_materialize_from_single_factory_queue() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let identity_spec_manager = test_identity_spec_manager(&layout);
+        let identity_manager = test_identity_manager(&layout, &identity_spec_manager);
+        let extension_context = ServerExtensionContext::new(identity_manager.handle());
+        let static_provider: Arc<dyn SourceIdentityProvider> = Arc::new(NoopSourceIdentityProvider);
+        let factory_provider: Arc<dyn SourceIdentityProvider> =
+            Arc::new(NoopSourceIdentityProvider);
+        let factory_called = Arc::new(AtomicBool::new(false));
+        let config = ServerConfig::new()
+            .add_source_identity_provider(Arc::clone(&static_provider))
+            .add_source_identity_provider_factory({
+                let factory_provider = Arc::clone(&factory_provider);
+                let factory_called = Arc::clone(&factory_called);
+                Arc::new(move |_context| {
+                    factory_called.store(true, Ordering::SeqCst);
+                    Arc::clone(&factory_provider)
+                })
+            });
+
+        let providers = source_identity_providers_for_server(
+            config.source_identity_provider_factories,
+            &extension_context,
+            &identity_manager,
+        );
+
+        assert!(factory_called.load(Ordering::SeqCst));
+        assert_eq!(providers.len(), 3);
+        assert!(Arc::ptr_eq(&providers[0], &static_provider));
+        assert!(Arc::ptr_eq(&providers[1], &factory_provider));
+        assert!(!Arc::ptr_eq(&providers[2], &static_provider));
+        assert!(!Arc::ptr_eq(&providers[2], &factory_provider));
     }
 
     #[derive(Clone)]

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -47,7 +47,7 @@ use crate::credentials::config::CredentialStorageConfig;
 use crate::credentials::{CredentialManager, CredentialStore};
 use crate::episode::service::EpisodeService;
 use crate::episode::store::EpisodeStore;
-use crate::features::FeatureOverrides;
+use crate::features::{FeatureOverrides, Features};
 use crate::feedback::manager::FeedbackManager;
 use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
@@ -555,32 +555,25 @@ impl ServerBuilder {
                 store: Arc::clone(store),
             }));
         }
-        let identity_spec_manager = if let Some(registry) = self.config.identity_spec_registry {
-            IdentitySpecManager::new_with_registry(
-                layout.clone(),
-                registry,
-                features.clone(),
-                identity_spec_usage_providers,
-            )
-        } else {
-            IdentitySpecManager::new_with_credential_store(
-                layout.clone(),
-                credential_store,
-                features.clone(),
-                identity_spec_usage_providers,
-            )
-        };
+        let identity_spec_manager = identity_spec_manager_for_server(
+            layout.clone(),
+            self.config.identity_spec_registry,
+            credential_store,
+            features.clone(),
+            identity_spec_usage_providers,
+        );
         let identity_manager = identity_manager_for_server(
             layout.clone(),
             identity_spec_manager.clone(),
             identity_store,
         );
         let extension_context = ServerExtensionContext::new(identity_manager.handle());
-        let mut source_identity_providers = self.config.source_identity_providers;
-        for source_identity_provider_factory in self.config.source_identity_provider_factories {
-            source_identity_providers.push(source_identity_provider_factory(&extension_context));
-        }
-        source_identity_providers.push(Arc::new(identity_manager.clone()));
+        let source_identity_providers = source_identity_providers_for_server(
+            self.config.source_identity_providers,
+            self.config.source_identity_provider_factories,
+            &extension_context,
+            &identity_manager,
+        );
         let source_manager = SourceManager::new_with_features(
             config_store.clone(),
             credential_manager.clone(),
@@ -653,6 +646,41 @@ impl IdentitySpecUsageProvider for IdentityStoreUsageProvider {
     fn count_identities_for_spec(&self, identity_spec_name: &str) -> Result<u32, AppError> {
         self.store.count_identities_for_spec(identity_spec_name)
     }
+}
+
+fn identity_spec_manager_for_server(
+    layout: AppStateLayout,
+    registry: Option<Arc<dyn IdentitySpecRegistry>>,
+    credential_store: CredentialStore,
+    features: Features,
+    usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
+) -> IdentitySpecManager {
+    match registry {
+        Some(registry) => {
+            IdentitySpecManager::new_with_registry(layout, registry, features, usage_providers)
+        }
+        None => IdentitySpecManager::new_with_credential_store(
+            layout,
+            credential_store,
+            features,
+            usage_providers,
+        ),
+    }
+}
+
+fn source_identity_providers_for_server(
+    mut providers: Vec<Arc<dyn SourceIdentityProvider>>,
+    factories: Vec<SourceIdentityProviderFactory>,
+    extension_context: &ServerExtensionContext,
+    identity_manager: &IdentityManager,
+) -> Vec<Arc<dyn SourceIdentityProvider>> {
+    providers.extend(
+        factories
+            .into_iter()
+            .map(|factory| factory(extension_context)),
+    );
+    providers.push(Arc::new(identity_manager.clone()));
+    providers
 }
 
 struct ServerServices {

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -32,6 +32,7 @@ use tokio::task::JoinHandle;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::codegen::http::header::CONTENT_TYPE;
 use tonic::codegen::http::{HeaderValue, Method, Request, Response, StatusCode};
+use tonic::server::NamedService;
 use tonic::service::Routes;
 use tonic::transport::Server;
 use tonic_web::GrpcWebLayer;
@@ -87,6 +88,30 @@ pub trait StaticAssetsProvider: Send + Sync + 'static {
     fn get(&self, path: &str) -> Option<StaticAsset>;
 }
 
+type GrpcRouteExtender = Arc<dyn Fn(&ServerExtensionContext, Routes) -> Routes + Send + Sync>;
+type SourceIdentityProviderFactory =
+    Arc<dyn Fn(&ServerExtensionContext) -> Arc<dyn SourceIdentityProvider> + Send + Sync>;
+
+/// Runtime context supplied to server extensions.
+#[derive(Clone)]
+pub struct ServerExtensionContext {
+    identity_management: IdentityManagementHandle,
+}
+
+impl ServerExtensionContext {
+    fn new(identity_management: IdentityManagementHandle) -> Self {
+        Self {
+            identity_management,
+        }
+    }
+
+    /// Returns the shared identity management handle for this server.
+    #[must_use]
+    pub fn identity_management(&self) -> &IdentityManagementHandle {
+        &self.identity_management
+    }
+}
+
 /// Server-side bootstrap configuration for the Coral server.
 #[derive(Clone)]
 pub(crate) struct ServerConfig {
@@ -98,9 +123,11 @@ pub(crate) struct ServerConfig {
     feature_overrides: FeatureOverrides,
     identity_store: Option<Arc<dyn IdentityStore>>,
     source_identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
+    source_identity_provider_factories: Vec<SourceIdentityProviderFactory>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
+    grpc_route_extenders: Vec<GrpcRouteExtender>,
     enable_stderr_logs: bool,
 }
 
@@ -121,9 +148,11 @@ impl ServerConfig {
             feature_overrides: FeatureOverrides::default(),
             identity_store: None,
             source_identity_providers: Vec::new(),
+            source_identity_provider_factories: Vec::new(),
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             management_authorizer: Arc::new(AllowAllManagementAuthorizer),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
+            grpc_route_extenders: Vec::new(),
             enable_stderr_logs: false,
         }
     }
@@ -195,6 +224,20 @@ impl ServerConfig {
     ) -> Self {
         self.source_identity_providers
             .push(source_identity_provider);
+        self
+    }
+
+    pub(crate) fn add_source_identity_provider_factory(
+        mut self,
+        source_identity_provider_factory: SourceIdentityProviderFactory,
+    ) -> Self {
+        self.source_identity_provider_factories
+            .push(source_identity_provider_factory);
+        self
+    }
+
+    pub(crate) fn add_grpc_route_extender(mut self, extender: GrpcRouteExtender) -> Self {
+        self.grpc_route_extenders.push(extender);
         self
     }
 
@@ -389,6 +432,26 @@ impl ServerBuilder {
     }
 
     #[must_use]
+    /// Adds a provider factory that receives server runtime extension context.
+    ///
+    /// Use this when a provider needs access to shared managers created during
+    /// server startup, such as identity management.
+    pub fn add_source_identity_provider_factory(
+        mut self,
+        source_identity_provider_factory: impl Fn(
+            &ServerExtensionContext,
+        ) -> Arc<dyn SourceIdentityProvider>
+        + Send
+        + Sync
+        + 'static,
+    ) -> Self {
+        self.config = self
+            .config
+            .add_source_identity_provider_factory(Arc::new(source_identity_provider_factory));
+        self
+    }
+
+    #[must_use]
     /// Enables or disables local stderr log rendering for this server.
     ///
     /// `MCP` stdio adapters can enable this for diagnostics while keeping
@@ -396,6 +459,53 @@ impl ServerBuilder {
     /// leave it disabled and rely on OTEL export for logs.
     pub fn with_stderr_logs(mut self, enable_stderr_logs: bool) -> Self {
         self.config = self.config.with_stderr_logs(enable_stderr_logs);
+        self
+    }
+
+    #[must_use]
+    /// Adds an already constructed gRPC service to the Coral listener.
+    pub fn add_grpc_service<S>(mut self, service: S) -> Self
+    where
+        S: Service<Request<tonic::body::Body>, Error = Infallible>
+            + NamedService
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        S::Response: axum::response::IntoResponse,
+        S::Future: Send + 'static,
+    {
+        let service = Arc::new(service);
+        self.config = self
+            .config
+            .add_grpc_route_extender(Arc::new(move |_context, routes| {
+                routes.add_service((*service).clone())
+            }));
+        self
+    }
+
+    #[must_use]
+    /// Adds a gRPC service factory to the Coral listener.
+    ///
+    /// The factory runs after core server managers are initialized and receives
+    /// [`ServerExtensionContext`], allowing services to reuse shared managers.
+    pub fn add_grpc_service_factory<F, S>(mut self, factory: F) -> Self
+    where
+        F: Fn(&ServerExtensionContext) -> S + Send + Sync + 'static,
+        S: Service<Request<tonic::body::Body>, Error = Infallible>
+            + NamedService
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        S::Response: axum::response::IntoResponse,
+        S::Future: Send + 'static,
+    {
+        self.config = self
+            .config
+            .add_grpc_route_extender(Arc::new(move |context, routes| {
+                routes.add_service(factory(context))
+            }));
         self
     }
 
@@ -465,14 +575,18 @@ impl ServerBuilder {
             identity_spec_manager.clone(),
             identity_store,
         );
+        let extension_context = ServerExtensionContext::new(identity_manager.handle());
+        let mut source_identity_providers = self.config.source_identity_providers;
+        for source_identity_provider_factory in self.config.source_identity_provider_factories {
+            source_identity_providers.push(source_identity_provider_factory(&extension_context));
+        }
+        source_identity_providers.push(Arc::new(identity_manager.clone()));
         let source_manager = SourceManager::new_with_features(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
             features.clone(),
         );
-        let mut source_identity_providers = self.config.source_identity_providers;
-        source_identity_providers.push(Arc::new(identity_manager.clone()));
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
         let episode_store = EpisodeStore::new(layout.clone());
@@ -510,6 +624,8 @@ impl ServerBuilder {
                 management_authorizer: self.config.management_authorizer,
                 identity_spec_manager,
                 identity_manager,
+                grpc_route_extenders: self.config.grpc_route_extenders,
+                extension_context,
             },
             self.config.mode,
         )
@@ -549,6 +665,8 @@ struct ServerServices {
     management_authorizer: Arc<dyn ManagementAuthorizer>,
     identity_spec_manager: IdentitySpecManager,
     identity_manager: IdentityManager,
+    grpc_route_extenders: Vec<GrpcRouteExtender>,
+    extension_context: ServerExtensionContext,
 }
 
 /// Running Coral server.
@@ -642,6 +760,8 @@ async fn start_server(
         management_authorizer,
         identity_spec_manager,
         identity_manager,
+        grpc_route_extenders,
+        extension_context,
     } = services;
     let source_service = SourceService::new(
         source_manager,
@@ -684,6 +804,9 @@ async fn start_server(
             TraceServiceServer::new(trace_service)
                 .max_encoding_message_size(TRACE_RESPONSE_MAX_MESSAGE_SIZE),
         );
+    }
+    for extend_routes in grpc_route_extenders {
+        routes = extend_routes(&extension_context, routes);
     }
 
     let listener = TcpListener::bind(mode.bind_addr()).await?;
@@ -915,7 +1038,8 @@ mod tests {
     use std::collections::BTreeMap;
     use std::net::{Ipv4Addr, TcpListener};
     use std::path::Path;
-    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use coral_api::v1::episode_service_client::EpisodeServiceClient;
@@ -923,21 +1047,29 @@ mod tests {
     use coral_api::v1::query_service_client::QueryServiceClient;
     use coral_api::v1::source_service_client::SourceServiceClient;
     use coral_api::v1::trace_service_client::TraceServiceClient;
+    use coral_api::v1::trace_service_server::{
+        TraceService as TraceServiceApi, TraceServiceServer,
+    };
     use coral_api::v1::{
         AddIdentitySpecRequest, CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
-        DeleteIdentitySpecRequest, DeleteSourceRequest, ExecuteSqlRequest, IdentitySpecInputValue,
-        ImportSourceRequest, ImportSourceResponse, ListSourcesRequest, ListTracesRequest,
-        OpenEpisodeRequest, Workspace, import_source_response,
+        DeleteIdentitySpecRequest, DeleteSourceRequest, ExecuteSqlRequest, GetTraceRequest,
+        GetTraceResponse, IdentitySpecInputValue, ImportSourceRequest, ImportSourceResponse,
+        ListSourcesRequest, ListTracesRequest, ListTracesResponse, OpenEpisodeRequest, Workspace,
+        import_source_response,
     };
-    use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
+    use coral_api::{
+        HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
+        TRACE_RESPONSE_MAX_MESSAGE_SIZE,
+    };
     use coral_engine::QueryRuntimeContext;
     use tempfile::TempDir;
     use tonic::transport::Endpoint;
-    use tonic::{Code, Request};
+    use tonic::{Code, Request, Response, Status};
 
     use super::{
-        RunningServer, ServerBuilder, ServerMode, ServerServices, StaticAsset,
-        StaticAssetsProvider, is_grpc_web_content_type, is_native_grpc_content_type, start_server,
+        RunningServer, ServerBuilder, ServerExtensionContext, ServerMode, ServerServices,
+        StaticAsset, StaticAssetsProvider, is_grpc_web_content_type, is_native_grpc_content_type,
+        start_server,
     };
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::episode::store::EpisodeStore;
@@ -957,7 +1089,9 @@ mod tests {
     use crate::{
         AllowAllManagementAuthorizer, AppError, AuthorizationError, AwsEngineExtensionsProvider,
         ManagementAuthorizer, ManagementMutation, NoopEngineExtensionsProvider,
-        ResourceMutationKind, SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider,
+        ResourceMutationKind, RuntimeSourceIdentity, SingleUserPrincipalProvider,
+        SourceIdentityProvider, SourceIdentityResolutionRequest, UserPrincipal,
+        UserPrincipalProvider,
     };
 
     fn default_workspace() -> Workspace {
@@ -1139,6 +1273,47 @@ enabled = false
                 )),
                 _ => Ok(()),
             }
+        }
+    }
+
+    #[derive(Debug)]
+    struct NoopSourceIdentityProvider;
+
+    #[tonic::async_trait]
+    impl SourceIdentityProvider for NoopSourceIdentityProvider {
+        async fn resolve_source_identity(
+            &self,
+            _request: &SourceIdentityResolutionRequest,
+        ) -> Result<Option<Arc<dyn RuntimeSourceIdentity>>, AppError> {
+            Ok(None)
+        }
+    }
+
+    #[derive(Clone)]
+    struct MethodRecordingTraceService {
+        observed_method: Arc<Mutex<Option<(String, String)>>>,
+    }
+
+    #[tonic::async_trait]
+    impl TraceServiceApi for MethodRecordingTraceService {
+        async fn list_traces(
+            &self,
+            request: Request<ListTracesRequest>,
+        ) -> Result<Response<ListTracesResponse>, Status> {
+            let metadata = crate::transport::grpc_method(&request);
+            *self.observed_method.lock().expect("recorded method lock") =
+                Some((metadata.service, metadata.method));
+            Ok(Response::new(ListTracesResponse {
+                traces: Vec::new(),
+                next_page_token: String::new(),
+            }))
+        }
+
+        async fn get_trace(
+            &self,
+            _request: Request<GetTraceRequest>,
+        ) -> Result<Response<GetTraceResponse>, Status> {
+            Err(Status::unimplemented("unused in test"))
         }
     }
 
@@ -1417,6 +1592,109 @@ type: fixed_token
     }
 
     #[tokio::test]
+    async fn server_builder_extension_factories_receive_context() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        disable_internal_tracing(&config_dir);
+        let source_factory_called = Arc::new(AtomicBool::new(false));
+        let grpc_factory_called = Arc::new(AtomicBool::new(false));
+        let trace_store = temp.path().join("factory-trace-store");
+        let server = ServerBuilder::new()
+            .with_config_dir(config_dir)
+            .add_source_identity_provider_factory({
+                let source_factory_called = Arc::clone(&source_factory_called);
+                move |context| {
+                    let _identity_management = context.identity_management().clone();
+                    source_factory_called.store(true, Ordering::SeqCst);
+                    Arc::new(NoopSourceIdentityProvider)
+                }
+            })
+            .add_grpc_service_factory({
+                let grpc_factory_called = Arc::clone(&grpc_factory_called);
+                move |context| {
+                    let _identity_management = context.identity_management().clone();
+                    grpc_factory_called.store(true, Ordering::SeqCst);
+                    TraceServiceServer::new(TraceService::new(
+                        trace_store.clone(),
+                        Duration::from_mins(1),
+                    ))
+                    .max_encoding_message_size(TRACE_RESPONSE_MAX_MESSAGE_SIZE)
+                }
+            })
+            .start()
+            .await
+            .expect("start server");
+
+        assert!(source_factory_called.load(Ordering::SeqCst));
+        assert!(grpc_factory_called.load(Ordering::SeqCst));
+
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut trace_client = TraceServiceClient::new(channel);
+        let response = trace_client
+            .list_traces(Request::new(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
+            }))
+            .await
+            .expect("factory-mounted trace service should be registered")
+            .into_inner();
+
+        assert!(response.traces.is_empty());
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn extension_grpc_services_receive_method_metadata() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        disable_internal_tracing(&config_dir);
+        let observed_method = Arc::new(Mutex::new(None));
+        let server = ServerBuilder::new()
+            .with_config_dir(config_dir)
+            .add_grpc_service_factory({
+                let observed_method = Arc::clone(&observed_method);
+                move |_context| {
+                    TraceServiceServer::new(MethodRecordingTraceService {
+                        observed_method: Arc::clone(&observed_method),
+                    })
+                }
+            })
+            .start()
+            .await
+            .expect("start server");
+
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut trace_client = TraceServiceClient::new(channel);
+        trace_client
+            .list_traces(Request::new(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
+            }))
+            .await
+            .expect("extension-mounted trace service should be registered");
+
+        assert_eq!(
+            observed_method
+                .lock()
+                .expect("recorded method lock")
+                .as_ref(),
+            Some(&(
+                "coral.v1.TraceService".to_string(),
+                "ListTraces".to_string()
+            ))
+        );
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
     async fn server_builder_applies_process_feature_overrides() {
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
@@ -1587,7 +1865,9 @@ type: fixed_token
                 user_principal_provider,
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                identity_manager,
+                identity_manager: identity_manager.clone(),
+                grpc_route_extenders: Vec::new(),
+                extension_context: ServerExtensionContext::new(identity_manager.handle()),
             },
             ServerMode::NativeGrpc,
         )
@@ -1635,6 +1915,16 @@ type: fixed_token
         let _builder = ServerBuilder::new()
             .add_engine_extensions_provider(Arc::new(AwsEngineExtensionsProvider))
             .add_engine_extensions_provider(Arc::new(NoopEngineExtensionsProvider));
+    }
+
+    #[test]
+    fn server_builder_accepts_static_grpc_services() {
+        let temp = TempDir::new().expect("temp dir");
+        let service = TraceServiceServer::new(TraceService::new(
+            temp.path().join("trace-store"),
+            Duration::from_mins(1),
+        ));
+        let _builder = ServerBuilder::new().add_grpc_service(service);
     }
 
     #[test]
@@ -2016,7 +2306,9 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                identity_manager,
+                identity_manager: identity_manager.clone(),
+                grpc_route_extenders: Vec::new(),
+                extension_context: ServerExtensionContext::new(identity_manager.handle()),
             },
             ServerMode::NativeGrpc,
         )
@@ -2129,7 +2421,9 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                identity_manager,
+                identity_manager: identity_manager.clone(),
+                grpc_route_extenders: Vec::new(),
+                extension_context: ServerExtensionContext::new(identity_manager.handle()),
             },
             ServerMode::NativeGrpc,
         )
@@ -2238,7 +2532,9 @@ tables:
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
                 identity_spec_manager,
-                identity_manager,
+                identity_manager: identity_manager.clone(),
+                grpc_route_extenders: Vec::new(),
+                extension_context: ServerExtensionContext::new(identity_manager.handle()),
             },
             ServerMode::NativeGrpc,
         )

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -66,7 +66,8 @@ pub use authorization::{
     ResourceMutationKind, WorkspaceSourceMutationKind,
 };
 pub use bootstrap::{
-    AppError, RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider,
+    AppError, RunningServer, ServerBuilder, ServerExtensionContext, ServerMode, StaticAsset,
+    StaticAssetsProvider,
 };
 pub use coral_engine::{
     EngineExtensions, QuerySource, RequestIdentityHttpAuthenticator,

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -44,7 +44,7 @@ use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
 use crate::identities::IdentityManager;
 use crate::identity::{
-    IdentityOwnerKind as AppSourceIdentityOwner, SourceIdentityBinding as AppSourceIdentityBinding,
+    IdentityOwnerKind, SourceIdentityBinding as AppSourceIdentityBinding,
     SourceIdentitySelection as AppSourceIdentitySelection, UserPrincipal,
 };
 use crate::identity_specs::{IdentitySpecInputValue, IdentitySpecManager, IdentitySpecSnapshot};
@@ -74,7 +74,7 @@ pub(crate) struct SourceService {
     sources: SourceManager,
     queries: QueryManager,
     identity_specs: IdentitySpecManager,
-    identity_instances: IdentityManager,
+    identities: IdentityManager,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
 }
 
@@ -83,14 +83,14 @@ impl SourceService {
         source_manager: SourceManager,
         query_manager: QueryManager,
         identity_spec_manager: IdentitySpecManager,
-        identity_instance_manager: IdentityManager,
+        identity_manager: IdentityManager,
         management_authorizer: Arc<dyn ManagementAuthorizer>,
     ) -> Self {
         Self {
             sources: source_manager,
             queries: query_manager,
             identity_specs: identity_spec_manager,
-            identity_instances: identity_instance_manager,
+            identities: identity_manager,
             management_authorizer,
         }
     }
@@ -283,7 +283,7 @@ impl SourceServiceApi for SourceService {
         let sources = self.sources.clone();
         let management_authorizer = Arc::clone(&self.management_authorizer);
         let identity_specs = self.identity_specs.clone();
-        let identity_instances = self.identity_instances.clone();
+        let identities = self.identities.clone();
         instrument_grpc(span, async move {
             let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
@@ -309,14 +309,7 @@ impl SourceServiceApi for SourceService {
                     .await
                     .map_err(authorization_status)?;
             }
-            handle_import_source(
-                sources,
-                identity_specs,
-                identity_instances,
-                principal,
-                request,
-            )
-            .await
+            handle_import_source(sources, identity_specs, identities, principal, request).await
         })
         .await
     }
@@ -382,7 +375,7 @@ impl SourceServiceApi for SourceService {
 async fn handle_import_source(
     sources: SourceManager,
     identity_specs: IdentitySpecManager,
-    identity_instances: IdentityManager,
+    identities: IdentityManager,
     principal: UserPrincipal,
     request: ImportSourceRequest,
 ) -> Result<Response<ImportSourceResponseStreamBox>, Status> {
@@ -395,7 +388,7 @@ async fn handle_import_source(
         .map_err(app_status)?;
     let identity_context = ImportSourceIdentityContext {
         identity_specs,
-        identity_instances,
+        identities,
         identity_spec_manifest_yamls: request.identity_spec_manifest_yamls,
         identity_spec_inputs: identity_spec_import_inputs_from_proto(request.identity_spec_inputs)
             .map_err(app_status)?,
@@ -443,7 +436,7 @@ async fn handle_import_source(
 
 struct ImportSourceIdentityContext {
     identity_specs: IdentitySpecManager,
-    identity_instances: IdentityManager,
+    identities: IdentityManager,
     identity_spec_manifest_yamls: Vec<String>,
     identity_spec_inputs: Vec<IdentitySpecImportInputValues>,
     user_principal: Option<UserPrincipal>,
@@ -462,7 +455,7 @@ async fn handle_import_source_without_credentials(
     let prepared_user_bindings =
         prepare_user_source_identity_bindings_for_import(ValidateUserSourceIdentityImport {
             sources: &sources,
-            identities: &identity_context.identity_instances,
+            identities: &identity_context.identities,
             principal: identity_context.user_principal.as_ref(),
             workspace_name: &workspace_name,
             manifest_yaml: &command.manifest_yaml,
@@ -472,7 +465,7 @@ async fn handle_import_source_without_credentials(
         })
         .await?;
     let user_binding_guard = persist_user_source_identity_bindings_for_import(
-        &identity_context.identity_instances,
+        &identity_context.identities,
         identity_context.user_principal.as_ref(),
         &workspace_name,
         &source_name,
@@ -527,7 +520,7 @@ async fn handle_import_source_with_credentials(
     let prepared_user_bindings =
         prepare_user_source_identity_bindings_for_import(ValidateUserSourceIdentityImport {
             sources: &sources,
-            identities: &identity_context.identity_instances,
+            identities: &identity_context.identities,
             principal: identity_context.user_principal.as_ref(),
             workspace_name: &workspace_name,
             manifest_yaml: &command.manifest_yaml,
@@ -540,7 +533,7 @@ async fn handle_import_source_with_credentials(
         instrument_grpc(span, async move {
             let identity_spec_guard = identity_spec_guard;
             let user_binding_guard = persist_user_source_identity_bindings_for_import(
-                &identity_context.identity_instances,
+                &identity_context.identities,
                 identity_context.user_principal.as_ref(),
                 &workspace_name,
                 &source_name,
@@ -776,8 +769,8 @@ fn import_source_identity_bindings_from_proto(
     let mut user_selections = BTreeMap::new();
     for binding in bindings {
         let owner = match ProtoIdentityOwner::try_from(binding.owner) {
-            Ok(ProtoIdentityOwner::User) => AppSourceIdentityOwner::User,
-            Ok(ProtoIdentityOwner::Workspace) => AppSourceIdentityOwner::Workspace,
+            Ok(ProtoIdentityOwner::User) => IdentityOwnerKind::User,
+            Ok(ProtoIdentityOwner::Workspace) => IdentityOwnerKind::Workspace,
             Ok(ProtoIdentityOwner::Unspecified) | Err(_) => {
                 return Err(AppError::InvalidInput(format!(
                     "source identity binding for surface '{}' has invalid owner",
@@ -792,7 +785,7 @@ fn import_source_identity_bindings_from_proto(
             )));
         }
         let binding = match owner {
-            AppSourceIdentityOwner::User => {
+            IdentityOwnerKind::User => {
                 if binding.identity.is_empty() {
                     return Err(AppError::InvalidInput(format!(
                         "user-owned source identity binding for surface '{surface_id}' requires identity"
@@ -804,7 +797,7 @@ fn import_source_identity_bindings_from_proto(
                 );
                 AppSourceIdentityBinding::user_owned()
             }
-            AppSourceIdentityOwner::Workspace => {
+            IdentityOwnerKind::Workspace => {
                 AppSourceIdentityBinding::workspace_owned(binding.identity)?
             }
         };
@@ -1046,7 +1039,7 @@ fn validate_user_source_identity_bindings_for_slots(
     selections: &BTreeMap<String, AppSourceIdentitySelection>,
 ) -> Result<(), AppError> {
     for (surface_id, slot) in required_slots {
-        if slot.owner == AppSourceIdentityOwner::User && !selections.contains_key(surface_id) {
+        if slot.owner == IdentityOwnerKind::User && !selections.contains_key(surface_id) {
             return Err(AppError::InvalidInput(format!(
                 "user-owned source identity binding for surface '{surface_id}' requires an identity selection"
             )));
@@ -1066,7 +1059,7 @@ fn require_user_owned_slot(
     surface_id: &str,
 ) -> Result<(), AppError> {
     match slots.get(surface_id) {
-        Some(slot) if slot.owner == AppSourceIdentityOwner::User => Ok(()),
+        Some(slot) if slot.owner == IdentityOwnerKind::User => Ok(()),
         Some(_) => Err(AppError::InvalidInput(format!(
             "identity selection for surface '{surface_id}' targets a workspace-owned source identity binding"
         ))),
@@ -1496,8 +1489,8 @@ fn source_identity_binding_to_proto(
     binding: AppSourceIdentityBinding,
 ) -> ProtoSourceIdentityBinding {
     let owner = match binding.owner {
-        AppSourceIdentityOwner::User => ProtoIdentityOwner::User,
-        AppSourceIdentityOwner::Workspace => ProtoIdentityOwner::Workspace,
+        IdentityOwnerKind::User => ProtoIdentityOwner::User,
+        IdentityOwnerKind::Workspace => ProtoIdentityOwner::Workspace,
     };
     ProtoSourceIdentityBinding {
         surface_id,

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -218,9 +218,9 @@ impl GrpcServerMethod {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-struct GrpcMethodMetadata {
-    service: String,
-    method: String,
+pub(crate) struct GrpcMethodMetadata {
+    pub(crate) service: String,
+    pub(crate) method: String,
 }
 
 impl GrpcMethodMetadata {
@@ -232,7 +232,7 @@ impl GrpcMethodMetadata {
     }
 }
 
-fn grpc_method<T>(request: &Request<T>) -> GrpcMethodMetadata {
+pub(crate) fn grpc_method<T>(request: &Request<T>) -> GrpcMethodMetadata {
     if let Some(method) = request.extensions().get::<tonic::GrpcMethod<'static>>() {
         return GrpcMethodMetadata::new(method.service(), method.method());
     }


### PR DESCRIPTION
## Intent

Land `feat(app): expose server extension factories` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-13-cli-runtime-entrypoints...sauldhernandez/dsl-v4-identity-v2-14-server-extension-factories
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
