### PR TITLE
feat(app): expose identity metadata validation

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -2098,7 +2098,7 @@ audience:
             .expect("validate metadata")
             .expect("identity");
 
-        assert_eq!(validated.name.as_str(), "github_local");
+        assert_eq!(validated.name, identity_name);
         identity_specs
             .remove_identity_spec("github_pat", true)
             .expect("force remove spec");
@@ -2131,9 +2131,10 @@ audience:
         );
         let manager = IdentityManager::new(layout, identity_specs);
         let owner = local_owner();
+        let identity_name = github_local_name();
         let record = IdentityRecord {
             owner: owner.clone(),
-            name: github_local_name(),
+            name: identity_name.clone(),
             identity_spec: manifest.name.clone(),
             identity_spec_fingerprint: Some(
                 identity_spec_fingerprint(&manifest).expect("fingerprint"),

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -410,6 +410,24 @@ impl IdentityManagementHandle {
         self.manager.list_identities(owner).await
     }
 
+    /// Validates that an identity exists under `owner` and still matches its
+    /// installed identity spec without reading credential material.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the store cannot be read or the identity is
+    /// orphaned because its installed spec is missing, changed, or has a
+    /// different type.
+    pub async fn validate_identity_metadata(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<Option<IdentityRecord>, AppError> {
+        self.manager
+            .validate_identity_metadata(owner, identity_name)
+            .await
+    }
+
     /// Deletes an identity stored under `owner`.
     ///
     /// # Errors
@@ -618,6 +636,19 @@ impl IdentityManager {
         self.store.list_identities(owner).await
     }
 
+    async fn validate_identity_metadata(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<Option<IdentityRecord>, AppError> {
+        let identity_name = validate_identity_name(identity_name)?;
+        let Some(record) = self.store.load_identity(owner, &identity_name).await? else {
+            return Ok(None);
+        };
+        self.load_spec_manifest_for_record(&record)?;
+        Ok(Some(record))
+    }
+
     pub(crate) async fn list_user_owned_identities(
         &self,
         principal: &UserPrincipal,
@@ -737,7 +768,28 @@ impl IdentityManager {
         &self,
         record: &IdentityRecord,
     ) -> Result<IdentitySpecRecord, AppError> {
-        let spec = match self.identity_specs.get_identity_spec(&record.identity_spec) {
+        Self::validate_loaded_spec_for_record(
+            record,
+            self.identity_specs.get_identity_spec(&record.identity_spec),
+        )
+    }
+
+    fn load_spec_manifest_for_record(
+        &self,
+        record: &IdentityRecord,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        Self::validate_loaded_spec_for_record(
+            record,
+            self.identity_specs
+                .get_identity_spec_manifest(&record.identity_spec),
+        )
+    }
+
+    fn validate_loaded_spec_for_record(
+        record: &IdentityRecord,
+        loaded: Result<IdentitySpecRecord, AppError>,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        let spec = match loaded {
             Ok(spec) => spec,
             Err(AppError::IdentitySpecNotFound(_)) => {
                 return Err(AppError::FailedPrecondition(format!(
@@ -1483,17 +1535,8 @@ fn validate_identity_spec_reference_unlocked(
 ) -> Result<(), AppError> {
     let spec = identity_specs
         .load_identity_spec_manifest_unlocked_for_state_lock(&record.identity_spec)?;
-    let fingerprint = identity_spec_fingerprint(&spec.manifest)?;
-    if spec.manifest.issuer != record.issuer
-        || spec.manifest.identity_type.label() != record.identity_type.as_str()
-        || record.identity_spec_fingerprint.as_deref() != Some(fingerprint.as_str())
-    {
-        return Err(AppError::FailedPrecondition(format!(
-            "identity '{}' references identity spec '{}' that changed before the identity could be stored",
-            record.name, record.identity_spec
-        )));
-    }
-    Ok(())
+    validate_record_identity_type(record, spec.manifest.identity_type)?;
+    validate_record_identity_spec_fingerprint(record, &spec.manifest)
 }
 
 fn checked_add_identity_count(
@@ -1571,6 +1614,7 @@ mod tests {
     use crate::identity::{
         SourceIdentityBinding, SourceIdentitySelection, SourceIdentitySelectionRequest,
     };
+    use crate::identity_specs::{IdentitySpecRegistry, IdentitySpecRegistryRecord};
     use tempfile::TempDir;
 
     #[test]
@@ -1648,6 +1692,14 @@ mod tests {
     }
 
     fn fixed_identity_spec_yaml_with_issuer(issuer: &str) -> String {
+        fixed_identity_spec_yaml_with(issuer, "github.com")
+    }
+
+    fn fixed_identity_spec_yaml_for_host(host: &str) -> String {
+        fixed_identity_spec_yaml_with("github", host)
+    }
+
+    fn fixed_identity_spec_yaml_with(issuer: &str, host: &str) -> String {
         format!(
             r"
 kind: identity
@@ -1657,7 +1709,7 @@ version: 0.1.0
 issuer: {issuer}
 type: fixed_token
 audience:
-  host: github.com
+  host: {host}
 "
         )
     }
@@ -1956,7 +2008,7 @@ audience:
             .expect_err("stale identity spec reference must be rejected");
 
         assert!(
-            matches!(error, AppError::FailedPrecondition(ref message) if message.contains("changed before the identity could be stored")),
+            matches!(error, AppError::FailedPrecondition(ref message) if message.contains("has changed since the identity was created")),
             "unexpected error: {error:?}"
         );
         let layout = test_layout(&temp);
@@ -2013,6 +2065,148 @@ audience:
                 reqwest::header::HeaderValue::from_static("Bearer ghp_token")
             )]
         );
+    }
+
+    #[tokio::test]
+    async fn handle_validates_identity_metadata_without_credential_material() {
+        let (_temp, manager, identity_specs) = manager_with_github_pat_spec();
+        manager
+            .create_user_owned_fixed_token_identity(
+                &UserPrincipal::local(),
+                github_local_command("identity-token"),
+            )
+            .await
+            .expect("create identity");
+        let owner = local_owner();
+        let identity_name = github_local_name();
+        let record = manager
+            .store
+            .load_identity(&owner, &identity_name)
+            .await
+            .expect("load identity")
+            .expect("identity");
+        manager
+            .store
+            .replace_identity(&record, &BTreeMap::new())
+            .await
+            .expect("remove credential material");
+        let handle = manager.handle();
+
+        let validated = handle
+            .validate_identity_metadata(&owner, "github_local")
+            .await
+            .expect("validate metadata")
+            .expect("identity");
+
+        assert_eq!(validated.name.as_str(), "github_local");
+        identity_specs
+            .remove_identity_spec("github_pat", true)
+            .expect("force remove spec");
+        identity_specs
+            .add_identity_spec(&fixed_identity_spec_yaml_for_host("api.github.com"))
+            .expect("add changed spec");
+        let error = handle
+            .validate_identity_metadata(&owner, "github_local")
+            .await
+            .expect_err("changed identity spec should fail metadata validation");
+        assert!(
+            error
+                .to_string()
+                .contains("has changed since the identity was created"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_validates_identity_metadata_from_manifest_only_registry_path() {
+        let temp = TempDir::new().expect("tempdir");
+        let layout = test_layout(&temp);
+        let manifest_yaml = fixed_identity_spec_yaml();
+        let manifest = coral_spec::parse_identity_manifest_yaml(&manifest_yaml).expect("manifest");
+        let identity_specs = IdentitySpecManager::new_with_registry(
+            layout.clone(),
+            Arc::new(ManifestOnlyIdentitySpecRegistry { manifest_yaml }),
+            dsl_v4_features(),
+            Vec::new(),
+        );
+        let manager = IdentityManager::new(layout, identity_specs);
+        let owner = local_owner();
+        let record = IdentityRecord {
+            owner: owner.clone(),
+            name: github_local_name(),
+            identity_spec: manifest.name.clone(),
+            identity_spec_fingerprint: Some(
+                identity_spec_fingerprint(&manifest).expect("fingerprint"),
+            ),
+            issuer: manifest.issuer.clone(),
+            identity_type: manifest.identity_type.label().to_string(),
+            metadata: BTreeMap::new(),
+        };
+        manager
+            .store
+            .replace_identity(&record, &BTreeMap::new())
+            .await
+            .expect("store identity");
+
+        let validated = manager
+            .handle()
+            .validate_identity_metadata(&owner, "github_local")
+            .await
+            .expect("validate metadata")
+            .expect("identity");
+
+        assert_eq!(validated, record);
+    }
+
+    #[derive(Debug)]
+    struct ManifestOnlyIdentitySpecRegistry {
+        manifest_yaml: String,
+    }
+
+    impl IdentitySpecRegistry for ManifestOnlyIdentitySpecRegistry {
+        fn list_identity_specs(&self) -> Result<Vec<IdentitySpecRegistryRecord>, AppError> {
+            Err(unexpected_manifest_only_registry_call(
+                "list identity specs",
+            ))
+        }
+
+        fn get_identity_spec(
+            &self,
+            _name: &str,
+        ) -> Result<Option<IdentitySpecRegistryRecord>, AppError> {
+            Err(unexpected_manifest_only_registry_call(
+                "hydrate identity spec input material",
+            ))
+        }
+
+        fn get_identity_spec_manifest_yaml(&self, name: &str) -> Result<Option<String>, AppError> {
+            if name != "github_pat" {
+                return Err(AppError::FailedPrecondition(format!(
+                    "unexpected identity spec lookup '{name}'"
+                )));
+            }
+            Ok(Some(self.manifest_yaml.clone()))
+        }
+
+        fn upsert_identity_spec(
+            &self,
+            _name: &str,
+            _record: IdentitySpecRegistryRecord,
+        ) -> Result<(), AppError> {
+            Err(unexpected_manifest_only_registry_call(
+                "upsert identity specs",
+            ))
+        }
+
+        fn remove_identity_spec(&self, _name: &str) -> Result<(), AppError> {
+            Err(unexpected_manifest_only_registry_call(
+                "remove identity specs",
+            ))
+        }
+    }
+
+    fn unexpected_manifest_only_registry_call(operation: &str) -> AppError {
+        AppError::FailedPrecondition(format!("metadata validation should not {operation}"))
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -166,12 +166,13 @@ pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
     fn get_identity_spec(&self, name: &str)
     -> Result<Option<IdentitySpecRegistryRecord>, AppError>;
 
-    /// Fetches one identity spec manifest without setup input material.
+    /// Fetches one identity spec manifest by name without hydrating stored
+    /// setup input material.
     ///
     /// # Errors
     ///
     /// Returns [`AppError`] when the registry cannot be read.
-    fn get_identity_spec_manifest(&self, name: &str) -> Result<Option<String>, AppError> {
+    fn get_identity_spec_manifest_yaml(&self, name: &str) -> Result<Option<String>, AppError> {
         Ok(self
             .get_identity_spec(name)?
             .map(|record| record.manifest_yaml))
@@ -183,7 +184,7 @@ pub trait IdentitySpecRegistry: Send + Sync + std::fmt::Debug + 'static {
     ///
     /// Returns [`AppError`] when the registry cannot be inspected.
     fn identity_spec_exists(&self, name: &str) -> Result<bool, AppError> {
-        self.get_identity_spec_manifest(name)
+        self.get_identity_spec_manifest_yaml(name)
             .map(|manifest| manifest.is_some())
     }
 
@@ -391,6 +392,17 @@ impl IdentitySpecManager {
         self.load_identity_spec_manifest_unlocked(&name)
     }
 
+    pub(crate) fn get_identity_spec_manifest(
+        &self,
+        name: &str,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        let span = info_span!("coral.app.identity_specs.get_manifest");
+        let _guard = span.enter();
+        let name = validate_identity_spec_name(name)?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        self.load_identity_spec_manifest_unlocked(&name)
+    }
+
     pub(crate) fn load_identity_spec_manifest_unlocked_for_state_lock(
         &self,
         name: &str,
@@ -409,7 +421,8 @@ impl IdentitySpecManager {
         let Some(stored) = self.registry.get_identity_spec(name.as_str())? else {
             return Ok(None);
         };
-        let record = parse_identity_spec_record_for_name(&name, &stored.manifest_yaml)?;
+        let record =
+            Self::parse_identity_spec_manifest_unlocked(name.as_str(), &stored.manifest_yaml)?;
         Ok(Some(IdentitySpecSnapshot {
             record,
             input_material: stored.input_material,
@@ -486,10 +499,27 @@ impl IdentitySpecManager {
         &self,
         name: &IdentitySpecName,
     ) -> Result<IdentitySpecRecord, AppError> {
-        let Some(manifest_yaml) = self.registry.get_identity_spec_manifest(name.as_str())? else {
+        let Some(manifest_yaml) = self
+            .registry
+            .get_identity_spec_manifest_yaml(name.as_str())?
+        else {
             return Err(AppError::IdentitySpecNotFound(name.as_str().to_string()));
         };
-        parse_identity_spec_record_for_name(name, &manifest_yaml)
+        Self::parse_identity_spec_manifest_unlocked(name.as_str(), &manifest_yaml)
+    }
+
+    fn parse_identity_spec_manifest_unlocked(
+        name: &str,
+        manifest_yaml: &str,
+    ) -> Result<IdentitySpecRecord, AppError> {
+        let record = parse_identity_spec_record(manifest_yaml)?;
+        if record.manifest.name == name {
+            return Ok(record);
+        }
+        Err(AppError::FailedPrecondition(format!(
+            "identity spec registry record '{name}' contains identity spec '{}'",
+            record.manifest.name
+        )))
     }
 
     fn count_identities_for_spec_unlocked(
@@ -745,7 +775,7 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
             let Some(name) = entry.file_name().to_str().map(ToString::to_string) else {
                 continue;
             };
-            if let Some(manifest_yaml) = self.get_identity_spec_manifest(&name)? {
+            if let Some(manifest_yaml) = self.get_identity_spec_manifest_yaml(&name)? {
                 manifests.push(manifest_yaml);
             }
         }
@@ -756,12 +786,10 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
         &self,
         name: &str,
     ) -> Result<Option<IdentitySpecRegistryRecord>, AppError> {
-        let name = validate_identity_spec_name(name)?;
-        let path = self.layout.identity_spec_manifest_file(&name);
-        if !path.exists() {
+        let Some(manifest_yaml) = self.get_identity_spec_manifest_yaml(name)? else {
             return Ok(None);
-        }
-        let manifest_yaml = fs::read_to_string(&path)?;
+        };
+        let name = validate_identity_spec_name(name)?;
         let state = self.load_input_material_state(&name)?;
         let input_material = match state.credential_storage {
             Some(storage) => self.read_input_material(&name, storage)?,
@@ -773,7 +801,7 @@ impl IdentitySpecRegistry for FileIdentitySpecRegistry {
         }))
     }
 
-    fn get_identity_spec_manifest(&self, name: &str) -> Result<Option<String>, AppError> {
+    fn get_identity_spec_manifest_yaml(&self, name: &str) -> Result<Option<String>, AppError> {
         let name = validate_identity_spec_name(name)?;
         let path = self.layout.identity_spec_manifest_file(&name);
         if !path.exists() {
@@ -1059,20 +1087,6 @@ fn normalized_manifest_yaml(manifest_yaml: &str) -> String {
 
 pub(crate) fn validate_identity_spec_name(name: &str) -> Result<IdentitySpecName, AppError> {
     IdentitySpecName::parse(name)
-}
-
-fn parse_identity_spec_record_for_name(
-    name: &IdentitySpecName,
-    manifest_yaml: &str,
-) -> Result<IdentitySpecRecord, AppError> {
-    let record = parse_identity_spec_record(manifest_yaml)?;
-    if record.manifest.name != name.as_str() {
-        return Err(AppError::FailedPrecondition(format!(
-            "identity spec registry record '{name}' contains identity spec '{}'",
-            record.manifest.name
-        )));
-    }
-    Ok(record)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Intent

Land `feat(app): expose identity metadata validation` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-14-server-extension-factories...sauldhernandez/dsl-v4-identity-v2-15-identity-metadata-validation
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
