### PR TITLE
feat(app): add source registry seam

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -62,6 +62,7 @@ use crate::identity_specs::{
 };
 use crate::query::manager::{QueryManager, QueryManagerOptions};
 use crate::query::service::QueryService;
+use crate::source_registry::SourceRegistry;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::{AppStateLayout, ConfigStore};
@@ -118,6 +119,7 @@ pub(crate) struct ServerConfig {
     config_dir: Option<PathBuf>,
     mode: ServerMode,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    source_registry: Option<Arc<dyn SourceRegistry>>,
     identity_spec_registry: Option<Arc<dyn IdentitySpecRegistry>>,
     identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
     feature_overrides: FeatureOverrides,
@@ -142,6 +144,7 @@ impl ServerConfig {
             config_dir: None,
             mode: ServerMode::NativeGrpc,
             engine_extensions_providers: Vec::new(),
+            source_registry: None,
             identity_spec_registry: None,
             identity_spec_usage_providers: Vec::new(),
             feature_overrides: FeatureOverrides::default(),
@@ -195,6 +198,11 @@ impl ServerConfig {
         identity_spec_registry: Arc<dyn IdentitySpecRegistry>,
     ) -> Self {
         self.identity_spec_registry = Some(identity_spec_registry);
+        self
+    }
+
+    pub(crate) fn with_source_registry(mut self, source_registry: Arc<dyn SourceRegistry>) -> Self {
+        self.source_registry = Some(source_registry);
         self
     }
 
@@ -380,6 +388,17 @@ impl ServerBuilder {
         self.config = self
             .config
             .with_identity_spec_registry(identity_spec_registry);
+        self
+    }
+
+    #[must_use]
+    /// Sets the durable registry used for workspace-installed sources.
+    ///
+    /// The default registry persists source records in local `config.toml`.
+    /// Product-specific siblings can install a registry backed by their own
+    /// durable control-plane store.
+    pub fn with_source_registry(mut self, source_registry: Arc<dyn SourceRegistry>) -> Self {
+        self.config = self.config.with_source_registry(source_registry);
         self
     }
 
@@ -573,8 +592,12 @@ impl ServerBuilder {
             &extension_context,
             &identity_manager,
         );
-        let source_manager = SourceManager::new_with_features(
-            config_store.clone(),
+        let source_registry = self
+            .config
+            .source_registry
+            .unwrap_or_else(|| Arc::new(config_store.clone()));
+        let source_manager = SourceManager::new_with_source_registry_and_features(
+            source_registry,
             credential_manager.clone(),
             layout.clone(),
             features.clone(),

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -26,6 +26,7 @@ use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
     TRACE_RESPONSE_MAX_MESSAGE_SIZE,
 };
+use coral_engine::QueryRuntimeContext;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -592,12 +593,9 @@ impl ServerBuilder {
             &extension_context,
             &identity_manager,
         );
-        let source_registry = self
-            .config
-            .source_registry
-            .unwrap_or_else(|| Arc::new(config_store.clone()));
-        let source_manager = SourceManager::new_with_source_registry_and_features(
-            source_registry,
+        let source_manager = source_manager_for_server(
+            self.config.source_registry,
+            &config_store,
             credential_manager.clone(),
             layout.clone(),
             features.clone(),
@@ -612,16 +610,14 @@ impl ServerBuilder {
             .query_runtime_context()
             .with_body_capture_max_bytes(body_capture_max_bytes);
 
-        let query_manager = QueryManager::new_with_options(
+        let query_manager = query_manager_for_server(
             config_store,
             credential_manager,
             query_runtime_context,
             layout,
             self.config.engine_extensions_providers,
-            QueryManagerOptions {
-                features,
-                source_identity_providers,
-            },
+            features,
+            source_identity_providers,
         );
         let trace_service = if telemetry_config.trace_history.enabled {
             installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))
@@ -701,6 +697,50 @@ fn source_identity_providers_for_server(
         .collect();
     providers.push(Arc::new(identity_manager.clone()));
     providers
+}
+
+fn source_registry_for_server(
+    registry: Option<Arc<dyn SourceRegistry>>,
+    config_store: &ConfigStore,
+) -> Arc<dyn SourceRegistry> {
+    registry.unwrap_or_else(|| Arc::new(config_store.clone()))
+}
+
+fn source_manager_for_server(
+    registry: Option<Arc<dyn SourceRegistry>>,
+    config_store: &ConfigStore,
+    credential_manager: CredentialManager,
+    layout: AppStateLayout,
+    features: Features,
+) -> SourceManager {
+    SourceManager::new_with_source_registry_and_features(
+        source_registry_for_server(registry, config_store),
+        credential_manager,
+        layout,
+        features,
+    )
+}
+
+fn query_manager_for_server(
+    config_store: ConfigStore,
+    credential_manager: CredentialManager,
+    query_runtime_context: QueryRuntimeContext,
+    layout: AppStateLayout,
+    engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    features: Features,
+    source_identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
+) -> QueryManager {
+    QueryManager::new_with_options(
+        config_store,
+        credential_manager,
+        query_runtime_context,
+        layout,
+        engine_extensions_providers,
+        QueryManagerOptions {
+            features,
+            source_identity_providers,
+        },
+    )
 }
 
 struct ServerServices {

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -54,6 +54,7 @@ mod identity;
 mod identity_specs;
 mod query;
 mod request_context;
+mod source_registry;
 mod sources;
 mod state;
 mod storage;
@@ -94,6 +95,13 @@ pub use identity_specs::{
 };
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
+};
+pub use source_registry::{
+    BundleIdentityInputDiscoveryError, BundleIdentityInputKind, BundleIdentityInputSpec,
+    SourceRegistry, SourceRegistryCredentialStorage, SourceRegistryOrigin, SourceRegistryRecord,
+    SourceSpecManifestMetadata, SpecBundleIdentitySpec, SpecBundleManifest, SpecBundleSourceSpec,
+    bundle_identity_inputs_from_yaml, parse_spec_bundle_manifest_yaml,
+    source_spec_manifest_metadata,
 };
 pub use telemetry::{RunContext, RunErrorTelemetry, run_with_context, shutdown_tracing};
 pub use transport::oauth_operation_response_stream;

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -97,10 +97,10 @@ pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };
 pub use source_registry::{
-    BundleIdentityInputDiscoveryError, BundleIdentityInputKind, BundleIdentityInputSpec,
-    SourceRegistry, SourceRegistryCredentialStorage, SourceRegistryOrigin, SourceRegistryRecord,
-    SourceSpecManifestMetadata, SpecBundleIdentitySpec, SpecBundleManifest, SpecBundleSourceSpec,
-    bundle_identity_inputs_from_yaml, parse_spec_bundle_manifest_yaml,
+    BundleIdentityInputDiscoveryError, BundleIdentityInputSpec, ManifestInputKind,
+    ManifestInputSpec, SourceRegistry, SourceRegistryCredentialStorage, SourceRegistryOrigin,
+    SourceRegistryRecord, SourceSpecManifestMetadata, SpecBundleIdentitySpec, SpecBundleManifest,
+    SpecBundleSourceSpec, bundle_identity_inputs_from_yaml, parse_spec_bundle_manifest_yaml,
     source_spec_manifest_metadata,
 };
 pub use telemetry::{RunContext, RunErrorTelemetry, run_with_context, shutdown_tracing};

--- a/crates/coral-app/src/source_registry.rs
+++ b/crates/coral-app/src/source_registry.rs
@@ -1,0 +1,430 @@
+//! Public source registry extension seam.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::bootstrap::AppError;
+use crate::credentials::CredentialStorageKind;
+use crate::identity::SourceIdentityBinding;
+use crate::sources::SourceName;
+use crate::sources::model::{InstalledSource, SourceOrigin};
+use crate::workspaces::WorkspaceName;
+
+/// Validated identity of one source-spec manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceSpecManifestMetadata {
+    /// Stable source-spec id declared by the manifest.
+    pub source_spec_id: String,
+    /// Declared source-spec DSL version.
+    pub dsl_version: u32,
+    /// Authored source-spec version, when present.
+    pub version: Option<String>,
+}
+
+/// Validates one source-spec manifest and returns its registry identity.
+///
+/// # Errors
+///
+/// Returns [`AppError`] when the manifest is invalid.
+pub fn source_spec_manifest_metadata(
+    manifest_yaml: &str,
+) -> Result<SourceSpecManifestMetadata, AppError> {
+    let manifest = coral_spec::parse_source_manifest_yaml(manifest_yaml)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    Ok(SourceSpecManifestMetadata {
+        source_spec_id: manifest.schema_name().to_string(),
+        dsl_version: manifest.dsl_version(),
+        version: manifest.source_version().map(str::to_string),
+    })
+}
+
+/// Parsed source/identity spec bundle ready for global registry import.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpecBundleManifest {
+    /// Source spec document from the bundle.
+    pub source_spec: SpecBundleSourceSpec,
+    /// Identity spec documents from the bundle.
+    pub identity_specs: Vec<SpecBundleIdentitySpec>,
+}
+
+/// Source spec document in a parsed spec bundle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpecBundleSourceSpec {
+    /// Stable source-spec id declared by the manifest.
+    pub source_spec_id: String,
+    /// Declared source-spec DSL version.
+    pub dsl_version: u32,
+    /// Authored source-spec version, when present.
+    pub version: Option<String>,
+    /// Canonical source manifest YAML.
+    pub manifest_yaml: String,
+}
+
+/// Identity spec document in a parsed spec bundle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpecBundleIdentitySpec {
+    /// Stable identity-spec id declared by the manifest.
+    pub identity_spec_id: String,
+    /// Authored identity-spec version.
+    pub version: String,
+    /// Canonical identity manifest YAML.
+    pub manifest_yaml: String,
+}
+
+/// Kind of identity-spec setup input declared by an imported bundle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BundleIdentityInputKind {
+    /// Non-secret input material.
+    Variable,
+    /// Secret input material.
+    Secret,
+}
+
+/// Promptable identity-spec setup input declared by an imported bundle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BundleIdentityInputSpec {
+    /// Identity spec that owns the input.
+    pub identity_spec_id: String,
+    /// Input key declared by the identity spec.
+    pub key: String,
+    /// Input kind.
+    pub kind: BundleIdentityInputKind,
+    /// Whether this input must be present after defaults and existing material are resolved.
+    pub required: bool,
+    /// Authored default value for variable inputs, if any.
+    pub default_value: String,
+    /// Optional authored prompt hint.
+    pub hint: Option<String>,
+}
+
+/// Error returned while discovering identity-spec inputs from a bundle.
+#[derive(Debug, thiserror::Error)]
+pub enum BundleIdentityInputDiscoveryError {
+    /// Bundle YAML failed to parse or validate.
+    #[error("spec bundle is invalid: {0}")]
+    Invalid(String),
+}
+
+/// Parses a source/identity spec bundle and returns canonical documents.
+///
+/// # Errors
+///
+/// Returns [`AppError`] when the bundle is invalid.
+pub fn parse_spec_bundle_manifest_yaml(raw: &str) -> Result<SpecBundleManifest, AppError> {
+    let bundle = coral_spec::parse_manifest_bundle_yaml(raw)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    Ok(SpecBundleManifest {
+        source_spec: SpecBundleSourceSpec {
+            source_spec_id: bundle.source_manifest.schema_name().to_string(),
+            dsl_version: bundle.source_manifest.dsl_version(),
+            version: bundle.source_manifest.source_version().map(str::to_string),
+            manifest_yaml: bundle.source_manifest_yaml,
+        },
+        identity_specs: bundle
+            .identity_manifests
+            .into_iter()
+            .map(|identity| SpecBundleIdentitySpec {
+                identity_spec_id: identity.manifest.name,
+                version: identity.manifest.version,
+                manifest_yaml: identity.manifest_yaml,
+            })
+            .collect(),
+    })
+}
+
+/// Discover identity-spec setup inputs declared by a source/identity bundle.
+///
+/// # Errors
+///
+/// Returns [`BundleIdentityInputDiscoveryError`] when the bundle YAML is invalid.
+pub fn bundle_identity_inputs_from_yaml(
+    bundle_yaml: &str,
+) -> Result<Vec<BundleIdentityInputSpec>, BundleIdentityInputDiscoveryError> {
+    let bundle = coral_spec::parse_manifest_bundle_yaml(bundle_yaml)
+        .map_err(|error| BundleIdentityInputDiscoveryError::Invalid(error.to_string()))?;
+    Ok(bundle
+        .identity_manifests
+        .into_iter()
+        .flat_map(|identity| {
+            let identity_spec_id = identity.manifest.name;
+            identity.manifest.inputs.into_iter().map(move |input| {
+                let kind = match input.kind {
+                    coral_spec::ManifestInputKind::Variable => BundleIdentityInputKind::Variable,
+                    coral_spec::ManifestInputKind::Secret => BundleIdentityInputKind::Secret,
+                };
+                BundleIdentityInputSpec {
+                    identity_spec_id: identity_spec_id.clone(),
+                    key: input.key,
+                    kind,
+                    required: input.required,
+                    default_value: input.default_value,
+                    hint: input.hint,
+                }
+            })
+        })
+        .collect())
+}
+
+/// Durable storage backend for workspace-installed sources.
+///
+/// The default implementation persists source records in local `config.toml`.
+/// Product runtimes can install an implementation backed by their own durable
+/// control-plane store.
+pub trait SourceRegistry: fmt::Debug + Send + Sync + 'static {
+    /// Lists all sources installed in one workspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the registry cannot be read or contains invalid
+    /// source records.
+    fn list_workspace_sources(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Vec<SourceRegistryRecord>, AppError>;
+
+    /// Fetches one installed source, returning `None` when it is absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the registry cannot be read or contains an
+    /// invalid source record.
+    fn get_source(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<SourceRegistryRecord>, AppError>;
+
+    /// Inserts or replaces one installed source.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the record is invalid or cannot be persisted.
+    fn upsert_source(&self, record: SourceRegistryRecord) -> Result<(), AppError>;
+
+    /// Removes one installed source if present.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the source cannot be removed.
+    fn remove_source(&self, workspace_id: &str, source_name: &str) -> Result<(), AppError>;
+}
+
+/// One source installed in a workspace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceRegistryRecord {
+    /// Workspace id that owns this source.
+    pub workspace_id: String,
+    /// Installed source name.
+    pub source_name: String,
+    /// Persisted source version, when applicable.
+    pub version: Option<String>,
+    /// Imported source manifest YAML.
+    ///
+    /// Bundled sources may leave this empty because their manifest is resolved
+    /// from the bundled catalog. Imported DSL v4 manifests are not secret
+    /// material and product registries can persist them here.
+    pub manifest_yaml: Option<String>,
+    /// Configured non-secret variable values.
+    pub variables: BTreeMap<String, String>,
+    /// Source-owned secret keys for legacy source specs.
+    ///
+    /// DSL v4 sources should leave this empty and express credentials through
+    /// identity requirements.
+    pub secrets: Vec<String>,
+    /// Credential storage backend for legacy source-owned secrets.
+    pub credential_storage: Option<SourceRegistryCredentialStorage>,
+    /// Source-surface identity slot configuration.
+    pub identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+    /// How this source entered the registry.
+    pub origin: SourceRegistryOrigin,
+}
+
+/// Source origin stored by a source registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceRegistryOrigin {
+    /// Source was installed from the bundled source catalog.
+    Bundled,
+    /// Source was imported from a user-provided manifest.
+    Imported,
+}
+
+/// Source-owned credential storage backend for legacy source specs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceRegistryCredentialStorage {
+    /// Credential material is stored in the local file store.
+    File,
+    /// Credential material is stored in the operating-system keychain.
+    Keychain,
+}
+
+pub(crate) fn record_from_installed_source(
+    workspace_name: &WorkspaceName,
+    source: InstalledSource,
+) -> SourceRegistryRecord {
+    SourceRegistryRecord {
+        workspace_id: workspace_name.as_str().to_string(),
+        source_name: source.name.as_str().to_string(),
+        version: source.version,
+        manifest_yaml: None,
+        variables: source.variables,
+        secrets: source.secrets,
+        credential_storage: source.credential_storage.map(Into::into),
+        identity_bindings: source.identity_bindings,
+        origin: source.origin.into(),
+    }
+}
+
+pub(crate) fn installed_source_from_record(
+    expected_workspace: &WorkspaceName,
+    record: SourceRegistryRecord,
+) -> Result<InstalledSource, AppError> {
+    let workspace_name = WorkspaceName::parse(&record.workspace_id)?;
+    if &workspace_name != expected_workspace {
+        return Err(AppError::InvalidInput(format!(
+            "source registry returned workspace '{workspace_name}' while loading workspace '{expected_workspace}'"
+        )));
+    }
+    let source_name = SourceName::parse(&record.source_name)?;
+    validate_registry_identity_bindings(source_name.as_str(), &record.identity_bindings)?;
+    Ok(InstalledSource {
+        name: source_name,
+        version: record.version,
+        variables: record.variables,
+        secrets: record.secrets,
+        credential_storage: record.credential_storage.map(Into::into),
+        identity_bindings: record.identity_bindings,
+        origin: record.origin.into(),
+    })
+}
+
+fn validate_registry_identity_bindings(
+    source_name: &str,
+    bindings: &BTreeMap<String, SourceIdentityBinding>,
+) -> Result<(), AppError> {
+    for (surface_id, binding) in bindings {
+        let mut chars = surface_id.chars();
+        let valid = matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+            && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+        if !valid {
+            return Err(AppError::InvalidInput(format!(
+                "source '{source_name}' identity binding surface '{surface_id}' must match [a-z][a-z0-9_]*"
+            )));
+        }
+        binding.validate().map_err(|error| {
+            AppError::InvalidInput(format!(
+                "source '{source_name}' identity binding for surface '{surface_id}' is invalid: {error}"
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+impl From<SourceOrigin> for SourceRegistryOrigin {
+    fn from(value: SourceOrigin) -> Self {
+        match value {
+            SourceOrigin::Bundled => Self::Bundled,
+            SourceOrigin::Imported => Self::Imported,
+        }
+    }
+}
+
+impl From<SourceRegistryOrigin> for SourceOrigin {
+    fn from(value: SourceRegistryOrigin) -> Self {
+        match value {
+            SourceRegistryOrigin::Bundled => Self::Bundled,
+            SourceRegistryOrigin::Imported => Self::Imported,
+        }
+    }
+}
+
+impl From<CredentialStorageKind> for SourceRegistryCredentialStorage {
+    fn from(value: CredentialStorageKind) -> Self {
+        match value {
+            CredentialStorageKind::File => Self::File,
+            CredentialStorageKind::Keychain => Self::Keychain,
+        }
+    }
+}
+
+impl From<SourceRegistryCredentialStorage> for CredentialStorageKind {
+    fn from(value: SourceRegistryCredentialStorage) -> Self {
+        match value {
+            SourceRegistryCredentialStorage::File => Self::File,
+            SourceRegistryCredentialStorage::Keychain => Self::Keychain,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BundleIdentityInputKind, bundle_identity_inputs_from_yaml};
+
+    #[test]
+    fn bundle_identity_inputs_from_yaml_discovers_identity_inputs() {
+        let inputs = bundle_identity_inputs_from_yaml(&format!(
+            "---\n{}---\n{}",
+            source_yaml("demo"),
+            oauth_identity_yaml()
+        ))
+        .expect("bundle inputs");
+
+        let [tenant, client_secret] = inputs.as_slice() else {
+            panic!("expected two inputs, got {inputs:?}");
+        };
+        assert_eq!(tenant.identity_spec_id, "demo_oauth");
+        assert_eq!(tenant.key, "DEMO_TENANT");
+        assert_eq!(tenant.kind, BundleIdentityInputKind::Variable);
+        assert_eq!(tenant.default_value, "oauth2");
+        assert_eq!(client_secret.identity_spec_id, "demo_oauth");
+        assert_eq!(client_secret.key, "DEMO_OAUTH_CLIENT_SECRET");
+        assert_eq!(client_secret.kind, BundleIdentityInputKind::Secret);
+        assert!(client_secret.required);
+    }
+
+    fn source_yaml(name: &str) -> String {
+        format!(
+            "name: {name}\nversion: 0.1.0\ndsl_version: 4\nsurfaces:\n  - id: rest\n    type: openapi\n    file: /tmp/openapi.yaml\n    sha256: 0000000000000000000000000000000000000000000000000000000000000000\n"
+        )
+    }
+
+    fn oauth_identity_yaml() -> &'static str {
+        r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+description: Demo OAuth identity.
+issuer: demo
+type: oauth
+audience:
+  host: api.example.test
+inputs:
+  DEMO_TENANT:
+    kind: variable
+    default: oauth2
+  DEMO_OAUTH_CLIENT_SECRET:
+    kind: secret
+    required: true
+oauth:
+  method:
+    label: Demo OAuth
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/callback
+    endpoints:
+      authorization_url: https://auth.example.test/authorize
+      token_url: https://auth.example.test/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+        transport: request_body
+"
+    }
+}

--- a/crates/coral-app/src/source_registry.rs
+++ b/crates/coral-app/src/source_registry.rs
@@ -5,6 +5,8 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+pub use coral_spec::{ManifestInputKind, ManifestInputSpec};
+
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialStorageKind;
 use crate::identity::SourceIdentityBinding;
@@ -69,17 +71,10 @@ pub struct SpecBundleIdentitySpec {
     pub identity_spec_id: String,
     /// Authored identity-spec version.
     pub version: String,
+    /// Identity-spec setup inputs in authored order.
+    pub inputs: Vec<ManifestInputSpec>,
     /// Canonical identity manifest YAML.
     pub manifest_yaml: String,
-}
-
-/// Kind of identity-spec setup input declared by an imported bundle.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BundleIdentityInputKind {
-    /// Non-secret input material.
-    Variable,
-    /// Secret input material.
-    Secret,
 }
 
 /// Promptable identity-spec setup input declared by an imported bundle.
@@ -87,16 +82,8 @@ pub enum BundleIdentityInputKind {
 pub struct BundleIdentityInputSpec {
     /// Identity spec that owns the input.
     pub identity_spec_id: String,
-    /// Input key declared by the identity spec.
-    pub key: String,
-    /// Input kind.
-    pub kind: BundleIdentityInputKind,
-    /// Whether this input must be present after defaults and existing material are resolved.
-    pub required: bool,
-    /// Authored default value for variable inputs, if any.
-    pub default_value: String,
-    /// Optional authored prompt hint.
-    pub hint: Option<String>,
+    /// Canonical manifest input declaration.
+    pub input: ManifestInputSpec,
 }
 
 /// Error returned while discovering identity-spec inputs from a bundle.
@@ -125,10 +112,14 @@ pub fn parse_spec_bundle_manifest_yaml(raw: &str) -> Result<SpecBundleManifest, 
         identity_specs: bundle
             .identity_manifests
             .into_iter()
-            .map(|identity| SpecBundleIdentitySpec {
-                identity_spec_id: identity.manifest.name,
-                version: identity.manifest.version,
-                manifest_yaml: identity.manifest_yaml,
+            .map(|identity| {
+                let manifest = identity.manifest;
+                SpecBundleIdentitySpec {
+                    identity_spec_id: manifest.name,
+                    version: manifest.version,
+                    inputs: manifest.inputs,
+                    manifest_yaml: identity.manifest_yaml,
+                }
             })
             .collect(),
     })
@@ -149,20 +140,14 @@ pub fn bundle_identity_inputs_from_yaml(
         .into_iter()
         .flat_map(|identity| {
             let identity_spec_id = identity.manifest.name;
-            identity.manifest.inputs.into_iter().map(move |input| {
-                let kind = match input.kind {
-                    coral_spec::ManifestInputKind::Variable => BundleIdentityInputKind::Variable,
-                    coral_spec::ManifestInputKind::Secret => BundleIdentityInputKind::Secret,
-                };
-                BundleIdentityInputSpec {
+            identity
+                .manifest
+                .inputs
+                .into_iter()
+                .map(move |input| BundleIdentityInputSpec {
                     identity_spec_id: identity_spec_id.clone(),
-                    key: input.key,
-                    kind,
-                    required: input.required,
-                    default_value: input.default_value,
-                    hint: input.hint,
-                }
-            })
+                    input,
+                })
         })
         .collect())
 }
@@ -361,7 +346,9 @@ impl From<SourceRegistryCredentialStorage> for CredentialStorageKind {
 
 #[cfg(test)]
 mod tests {
-    use super::{BundleIdentityInputKind, bundle_identity_inputs_from_yaml};
+    use super::{
+        ManifestInputKind, bundle_identity_inputs_from_yaml, parse_spec_bundle_manifest_yaml,
+    };
 
     #[test]
     fn bundle_identity_inputs_from_yaml_discovers_identity_inputs() {
@@ -376,13 +363,42 @@ mod tests {
             panic!("expected two inputs, got {inputs:?}");
         };
         assert_eq!(tenant.identity_spec_id, "demo_oauth");
-        assert_eq!(tenant.key, "DEMO_TENANT");
-        assert_eq!(tenant.kind, BundleIdentityInputKind::Variable);
-        assert_eq!(tenant.default_value, "oauth2");
+        assert_eq!(tenant.input.key, "DEMO_TENANT");
+        assert_eq!(tenant.input.kind, ManifestInputKind::Variable);
+        assert_eq!(tenant.input.default_value, "oauth2");
         assert_eq!(client_secret.identity_spec_id, "demo_oauth");
-        assert_eq!(client_secret.key, "DEMO_OAUTH_CLIENT_SECRET");
-        assert_eq!(client_secret.kind, BundleIdentityInputKind::Secret);
-        assert!(client_secret.required);
+        assert_eq!(client_secret.input.key, "DEMO_OAUTH_CLIENT_SECRET");
+        assert_eq!(client_secret.input.kind, ManifestInputKind::Secret);
+        assert!(client_secret.input.required);
+    }
+
+    #[test]
+    fn parsed_bundle_identity_specs_reuse_manifest_input_specs() {
+        let bundle = parse_spec_bundle_manifest_yaml(&format!(
+            "---\n{}---\n{}",
+            source_yaml("demo"),
+            oauth_identity_yaml()
+        ))
+        .expect("bundle manifest");
+
+        let [identity] = bundle.identity_specs.as_slice() else {
+            panic!(
+                "expected one identity spec, got {:?}",
+                bundle.identity_specs
+            );
+        };
+        assert_eq!(identity.identity_spec_id, "demo_oauth");
+        assert_eq!(
+            identity
+                .inputs
+                .iter()
+                .map(|input| (input.key.as_str(), input.kind))
+                .collect::<Vec<_>>(),
+            vec![
+                ("DEMO_TENANT", ManifestInputKind::Variable),
+                ("DEMO_OAUTH_CLIENT_SECRET", ManifestInputKind::Secret),
+            ]
+        );
     }
 
     fn source_yaml(name: &str) -> String {

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use coral_spec::v4::SurfaceDescriptor;
 use serde_yaml::Value as YamlValue;
@@ -17,6 +18,9 @@ use crate::credentials::{
 };
 use crate::features::Features;
 use crate::identity::SourceIdentityBinding;
+use crate::source_registry::{
+    SourceRegistry, installed_source_from_record, record_from_installed_source,
+};
 use crate::sources::SourceName;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
@@ -27,7 +31,9 @@ use crate::sources::materialization::{
     new_materialization_suffix, replace_v4_materialization, restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
-use crate::state::{AppStateLayout, ConfigStore};
+use crate::state::AppStateLayout;
+#[cfg(test)]
+use crate::state::ConfigStore;
 use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
@@ -38,7 +44,7 @@ use uuid::Uuid;
 
 #[derive(Clone)]
 pub(crate) struct SourceManager {
-    config_store: ConfigStore,
+    source_registry: Arc<dyn SourceRegistry>,
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
     layout: AppStateLayout,
@@ -188,22 +194,51 @@ impl SourceManager {
         credential_manager: CredentialManager,
         layout: AppStateLayout,
     ) -> Self {
-        Self::new_with_features(
-            config_store,
+        Self::new_with_source_registry_and_features(
+            Arc::new(config_store),
             credential_manager,
             layout,
             Features::default(),
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn new_with_features(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
         layout: AppStateLayout,
         features: Features,
     ) -> Self {
+        Self::new_with_source_registry_and_features(
+            Arc::new(config_store),
+            credential_manager,
+            layout,
+            features,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_source_registry(
+        source_registry: Arc<dyn SourceRegistry>,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+    ) -> Self {
+        Self::new_with_source_registry_and_features(
+            source_registry,
+            credential_manager,
+            layout,
+            Features::default(),
+        )
+    }
+
+    pub(crate) fn new_with_source_registry_and_features(
+        source_registry: Arc<dyn SourceRegistry>,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+        features: Features,
+    ) -> Self {
         Self {
-            config_store,
+            source_registry,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
             layout,
@@ -211,13 +246,54 @@ impl SourceManager {
         }
     }
 
+    fn list_registry_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        self.source_registry
+            .list_workspace_sources(workspace_name.as_str())?
+            .into_iter()
+            .map(|record| installed_source_from_record(workspace_name, record))
+            .collect()
+    }
+
+    fn get_registry_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, AppError> {
+        self.source_registry
+            .get_source(workspace_name.as_str(), source_name.as_str())?
+            .map(|record| installed_source_from_record(workspace_name, record))
+            .transpose()
+    }
+
+    fn require_registry_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<InstalledSource, AppError> {
+        self.get_registry_source(workspace_name, source_name)?
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
+    }
+
+    fn upsert_registry_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: InstalledSource,
+        manifest_yaml: Option<&str>,
+    ) -> Result<(), AppError> {
+        let mut record = record_from_installed_source(workspace_name, source);
+        record.manifest_yaml = manifest_yaml.map(ToString::to_string);
+        self.source_registry.upsert_source(record)
+    }
+
     pub(crate) fn list_workspace_sources(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<InstalledSource>, AppError> {
         Ok(self
-            .config_store
-            .list_workspace_sources(workspace_name)?
+            .list_registry_sources(workspace_name)?
             .into_iter()
             .map(|source| self.populate_source_version_or_keep(workspace_name, source))
             .collect())
@@ -230,7 +306,7 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         Ok(self.populate_source_version_or_keep(
             workspace_name,
-            self.config_store.get_source(workspace_name, source_name)?,
+            self.require_registry_source(workspace_name, source_name)?,
         ))
     }
 
@@ -239,14 +315,10 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<CandidateSource, AppError> {
-        match self.config_store.get_source(workspace_name, source_name) {
-            Ok(source) => {
-                return Ok(
-                    resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
-                );
-            }
-            Err(AppError::SourceNotFound(_)) => {}
-            Err(error) => return Err(error),
+        if let Some(source) = self.get_registry_source(workspace_name, source_name)? {
+            return Ok(
+                resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
+            );
         }
 
         match load_bundled_source(source_name) {
@@ -262,7 +334,7 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<CandidateSource>, AppError> {
-        let installed_sources = self.config_store.list_workspace_sources(workspace_name)?;
+        let installed_sources = self.list_registry_sources(workspace_name)?;
         let installed = installed_sources
             .iter()
             .map(|source| source.name.clone())
@@ -532,7 +604,7 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
-        let stored = self.config_store.get_source(workspace_name, source_name)?;
+        let stored = self.require_registry_source(workspace_name, source_name)?;
         let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
         let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
@@ -583,7 +655,10 @@ impl SourceManager {
                 return Err(error.into());
             }
         }
-        if let Err(error) = self.config_store.remove_source(workspace_name, source_name) {
+        if let Err(error) = self
+            .source_registry
+            .remove_source(workspace_name.as_str(), source_name.as_str())
+        {
             if had_source_dir
                 && source_dir_backup.exists()
                 && let Err(restore_error) = std::fs::rename(&source_dir_backup, &source_dir)
@@ -643,18 +718,14 @@ impl SourceManager {
         let credential_guard = self
             .credential_manager
             .material_guard(workspace_name, &credential_set_id)?;
-        let current_source = match self.config_store.get_source(workspace_name, &source_name) {
-            Ok(source) => Some(source),
-            Err(AppError::SourceNotFound(_)) => None,
-            Err(error) => return Err(error),
-        };
+        let current_source = self.get_registry_source(workspace_name, &source_name)?;
         let new_material_storage = current_source
             .as_ref()
             .and_then(InstalledSource::credential_storage_for_material);
         let remove_result = if previous.is_none() {
             match self
-                .config_store
-                .remove_source(workspace_name, &source_name)
+                .source_registry
+                .remove_source(workspace_name.as_str(), source_name.as_str())
             {
                 Ok(()) | Err(AppError::SourceNotFound(_)) => Ok(()),
                 Err(error) => Err(error),
@@ -801,9 +872,8 @@ impl SourceManager {
             identity_bindings: request.identity_bindings,
             origin: request.origin,
         };
-        if let Err(error) = self
-            .config_store
-            .upsert_source(workspace_name, stored.clone())
+        if let Err(error) =
+            self.upsert_registry_source(workspace_name, stored.clone(), request.manifest_yaml)
         {
             let restore_result = restore_materialization_backup(
                 &self.layout,
@@ -896,7 +966,7 @@ impl SourceManager {
         let candidate_manifest = parse_source_manifest_yaml(manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let candidate_schema_names = runtime_schema_names(&candidate_manifest);
-        for installed in self.config_store.list_workspace_sources(workspace_name)? {
+        for installed in self.list_registry_sources(workspace_name)? {
             if installed.name == *candidate_name {
                 continue;
             }
@@ -921,10 +991,8 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<bool, AppError> {
-        Ok(self
-            .config_store
-            .load_catalog()?
-            .contains(workspace_name, source_name))
+        self.get_registry_source(workspace_name, source_name)
+            .map(|source| source.is_some())
     }
 
     pub(crate) fn effective_source_identity_bindings_for_import(
@@ -955,11 +1023,8 @@ impl SourceManager {
         if replace_identity_bindings || !requested.is_empty() {
             return Ok(requested.clone());
         }
-        match self.config_store.get_source(workspace_name, source_name) {
-            Ok(source) => Ok(source.identity_bindings),
-            Err(AppError::SourceNotFound(_)) => Ok(BTreeMap::new()),
-            Err(error) => Err(error),
-        }
+        self.get_registry_source(workspace_name, source_name)
+            .map(|source| source.map_or_else(BTreeMap::new, |source| source.identity_bindings))
     }
 
     fn read_source_material(
@@ -991,25 +1056,21 @@ impl SourceManager {
         bindings: &SourceBindings,
         filled_secret_keys: &BTreeSet<String>,
     ) -> Result<BTreeMap<String, String>, AppError> {
-        let (credential_storage, persisted_secret_keys) = match self
-            .config_store
-            .get_source(workspace_name, &candidate.name)
-        {
-            Ok(source) => (
-                source.credential_storage_for_material(),
-                Some(source.secrets.iter().cloned().collect::<BTreeSet<_>>()),
-            ),
-            Err(AppError::SourceNotFound(_))
-                if self
+        let (credential_storage, persisted_secret_keys) =
+            match self.get_registry_source(workspace_name, &candidate.name)? {
+                Some(source) => (
+                    source.credential_storage_for_material(),
+                    Some(source.secrets.iter().cloned().collect::<BTreeSet<_>>()),
+                ),
+                None if self
                     .layout
                     .secret_file(workspace_name, &candidate.name)
                     .exists() =>
-            {
-                (Some(CredentialStorageKind::File), None)
-            }
-            Err(AppError::SourceNotFound(_)) => (None, Some(BTreeSet::new())),
-            Err(error) => return Err(error),
-        };
+                {
+                    (Some(CredentialStorageKind::File), None)
+                }
+                None => (None, Some(BTreeSet::new())),
+            };
 
         if !source_needs_stored_material_for_validation(
             candidate,
@@ -1035,19 +1096,12 @@ impl SourceManager {
         bindings: &ValidatedBindings,
         has_stored_material: bool,
     ) -> Result<Option<CredentialStorageKind>, AppError> {
-        match self.config_store.get_source(workspace_name, source_name) {
-            Ok(source) if !source.secrets.is_empty() => {
+        match self.get_registry_source(workspace_name, source_name)? {
+            Some(source) if !source.secrets.is_empty() => {
                 Ok(Some(source.effective_credential_storage()))
             }
-            Ok(_) | Err(AppError::SourceNotFound(_))
-                if bindings.secrets.is_empty() && !has_stored_material =>
-            {
-                Ok(None)
-            }
-            Ok(_) | Err(AppError::SourceNotFound(_)) => {
-                self.credential_manager.default_write_storage().map(Some)
-            }
-            Err(error) => Err(error),
+            Some(_) | None if bindings.secrets.is_empty() && !has_stored_material => Ok(None),
+            Some(_) | None => self.credential_manager.default_write_storage().map(Some),
         }
     }
 
@@ -1199,10 +1253,8 @@ impl SourceManager {
         source_name: &SourceName,
         credential_material: &CredentialMaterialGuard<'_>,
     ) -> Result<Option<SourceRollbackState>, AppError> {
-        let source = match self.config_store.get_source(workspace_name, source_name) {
-            Ok(source) => source,
-            Err(AppError::SourceNotFound(_)) => return Ok(None),
-            Err(error) => return Err(error),
+        let Some(source) = self.get_registry_source(workspace_name, source_name)? else {
+            return Ok(None);
         };
         let credential_material = source
             .credential_storage_for_material()
@@ -1229,6 +1281,7 @@ impl SourceManager {
         credential_material: &CredentialMaterialGuard<'_>,
     ) {
         if let Some(previous) = previous {
+            let previous_manifest_yaml = previous.manifest_yaml.clone();
             let manifest_path = self.layout.manifest_file(workspace_name, source_name);
             match previous.manifest_yaml {
                 Some(manifest_yaml) => {
@@ -1262,10 +1315,11 @@ impl SourceManager {
                     }
                 }
             }
-            if let Err(e) = self
-                .config_store
-                .upsert_source(workspace_name, previous.source)
-            {
+            if let Err(e) = self.upsert_registry_source(
+                workspace_name,
+                previous.source,
+                previous_manifest_yaml.as_deref(),
+            ) {
                 warn!("rollback: failed to restore source config: {e}");
             }
         } else {
@@ -1692,7 +1746,7 @@ mod tests {
     use std::io::{Read as _, Write as _};
     use std::net::TcpListener as StdTcpListener;
     use std::path::Path;
-    use std::sync::mpsc as std_mpsc;
+    use std::sync::{Arc, Mutex, mpsc as std_mpsc};
     use std::thread;
     use std::time::Duration;
 
@@ -1715,6 +1769,7 @@ mod tests {
     };
     use crate::features::dsl_v4_features;
     use crate::identity::{IdentityOwnerKind, SourceIdentityBinding};
+    use crate::source_registry::{SourceRegistry, SourceRegistryRecord};
     use crate::sources::SourceName;
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
     use crate::state::{AppStateLayout, ConfigStore};
@@ -1975,6 +2030,70 @@ tables:
         type: Utf8
 "#
         .to_string()
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingSourceRegistry {
+        current: Mutex<BTreeMap<(String, String), SourceRegistryRecord>>,
+        upserts: Mutex<Vec<SourceRegistryRecord>>,
+    }
+
+    fn test_registry_lock_error() -> AppError {
+        AppError::FailedPrecondition("test source registry lock poisoned".to_string())
+    }
+
+    impl SourceRegistry for RecordingSourceRegistry {
+        fn list_workspace_sources(
+            &self,
+            workspace_id: &str,
+        ) -> Result<Vec<SourceRegistryRecord>, AppError> {
+            let current = self
+                .current
+                .lock()
+                .map_err(|_poisoned| test_registry_lock_error())?;
+            Ok(current
+                .values()
+                .filter(|record| record.workspace_id == workspace_id)
+                .cloned()
+                .collect())
+        }
+
+        fn get_source(
+            &self,
+            workspace_id: &str,
+            source_name: &str,
+        ) -> Result<Option<SourceRegistryRecord>, AppError> {
+            let current = self
+                .current
+                .lock()
+                .map_err(|_poisoned| test_registry_lock_error())?;
+            Ok(current
+                .get(&(workspace_id.to_string(), source_name.to_string()))
+                .cloned())
+        }
+
+        fn upsert_source(&self, record: SourceRegistryRecord) -> Result<(), AppError> {
+            self.current
+                .lock()
+                .map_err(|_poisoned| test_registry_lock_error())?
+                .insert(
+                    (record.workspace_id.clone(), record.source_name.clone()),
+                    record.clone(),
+                );
+            self.upserts
+                .lock()
+                .map_err(|_poisoned| test_registry_lock_error())?
+                .push(record);
+            Ok(())
+        }
+
+        fn remove_source(&self, workspace_id: &str, source_name: &str) -> Result<(), AppError> {
+            self.current
+                .lock()
+                .map_err(|_poisoned| test_registry_lock_error())?
+                .remove(&(workspace_id.to_string(), source_name.to_string()));
+            Ok(())
+        }
     }
 
     fn manifest_with_oauth_secret(token_url: &str, redirect_port: u16) -> String {
@@ -2266,6 +2385,41 @@ tables:
         assert!(
             event_rx.try_recv().is_err(),
             "feature gate should fail before OAuth retrieval emits events"
+        );
+    }
+
+    #[test]
+    fn imported_source_upsert_includes_manifest_yaml_for_registry() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let registry = Arc::new(RecordingSourceRegistry::default());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager =
+            SourceManager::new_with_source_registry(registry.clone(), credential_manager, layout);
+        let manifest_yaml = manifest_without_secrets();
+
+        manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_yaml.clone(),
+                    bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
+                },
+            )
+            .expect("import source");
+
+        let upserts = registry.upserts.lock().expect("registry lock");
+        let record = upserts.last().expect("source upsert");
+        assert_eq!(record.workspace_id, default_workspace().as_str());
+        assert_eq!(record.source_name, "public_messages");
+        assert_eq!(
+            record.manifest_yaml.as_deref(),
+            Some(manifest_yaml.as_str())
         );
     }
 

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -11,6 +11,10 @@ use tracing::{info_span, warn};
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialStorageKind;
 use crate::identity::SourceIdentityBinding;
+use crate::source_registry::{
+    SourceRegistry, SourceRegistryRecord, installed_source_from_record,
+    record_from_installed_source,
+};
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
@@ -256,16 +260,6 @@ impl SourceCatalog {
             .cloned()
     }
 
-    pub(crate) fn contains(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> bool {
-        self.0
-            .get(workspace_name)
-            .is_some_and(|sources| sources.contains_key(source_name))
-    }
-
     pub(crate) fn upsert_source(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -487,6 +481,47 @@ impl ConfigStore {
         self.update_catalog(|catalog| {
             catalog.remove_source(workspace_name, source_name);
         })
+    }
+}
+
+impl SourceRegistry for ConfigStore {
+    fn list_workspace_sources(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Vec<SourceRegistryRecord>, AppError> {
+        let workspace_name = WorkspaceName::parse(workspace_id)?;
+        ConfigStore::list_workspace_sources(self, &workspace_name).map(|sources| {
+            sources
+                .into_iter()
+                .map(|source| record_from_installed_source(&workspace_name, source))
+                .collect()
+        })
+    }
+
+    fn get_source(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<SourceRegistryRecord>, AppError> {
+        let workspace_name = WorkspaceName::parse(workspace_id)?;
+        let source_name = SourceName::parse(source_name)?;
+        match ConfigStore::get_source(self, &workspace_name, &source_name) {
+            Ok(source) => Ok(Some(record_from_installed_source(&workspace_name, source))),
+            Err(AppError::SourceNotFound(_)) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn upsert_source(&self, record: SourceRegistryRecord) -> Result<(), AppError> {
+        let workspace_name = WorkspaceName::parse(&record.workspace_id)?;
+        let source = installed_source_from_record(&workspace_name, record)?;
+        ConfigStore::upsert_source(self, &workspace_name, source)
+    }
+
+    fn remove_source(&self, workspace_id: &str, source_name: &str) -> Result<(), AppError> {
+        let workspace_name = WorkspaceName::parse(workspace_id)?;
+        let source_name = SourceName::parse(source_name)?;
+        ConfigStore::remove_source(self, &workspace_name, &source_name)
     }
 }
 


### PR DESCRIPTION
## Intent

Land `feat(app): add source registry seam` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-15-identity-metadata-validation...sauldhernandez/dsl-v4-identity-v2-16-source-registry-seam
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
