### PR TITLE
feat(app): add source artifact store

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -63,12 +63,13 @@ use crate::identity_specs::{
 };
 use crate::query::manager::{QueryManager, QueryManagerOptions};
 use crate::query::service::QueryService;
+use crate::source_artifacts::{LocalSourceArtifactStore, SourceArtifactStore};
 use crate::source_registry::SourceRegistry;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::{AppStateLayout, ConfigStore};
-use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
+use crate::telemetry::{InstalledLocalTraceStore, TelemetryConfig};
 use crate::transport::GrpcRequestContextLayer;
 
 /// A static asset (e.g., a built SPA file) served on the same port as
@@ -121,6 +122,7 @@ pub(crate) struct ServerConfig {
     mode: ServerMode,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     source_registry: Option<Arc<dyn SourceRegistry>>,
+    source_artifact_store: Option<Arc<dyn SourceArtifactStore>>,
     identity_spec_registry: Option<Arc<dyn IdentitySpecRegistry>>,
     identity_spec_usage_providers: Vec<Arc<dyn IdentitySpecUsageProvider>>,
     feature_overrides: FeatureOverrides,
@@ -146,6 +148,7 @@ impl ServerConfig {
             mode: ServerMode::NativeGrpc,
             engine_extensions_providers: Vec::new(),
             source_registry: None,
+            source_artifact_store: None,
             identity_spec_registry: None,
             identity_spec_usage_providers: Vec::new(),
             feature_overrides: FeatureOverrides::default(),
@@ -204,6 +207,14 @@ impl ServerConfig {
 
     pub(crate) fn with_source_registry(mut self, source_registry: Arc<dyn SourceRegistry>) -> Self {
         self.source_registry = Some(source_registry);
+        self
+    }
+
+    pub(crate) fn with_source_artifact_store(
+        mut self,
+        source_artifact_store: Arc<dyn SourceArtifactStore>,
+    ) -> Self {
+        self.source_artifact_store = Some(source_artifact_store);
         self
     }
 
@@ -404,6 +415,23 @@ impl ServerBuilder {
     }
 
     #[must_use]
+    /// Sets the durable artifact store used for installed source manifests and
+    /// DSL v4 materialized artifacts.
+    ///
+    /// The default store persists artifacts in the local config directory.
+    /// Product-specific siblings can install a store backed by their own
+    /// durable artifact storage.
+    pub fn with_source_artifact_store(
+        mut self,
+        source_artifact_store: Arc<dyn SourceArtifactStore>,
+    ) -> Self {
+        self.config = self
+            .config
+            .with_source_artifact_store(source_artifact_store);
+        self
+    }
+
+    #[must_use]
     /// Adds a provider that reports stored identity usage for identity specs.
     ///
     /// Providers are consulted before deleting an identity spec so deletion can
@@ -593,37 +621,38 @@ impl ServerBuilder {
             &extension_context,
             &identity_manager,
         );
-        let source_manager = source_manager_for_server(
-            self.config.source_registry,
-            &config_store,
-            credential_manager.clone(),
+        let (source_manager, source_artifact_store) = source_manager_for_server(
             layout.clone(),
+            config_store.clone(),
+            self.config.source_registry,
+            self.config.source_artifact_store,
+            credential_manager.clone(),
             features.clone(),
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
         let episode_store = EpisodeStore::new(layout.clone());
-        let body_capture_max_bytes = telemetry_config
-            .trace_history
-            .http_body_recording_max_bytes();
-        let query_runtime_context = env
-            .query_runtime_context()
-            .with_body_capture_max_bytes(body_capture_max_bytes);
+        let query_runtime_context = env.query_runtime_context().with_body_capture_max_bytes(
+            telemetry_config
+                .trace_history
+                .http_body_recording_max_bytes(),
+        );
 
+        let query_manager_options = QueryManagerOptions {
+            features,
+            source_identity_providers,
+        };
         let query_manager = query_manager_for_server(
             config_store,
             credential_manager,
             query_runtime_context,
             layout,
+            source_artifact_store,
             self.config.engine_extensions_providers,
-            features,
-            source_identity_providers,
+            query_manager_options,
         );
-        let trace_service = if telemetry_config.trace_history.enabled {
-            installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))
-        } else {
-            None
-        };
+        let user_principal_provider = self.config.user_principal_provider;
+        let trace_service = trace_service_for_server(&telemetry_config, installed_trace_store);
         start_server(
             ServerServices {
                 source_manager,
@@ -631,7 +660,7 @@ impl ServerBuilder {
                 feedback_manager,
                 episode_store,
                 trace_service,
-                user_principal_provider: self.config.user_principal_provider,
+                user_principal_provider,
                 management_authorizer: self.config.management_authorizer,
                 identity_spec_manager,
                 identity_manager,
@@ -699,26 +728,25 @@ fn source_identity_providers_for_server(
     providers
 }
 
-fn source_registry_for_server(
-    registry: Option<Arc<dyn SourceRegistry>>,
-    config_store: &ConfigStore,
-) -> Arc<dyn SourceRegistry> {
-    registry.unwrap_or_else(|| Arc::new(config_store.clone()))
-}
-
 fn source_manager_for_server(
-    registry: Option<Arc<dyn SourceRegistry>>,
-    config_store: &ConfigStore,
-    credential_manager: CredentialManager,
     layout: AppStateLayout,
+    config_store: ConfigStore,
+    source_registry: Option<Arc<dyn SourceRegistry>>,
+    source_artifact_store: Option<Arc<dyn SourceArtifactStore>>,
+    credential_manager: CredentialManager,
     features: Features,
-) -> SourceManager {
-    SourceManager::new_with_source_registry_and_features(
-        source_registry_for_server(registry, config_store),
+) -> (SourceManager, Arc<dyn SourceArtifactStore>) {
+    let source_registry = source_registry.unwrap_or_else(|| Arc::new(config_store));
+    let source_artifact_store = source_artifact_store
+        .unwrap_or_else(|| Arc::new(LocalSourceArtifactStore::new(layout.clone())));
+    let source_manager = SourceManager::new_with_source_registry_and_artifact_store(
+        source_registry,
+        Arc::clone(&source_artifact_store),
         credential_manager,
         layout,
         features,
-    )
+    );
+    (source_manager, source_artifact_store)
 }
 
 fn query_manager_for_server(
@@ -726,21 +754,30 @@ fn query_manager_for_server(
     credential_manager: CredentialManager,
     query_runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
+    source_artifact_store: Arc<dyn SourceArtifactStore>,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-    features: Features,
-    source_identity_providers: Vec<Arc<dyn SourceIdentityProvider>>,
+    options: QueryManagerOptions,
 ) -> QueryManager {
-    QueryManager::new_with_options(
+    QueryManager::new_with_source_identity_providers_and_artifact_store(
         config_store,
         credential_manager,
         query_runtime_context,
         layout,
+        source_artifact_store,
         engine_extensions_providers,
-        QueryManagerOptions {
-            features,
-            source_identity_providers,
-        },
+        options,
     )
+}
+
+fn trace_service_for_server(
+    telemetry_config: &TelemetryConfig,
+    installed_trace_store: Option<InstalledLocalTraceStore>,
+) -> Option<TraceService> {
+    if telemetry_config.trace_history.enabled {
+        installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))
+    } else {
+        None
+    }
 }
 
 struct ServerServices {

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -758,7 +758,7 @@ fn query_manager_for_server(
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     options: QueryManagerOptions,
 ) -> QueryManager {
-    QueryManager::new_with_source_identity_providers_and_artifact_store(
+    QueryManager::new(
         config_store,
         credential_manager,
         query_runtime_context,
@@ -2006,7 +2006,7 @@ type: fixed_token
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::new_for_tests(
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
@@ -2446,7 +2446,7 @@ tables:
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::new_for_tests(
             config_store,
             credential_manager,
             QueryRuntimeContext {
@@ -2564,7 +2564,7 @@ tables:
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::new_for_tests(
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
@@ -2675,7 +2675,7 @@ tables:
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::new_for_tests(
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -54,6 +54,7 @@ mod identity;
 mod identity_specs;
 mod query;
 mod request_context;
+mod source_artifacts;
 mod source_registry;
 mod sources;
 mod state;
@@ -96,6 +97,7 @@ pub use identity_specs::{
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };
+pub use source_artifacts::{SourceArtifactBackup, SourceArtifactStore};
 pub use source_registry::{
     BundleIdentityInputDiscoveryError, BundleIdentityInputSpec, ManifestInputKind,
     ManifestInputSpec, SourceRegistry, SourceRegistryCredentialStorage, SourceRegistryOrigin,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -32,11 +32,12 @@ use crate::query::QueryContext;
 use crate::query::extensions::{
     CredentialRefreshingInputResolver, EngineExtensionsProvider, engine_extensions_for_providers,
 };
+#[cfg(test)]
+use crate::source_artifacts::LocalSourceArtifactStore;
+use crate::source_artifacts::SourceArtifactStore;
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
-use crate::sources::materialization::{
-    incompatible_materialization_error, load_v4_materialization,
-};
+use crate::sources::materialization::incompatible_materialization_error;
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::runtime_components_for_v4_source;
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
@@ -73,7 +74,9 @@ pub(crate) struct QueryManager {
     config_store: ConfigStore,
     credential_manager: CredentialManager,
     runtime_context: QueryRuntimeContext,
+    #[cfg(test)]
     layout: AppStateLayout,
+    artifact_store: Arc<dyn SourceArtifactStore>,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     features: Features,
     identity_manager: IdentityManager,
@@ -98,6 +101,7 @@ impl QueryManager {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn new_with_options(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
@@ -106,11 +110,35 @@ impl QueryManager {
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
         options: QueryManagerOptions,
     ) -> Self {
-        Self {
+        let artifact_store = Arc::new(LocalSourceArtifactStore::new(layout.clone()));
+        Self::new_with_source_identity_providers_and_artifact_store(
             config_store,
             credential_manager,
             runtime_context,
             layout,
+            artifact_store,
+            engine_extensions_providers,
+            options,
+        )
+    }
+
+    pub(crate) fn new_with_source_identity_providers_and_artifact_store(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        #[cfg(test)] layout: AppStateLayout,
+        #[cfg(not(test))] _layout: AppStateLayout,
+        artifact_store: Arc<dyn SourceArtifactStore>,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        options: QueryManagerOptions,
+    ) -> Self {
+        Self {
+            config_store,
+            credential_manager,
+            runtime_context,
+            #[cfg(test)]
+            layout,
+            artifact_store,
             engine_extensions_providers,
             features: options.features,
             identity_manager: IdentityManager::new(options.source_identity_providers),
@@ -352,14 +380,14 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
     ) -> Result<LoadedQuerySource, AppError> {
-        let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
+        let installed =
+            resolve_installed_manifest(workspace_name, source, self.artifact_store.as_ref())?;
         let source_spec = installed.source_spec;
         let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
             self.features.ensure_dsl_v4_enabled()?;
-            let materialized = load_v4_materialization(
-                &self.layout,
-                workspace_name,
-                &source.name,
+            let materialized = self.artifact_store.load_v4_materialization(
+                workspace_name.as_str(),
+                source.name.as_str(),
                 &installed.manifest_yaml,
                 v4,
             )?;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -83,46 +83,7 @@ pub(crate) struct QueryManager {
 }
 
 impl QueryManager {
-    #[cfg(test)]
     pub(crate) fn new(
-        config_store: ConfigStore,
-        credential_manager: CredentialManager,
-        runtime_context: QueryRuntimeContext,
-        layout: AppStateLayout,
-        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-    ) -> Self {
-        Self::new_with_options(
-            config_store,
-            credential_manager,
-            runtime_context,
-            layout,
-            engine_extensions_providers,
-            QueryManagerOptions::default(),
-        )
-    }
-
-    #[cfg(test)]
-    pub(crate) fn new_with_options(
-        config_store: ConfigStore,
-        credential_manager: CredentialManager,
-        runtime_context: QueryRuntimeContext,
-        layout: AppStateLayout,
-        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-        options: QueryManagerOptions,
-    ) -> Self {
-        let artifact_store = Arc::new(LocalSourceArtifactStore::new(layout.clone()));
-        Self::new_with_source_identity_providers_and_artifact_store(
-            config_store,
-            credential_manager,
-            runtime_context,
-            layout,
-            artifact_store,
-            engine_extensions_providers,
-            options,
-        )
-    }
-
-    pub(crate) fn new_with_source_identity_providers_and_artifact_store(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
         runtime_context: QueryRuntimeContext,
@@ -143,6 +104,45 @@ impl QueryManager {
             features: options.features,
             identity_manager: IdentityManager::new(options.source_identity_providers),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_tests(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    ) -> Self {
+        Self::new_for_tests_with_options(
+            config_store,
+            credential_manager,
+            runtime_context,
+            layout,
+            engine_extensions_providers,
+            QueryManagerOptions::default(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_tests_with_options(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        options: QueryManagerOptions,
+    ) -> Self {
+        let artifact_store = Arc::new(LocalSourceArtifactStore::new(layout.clone()));
+        Self::new(
+            config_store,
+            credential_manager,
+            runtime_context,
+            layout,
+            artifact_store,
+            engine_extensions_providers,
+            options,
+        )
     }
 
     fn load_query_runtime(
@@ -1043,7 +1043,7 @@ mod tests {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        let manager = QueryManager::new_with_options(
+        let manager = QueryManager::new_for_tests_with_options(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             runtime_context,
@@ -1834,7 +1834,7 @@ surfaces:
             layout.clone(),
             CredentialStoragePreference::Keychain,
         );
-        let manager = QueryManager::new(
+        let manager = QueryManager::new_for_tests(
             config_store,
             CredentialManager::new(credential_store),
             QueryRuntimeContext::default(),

--- a/crates/coral-app/src/source_artifacts.rs
+++ b/crates/coral-app/src/source_artifacts.rs
@@ -1,0 +1,436 @@
+//! Source artifact storage extension seam.
+
+use std::any::Any;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use coral_spec::v4::{V4MaterializedSource, V4SourceManifest};
+use uuid::Uuid;
+
+use crate::bootstrap::AppError;
+use crate::sources::SourceName;
+use crate::sources::materialization::{
+    load_v4_materialization, replace_v4_materialization, restore_materialization_backup,
+};
+use crate::state::AppStateLayout;
+use crate::storage::fs;
+use crate::workspaces::WorkspaceName;
+
+/// Store-specific source artifact backup used to roll back failed source mutations.
+pub trait SourceArtifactBackup: fmt::Debug + Send + Sync + 'static {
+    /// Returns this backup as [`Any`] so the store that created it can recover
+    /// its concrete state.
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T> SourceArtifactBackup for T
+where
+    T: fmt::Debug + Send + Sync + 'static,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Durable storage backend for source manifest and DSL v4 materialized artifacts.
+///
+/// The default implementation stores artifacts under the local config
+/// directory. Product runtimes can install an implementation that stores the
+/// authoritative artifact package elsewhere while preserving the source
+/// lifecycle logic in `SourceManager`.
+pub trait SourceArtifactStore: fmt::Debug + Send + Sync + 'static {
+    /// Reads the installed imported-source manifest, returning `None` when no
+    /// manifest artifact exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be read.
+    fn read_manifest_artifact(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<String>, AppError>;
+
+    /// Writes or removes the installed imported-source manifest artifact.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be updated.
+    fn persist_manifest_artifact(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        manifest_yaml: Option<&str>,
+    ) -> Result<(), AppError>;
+
+    /// Removes all artifacts for one source and returns a rollback backup when
+    /// the store had prior artifacts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be updated.
+    fn remove_source_artifacts(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<Box<dyn SourceArtifactBackup>>, AppError>;
+
+    /// Restores a backup produced by [`SourceArtifactStore::remove_source_artifacts`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be restored.
+    fn restore_source_artifacts_backup(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        backup: Option<Box<dyn SourceArtifactBackup>>,
+    ) -> Result<(), AppError>;
+
+    /// Cleans up a backup produced by [`SourceArtifactStore::remove_source_artifacts`].
+    fn cleanup_source_artifacts_backup(&self, backup: Option<Box<dyn SourceArtifactBackup>>);
+
+    /// Replaces the installed DSL v4 materialization from a prepared temporary
+    /// materialization directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be updated.
+    fn replace_v4_materialization(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        temp_dir: &Path,
+    ) -> Result<Option<Box<dyn SourceArtifactBackup>>, AppError>;
+
+    /// Restores a backup produced by [`SourceArtifactStore::replace_v4_materialization`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the artifact store cannot be restored.
+    fn restore_v4_materialization_backup(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        backup: Option<Box<dyn SourceArtifactBackup>>,
+    ) -> Result<(), AppError>;
+
+    /// Cleans up a backup produced by [`SourceArtifactStore::replace_v4_materialization`].
+    fn cleanup_v4_materialization_backup(&self, backup: Option<Box<dyn SourceArtifactBackup>>);
+
+    /// Loads and validates the installed DSL v4 materialization for query-time
+    /// runtime assembly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when artifacts are missing, incompatible, or cannot
+    /// be read.
+    fn load_v4_materialization(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        manifest_yaml: &str,
+        manifest: &V4SourceManifest,
+    ) -> Result<V4MaterializedSource, AppError>;
+}
+
+#[derive(Debug)]
+pub(crate) struct LocalSourceArtifactStore {
+    layout: AppStateLayout,
+}
+
+#[derive(Debug)]
+struct LocalPathBackup {
+    path: PathBuf,
+}
+
+impl LocalSourceArtifactStore {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
+    fn source_paths(
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<(WorkspaceName, SourceName), AppError> {
+        Ok((
+            WorkspaceName::parse(workspace_id)?,
+            SourceName::parse(source_name)?,
+        ))
+    }
+
+    fn backup_path(backup: &dyn SourceArtifactBackup) -> Result<PathBuf, AppError> {
+        backup
+            .as_any()
+            .downcast_ref::<LocalPathBackup>()
+            .map(|backup| backup.path.clone())
+            .ok_or_else(|| {
+                AppError::InvalidInput(
+                    "source artifact backup was not produced by the local artifact store"
+                        .to_string(),
+                )
+            })
+    }
+}
+
+impl SourceArtifactStore for LocalSourceArtifactStore {
+    fn read_manifest_artifact(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<String>, AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        let manifest_path = self.layout.manifest_file(&workspace_name, &source_name);
+        if !manifest_path.exists() {
+            return Ok(None);
+        }
+        std::fs::read_to_string(manifest_path)
+            .map(Some)
+            .map_err(Into::into)
+    }
+
+    fn persist_manifest_artifact(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        manifest_yaml: Option<&str>,
+    ) -> Result<(), AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        let manifest_path = self.layout.manifest_file(&workspace_name, &source_name);
+        match manifest_yaml {
+            Some(manifest_yaml) => {
+                if let Some(parent) = manifest_path.parent() {
+                    fs::ensure_dir(parent)?;
+                }
+                fs::write_atomic(&manifest_path, manifest_yaml.as_bytes())?;
+            }
+            None if manifest_path.exists() => {
+                std::fs::remove_file(&manifest_path)?;
+            }
+            None => {}
+        }
+        cleanup_empty_parent(&self.layout.workspaces_root(), manifest_path.parent());
+        Ok(())
+    }
+
+    fn remove_source_artifacts(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<Option<Box<dyn SourceArtifactBackup>>, AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        let source_dir = self.layout.source_dir(&workspace_name, &source_name);
+        if !source_dir.exists() {
+            return Ok(None);
+        }
+        let backup =
+            source_dir.with_file_name(format!("{source_name}.delete.rollback.{}", Uuid::new_v4()));
+        if backup.exists() {
+            std::fs::remove_dir_all(&backup)?;
+        }
+        std::fs::rename(&source_dir, &backup)?;
+        Ok(Some(Box::new(LocalPathBackup { path: backup })))
+    }
+
+    fn restore_source_artifacts_backup(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        backup: Option<Box<dyn SourceArtifactBackup>>,
+    ) -> Result<(), AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        let source_dir = self.layout.source_dir(&workspace_name, &source_name);
+        if let Some(backup) = backup {
+            let backup = Self::backup_path(backup.as_ref())?;
+            if !backup.exists() {
+                return Err(AppError::FailedPrecondition(format!(
+                    "source artifact backup '{}' does not exist",
+                    backup.display()
+                )));
+            }
+            if source_dir.exists() {
+                std::fs::remove_dir_all(&source_dir)?;
+            }
+            std::fs::rename(backup, source_dir)?;
+        } else if source_dir.exists() {
+            std::fs::remove_dir_all(&source_dir)?;
+            cleanup_empty_parent(&self.layout.workspaces_root(), source_dir.parent());
+        }
+        Ok(())
+    }
+
+    fn cleanup_source_artifacts_backup(&self, backup: Option<Box<dyn SourceArtifactBackup>>) {
+        let Some(backup) = backup else {
+            return;
+        };
+        if let Ok(path) = Self::backup_path(backup.as_ref()) {
+            let parent = path.parent().map(Path::to_path_buf);
+            if path.exists() {
+                drop(std::fs::remove_dir_all(path));
+            }
+            cleanup_empty_parent(&self.layout.workspaces_root(), parent.as_deref());
+        }
+    }
+
+    fn replace_v4_materialization(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        temp_dir: &Path,
+    ) -> Result<Option<Box<dyn SourceArtifactBackup>>, AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        replace_v4_materialization(&self.layout, &workspace_name, &source_name, temp_dir).map(
+            |backup| {
+                backup
+                    .map(|path| Box::new(LocalPathBackup { path }) as Box<dyn SourceArtifactBackup>)
+            },
+        )
+    }
+
+    fn restore_v4_materialization_backup(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        backup: Option<Box<dyn SourceArtifactBackup>>,
+    ) -> Result<(), AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        let backup = backup.as_deref().map(Self::backup_path).transpose()?;
+        restore_materialization_backup(&self.layout, &workspace_name, &source_name, backup)
+    }
+
+    fn cleanup_v4_materialization_backup(&self, backup: Option<Box<dyn SourceArtifactBackup>>) {
+        self.cleanup_source_artifacts_backup(backup);
+    }
+
+    fn load_v4_materialization(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        manifest_yaml: &str,
+        manifest: &V4SourceManifest,
+    ) -> Result<V4MaterializedSource, AppError> {
+        let (workspace_name, source_name) = Self::source_paths(workspace_id, source_name)?;
+        load_v4_materialization(
+            &self.layout,
+            &workspace_name,
+            &source_name,
+            manifest_yaml,
+            manifest,
+        )
+    }
+}
+
+fn cleanup_empty_parent(root: &Path, path: Option<&Path>) {
+    let Some(mut current) = path.map(Path::to_path_buf) else {
+        return;
+    };
+    while current.starts_with(root) && current != root {
+        let Ok(mut entries) = std::fs::read_dir(&current) else {
+            break;
+        };
+        if entries.next().is_some() {
+            break;
+        }
+        let next = current.parent().unwrap_or(root).to_path_buf();
+        if std::fs::remove_dir(&current).is_err() {
+            break;
+        }
+        current = next;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::{LocalSourceArtifactStore, SourceArtifactStore};
+    use crate::state::AppStateLayout;
+    use crate::{sources::SourceName, workspaces::WorkspaceName};
+
+    fn test_layout(temp: &TempDir) -> AppStateLayout {
+        AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout")
+    }
+
+    fn default_workspace() -> WorkspaceName {
+        WorkspaceName::parse("default").expect("workspace")
+    }
+
+    fn source_name() -> SourceName {
+        SourceName::parse("github_v4_test").expect("source")
+    }
+
+    #[test]
+    fn restore_source_artifacts_backup_errors_when_backup_path_is_missing() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let store = LocalSourceArtifactStore::new(layout.clone());
+        let workspace = default_workspace();
+        let source = source_name();
+        let source_dir = layout.source_dir(&workspace, &source);
+        std::fs::create_dir_all(&source_dir).expect("create source dir");
+        std::fs::write(source_dir.join("manifest.yaml"), "old").expect("write old manifest");
+
+        let backup = store
+            .remove_source_artifacts(workspace.as_str(), source.as_str())
+            .expect("remove artifacts")
+            .expect("backup");
+        let backup_path =
+            LocalSourceArtifactStore::backup_path(backup.as_ref()).expect("backup path");
+        std::fs::remove_dir_all(&backup_path).expect("remove backup");
+        std::fs::create_dir_all(&source_dir).expect("recreate source dir");
+        std::fs::write(source_dir.join("manifest.yaml"), "current")
+            .expect("write current manifest");
+
+        let error = store
+            .restore_source_artifacts_backup(workspace.as_str(), source.as_str(), Some(backup))
+            .expect_err("missing backup should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains(&backup_path.display().to_string())
+        );
+        assert_eq!(
+            std::fs::read_to_string(source_dir.join("manifest.yaml")).expect("current manifest"),
+            "current"
+        );
+    }
+
+    #[test]
+    fn restore_v4_materialization_backup_errors_when_backup_path_is_missing() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let store = LocalSourceArtifactStore::new(layout.clone());
+        let workspace = default_workspace();
+        let source = source_name();
+        let materialized = layout.v4_materialized_dir(&workspace, &source);
+        std::fs::create_dir_all(&materialized).expect("create materialization");
+        std::fs::write(materialized.join("fingerprint"), "old").expect("write old materialization");
+        let replacement = temp.path().join("replacement");
+        std::fs::create_dir_all(&replacement).expect("create replacement");
+        std::fs::write(replacement.join("fingerprint"), "new").expect("write replacement");
+
+        let backup = store
+            .replace_v4_materialization(workspace.as_str(), source.as_str(), &replacement)
+            .expect("replace materialization")
+            .expect("backup");
+        let backup_path =
+            LocalSourceArtifactStore::backup_path(backup.as_ref()).expect("backup path");
+        std::fs::remove_dir_all(&backup_path).expect("remove backup");
+
+        let error = store
+            .restore_v4_materialization_backup(workspace.as_str(), source.as_str(), Some(backup))
+            .expect_err("missing backup should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains(&backup_path.display().to_string())
+        );
+        assert_eq!(
+            std::fs::read_to_string(materialized.join("fingerprint"))
+                .expect("current materialization"),
+            "new"
+        );
+    }
+}

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -5,9 +5,9 @@ use std::collections::BTreeSet;
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 
 use crate::bootstrap::AppError;
+use crate::source_artifacts::SourceArtifactStore;
 use crate::sources::SourceName;
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
-use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 
 include!(concat!(env!("OUT_DIR"), "/bundled_sources.rs"));
@@ -63,13 +63,21 @@ pub(crate) fn load_bundled_source(name: &SourceName) -> Result<BundledSourceMani
 pub(crate) fn resolve_installed_manifest(
     workspace_name: &WorkspaceName,
     source: &InstalledSource,
-    layout: &AppStateLayout,
+    artifacts: &dyn SourceArtifactStore,
 ) -> Result<InstalledSourceManifest, AppError> {
     let manifest_yaml = match source.origin {
         SourceOrigin::Bundled => load_bundled_source(&source.name)?.manifest_yaml,
-        SourceOrigin::Imported => {
-            std::fs::read_to_string(layout.manifest_file(workspace_name, &source.name))?
-        }
+        SourceOrigin::Imported => artifacts
+            .read_manifest_artifact(workspace_name.as_str(), source.name.as_str())?
+            .ok_or_else(|| {
+                AppError::Io(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!(
+                        "source '{}' is missing installed manifest artifact",
+                        source.name
+                    ),
+                ))
+            })?,
     };
     let source_spec = parse_source_manifest_yaml(&manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -18,6 +18,9 @@ use crate::credentials::{
 };
 use crate::features::Features;
 use crate::identity::SourceIdentityBinding;
+#[cfg(test)]
+use crate::source_artifacts::LocalSourceArtifactStore;
+use crate::source_artifacts::SourceArtifactStore;
 use crate::source_registry::{
     SourceRegistry, installed_source_from_record, record_from_installed_source,
 };
@@ -27,24 +30,22 @@ use crate::sources::catalog::{
 };
 use crate::sources::materialization::{
     MaterializationBuild, MaterializationInputs, build_v4_materialization_tmp,
-    canonicalize_file_descriptor, cleanup_materialization_backup, cleanup_materialization_tmp,
-    new_materialization_suffix, replace_v4_materialization, restore_materialization_backup,
+    canonicalize_file_descriptor, cleanup_materialization_tmp, new_materialization_suffix,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
 #[cfg(test)]
 use crate::state::ConfigStore;
-use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
-use uuid::Uuid;
 
 #[derive(Clone)]
 pub(crate) struct SourceManager {
     source_registry: Arc<dyn SourceRegistry>,
+    artifact_store: Arc<dyn SourceArtifactStore>,
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
     layout: AppStateLayout,
@@ -231,14 +232,32 @@ impl SourceManager {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn new_with_source_registry_and_features(
         source_registry: Arc<dyn SourceRegistry>,
         credential_manager: CredentialManager,
         layout: AppStateLayout,
         features: Features,
     ) -> Self {
+        Self::new_with_source_registry_and_artifact_store(
+            source_registry,
+            Arc::new(LocalSourceArtifactStore::new(layout.clone())),
+            credential_manager,
+            layout,
+            features,
+        )
+    }
+
+    pub(crate) fn new_with_source_registry_and_artifact_store(
+        source_registry: Arc<dyn SourceRegistry>,
+        artifact_store: Arc<dyn SourceArtifactStore>,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+        features: Features,
+    ) -> Self {
         Self {
             source_registry,
+            artifact_store,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
             layout,
@@ -316,9 +335,12 @@ impl SourceManager {
         source_name: &SourceName,
     ) -> Result<CandidateSource, AppError> {
         if let Some(source) = self.get_registry_source(workspace_name, source_name)? {
-            return Ok(
-                resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
-            );
+            return Ok(resolve_installed_manifest(
+                workspace_name,
+                &source,
+                self.artifact_store.as_ref(),
+            )?
+            .candidate);
         }
 
         match load_bundled_source(source_name) {
@@ -606,7 +628,6 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let stored = self.require_registry_source(workspace_name, source_name)?;
         let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
-        let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
         let credential_guard = self
             .credential_manager
@@ -619,9 +640,9 @@ impl SourceManager {
             source: stored,
             manifest_yaml: match removed.origin {
                 SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
+                SourceOrigin::Imported => self
+                    .artifact_store
+                    .read_manifest_artifact(workspace_name.as_str(), source_name.as_str())?,
             },
             credential_material,
         };
@@ -637,14 +658,12 @@ impl SourceManager {
             );
             return Err(error);
         }
-        let source_dir_backup =
-            source_dir.with_file_name(format!("{source_name}.delete.rollback.{}", Uuid::new_v4()));
-        let had_source_dir = source_dir.exists();
-        if had_source_dir {
-            if source_dir_backup.exists() {
-                std::fs::remove_dir_all(&source_dir_backup)?;
-            }
-            if let Err(error) = std::fs::rename(&source_dir, &source_dir_backup) {
+        let artifact_backup = match self
+            .artifact_store
+            .remove_source_artifacts(workspace_name.as_str(), source_name.as_str())
+        {
+            Ok(backup) => backup,
+            Err(error) => {
                 self.restore_source_rollback_state(
                     workspace_name,
                     source_name,
@@ -652,20 +671,20 @@ impl SourceManager {
                     None,
                     &credential_guard,
                 );
-                return Err(error.into());
+                return Err(error);
             }
-        }
+        };
         if let Err(error) = self
             .source_registry
             .remove_source(workspace_name.as_str(), source_name.as_str())
         {
-            if had_source_dir
-                && source_dir_backup.exists()
-                && let Err(restore_error) = std::fs::rename(&source_dir_backup, &source_dir)
-            {
+            if let Err(restore_error) = self.artifact_store.restore_source_artifacts_backup(
+                workspace_name.as_str(),
+                source_name.as_str(),
+                artifact_backup,
+            ) {
                 return Err(AppError::FailedPrecondition(format!(
-                    "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
-                    source_dir_backup.display()
+                    "failed to remove source '{source_name}': {error}; failed to restore source artifacts: {restore_error}"
                 )));
             }
             self.restore_source_rollback_state(
@@ -677,14 +696,8 @@ impl SourceManager {
             );
             return Err(error);
         }
-        if source_dir_backup.exists() {
-            std::fs::remove_dir_all(&source_dir_backup)?;
-        }
-        cleanup_empty_parent(&self.layout.workspaces_root(), source_dir.parent());
-        cleanup_empty_parent(
-            &self.layout.workspaces_root(),
-            self.layout.workspace_dir(workspace_name).parent(),
-        );
+        self.artifact_store
+            .cleanup_source_artifacts_backup(artifact_backup);
         Ok(removed)
     }
 
@@ -769,9 +782,11 @@ impl SourceManager {
             .material_guard(workspace_name, &credential_set_id)?;
         let previous =
             self.load_source_rollback_state(workspace_name, &source_name, &credential_guard)?;
-        if let Err(error) =
-            self.persist_manifest_artifact(workspace_name, &source_name, request.manifest_yaml)
-        {
+        if let Err(error) = self.artifact_store.persist_manifest_artifact(
+            workspace_name.as_str(),
+            source_name.as_str(),
+            request.manifest_yaml,
+        ) {
             cleanup_materialization_tmp(request.materialization_tmp.as_deref());
             self.restore_source_rollback_state(
                 workspace_name,
@@ -836,10 +851,9 @@ impl SourceManager {
 
         let materialization_backup =
             if let Some(materialization_tmp) = request.materialization_tmp.as_ref() {
-                match replace_v4_materialization(
-                    &self.layout,
-                    workspace_name,
-                    &source_name,
+                match self.artifact_store.replace_v4_materialization(
+                    workspace_name.as_str(),
+                    source_name.as_str(),
                     materialization_tmp,
                 ) {
                     Ok(backup) => backup,
@@ -875,10 +889,9 @@ impl SourceManager {
         if let Err(error) =
             self.upsert_registry_source(workspace_name, stored.clone(), request.manifest_yaml)
         {
-            let restore_result = restore_materialization_backup(
-                &self.layout,
-                workspace_name,
-                &source_name,
+            let restore_result = self.artifact_store.restore_v4_materialization_backup(
+                workspace_name.as_str(),
+                source_name.as_str(),
                 materialization_backup,
             );
             self.restore_source_rollback_state(
@@ -895,7 +908,8 @@ impl SourceManager {
             }
             return Err(error);
         }
-        cleanup_materialization_backup(materialization_backup);
+        self.artifact_store
+            .cleanup_v4_materialization_backup(materialization_backup);
         let mut resolved = stored;
         resolved.version.clone_from(&request.candidate.version);
         Ok(resolved)
@@ -970,8 +984,11 @@ impl SourceManager {
             if installed.name == *candidate_name {
                 continue;
             }
-            let installed_manifest =
-                resolve_installed_manifest(workspace_name, &installed, &self.layout)?;
+            let installed_manifest = resolve_installed_manifest(
+                workspace_name,
+                &installed,
+                self.artifact_store.as_ref(),
+            )?;
             let installed_schema_names = runtime_schema_names(&installed_manifest.source_spec);
             if let Some(schema_name) = candidate_schema_names
                 .intersection(&installed_schema_names)
@@ -1263,9 +1280,9 @@ impl SourceManager {
         Ok(Some(SourceRollbackState {
             manifest_yaml: match source.origin {
                 SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
+                SourceOrigin::Imported => self
+                    .artifact_store
+                    .read_manifest_artifact(workspace_name.as_str(), source_name.as_str())?,
             },
             source,
             credential_material,
@@ -1282,24 +1299,12 @@ impl SourceManager {
     ) {
         if let Some(previous) = previous {
             let previous_manifest_yaml = previous.manifest_yaml.clone();
-            let manifest_path = self.layout.manifest_file(workspace_name, source_name);
-            match previous.manifest_yaml {
-                Some(manifest_yaml) => {
-                    if let Some(parent) = manifest_path.parent()
-                        && let Err(e) = fs::ensure_dir(parent)
-                    {
-                        warn!("rollback: failed to create manifest parent dir: {e}");
-                    }
-                    if let Err(e) = fs::write_atomic(&manifest_path, manifest_yaml.as_bytes()) {
-                        warn!("rollback: failed to restore manifest file: {e}");
-                    }
-                }
-                None if manifest_path.exists() => {
-                    if let Err(e) = std::fs::remove_file(&manifest_path) {
-                        warn!("rollback: failed to remove manifest file: {e}");
-                    }
-                }
-                None => {}
+            if let Err(e) = self.artifact_store.persist_manifest_artifact(
+                workspace_name.as_str(),
+                source_name.as_str(),
+                previous.manifest_yaml.as_deref(),
+            ) {
+                warn!("rollback: failed to restore source manifest artifact: {e}");
             }
             match previous.credential_material {
                 Some(snapshot) => {
@@ -1323,11 +1328,12 @@ impl SourceManager {
                 warn!("rollback: failed to restore source config: {e}");
             }
         } else {
-            let source_dir = self.layout.source_dir(workspace_name, source_name);
-            if source_dir.exists()
-                && let Err(e) = std::fs::remove_dir_all(&source_dir)
-            {
-                warn!("rollback: failed to remove source directory: {e}");
+            if let Err(e) = self.artifact_store.restore_source_artifacts_backup(
+                workspace_name.as_str(),
+                source_name.as_str(),
+                None,
+            ) {
+                warn!("rollback: failed to remove source artifacts: {e}");
             }
             if let Some(storage) = new_material_storage
                 && let Err(e) = credential_material.remove_material(storage)
@@ -1337,37 +1343,15 @@ impl SourceManager {
         }
     }
 
-    fn persist_manifest_artifact(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-        manifest_yaml: Option<&str>,
-    ) -> Result<(), AppError> {
-        let manifest_path = self.layout.manifest_file(workspace_name, source_name);
-        match manifest_yaml {
-            Some(manifest_yaml) => {
-                if let Some(parent) = manifest_path.parent() {
-                    fs::ensure_dir(parent)?;
-                }
-                fs::write_atomic(&manifest_path, manifest_yaml.as_bytes())?;
-            }
-            None if manifest_path.exists() => {
-                std::fs::remove_file(&manifest_path)?;
-            }
-            None => {}
-        }
-        cleanup_empty_parent(&self.layout.workspaces_root(), manifest_path.parent());
-        Ok(())
-    }
-
     fn populate_source_version(
         &self,
         workspace_name: &WorkspaceName,
         mut source: InstalledSource,
     ) -> Result<InstalledSource, AppError> {
-        source.version = resolve_installed_manifest(workspace_name, &source, &self.layout)?
-            .candidate
-            .version;
+        source.version =
+            resolve_installed_manifest(workspace_name, &source, self.artifact_store.as_ref())?
+                .candidate
+                .version;
         Ok(source)
     }
 
@@ -1719,25 +1703,6 @@ fn durable_import_manifest_yaml(
         );
     }
     serde_yaml::to_string(&value).map_err(AppError::from)
-}
-
-fn cleanup_empty_parent(root: &std::path::Path, path: Option<&std::path::Path>) {
-    let Some(mut current) = path.map(std::path::Path::to_path_buf) else {
-        return;
-    };
-    while current.starts_with(root) && current != root {
-        let Ok(mut entries) = std::fs::read_dir(&current) else {
-            break;
-        };
-        if entries.next().is_some() {
-            break;
-        }
-        let next = current.parent().unwrap_or(root).to_path_buf();
-        if std::fs::remove_dir(&current).is_err() {
-            break;
-        }
-        current = next;
-    }
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -107,14 +107,6 @@ pub(crate) fn replace_v4_materialization(
     Ok(had_existing.then_some(backup))
 }
 
-pub(crate) fn cleanup_materialization_backup(backup: Option<PathBuf>) {
-    if let Some(backup) = backup
-        && backup.exists()
-    {
-        drop(std::fs::remove_dir_all(backup));
-    }
-}
-
 pub(crate) fn cleanup_materialization_tmp(temp_dir: Option<&Path>) {
     if let Some(temp_dir) = temp_dir
         && temp_dir.exists()
@@ -131,12 +123,16 @@ pub(crate) fn restore_materialization_backup(
 ) -> Result<(), AppError> {
     let target = layout.v4_materialized_dir(workspace_name, source_name);
     if let Some(backup) = backup {
+        if !backup.exists() {
+            return Err(AppError::FailedPrecondition(format!(
+                "DSL v4 materialization backup '{}' does not exist",
+                backup.display()
+            )));
+        }
         if target.exists() {
             std::fs::remove_dir_all(&target)?;
         }
-        if backup.exists() {
-            std::fs::rename(backup, target)?;
-        }
+        std::fs::rename(backup, target)?;
     } else if target.exists() {
         std::fs::remove_dir_all(target)?;
     }


### PR DESCRIPTION
## Intent

Land `feat(app): add source artifact store` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-16-source-registry-seam...sauldhernandez/dsl-v4-identity-v2-17-source-artifact-store
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
