### PR TITLE
feat(app): load query sources from registry

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -621,22 +621,22 @@ impl ServerBuilder {
             &extension_context,
             &identity_manager,
         );
-        let (source_manager, source_artifact_store) = source_manager_for_server(
+        let source_stores = source_stores_for_server(
             layout.clone(),
             config_store.clone(),
             self.config.source_registry,
             self.config.source_artifact_store,
+        );
+        let source_manager = source_manager_for_server(
+            &source_stores,
             credential_manager.clone(),
+            layout.clone(),
             features.clone(),
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
         let episode_store = EpisodeStore::new(layout.clone());
-        let query_runtime_context = env.query_runtime_context().with_body_capture_max_bytes(
-            telemetry_config
-                .trace_history
-                .http_body_recording_max_bytes(),
-        );
+        let query_runtime_context = query_runtime_context(&env, &telemetry_config);
 
         let query_manager_options = QueryManagerOptions {
             features,
@@ -647,7 +647,7 @@ impl ServerBuilder {
             credential_manager,
             query_runtime_context,
             layout,
-            source_artifact_store,
+            source_stores,
             self.config.engine_extensions_providers,
             query_manager_options,
         );
@@ -728,25 +728,37 @@ fn source_identity_providers_for_server(
     providers
 }
 
-fn source_manager_for_server(
+struct ServerSourceStores {
+    registry: Arc<dyn SourceRegistry>,
+    artifact_store: Arc<dyn SourceArtifactStore>,
+}
+
+fn source_stores_for_server(
     layout: AppStateLayout,
     config_store: ConfigStore,
     source_registry: Option<Arc<dyn SourceRegistry>>,
     source_artifact_store: Option<Arc<dyn SourceArtifactStore>>,
+) -> ServerSourceStores {
+    ServerSourceStores {
+        registry: source_registry.unwrap_or_else(|| Arc::new(config_store)),
+        artifact_store: source_artifact_store
+            .unwrap_or_else(|| Arc::new(LocalSourceArtifactStore::new(layout))),
+    }
+}
+
+fn source_manager_for_server(
+    source_stores: &ServerSourceStores,
     credential_manager: CredentialManager,
+    layout: AppStateLayout,
     features: Features,
-) -> (SourceManager, Arc<dyn SourceArtifactStore>) {
-    let source_registry = source_registry.unwrap_or_else(|| Arc::new(config_store));
-    let source_artifact_store = source_artifact_store
-        .unwrap_or_else(|| Arc::new(LocalSourceArtifactStore::new(layout.clone())));
-    let source_manager = SourceManager::new_with_source_registry_and_artifact_store(
-        source_registry,
-        Arc::clone(&source_artifact_store),
+) -> SourceManager {
+    SourceManager::new_with_source_registry_and_artifact_store(
+        Arc::clone(&source_stores.registry),
+        Arc::clone(&source_stores.artifact_store),
         credential_manager,
         layout,
         features,
-    );
-    (source_manager, source_artifact_store)
+    )
 }
 
 fn query_manager_for_server(
@@ -754,16 +766,17 @@ fn query_manager_for_server(
     credential_manager: CredentialManager,
     query_runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
-    source_artifact_store: Arc<dyn SourceArtifactStore>,
+    source_stores: ServerSourceStores,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     options: QueryManagerOptions,
 ) -> QueryManager {
     QueryManager::new(
         config_store,
+        source_stores.registry,
         credential_manager,
         query_runtime_context,
         layout,
-        source_artifact_store,
+        source_stores.artifact_store,
         engine_extensions_providers,
         options,
     )
@@ -778,6 +791,17 @@ fn trace_service_for_server(
     } else {
         None
     }
+}
+
+fn query_runtime_context(
+    env: &AppEnvironment,
+    telemetry_config: &TelemetryConfig,
+) -> coral_engine::QueryRuntimeContext {
+    env.query_runtime_context().with_body_capture_max_bytes(
+        telemetry_config
+            .trace_history
+            .http_body_recording_max_bytes(),
+    )
 }
 
 struct ServerServices {

--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -13,8 +13,8 @@ use coral_spec::ManifestInputKind;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
+use crate::source_registry::{SourceRegistry, installed_source_from_record};
 use crate::sources::SourceName;
-use crate::state::ConfigStore;
 use crate::workspaces::WorkspaceName;
 
 /// App-layer provider that selects engine extensions for one runtime build.
@@ -55,7 +55,7 @@ impl EngineExtensionsProvider for AwsEngineExtensionsProvider {
 #[derive(Clone)]
 pub(crate) struct CredentialRefreshingInputResolver {
     workspace_name: WorkspaceName,
-    config_store: ConfigStore,
+    source_registry: Arc<dyn SourceRegistry>,
     credential_manager: CredentialManager,
     delegate: Option<Arc<dyn SourceInputResolver>>,
 }
@@ -63,13 +63,13 @@ pub(crate) struct CredentialRefreshingInputResolver {
 impl CredentialRefreshingInputResolver {
     pub(crate) fn new(
         workspace_name: WorkspaceName,
-        config_store: ConfigStore,
+        source_registry: Arc<dyn SourceRegistry>,
         credential_manager: CredentialManager,
         delegate: Option<Arc<dyn SourceInputResolver>>,
     ) -> Self {
         Self {
             workspace_name,
-            config_store,
+            source_registry,
             credential_manager,
             delegate,
         }
@@ -95,8 +95,15 @@ impl SourceInputResolver for CredentialRefreshingInputResolver {
             .map_err(|error| SourceInputResolverError::invalid_input(error.to_string()))?;
         let credential_set_id = CredentialSetId::for_source(&source_name);
         let installed_source = self
-            .config_store
-            .get_source(&self.workspace_name, &source_name)
+            .source_registry
+            .get_source(self.workspace_name.as_str(), source_name.as_str())
+            .map_err(source_input_error)?
+            .map(|record| installed_source_from_record(&self.workspace_name, record))
+            .transpose()
+            .map_err(source_input_error)?
+            .ok_or_else(|| {
+                AppError::SourceNotFound(format!("{}:{source_name}", self.workspace_name))
+            })
             .map_err(source_input_error)?;
         let material =
             if let Some(credential_storage) = installed_source.credential_storage_for_material() {

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -565,7 +565,7 @@ impl QueryManager {
         let provider_input_resolver = extensions.source_input_resolver.take();
         extensions.source_input_resolver = Some(Arc::new(CredentialRefreshingInputResolver::new(
             workspace_name.clone(),
-            self.config_store.clone(),
+            Arc::clone(&self.source_registry),
             self.credential_manager.clone(),
             provider_input_resolver,
         )));
@@ -1088,6 +1088,22 @@ mod tests {
         QueryManagerFixture {
             _temp: temp,
             manager,
+        }
+    }
+
+    fn test_installed_source(
+        name: &SourceName,
+        secrets: Vec<&str>,
+        credential_storage: Option<CredentialStorageKind>,
+    ) -> InstalledSource {
+        InstalledSource {
+            name: name.clone(),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: secrets.into_iter().map(ToString::to_string).collect(),
+            credential_storage,
+            identity_bindings: BTreeMap::new(),
+            origin: SourceOrigin::Bundled,
         }
     }
 
@@ -2030,6 +2046,104 @@ tables:
                 .expect("observed token lock")
                 .as_deref(),
             Some("stored-token")
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_config_refreshes_credentials_from_source_registry_metadata() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let registry_layout =
+            AppStateLayout::discover(Some(temp.path().join("registry-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        registry_layout.ensure().expect("ensure registry layout");
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("secured_messages").expect("source name");
+        let config_store = ConfigStore::new(layout.clone());
+        let registry_store = ConfigStore::new(registry_layout);
+        config_store
+            .upsert_source(
+                &workspace_name,
+                test_installed_source(&source_name, Vec::new(), None),
+            )
+            .expect("persist stale config source");
+        registry_store
+            .upsert_source(
+                &workspace_name,
+                test_installed_source(
+                    &source_name,
+                    vec!["API_TOKEN"],
+                    Some(CredentialStorageKind::File),
+                ),
+            )
+            .expect("persist registry source");
+        let source_registry: Arc<dyn SourceRegistry> = Arc::new(registry_store);
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        credential_manager
+            .replace_material(
+                &workspace_name,
+                &CredentialSetId::for_source(&source_name),
+                CredentialStorageKind::File,
+                &BTreeMap::from([("API_TOKEN".to_string(), "registry-token".to_string())]),
+            )
+            .expect("write credential material");
+        let manager = QueryManager::new(
+            config_store,
+            source_registry,
+            credential_manager,
+            QueryRuntimeContext::default(),
+            layout.clone(),
+            Arc::new(LocalSourceArtifactStore::new(layout)),
+            Vec::new(),
+            QueryManagerOptions::default(),
+        );
+        let source_spec = parse_source_manifest_yaml(
+            r"
+name: secured_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+inputs:
+  API_TOKEN:
+    kind: secret
+tables:
+  - name: messages
+    description: Secured messages
+    request:
+      method: GET
+      path: /messages
+    response: {}
+    columns:
+      - name: id
+        type: Utf8
+",
+        )
+        .expect("parse source manifest");
+        let source = QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new());
+        let runtime = manager
+            .runtime_config(
+                &workspace_name,
+                &UserPrincipal::local(),
+                std::slice::from_ref(&source),
+                BTreeMap::new(),
+                &AppConfig::default(),
+            )
+            .expect("runtime config");
+        let input_resolver = runtime
+            .extensions
+            .source_input_resolver
+            .expect("runtime installs input resolver");
+
+        let resolved_inputs = input_resolver
+            .resolve_inputs(&SourceInputResolutionContext::from_query_source(&source))
+            .await
+            .expect("resolve source inputs from registry metadata");
+
+        assert_eq!(
+            resolved_inputs.get("API_TOKEN").map(String::as_str),
+            Some("registry-token")
         );
     }
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -35,6 +35,7 @@ use crate::query::extensions::{
 #[cfg(test)]
 use crate::source_artifacts::LocalSourceArtifactStore;
 use crate::source_artifacts::SourceArtifactStore;
+use crate::source_registry::{SourceRegistry, installed_source_from_record};
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::incompatible_materialization_error;
@@ -72,6 +73,7 @@ pub(crate) struct QueryManagerOptions {
 #[derive(Clone)]
 pub(crate) struct QueryManager {
     config_store: ConfigStore,
+    source_registry: Arc<dyn SourceRegistry>,
     credential_manager: CredentialManager,
     runtime_context: QueryRuntimeContext,
     #[cfg(test)]
@@ -83,8 +85,13 @@ pub(crate) struct QueryManager {
 }
 
 impl QueryManager {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one-time wiring constructor; every argument is a distinct runtime dependency"
+    )]
     pub(crate) fn new(
         config_store: ConfigStore,
+        source_registry: Arc<dyn SourceRegistry>,
         credential_manager: CredentialManager,
         runtime_context: QueryRuntimeContext,
         #[cfg(test)] layout: AppStateLayout,
@@ -95,6 +102,7 @@ impl QueryManager {
     ) -> Self {
         Self {
             config_store,
+            source_registry,
             credential_manager,
             runtime_context,
             #[cfg(test)]
@@ -133,9 +141,11 @@ impl QueryManager {
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
         options: QueryManagerOptions,
     ) -> Self {
+        let source_registry = Arc::new(config_store.clone());
         let artifact_store = Arc::new(LocalSourceArtifactStore::new(layout.clone()));
         Self::new(
             config_store,
+            source_registry,
             credential_manager,
             runtime_context,
             layout,
@@ -143,6 +153,29 @@ impl QueryManager {
             engine_extensions_providers,
             options,
         )
+    }
+
+    fn list_registry_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        self.source_registry
+            .list_workspace_sources(workspace_name.as_str())?
+            .into_iter()
+            .map(|record| installed_source_from_record(workspace_name, record))
+            .collect()
+    }
+
+    fn require_registry_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<InstalledSource, AppError> {
+        self.source_registry
+            .get_source(workspace_name.as_str(), source_name.as_str())?
+            .map(|record| installed_source_from_record(workspace_name, record))
+            .transpose()?
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }
 
     fn load_query_runtime(
@@ -155,7 +188,7 @@ impl QueryManager {
             .load_config()
             .map_err(QueryManagerError::App)?;
         let loaded_sources = self
-            .load_query_sources(workspace_name, &config)
+            .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
         let identity_bindings = identity_binding_snapshot_for_sources(&loaded_sources);
         let sources = query_sources_from_loaded(loaded_sources);
@@ -306,9 +339,8 @@ impl QueryManager {
             .config_store
             .load_config()
             .map_err(QueryManagerError::App)?;
-        let source = config
-            .get_source(workspace_name, source_name)
-            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
+        let source = self
+            .require_registry_source(workspace_name, source_name)
             .map_err(QueryManagerError::App)?;
         let loaded_source = self
             .load_query_source(workspace_name, &source)
@@ -343,7 +375,6 @@ impl QueryManager {
     fn load_query_sources(
         &self,
         workspace_name: &WorkspaceName,
-        config: &AppConfig,
     ) -> Result<Vec<LoadedQuerySource>, AppError> {
         let span = tracing::info_span!(
             "coral.app.query_sources.load",
@@ -352,7 +383,7 @@ impl QueryManager {
         );
         let _guard = span.enter();
         let mut query_sources = Vec::new();
-        for source in config.workspace_sources(workspace_name) {
+        for source in self.list_registry_sources(workspace_name)? {
             match self.load_query_source(workspace_name, &source) {
                 Ok(query_source) => query_sources.push(query_source),
                 Err(
@@ -1727,14 +1758,9 @@ surfaces:
             .config_store
             .upsert_source(&workspace_name, source)
             .expect("persist v4 source");
-        let config = fixture
-            .manager
-            .config_store
-            .load_config()
-            .expect("load config");
         let error = fixture
             .manager
-            .load_query_sources(&workspace_name, &config)
+            .load_query_sources(&workspace_name)
             .expect_err("normal query loading should fail on disabled v4 source");
 
         assert!(
@@ -1788,14 +1814,9 @@ surfaces:
             )
             .expect("persist source");
 
-        let config = fixture
-            .manager
-            .config_store
-            .load_config()
-            .expect("load config");
         let error = fixture
             .manager
-            .load_query_sources(&workspace_name, &config)
+            .load_query_sources(&workspace_name)
             .expect_err("missing materialization should fail closed");
 
         assert!(
@@ -1841,10 +1862,8 @@ surfaces:
             layout,
             Vec::new(),
         );
-        let config = manager.config_store.load_config().expect("load config");
-
         let error = manager
-            .load_query_sources(&workspace_name, &config)
+            .load_query_sources(&workspace_name)
             .expect_err("unavailable keychain should fail closed");
 
         assert!(

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -39,18 +39,6 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
-    pub(crate) fn workspace_sources(&self, workspace_name: &WorkspaceName) -> Vec<InstalledSource> {
-        self.catalog.workspace_sources(workspace_name)
-    }
-
-    pub(crate) fn get_source(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Option<InstalledSource> {
-        self.catalog.get_source(workspace_name, source_name)
-    }
-
     pub(crate) fn dependent_join_config(
         &self,
         selected_source_names: &[String],


### PR DESCRIPTION
## Intent

Land `feat(app): load query sources from registry` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-17-source-artifact-store...sauldhernandez/dsl-v4-identity-v2-18-query-source-registry
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
