### PR TITLE
feat(app): add source management handle

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -64,6 +64,7 @@ use crate::identity_specs::{
 use crate::query::manager::{QueryManager, QueryManagerOptions};
 use crate::query::service::QueryService;
 use crate::source_artifacts::{LocalSourceArtifactStore, SourceArtifactStore};
+use crate::source_management::SourceManagementHandle;
 use crate::source_registry::SourceRegistry;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
@@ -99,12 +100,17 @@ type SourceIdentityProviderFactory =
 #[derive(Clone)]
 pub struct ServerExtensionContext {
     identity_management: IdentityManagementHandle,
+    source_management: SourceManagementHandle,
 }
 
 impl ServerExtensionContext {
-    fn new(identity_management: IdentityManagementHandle) -> Self {
+    fn new(
+        identity_management: IdentityManagementHandle,
+        source_management: SourceManagementHandle,
+    ) -> Self {
         Self {
             identity_management,
+            source_management,
         }
     }
 
@@ -112,6 +118,12 @@ impl ServerExtensionContext {
     #[must_use]
     pub fn identity_management(&self) -> &IdentityManagementHandle {
         &self.identity_management
+    }
+
+    /// Returns the shared source management handle for this server.
+    #[must_use]
+    pub fn source_management(&self) -> &SourceManagementHandle {
+        &self.source_management
     }
 }
 
@@ -615,12 +627,6 @@ impl ServerBuilder {
             identity_spec_manager.clone(),
             identity_store,
         );
-        let extension_context = ServerExtensionContext::new(identity_manager.handle());
-        let source_identity_providers = source_identity_providers_for_server(
-            self.config.source_identity_provider_factories,
-            &extension_context,
-            &identity_manager,
-        );
         let source_stores = source_stores_for_server(
             layout.clone(),
             config_store.clone(),
@@ -632,6 +638,15 @@ impl ServerBuilder {
             credential_manager.clone(),
             layout.clone(),
             features.clone(),
+        );
+        let extension_context = ServerExtensionContext::new(
+            identity_manager.handle(),
+            SourceManagementHandle::new(source_manager.clone()),
+        );
+        let source_identity_providers = source_identity_providers_for_server(
+            self.config.source_identity_provider_factories,
+            &extension_context,
+            &identity_manager,
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
@@ -1230,6 +1245,7 @@ mod tests {
     };
     use crate::identity_specs::IdentitySpecManager;
     use crate::query::manager::QueryManager;
+    use crate::source_management::SourceManagementHandle;
     use crate::sources::manager::SourceManager;
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::telemetry::service::TraceService;
@@ -1443,9 +1459,16 @@ enabled = false
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let source_manager = SourceManager::new(config_store, credential_manager, layout.clone());
         let identity_spec_manager = test_identity_spec_manager(&layout);
         let identity_manager = test_identity_manager(&layout, &identity_spec_manager);
-        let extension_context = ServerExtensionContext::new(identity_manager.handle());
+        let extension_context = ServerExtensionContext::new(
+            identity_manager.handle(),
+            SourceManagementHandle::new(source_manager),
+        );
         let static_provider: Arc<dyn SourceIdentityProvider> = Arc::new(NoopSourceIdentityProvider);
         let factory_provider: Arc<dyn SourceIdentityProvider> =
             Arc::new(NoopSourceIdentityProvider);
@@ -1791,6 +1814,7 @@ type: fixed_token
                 let source_factory_called = Arc::clone(&source_factory_called);
                 move |context| {
                     let _identity_management = context.identity_management().clone();
+                    let _source_management = context.source_management().clone();
                     source_factory_called.store(true, Ordering::SeqCst);
                     Arc::new(NoopSourceIdentityProvider)
                 }
@@ -1799,6 +1823,7 @@ type: fixed_token
                 let grpc_factory_called = Arc::clone(&grpc_factory_called);
                 move |context| {
                     let _identity_management = context.identity_management().clone();
+                    let _source_management = context.source_management().clone();
                     grpc_factory_called.store(true, Ordering::SeqCst);
                     TraceServiceServer::new(TraceService::new(
                         trace_store.clone(),
@@ -2041,6 +2066,7 @@ type: fixed_token
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
         let identity_spec_manager = test_identity_spec_manager(&layout);
         let identity_manager = test_identity_manager(&layout, &identity_spec_manager);
+        let source_management = SourceManagementHandle::new(source_manager.clone());
         start_server(
             ServerServices {
                 source_manager,
@@ -2053,7 +2079,10 @@ type: fixed_token
                 identity_spec_manager,
                 identity_manager: identity_manager.clone(),
                 grpc_route_extenders: Vec::new(),
-                extension_context: ServerExtensionContext::new(identity_manager.handle()),
+                extension_context: ServerExtensionContext::new(
+                    identity_manager.handle(),
+                    source_management,
+                ),
             },
             ServerMode::NativeGrpc,
         )
@@ -2482,6 +2511,7 @@ tables:
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
         let identity_manager = test_identity_manager(&layout, &identity_spec_manager);
+        let source_management = SourceManagementHandle::new(source_manager.clone());
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -2494,7 +2524,10 @@ tables:
                 identity_spec_manager,
                 identity_manager: identity_manager.clone(),
                 grpc_route_extenders: Vec::new(),
-                extension_context: ServerExtensionContext::new(identity_manager.handle()),
+                extension_context: ServerExtensionContext::new(
+                    identity_manager.handle(),
+                    source_management,
+                ),
             },
             ServerMode::NativeGrpc,
         )
@@ -2597,6 +2630,7 @@ tables:
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
         let identity_manager = test_identity_manager(&layout, &identity_spec_manager);
+        let source_management = SourceManagementHandle::new(source_manager.clone());
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -2609,7 +2643,10 @@ tables:
                 identity_spec_manager,
                 identity_manager: identity_manager.clone(),
                 grpc_route_extenders: Vec::new(),
-                extension_context: ServerExtensionContext::new(identity_manager.handle()),
+                extension_context: ServerExtensionContext::new(
+                    identity_manager.handle(),
+                    source_management,
+                ),
             },
             ServerMode::NativeGrpc,
         )
@@ -2708,6 +2745,7 @@ tables:
         );
         let identity_spec_manager = test_identity_spec_manager(&layout);
         let identity_manager = test_identity_manager(&layout, &identity_spec_manager);
+        let source_management = SourceManagementHandle::new(source_manager.clone());
         let running = start_server(
             ServerServices {
                 source_manager,
@@ -2720,7 +2758,10 @@ tables:
                 identity_spec_manager,
                 identity_manager: identity_manager.clone(),
                 grpc_route_extenders: Vec::new(),
-                extension_context: ServerExtensionContext::new(identity_manager.handle()),
+                extension_context: ServerExtensionContext::new(
+                    identity_manager.handle(),
+                    source_management,
+                ),
             },
             ServerMode::NativeGrpc,
         )

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -55,6 +55,7 @@ mod identity_specs;
 mod query;
 mod request_context;
 mod source_artifacts;
+mod source_management;
 mod source_registry;
 mod sources;
 mod state;
@@ -98,6 +99,7 @@ pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };
 pub use source_artifacts::{SourceArtifactBackup, SourceArtifactStore};
+pub use source_management::{ImportManagedSourceCommand, ManagedSource, SourceManagementHandle};
 pub use source_registry::{
     BundleIdentityInputDiscoveryError, BundleIdentityInputSpec, ManifestInputKind,
     ManifestInputSpec, SourceRegistry, SourceRegistryCredentialStorage, SourceRegistryOrigin,

--- a/crates/coral-app/src/source_management.rs
+++ b/crates/coral-app/src/source_management.rs
@@ -1,0 +1,195 @@
+//! Public source-management handle for server extensions.
+
+use std::collections::BTreeMap;
+
+use crate::bootstrap::AppError;
+use crate::identity::SourceIdentityBinding;
+use crate::sources::SourceName;
+use crate::sources::manager::{
+    ImportSourceCommand as ManagerImportSourceCommand, SourceBinding, SourceBindings, SourceManager,
+};
+use crate::workspaces::WorkspaceName;
+
+/// Source import command accepted by [`SourceManagementHandle`].
+pub struct ImportManagedSourceCommand {
+    /// Source manifest YAML to install into the workspace.
+    pub manifest_yaml: String,
+    /// Non-secret source variables.
+    pub variables: BTreeMap<String, String>,
+    /// Source-surface identity bindings.
+    pub identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+    /// Whether supplied identity bindings replace existing bindings.
+    pub replace_identity_bindings: bool,
+}
+
+/// Source installed or removed through [`SourceManagementHandle`].
+pub struct ManagedSource {
+    /// Installed source name.
+    pub name: String,
+    /// Authored source version, when available.
+    pub version: Option<String>,
+}
+
+/// Narrow source lifecycle handle exposed to server extensions.
+#[derive(Clone)]
+pub struct SourceManagementHandle {
+    sources: SourceManager,
+}
+
+impl SourceManagementHandle {
+    pub(crate) fn new(sources: SourceManager) -> Self {
+        Self { sources }
+    }
+
+    /// Imports a source into a workspace using the shared source lifecycle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the workspace or source input is invalid, or
+    /// when source installation fails.
+    pub fn import_source(
+        &self,
+        workspace_id: &str,
+        command: ImportManagedSourceCommand,
+    ) -> Result<ManagedSource, AppError> {
+        let workspace_name = WorkspaceName::parse(workspace_id)?;
+        let installed = self.sources.import_source(
+            &workspace_name,
+            &ManagerImportSourceCommand {
+                manifest_yaml: command.manifest_yaml,
+                bindings: SourceBindings {
+                    variables: command
+                        .variables
+                        .into_iter()
+                        .map(|(key, value)| SourceBinding { key, value })
+                        .collect(),
+                    secrets: Vec::new(),
+                },
+                identity_bindings: command.identity_bindings,
+                replace_identity_bindings: command.replace_identity_bindings,
+            },
+        )?;
+        Ok(ManagedSource {
+            name: installed.name.as_str().to_string(),
+            version: installed.version,
+        })
+    }
+
+    /// Deletes a source from a workspace using the shared source lifecycle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the workspace/source input is invalid, or when
+    /// source removal fails.
+    pub fn delete_source(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<ManagedSource, AppError> {
+        let workspace_name = WorkspaceName::parse(workspace_id)?;
+        let source_name = SourceName::parse(source_name)?;
+        let removed = self.sources.delete_source(&workspace_name, &source_name)?;
+        Ok(ManagedSource {
+            name: removed.name.as_str().to_string(),
+            version: removed.version,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credentials::{CredentialManager, CredentialStore};
+    use crate::source_registry::SourceRegistry;
+    use crate::state::{AppStateLayout, ConfigStore};
+    use tempfile::TempDir;
+
+    fn handle() -> (TempDir, SourceManagementHandle, ConfigStore) {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let source_manager = SourceManager::new(config_store.clone(), credential_manager, layout);
+        (
+            temp,
+            SourceManagementHandle::new(source_manager),
+            config_store,
+        )
+    }
+
+    fn manifest_without_secrets() -> String {
+        r#"
+name: public_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: "https://example.com"
+tables:
+  - name: messages
+    description: Public messages
+    request:
+      method: GET
+      path: /messages
+    response: {}
+    columns:
+      - name: id
+        type: Utf8
+"#
+        .to_string()
+    }
+
+    #[test]
+    fn import_source_uses_shared_source_lifecycle() {
+        let (_temp, handle, config_store) = handle();
+
+        let installed = handle
+            .import_source(
+                "default",
+                ImportManagedSourceCommand {
+                    manifest_yaml: manifest_without_secrets(),
+                    variables: BTreeMap::new(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
+                },
+            )
+            .expect("import source");
+
+        assert_eq!(installed.name, "public_messages");
+        assert_eq!(installed.version.as_deref(), Some("0.1.0"));
+        let sources = SourceRegistry::list_workspace_sources(&config_store, "default")
+            .expect("workspace sources");
+        let source_names = sources
+            .iter()
+            .map(|source| source.source_name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(source_names, ["public_messages"]);
+    }
+
+    #[test]
+    fn delete_source_uses_shared_source_lifecycle() {
+        let (_temp, handle, config_store) = handle();
+        handle
+            .import_source(
+                "default",
+                ImportManagedSourceCommand {
+                    manifest_yaml: manifest_without_secrets(),
+                    variables: BTreeMap::new(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
+                },
+            )
+            .expect("import source");
+
+        let removed = handle
+            .delete_source("default", "public_messages")
+            .expect("delete source");
+
+        assert_eq!(removed.name, "public_messages");
+        assert_eq!(removed.version.as_deref(), Some("0.1.0"));
+        let sources = SourceRegistry::list_workspace_sources(&config_store, "default")
+            .expect("workspace sources");
+        assert!(sources.is_empty());
+    }
+}


### PR DESCRIPTION
## Intent

Land `feat(app): add source management handle` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-18-query-source-registry...sauldhernandez/dsl-v4-identity-v2-19-source-management-handle
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
