### PR TITLE
feat(cli): add identity management commands

### DIFF
--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -65,6 +65,27 @@ message ListUserOwnedIdentitiesResponse {
   repeated Identity identities = 1;
 }
 
+// Fetches one user-owned identity for the request Coral user principal.
+message GetUserOwnedIdentityRequest {
+  // Stored identity name.
+  string name = 1;
+}
+
+// Returns one user-owned identity.
+message GetUserOwnedIdentityResponse {
+  // Stored identity.
+  Identity identity = 1;
+}
+
+// Deletes one user-owned identity for the request Coral user principal.
+message DeleteUserOwnedIdentityRequest {
+  // Stored identity name.
+  string name = 1;
+}
+
+// Confirms user-owned identity deletion.
+message DeleteUserOwnedIdentityResponse {}
+
 // Stored identity APIs.
 service IdentityService {
   // Creates or replaces one identity owned by the request Coral user principal.
@@ -73,4 +94,9 @@ service IdentityService {
   // Lists user-owned identities.
   rpc ListUserOwnedIdentities(ListUserOwnedIdentitiesRequest)
       returns (ListUserOwnedIdentitiesResponse);
+  // Fetches one user-owned identity.
+  rpc GetUserOwnedIdentity(GetUserOwnedIdentityRequest) returns (GetUserOwnedIdentityResponse);
+  // Deletes one user-owned identity.
+  rpc DeleteUserOwnedIdentity(DeleteUserOwnedIdentityRequest)
+      returns (DeleteUserOwnedIdentityResponse);
 }

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -660,6 +660,29 @@ impl IdentityManager {
         self.list_identities(&owner).await
     }
 
+    async fn get_identity(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<IdentityRecord, AppError> {
+        let identity_name = validate_identity_name(identity_name)?;
+        self.store
+            .load_identity(owner, &identity_name)
+            .await?
+            .ok_or_else(|| AppError::IdentityNotFound(identity_name.to_string()))
+    }
+
+    pub(crate) async fn get_user_owned_identity(
+        &self,
+        principal: &UserPrincipal,
+        identity_name: &str,
+    ) -> Result<IdentityRecord, AppError> {
+        let span = info_span!("coral.app.identities.get_user_owned");
+        let _guard = span.enter();
+        let owner = IdentityOwner::for_user_principal(principal)?;
+        self.get_identity(&owner, identity_name).await
+    }
+
     async fn delete_identity(
         &self,
         owner: &IdentityOwner,
@@ -667,6 +690,22 @@ impl IdentityManager {
     ) -> Result<bool, AppError> {
         let identity_name = validate_identity_name(identity_name)?;
         self.store.delete_identity(owner, &identity_name).await
+    }
+
+    pub(crate) async fn delete_user_owned_identity(
+        &self,
+        principal: &UserPrincipal,
+        identity_name: &str,
+    ) -> Result<(), AppError> {
+        let span = info_span!("coral.app.identities.delete_user_owned");
+        let _guard = span.enter();
+        let owner = IdentityOwner::for_user_principal(principal)?;
+        let identity_name = validate_identity_name(identity_name)?;
+        if self.store.delete_identity(&owner, &identity_name).await? {
+            Ok(())
+        } else {
+            Err(AppError::IdentityNotFound(identity_name.to_string()))
+        }
     }
 
     pub(crate) async fn replace_user_owned_source_identity_binding(
@@ -2234,6 +2273,50 @@ audience:
 
     fn unexpected_manifest_only_registry_call(operation: &str) -> AppError {
         AppError::FailedPrecondition(format!("metadata validation should not {operation}"))
+    }
+
+    #[tokio::test]
+    async fn gets_user_owned_identity_record() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        let principal = UserPrincipal::local();
+        let record = manager
+            .create_user_owned_fixed_token_identity(&principal, github_local_command("ghp_token"))
+            .await
+            .expect("create identity");
+
+        let loaded = manager
+            .get_user_owned_identity(&principal, "github_local")
+            .await
+            .expect("get identity");
+        assert_eq!(loaded, record);
+    }
+
+    #[tokio::test]
+    async fn deletes_user_owned_identity_record() {
+        let (_temp, manager, _identity_specs) = manager_with_github_pat_spec();
+        manager
+            .create_user_owned_fixed_token_identity(
+                &UserPrincipal::local(),
+                github_local_command("ghp_token"),
+            )
+            .await
+            .expect("create identity");
+
+        manager
+            .delete_user_owned_identity(&UserPrincipal::local(), "github_local")
+            .await
+            .expect("delete identity");
+
+        let listed = manager
+            .list_user_owned_identities(&UserPrincipal::local())
+            .await
+            .expect("list identities");
+        assert!(listed.is_empty(), "identity should be removed");
+        let error = manager
+            .delete_user_owned_identity(&UserPrincipal::local(), "github_local")
+            .await
+            .expect_err("second delete should report missing identity");
+        assert!(matches!(error, AppError::IdentityNotFound(name) if name == "github_local"));
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -5,9 +5,11 @@ use std::pin::Pin;
 use coral_api::v1::identity_service_server::IdentityService as IdentityServiceApi;
 use coral_api::v1::{
     CreateUserOwnedIdentityRequest, CreateUserOwnedIdentityResponse, CredentialMetadata,
-    FixedTokenUserOwnedIdentitySetup, Identity, IdentityOwner as ProtoIdentityOwner,
-    ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
-    create_user_owned_identity_request, create_user_owned_identity_response,
+    DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse,
+    FixedTokenUserOwnedIdentitySetup, GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse,
+    Identity, IdentityOwner as ProtoIdentityOwner, ListUserOwnedIdentitiesRequest,
+    ListUserOwnedIdentitiesResponse, create_user_owned_identity_request,
+    create_user_owned_identity_response,
 };
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
@@ -112,6 +114,44 @@ impl IdentityServiceApi for IdentityService {
             Ok(Response::new(ListUserOwnedIdentitiesResponse {
                 identities: records.into_iter().map(identity_record_to_proto).collect(),
             }))
+        })
+        .await
+    }
+
+    async fn get_user_owned_identity(
+        &self,
+        request: Request<GetUserOwnedIdentityRequest>,
+    ) -> Result<Response<GetUserOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
+            let request = request.into_inner();
+            let record = identities
+                .get_user_owned_identity(&principal, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(GetUserOwnedIdentityResponse {
+                identity: Some(identity_record_to_proto(record)),
+            }))
+        })
+        .await
+    }
+
+    async fn delete_user_owned_identity(
+        &self,
+        request: Request<DeleteUserOwnedIdentityRequest>,
+    ) -> Result<Response<DeleteUserOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
+            let request = request.into_inner();
+            identities
+                .delete_user_owned_identity(&principal, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(DeleteUserOwnedIdentityResponse {}))
         })
         .await
     }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -66,6 +66,10 @@ enum Command {
     Sql(SqlArgs),
     /// Manage data sources
     Source(SourceArgs),
+    /// Manage stored user-owned identities
+    Identity(IdentityArgs),
+    /// Manage global identity specs used by source identity requirements
+    IdentitySpec(IdentitySpecArgs),
     /// Interactive wizard to set up Coral and explore use cases
     Onboard,
     /// Start the MCP server over stdio
@@ -326,6 +330,72 @@ enum SourceCommand {
     },
 }
 
+#[derive(Debug, Args)]
+/// Manage stored user-owned identities
+struct IdentityArgs {
+    #[command(subcommand)]
+    command: IdentityCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum IdentityCommand {
+    /// List stored user-owned identities
+    List,
+    /// Show a stored user-owned identity
+    Info {
+        /// Identity name
+        name: String,
+    },
+    /// Create or replace a user-owned identity from an identity spec
+    Add {
+        /// Identity name used by source identity bindings
+        name: String,
+        /// Installed identity spec name
+        #[arg(long = "identity-spec")]
+        identity_spec: String,
+        /// Read the fixed-token credential from stdin instead of prompting
+        #[arg(long = "token-stdin")]
+        token_stdin: bool,
+    },
+    /// Remove a stored user-owned identity
+    Remove {
+        /// Identity name
+        name: String,
+    },
+}
+
+#[derive(Debug, Args)]
+/// Manage global identity specs used by source identity requirements
+struct IdentitySpecArgs {
+    #[command(subcommand)]
+    command: IdentitySpecCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum IdentitySpecCommand {
+    /// List installed identity specs
+    List,
+    /// Show an installed identity spec
+    Info {
+        /// Identity spec name
+        name: String,
+    },
+    /// Install an identity spec or replace an unused existing spec from a manifest file
+    Add {
+        /// Path to an identity spec YAML file
+        #[arg(long)]
+        file: PathBuf,
+    },
+    /// Remove an installed identity spec
+    Remove {
+        /// Identity spec name
+        name: String,
+        /// Confirm removal when stored identity instances would become orphaned
+        #[arg(long)]
+        force: bool,
+    },
+}
+
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 /// Output format for rendered SQL query results.
 pub enum OutputFormat {
@@ -396,9 +466,12 @@ impl CliError {
 impl Command {
     fn required_runtime(&self) -> RequiredRuntime {
         match self {
-            Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
-                RequiredRuntime::AppClient
-            }
+            Command::Sql(_)
+            | Command::Source(_)
+            | Command::Identity(_)
+            | Command::IdentitySpec(_)
+            | Command::Onboard
+            | Command::McpStdio(_) => RequiredRuntime::AppClient,
             Command::Features(_) | Command::Completion(_) => RequiredRuntime::None,
             #[cfg(feature = "embedded-ui")]
             Command::Ui(_) => RequiredRuntime::None,
@@ -668,7 +741,12 @@ async fn run_no_runtime_command(
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args, feature_overrides).await.map_err(Into::into),
-        Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
+        Command::Sql(_)
+        | Command::Source(_)
+        | Command::Identity(_)
+        | Command::IdentitySpec(_)
+        | Command::Onboard
+        | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
         }
     }
@@ -685,6 +763,8 @@ async fn run_app_command(
             run_sql(&app, default_workspace(), args.sql, args.format).await?;
         }
         Command::Source(args) => run_source(&app, args).await?,
+        Command::Identity(args) => run_identity(&app, args).await?,
+        Command::IdentitySpec(args) => run_identity_spec(&app, args).await?,
         Command::Onboard => {
             onboard::run(&app).await?;
         }
@@ -818,6 +898,160 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
         }
         SourceCommand::Remove { name } => {
             source_ops::remove_and_print(app, &name).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn run_identity(app: &AppClient, args: IdentityArgs) -> Result<(), CliError> {
+    match args.command {
+        IdentityCommand::List => {
+            let identities = source_ops::list_user_owned_identities(app).await?;
+            if identities.is_empty() {
+                println!("No identities configured.");
+            } else {
+                let rows = identities.into_iter().map(|identity| {
+                    [
+                        identity.name,
+                        identity.identity_spec,
+                        identity.issuer,
+                        identity.identity_type,
+                        source_ops::identity_owner_label(identity.owner).to_string(),
+                    ]
+                });
+                print_text_table(
+                    ["Identity", "Identity Spec", "Issuer", "Type", "Owner"],
+                    rows,
+                );
+            }
+        }
+        IdentityCommand::Info { name } => {
+            let identity = source_ops::get_user_owned_identity(app, &name).await?;
+            print_identity_info(&identity);
+        }
+        IdentityCommand::Add {
+            name,
+            identity_spec,
+            token_stdin,
+        } => {
+            let identity_spec_record = source_ops::get_identity_spec(app, &identity_spec).await?;
+            let manifest =
+                coral_spec::parse_identity_manifest_yaml(&identity_spec_record.manifest_yaml)
+                    .map_err(anyhow::Error::from)?;
+            let identity = match manifest.identity_type {
+                coral_spec::IdentitySpecType::OAuth => {
+                    if token_stdin {
+                        return Err(anyhow::anyhow!(
+                            "--token-stdin is only supported for fixed-token identity specs"
+                        )
+                        .into());
+                    }
+                    source_ops::require_interactive_for("identity OAuth setup")?;
+                    let selected = source_ops::identity_oauth_method(&manifest)?;
+                    source_ops::print_oauth_hint(selected.hint);
+                    source_ops::create_user_owned_identity_with_oauth(
+                        app,
+                        &name,
+                        &identity_spec,
+                        &selected.label,
+                    )
+                    .await?
+                }
+                coral_spec::IdentitySpecType::FixedToken => {
+                    let token = if token_stdin {
+                        source_ops::read_fixed_token_identity_token_from_stdin()?
+                    } else {
+                        source_ops::require_interactive_for("fixed-token identity setup")?;
+                        source_ops::prompt_fixed_token_identity_token(&identity_spec)?
+                    };
+                    source_ops::create_user_owned_identity_with_fixed_token(
+                        app,
+                        &name,
+                        &identity_spec,
+                        token,
+                    )
+                    .await?
+                }
+            };
+            println!(
+                "Created identity {} ({})",
+                identity.name, identity.identity_spec
+            );
+        }
+        IdentityCommand::Remove { name } => {
+            source_ops::delete_user_owned_identity(app, &name).await?;
+            println!("Removed identity {name}");
+        }
+    }
+    Ok(())
+}
+
+fn print_identity_info(identity: &coral_api::v1::Identity) {
+    println!("{}", identity.name);
+    println!("  Identity spec: {}", identity.identity_spec);
+    println!("  Issuer:        {}", identity.issuer);
+    println!("  Type:          {}", identity.identity_type);
+    println!(
+        "  Owner:         {}",
+        source_ops::identity_owner_label(identity.owner)
+    );
+    if !identity.metadata.is_empty() {
+        println!("  Metadata:");
+        for item in &identity.metadata {
+            println!("    {}: {}", item.key, item.value);
+        }
+    }
+}
+
+async fn run_identity_spec(app: &AppClient, args: IdentitySpecArgs) -> Result<(), CliError> {
+    match args.command {
+        IdentitySpecCommand::List => {
+            let identity_specs = source_ops::list_identity_specs(app).await?;
+            if identity_specs.is_empty() {
+                println!("No identity specs installed.");
+            } else {
+                let rows = identity_specs.into_iter().map(|identity_spec| {
+                    [
+                        identity_spec.name,
+                        source_ops::display_version(&identity_spec.version),
+                        identity_spec.issuer,
+                        identity_spec.identity_type,
+                    ]
+                });
+                print_text_table(["Identity Spec", "Version", "Issuer", "Type"], rows);
+            }
+        }
+        IdentitySpecCommand::Info { name } => {
+            let identity_spec = source_ops::get_identity_spec(app, &name).await?;
+            print!("{}", identity_spec.manifest_yaml);
+        }
+        IdentitySpecCommand::Add { file } => {
+            let manifest_yaml = source_ops::load_validated_identity_spec_file(&file)?;
+            let manifest = coral_spec::parse_identity_manifest_yaml(&manifest_yaml)
+                .map_err(anyhow::Error::from)?;
+            let inputs = source_ops::identity_spec_inputs_for_add(
+                &manifest,
+                format!(
+                    "coral identity-spec add --file {}",
+                    source_ops::shell_quote_arg(&file.display().to_string())
+                ),
+            )?;
+            let (identity_spec, replaced) =
+                source_ops::add_identity_spec(app, manifest_yaml, inputs).await?;
+            let action = if replaced { "Replaced" } else { "Added" };
+            println!(
+                "{action} identity spec {} ({})",
+                identity_spec.name,
+                source_ops::display_version(&identity_spec.version)
+            );
+        }
+        IdentitySpecCommand::Remove { name, force } => {
+            let orphaned = source_ops::remove_identity_spec(app, &name, force).await?;
+            if orphaned == 0 {
+                println!("Removed identity spec {name}");
+            } else {
+                println!("Removed identity spec {name} (orphaned identities: {orphaned})");
+            }
         }
     }
     Ok(())

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -11,21 +11,26 @@ use std::time::Duration;
 use anyhow::{Context as _, bail};
 use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
-    CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
-    CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DiscoverSourcesRequest,
-    GetSourceInfoRequest, IdentityOwner, ImportSourceRequest, ImportSourceResponse,
-    ListSourcesRequest, OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure,
-    QueryTestSuccess, Source, SourceCredentialStorage, SourceIdentityBinding, SourceInfo,
-    SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
-    create_bundled_source_with_o_auth_response, import_source_response, query_test_result,
+    AddIdentitySpecRequest, CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
+    CreateBundledSourceWithOAuthResponse, CreateUserOwnedIdentityRequest,
+    CreateUserOwnedIdentityResponse, DeleteIdentitySpecRequest, DeleteSourceRequest,
+    DeleteUserOwnedIdentityRequest, DiscoverSourcesRequest, FixedTokenUserOwnedIdentitySetup,
+    GetIdentitySpecRequest, GetSourceInfoRequest, GetUserOwnedIdentityRequest, Identity,
+    IdentityOwner, IdentitySpec, IdentitySpecInputValue, ImportSourceRequest, ImportSourceResponse,
+    ListIdentitySpecsRequest, ListSourcesRequest, ListUserOwnedIdentitiesRequest,
+    OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source,
+    SourceCredentialStorage, SourceIdentityBinding, SourceInfo, SourceOrigin, SourceSecret,
+    SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
+    create_bundled_source_with_o_auth_response, create_user_owned_identity_request,
+    create_user_owned_identity_response, import_source_response, query_test_result,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::{AppClient, DecodedStatusError, decode_status_error, default_workspace};
 use coral_spec::v4::SurfaceDescriptor;
 use coral_spec::{
-    ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
-    ManifestInputKind, ManifestInputSpec, ManifestOAuthCredentialSpec, ValidatedSourceManifest,
-    parse_source_manifest_yaml,
+    IdentityManifest, IdentitySpecConfig, ManifestCredentialMethod, ManifestCredentialMethodKind,
+    ManifestCredentialSpec, ManifestInputKind, ManifestInputSpec, ManifestOAuthCredentialSpec,
+    ValidatedSourceManifest, parse_identity_manifest_yaml, parse_source_manifest_yaml,
 };
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
@@ -91,6 +96,146 @@ pub(crate) async fn list_sources(app: &AppClient) -> Result<Vec<Source>, anyhow:
         .await?
         .into_inner()
         .sources)
+}
+
+pub(crate) async fn list_identity_specs(
+    app: &AppClient,
+) -> Result<Vec<IdentitySpec>, anyhow::Error> {
+    Ok(app
+        .identity_spec_client()
+        .list_identity_specs(Request::new(ListIdentitySpecsRequest {}))
+        .await?
+        .into_inner()
+        .identity_specs)
+}
+
+pub(crate) async fn get_identity_spec(
+    app: &AppClient,
+    name: &str,
+) -> Result<IdentitySpec, anyhow::Error> {
+    let response = app
+        .identity_spec_client()
+        .get_identity_spec(Request::new(GetIdentitySpecRequest {
+            name: name.to_string(),
+        }))
+        .await?
+        .into_inner();
+    response
+        .identity_spec
+        .ok_or_else(|| anyhow::anyhow!("get identity spec response missing identity_spec"))
+}
+
+pub(crate) async fn add_identity_spec(
+    app: &AppClient,
+    manifest_yaml: String,
+    inputs: Vec<IdentitySpecInputValue>,
+) -> Result<(IdentitySpec, bool), anyhow::Error> {
+    let response = app
+        .identity_spec_client()
+        .add_identity_spec(Request::new(AddIdentitySpecRequest {
+            manifest_yaml,
+            input_values: inputs,
+        }))
+        .await?
+        .into_inner();
+    Ok((
+        response
+            .identity_spec
+            .ok_or_else(|| anyhow::anyhow!("add identity spec response missing identity_spec"))?,
+        response.replaced,
+    ))
+}
+
+pub(crate) async fn remove_identity_spec(
+    app: &AppClient,
+    name: &str,
+    force: bool,
+) -> Result<u32, anyhow::Error> {
+    Ok(app
+        .identity_spec_client()
+        .delete_identity_spec(Request::new(DeleteIdentitySpecRequest {
+            name: name.to_string(),
+            force,
+        }))
+        .await?
+        .into_inner()
+        .orphaned_identities)
+}
+
+pub(crate) async fn list_user_owned_identities(
+    app: &AppClient,
+) -> Result<Vec<Identity>, anyhow::Error> {
+    Ok(app
+        .identity_client()
+        .list_user_owned_identities(Request::new(ListUserOwnedIdentitiesRequest {}))
+        .await?
+        .into_inner()
+        .identities)
+}
+
+pub(crate) async fn get_user_owned_identity(
+    app: &AppClient,
+    name: &str,
+) -> Result<Identity, anyhow::Error> {
+    let response = app
+        .identity_client()
+        .get_user_owned_identity(Request::new(GetUserOwnedIdentityRequest {
+            name: name.to_string(),
+        }))
+        .await?
+        .into_inner();
+    response
+        .identity
+        .ok_or_else(|| anyhow::anyhow!("get user-owned identity response missing identity"))
+}
+
+pub(crate) async fn delete_user_owned_identity(
+    app: &AppClient,
+    name: &str,
+) -> Result<(), anyhow::Error> {
+    app.identity_client()
+        .delete_user_owned_identity(Request::new(DeleteUserOwnedIdentityRequest {
+            name: name.to_string(),
+        }))
+        .await?;
+    Ok(())
+}
+
+pub(crate) async fn create_user_owned_identity_with_oauth(
+    app: &AppClient,
+    name: &str,
+    identity_spec: &str,
+    label: &str,
+) -> Result<Identity, anyhow::Error> {
+    let response = app
+        .identity_client()
+        .create_user_owned_identity(Request::new(CreateUserOwnedIdentityRequest {
+            name: name.to_string(),
+            identity_spec: identity_spec.to_string(),
+            setup: None,
+        }))
+        .await?;
+    let oauth_labels = BTreeMap::from([(name.to_string(), label.to_string())]);
+    identity_from_create_identity_stream(response.into_inner(), &oauth_labels).await
+}
+
+pub(crate) async fn create_user_owned_identity_with_fixed_token(
+    app: &AppClient,
+    name: &str,
+    identity_spec: &str,
+    token: String,
+) -> Result<Identity, anyhow::Error> {
+    let response = app
+        .identity_client()
+        .create_user_owned_identity(Request::new(CreateUserOwnedIdentityRequest {
+            name: name.to_string(),
+            identity_spec: identity_spec.to_string(),
+            setup: Some(create_user_owned_identity_request::Setup::FixedToken(
+                FixedTokenUserOwnedIdentitySetup { token },
+            )),
+        }))
+        .await?;
+    identity_from_create_identity_stream(response.into_inner(), &BTreeMap::new()).await
 }
 
 pub(crate) async fn add_bundled_source(
@@ -375,6 +520,50 @@ async fn source_from_import_credential_stream(
     }
 }
 
+async fn identity_from_create_identity_stream(
+    mut stream: tonic::Streaming<CreateUserOwnedIdentityResponse>,
+    oauth_labels: &BTreeMap<String, String>,
+) -> Result<Identity, anyhow::Error> {
+    let mut redirect_prompt = OAuthRedirectPastePrompt::default();
+    loop {
+        let response = match stream.message().await {
+            Ok(Some(response)) => response,
+            Ok(None) => {
+                redirect_prompt.cancel_and_join();
+                return Err(anyhow::anyhow!(
+                    "identity OAuth stream ended before identity creation completed"
+                ));
+            }
+            Err(error) => {
+                redirect_prompt.cancel_and_join();
+                return Err(oauth_error_with_retry(
+                    "identity creation",
+                    &error,
+                    "coral identity add",
+                ));
+            }
+        };
+        match response.event {
+            Some(create_user_owned_identity_response::Event::Identity(identity)) => {
+                redirect_prompt.cancel_and_join();
+                return Ok(identity);
+            }
+            Some(create_user_owned_identity_response::Event::OauthAuthorization(authorization)) => {
+                handle_oauth_authorization_event(
+                    &authorization.input_key,
+                    &authorization.authorization_url,
+                    &authorization.user_code,
+                    oauth_labels,
+                    &mut redirect_prompt,
+                );
+            }
+            Some(create_user_owned_identity_response::Event::OauthCompleted(_)) | None => {
+                redirect_prompt.cancel_and_join();
+            }
+        }
+    }
+}
+
 enum CredentialStreamEvent {
     Source(Source),
     OAuthAuthorization {
@@ -432,21 +621,13 @@ fn handle_credential_stream_event(
             authorization_url,
             user_code,
         }) => {
-            let label = oauth_labels
-                .get(&input_key)
-                .map_or(input_key.as_str(), String::as_str);
-            println!("Open this URL to connect {label}:");
-            println!("{authorization_url}");
-            redirect_prompt.cancel_and_join();
-            if user_code.is_empty() {
-                redirect_prompt
-                    .replace(spawn_oauth_redirect_paste_prompt(&authorization_url, label));
-            } else {
-                println!("Enter this code when prompted: {user_code}");
-            }
-            if let Err(err) = crate::browser::open_url(&authorization_url) {
-                println!("{}", style(format!("Could not open browser: {err}")).dim());
-            }
+            handle_oauth_authorization_event(
+                &input_key,
+                &authorization_url,
+                &user_code,
+                oauth_labels,
+                redirect_prompt,
+            );
             None
         }
         Some(CredentialStreamEvent::Source(source)) => {
@@ -458,6 +639,29 @@ fn handle_credential_stream_event(
             None
         }
         None => None,
+    }
+}
+
+fn handle_oauth_authorization_event(
+    input_key: &str,
+    authorization_url: &str,
+    user_code: &str,
+    oauth_labels: &BTreeMap<String, String>,
+    redirect_prompt: &mut OAuthRedirectPastePrompt,
+) {
+    let label = oauth_labels
+        .get(input_key)
+        .map_or(input_key, String::as_str);
+    println!("Open this URL to connect {label}:");
+    println!("{authorization_url}");
+    redirect_prompt.cancel_and_join();
+    if user_code.is_empty() {
+        redirect_prompt.replace(spawn_oauth_redirect_paste_prompt(authorization_url, label));
+    } else {
+        println!("Enter this code when prompted: {user_code}");
+    }
+    if let Err(err) = crate::browser::open_url(authorization_url) {
+        println!("{}", style(format!("Could not open browser: {err}")).dim());
     }
 }
 
@@ -492,6 +696,12 @@ pub(crate) fn load_validated_manifest_file(
         durable_manifest_file_yaml(&manifest_yaml, &manifest, manifest_dir.as_path())?;
     let manifest = parse_source_manifest_yaml(manifest_yaml.as_str())?;
     Ok((manifest_yaml, manifest))
+}
+
+pub(crate) fn load_validated_identity_spec_file(file: &Path) -> Result<String, anyhow::Error> {
+    let raw = std::fs::read_to_string(file)?;
+    parse_identity_manifest_yaml(&raw)?;
+    Ok(raw)
 }
 
 fn manifest_file_parent_dir(file: &Path) -> Result<PathBuf, anyhow::Error> {
@@ -698,8 +908,12 @@ pub(crate) async fn delete_source(app: &AppClient, name: &str) -> Result<(), any
 }
 
 pub(crate) fn require_interactive() -> Result<(), anyhow::Error> {
+    require_interactive_for("interactive source install")
+}
+
+pub(crate) fn require_interactive_for(action: &str) -> Result<(), anyhow::Error> {
     if !stdin().is_terminal() || !stdout().is_terminal() {
-        return Err(anyhow::anyhow!("interactive source install requires a TTY"));
+        return Err(anyhow::anyhow!("{action} requires a TTY"));
     }
     Ok(())
 }
@@ -798,6 +1012,79 @@ pub(crate) fn collect_inputs_from_env(
     )
 }
 
+pub(crate) fn identity_spec_inputs_for_add(
+    manifest: &IdentityManifest,
+    interactive_command: String,
+) -> Result<Vec<IdentitySpecInputValue>, anyhow::Error> {
+    if manifest.inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+    if stdin().is_terminal() && stdout().is_terminal() {
+        return prompt_identity_spec_inputs(manifest);
+    }
+    collect_identity_spec_inputs_from_env(manifest, interactive_command)
+}
+
+fn collect_identity_spec_inputs_from_env(
+    manifest: &IdentityManifest,
+    interactive_command: String,
+) -> Result<Vec<IdentitySpecInputValue>, anyhow::Error> {
+    let mut values = Vec::new();
+    let mut missing = Vec::new();
+
+    for input in &manifest.inputs {
+        let value = read_identity_spec_input_env(&input.key).filter(|value| !value.is_empty());
+        if let Some(value) = value {
+            values.push(IdentitySpecInputValue {
+                key: input.key.clone(),
+                value,
+            });
+            continue;
+        }
+        let default_resolves_in_manifest =
+            input.kind == ManifestInputKind::Variable && !input.default_value.is_empty();
+        if input.required && !default_resolves_in_manifest {
+            missing.push(input.key.clone());
+        }
+    }
+
+    if !missing.is_empty() {
+        return Err(missing_environment_variables_error(
+            &missing,
+            Some(interactive_command),
+        ));
+    }
+
+    Ok(values)
+}
+
+fn prompt_identity_spec_inputs(
+    manifest: &IdentityManifest,
+) -> Result<Vec<IdentitySpecInputValue>, anyhow::Error> {
+    let mut values = Vec::new();
+    for input in &manifest.inputs {
+        match input.kind {
+            ManifestInputKind::Variable => {
+                if let Some(variable) = prompt_variable(input)? {
+                    values.push(IdentitySpecInputValue {
+                        key: variable.key,
+                        value: variable.value,
+                    });
+                }
+            }
+            ManifestInputKind::Secret => {
+                if let Some(secret) = prompt_source_config_secret(input, None)? {
+                    values.push(IdentitySpecInputValue {
+                        key: secret.key,
+                        value: secret.value,
+                    });
+                }
+            }
+        }
+    }
+    Ok(values)
+}
+
 pub(crate) fn shell_quote_arg(value: &str) -> String {
     if value
         .chars()
@@ -813,6 +1100,14 @@ pub(crate) fn shell_quote_arg(value: &str) -> String {
     reason = "`coral source add` reads install-time source inputs from matching environment variables."
 )]
 fn read_source_input_env(key: &str) -> Option<String> {
+    std::env::var(key).ok()
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "Identity spec setup reads install-time inputs from matching environment variables."
+)]
+fn read_identity_spec_input_env(key: &str) -> Option<String> {
     std::env::var(key).ok()
 }
 
@@ -851,19 +1146,29 @@ fn collect_inputs_with_hint(
     }
 
     if !missing.is_empty() {
-        let interactive_hint = interactive_command.map_or_else(
-            || "--interactive".to_string(),
-            |command| format!("`{command}`"),
-        );
-        return Err(anyhow::anyhow!(
-            "missing required environment variable{}: {}. Set the variable{} or run {interactive_hint}.",
-            if missing.len() == 1 { "" } else { "s" },
-            missing.join(", "),
-            if missing.len() == 1 { "" } else { "s" },
+        return Err(missing_environment_variables_error(
+            &missing,
+            interactive_command,
         ));
     }
 
     Ok((variables, secrets))
+}
+
+fn missing_environment_variables_error(
+    missing: &[String],
+    interactive_command: Option<String>,
+) -> anyhow::Error {
+    let interactive_hint = interactive_command.map_or_else(
+        || "--interactive".to_string(),
+        |command| format!("`{command}`"),
+    );
+    anyhow::anyhow!(
+        "missing required environment variable{}: {}. Set the variable{} or run {interactive_hint}.",
+        if missing.len() == 1 { "" } else { "s" },
+        missing.join(", "),
+        if missing.len() == 1 { "" } else { "s" },
+    )
 }
 
 pub(crate) fn source_origin_label(origin: i32) -> &'static str {
@@ -881,6 +1186,40 @@ pub(crate) fn source_credential_storage_label(storage: i32) -> &'static str {
         Ok(SourceCredentialStorage::Keychain) => "keychain",
         Err(_) => "unknown",
     }
+}
+
+pub(crate) fn identity_owner_label(owner: i32) -> &'static str {
+    match IdentityOwner::try_from(owner) {
+        Ok(IdentityOwner::User) => "user",
+        Ok(IdentityOwner::Workspace) => "workspace",
+        Ok(IdentityOwner::Unspecified) | Err(_) => "unknown",
+    }
+}
+
+pub(crate) struct SelectedIdentityOAuthMethod<'a> {
+    pub(crate) label: String,
+    pub(crate) hint: Option<&'a str>,
+}
+
+pub(crate) fn identity_oauth_method(
+    manifest: &IdentityManifest,
+) -> Result<SelectedIdentityOAuthMethod<'_>, anyhow::Error> {
+    let IdentitySpecConfig::OAuth(oauth) = &manifest.config else {
+        return Err(anyhow::anyhow!(
+            "identity spec '{}' has type '{}'; expected oauth",
+            manifest.name,
+            manifest.identity_type.label()
+        ));
+    };
+    let method = &oauth.method;
+    Ok(SelectedIdentityOAuthMethod {
+        label: identity_oauth_method_label(method),
+        hint: method.hint.as_deref(),
+    })
+}
+
+pub(crate) fn print_oauth_hint(hint: Option<&str>) {
+    print_prompt_hint(hint);
 }
 
 pub(crate) async fn validate_and_print(
@@ -1288,6 +1627,39 @@ fn credential_method_label(method: &ManifestCredentialMethod) -> String {
     })
 }
 
+fn identity_oauth_method_label(method: &coral_spec::IdentityOAuthMethodSpec) -> String {
+    method
+        .label
+        .clone()
+        .unwrap_or_else(|| "Connect with OAuth".to_string())
+}
+
+pub(crate) fn prompt_fixed_token_identity_token(
+    identity_spec_name: &str,
+) -> Result<String, anyhow::Error> {
+    let token = Password::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!("Token for {identity_spec_name}"))
+        .allow_empty_password(false)
+        .interact()?;
+    normalize_fixed_token_identity_token(&token)
+}
+
+pub(crate) fn read_fixed_token_identity_token_from_stdin() -> Result<String, anyhow::Error> {
+    let mut token = String::new();
+    stdin().read_to_string(&mut token)?;
+    normalize_fixed_token_identity_token(&token)
+}
+
+fn normalize_fixed_token_identity_token(token: &str) -> Result<String, anyhow::Error> {
+    let token = token.trim_end_matches(['\r', '\n']).to_string();
+    if token.is_empty() {
+        return Err(anyhow::anyhow!(
+            "fixed token identity token must not be empty"
+        ));
+    }
+    Ok(token)
+}
+
 fn collect_oauth_credential_method(
     input: &ManifestInputSpec,
     method_index: usize,
@@ -1305,8 +1677,16 @@ fn collect_oauth_credential_method(
 }
 
 fn oauth_error(action: &str, error: &tonic::Status) -> anyhow::Error {
+    oauth_error_with_retry(action, error, "coral source add")
+}
+
+fn oauth_error_with_retry(
+    action: &str,
+    error: &tonic::Status,
+    retry_command: &str,
+) -> anyhow::Error {
     anyhow::anyhow!(
-        "OAuth credential retrieval failed during {action}: {error}. Rerun `coral source add` to try again."
+        "OAuth credential retrieval failed during {action}: {error}. Rerun `{retry_command}` to try again."
     )
 }
 

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -17,8 +17,9 @@ use arrow::record_batch::RecordBatch;
 #[cfg(feature = "embedded-ui")]
 use assert_cmd::Command;
 use coral_api::v1::{
-    DiscoverSourcesResponse, ExecuteSqlResponse, IdentityOwner, ListSourcesResponse, Source,
-    SourceCredentialStorage, SourceInfo, SourceOrigin,
+    DiscoverSourcesResponse, ExecuteSqlResponse, GetIdentitySpecResponse, IdentityOwner,
+    IdentitySpec, ListSourcesResponse, Source, SourceCredentialStorage, SourceInfo, SourceOrigin,
+    create_user_owned_identity_request,
 };
 use tempfile::tempdir;
 use tonic::Code;
@@ -848,6 +849,198 @@ surfaces:
     assert_eq!(source_binding.owner, IdentityOwner::User as i32);
     assert_eq!(source_binding.identity, "local_github");
     assert!(requests[0].replace_identity_bindings);
+
+    server.shutdown().await;
+}
+
+fn fixed_token_spec_yaml(name: &str) -> String {
+    format!(
+        r"
+kind: identity
+spec_version: 1
+name: {name}
+version: 0.1.0
+issuer: github
+type: fixed_token
+"
+    )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_commands_use_identity_spec_service() {
+    let server = MockServer::start().await;
+    let source_dir = tempdir().expect("identity spec dir");
+    let identity_file = source_dir.path().join("github_oauth.yaml");
+    std::fs::write(&identity_file, fixed_token_spec_yaml("github_oauth"))
+        .expect("write identity spec fixture");
+
+    server
+        .cmd()
+        .args([
+            "identity-spec",
+            "add",
+            "--file",
+            identity_file.to_str().expect("identity file path utf8"),
+        ])
+        .assert()
+        .success();
+    server
+        .cmd()
+        .args(["identity-spec", "list"])
+        .assert()
+        .success();
+    server
+        .cmd()
+        .args(["identity-spec", "info", "github_oauth"])
+        .assert()
+        .success();
+    server
+        .cmd()
+        .args(["identity-spec", "remove", "github_oauth", "--force"])
+        .assert()
+        .success();
+
+    assert_eq!(server.add_identity_spec_requests().len(), 1);
+    assert_eq!(server.list_identity_specs_requests().len(), 1);
+    assert_eq!(server.get_identity_spec_requests()[0].name, "github_oauth");
+    let delete_requests = server.delete_identity_spec_requests();
+    assert_eq!(delete_requests[0].name, "github_oauth");
+    assert!(delete_requests[0].force);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_add_noninteractive_does_not_send_manifest_defaults_as_inputs() {
+    let server = MockServer::start().await;
+    let source_dir = tempdir().expect("identity spec dir");
+    let identity_file = source_dir.path().join("demo_oauth.yaml");
+    std::fs::write(
+        &identity_file,
+        r"
+kind: identity
+spec_version: 1
+name: demo_oauth
+version: 0.1.0
+description: Demo OAuth identity.
+issuer: demo
+type: oauth
+audience:
+  host: example.test
+inputs:
+  DEMO_TENANT: {kind: variable, default: default-tenant}
+  DEMO_OAUTH_CLIENT_SECRET: {kind: secret}
+oauth:
+  method:
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    endpoints:
+      authorization_url: https://example.test/authorize
+      token_url: https://example.test/token
+    client:
+      id:
+        default: demo-client
+      secret:
+        input: DEMO_OAUTH_CLIENT_SECRET
+        transport: request_body
+",
+    )
+    .expect("write identity spec fixture");
+
+    server
+        .cmd()
+        .args([
+            "identity-spec",
+            "add",
+            "--file",
+            identity_file.to_str().expect("identity file path utf8"),
+        ])
+        .env_remove("DEMO_TENANT")
+        .env("DEMO_OAUTH_CLIENT_SECRET", "client-secret")
+        .assert()
+        .success();
+
+    let requests = server.add_identity_spec_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].input_values.len(), 1);
+    assert_eq!(requests[0].input_values[0].key, "DEMO_OAUTH_CLIENT_SECRET");
+    assert_eq!(requests[0].input_values[0].value, "client-secret");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_commands_use_identity_service() {
+    let server = MockServer::start().await;
+
+    server.cmd().args(["identity", "list"]).assert().success();
+    server
+        .cmd()
+        .args(["identity", "info", "github_local"])
+        .assert()
+        .success();
+    server
+        .cmd()
+        .args(["identity", "remove", "github_local"])
+        .assert()
+        .success();
+
+    assert_eq!(server.list_user_owned_identities_requests().len(), 1);
+    assert_eq!(
+        server.get_user_owned_identity_requests()[0].name,
+        "github_local"
+    );
+    assert_eq!(
+        server.delete_user_owned_identity_requests()[0].name,
+        "github_local"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_add_fixed_token_reads_token_from_stdin() {
+    let server = MockServer::start_with_config(MockServerConfig::default().with_get_identity_spec(
+        GetIdentitySpecResponse {
+            identity_spec: Some(IdentitySpec {
+                name: "github_pat".to_string(),
+                version: "0.1.0".to_string(),
+                description: "GitHub PAT identity.".to_string(),
+                issuer: "github".to_string(),
+                identity_type: "fixed_token".to_string(),
+                manifest_yaml: fixed_token_spec_yaml("github_pat"),
+            }),
+        },
+    ))
+    .await;
+
+    server
+        .cmd()
+        .args([
+            "identity",
+            "add",
+            "github_local",
+            "--identity-spec",
+            "github_pat",
+            "--token-stdin",
+        ])
+        .write_stdin("pat-token\n")
+        .assert()
+        .success()
+        .stdout("Created identity github_local (github_pat)\n");
+
+    assert_eq!(server.get_identity_spec_requests()[0].name, "github_pat");
+    let requests = server.create_user_owned_identity_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].name, "github_local");
+    assert_eq!(requests[0].identity_spec, "github_pat");
+    match requests[0].setup.as_ref().expect("identity setup") {
+        create_user_owned_identity_request::Setup::FixedToken(setup) => {
+            assert_eq!(setup.token, "pat-token");
+        }
+    }
 
     server.shutdown().await;
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -14,21 +14,31 @@ use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
 use assert_cmd::Command;
 use coral_api::v1::catalog_service_server::{CatalogService, CatalogServiceServer};
+use coral_api::v1::identity_service_server::{IdentityService, IdentityServiceServer};
+use coral_api::v1::identity_spec_service_server::{IdentitySpecService, IdentitySpecServiceServer};
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::{
-    CatalogCounts, CatalogItem, CatalogSearchResult, Column, ColumnSearchResult,
-    CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
-    CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DeleteSourceResponse,
-    DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
-    ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
+    AddIdentitySpecRequest, AddIdentitySpecResponse, CatalogCounts, CatalogItem,
+    CatalogSearchResult, Column, ColumnSearchResult, CreateBundledSourceRequest,
+    CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
+    CreateBundledSourceWithOAuthResponse, CreateUserOwnedIdentityRequest,
+    CreateUserOwnedIdentityResponse, DeleteIdentitySpecRequest, DeleteIdentitySpecResponse,
+    DeleteSourceRequest, DeleteSourceResponse, DeleteUserOwnedIdentityRequest,
+    DeleteUserOwnedIdentityResponse, DescribeTableRequest, DescribeTableResponse,
+    DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse,
+    ExplainSqlRequest, ExplainSqlResponse, GetIdentitySpecRequest, GetIdentitySpecResponse,
     GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest, GetSourceResponse,
-    ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
-    ListColumnsRequest, ListColumnsResponse, ListSourcesRequest, ListSourcesResponse,
-    PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse,
-    Source, SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput,
-    Table, TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
-    create_bundled_source_with_o_auth_response, import_source_response,
+    GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse, Identity, IdentityOwner,
+    IdentitySpec, ImportSourceRequest, ImportSourceResponse, ListCatalogRequest,
+    ListCatalogResponse, ListColumnsRequest, ListColumnsResponse, ListIdentitySpecsRequest,
+    ListIdentitySpecsResponse, ListSourcesRequest, ListSourcesResponse,
+    ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse, PaginationRequest,
+    PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse, Source,
+    SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table,
+    TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
+    create_bundled_source_with_o_auth_response, create_user_owned_identity_request,
+    create_user_owned_identity_response, import_source_response,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
@@ -58,6 +68,64 @@ fn mock_source() -> Source {
         origin: SourceOrigin::Bundled as i32,
         credential_storage: SourceCredentialStorage::File as i32,
         identity_bindings: Vec::new(),
+    }
+}
+
+fn mock_identity_spec() -> IdentitySpec {
+    IdentitySpec {
+        name: "github_oauth".to_string(),
+        version: "0.1.0".to_string(),
+        description: "GitHub OAuth identity.".to_string(),
+        issuer: "github".to_string(),
+        identity_type: "oauth".to_string(),
+        manifest_yaml: r"
+kind: identity
+spec_version: 1
+name: github_oauth
+version: 0.1.0
+issuer: github
+type: oauth
+oauth:
+  method:
+    flow:
+      type: device_code
+    endpoints:
+      device_authorization_url: https://github.com/login/device/code
+      token_url: https://github.com/login/oauth/access_token
+    client:
+      id:
+        input: GITHUB_OAUTH_CLIENT_ID
+"
+        .to_string(),
+    }
+}
+
+fn mock_identity() -> Identity {
+    mock_oauth_identity("github_local", "github_oauth")
+}
+
+fn mock_oauth_identity(name: impl Into<String>, identity_spec: impl Into<String>) -> Identity {
+    Identity {
+        name: name.into(),
+        identity_spec: identity_spec.into(),
+        issuer: "github".to_string(),
+        identity_type: "oauth".to_string(),
+        owner: IdentityOwner::User as i32,
+        metadata: Vec::new(),
+    }
+}
+
+fn mock_fixed_token_identity(
+    name: impl Into<String>,
+    identity_spec: impl Into<String>,
+) -> Identity {
+    Identity {
+        name: name.into(),
+        identity_spec: identity_spec.into(),
+        issuer: "github".to_string(),
+        identity_type: "fixed_token".to_string(),
+        owner: IdentityOwner::User as i32,
+        metadata: Vec::new(),
     }
 }
 
@@ -442,6 +510,14 @@ pub(crate) struct MockServerConfig {
     execute_sql_override: Option<MockResult<ExecuteSqlResponse>>,
     discover_sources: MockResult<DiscoverSourcesResponse>,
     list_sources: MockResult<ListSourcesResponse>,
+    list_user_owned_identities: MockResult<ListUserOwnedIdentitiesResponse>,
+    get_user_owned_identity: MockResult<GetUserOwnedIdentityResponse>,
+    delete_user_owned_identity: MockResult<()>,
+    create_user_owned_identity_with_oauth: Option<MockResult<Identity>>,
+    create_user_owned_identity_with_fixed_token: Option<MockResult<Identity>>,
+    list_identity_specs: MockResult<ListIdentitySpecsResponse>,
+    get_identity_spec: MockResult<GetIdentitySpecResponse>,
+    delete_identity_spec: MockResult<()>,
     validate_source: MockResult<ValidateSourceResponse>,
     delete_source: MockResult<()>,
 }
@@ -451,6 +527,22 @@ impl Default for MockServerConfig {
         Self {
             execute_sql_override: None,
             discover_sources: MockResult::ok(mock_discover_response()),
+            list_identity_specs: MockResult::ok(ListIdentitySpecsResponse {
+                identity_specs: vec![mock_identity_spec()],
+            }),
+            get_identity_spec: MockResult::ok(GetIdentitySpecResponse {
+                identity_spec: Some(mock_identity_spec()),
+            }),
+            list_user_owned_identities: MockResult::ok(ListUserOwnedIdentitiesResponse {
+                identities: vec![mock_identity()],
+            }),
+            get_user_owned_identity: MockResult::ok(GetUserOwnedIdentityResponse {
+                identity: Some(mock_identity()),
+            }),
+            delete_user_owned_identity: MockResult::ok(()),
+            create_user_owned_identity_with_oauth: None,
+            create_user_owned_identity_with_fixed_token: None,
+            delete_identity_spec: MockResult::ok(()),
             list_sources: MockResult::ok(ListSourcesResponse {
                 sources: vec![
                     Source {
@@ -489,6 +581,24 @@ impl MockServerConfig {
 
     pub(crate) fn with_list_sources(mut self, response: ListSourcesResponse) -> Self {
         self.list_sources = MockResult::ok(response);
+        self
+    }
+
+    pub(crate) fn with_get_identity_spec(mut self, response: GetIdentitySpecResponse) -> Self {
+        self.get_identity_spec = MockResult::ok(response);
+        self
+    }
+
+    pub(crate) fn with_create_user_owned_identity_with_oauth(mut self, identity: Identity) -> Self {
+        self.create_user_owned_identity_with_oauth = Some(MockResult::ok(identity));
+        self
+    }
+
+    pub(crate) fn with_create_user_owned_identity_with_fixed_token(
+        mut self,
+        identity: Identity,
+    ) -> Self {
+        self.create_user_owned_identity_with_fixed_token = Some(MockResult::ok(identity));
         self
     }
 
@@ -589,6 +699,14 @@ struct Captured {
     create_bundled_source: Mutex<Vec<CreateBundledSourceRequest>>,
     create_bundled_source_with_oauth: Mutex<Vec<CreateBundledSourceWithOAuthRequest>>,
     import_source: Mutex<Vec<ImportSourceRequest>>,
+    add_identity_spec: Mutex<Vec<AddIdentitySpecRequest>>,
+    list_identity_specs: Mutex<Vec<ListIdentitySpecsRequest>>,
+    get_identity_spec: Mutex<Vec<GetIdentitySpecRequest>>,
+    delete_identity_spec: Mutex<Vec<DeleteIdentitySpecRequest>>,
+    create_user_owned_identity: Mutex<Vec<CreateUserOwnedIdentityRequest>>,
+    list_user_owned_identities: Mutex<Vec<ListUserOwnedIdentitiesRequest>>,
+    get_user_owned_identity: Mutex<Vec<GetUserOwnedIdentityRequest>>,
+    delete_user_owned_identity: Mutex<Vec<DeleteUserOwnedIdentityRequest>>,
     delete_source: Mutex<Vec<DeleteSourceRequest>>,
     validate_source: Mutex<Vec<ValidateSourceRequest>>,
 }
@@ -814,6 +932,188 @@ impl CatalogService for MockCatalogService {
 }
 
 #[derive(Clone)]
+struct MockIdentitySpecService {
+    config: Arc<MockServerConfig>,
+    captured: Arc<Captured>,
+}
+
+#[tonic::async_trait]
+impl IdentitySpecService for MockIdentitySpecService {
+    async fn add_identity_spec(
+        &self,
+        request: Request<AddIdentitySpecRequest>,
+    ) -> Result<Response<AddIdentitySpecResponse>, Status> {
+        self.captured
+            .add_identity_spec
+            .lock()
+            .expect("add_identity_spec capture")
+            .push(request.into_inner());
+        Ok(Response::new(AddIdentitySpecResponse {
+            identity_spec: Some(mock_identity_spec()),
+            replaced: false,
+        }))
+    }
+
+    async fn list_identity_specs(
+        &self,
+        request: Request<ListIdentitySpecsRequest>,
+    ) -> Result<Response<ListIdentitySpecsResponse>, Status> {
+        self.captured
+            .list_identity_specs
+            .lock()
+            .expect("list_identity_specs capture")
+            .push(request.into_inner());
+        Ok(Response::new(
+            self.config
+                .list_identity_specs
+                .clone()
+                .into_tonic_result()?,
+        ))
+    }
+
+    async fn get_identity_spec(
+        &self,
+        request: Request<GetIdentitySpecRequest>,
+    ) -> Result<Response<GetIdentitySpecResponse>, Status> {
+        self.captured
+            .get_identity_spec
+            .lock()
+            .expect("get_identity_spec capture")
+            .push(request.into_inner());
+        Ok(Response::new(
+            self.config.get_identity_spec.clone().into_tonic_result()?,
+        ))
+    }
+
+    async fn delete_identity_spec(
+        &self,
+        request: Request<DeleteIdentitySpecRequest>,
+    ) -> Result<Response<DeleteIdentitySpecResponse>, Status> {
+        self.captured
+            .delete_identity_spec
+            .lock()
+            .expect("delete_identity_spec capture")
+            .push(request.into_inner());
+        self.config
+            .delete_identity_spec
+            .clone()
+            .into_tonic_result()?;
+        Ok(Response::new(DeleteIdentitySpecResponse {
+            orphaned_identities: 0,
+        }))
+    }
+}
+
+#[derive(Clone)]
+struct MockIdentityService {
+    config: Arc<MockServerConfig>,
+    captured: Arc<Captured>,
+}
+
+type MockCreateUserOwnedIdentityStream =
+    Pin<Box<dyn Stream<Item = Result<CreateUserOwnedIdentityResponse, Status>> + Send>>;
+
+fn mock_user_owned_identity_stream(identity: Identity) -> MockCreateUserOwnedIdentityStream {
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<CreateUserOwnedIdentityResponse, Status>>(1);
+    tx.try_send(Ok(CreateUserOwnedIdentityResponse {
+        event: Some(create_user_owned_identity_response::Event::Identity(
+            identity,
+        )),
+    }))
+    .expect("send mock user-owned identity event");
+    Box::pin(ReceiverStream::new(rx))
+}
+
+#[tonic::async_trait]
+impl IdentityService for MockIdentityService {
+    type CreateUserOwnedIdentityStream = MockCreateUserOwnedIdentityStream;
+
+    async fn create_user_owned_identity(
+        &self,
+        request: Request<CreateUserOwnedIdentityRequest>,
+    ) -> Result<Response<Self::CreateUserOwnedIdentityStream>, Status> {
+        let request = request.into_inner();
+        let identity = match request.setup.as_ref() {
+            Some(create_user_owned_identity_request::Setup::FixedToken(_)) => self
+                .config
+                .create_user_owned_identity_with_fixed_token
+                .clone()
+                .unwrap_or_else(|| {
+                    MockResult::ok(mock_fixed_token_identity(
+                        &request.name,
+                        &request.identity_spec,
+                    ))
+                })
+                .into_tonic_result()?,
+            None => self
+                .config
+                .create_user_owned_identity_with_oauth
+                .clone()
+                .unwrap_or_else(|| {
+                    MockResult::ok(mock_oauth_identity(&request.name, &request.identity_spec))
+                })
+                .into_tonic_result()?,
+        };
+        self.captured
+            .create_user_owned_identity
+            .lock()
+            .expect("create_user_owned_identity capture")
+            .push(request);
+        Ok(Response::new(mock_user_owned_identity_stream(identity)))
+    }
+
+    async fn list_user_owned_identities(
+        &self,
+        request: Request<ListUserOwnedIdentitiesRequest>,
+    ) -> Result<Response<ListUserOwnedIdentitiesResponse>, Status> {
+        self.captured
+            .list_user_owned_identities
+            .lock()
+            .expect("list_user_owned_identities capture")
+            .push(request.into_inner());
+        Ok(Response::new(
+            self.config
+                .list_user_owned_identities
+                .clone()
+                .into_tonic_result()?,
+        ))
+    }
+
+    async fn get_user_owned_identity(
+        &self,
+        request: Request<GetUserOwnedIdentityRequest>,
+    ) -> Result<Response<GetUserOwnedIdentityResponse>, Status> {
+        self.captured
+            .get_user_owned_identity
+            .lock()
+            .expect("get_user_owned_identity capture")
+            .push(request.into_inner());
+        Ok(Response::new(
+            self.config
+                .get_user_owned_identity
+                .clone()
+                .into_tonic_result()?,
+        ))
+    }
+
+    async fn delete_user_owned_identity(
+        &self,
+        request: Request<DeleteUserOwnedIdentityRequest>,
+    ) -> Result<Response<DeleteUserOwnedIdentityResponse>, Status> {
+        self.captured
+            .delete_user_owned_identity
+            .lock()
+            .expect("delete_user_owned_identity capture")
+            .push(request.into_inner());
+        self.config
+            .delete_user_owned_identity
+            .clone()
+            .into_tonic_result()?;
+        Ok(Response::new(DeleteUserOwnedIdentityResponse {}))
+    }
+}
+
+#[derive(Clone)]
 struct MockSourceService {
     config: Arc<MockServerConfig>,
     captured: Arc<Captured>,
@@ -996,8 +1296,13 @@ impl MockServer {
         let captured = Arc::new(Captured::default());
         let query_captured = Arc::clone(&captured);
         let catalog_captured = Arc::clone(&captured);
+        let identity_spec_captured = Arc::clone(&captured);
+        let identity_captured = Arc::clone(&captured);
         let source_captured = Arc::clone(&captured);
         let query_config = Arc::clone(&config);
+        let identity_spec_config = Arc::clone(&config);
+        let identity_config = Arc::clone(&config);
+        let source_config = Arc::clone(&config);
         let task = tokio::spawn(async move {
             Server::builder()
                 .add_service(CatalogServiceServer::new(MockCatalogService {
@@ -1007,8 +1312,16 @@ impl MockServer {
                     config: query_config,
                     captured: query_captured,
                 }))
+                .add_service(IdentitySpecServiceServer::new(MockIdentitySpecService {
+                    config: identity_spec_config,
+                    captured: identity_spec_captured,
+                }))
+                .add_service(IdentityServiceServer::new(MockIdentityService {
+                    config: identity_config,
+                    captured: identity_captured,
+                }))
                 .add_service(SourceServiceServer::new(MockSourceService {
-                    config,
+                    config: source_config,
                     captured: source_captured,
                 }))
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
@@ -1130,6 +1443,76 @@ impl MockServer {
             .import_source
             .lock()
             .expect("import_source capture")
+            .clone()
+    }
+
+    pub(crate) fn add_identity_spec_requests(&self) -> Vec<AddIdentitySpecRequest> {
+        self.captured
+            .add_identity_spec
+            .lock()
+            .expect("add_identity_spec capture")
+            .clone()
+    }
+
+    pub(crate) fn list_identity_specs_requests(&self) -> Vec<ListIdentitySpecsRequest> {
+        self.captured
+            .list_identity_specs
+            .lock()
+            .expect("list_identity_specs capture")
+            .clone()
+    }
+
+    pub(crate) fn get_identity_spec_requests(&self) -> Vec<GetIdentitySpecRequest> {
+        self.captured
+            .get_identity_spec
+            .lock()
+            .expect("get_identity_spec capture")
+            .clone()
+    }
+
+    pub(crate) fn delete_identity_spec_requests(&self) -> Vec<DeleteIdentitySpecRequest> {
+        self.captured
+            .delete_identity_spec
+            .lock()
+            .expect("delete_identity_spec capture")
+            .clone()
+    }
+
+    pub(crate) fn create_user_owned_identity_requests(
+        &self,
+    ) -> Vec<CreateUserOwnedIdentityRequest> {
+        self.captured
+            .create_user_owned_identity
+            .lock()
+            .expect("create_user_owned_identity capture")
+            .clone()
+    }
+
+    pub(crate) fn list_user_owned_identities_requests(
+        &self,
+    ) -> Vec<ListUserOwnedIdentitiesRequest> {
+        self.captured
+            .list_user_owned_identities
+            .lock()
+            .expect("list_user_owned_identities capture")
+            .clone()
+    }
+
+    pub(crate) fn get_user_owned_identity_requests(&self) -> Vec<GetUserOwnedIdentityRequest> {
+        self.captured
+            .get_user_owned_identity
+            .lock()
+            .expect("get_user_owned_identity capture")
+            .clone()
+    }
+
+    pub(crate) fn delete_user_owned_identity_requests(
+        &self,
+    ) -> Vec<DeleteUserOwnedIdentityRequest> {
+        self.captured
+            .delete_user_owned_identity
+            .lock()
+            .expect("delete_user_owned_identity capture")
             .clone()
     }
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -160,6 +160,99 @@ Remove an installed source.
 coral source remove github
 ```
 
+## `coral identity`
+
+Manage stored user-owned identities (see the
+[identity spec reference](/reference/identity-spec-reference) for what
+user-owned identities are and how DSL v4 sources resolve them).
+
+### `coral identity list`
+
+List stored user-owned identities.
+
+```shellscript
+coral identity list
+```
+
+### `coral identity info <NAME>`
+
+Show one stored user-owned identity without revealing credential material.
+
+```shellscript
+coral identity info github_local
+```
+
+### `coral identity add <NAME> --identity-spec <SPEC> [--token-stdin]`
+
+Create or replace a user-owned identity from an installed OAuth or fixed-token
+identity spec. For OAuth specs, Coral runs the spec's OAuth setup method. For
+fixed-token specs, Coral prompts for the bearer token by default, or reads it
+from stdin when `--token-stdin` is set. In both cases, Coral stores provider
+identity material for the local Coral user principal.
+
+```shellscript
+coral identity add github_local --identity-spec github_oauth
+printf '%s\n' "$GITHUB_TOKEN" | coral identity add github_pat --identity-spec github_pat --token-stdin
+```
+
+### `coral identity remove <NAME>`
+
+Remove one stored user-owned identity and its local credential material.
+
+```shellscript
+coral identity remove github_local
+```
+
+## `coral identity-spec`
+
+Manage global identity specs used by DSL v4 source `identity_requirements`.
+Identity specs are installed once for the local Coral app and are visible to all
+workspaces. Installing a spec does not instantiate an identity; use
+`coral identity add` for that.
+
+### `coral identity-spec list`
+
+List installed identity specs.
+
+```shellscript
+coral identity-spec list
+```
+
+### `coral identity-spec info <NAME>`
+
+Print one installed identity spec manifest.
+
+```shellscript
+coral identity-spec info github_oauth
+```
+
+### `coral identity-spec add --file <PATH>`
+
+Install one identity spec from a YAML file. If a spec with the same name already
+exists, Coral replaces it only when no stored identities reference it, or when
+the new manifest is equivalent to the installed manifest.
+
+If the identity spec declares `inputs`, `coral identity-spec add` collects those
+values when the spec is installed. In an interactive terminal Coral prompts for
+missing values; otherwise it reads environment variables matching the input
+keys. Secret inputs are stored as identity-spec material and are not stored on
+identities created from the spec.
+
+```shellscript
+coral identity-spec add --file ./github-oauth.identity.yaml
+```
+
+### `coral identity-spec remove <NAME>`
+
+Remove one installed identity spec. Stored identities that depend on the spec
+become orphaned (see
+[identity spec reference](/reference/identity-spec-reference)); when any exist,
+the command fails unless `--force` is passed.
+
+```shellscript
+coral identity-spec remove github_oauth --force
+```
+
 ## `coral onboard`
 
 Run the guided source setup flow.


### PR DESCRIPTION
## Intent

Land `feat(cli): add identity management commands` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-22-dsl-v4-fail-closed...sauldhernandez/dsl-v4-identity-v2-23-cli-identity-commands
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
