### PR TITLE
feat(app): support source spec aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "sqlparser 0.59.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1655,7 +1656,7 @@ dependencies = [
  "parquet",
  "rand 0.9.4",
  "regex",
- "sqlparser",
+ "sqlparser 0.61.0",
  "tempfile",
  "tokio",
  "url",
@@ -1731,7 +1732,7 @@ dependencies = [
  "parquet",
  "paste",
  "recursive",
- "sqlparser",
+ "sqlparser 0.61.0",
  "tokio",
  "web-time",
 ]
@@ -1932,7 +1933,7 @@ dependencies = [
  "paste",
  "recursive",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.61.0",
 ]
 
 [[package]]
@@ -2281,7 +2282,7 @@ dependencies = [
  "log",
  "recursive",
  "regex",
- "sqlparser",
+ "sqlparser 0.61.0",
 ]
 
 [[package]]
@@ -5218,13 +5219,35 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
+dependencies = [
+ "log",
+ "recursive",
+ "sqlparser_derive 0.3.0",
+]
+
+[[package]]
+name = "sqlparser"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
 dependencies = [
  "log",
  "recursive",
- "sqlparser_derive",
+ "sqlparser_derive 0.5.0",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -27,6 +27,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
+sqlparser = { workspace = true, features = ["visitor"] }
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { workspace = true, features = ["net"] }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::future::Future;
+use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -14,8 +15,13 @@ use coral_engine::{
     RuntimeIdentityRequirements, RuntimeSourceComponent, RuntimeSourcePackage,
     SelectedRequestIdentity, SourceValidationReport, StatusCode, TableInfo,
 };
-use coral_spec::{ManifestInputKind, ManifestInputSpec};
+use coral_spec::{ManifestInputKind, ManifestInputSpec, ValidatedSourceManifest};
 use opentelemetry::trace::Status as OtelStatus;
+use sqlparser::ast::{
+    ObjectName as SqlObjectName, ObjectNamePart as SqlObjectNamePart, visit_relations_mut,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
 use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
@@ -40,7 +46,9 @@ use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::incompatible_materialization_error;
 use crate::sources::model::InstalledSource;
-use crate::sources::runtime_package::runtime_components_for_v4_source;
+use crate::sources::runtime_package::{
+    runtime_components_for_v4_source, runtime_relation_namespace,
+};
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::workspaces::WorkspaceName;
 
@@ -345,6 +353,9 @@ impl QueryManager {
         let loaded_source = self
             .load_query_source(workspace_name, &source)
             .map_err(QueryManagerError::App)?;
+        let validation_test_queries = self
+            .source_validation_test_queries(workspace_name, &source)
+            .map_err(QueryManagerError::App)?;
         self.validate_source_identity_bindings(workspace_name, context.principal(), &loaded_source)
             .await
             .map_err(QueryManagerError::App)?;
@@ -362,7 +373,7 @@ impl QueryManager {
         let report = CoralQuery::validate_source(
             &loaded_source.query_source,
             runtime,
-            loaded_source.query_source.test_queries(),
+            &validation_test_queries,
         )
         .await
         .map_err(QueryManagerError::Core)?;
@@ -423,7 +434,13 @@ impl QueryManager {
                 v4,
             )?;
             Some(
-                runtime_components_for_v4_source(v4, &materialized).map_err(|error| {
+                runtime_components_for_v4_source(
+                    v4,
+                    &materialized,
+                    source.source_spec_id(),
+                    source.name.as_str(),
+                )
+                .map_err(|error| {
                     incompatible_materialization_error(
                         &source.name,
                         format!("failed to assemble runtime package: {error}"),
@@ -431,6 +448,13 @@ impl QueryManager {
                 })?,
             )
         } else {
+            if source.name.as_str() != source_spec.schema_name() {
+                return Err(AppError::FailedPrecondition(format!(
+                    "installed source alias '{}' for source spec '{}' requires DSL v4",
+                    source.name,
+                    source_spec.schema_name()
+                )));
+            }
             None
         };
         validate_required_variables(source, source_spec.declared_inputs())?;
@@ -470,7 +494,7 @@ impl QueryManager {
         let query_source = if let Some(components) = v4_runtime_components {
             QuerySource::from_runtime_components(
                 RuntimeSourcePackage {
-                    source_name: source_spec.schema_name().to_string(),
+                    source_name: source.name.as_str().to_string(),
                     authored_version: source_spec.source_version().map(ToString::to_string),
                     description: source_spec.description().to_string(),
                     declared_inputs: source_spec.declared_inputs().to_vec(),
@@ -489,6 +513,16 @@ impl QueryManager {
             version: installed.candidate.version,
             identity_bindings: source.identity_bindings.clone(),
         })
+    }
+
+    fn source_validation_test_queries(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<Vec<String>, AppError> {
+        let installed =
+            resolve_installed_manifest(workspace_name, source, self.artifact_store.as_ref())?;
+        validation_test_queries(&installed.source_spec, source)
     }
 
     fn request_identity_selector_and_factory(
@@ -612,6 +646,80 @@ fn identity_binding_snapshot_for_sources(
             )
         })
         .collect()
+}
+
+fn validation_test_queries(
+    source_spec: &ValidatedSourceManifest,
+    source: &InstalledSource,
+) -> Result<Vec<String>, AppError> {
+    let Some(v4) = source_spec.as_v4() else {
+        return Ok(source_spec.test_queries().to_vec());
+    };
+    if source.source_spec_id() == source.name.as_str() {
+        return Ok(source_spec.test_queries().to_vec());
+    }
+    let namespace_map = v4
+        .surfaces
+        .iter()
+        .map(|surface| {
+            (
+                surface.relation_namespace.clone(),
+                runtime_relation_namespace(
+                    &surface.relation_namespace,
+                    source.source_spec_id(),
+                    source.name.as_str(),
+                ),
+            )
+        })
+        .filter(|(authored, runtime)| authored != runtime)
+        .collect::<BTreeMap<_, _>>();
+    source_spec
+        .test_queries()
+        .iter()
+        .map(|sql| rewrite_query_namespaces(sql, &namespace_map))
+        .collect()
+}
+
+fn rewrite_query_namespaces(
+    sql: &str,
+    namespace_map: &BTreeMap<String, String>,
+) -> Result<String, AppError> {
+    if namespace_map.is_empty() {
+        return Ok(sql.to_string());
+    }
+    let dialect = GenericDialect;
+    let mut statements = Parser::parse_sql(&dialect, sql).map_err(|error| {
+        AppError::InvalidInput(format!("source test query is invalid: {error}"))
+    })?;
+    match visit_relations_mut(&mut statements, |relation| {
+        rewrite_relation_namespace(relation, namespace_map);
+        ControlFlow::<()>::Continue(())
+    }) {
+        ControlFlow::Continue(()) => {}
+        ControlFlow::Break(()) => unreachable!("query namespace rewrite never breaks traversal"),
+    }
+    Ok(statements
+        .into_iter()
+        .map(|statement| statement.to_string())
+        .collect::<Vec<_>>()
+        .join("; "))
+}
+
+fn rewrite_relation_namespace(
+    relation: &mut SqlObjectName,
+    namespace_map: &BTreeMap<String, String>,
+) {
+    if relation.0.len() < 2 {
+        return;
+    }
+    let namespace_index = relation.0.len() - 2;
+    let Some(SqlObjectNamePart::Identifier(namespace)) = relation.0.get_mut(namespace_index) else {
+        return;
+    };
+    let Some(runtime_namespace) = namespace_map.get(&namespace.value) else {
+        return;
+    };
+    namespace.value.clone_from(runtime_namespace);
 }
 
 #[derive(Clone)]
@@ -1316,6 +1424,33 @@ mod tests {
         serde_json::from_slice(&bytes).expect("json rows should decode")
     }
 
+    fn issues_openapi_fixture(server_uri: impl std::fmt::Display) -> String {
+        format!(
+            r"
+openapi: 3.0.3
+info:
+  title: GitHub
+servers:
+  - url: {server_uri}
+paths:
+  /issues:
+    get:
+      operationId: issues/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {{type: integer}}
+                    title: {{type: string}}
+"
+        )
+    }
+
     #[test]
     fn runtime_config_preserves_app_owned_body_capture_max_bytes() {
         let fixture = query_manager_with(
@@ -1594,6 +1729,7 @@ tables:
         .expect("write manifest");
         let source = InstalledSource {
             name: source_name.clone(),
+            source_spec_id: None,
             version: Some("0.1.0".to_string()),
             variables: BTreeMap::new(),
             secrets: vec!["API_KEY".to_string(), "OAUTH_TOKEN".to_string()],
@@ -1725,6 +1861,213 @@ surfaces:
         );
     }
 
+    #[tokio::test]
+    async fn aliased_v4_source_queries_and_validates_through_installed_source_name() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/issues"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {"id": 7, "title": "Aliased runtime package"}
+            ])))
+            .mount(&server)
+            .await;
+
+        let fixture = query_manager_with_features(
+            QueryRuntimeContext::default(),
+            Vec::new(),
+            dsl_v4_features(),
+        );
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let source_manager = SourceManager::new_with_features(
+            fixture.manager.config_store.clone(),
+            fixture.manager.credential_manager.clone(),
+            fixture.manager.layout.clone(),
+            dsl_v4_features(),
+        );
+        let workspace_name = WorkspaceName::default();
+        let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
+        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
+        std::fs::write(
+            &openapi_file,
+            format!(
+                r"
+openapi: 3.0.3
+info:
+  title: GitHub
+servers:
+  - url: {}
+paths:
+  /issues:
+    get:
+      operationId: issues/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {{type: integer}}
+                    title: {{type: string}}
+",
+                server.uri()
+            ),
+        )
+        .expect("write OpenAPI fixture");
+        let source_name = SourceName::parse("github_alias").expect("source alias");
+        let source_spec_id = SourceName::parse("github_v4_query").expect("source spec");
+        source_manager
+            .import_source_as(
+                &workspace_name,
+                &source_name,
+                &source_spec_id,
+                &ImportSourceCommand {
+                    manifest_yaml: format!(
+                        r"
+name: github_v4_query
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+test_queries:
+  - SELECT id, title FROM github_v4_query.issues
+",
+                        openapi_file.display()
+                    ),
+                    bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
+                },
+            )
+            .expect("import v4 source alias");
+
+        fixture
+            .manager
+            .validate_source(&workspace_name, &UserPrincipal::local(), &source_name)
+            .await
+            .expect("authored validation query is rewritten to installed alias");
+        let execution = fixture
+            .manager
+            .execute_sql(
+                &workspace_name,
+                "SELECT id, title FROM github_alias.issues",
+                &QueryAttribution::default(),
+            )
+            .await
+            .expect("query executes through installed alias");
+
+        assert_eq!(
+            execution_to_rows(&execution),
+            vec![json!({"id": 7, "title": "Aliased runtime package"})]
+        );
+    }
+
+    #[tokio::test]
+    async fn aliased_v4_source_runtime_load_keeps_authored_test_queries_unparsed() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/issues"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {"id": 9, "title": "Runtime ignores invalid validation SQL"}
+            ])))
+            .mount(&server)
+            .await;
+
+        let fixture = query_manager_with_features(
+            QueryRuntimeContext::default(),
+            Vec::new(),
+            dsl_v4_features(),
+        );
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let source_manager = SourceManager::new_with_features(
+            fixture.manager.config_store.clone(),
+            fixture.manager.credential_manager.clone(),
+            fixture.manager.layout.clone(),
+            dsl_v4_features(),
+        );
+        let workspace_name = WorkspaceName::default();
+        let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
+        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
+        std::fs::write(&openapi_file, issues_openapi_fixture(server.uri()))
+            .expect("write OpenAPI fixture");
+        let source_name = SourceName::parse("github_alias").expect("source alias");
+        let source_spec_id = SourceName::parse("github_v4_query").expect("source spec");
+        source_manager
+            .import_source_as(
+                &workspace_name,
+                &source_name,
+                &source_spec_id,
+                &ImportSourceCommand {
+                    manifest_yaml: format!(
+                        r"
+name: github_v4_query
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+test_queries:
+  - SELECT * FROM github_v4_query.issues WHERE
+",
+                        openapi_file.display()
+                    ),
+                    bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
+                },
+            )
+            .expect("import v4 source alias");
+
+        let execution = fixture
+            .manager
+            .execute_sql(
+                &workspace_name,
+                "SELECT id, title FROM github_alias.issues",
+                &QueryAttribution::default(),
+            )
+            .await
+            .expect("query executes without parsing validation SQL during runtime load");
+        assert_eq!(
+            execution_to_rows(&execution),
+            vec![json!({"id": 9, "title": "Runtime ignores invalid validation SQL"})]
+        );
+
+        let validation_result = fixture
+            .manager
+            .validate_source(&workspace_name, &UserPrincipal::local(), &source_name)
+            .await;
+        assert!(
+            validation_result.is_err(),
+            "validation should parse and reject invalid validation SQL"
+        );
+    }
+
+    #[test]
+    fn rewrite_query_namespaces_updates_relations_without_touching_literals() {
+        let namespace_map = BTreeMap::from([
+            ("github_v4".to_string(), "github".to_string()),
+            ("github_v4_mcp".to_string(), "github_mcp".to_string()),
+        ]);
+
+        let rewritten_table = rewrite_query_namespaces(
+            "SELECT id FROM github_v4.issues WHERE note = 'github_v4.issues'",
+            &namespace_map,
+        )
+        .expect("rewrite table query");
+        assert!(rewritten_table.contains("FROM github.issues"));
+        assert!(rewritten_table.contains("'github_v4.issues'"));
+
+        let rewritten_function = rewrite_query_namespaces(
+            "SELECT result FROM github_v4_mcp.list_pull_requests('withcoral')",
+            &namespace_map,
+        )
+        .expect("rewrite table function query");
+        assert!(rewritten_function.contains("github_mcp.list_pull_requests"));
+    }
+
     #[test]
     fn load_query_source_rejects_v4_when_dsl_v4_feature_is_disabled() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
@@ -1751,6 +2094,7 @@ surfaces:
         .expect("write manifest");
         let source = InstalledSource {
             name: source_name,
+            source_spec_id: None,
             version: None,
             variables: BTreeMap::new(),
             secrets: Vec::new(),
@@ -1820,6 +2164,7 @@ surfaces:
                 &workspace_name,
                 InstalledSource {
                     name: source_name.clone(),
+                    source_spec_id: None,
                     version: None,
                     variables: BTreeMap::new(),
                     secrets: Vec::new(),
@@ -1875,6 +2220,7 @@ surfaces:
                 &workspace_name,
                 InstalledSource {
                     name: source_name,
+                    source_spec_id: None,
                     version: None,
                     variables: BTreeMap::new(),
                     secrets: Vec::new(),
@@ -1910,6 +2256,7 @@ surfaces:
                 &workspace_name,
                 InstalledSource {
                     name: source_name,
+                    source_spec_id: None,
                     version: None,
                     variables: BTreeMap::new(),
                     secrets: vec!["GITHUB_TOKEN".to_string()],
@@ -1991,6 +2338,7 @@ surfaces:
     fn installed_api_token_source(source_name: SourceName) -> InstalledSource {
         InstalledSource {
             name: source_name,
+            source_spec_id: None,
             version: None,
             variables: BTreeMap::new(),
             secrets: vec!["API_TOKEN".to_string()],
@@ -2043,7 +2391,10 @@ tables:
             layout.clone(),
             Arc::new(LocalSourceArtifactStore::new(layout)),
             Vec::new(),
-            QueryManagerOptions::default(),
+            QueryManagerOptions {
+                features: Features::default(),
+                source_identity_providers: Vec::new(),
+            },
         )
     }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1943,19 +1943,19 @@ test_queries:
                 },
             )
             .expect("import v4 source alias");
+        let query_context = QueryContext::new(
+            workspace_name.clone(),
+            RequestContext::with_attribution(UserPrincipal::local(), QueryAttribution::default()),
+        );
 
         fixture
             .manager
-            .validate_source(&workspace_name, &UserPrincipal::local(), &source_name)
+            .validate_source(&query_context, &source_name)
             .await
             .expect("authored validation query is rewritten to installed alias");
         let execution = fixture
             .manager
-            .execute_sql(
-                &workspace_name,
-                "SELECT id, title FROM github_alias.issues",
-                &QueryAttribution::default(),
-            )
+            .execute_sql(&query_context, "SELECT id, title FROM github_alias.issues")
             .await
             .expect("query executes through installed alias");
 
@@ -2020,14 +2020,14 @@ test_queries:
                 },
             )
             .expect("import v4 source alias");
+        let query_context = QueryContext::new(
+            workspace_name.clone(),
+            RequestContext::with_attribution(UserPrincipal::local(), QueryAttribution::default()),
+        );
 
         let execution = fixture
             .manager
-            .execute_sql(
-                &workspace_name,
-                "SELECT id, title FROM github_alias.issues",
-                &QueryAttribution::default(),
-            )
+            .execute_sql(&query_context, "SELECT id, title FROM github_alias.issues")
             .await
             .expect("query executes without parsing validation SQL during runtime load");
         assert_eq!(
@@ -2037,7 +2037,7 @@ test_queries:
 
         let validation_result = fixture
             .manager
-            .validate_source(&workspace_name, &UserPrincipal::local(), &source_name)
+            .validate_source(&query_context, &source_name)
             .await;
         assert!(
             validation_result.is_err(),

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1206,6 +1206,7 @@ mod tests {
     ) -> InstalledSource {
         InstalledSource {
             name: name.clone(),
+            source_spec_id: None,
             version: None,
             variables: BTreeMap::new(),
             secrets: secrets.into_iter().map(ToString::to_string).collect(),

--- a/crates/coral-app/src/source_management.rs
+++ b/crates/coral-app/src/source_management.rs
@@ -8,6 +8,7 @@ use crate::sources::SourceName;
 use crate::sources::manager::{
     ImportSourceCommand as ManagerImportSourceCommand, SourceBinding, SourceBindings, SourceManager,
 };
+use crate::sources::model::InstalledSource;
 use crate::workspaces::WorkspaceName;
 
 /// Source import command accepted by [`SourceManagementHandle`].
@@ -53,26 +54,37 @@ impl SourceManagementHandle {
         command: ImportManagedSourceCommand,
     ) -> Result<ManagedSource, AppError> {
         let workspace_name = WorkspaceName::parse(workspace_id)?;
-        let installed = self.sources.import_source(
+        let installed = self
+            .sources
+            .import_source(&workspace_name, &manager_import_command(command))?;
+        Ok(managed_source_from_installed(installed))
+    }
+
+    /// Imports a source under a workspace-local name while preserving the
+    /// authored source-spec id declared by the manifest.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the workspace/source input is invalid, when
+    /// the manifest name does not match `source_spec_id`, or when source
+    /// installation fails.
+    pub fn import_source_as(
+        &self,
+        workspace_id: &str,
+        source_name: &str,
+        source_spec_id: &str,
+        command: ImportManagedSourceCommand,
+    ) -> Result<ManagedSource, AppError> {
+        let workspace_name = WorkspaceName::parse(workspace_id)?;
+        let source_name = SourceName::parse(source_name)?;
+        let source_spec_id = SourceName::parse(source_spec_id)?;
+        let installed = self.sources.import_source_as(
             &workspace_name,
-            &ManagerImportSourceCommand {
-                manifest_yaml: command.manifest_yaml,
-                bindings: SourceBindings {
-                    variables: command
-                        .variables
-                        .into_iter()
-                        .map(|(key, value)| SourceBinding { key, value })
-                        .collect(),
-                    secrets: Vec::new(),
-                },
-                identity_bindings: command.identity_bindings,
-                replace_identity_bindings: command.replace_identity_bindings,
-            },
+            &source_name,
+            &source_spec_id,
+            &manager_import_command(command),
         )?;
-        Ok(ManagedSource {
-            name: installed.name.as_str().to_string(),
-            version: installed.version,
-        })
+        Ok(managed_source_from_installed(installed))
     }
 
     /// Deletes a source from a workspace using the shared source lifecycle.
@@ -93,6 +105,29 @@ impl SourceManagementHandle {
             name: removed.name.as_str().to_string(),
             version: removed.version,
         })
+    }
+}
+
+fn manager_import_command(command: ImportManagedSourceCommand) -> ManagerImportSourceCommand {
+    ManagerImportSourceCommand {
+        manifest_yaml: command.manifest_yaml,
+        bindings: SourceBindings {
+            variables: command
+                .variables
+                .into_iter()
+                .map(|(key, value)| SourceBinding { key, value })
+                .collect(),
+            secrets: Vec::new(),
+        },
+        identity_bindings: command.identity_bindings,
+        replace_identity_bindings: command.replace_identity_bindings,
+    }
+}
+
+fn managed_source_from_installed(installed: InstalledSource) -> ManagedSource {
+    ManagedSource {
+        name: installed.name.as_str().to_string(),
+        version: installed.version,
     }
 }
 

--- a/crates/coral-app/src/source_registry.rs
+++ b/crates/coral-app/src/source_registry.rs
@@ -203,6 +203,11 @@ pub struct SourceRegistryRecord {
     pub workspace_id: String,
     /// Installed source name.
     pub source_name: String,
+    /// Authored source-spec id declared by the manifest.
+    ///
+    /// When absent, registries should treat `source_name` as the source-spec id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_spec_id: Option<String>,
     /// Persisted source version, when applicable.
     pub version: Option<String>,
     /// Imported source manifest YAML.
@@ -253,6 +258,7 @@ pub(crate) fn record_from_installed_source(
     SourceRegistryRecord {
         workspace_id: workspace_name.as_str().to_string(),
         source_name: source.name.as_str().to_string(),
+        source_spec_id: source.source_spec_id,
         version: source.version,
         manifest_yaml: None,
         variables: source.variables,
@@ -274,9 +280,14 @@ pub(crate) fn installed_source_from_record(
         )));
     }
     let source_name = SourceName::parse(&record.source_name)?;
+    let source_spec_id = record
+        .source_spec_id
+        .map(|id| SourceName::parse(&id).map(|parsed| parsed.as_str().to_string()))
+        .transpose()?;
     validate_registry_identity_bindings(source_name.as_str(), &record.identity_bindings)?;
     Ok(InstalledSource {
         name: source_name,
+        source_spec_id,
         version: record.version,
         variables: record.variables,
         secrets: record.secrets,

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -66,7 +66,10 @@ pub(crate) fn resolve_installed_manifest(
     artifacts: &dyn SourceArtifactStore,
 ) -> Result<InstalledSourceManifest, AppError> {
     let manifest_yaml = match source.origin {
-        SourceOrigin::Bundled => load_bundled_source(&source.name)?.manifest_yaml,
+        SourceOrigin::Bundled => {
+            let source_spec_id = SourceName::parse(source.source_spec_id())?;
+            load_bundled_source(&source_spec_id)?.manifest_yaml
+        }
         SourceOrigin::Imported => artifacts
             .read_manifest_artifact(workspace_name.as_str(), source.name.as_str())?
             .ok_or_else(|| {
@@ -82,12 +85,15 @@ pub(crate) fn resolve_installed_manifest(
     let source_spec = parse_source_manifest_yaml(&manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;
     let mut candidate = candidate_from_manifest(&source_spec, source.origin, false)?;
-    if candidate.name != source.name {
+    if candidate.name.as_str() != source.source_spec_id() {
         return Err(AppError::FailedPrecondition(format!(
-            "installed source '{}' does not match manifest name '{}'",
-            source.name, candidate.name
+            "installed source '{}' references source spec '{}' but manifest declares '{}'",
+            source.name,
+            source.source_spec_id(),
+            candidate.name
         )));
     }
+    candidate.name = source.name.clone();
     candidate.installed = true;
     candidate.credential_storage = Some(source.effective_credential_storage());
     Ok(InstalledSourceManifest {

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -33,6 +33,7 @@ use crate::sources::materialization::{
     canonicalize_file_descriptor, cleanup_materialization_tmp, new_materialization_suffix,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
+use crate::sources::runtime_package::runtime_relation_namespace;
 use crate::state::AppStateLayout;
 #[cfg(test)]
 use crate::state::ConfigStore;
@@ -160,6 +161,7 @@ struct PersistSourceRequest<'a> {
     manifest_yaml: Option<&'a str>,
     bindings: ValidatedBindings,
     identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+    source_spec_id: &'a SourceName,
     origin: SourceOrigin,
     credential_storage: Option<CredentialStorageKind>,
     materialization_tmp: Option<PathBuf>,
@@ -391,6 +393,7 @@ impl SourceManager {
             &candidate,
             &command.bindings,
             BTreeMap::new(),
+            &candidate.name,
             None,
             &bundled.manifest_yaml,
             SourceOrigin::Bundled,
@@ -412,6 +415,7 @@ impl SourceManager {
             command.oauth_credential_retrievals,
             events,
             BTreeMap::new(),
+            &candidate.name,
             None,
             &bundled.manifest_yaml,
             SourceOrigin::Bundled,
@@ -424,11 +428,44 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         command: &ImportSourceCommand,
     ) -> Result<InstalledSource, AppError> {
+        self.import_source_with_names(workspace_name, command, None, None)
+    }
+
+    pub(crate) fn import_source_as(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        source_spec_id: &SourceName,
+        command: &ImportSourceCommand,
+    ) -> Result<InstalledSource, AppError> {
+        self.import_source_with_names(
+            workspace_name,
+            command,
+            Some(source_name),
+            Some(source_spec_id),
+        )
+    }
+
+    fn import_source_with_names(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: &ImportSourceCommand,
+        installed_source_name: Option<&SourceName>,
+        expected_source_spec_id: Option<&SourceName>,
+    ) -> Result<InstalledSource, AppError> {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         self.ensure_dsl_v4_enabled_for_manifest(&manifest)?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
+        let source_spec_id = expected_source_spec_id
+            .cloned()
+            .unwrap_or_else(|| candidate.name.clone());
+        ensure_manifest_source_spec_matches(&manifest, &source_spec_id)?;
+        if let Some(source_name) = installed_source_name {
+            ensure_source_alias_supported(&manifest, source_name, &source_spec_id)?;
+            candidate.name = source_name.clone();
+        }
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         let identity_bindings = self.effective_source_identity_bindings(
             workspace_name,
@@ -442,6 +479,7 @@ impl SourceManager {
             &candidate,
             &command.bindings,
             identity_bindings,
+            &source_spec_id,
             Some(&manifest_yaml),
             &manifest_yaml,
             SourceOrigin::Imported,
@@ -459,6 +497,7 @@ impl SourceManager {
         self.ensure_dsl_v4_enabled_for_manifest(&manifest)?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
+        let source_spec_id = candidate.name.clone();
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         let identity_bindings = self.effective_source_identity_bindings(
             workspace_name,
@@ -474,6 +513,7 @@ impl SourceManager {
             command.oauth_credential_retrievals,
             events,
             identity_bindings,
+            &source_spec_id,
             Some(&manifest_yaml),
             &manifest_yaml,
             SourceOrigin::Imported,
@@ -495,6 +535,7 @@ impl SourceManager {
         candidate: &CandidateSource,
         bindings: &SourceBindings,
         identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+        source_spec_id: &SourceName,
         manifest_yaml: Option<&str>,
         materialization_manifest_yaml: &str,
         origin: SourceOrigin,
@@ -503,6 +544,7 @@ impl SourceManager {
         self.validate_runtime_schema_names_available(
             workspace_name,
             &candidate.name,
+            source_spec_id,
             materialization_manifest_yaml,
         )?;
         let stored_material = self.source_stored_material_for_validation(
@@ -527,6 +569,7 @@ impl SourceManager {
                 manifest_yaml,
                 bindings,
                 identity_bindings,
+                source_spec_id,
                 origin,
                 credential_storage,
                 materialization_tmp: self
@@ -559,6 +602,7 @@ impl SourceManager {
         oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
         events: ImportSourceEventSender,
         identity_bindings: BTreeMap<String, SourceIdentityBinding>,
+        source_spec_id: &SourceName,
         manifest_yaml: Option<&str>,
         materialization_manifest_yaml: &str,
         origin: SourceOrigin,
@@ -567,6 +611,7 @@ impl SourceManager {
         self.validate_runtime_schema_names_available(
             workspace_name,
             &candidate.name,
+            source_spec_id,
             materialization_manifest_yaml,
         )?;
         let oauth_input_keys = oauth_credential_retrievals
@@ -605,6 +650,7 @@ impl SourceManager {
                 manifest_yaml,
                 bindings,
                 identity_bindings,
+                source_spec_id,
                 origin,
                 credential_storage,
                 materialization_tmp: self
@@ -879,6 +925,8 @@ impl SourceManager {
         };
         let stored = InstalledSource {
             name: source_name.clone(),
+            source_spec_id: (request.source_spec_id.as_str() != source_name.as_str())
+                .then(|| request.source_spec_id.as_str().to_string()),
             version: persisted_version,
             variables,
             secrets: visible_secret_keys,
@@ -975,11 +1023,13 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         candidate_name: &SourceName,
+        source_spec_id: &SourceName,
         manifest_yaml: &str,
     ) -> Result<(), AppError> {
         let candidate_manifest = parse_source_manifest_yaml(manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
-        let candidate_schema_names = runtime_schema_names(&candidate_manifest);
+        let candidate_schema_names =
+            runtime_schema_names(&candidate_manifest, source_spec_id, candidate_name);
         for installed in self.list_registry_sources(workspace_name)? {
             if installed.name == *candidate_name {
                 continue;
@@ -989,7 +1039,18 @@ impl SourceManager {
                 &installed,
                 self.artifact_store.as_ref(),
             )?;
-            let installed_schema_names = runtime_schema_names(&installed_manifest.source_spec);
+            let installed_source_spec_id =
+                SourceName::parse(installed.source_spec_id()).map_err(|error| {
+                    AppError::InvalidInput(format!(
+                        "source '{}' has invalid source spec id: {error}",
+                        installed.name
+                    ))
+                })?;
+            let installed_schema_names = runtime_schema_names(
+                &installed_manifest.source_spec,
+                &installed_source_spec_id,
+                &installed.name,
+            );
             if let Some(schema_name) = candidate_schema_names
                 .intersection(&installed_schema_names)
                 .next()
@@ -1485,6 +1546,35 @@ fn validate_import_identity_bindings(
     Ok(())
 }
 
+fn ensure_manifest_source_spec_matches(
+    manifest: &ValidatedSourceManifest,
+    source_spec_id: &SourceName,
+) -> Result<(), AppError> {
+    if manifest.schema_name() == source_spec_id.as_str() {
+        return Ok(());
+    }
+    Err(AppError::InvalidInput(format!(
+        "source spec id '{source_spec_id}' does not match manifest name '{}'",
+        manifest.schema_name()
+    )))
+}
+
+fn ensure_source_alias_supported(
+    manifest: &ValidatedSourceManifest,
+    source_name: &SourceName,
+    source_spec_id: &SourceName,
+) -> Result<(), AppError> {
+    if source_name == source_spec_id {
+        return Ok(());
+    }
+    if manifest.as_v4().is_some() {
+        return Ok(());
+    }
+    Err(AppError::InvalidInput(format!(
+        "source alias '{source_name}' for source spec '{source_spec_id}' requires DSL v4"
+    )))
+}
+
 fn source_needs_stored_material_for_validation(
     candidate: &CandidateSource,
     bindings: &SourceBindings,
@@ -1646,12 +1736,22 @@ fn normalize_binding_key(label: &str, value: &str) -> Result<String, AppError> {
     Ok(trimmed.to_string())
 }
 
-fn runtime_schema_names(manifest: &ValidatedSourceManifest) -> BTreeSet<String> {
+fn runtime_schema_names(
+    manifest: &ValidatedSourceManifest,
+    source_spec_id: &SourceName,
+    runtime_source_name: &SourceName,
+) -> BTreeSet<String> {
     if let Some(v4) = manifest.as_v4() {
         return v4
             .surfaces
             .iter()
-            .map(|surface| surface.relation_namespace.clone())
+            .map(|surface| {
+                runtime_relation_namespace(
+                    &surface.relation_namespace,
+                    source_spec_id.as_str(),
+                    runtime_source_name.as_str(),
+                )
+            })
             .collect();
     }
     BTreeSet::from([manifest.schema_name().to_string()])
@@ -2214,6 +2314,7 @@ tables:
                 &default_workspace(),
                 InstalledSource {
                     name: candidate.name.clone(),
+                    source_spec_id: None,
                     version: None,
                     variables: BTreeMap::new(),
                     secrets: vec!["OTHER_TOKEN".to_string()],
@@ -2431,6 +2532,92 @@ tables:
             .get_source_info(&default_workspace(), &source_name)
             .expect("installed v4 source should be usable");
         assert_eq!(info.name.as_str(), "github_v4_test");
+    }
+
+    #[test]
+    fn import_v4_source_can_install_under_alias() {
+        let temp = TempDir::new().expect("temp dir");
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
+        std::fs::write(&openapi_file, v4_openapi_fixture()).expect("write fixture");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let manager = SourceManager::new_with_features(
+            config_store,
+            credential_manager,
+            layout.clone(),
+            dsl_v4_features(),
+        );
+        let source_name = SourceName::parse("github_alias").expect("source alias");
+        let source_spec_id = SourceName::parse("github_v4_test").expect("source spec");
+
+        let installed = manager
+            .import_source_as(
+                &default_workspace(),
+                &source_name,
+                &source_spec_id,
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_v4_with_file_descriptor(&openapi_file),
+                    bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
+                },
+            )
+            .expect("import v4 source under alias");
+
+        assert_eq!(installed.name.as_str(), "github_alias");
+        assert_eq!(installed.source_spec_id.as_deref(), Some("github_v4_test"));
+        assert!(
+            layout
+                .v4_materialized_dir(&default_workspace(), &source_name)
+                .join("fingerprint.yaml")
+                .exists()
+        );
+        let stored = manager
+            .get_source(&default_workspace(), &source_name)
+            .expect("stored source");
+        assert_eq!(stored.source_spec_id.as_deref(), Some("github_v4_test"));
+        let stored_manifest =
+            std::fs::read_to_string(layout.manifest_file(&default_workspace(), &source_name))
+                .expect("stored manifest");
+        assert!(
+            stored_manifest.contains("name: github_v4_test"),
+            "stored manifest should preserve authored source-spec id: {stored_manifest}"
+        );
+    }
+
+    #[test]
+    fn import_source_rejects_alias_for_non_v4_manifest() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let manager =
+            SourceManager::new(ConfigStore::new(layout.clone()), credential_manager, layout);
+        let source_name = SourceName::parse("public_alias").expect("source alias");
+        let source_spec_id = SourceName::parse("public_messages").expect("source spec");
+
+        let error = manager
+            .import_source_as(
+                &default_workspace(),
+                &source_name,
+                &source_spec_id,
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_without_secrets(),
+                    bindings: SourceBindings::default(),
+                    identity_bindings: BTreeMap::new(),
+                    replace_identity_bindings: false,
+                },
+            )
+            .expect_err("non-v4 alias should be rejected");
+
+        assert!(
+            error.to_string().contains("requires DSL v4"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -26,6 +26,12 @@ pub(crate) struct CandidateSource {
 pub(crate) struct InstalledSource {
     /// Bare installed source name.
     pub(crate) name: SourceName,
+    /// Authored source-spec id declared by the manifest.
+    ///
+    /// When absent, the installed source name is also the source-spec id. This
+    /// preserves older local config records and bundled sources.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) source_spec_id: Option<String>,
     /// Persisted manifest version when it should live in app state.
     ///
     /// Bundled sources resolve their manifest directly from the compiled-in
@@ -52,6 +58,12 @@ pub(crate) struct InstalledSource {
 }
 
 impl InstalledSource {
+    pub(crate) fn source_spec_id(&self) -> &str {
+        self.source_spec_id
+            .as_deref()
+            .unwrap_or_else(|| self.name.as_str())
+    }
+
     pub(crate) fn effective_credential_storage(&self) -> CredentialStorageKind {
         self.credential_storage
             .unwrap_or(CredentialStorageKind::File)

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -23,6 +23,8 @@ use crate::bootstrap::AppError;
 pub(crate) fn runtime_components_for_v4_source(
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
+    source_spec_id: &str,
+    runtime_source_name: &str,
 ) -> Result<Vec<RuntimeSourceComponent>, AppError> {
     let mut components = Vec::new();
     for surface in &manifest.surfaces {
@@ -31,7 +33,13 @@ pub(crate) fn runtime_components_for_v4_source(
         }
         match surface.surface_type {
             SurfaceType::OpenApi => {
-                let http_manifest = http_manifest_for_surface(manifest, materialized, &surface.id)?;
+                let http_manifest = http_manifest_for_surface(
+                    manifest,
+                    materialized,
+                    &surface.id,
+                    source_spec_id,
+                    runtime_source_name,
+                )?;
                 let http_component =
                     if let Some(identity_requirements) = surface.identity_requirements.clone() {
                         RuntimeHttpSourceComponent::with_identity_requirements(
@@ -49,6 +57,8 @@ pub(crate) fn runtime_components_for_v4_source(
                     manifest,
                     materialized,
                     &surface.id,
+                    source_spec_id,
+                    runtime_source_name,
                 )?));
             }
         }
@@ -71,6 +81,8 @@ fn http_manifest_for_surface(
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
     surface_id: &str,
+    source_spec_id: &str,
+    runtime_source_name: &str,
 ) -> Result<HttpSourceManifest, AppError> {
     let surface = manifest.surface(surface_id).ok_or_else(|| {
         AppError::FailedPrecondition(format!("DSL v4 manifest is missing surface '{surface_id}'"))
@@ -154,13 +166,12 @@ fn http_manifest_for_surface(
         }
     }
     Ok(HttpSourceManifest {
-        common: SourceManifestCommon {
-            dsl_version: manifest.common.dsl_version,
-            name: surface.relation_namespace.clone(),
-            version: String::new(),
-            description: manifest.common.description.clone(),
-            test_queries: Vec::new(),
-        },
+        common: runtime_source_common(
+            manifest,
+            &surface.relation_namespace,
+            source_spec_id,
+            runtime_source_name,
+        ),
         base_url: surface_base_url(manifest, surface, materialized_surface)?,
         auth: openapi_runtime.auth.clone(),
         request_headers: openapi_runtime.request_headers.clone(),
@@ -187,6 +198,8 @@ fn mcp_manifest_for_surface(
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
     surface_id: &str,
+    source_spec_id: &str,
+    runtime_source_name: &str,
 ) -> Result<McpSourceManifest, AppError> {
     let surface = manifest.surface(surface_id).ok_or_else(|| {
         AppError::FailedPrecondition(format!("DSL v4 manifest is missing surface '{surface_id}'"))
@@ -251,18 +264,52 @@ fn mcp_manifest_for_surface(
         }
     }
     Ok(McpSourceManifest {
-        common: SourceManifestCommon {
-            dsl_version: manifest.common.dsl_version,
-            name: surface.relation_namespace.clone(),
-            version: String::new(),
-            description: manifest.common.description.clone(),
-            test_queries: Vec::new(),
-        },
+        common: runtime_source_common(
+            manifest,
+            &surface.relation_namespace,
+            source_spec_id,
+            runtime_source_name,
+        ),
         server: mcp_runtime.server.clone(),
         functions,
         tables,
         declared_inputs: manifest.declared_inputs.clone(),
     })
+}
+
+fn runtime_source_common(
+    manifest: &V4SourceManifest,
+    authored_namespace: &str,
+    source_spec_id: &str,
+    runtime_source_name: &str,
+) -> SourceManifestCommon {
+    SourceManifestCommon {
+        dsl_version: manifest.common.dsl_version,
+        name: runtime_relation_namespace(authored_namespace, source_spec_id, runtime_source_name),
+        version: String::new(),
+        description: manifest.common.description.clone(),
+        test_queries: Vec::new(),
+    }
+}
+
+pub(crate) fn runtime_relation_namespace(
+    authored_namespace: &str,
+    source_spec_id: &str,
+    runtime_source_name: &str,
+) -> String {
+    if source_spec_id == runtime_source_name {
+        return authored_namespace.to_string();
+    }
+    if authored_namespace == source_spec_id {
+        return runtime_source_name.to_string();
+    }
+    let source_spec_prefix = format!("{source_spec_id}_");
+    authored_namespace
+        .strip_prefix(&source_spec_prefix)
+        .map_or_else(
+            || authored_namespace.to_string(),
+            |suffix| format!("{runtime_source_name}_{suffix}"),
+        )
 }
 
 fn mcp_table_spec(
@@ -611,7 +658,8 @@ mod tests {
         };
 
         let components =
-            runtime_components_for_v4_source(&manifest, &materialized).expect("runtime components");
+            runtime_components_for_v4_source(&manifest, &materialized, "github_v4", "github_v4")
+                .expect("runtime components");
         let schema_names = components
             .iter()
             .map(coral_engine::RuntimeSourceComponent::source_name)
@@ -668,7 +716,8 @@ mod tests {
         };
 
         let components =
-            runtime_components_for_v4_source(&manifest, &materialized).expect("runtime components");
+            runtime_components_for_v4_source(&manifest, &materialized, "github_v4", "github_v4")
+                .expect("runtime components");
         let coral_engine::RuntimeSourceComponent::Mcp(mcp) =
             components.first().expect("mcp component")
         else {
@@ -733,7 +782,8 @@ mod tests {
         };
 
         let components =
-            runtime_components_for_v4_source(&manifest, &materialized).expect("runtime components");
+            runtime_components_for_v4_source(&manifest, &materialized, "github_v4", "github_v4")
+                .expect("runtime components");
         let coral_engine::RuntimeSourceComponent::Mcp(mcp) =
             components.first().expect("mcp component")
         else {

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -173,6 +173,8 @@ struct PersistedWorkspaceConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PersistedInstalledSource {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_spec_id: Option<String>,
     #[serde(default)]
     version: Option<String>,
     #[serde(default)]
@@ -189,8 +191,13 @@ struct PersistedInstalledSource {
 impl PersistedInstalledSource {
     fn into_installed_source(self, source_name: SourceName) -> Result<InstalledSource, AppError> {
         validate_identity_bindings(source_name.as_str(), &self.identity_bindings)?;
+        let source_spec_id = self
+            .source_spec_id
+            .map(|id| SourceName::parse(&id).map(|parsed| parsed.as_str().to_string()))
+            .transpose()?;
         Ok(InstalledSource {
             name: source_name,
+            source_spec_id,
             version: self.version,
             variables: self.variables,
             secrets: self.secrets,
@@ -204,6 +211,7 @@ impl PersistedInstalledSource {
 impl From<&InstalledSource> for PersistedInstalledSource {
     fn from(value: &InstalledSource) -> Self {
         Self {
+            source_spec_id: value.source_spec_id.clone(),
             version: value.version.clone(),
             variables: value.variables.clone(),
             secrets: value.secrets.clone(),
@@ -546,6 +554,14 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
                     .as_table_mut()
                     .expect("source config entry should be a table after initialization");
                 source_table.remove("version");
+            }
+            if let Some(source_spec_id) = &source.source_spec_id {
+                source_item["source_spec_id"] = value(source_spec_id.clone());
+            } else {
+                let source_table = source_item
+                    .as_table_mut()
+                    .expect("source config entry should be a table after initialization");
+                source_table.remove("source_spec_id");
             }
             source_item["variables"] = Item::Value(render_inline_table(&source.variables));
             source_item["secrets"] = Item::Value(render_string_array(&source.secrets));
@@ -893,6 +909,7 @@ mod tests {
     fn installed_source(name: &str) -> InstalledSource {
         InstalledSource {
             name: SourceName::parse(name).expect("source"),
+            source_spec_id: None,
             version: Some("1.1.4".to_string()),
             variables: BTreeMap::from([(
                 "GITHUB_API_BASE".to_string(),
@@ -981,6 +998,30 @@ mod tests {
         let raw = render_config(&PersistedAppConfig::from(&config), None);
         assert!(!raw.contains("version = \"\""));
         assert!(!raw.contains("version = \""));
+    }
+
+    #[test]
+    fn renders_and_loads_source_spec_id_for_aliased_sources() {
+        let workspace_name = default_workspace();
+        let mut source = installed_source("github");
+        source.source_spec_id = Some("github_v4".to_string());
+        let mut catalog = SourceCatalog::default();
+        catalog.upsert_source(&workspace_name, source);
+        let config = AppConfig {
+            version: 1,
+            engine: PersistedEngineConfig::default(),
+            catalog,
+        };
+
+        let raw = render_config(&PersistedAppConfig::from(&config), None);
+        assert!(raw.contains("source_spec_id = \"github_v4\""));
+
+        let loaded = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(&raw).expect("rendered config should parse"),
+        )
+        .expect("config");
+        let sources = loaded.catalog.workspace_sources(&workspace_name);
+        assert_eq!(sources[0].source_spec_id.as_deref(), Some("github_v4"));
     }
 
     #[test]


### PR DESCRIPTION
## Intent

Land `feat(app): support source spec aliases` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-24-registry-refresh-inputs...sauldhernandez/dsl-v4-identity-v2-25-source-spec-aliases
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
