### PR TITLE
feat(app): authorize workspace reads

### DIFF
--- a/crates/coral-app/src/authorization.rs
+++ b/crates/coral-app/src/authorization.rs
@@ -135,22 +135,20 @@ pub trait WorkspaceReadAuthorizer: fmt::Debug + Send + Sync + 'static {
         workspace_id: &str,
     ) -> Result<(), AuthorizationError>;
 
-    /// Returns whether every workspace read is allowed without filtering.
+    /// Returns whether reads without recoverable workspace metadata are allowed.
     ///
-    /// Product runtimes should keep the default `false`; the default OSS
-    /// allow-all authorizer overrides this to preserve local single-user
-    /// behavior on loopback transports.
-    fn allows_all_workspace_reads(&self) -> bool {
+    /// Product runtimes should keep the default `false` so records that cannot
+    /// be mapped to a workspace fail closed.
+    fn allows_unscoped_workspace_reads(&self) -> bool {
         false
     }
 
-    /// Returns whether workspace reads may proceed without a scoped workspace
-    /// authorization decision.
+    /// Returns whether every workspace read is allowed without filtering.
     ///
-    /// Product runtimes should keep the default `false`; this lets native gRPC
-    /// public-bind validation reject authorizers that are safe only for local
-    /// single-user transports.
-    fn allows_unscoped_workspace_reads(&self) -> bool {
+    /// Product runtimes should keep the default `false`; the default OSS
+    /// allow-all authorizer overrides this to preserve local single-user trace
+    /// pagination behavior.
+    fn allows_all_workspace_reads(&self) -> bool {
         false
     }
 }
@@ -188,11 +186,11 @@ impl WorkspaceReadAuthorizer for AllowAllWorkspaceReadAuthorizer {
         Ok(())
     }
 
-    fn allows_all_workspace_reads(&self) -> bool {
+    fn allows_unscoped_workspace_reads(&self) -> bool {
         true
     }
 
-    fn allows_unscoped_workspace_reads(&self) -> bool {
+    fn allows_all_workspace_reads(&self) -> bool {
         true
     }
 }

--- a/crates/coral-app/src/authorization.rs
+++ b/crates/coral-app/src/authorization.rs
@@ -1,4 +1,4 @@
-//! Product authorization seam for management-plane mutations.
+//! Product authorization seams for product runtimes.
 
 use std::fmt;
 
@@ -104,11 +104,64 @@ pub trait ManagementAuthorizer: fmt::Debug + Send + Sync + 'static {
         principal: &UserPrincipal,
         mutation: ManagementMutation<'_>,
     ) -> Result<(), AuthorizationError>;
+
+    /// Returns whether every management mutation is allowed without filtering.
+    ///
+    /// Product runtimes should keep the default `false`; the default OSS
+    /// allow-all authorizer overrides this to preserve local single-user
+    /// behavior on loopback transports.
+    fn allows_all_management_mutations(&self) -> bool {
+        false
+    }
+}
+
+/// Product-provided authorization policy for workspace data-plane reads.
+///
+/// OSS Coral installs [`AllowAllWorkspaceReadAuthorizer`] by default to
+/// preserve local single-user behavior. Product runtimes can replace it to gate
+/// SQL query, catalog, and source metadata reads for multi-user workspace
+/// control planes.
+#[tonic::async_trait]
+pub trait WorkspaceReadAuthorizer: fmt::Debug + Send + Sync + 'static {
+    /// Authorizes reading query-visible data from a workspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthorizationError`] when the principal is not allowed to read
+    /// from the workspace.
+    async fn authorize_workspace_read(
+        &self,
+        principal: &UserPrincipal,
+        workspace_id: &str,
+    ) -> Result<(), AuthorizationError>;
+
+    /// Returns whether every workspace read is allowed without filtering.
+    ///
+    /// Product runtimes should keep the default `false`; the default OSS
+    /// allow-all authorizer overrides this to preserve local single-user
+    /// behavior on loopback transports.
+    fn allows_all_workspace_reads(&self) -> bool {
+        false
+    }
+
+    /// Returns whether workspace reads may proceed without a scoped workspace
+    /// authorization decision.
+    ///
+    /// Product runtimes should keep the default `false`; this lets native gRPC
+    /// public-bind validation reject authorizers that are safe only for local
+    /// single-user transports.
+    fn allows_unscoped_workspace_reads(&self) -> bool {
+        false
+    }
 }
 
 /// Default OSS authorizer for local single-user usage.
 #[derive(Debug, Default)]
 pub struct AllowAllManagementAuthorizer;
+
+/// Default OSS workspace read authorizer for local single-user usage.
+#[derive(Debug, Default)]
+pub struct AllowAllWorkspaceReadAuthorizer;
 
 #[tonic::async_trait]
 impl ManagementAuthorizer for AllowAllManagementAuthorizer {
@@ -118,6 +171,29 @@ impl ManagementAuthorizer for AllowAllManagementAuthorizer {
         _mutation: ManagementMutation<'_>,
     ) -> Result<(), AuthorizationError> {
         Ok(())
+    }
+
+    fn allows_all_management_mutations(&self) -> bool {
+        true
+    }
+}
+
+#[tonic::async_trait]
+impl WorkspaceReadAuthorizer for AllowAllWorkspaceReadAuthorizer {
+    async fn authorize_workspace_read(
+        &self,
+        _principal: &UserPrincipal,
+        _workspace_id: &str,
+    ) -> Result<(), AuthorizationError> {
+        Ok(())
+    }
+
+    fn allows_all_workspace_reads(&self) -> bool {
+        true
+    }
+
+    fn allows_unscoped_workspace_reads(&self) -> bool {
+        true
     }
 }
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -42,7 +42,10 @@ use tower::{Layer, Service};
 use super::env::AppEnvironment;
 use super::error::AppError;
 use crate::EngineExtensionsProvider;
-use crate::authorization::{AllowAllManagementAuthorizer, ManagementAuthorizer};
+use crate::authorization::{
+    AllowAllManagementAuthorizer, AllowAllWorkspaceReadAuthorizer, ManagementAuthorizer,
+    WorkspaceReadAuthorizer,
+};
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
 use crate::credentials::{CredentialManager, CredentialStore};
@@ -143,6 +146,7 @@ pub(crate) struct ServerConfig {
     source_identity_provider_factories: Vec<SourceIdentityProviderFactory>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
+    workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
     grpc_route_extenders: Vec<GrpcRouteExtender>,
     enable_stderr_logs: bool,
@@ -170,6 +174,7 @@ impl ServerConfig {
             source_identity_provider_factories: Vec::new(),
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+            workspace_read_authorizer: Arc::new(AllowAllWorkspaceReadAuthorizer),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
             grpc_route_extenders: Vec::new(),
             enable_stderr_logs: false,
@@ -213,6 +218,14 @@ impl ServerConfig {
         management_authorizer: Arc<dyn ManagementAuthorizer>,
     ) -> Self {
         self.management_authorizer = management_authorizer;
+        self
+    }
+
+    pub(crate) fn with_workspace_read_authorizer(
+        mut self,
+        workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
+    ) -> Self {
+        self.workspace_read_authorizer = workspace_read_authorizer;
         self
     }
 
@@ -284,6 +297,33 @@ impl ServerConfig {
     pub(crate) fn with_stderr_logs(mut self, enable_stderr_logs: bool) -> Self {
         self.enable_stderr_logs = enable_stderr_logs;
         self
+    }
+
+    fn validate_native_grpc_bind_security(&self) -> Result<(), AppError> {
+        if !matches!(self.mode, ServerMode::NativeGrpc) {
+            return Ok(());
+        }
+        let Some(bind_addr) = self.native_grpc_bind_addr else {
+            return Ok(());
+        };
+        if bind_addr.ip().is_loopback() {
+            return Ok(());
+        }
+        if self.management_authorizer.allows_all_management_mutations() {
+            return Err(AppError::InvalidInput(format!(
+                "native gRPC bind address {bind_addr} is not loopback; configure a management authorizer before binding publicly"
+            )));
+        }
+        if self.workspace_read_authorizer.allows_all_workspace_reads()
+            || self
+                .workspace_read_authorizer
+                .allows_unscoped_workspace_reads()
+        {
+            return Err(AppError::InvalidInput(format!(
+                "native gRPC bind address {bind_addr} is not loopback; configure a workspace read authorizer before binding publicly"
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -417,6 +457,21 @@ impl ServerBuilder {
         self.config = self
             .config
             .with_management_authorizer(management_authorizer);
+        self
+    }
+
+    #[must_use]
+    /// Sets the server-side workspace read authorizer.
+    ///
+    /// The default authorizer allows every read, preserving local single-user
+    /// behavior.
+    pub fn with_workspace_read_authorizer(
+        mut self,
+        workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
+    ) -> Self {
+        self.config = self
+            .config
+            .with_workspace_read_authorizer(workspace_read_authorizer);
         self
     }
 
@@ -608,6 +663,7 @@ impl ServerBuilder {
     /// required directories cannot be created, the config or credential backends
     /// fail to initialize, or the gRPC server cannot be started.
     pub async fn start(self) -> Result<RunningServer, AppError> {
+        self.config.validate_native_grpc_bind_security()?;
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir)?;
         layout.ensure()?;
@@ -690,6 +746,7 @@ impl ServerBuilder {
                 trace_service,
                 user_principal_provider,
                 management_authorizer: self.config.management_authorizer,
+                workspace_read_authorizer: self.config.workspace_read_authorizer,
                 identity_spec_manager,
                 identity_manager,
                 grpc_route_extenders: self.config.grpc_route_extenders,
@@ -857,6 +914,7 @@ struct ServerServices {
     trace_service: Option<TraceService>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
+    workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
     identity_spec_manager: IdentitySpecManager,
     identity_manager: IdentityManager,
     grpc_route_extenders: Vec<GrpcRouteExtender>,
@@ -953,6 +1011,7 @@ async fn start_server(
         trace_service,
         user_principal_provider,
         management_authorizer,
+        workspace_read_authorizer,
         identity_spec_manager,
         identity_manager,
         grpc_route_extenders,
@@ -964,9 +1023,13 @@ async fn start_server(
         identity_spec_manager.clone(),
         identity_manager.clone(),
         Arc::clone(&management_authorizer),
+        Arc::clone(&workspace_read_authorizer),
     );
-    let catalog_service = CatalogService::new(query_manager.clone());
-    let query_service = QueryService::new(query_manager);
+    let catalog_service = CatalogService::new(
+        query_manager.clone(),
+        Arc::clone(&workspace_read_authorizer),
+    );
+    let query_service = QueryService::new(query_manager, workspace_read_authorizer);
     let feedback_service = FeedbackService::new(feedback_manager);
     let identity_spec_service =
         IdentitySpecService::new(identity_spec_manager, management_authorizer);
@@ -1237,6 +1300,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
+    use coral_api::v1::catalog_service_client::CatalogServiceClient;
     use coral_api::v1::episode_service_client::EpisodeServiceClient;
     use coral_api::v1::identity_spec_service_client::IdentitySpecServiceClient;
     use coral_api::v1::query_service_client::QueryServiceClient;
@@ -1247,10 +1311,12 @@ mod tests {
     };
     use coral_api::v1::{
         AddIdentitySpecRequest, CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
-        DeleteIdentitySpecRequest, DeleteSourceRequest, ExecuteSqlRequest, GetTraceRequest,
-        GetTraceResponse, IdentitySpecInputValue, ImportSourceRequest, ImportSourceResponse,
-        ListSourcesRequest, ListTracesRequest, ListTracesResponse, OpenEpisodeRequest, Workspace,
-        import_source_response,
+        DeleteIdentitySpecRequest, DeleteSourceRequest, DescribeTableRequest,
+        DiscoverSourcesRequest, ExecuteSqlRequest, ExplainSqlRequest, GetSourceInfoRequest,
+        GetSourceRequest, GetTraceRequest, GetTraceResponse, IdentitySpecInputValue,
+        ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListColumnsRequest,
+        ListSourcesRequest, ListTracesRequest, ListTracesResponse, OpenEpisodeRequest,
+        SearchCatalogRequest, ValidateSourceRequest, Workspace, import_source_response,
     };
     use coral_api::{
         HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
@@ -1283,11 +1349,11 @@ mod tests {
     use crate::transport::workspace_to_proto;
     use crate::workspaces::WorkspaceName;
     use crate::{
-        AllowAllManagementAuthorizer, AppError, AuthorizationError, AwsEngineExtensionsProvider,
-        ManagementAuthorizer, ManagementMutation, NoopEngineExtensionsProvider,
-        ResourceMutationKind, RuntimeSourceIdentity, SingleUserPrincipalProvider,
-        SourceIdentityProvider, SourceIdentityResolutionRequest, UserPrincipal,
-        UserPrincipalProvider,
+        AllowAllManagementAuthorizer, AllowAllWorkspaceReadAuthorizer, AppError,
+        AuthorizationError, AwsEngineExtensionsProvider, ManagementAuthorizer, ManagementMutation,
+        NoopEngineExtensionsProvider, ResourceMutationKind, RuntimeSourceIdentity,
+        SingleUserPrincipalProvider, SourceIdentityProvider, SourceIdentityResolutionRequest,
+        UserPrincipal, UserPrincipalProvider, WorkspaceReadAuthorizer,
     };
 
     fn default_workspace() -> Workspace {
@@ -1473,6 +1539,22 @@ enabled = false
     }
 
     #[derive(Debug)]
+    struct RejectingWorkspaceReadAuthorizer;
+
+    #[tonic::async_trait]
+    impl WorkspaceReadAuthorizer for RejectingWorkspaceReadAuthorizer {
+        async fn authorize_workspace_read(
+            &self,
+            _principal: &UserPrincipal,
+            workspace_id: &str,
+        ) -> Result<(), AuthorizationError> {
+            Err(AuthorizationError::forbidden(format!(
+                "workspace read rejected for {workspace_id}"
+            )))
+        }
+    }
+
+    #[derive(Debug)]
     struct NoopSourceIdentityProvider;
 
     #[tonic::async_trait]
@@ -1555,6 +1637,11 @@ enabled = false
         ) -> Result<Response<GetTraceResponse>, Status> {
             Err(Status::unimplemented("unused in test"))
         }
+    }
+
+    fn assert_workspace_read_denied(status: &tonic::Status) {
+        assert_eq!(status.code(), Code::PermissionDenied);
+        assert!(status.message().contains("workspace read rejected"));
     }
 
     #[tokio::test]
@@ -1799,6 +1886,148 @@ type: fixed_token
             status.message().contains("1 stored identity"),
             "unexpected status: {status:?}"
         );
+
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn query_and_catalog_services_enforce_workspace_read_authorizer() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_workspace_read_authorizer(Arc::new(RejectingWorkspaceReadAuthorizer))
+            .start()
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut query_client = QueryServiceClient::new(channel.clone());
+        let mut catalog_client = CatalogServiceClient::new(channel);
+
+        let status = query_client
+            .execute_sql(Request::new(ExecuteSqlRequest {
+                workspace: Some(default_workspace()),
+                sql: "SELECT 1".to_string(),
+            }))
+            .await
+            .expect_err("query should be denied");
+        assert_workspace_read_denied(&status);
+
+        let status = query_client
+            .explain_sql(Request::new(ExplainSqlRequest {
+                workspace: Some(default_workspace()),
+                sql: "SELECT 1".to_string(),
+            }))
+            .await
+            .expect_err("query planning should be denied");
+        assert_workspace_read_denied(&status);
+
+        let status = catalog_client
+            .list_catalog(Request::new(ListCatalogRequest {
+                workspace: Some(default_workspace()),
+                ..ListCatalogRequest::default()
+            }))
+            .await
+            .expect_err("catalog listing should be denied");
+        assert_workspace_read_denied(&status);
+
+        let status = catalog_client
+            .search_catalog(Request::new(SearchCatalogRequest {
+                workspace: Some(default_workspace()),
+                pattern: "missing".to_string(),
+                ignore_case: true,
+                ..SearchCatalogRequest::default()
+            }))
+            .await
+            .expect_err("catalog search should be denied");
+        assert_workspace_read_denied(&status);
+
+        let status = catalog_client
+            .describe_table(Request::new(DescribeTableRequest {
+                workspace: Some(default_workspace()),
+                schema_name: "missing".to_string(),
+                table_name: "missing".to_string(),
+            }))
+            .await
+            .expect_err("table description should be denied");
+        assert_workspace_read_denied(&status);
+
+        let status = catalog_client
+            .list_columns(Request::new(ListColumnsRequest {
+                workspace: Some(default_workspace()),
+                schema_name: "missing".to_string(),
+                table_name: "missing".to_string(),
+                ..ListColumnsRequest::default()
+            }))
+            .await
+            .expect_err("column listing should be denied");
+        assert_workspace_read_denied(&status);
+
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn source_read_services_enforce_workspace_read_authorizer() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_workspace_read_authorizer(Arc::new(RejectingWorkspaceReadAuthorizer))
+            .start()
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut source_client = SourceServiceClient::new(channel);
+
+        let status = source_client
+            .discover_sources(Request::new(DiscoverSourcesRequest {
+                workspace: Some(default_workspace()),
+            }))
+            .await
+            .expect_err("source discovery should be denied");
+        assert_workspace_read_denied(&status);
+
+        let status = source_client
+            .list_sources(Request::new(ListSourcesRequest {
+                workspace: Some(default_workspace()),
+            }))
+            .await
+            .expect_err("source listing should be denied");
+        assert_workspace_read_denied(&status);
+
+        let status = source_client
+            .get_source(Request::new(GetSourceRequest {
+                workspace: Some(default_workspace()),
+                name: "missing".to_string(),
+            }))
+            .await
+            .expect_err("source lookup should be denied");
+        assert_workspace_read_denied(&status);
+
+        let status = source_client
+            .get_source_info(Request::new(GetSourceInfoRequest {
+                workspace: Some(default_workspace()),
+                name: "missing".to_string(),
+            }))
+            .await
+            .expect_err("source info should be denied");
+        assert_workspace_read_denied(&status);
+
+        let status = source_client
+            .validate_source(Request::new(ValidateSourceRequest {
+                workspace: Some(default_workspace()),
+                name: "missing".to_string(),
+            }))
+            .await
+            .expect_err("source validation should be denied");
+        assert_workspace_read_denied(&status);
+
         server.shutdown().await.expect("shutdown");
     }
 
@@ -2107,6 +2336,7 @@ type: fixed_token
                 trace_service: Some(trace_service),
                 user_principal_provider,
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+                workspace_read_authorizer: Arc::new(AllowAllWorkspaceReadAuthorizer),
                 identity_spec_manager,
                 identity_manager: identity_manager.clone(),
                 grpc_route_extenders: Vec::new(),
@@ -2183,6 +2413,41 @@ type: fixed_token
             ServerMode::NativeGrpc.bind_addr(None),
             SocketAddr::from((Ipv4Addr::LOCALHOST, 0))
         );
+    }
+
+    #[test]
+    fn native_grpc_public_bind_rejects_default_authorizers() {
+        let bind_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0));
+
+        let error = super::ServerConfig::new()
+            .with_native_grpc_bind_addr(bind_addr)
+            .validate_native_grpc_bind_security()
+            .expect_err("public native gRPC bind should require explicit authorizers");
+
+        assert!(
+            error.to_string().contains("management authorizer"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn native_grpc_public_bind_accepts_explicit_authorizers() {
+        let bind_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0));
+
+        super::ServerConfig::new()
+            .with_native_grpc_bind_addr(bind_addr)
+            .with_management_authorizer(Arc::new(DenyingSourceManagementAuthorizer))
+            .with_workspace_read_authorizer(Arc::new(RejectingWorkspaceReadAuthorizer))
+            .validate_native_grpc_bind_security()
+            .expect("explicit authorizers should allow public native gRPC bind");
+    }
+
+    #[test]
+    fn native_grpc_loopback_bind_accepts_default_authorizers() {
+        super::ServerConfig::new()
+            .with_native_grpc_bind_addr(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .validate_native_grpc_bind_security()
+            .expect("loopback bind should preserve local allow-all defaults");
     }
 
     #[test]
@@ -2564,6 +2829,7 @@ tables:
                 trace_service: None,
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+                workspace_read_authorizer: Arc::new(AllowAllWorkspaceReadAuthorizer),
                 identity_spec_manager,
                 identity_manager: identity_manager.clone(),
                 grpc_route_extenders: Vec::new(),
@@ -2684,6 +2950,7 @@ tables:
                 trace_service: None,
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+                workspace_read_authorizer: Arc::new(AllowAllWorkspaceReadAuthorizer),
                 identity_spec_manager,
                 identity_manager: identity_manager.clone(),
                 grpc_route_extenders: Vec::new(),
@@ -2800,6 +3067,7 @@ tables:
                 trace_service: None,
                 user_principal_provider: Arc::new(SingleUserPrincipalProvider),
                 management_authorizer: Arc::new(AllowAllManagementAuthorizer),
+                workspace_read_authorizer: Arc::new(AllowAllWorkspaceReadAuthorizer),
                 identity_spec_manager,
                 identity_manager: identity_manager.clone(),
                 grpc_route_extenders: Vec::new(),

--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -1,5 +1,7 @@
 //! Implements the gRPC `CatalogService`.
 
+use std::sync::Arc;
+
 use coral_api::v1::catalog_service_server::CatalogService as CatalogServiceApi;
 use coral_api::v1::{
     CatalogCounts as ProtoCatalogCounts, CatalogItemKind as ProtoCatalogItemKind,
@@ -9,6 +11,7 @@ use coral_api::v1::{
 };
 use tonic::{Request, Response, Status};
 
+use crate::authorization::{WorkspaceReadAuthorizer, authorization_status};
 use crate::bootstrap::app_status;
 use crate::catalog::discovery::{
     CatalogDiscovery, CatalogItemKind, CatalogTableRef, ListColumnsQuery, Pagination,
@@ -25,12 +28,17 @@ use crate::transport::{
 #[derive(Clone)]
 pub(crate) struct CatalogService {
     catalog: CatalogDiscovery,
+    workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
 }
 
 impl CatalogService {
-    pub(crate) fn new(query_manager: QueryManager) -> Self {
+    pub(crate) fn new(
+        query_manager: QueryManager,
+        workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
+    ) -> Self {
         Self {
             catalog: CatalogDiscovery::new(query_manager),
+            workspace_read_authorizer,
         }
     }
 }
@@ -43,9 +51,14 @@ impl CatalogServiceApi for CatalogService {
     ) -> Result<Response<ListCatalogResponse>, Status> {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
             let workspace_name = workspace_name_from_proto(request.get_ref().workspace.as_ref())?;
             let context = QueryContext::from_request(workspace_name.clone(), &request)?;
+            workspace_read_authorizer
+                .authorize_workspace_read(context.principal(), context.workspace_name().as_str())
+                .await
+                .map_err(authorization_status)?;
             let request = request.into_inner();
             let pagination = pagination_from_proto(request.pagination.unwrap_or_default());
             let schema_name = optional_trimmed(&request.schema_name);
@@ -84,9 +97,14 @@ impl CatalogServiceApi for CatalogService {
     ) -> Result<Response<SearchCatalogResponse>, Status> {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
             let workspace_name = workspace_name_from_proto(request.get_ref().workspace.as_ref())?;
             let context = QueryContext::from_request(workspace_name.clone(), &request)?;
+            workspace_read_authorizer
+                .authorize_workspace_read(context.principal(), context.workspace_name().as_str())
+                .await
+                .map_err(authorization_status)?;
             let request = request.into_inner();
             let schema_name = optional_trimmed(&request.schema_name);
             let kind = catalog_item_kind_from_proto(request.kind)?;
@@ -128,9 +146,14 @@ impl CatalogServiceApi for CatalogService {
     ) -> Result<Response<DescribeTableResponse>, Status> {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
             let workspace_name = workspace_name_from_proto(request.get_ref().workspace.as_ref())?;
             let context = QueryContext::from_request(workspace_name.clone(), &request)?;
+            workspace_read_authorizer
+                .authorize_workspace_read(context.principal(), context.workspace_name().as_str())
+                .await
+                .map_err(authorization_status)?;
             let request = request.into_inner();
             let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
             let table_name = required_trimmed(&request.table_name, "table_name")?;
@@ -152,9 +175,14 @@ impl CatalogServiceApi for CatalogService {
     ) -> Result<Response<ListColumnsResponse>, Status> {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
             let workspace_name = workspace_name_from_proto(request.get_ref().workspace.as_ref())?;
             let context = QueryContext::from_request(workspace_name.clone(), &request)?;
+            workspace_read_authorizer
+                .authorize_workspace_read(context.principal(), context.workspace_name().as_str())
+                .await
+                .map_err(authorization_status)?;
             let request = request.into_inner();
             let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
             let table_name = required_trimmed(&request.table_name, "table_name")?;

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -65,8 +65,9 @@ mod transport;
 mod workspaces;
 
 pub use authorization::{
-    AllowAllManagementAuthorizer, AuthorizationError, ManagementAuthorizer, ManagementMutation,
-    ResourceMutationKind, WorkspaceSourceMutationKind,
+    AllowAllManagementAuthorizer, AllowAllWorkspaceReadAuthorizer, AuthorizationError,
+    ManagementAuthorizer, ManagementMutation, ResourceMutationKind, WorkspaceReadAuthorizer,
+    WorkspaceSourceMutationKind,
 };
 pub use bootstrap::{
     AppError, RunningServer, ServerBuilder, ServerExtensionContext, ServerMode, StaticAsset,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1295,7 +1295,10 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
-        let service = CatalogService::new(fixture.manager.clone());
+        let service = CatalogService::new(
+            fixture.manager.clone(),
+            Arc::new(AllowAllWorkspaceReadAuthorizer),
+        );
 
         call_catalog_tools_with_episode(&service).await;
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1132,6 +1132,7 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
+    use crate::authorization::AllowAllWorkspaceReadAuthorizer;
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
     use crate::features::{Features, dsl_v4_features};
     use crate::identity::UserPrincipal;
@@ -1239,7 +1240,10 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
-        let service = QueryService::new(fixture.manager.clone());
+        let service = QueryService::new(
+            fixture.manager.clone(),
+            Arc::new(AllowAllWorkspaceReadAuthorizer),
+        );
 
         let mut request = Request::new(ExecuteSqlRequest {
             workspace: Some(Workspace {
@@ -2392,10 +2396,7 @@ tables:
             layout.clone(),
             Arc::new(LocalSourceArtifactStore::new(layout)),
             Vec::new(),
-            QueryManagerOptions {
-                features: Features::default(),
-                source_identity_providers: Vec::new(),
-            },
+            QueryManagerOptions::default(),
         )
     }
 

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -1,5 +1,7 @@
 //! Implements the gRPC `QueryService`.
 
+use std::sync::Arc;
+
 use arrow::datatypes::SchemaRef;
 use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
@@ -10,6 +12,7 @@ use coral_api::v1::{
 };
 use tonic::{Request, Response, Status};
 
+use crate::authorization::{WorkspaceReadAuthorizer, authorization_status};
 use crate::bootstrap::core_status;
 use crate::query::QueryContext;
 use crate::query::manager::QueryManager;
@@ -18,12 +21,17 @@ use crate::transport::{grpc_span, instrument_grpc, query_status, workspace_name_
 #[derive(Clone)]
 pub(crate) struct QueryService {
     queries: QueryManager,
+    workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
 }
 
 impl QueryService {
-    pub(crate) fn new(query_manager: QueryManager) -> Self {
+    pub(crate) fn new(
+        query_manager: QueryManager,
+        workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
+    ) -> Self {
         Self {
             queries: query_manager,
+            workspace_read_authorizer,
         }
     }
 }
@@ -36,9 +44,14 @@ impl QueryServiceApi for QueryService {
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
             let workspace_name = workspace_name_from_proto(request.get_ref().workspace.as_ref())?;
             let context = QueryContext::from_request(workspace_name, &request)?;
+            workspace_read_authorizer
+                .authorize_workspace_read(context.principal(), context.workspace_name().as_str())
+                .await
+                .map_err(authorization_status)?;
             let inner = request.into_inner();
             let execution = queries
                 .execute_sql(&context, &inner.sql)
@@ -64,9 +77,14 @@ impl QueryServiceApi for QueryService {
     ) -> Result<Response<ExplainSqlResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
             let workspace_name = workspace_name_from_proto(request.get_ref().workspace.as_ref())?;
             let context = QueryContext::from_request(workspace_name, &request)?;
+            workspace_read_authorizer
+                .authorize_workspace_read(context.principal(), context.workspace_name().as_str())
+                .await
+                .map_err(authorization_status)?;
             let inner = request.into_inner();
             let plan = queries
                 .explain_sql(&context, &inner.sql)

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -37,8 +37,8 @@ use coral_spec::{
 use tonic::{Request, Response, Status};
 
 use crate::authorization::{
-    ManagementAuthorizer, ManagementMutation, ResourceMutationKind, WorkspaceSourceMutationKind,
-    authorization_status,
+    ManagementAuthorizer, ManagementMutation, ResourceMutationKind, WorkspaceReadAuthorizer,
+    WorkspaceSourceMutationKind, authorization_status,
 };
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
@@ -76,6 +76,7 @@ pub(crate) struct SourceService {
     identity_specs: IdentitySpecManager,
     identities: IdentityManager,
     management_authorizer: Arc<dyn ManagementAuthorizer>,
+    workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
 }
 
 impl SourceService {
@@ -85,6 +86,7 @@ impl SourceService {
         identity_spec_manager: IdentitySpecManager,
         identity_manager: IdentityManager,
         management_authorizer: Arc<dyn ManagementAuthorizer>,
+        workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
     ) -> Self {
         Self {
             sources: source_manager,
@@ -92,6 +94,7 @@ impl SourceService {
             identity_specs: identity_spec_manager,
             identities: identity_manager,
             management_authorizer,
+            workspace_read_authorizer,
         }
     }
 }
@@ -107,9 +110,17 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<DiscoverSourcesResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
+            let request_context = RequestContext::from_request(&request)?;
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_workspace_read(
+                workspace_read_authorizer.as_ref(),
+                request_context.principal(),
+                &workspace_name,
+            )
+            .await?;
             let sources = sources
                 .discover_sources(&workspace_name)
                 .map_err(app_status)?
@@ -127,9 +138,17 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<ListSourcesResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
+            let request_context = RequestContext::from_request(&request)?;
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_workspace_read(
+                workspace_read_authorizer.as_ref(),
+                request_context.principal(),
+                &workspace_name,
+            )
+            .await?;
             let sources: Vec<_> = sources
                 .list_workspace_sources(&workspace_name)
                 .map_err(app_status)?
@@ -147,9 +166,17 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<GetSourceResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
+            let request_context = RequestContext::from_request(&request)?;
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_workspace_read(
+                workspace_read_authorizer.as_ref(),
+                request_context.principal(),
+                &workspace_name,
+            )
+            .await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             let source = sources
                 .get_source(&workspace_name, &source_name)
@@ -167,9 +194,17 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<GetSourceInfoResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
+            let request_context = RequestContext::from_request(&request)?;
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_workspace_read(
+                workspace_read_authorizer.as_ref(),
+                request_context.principal(),
+                &workspace_name,
+            )
+            .await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             let source = sources
                 .get_source_info(&workspace_name, &source_name)
@@ -351,9 +386,16 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<ValidateSourceResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
             let workspace_name = workspace_name_from_proto(request.get_ref().workspace.as_ref())?;
             let context = QueryContext::from_request(workspace_name, &request)?;
+            authorize_workspace_read(
+                workspace_read_authorizer.as_ref(),
+                context.principal(),
+                context.workspace_name(),
+            )
+            .await?;
             let request = request.into_inner();
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             let result = queries
@@ -567,6 +609,17 @@ type CreateBundledSourceWithOAuthResponseStreamBox =
 type ImportSourceResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 type ImportSourceFuture = Pin<Box<dyn Future<Output = Result<InstalledSource, Status>> + Send>>;
+
+async fn authorize_workspace_read(
+    authorizer: &dyn WorkspaceReadAuthorizer,
+    principal: &UserPrincipal,
+    workspace_name: &WorkspaceName,
+) -> Result<(), Status> {
+    authorizer
+        .authorize_workspace_read(principal, workspace_name.as_str())
+        .await
+        .map_err(authorization_status)
+}
 
 async fn run_blocking_source_operation<T, F>(operation: F) -> Result<T, Status>
 where


### PR DESCRIPTION
## Intent

Land `feat(app): authorize workspace reads` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-25-source-spec-aliases...sauldhernandez/dsl-v4-identity-v2-26-workspace-read-authorizer
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
