### PR TITLE
feat(app): authorize trace reads

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1029,7 +1029,7 @@ async fn start_server(
         query_manager.clone(),
         Arc::clone(&workspace_read_authorizer),
     );
-    let query_service = QueryService::new(query_manager, workspace_read_authorizer);
+    let query_service = QueryService::new(query_manager, Arc::clone(&workspace_read_authorizer));
     let feedback_service = FeedbackService::new(feedback_manager);
     let identity_spec_service =
         IdentitySpecService::new(identity_spec_manager, management_authorizer);
@@ -1058,6 +1058,8 @@ async fn start_server(
                 .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
         );
     if let Some(trace_service) = trace_service {
+        let trace_service =
+            trace_service.with_workspace_read_authorizer(Arc::clone(&workspace_read_authorizer));
         routes = routes.add_service(
             TraceServiceServer::new(trace_service)
                 .max_encoding_message_size(TRACE_RESPONSE_MAX_MESSAGE_SIZE),

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -1,6 +1,6 @@
 //! JSONL-backed span export for local trace capture.
 
-use std::collections::{HashMap, HashSet, hash_map::Entry};
+use std::collections::{BTreeSet, HashMap, HashSet, hash_map::Entry};
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -404,6 +404,7 @@ pub(crate) struct TraceSummaryRecord {
     pub(crate) trace_id: String,
     pub(crate) root_span_id: String,
     pub(crate) name: String,
+    pub(crate) workspaces: BTreeSet<String>,
     pub(crate) query: String,
     pub(crate) status: StoredTraceStatus,
     pub(crate) start_time_unix_nanos: i64,
@@ -453,6 +454,7 @@ struct TraceAggregate {
     end_time_unix_nanos: i64,
     span_count: u32,
     error_count: u32,
+    workspaces: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -486,6 +488,7 @@ struct TraceListAggregate {
     span_count: u32,
     error_count: u32,
     found_root_span: bool,
+    workspaces: BTreeSet<String>,
     primary: Option<TracePrimaryCandidate>,
 }
 
@@ -725,6 +728,7 @@ impl TraceListAggregate {
             span_count: 0,
             error_count: 0,
             found_root_span: false,
+            workspaces: BTreeSet::new(),
             primary: None,
         };
         aggregate.record_span(span);
@@ -739,6 +743,9 @@ impl TraceListAggregate {
             self.error_count = self.error_count.saturating_add(1);
         }
         self.found_root_span |= is_root_span_parent(span.parent_span_id.as_deref());
+        if let Some(workspace) = workspace_from_attributes_json(&span.attributes_json) {
+            self.workspaces.insert(workspace);
+        }
 
         let primary = TracePrimaryCandidate::from_span(span);
         if self
@@ -757,6 +764,7 @@ impl TraceListAggregate {
             end_time_unix_nanos: self.end_time_unix_nanos,
             span_count: self.span_count,
             error_count: self.error_count,
+            workspaces: self.workspaces,
         };
         summary_from_list_aggregate(&aggregate, self.primary.as_ref())
     }
@@ -1057,6 +1065,7 @@ fn summary_from_spans(trace_id: &str, spans: &[TraceSpanRecord]) -> TraceSummary
         end_time_unix_nanos,
         span_count: usize_to_u32(spans.len()),
         error_count: usize_to_u32(error_count),
+        workspaces: trace_workspaces(spans.iter().map(|span| span.attributes_json.as_str())),
     };
     let primary = spans.iter().min_by_key(|span| {
         (
@@ -1086,6 +1095,7 @@ fn summary_from_list_aggregate(
             trace_id: aggregate.trace_id.clone(),
             root_span_id: String::new(),
             name: "trace".to_string(),
+            workspaces: aggregate.workspaces.clone(),
             query: String::new(),
             status: fallback_status,
             start_time_unix_nanos: aggregate.start_time_unix_nanos,
@@ -1112,6 +1122,7 @@ fn summary_from_list_aggregate(
                 trace_id: aggregate.trace_id.clone(),
                 root_span_id: primary.span_id.clone(),
                 name: primary.name.clone(),
+                workspaces: aggregate.workspaces.clone(),
                 query: attributes
                     .as_ref()
                     .and_then(|attrs| attr_string(attrs, "sql"))
@@ -1146,6 +1157,7 @@ fn summary_from_aggregate(
             trace_id: aggregate.trace_id.clone(),
             root_span_id: String::new(),
             name: "trace".to_string(),
+            workspaces: aggregate.workspaces.clone(),
             query: String::new(),
             status: fallback_status,
             start_time_unix_nanos: aggregate.start_time_unix_nanos,
@@ -1172,6 +1184,7 @@ fn summary_from_aggregate(
                 trace_id: aggregate.trace_id.clone(),
                 root_span_id: primary.span_id.clone(),
                 name: primary.name.clone(),
+                workspaces: aggregate.workspaces.clone(),
                 query: attributes
                     .as_ref()
                     .and_then(|attrs| attr_string(attrs, "sql"))
@@ -1236,6 +1249,18 @@ fn status_from_attributes(attributes: Option<&JsonValue>) -> Option<StoredTraceS
         "error" => Some(StoredTraceStatus::Error),
         _ => None,
     }
+}
+
+fn trace_workspaces<'a>(attributes_json: impl IntoIterator<Item = &'a str>) -> BTreeSet<String> {
+    attributes_json
+        .into_iter()
+        .filter_map(workspace_from_attributes_json)
+        .collect()
+}
+
+fn workspace_from_attributes_json(attributes_json: &str) -> Option<String> {
+    let attributes = parse_attributes(attributes_json)?;
+    attr_string(&attributes, "workspace").filter(|workspace| !workspace.is_empty())
 }
 
 fn attr_string(attributes: &JsonValue, key: &str) -> Option<String> {

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -1,6 +1,10 @@
 //! Implements the gRPC `TraceService` for local trace inspection.
 
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
@@ -10,6 +14,12 @@ use coral_api::v1::{
 };
 use tonic::{Code, Request, Response, Status};
 
+use crate::authorization::{
+    AllowAllWorkspaceReadAuthorizer, AuthorizationError, WorkspaceReadAuthorizer,
+    authorization_status,
+};
+use crate::identity::UserPrincipal;
+use crate::request_context::RequestContext;
 use crate::telemetry::local_store::{
     StoredTraceStatus, TraceDetailRecord, TraceSpanRecord, TraceStore, TraceStoreError,
     TraceSummaryRecord,
@@ -18,17 +28,77 @@ use crate::transport::{grpc_span, instrument_grpc};
 
 const DEFAULT_TRACE_PAGE_SIZE: usize = 50;
 const MAX_TRACE_PAGE_SIZE: usize = 200;
+const FILTERED_TRACE_SCAN_BATCHES: usize = 5;
+const FILTERED_TRACE_SCAN_LIMIT: usize = MAX_TRACE_PAGE_SIZE * FILTERED_TRACE_SCAN_BATCHES;
+const MAX_TRACE_PAGE_CURSORS: usize = 1024;
+const TRACE_PAGE_CURSOR_PREFIX: &str = "cursor-";
 
 #[derive(Clone)]
 pub(crate) struct TraceService {
     traces: TraceStore,
+    workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
+    page_cursors: Arc<TracePageCursorStore>,
 }
 
 impl TraceService {
     pub(crate) fn new(trace_store_file: PathBuf, retention: Duration) -> Self {
         Self {
             traces: TraceStore::with_retention(trace_store_file, retention),
+            workspace_read_authorizer: Arc::new(AllowAllWorkspaceReadAuthorizer),
+            page_cursors: Arc::new(TracePageCursorStore::default()),
         }
+    }
+
+    pub(crate) fn with_workspace_read_authorizer(
+        mut self,
+        workspace_read_authorizer: Arc<dyn WorkspaceReadAuthorizer>,
+    ) -> Self {
+        self.workspace_read_authorizer = workspace_read_authorizer;
+        self
+    }
+}
+
+#[derive(Debug, Default)]
+struct TracePageCursorStore {
+    next_id: AtomicU64,
+    cursors: Mutex<TracePageCursors>,
+}
+
+#[derive(Debug, Default)]
+struct TracePageCursors {
+    offsets: HashMap<String, usize>,
+    order: VecDeque<String>,
+}
+
+impl TracePageCursorStore {
+    fn insert(&self, offset: usize) -> Result<String, Status> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let token = format!("{TRACE_PAGE_CURSOR_PREFIX}{id:x}");
+        let mut cursors = self
+            .cursors
+            .lock()
+            .map_err(|_poisoned| Status::internal("trace page cursor store is unavailable"))?;
+        cursors.offsets.insert(token.clone(), offset);
+        cursors.order.push_back(token.clone());
+        while cursors.order.len() > MAX_TRACE_PAGE_CURSORS {
+            if let Some(expired) = cursors.order.pop_front() {
+                cursors.offsets.remove(&expired);
+            }
+        }
+        Ok(token)
+    }
+
+    fn resolve(&self, page_token: &str) -> Result<usize, Status> {
+        if page_token.is_empty() {
+            return Ok(0);
+        }
+        self.cursors
+            .lock()
+            .map_err(|_poisoned| Status::internal("trace page cursor store is unavailable"))?
+            .offsets
+            .get(page_token)
+            .copied()
+            .ok_or_else(invalid_page_token_status)
     }
 }
 
@@ -40,24 +110,26 @@ impl TraceServiceApi for TraceService {
     ) -> Result<Response<ListTracesResponse>, Status> {
         let span = grpc_span(&request);
         let traces = self.traces.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
+        let page_cursors = Arc::clone(&self.page_cursors);
         instrument_grpc(span, async move {
+            let request_context = RequestContext::from_request(&request)?;
             let request = request.into_inner();
             let page_size = normalize_page_size(request.page_size);
-            let offset = parse_page_token(&request.page_token)?;
-            let mut summaries = traces
-                .list_traces(page_size.saturating_add(1), offset)
-                .await
-                .map_err(trace_store_status)?;
-            let next_page_token = if summaries.len() > page_size {
-                summaries.truncate(page_size);
-                offset.saturating_add(page_size).to_string()
+            let response = if workspace_read_authorizer.allows_all_workspace_reads() {
+                list_traces_unfiltered(&traces, page_size, &request.page_token).await?
             } else {
-                String::new()
+                list_traces_filtered(
+                    &traces,
+                    page_cursors.as_ref(),
+                    workspace_read_authorizer.as_ref(),
+                    request_context.principal(),
+                    page_size,
+                    &request.page_token,
+                )
+                .await?
             };
-            Ok(Response::new(ListTracesResponse {
-                traces: summaries.into_iter().map(trace_summary_to_proto).collect(),
-                next_page_token,
-            }))
+            Ok(Response::new(response))
         })
         .await
     }
@@ -68,7 +140,9 @@ impl TraceServiceApi for TraceService {
     ) -> Result<Response<GetTraceResponse>, Status> {
         let span = grpc_span(&request);
         let traces = self.traces.clone();
+        let workspace_read_authorizer = Arc::clone(&self.workspace_read_authorizer);
         instrument_grpc(span, async move {
+            let request_context = RequestContext::from_request(&request)?;
             let request = request.into_inner();
             if request.trace_id.trim().is_empty() {
                 return Err(Status::new(
@@ -80,10 +154,152 @@ impl TraceServiceApi for TraceService {
                 .get_trace(request.trace_id)
                 .await
                 .map_err(trace_store_status)?;
+            authorize_trace_summary(
+                workspace_read_authorizer.as_ref(),
+                request_context.principal(),
+                &trace.summary,
+            )
+            .await?;
             Ok(Response::new(trace_detail_to_proto(trace)))
         })
         .await
     }
+}
+
+async fn list_traces_unfiltered(
+    traces: &TraceStore,
+    page_size: usize,
+    page_token: &str,
+) -> Result<ListTracesResponse, Status> {
+    let offset = parse_page_token(page_token)?;
+    let mut summaries = traces
+        .list_traces(page_size.saturating_add(1), offset)
+        .await
+        .map_err(trace_store_status)?;
+    let next_page_token = if summaries.len() > page_size {
+        summaries.truncate(page_size);
+        offset.saturating_add(page_size).to_string()
+    } else {
+        String::new()
+    };
+    Ok(ListTracesResponse {
+        traces: summaries.into_iter().map(trace_summary_to_proto).collect(),
+        next_page_token,
+    })
+}
+
+async fn list_traces_filtered(
+    traces: &TraceStore,
+    page_cursors: &TracePageCursorStore,
+    authorizer: &dyn WorkspaceReadAuthorizer,
+    principal: &UserPrincipal,
+    page_size: usize,
+    page_token: &str,
+) -> Result<ListTracesResponse, Status> {
+    let mut offset = page_cursors.resolve(page_token)?;
+    let mut summaries = Vec::with_capacity(page_size);
+    let mut has_more_traces = false;
+    let mut scanned = 0usize;
+
+    'scan: loop {
+        let remaining_scan = FILTERED_TRACE_SCAN_LIMIT.saturating_sub(scanned);
+        if remaining_scan == 0 {
+            has_more_traces = trace_store_has_more(traces, offset).await?;
+            break;
+        }
+
+        let batch_limit = remaining_scan.min(MAX_TRACE_PAGE_SIZE);
+        let batch = traces
+            .list_traces(batch_limit, offset)
+            .await
+            .map_err(trace_store_status)?;
+        if batch.is_empty() {
+            break;
+        }
+
+        let batch_len = batch.len();
+        scanned = scanned.saturating_add(batch_len);
+        for (index, summary) in batch.into_iter().enumerate() {
+            offset = offset.saturating_add(1);
+            if trace_summary_is_authorized(authorizer, principal, &summary).await? {
+                summaries.push(summary);
+                if summaries.len() == page_size {
+                    has_more_traces = index + 1 < batch_len
+                        || (batch_len == batch_limit
+                            && trace_store_has_more(traces, offset).await?);
+                    break 'scan;
+                }
+            }
+        }
+
+        if batch_len < batch_limit {
+            break;
+        }
+    }
+
+    let next_page_token = if has_more_traces {
+        page_cursors.insert(offset)?
+    } else {
+        String::new()
+    };
+
+    Ok(ListTracesResponse {
+        traces: summaries.into_iter().map(trace_summary_to_proto).collect(),
+        next_page_token,
+    })
+}
+
+async fn trace_store_has_more(traces: &TraceStore, offset: usize) -> Result<bool, Status> {
+    Ok(!traces
+        .list_traces(1, offset)
+        .await
+        .map_err(trace_store_status)?
+        .is_empty())
+}
+
+async fn trace_summary_is_authorized(
+    authorizer: &dyn WorkspaceReadAuthorizer,
+    principal: &UserPrincipal,
+    summary: &TraceSummaryRecord,
+) -> Result<bool, Status> {
+    if summary.workspaces.is_empty() {
+        return Ok(authorizer.allows_unscoped_workspace_reads());
+    }
+
+    for workspace_id in &summary.workspaces {
+        match authorizer
+            .authorize_workspace_read(principal, workspace_id)
+            .await
+        {
+            Ok(()) => {}
+            Err(AuthorizationError::Forbidden(_)) => return Ok(false),
+            Err(error) => return Err(authorization_status(error)),
+        }
+    }
+    Ok(true)
+}
+
+async fn authorize_trace_summary(
+    authorizer: &dyn WorkspaceReadAuthorizer,
+    principal: &UserPrincipal,
+    summary: &TraceSummaryRecord,
+) -> Result<(), Status> {
+    if summary.workspaces.is_empty() {
+        if authorizer.allows_unscoped_workspace_reads() {
+            return Ok(());
+        }
+        return Err(Status::permission_denied(
+            "trace workspace metadata is unavailable",
+        ));
+    }
+
+    for workspace_id in &summary.workspaces {
+        authorizer
+            .authorize_workspace_read(principal, workspace_id)
+            .await
+            .map_err(authorization_status)?;
+    }
+    Ok(())
 }
 
 fn normalize_page_size(page_size: i32) -> usize {
@@ -100,12 +316,16 @@ fn parse_page_token(page_token: &str) -> Result<usize, Status> {
     if page_token.is_empty() {
         return Ok(0);
     }
-    page_token.parse().map_err(|_parse_error| {
-        Status::new(
-            Code::InvalidArgument,
-            "invalid input: page_token must be returned by ListTraces",
-        )
-    })
+    page_token
+        .parse()
+        .map_err(|_parse_error| invalid_page_token_status())
+}
+
+fn invalid_page_token_status() -> Status {
+    Status::new(
+        Code::InvalidArgument,
+        "invalid input: page_token must be returned by ListTraces",
+    )
 }
 
 fn trace_store_status(error: TraceStoreError) -> Status {
@@ -183,7 +403,54 @@ fn trace_status_to_proto(status: StoredTraceStatus) -> TraceStatus {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_page_size, parse_page_token};
+    use std::fs;
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
+    use coral_api::v1::{GetTraceRequest, ListTracesRequest};
+    use serde_json::json;
+    use tempfile::TempDir;
+    use tonic::{Code, Request};
+
+    use super::{TraceService, normalize_page_size, parse_page_token};
+    use crate::authorization::{AuthorizationError, WorkspaceReadAuthorizer};
+    use crate::identity::UserPrincipal;
+    use crate::query::QueryAttribution;
+    use crate::request_context::RequestContext;
+    use crate::telemetry::local_store::{StoredTraceStatus, TraceSpanRecord};
+
+    #[derive(Debug)]
+    struct AllowOneWorkspaceAuthorizer;
+
+    #[tonic::async_trait]
+    impl WorkspaceReadAuthorizer for AllowOneWorkspaceAuthorizer {
+        async fn authorize_workspace_read(
+            &self,
+            _principal: &UserPrincipal,
+            workspace_id: &str,
+        ) -> Result<(), AuthorizationError> {
+            if workspace_id == "allowed" {
+                Ok(())
+            } else {
+                Err(AuthorizationError::forbidden(format!(
+                    "workspace read rejected for {workspace_id}"
+                )))
+            }
+        }
+    }
+
+    fn trace_request<T>(message: T) -> Request<T> {
+        let mut request = Request::new(message);
+        request
+            .extensions_mut()
+            .insert(RequestContext::with_attribution(
+                UserPrincipal::local(),
+                QueryAttribution::default(),
+            ));
+        request
+    }
 
     #[test]
     fn page_size_defaults_and_caps() {
@@ -198,5 +465,285 @@ mod tests {
         assert_eq!(parse_page_token("").expect("empty token"), 0);
         assert_eq!(parse_page_token("25").expect("offset token"), 25);
         parse_page_token("not-an-offset").unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn trace_reads_enforce_workspace_read_authorizer() {
+        let temp = TempDir::new().expect("temp dir");
+        let trace_dir = temp.path().join("traces");
+        write_trace_records(
+            &trace_dir,
+            &[
+                trace_record("allowed-trace", "allowed", "SELECT allowed", 10),
+                trace_record("denied-trace", "denied", "SELECT denied", 20),
+                trace_record_without_workspace("missing-workspace-trace", "SELECT missing", 30),
+                trace_record_with_span(
+                    "mixed-trace",
+                    "allowed-query-span",
+                    Some("allowed"),
+                    "SELECT mixed allowed",
+                    40,
+                ),
+                trace_record_with_span(
+                    "mixed-trace",
+                    "denied-query-span",
+                    Some("denied"),
+                    "SELECT mixed denied",
+                    41,
+                ),
+            ],
+        );
+
+        let service = TraceService::new(trace_dir, Duration::from_mins(1))
+            .with_workspace_read_authorizer(Arc::new(AllowOneWorkspaceAuthorizer));
+
+        let list = TraceServiceApi::list_traces(
+            &service,
+            trace_request(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
+            }),
+        )
+        .await
+        .expect("list traces")
+        .into_inner();
+        assert_eq!(list.traces.len(), 1);
+        let summary = list.traces.first().expect("allowed trace summary");
+        assert_eq!(summary.trace_id, "allowed-trace");
+        assert_eq!(summary.query, "SELECT allowed");
+        assert!(list.next_page_token.is_empty());
+
+        let mixed = TraceServiceApi::get_trace(
+            &service,
+            trace_request(GetTraceRequest {
+                trace_id: "mixed-trace".to_string(),
+            }),
+        )
+        .await
+        .expect_err("mixed-workspace trace should require every workspace");
+        assert_eq!(mixed.code(), Code::PermissionDenied);
+
+        let denied = TraceServiceApi::get_trace(
+            &service,
+            trace_request(GetTraceRequest {
+                trace_id: "denied-trace".to_string(),
+            }),
+        )
+        .await
+        .expect_err("denied trace should require workspace read authorization");
+        assert_eq!(denied.code(), Code::PermissionDenied);
+        assert!(denied.message().contains("workspace read rejected"));
+
+        let missing_workspace = TraceServiceApi::get_trace(
+            &service,
+            trace_request(GetTraceRequest {
+                trace_id: "missing-workspace-trace".to_string(),
+            }),
+        )
+        .await
+        .expect_err("trace without workspace metadata should fail closed");
+        assert_eq!(missing_workspace.code(), Code::PermissionDenied);
+
+        let allowed = TraceServiceApi::get_trace(
+            &service,
+            trace_request(GetTraceRequest {
+                trace_id: "allowed-trace".to_string(),
+            }),
+        )
+        .await
+        .expect("allowed trace")
+        .into_inner();
+        assert_eq!(allowed.summary.expect("summary").trace_id, "allowed-trace");
+    }
+
+    #[tokio::test]
+    async fn filtered_trace_pagination_uses_opaque_cursors() {
+        let temp = TempDir::new().expect("temp dir");
+        let trace_dir = temp.path().join("traces");
+        write_trace_records(
+            &trace_dir,
+            &[
+                trace_record("allowed-new-trace", "allowed", "SELECT new", 30),
+                trace_record("denied-trace", "denied", "SELECT denied", 20),
+                trace_record("allowed-old-trace", "allowed", "SELECT old", 10),
+            ],
+        );
+        let service = TraceService::new(trace_dir, Duration::from_mins(1))
+            .with_workspace_read_authorizer(Arc::new(AllowOneWorkspaceAuthorizer));
+
+        let first_page = TraceServiceApi::list_traces(
+            &service,
+            trace_request(ListTracesRequest {
+                page_size: 1,
+                page_token: String::new(),
+            }),
+        )
+        .await
+        .expect("first trace page")
+        .into_inner();
+        assert_eq!(
+            first_page.traces.first().expect("first trace").trace_id,
+            "allowed-new-trace"
+        );
+        assert!(!first_page.next_page_token.is_empty());
+        first_page
+            .next_page_token
+            .parse::<usize>()
+            .expect_err("filtered cursor should not be a raw offset");
+
+        let second_page = TraceServiceApi::list_traces(
+            &service,
+            trace_request(ListTracesRequest {
+                page_size: 1,
+                page_token: first_page.next_page_token,
+            }),
+        )
+        .await
+        .expect("second trace page")
+        .into_inner();
+        assert_eq!(
+            second_page.traces.first().expect("second trace").trace_id,
+            "allowed-old-trace"
+        );
+    }
+
+    #[tokio::test]
+    async fn filtered_trace_pagination_continues_after_denied_scan_window() {
+        let temp = TempDir::new().expect("temp dir");
+        let trace_dir = temp.path().join("traces");
+        let mut records = (0..super::FILTERED_TRACE_SCAN_LIMIT)
+            .map(|index| {
+                trace_record(
+                    &format!("denied-trace-{index}"),
+                    "denied",
+                    "SELECT denied",
+                    i64::try_from(index).expect("fixture index fits i64"),
+                )
+            })
+            .collect::<Vec<_>>();
+        records.push(trace_record(
+            "allowed-old-trace",
+            "allowed",
+            "SELECT old",
+            -1,
+        ));
+        write_trace_records(&trace_dir, &records);
+        let service = TraceService::new(trace_dir, Duration::from_mins(1))
+            .with_workspace_read_authorizer(Arc::new(AllowOneWorkspaceAuthorizer));
+
+        let first_page = TraceServiceApi::list_traces(
+            &service,
+            trace_request(ListTracesRequest {
+                page_size: 1,
+                page_token: String::new(),
+            }),
+        )
+        .await
+        .expect("first trace page")
+        .into_inner();
+        assert!(first_page.traces.is_empty());
+        assert!(!first_page.next_page_token.is_empty());
+
+        let second_page = TraceServiceApi::list_traces(
+            &service,
+            trace_request(ListTracesRequest {
+                page_size: 1,
+                page_token: first_page.next_page_token,
+            }),
+        )
+        .await
+        .expect("second trace page")
+        .into_inner();
+        assert_eq!(
+            second_page.traces.first().expect("second trace").trace_id,
+            "allowed-old-trace"
+        );
+        assert!(second_page.next_page_token.is_empty());
+    }
+
+    fn write_trace_records(dir: &Path, records: &[TraceSpanRecord]) {
+        fs::create_dir_all(dir).expect("create trace dir");
+        let contents = records
+            .iter()
+            .map(|record| serde_json::to_string(record).expect("serialize trace record"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(
+            dir.join("spans-00000000000000000001-test-0000000000000000.jsonl"),
+            format!("{contents}\n"),
+        )
+        .expect("write trace records");
+    }
+
+    fn trace_record(
+        trace_id: &str,
+        workspace: &str,
+        sql: &str,
+        end_time_unix_nanos: i64,
+    ) -> TraceSpanRecord {
+        trace_record_with_span(
+            trace_id,
+            "query-span",
+            Some(workspace),
+            sql,
+            end_time_unix_nanos,
+        )
+    }
+
+    fn trace_record_without_workspace(
+        trace_id: &str,
+        sql: &str,
+        end_time_unix_nanos: i64,
+    ) -> TraceSpanRecord {
+        trace_record_with_span(trace_id, "query-span", None, sql, end_time_unix_nanos)
+    }
+
+    fn trace_record_with_span(
+        trace_id: &str,
+        span_id: &str,
+        workspace: Option<&str>,
+        sql: &str,
+        end_time_unix_nanos: i64,
+    ) -> TraceSpanRecord {
+        let attributes = workspace.map_or_else(
+            || {
+                json!({
+                    "sql": sql,
+                    "status": "ok"
+                })
+            },
+            |workspace| {
+                json!({
+                    "workspace": workspace,
+                    "sql": sql,
+                    "status": "ok"
+                })
+            },
+        );
+
+        TraceSpanRecord {
+            trace_id: trace_id.to_string(),
+            span_id: span_id.to_string(),
+            parent_span_id: None,
+            parent_span_is_remote: false,
+            name: "coral.query".to_string(),
+            kind: "internal".to_string(),
+            status: StoredTraceStatus::Ok,
+            status_message: None,
+            start_time_unix_nanos: end_time_unix_nanos.saturating_sub(1),
+            end_time_unix_nanos,
+            duration_nanos: 1,
+            attributes_json: attributes.to_string(),
+            events_json: "[]".to_string(),
+            links_json: "[]".to_string(),
+            resource_json: "{}".to_string(),
+            scope_name: "test".to_string(),
+            scope_version: None,
+            scope_schema_url: None,
+            scope_attributes_json: "{}".to_string(),
+            trace_flags: 0,
+            trace_state: String::new(),
+            is_remote: false,
+        }
     }
 }


### PR DESCRIPTION
## Intent

Land `feat(app): authorize trace reads` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-26-workspace-read-authorizer...sauldhernandez/dsl-v4-identity-v2-27-telemetry-read-authorizer
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
