### PR TITLE
docs: document DSL v4 identity specs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -90,7 +90,8 @@
           "reference/engine-configuration",
           "reference/bundled-sources",
           "reference/community-sources",
-          "reference/source-spec-reference"
+          "reference/source-spec-reference",
+          "reference/identity-spec-reference"
         ]
       },
       {

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -10,10 +10,63 @@ Coral stores local configuration in `config.toml` inside its platform-specific [
 Coral writes source installation state to `config.toml` when you run commands such as `coral source add` and `coral source remove`.
 
 This state includes installed-source metadata and non-secret source variables. Source secrets are stored separately within the same local trust boundary.
+Global identity specs installed with `coral identity-spec add` or bundled in
+`coral source add --file` live under `identity-specs/` in the same local state
+directory and are shared by every workspace. Declared identity-spec input
+material, including secret inputs, is stored with the installed identity spec
+through Coral credential storage rather than with identities created from the
+spec.
+User-owned identities created with `coral identity add` live under
+`identities/users/local/` in the same local state directory. A user-owned
+identity is provider-facing credential material owned by a Coral user principal.
+OSS Coral has one user principal, `local`; products built on Coral can provide
+workspace-owned identity storage through Coral's runtime identity provider seam.
+Ownership is independent of identity type, so user-owned and workspace-owned
+identity stores can hold OAuth or fixed-token identities.
+User-owned source-surface selections live separately under
+`identities/source-bindings/users/<user>/<workspace>/<source>/<surface>/`.
 
 <Note>
   Prefer the `coral source` commands for source state instead of editing workspace entries manually.
 </Note>
+
+DSL v4 sources that declare surface `identity_requirements` may also carry
+workspace source-surface identity bindings. Bindings live on the installed
+source entry because surface ids are source-local:
+
+```toml
+[workspaces.default.sources.github_v4]
+variables = {}
+secrets = []
+identity_bindings = { rest = { owner = "user" } }
+origin = "imported"
+```
+
+For user-owned identity slots, app config stores only the owner because the
+concrete identity and accepted branch can differ per Coral user principal:
+
+```toml
+identity_bindings = { rest = { owner = "user" } }
+```
+
+In OSS Coral the only user principal is `local`. To change that user's selected
+identity for an imported DSL v4 source, re-run `coral source add --file` with
+the same source manifest and choose a different compatible identity. CLI source
+re-import replaces the source's identity binding set with the bindings required
+by the new manifest, so removing a surface identity requirement clears the stale
+workspace binding from config.
+
+For workspace-owned identity slots, app config stores the concrete workspace
+selection because all callers share it:
+
+```toml
+identity_bindings = { rest = { owner = "workspace", identity = "github_workspace", accepted_identity = "github-rest-read" } }
+```
+
+Each binding key is a surface id. `owner` is either `user` or `workspace`.
+`identity` names an existing identity reference and `accepted_identity`
+optionally selects one entry from the surface's `identity_requirements.accepts`
+list for workspace-owned bindings.
 
 ## Runtime features
 
@@ -41,6 +94,7 @@ Feature values must be booleans. Unknown feature keys are preserved in `config.t
 
 | Feature | Default | Description |
 | ------- | ------- | ----------- |
+| `dsl_v4` | `false` | Experimental. Enables preview DSL v4 manifests imported with `coral source add --file`. |
 | `feedback` | `false` | Experimental. Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral. |
 
 ## OpenTelemetry

--- a/docs/reference/identity-spec-reference.mdx
+++ b/docs/reference/identity-spec-reference.mdx
@@ -1,0 +1,213 @@
+---
+title: Identity Spec Reference
+description: YAML format for declaring Coral identity types and setup behavior.
+---
+
+Identity specs describe reusable app-owned identity types. The identity `type`
+determines both how Coral can instantiate the identity and how the resolved
+credential material is applied to outbound HTTP requests.
+
+Identity specs do not install sources or bind a source surface to an identity.
+They are the declarative contract that identity setup and runtime providers can
+consume. Use `coral identity add <NAME> --identity-spec <SPEC>` to instantiate a
+stored user-owned identity from an installed OAuth or fixed-token identity spec.
+
+A user-owned identity represents a Coral user principal to a source provider. It
+is not the Coral user principal itself. OSS Coral has one local principal,
+`local`, so `coral identity add` stores provider-facing identity material under
+that principal.
+
+Identity ownership is independent of identity type. An `oauth` or `fixed_token`
+identity can be user-owned or workspace-owned. OSS Coral currently implements
+local storage and CLI instantiation for user-owned OAuth and fixed-token
+identities; products built on Coral can provide workspace-owned storage and
+additional type-specific instantiation flows through the app identity seams.
+
+Identity specs are installed globally for the local Coral app, not per
+workspace. Every workspace can use the same installed spec.
+
+Identity specs, and the user-owned identities created from them, are part of
+DSL v4 and are gated behind the same `dsl_v4` runtime feature as v4 sources.
+Enable it with `coral features enable dsl_v4` before managing identity specs or
+creating identities.
+
+Install or inspect specs with:
+
+```shellscript
+coral identity-spec add --file ./github-oauth.identity.yaml
+coral identity-spec list
+coral identity-spec info github_oauth
+coral identity-spec remove github_oauth --force
+coral identity add github_local --identity-spec github_oauth
+printf '%s\n' "$GITHUB_TOKEN" | coral identity add github_pat --identity-spec github_pat --token-stdin
+```
+
+`coral source add --file` also accepts YAML streams containing exactly one
+source spec document and one or more `kind: identity` documents separated by
+`---`. Coral installs those identity specs globally before importing the source
+document. Declared identity-spec inputs in those bundled specs are collected at
+that install step and stored with the installed identity spec. When that source
+is DSL v4 and declares `identity_requirements`, the CLI uses those installed
+specs to prompt for an existing compatible user-owned identity or to create and
+bind a new user-owned identity for the source surface.
+
+Stored identities are separate from identity specs. Removing an identity spec
+does not delete stored identities that were created from it, but those identities
+become orphaned. They can be used again only if the same identity spec manifest
+is installed again; installing a different manifest under the same spec name
+does not reattach the stored identity.
+Because identity specs define where and how stored identity material may be
+injected, Coral refuses to replace an installed spec with a different manifest
+while stored identities reference that spec. Re-adding the same manifest is
+allowed; changing an in-use spec requires creating new stored identities from
+the new spec.
+
+## Example
+
+```yaml
+kind: identity
+spec_version: 1
+name: google_oauth
+version: 0.1.0
+description: Google OAuth access token for Google APIs.
+issuer: google
+type: oauth
+audience:
+  host: googleapis.com
+inputs:
+  GOOGLE_OAUTH_CLIENT_SECRET:
+    kind: secret
+    hint: Client secret from your Google OAuth desktop app.
+oauth:
+  method:
+    label: Connect with Google
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    endpoints:
+      authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+      token_url: https://oauth2.googleapis.com/token
+    client:
+      id:
+        default: your-public-client-id.apps.googleusercontent.com
+      secret:
+        input: GOOGLE_OAUTH_CLIENT_SECRET
+        transport: request_body
+    scopes:
+      scope:
+        delimiter: space
+        values:
+          - https://www.googleapis.com/auth/calendar.readonly
+```
+
+## Top-Level Fields
+
+| Field | Description |
+| --- | --- |
+| `kind` | Must be `identity`. |
+| `spec_version` | Identity spec format version. The current version is `1`. |
+| `name` | Stable identity spec name. Use an identifier such as `github_oauth` or `github_pat`. |
+| `version` | Version of this identity spec. |
+| `description` | Optional human-readable description. |
+| `issuer` | Provider or issuer name, such as `github` or `google`. |
+| `type` | Identity type. Supported values are `oauth` and `fixed_token`. |
+| `audience` | Optional provider-specific object that scopes the identity target, such as a host, tenant, organization, or account. Built-in HTTP request injection requires a string `audience.host`. |
+| `inputs` | Optional setup inputs for OAuth identity creation. Inputs can be `kind: variable` or `kind: secret`. |
+| `oauth` | Required only for `type: oauth`; declares exactly one OAuth setup method. |
+
+Identity specs do not declare source-style `auth` or `injection_method`. The
+identity `type` determines request injection. OAuth identity specs may declare
+setup `inputs`; fixed-token identity specs currently must not.
+
+## Identity Types
+
+Use separate identity specs when the instantiation behavior or semantics differ.
+For example, `github_oauth`, `github_oauth_app`, and `github_pat` are distinct
+specs even though all ultimately authenticate GitHub HTTP requests.
+
+The built-in HTTP identity runtimes require `audience.host` before injecting an
+`Authorization` header. At request time, Coral compares that host to the actual
+outbound request host and only injects credentials for the exact host or one of
+its subdomains. For example, an identity with `audience.host: github.com` may
+authenticate requests to `github.com` and `api.github.com`, but not
+`github.com.example.test`.
+
+`type: oauth` uses the `oauth.method` block to describe the provider flow,
+endpoints, client, and scopes. At request time, OAuth identities refresh stored
+token material when needed and inject `Authorization: Bearer <access-token>`
+from the identity's `ACCESS_TOKEN` material.
+
+`type: fixed_token` represents a user-supplied bearer token. At request time,
+fixed-token identities inject `Authorization: Bearer <token>` from the
+identity's `TOKEN` material.
+
+Request injection is owned by the identity provider for that type, not by the
+source spec. A source can require acceptable identity spec ids and audience, but
+it does not author how that identity mutates outbound HTTP requests.
+
+## OAuth Setup
+
+OAuth identity specs declare one setup method directly under `oauth.method`.
+The method can declare display metadata plus the OAuth `flow`, `endpoints`,
+`client`, and `scopes` blocks. If a provider supports multiple OAuth setup
+paths, author multiple identity specs and let sources list the acceptable spec
+ids.
+
+`oauth.client.id` may declare `default`, `input`, or both. A default client ID
+lets Coral run the OAuth flow without prompting the user for that value; when
+both are present, an entered input value overrides the default. If
+`oauth.client.id.input` references a declared identity input, that input must be
+`kind: variable`.
+
+Confidential OAuth clients declare `oauth.client.secret.input` plus
+`oauth.client.secret.transport`. When the secret input is declared under
+`inputs`, it must be `kind: secret`. Coral stores declared identity input
+material with the installed identity spec, not with identities instantiated
+from it, so identity materialization and token refresh can retrieve the
+spec-owned values.
+
+OAuth endpoint templates may reference declared identity inputs with
+`{{input.KEY}}`, but only `kind: variable` inputs can be used in URLs. Use this
+for non-secret endpoint components such as a tenant, host, or realm. Endpoint
+templates do not use source inputs; identity setup is global rather than
+source-scoped.
+
+## Source Identity Requirements
+
+DSL v4 source surfaces can declare `identity_requirements`. An identity spec's
+`name` is the spec id that source requirements list under `identity_specs`.
+Matching uses that spec id plus the source-declared `audience`; issuer and
+identity type do not participate in source matching.
+
+Workspace source config stores the owner slot for each identity-required
+surface. For user-owned identities, the source config does not store the
+concrete identity name or accepted branch because those can differ per Coral
+user principal:
+
+```toml
+identity_bindings = { rest = { owner = "user" } }
+```
+
+Coral stores the concrete user-owned source-surface selection separately for
+each user. In OSS Coral there is only the local `local` user, so
+`coral source add --file` creates or selects a compatible user-owned identity
+and records that local user's selection while importing the source.
+Re-running `coral source add --file` with the same DSL v4 source manifest
+replaces that local user's selected identity for the source surface.
+
+Workspace-owned identities can store the concrete identity reference in the
+workspace source config because the selection is shared by the workspace:
+
+```toml
+identity_bindings = { rest = { owner = "workspace", identity = "github_workspace", accepted_identity = "github-rest-read" } }
+```
+
+Removing an identity spec removes the global spec document and any spec-owned
+input material. Stored identity records and source bindings are not deleted.
+Identities of any owner or type that depend on the removed spec become orphaned
+and cannot satisfy source identity requirements until the same identity spec
+manifest is reinstalled, the identity is recreated from a new spec, or the
+binding is changed. When stored identities depend on the spec,
+`coral identity-spec remove` requires `--force` and reports how many stored
+identities became orphaned.

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -29,9 +29,149 @@ test_queries:
 | ------------- | -------------------------------------------------- |
 | `name`        | Source name, also used as the SQL schema name      |
 | `version`     | Source spec version string                         |
-| `dsl_version` | Coral source spec DSL version (currently `3`)      |
-| `backend`     | How data is fetched: `http`, `file`, or `mcp` |
+| `dsl_version` | Coral source spec DSL version: `3` or `4`      |
+| `backend`     | DSL v3 only. How data is fetched: `http`, `file`, or `mcp` |
 | `test_queries` | Optional read-only SQL checks Coral runs during source validation |
+
+DSL v4 top-level fields are limited to `name`, `version`, `dsl_version`,
+`description`, `test_queries`, and `surfaces`. Top-level `backend`, `inputs`,
+`tables`, `functions`, HTTP runtime fields, and projection override fields are
+rejected for DSL v4.
+
+## DSL v4 surfaces
+
+DSL v4 is surface-first. It keeps existing DSL v3 support intact while adding a
+new manifest shape for imported upstream surfaces:
+
+```yaml
+name: github_v4
+version: 2.0.0
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/pinned/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    inputs:
+      GITHUB_API_BASE:
+        kind: variable
+        default: https://api.github.com
+    base_url: "{{input.GITHUB_API_BASE}}"
+    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+            - github_pat
+          audience:
+            host: github.com
+    request_headers:
+      - name: X-GitHub-Api-Version
+        from: literal
+        value: "2022-11-28"
+```
+
+Enable the `dsl_v4` runtime feature before importing a `dsl_version: 4` source:
+
+```shellscript
+coral features enable dsl_v4
+```
+
+Each surface requires:
+
+- `id`: stable source-local identifier matching `[a-z][a-z0-9_]*`
+- `type`: `openapi` or `mcp`
+- `namespace_suffix`: optional source-relative relation namespace suffix. When
+  omitted, the surface uses the installed source name as its relation namespace.
+  When present, Coral exposes the surface as `<source_name>_<namespace_suffix>`.
+  In a multi-surface source, at most one surface may omit `namespace_suffix`.
+
+OpenAPI surfaces declare:
+
+- exactly one descriptor location, either `url` or `file`
+- `sha256`: optional lowercase hex SHA-256 of the exact descriptor bytes
+- `base_url`: optional runtime base URL template. If omitted, Coral derives it
+  from the OpenAPI document's first non-empty `servers[].url` during source
+  add/materialization, substituting OpenAPI server variable defaults.
+- `inputs`: optional surface-scoped variables and secrets. Reusing an input key
+  across surfaces is valid only when the declarations are structurally
+  identical.
+- `identity_requirements`: optional request identity contract. Use this when
+  access should come from a configured source-surface identity binding.
+- `auth`: optional OpenAPI HTTP authentication config for source-owned
+  credentials. Do not combine this with `identity_requirements` for the same
+  credential path.
+- `request_headers`: optional non-auth headers applied to every request, such
+  as API version or User-Agent.
+- `rate_limit`: optional retry/rate-limit response header configuration.
+
+MCP surfaces declare:
+
+- `server`: MCP server launch or streamable HTTP connection config
+- `inputs`: optional surface-scoped variables and secrets referenced by the MCP
+  server config
+
+Remote OpenAPI descriptors must use HTTPS and can be pinned by `sha256`. Local
+`file` descriptors are for imported development sources only; they must be
+regular files under the current working directory, must not be symlinks, and
+are bounded to the same descriptor size limit as remote descriptors. Bundled
+sources should not depend on local OpenAPI files.
+
+### Identity requirements
+
+Surface `identity_requirements` declare which bound identities can satisfy the
+surface:
+
+```yaml
+identity_requirements:
+  accepts:
+    - id: github-rest-read
+      identity_specs:
+        - github_oauth
+        - github_pat
+      audience:
+        host: github.com
+```
+
+`accepts` is a non-empty list. Each accepted identity requires:
+
+- `id`: stable source-local identifier for this accepted identity entry
+- `identity_specs`: non-empty list of global identity spec names
+- `audience`: optional provider-specific object that narrows the target API,
+  tenant, host, organization, or account
+
+Accepted identity entries have OR semantics: any one accepted entry may satisfy
+the surface. Within an accepted entry, the resolved identity must have one of
+the listed identity spec ids and its audience must include every key/value
+declared by the source. For surfaces that use `identity_requirements`, request
+credential injection is delegated to the resolved identity and its identity spec
+type.
+
+OpenAPI surfaces that declare `identity_requirements` cannot use secret inputs;
+use [identity specs](/reference/identity-spec-reference) for credentials. A
+source bundle passed to `coral source add --file` can contain one source spec
+document and one or more `kind: identity` documents separated by `---`; Coral
+installs those identity specs before importing the source.
+
+### Generated artifacts
+
+Coral publishes deterministic SQL tables and table functions for supported
+read-only OpenAPI `GET` operations. Mutating operations, request-body
+operations, no-body responses, unsupported parameter serialization, and
+unknown-cardinality responses are imported as diagnostics or hidden projections.
+MCP surfaces expose the runtime operations provided by their MCP server.
+
+Generated DSL v4 artifacts are stored under:
+
+```text
+workspaces/<workspace>/sources/<source>/materialized/v4/
+```
+
+The directory contains `fingerprint.yaml`, `diagnostics.yaml`,
+`projections.yaml`, per-surface `semantic-ir.yaml`, the exact
+`source-document.raw`, and a normalized `source-document.yaml`. If these
+artifacts are missing or stale, catalog and query operations fail with a message
+that points to re-adding or reinstalling the source.
 
 ## Test queries
 


### PR DESCRIPTION
## Intent

Land `docs: document DSL v4 identity specs` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-28-source-mutation-authorizer...sauldhernandez/dsl-v4-identity-v2-29-identity-docs
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
