### PR TITLE
feat(cli): import source identity bundles

### DIFF
--- a/crates/coral-app/src/identities/runtime.rs
+++ b/crates/coral-app/src/identities/runtime.rs
@@ -292,7 +292,7 @@ mod tests {
         prepared: &PreparedRuntimeIdentity,
         url: &str,
     ) -> Result<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError> {
-        let context = SelectedRequestIdentity::new(
+        let identity = SelectedRequestIdentity::new(
             "demo".to_string(),
             prepared.identity.identity_spec_id().to_string(),
             prepared.identity.audience().clone(),
@@ -300,7 +300,7 @@ mod tests {
         let request = reqwest::Request::new(reqwest::Method::GET, url.parse().expect("url"));
         prepared
             .identity
-            .resolve_headers(&context, &request, &BTreeMap::new())
+            .resolve_headers(&identity, &request, &BTreeMap::new())
             .await
     }
 

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -227,16 +227,13 @@ impl SourceServiceApi for SourceService {
             let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            management_authorizer
-                .authorize_management_mutation(
-                    &principal,
-                    ManagementMutation::WorkspaceSource {
-                        workspace_id: workspace_name.as_str(),
-                        kind: WorkspaceSourceMutationKind::CreateBundled,
-                    },
-                )
-                .await
-                .map_err(authorization_status)?;
+            authorize_source_mutation(
+                management_authorizer.as_ref(),
+                &principal,
+                &workspace_name,
+                WorkspaceSourceMutationKind::CreateBundled,
+            )
+            .await?;
             let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
             let command = CreateBundledSourceCommand {
                 name: bundled_name,
@@ -268,16 +265,13 @@ impl SourceServiceApi for SourceService {
             let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            management_authorizer
-                .authorize_management_mutation(
-                    &principal,
-                    ManagementMutation::WorkspaceSource {
-                        workspace_id: workspace_name.as_str(),
-                        kind: WorkspaceSourceMutationKind::CreateBundledWithOAuth,
-                    },
-                )
-                .await
-                .map_err(authorization_status)?;
+            authorize_source_mutation(
+                management_authorizer.as_ref(),
+                &principal,
+                &workspace_name,
+                WorkspaceSourceMutationKind::CreateBundledWithOAuth,
+            )
+            .await?;
             let response_workspace_name = workspace_name.clone();
             let command = CreateBundledSourceWithOAuthCommand {
                 name: SourceName::parse(&request.name).map_err(app_status)?,
@@ -323,12 +317,18 @@ impl SourceServiceApi for SourceService {
             let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_source_mutation(
+                management_authorizer.as_ref(),
+                &principal,
+                &workspace_name,
+                WorkspaceSourceMutationKind::CreateFromSourceSpec,
+            )
+            .await?;
             management_authorizer
                 .authorize_management_mutation(
                     &principal,
-                    ManagementMutation::WorkspaceSource {
-                        workspace_id: workspace_name.as_str(),
-                        kind: WorkspaceSourceMutationKind::CreateFromSourceSpec,
+                    ManagementMutation::SourceSpec {
+                        kind: ResourceMutationKind::Upsert,
                     },
                 )
                 .await
@@ -360,16 +360,13 @@ impl SourceServiceApi for SourceService {
             let principal = RequestContext::from_request(&request)?.principal().clone();
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            management_authorizer
-                .authorize_management_mutation(
-                    &principal,
-                    ManagementMutation::WorkspaceSource {
-                        workspace_id: workspace_name.as_str(),
-                        kind: WorkspaceSourceMutationKind::Delete,
-                    },
-                )
-                .await
-                .map_err(authorization_status)?;
+            authorize_source_mutation(
+                management_authorizer.as_ref(),
+                &principal,
+                &workspace_name,
+                WorkspaceSourceMutationKind::Delete,
+            )
+            .await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             run_blocking_source_operation(move || {
                 sources.delete_source(&workspace_name, &source_name)
@@ -609,6 +606,24 @@ type CreateBundledSourceWithOAuthResponseStreamBox =
 type ImportSourceResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 type ImportSourceFuture = Pin<Box<dyn Future<Output = Result<InstalledSource, Status>> + Send>>;
+
+async fn authorize_source_mutation(
+    authorizer: &dyn ManagementAuthorizer,
+    principal: &UserPrincipal,
+    workspace_name: &WorkspaceName,
+    kind: WorkspaceSourceMutationKind,
+) -> Result<(), Status> {
+    authorizer
+        .authorize_management_mutation(
+            principal,
+            ManagementMutation::WorkspaceSource {
+                workspace_id: workspace_name.as_str(),
+                kind,
+            },
+        )
+        .await
+        .map_err(authorization_status)
+}
 
 async fn authorize_workspace_read(
     authorizer: &dyn WorkspaceReadAuthorizer,

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -1376,7 +1376,6 @@ async fn prompt_user_identity_bindings_for_import(
         bindings.push(UserSourceIdentityBinding {
             surface_id: surface.id.clone(),
             identity,
-            accepted_identity: accepted.id,
         });
     }
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -28,7 +28,9 @@ use clap::{
     Parser, Subcommand, ValueEnum,
 };
 use clap_complete::{Shell, generate};
-use coral_api::v1::{ExecuteSqlRequest, ExecuteSqlResponse, UserSourceIdentityBinding, Workspace};
+use coral_api::v1::{
+    ExecuteSqlRequest, ExecuteSqlResponse, IdentityOwner, SourceIdentityBinding, Workspace,
+};
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
 use coral_client::{
@@ -1373,9 +1375,10 @@ async fn prompt_user_identity_bindings_for_import(
         let accepted = select_accepted_identity_for_surface(&surface.id, requirements)?;
         let identity =
             select_or_create_user_identity_for_surface(app, loaded, &surface.id, &accepted).await?;
-        bindings.push(UserSourceIdentityBinding {
+        bindings.push(SourceIdentityBinding {
             surface_id: surface.id.clone(),
             identity,
+            owner: IdentityOwner::User as i32,
         });
     }
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -1259,33 +1259,14 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
             }
         }
         (None, Some(file)) => {
-            let (manifest_yaml, manifest) = source_ops::load_validated_manifest_file(&file)?;
-            let identity_bindings = source_ops::import_source_identity_bindings_from_args(
+            import_source_file(
+                app,
+                file,
+                interactive,
                 &user_identity_bindings,
                 &workspace_identity_bindings,
-            )?;
-            if interactive {
-                let inputs = source_ops::prompt_for_inputs_with_credential_methods(
-                    manifest.declared_inputs(),
-                )?;
-                source_ops::import_source_with_credentials(
-                    app,
-                    manifest_yaml,
-                    inputs,
-                    identity_bindings,
-                )
-                .await?
-            } else {
-                let (variables, secrets) = source_ops::collect_inputs_from_env(
-                    manifest.declared_inputs(),
-                    format!(
-                        "coral source add --interactive --file {}",
-                        source_ops::shell_quote_arg(&file.display().to_string())
-                    ),
-                )?;
-                source_ops::import_source(app, manifest_yaml, variables, secrets, identity_bindings)
-                    .await?
-            }
+            )
+            .await?
         }
         _ => unreachable!("clap enforces exactly one of name or file"),
     };
@@ -1297,6 +1278,63 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
     source_ops::validate_and_warn(app, &response.name, source_ops::TableDisplayLimit::DEFAULT)
         .await
         .map_err(Into::into)
+}
+
+async fn import_source_file(
+    app: &AppClient,
+    file: PathBuf,
+    interactive: bool,
+    user_identity_bindings: &[String],
+    workspace_identity_bindings: &[String],
+) -> Result<coral_api::v1::Source, CliError> {
+    let loaded = source_ops::load_validated_manifest_file(&file)?;
+    let interactive_command = format!(
+        "coral source add --interactive --file {}",
+        source_ops::shell_quote_arg(&file.display().to_string())
+    );
+    let identity_spec_manifest_yamls = loaded.identity_spec_manifest_yamls();
+    let identity_bindings = source_ops::import_source_identity_bindings_from_args(
+        user_identity_bindings,
+        workspace_identity_bindings,
+    )?;
+
+    if interactive {
+        let inputs = source_ops::prompt_for_inputs_with_credential_methods(
+            loaded.manifest.declared_inputs(),
+        )?;
+        let identity_spec_inputs =
+            source_ops::prompt_identity_spec_inputs_for_import(&loaded.identity_manifests)?;
+        return source_ops::import_source_with_credentials(
+            app,
+            loaded.manifest_yaml,
+            inputs,
+            identity_spec_manifest_yamls,
+            identity_spec_inputs,
+            identity_bindings,
+        )
+        .await
+        .map_err(Into::into);
+    }
+
+    let (variables, secrets) = source_ops::collect_inputs_from_env(
+        loaded.manifest.declared_inputs(),
+        interactive_command.clone(),
+    )?;
+    let identity_spec_inputs = source_ops::identity_spec_inputs_for_import_from_env(
+        &loaded.identity_manifests,
+        &interactive_command,
+    )?;
+    source_ops::import_source(
+        app,
+        loaded.manifest_yaml,
+        variables,
+        secrets,
+        identity_spec_manifest_yamls,
+        identity_spec_inputs,
+        identity_bindings,
+    )
+    .await
+    .map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -28,7 +28,7 @@ use clap::{
     Parser, Subcommand, ValueEnum,
 };
 use clap_complete::{Shell, generate};
-use coral_api::v1::{ExecuteSqlRequest, ExecuteSqlResponse, Workspace};
+use coral_api::v1::{ExecuteSqlRequest, ExecuteSqlResponse, UserSourceIdentityBinding, Workspace};
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
 use coral_client::{
@@ -36,6 +36,7 @@ use coral_client::{
     format_batches_table, manifest_input_from_proto,
 };
 use dialoguer::console::measure_text_width;
+use dialoguer::{Input, Select, theme::ColorfulTheme};
 use tonic::Request;
 
 #[cfg(test)]
@@ -1293,17 +1294,28 @@ async fn import_source_file(
         source_ops::shell_quote_arg(&file.display().to_string())
     );
     let identity_spec_manifest_yamls = loaded.identity_spec_manifest_yamls();
-    let identity_bindings = source_ops::import_source_identity_bindings_from_args(
+    let has_identity_binding_args =
+        !user_identity_bindings.is_empty() || !workspace_identity_bindings.is_empty();
+    let mut identity_bindings = source_ops::import_source_identity_bindings_from_args(
         user_identity_bindings,
         workspace_identity_bindings,
     )?;
+    let should_prompt_identity_bindings =
+        interactive && !has_identity_binding_args && source_has_identity_requirements(&loaded);
 
     if interactive {
         let inputs = source_ops::prompt_for_inputs_with_credential_methods(
             loaded.manifest.declared_inputs(),
         )?;
-        let identity_spec_inputs =
-            source_ops::prompt_identity_spec_inputs_for_import(&loaded.identity_manifests)?;
+        let (identity_spec_manifest_yamls, identity_spec_inputs) =
+            if should_prompt_identity_bindings {
+                identity_bindings = prompt_user_identity_bindings_for_import(app, &loaded).await?;
+                (Vec::new(), Vec::new())
+            } else {
+                let identity_spec_inputs =
+                    source_ops::prompt_identity_spec_inputs_for_import(&loaded.identity_manifests)?;
+                (identity_spec_manifest_yamls, identity_spec_inputs)
+            };
         return source_ops::import_source_with_credentials(
             app,
             loaded.manifest_yaml,
@@ -1335,6 +1347,214 @@ async fn import_source_file(
     )
     .await
     .map_err(Into::into)
+}
+
+fn source_has_identity_requirements(loaded: &source_ops::LoadedManifestFile) -> bool {
+    loaded.manifest.as_v4().is_some_and(|v4| {
+        v4.surfaces
+            .iter()
+            .any(|surface| surface.identity_requirements.is_some())
+    })
+}
+
+async fn prompt_user_identity_bindings_for_import(
+    app: &AppClient,
+    loaded: &source_ops::LoadedManifestFile,
+) -> Result<source_ops::ImportSourceIdentityBindings, CliError> {
+    let Some(v4) = loaded.manifest.as_v4() else {
+        return Ok(source_ops::ImportSourceIdentityBindings::default());
+    };
+
+    let mut bindings = Vec::new();
+    for surface in &v4.surfaces {
+        let Some(requirements) = &surface.identity_requirements else {
+            continue;
+        };
+        let accepted = select_accepted_identity_for_surface(&surface.id, requirements)?;
+        let identity =
+            select_or_create_user_identity_for_surface(app, loaded, &surface.id, &accepted).await?;
+        bindings.push(UserSourceIdentityBinding {
+            surface_id: surface.id.clone(),
+            identity,
+            accepted_identity: accepted.id,
+        });
+    }
+
+    source_ops::import_source_user_identity_bindings(bindings).map_err(Into::into)
+}
+
+fn select_accepted_identity_for_surface(
+    surface_id: &str,
+    requirements: &coral_spec::v4::IdentityRequirements,
+) -> Result<coral_spec::v4::AcceptedIdentityRequirement, anyhow::Error> {
+    if requirements.accepts.len() == 1 {
+        let accepted = requirements
+            .accepts
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("surface {surface_id} accepts no identities"))?;
+        return Ok(accepted.clone());
+    }
+    let theme = ColorfulTheme::default();
+    let labels = requirements
+        .accepts
+        .iter()
+        .map(|accepted| accepted.id.clone())
+        .collect::<Vec<_>>();
+    let selected = Select::with_theme(&theme)
+        .with_prompt(format!("Identity requirement for surface {surface_id}"))
+        .items(&labels)
+        .default(0)
+        .interact()?;
+    requirements
+        .accepts
+        .get(selected)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("identity requirement selection is out of range"))
+}
+
+async fn select_or_create_user_identity_for_surface(
+    app: &AppClient,
+    loaded: &source_ops::LoadedManifestFile,
+    surface_id: &str,
+    accepted: &coral_spec::v4::AcceptedIdentityRequirement,
+) -> Result<String, CliError> {
+    let identities = source_ops::list_user_owned_identities(app).await?;
+    let compatible = identities
+        .into_iter()
+        .filter(|identity| {
+            accepted
+                .identity_specs
+                .iter()
+                .any(|identity_spec| identity_spec == &identity.identity_spec)
+        })
+        .collect::<Vec<_>>();
+
+    if compatible.is_empty() {
+        return create_user_identity_for_surface(app, loaded, surface_id, accepted).await;
+    }
+
+    let theme = ColorfulTheme::default();
+    let mut labels = compatible
+        .iter()
+        .map(|identity| format!("Use {} ({})", identity.name, identity.identity_spec))
+        .collect::<Vec<_>>();
+    labels.push("Create new identity".to_string());
+    let create_index = labels.len() - 1;
+    let selected = Select::with_theme(&theme)
+        .with_prompt(format!("Identity for surface {surface_id}"))
+        .items(&labels)
+        .default(0)
+        .interact()
+        .map_err(anyhow::Error::from)?;
+    if selected == create_index {
+        create_user_identity_for_surface(app, loaded, surface_id, accepted).await
+    } else {
+        compatible
+            .get(selected)
+            .map(|identity| identity.name.clone())
+            .ok_or_else(|| anyhow::anyhow!("identity selection is out of range").into())
+    }
+}
+
+async fn create_user_identity_for_surface(
+    app: &AppClient,
+    loaded: &source_ops::LoadedManifestFile,
+    surface_id: &str,
+    accepted: &coral_spec::v4::AcceptedIdentityRequirement,
+) -> Result<String, CliError> {
+    let identity_spec = select_identity_spec_for_surface(surface_id, accepted)?;
+    let manifest = ensure_identity_spec_available(app, loaded, &identity_spec).await?;
+    let default_name = default_identity_name(&manifest);
+    let name = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Identity name")
+        .default(default_name)
+        .interact_text()
+        .map_err(anyhow::Error::from)?;
+    let identity = match manifest.identity_type {
+        coral_spec::IdentitySpecType::OAuth => {
+            let selected = source_ops::identity_oauth_method(&manifest)?;
+            source_ops::print_oauth_hint(selected.hint);
+            source_ops::create_user_owned_identity_with_oauth(
+                app,
+                &name,
+                &manifest.name,
+                &selected.label,
+            )
+            .await?
+        }
+        coral_spec::IdentitySpecType::FixedToken => {
+            let token = source_ops::prompt_fixed_token_identity_token(&manifest.name)?;
+            source_ops::create_user_owned_identity_with_fixed_token(
+                app,
+                &name,
+                &manifest.name,
+                token,
+            )
+            .await?
+        }
+    };
+    Ok(identity.name)
+}
+
+fn select_identity_spec_for_surface(
+    surface_id: &str,
+    accepted: &coral_spec::v4::AcceptedIdentityRequirement,
+) -> Result<String, anyhow::Error> {
+    if accepted.identity_specs.len() == 1 {
+        let identity_spec = accepted.identity_specs.first().ok_or_else(|| {
+            anyhow::anyhow!("accepted identity '{}' has no identity specs", accepted.id)
+        })?;
+        return Ok(identity_spec.clone());
+    }
+    let selected = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!("Identity spec for surface {surface_id}"))
+        .items(&accepted.identity_specs)
+        .default(0)
+        .interact()?;
+    accepted
+        .identity_specs
+        .get(selected)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("identity spec selection is out of range"))
+}
+
+async fn ensure_identity_spec_available(
+    app: &AppClient,
+    loaded: &source_ops::LoadedManifestFile,
+    identity_spec: &str,
+) -> Result<coral_spec::IdentityManifest, CliError> {
+    if let Some(document) = loaded
+        .identity_manifests
+        .iter()
+        .find(|document| document.manifest.name == identity_spec)
+    {
+        let inputs = source_ops::prompt_required_identity_spec_inputs(&document.manifest)?;
+        source_ops::add_identity_spec(app, document.manifest_yaml.clone(), inputs).await?;
+        return Ok(document.manifest.clone());
+    }
+
+    let installed = source_ops::get_identity_spec(app, identity_spec).await?;
+    coral_spec::parse_identity_manifest_yaml(&installed.manifest_yaml)
+        .map_err(anyhow::Error::from)
+        .map_err(Into::into)
+}
+
+fn default_identity_name(manifest: &coral_spec::IdentityManifest) -> String {
+    let mut issuer = manifest
+        .issuer
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                ch.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if issuer.is_empty() || issuer.starts_with(|ch: char| ch.is_ascii_digit()) {
+        issuer.insert_str(0, "identity_");
+    }
+    format!("{issuer}_local")
 }
 
 #[cfg(test)]

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -16,21 +16,22 @@ use coral_api::v1::{
     CreateUserOwnedIdentityResponse, DeleteIdentitySpecRequest, DeleteSourceRequest,
     DeleteUserOwnedIdentityRequest, DiscoverSourcesRequest, FixedTokenUserOwnedIdentitySetup,
     GetIdentitySpecRequest, GetSourceInfoRequest, GetUserOwnedIdentityRequest, Identity,
-    IdentityOwner, IdentitySpec, IdentitySpecInputValue, ImportSourceRequest, ImportSourceResponse,
-    ListIdentitySpecsRequest, ListSourcesRequest, ListUserOwnedIdentitiesRequest,
-    OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source,
-    SourceCredentialStorage, SourceIdentityBinding, SourceInfo, SourceOrigin, SourceSecret,
-    SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
-    create_bundled_source_with_o_auth_response, create_user_owned_identity_request,
-    create_user_owned_identity_response, import_source_response, query_test_result,
-    source_input_spec::Input as ProtoSourceInput,
+    IdentityOwner, IdentitySpec, IdentitySpecImportInputs, IdentitySpecInputValue,
+    ImportSourceRequest, ImportSourceResponse, ListIdentitySpecsRequest, ListSourcesRequest,
+    ListUserOwnedIdentitiesRequest, OAuthCredentialInput, OAuthCredentialRetrieval,
+    QueryTestFailure, QueryTestSuccess, Source, SourceCredentialStorage, SourceIdentityBinding,
+    SourceInfo, SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
+    ValidateSourceResponse, create_bundled_source_with_o_auth_response,
+    create_user_owned_identity_request, create_user_owned_identity_response,
+    import_source_response, query_test_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::{AppClient, DecodedStatusError, decode_status_error, default_workspace};
 use coral_spec::v4::SurfaceDescriptor;
 use coral_spec::{
-    IdentityManifest, IdentitySpecConfig, ManifestCredentialMethod, ManifestCredentialMethodKind,
-    ManifestCredentialSpec, ManifestInputKind, ManifestInputSpec, ManifestOAuthCredentialSpec,
-    ValidatedSourceManifest, parse_identity_manifest_yaml, parse_source_manifest_yaml,
+    IdentityManifest, IdentityManifestDocument, IdentitySpecConfig, ManifestCredentialMethod,
+    ManifestCredentialMethodKind, ManifestCredentialSpec, ManifestInputKind, ManifestInputSpec,
+    ManifestOAuthCredentialSpec, ValidatedSourceManifest, parse_identity_manifest_yaml,
+    parse_manifest_bundle_yaml, parse_source_manifest_yaml,
 };
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
@@ -264,6 +265,8 @@ pub(crate) async fn import_source(
     manifest_yaml: String,
     variables: Vec<SourceVariable>,
     secrets: Vec<SourceSecret>,
+    identity_spec_manifest_yamls: Vec<String>,
+    identity_spec_inputs: Vec<IdentitySpecImportInputs>,
     identity_bindings: ImportSourceIdentityBindings,
 ) -> Result<Source, anyhow::Error> {
     let mut responses = app
@@ -274,8 +277,8 @@ pub(crate) async fn import_source(
             variables,
             secrets,
             oauth_credential_retrievals: Vec::new(),
-            identity_spec_manifest_yamls: Vec::new(),
-            identity_spec_inputs: Vec::new(),
+            identity_spec_manifest_yamls,
+            identity_spec_inputs,
             identity_bindings: identity_bindings.source_bindings,
             replace_identity_bindings: identity_bindings.replace_existing,
         }))
@@ -349,6 +352,8 @@ pub(crate) async fn import_source_with_credentials(
     app: &AppClient,
     manifest_yaml: String,
     inputs: CollectedSourceInputs,
+    identity_spec_manifest_yamls: Vec<String>,
+    identity_spec_inputs: Vec<IdentitySpecImportInputs>,
     identity_bindings: ImportSourceIdentityBindings,
 ) -> Result<Source, anyhow::Error> {
     if inputs.oauth_credential_retrievals.is_empty() {
@@ -357,6 +362,8 @@ pub(crate) async fn import_source_with_credentials(
             manifest_yaml,
             inputs.variables,
             inputs.secrets,
+            identity_spec_manifest_yamls,
+            identity_spec_inputs,
             identity_bindings,
         )
         .await;
@@ -369,8 +376,8 @@ pub(crate) async fn import_source_with_credentials(
             variables: inputs.variables,
             secrets: inputs.secrets,
             oauth_credential_retrievals: inputs.oauth_credential_retrievals,
-            identity_spec_manifest_yamls: Vec::new(),
-            identity_spec_inputs: Vec::new(),
+            identity_spec_manifest_yamls,
+            identity_spec_inputs,
             identity_bindings: identity_bindings.source_bindings,
             replace_identity_bindings: identity_bindings.replace_existing,
         }))
@@ -686,16 +693,38 @@ async fn validate_source_request(
         .into_inner())
 }
 
+pub(crate) struct LoadedManifestFile {
+    pub(crate) manifest_yaml: String,
+    pub(crate) manifest: ValidatedSourceManifest,
+    pub(crate) identity_manifests: Vec<IdentityManifestDocument>,
+}
+
+impl LoadedManifestFile {
+    pub(crate) fn identity_spec_manifest_yamls(&self) -> Vec<String> {
+        self.identity_manifests
+            .iter()
+            .map(|document| document.manifest_yaml.clone())
+            .collect()
+    }
+}
+
 pub(crate) fn load_validated_manifest_file(
     file: &Path,
-) -> Result<(String, ValidatedSourceManifest), anyhow::Error> {
-    let manifest_yaml = std::fs::read_to_string(file)?;
-    let manifest = parse_source_manifest_yaml(manifest_yaml.as_str())?;
+) -> Result<LoadedManifestFile, anyhow::Error> {
+    let raw = std::fs::read_to_string(file)?;
+    let bundle = parse_manifest_bundle_yaml(raw.as_str())?;
     let manifest_dir = manifest_file_parent_dir(file)?;
-    let manifest_yaml =
-        durable_manifest_file_yaml(&manifest_yaml, &manifest, manifest_dir.as_path())?;
+    let manifest_yaml = durable_manifest_file_yaml(
+        &bundle.source_manifest_yaml,
+        &bundle.source_manifest,
+        manifest_dir.as_path(),
+    )?;
     let manifest = parse_source_manifest_yaml(manifest_yaml.as_str())?;
-    Ok((manifest_yaml, manifest))
+    Ok(LoadedManifestFile {
+        manifest_yaml,
+        manifest,
+        identity_manifests: bundle.identity_manifests,
+    })
 }
 
 pub(crate) fn load_validated_identity_spec_file(file: &Path) -> Result<String, anyhow::Error> {
@@ -1023,6 +1052,39 @@ pub(crate) fn identity_spec_inputs_for_add(
         return prompt_identity_spec_inputs(manifest);
     }
     collect_identity_spec_inputs_from_env(manifest, interactive_command)
+}
+
+pub(crate) fn prompt_identity_spec_inputs_for_import(
+    identity_manifests: &[IdentityManifestDocument],
+) -> Result<Vec<IdentitySpecImportInputs>, anyhow::Error> {
+    identity_spec_inputs_for_import_with(identity_manifests, |manifest| {
+        prompt_identity_spec_inputs(manifest)
+    })
+}
+
+pub(crate) fn identity_spec_inputs_for_import_from_env(
+    identity_manifests: &[IdentityManifestDocument],
+    interactive_command: &str,
+) -> Result<Vec<IdentitySpecImportInputs>, anyhow::Error> {
+    identity_spec_inputs_for_import_with(identity_manifests, |manifest| {
+        collect_identity_spec_inputs_from_env(manifest, interactive_command.to_string())
+    })
+}
+
+fn identity_spec_inputs_for_import_with(
+    identity_manifests: &[IdentityManifestDocument],
+    collect_inputs: impl Fn(&IdentityManifest) -> Result<Vec<IdentitySpecInputValue>, anyhow::Error>,
+) -> Result<Vec<IdentitySpecImportInputs>, anyhow::Error> {
+    identity_manifests
+        .iter()
+        .filter(|document| !document.manifest.inputs.is_empty())
+        .map(|document| {
+            Ok(IdentitySpecImportInputs {
+                identity_spec_name: document.manifest.name.clone(),
+                input_values: collect_inputs(&document.manifest)?,
+            })
+        })
+        .collect()
 }
 
 fn collect_identity_spec_inputs_from_env(

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -424,6 +424,28 @@ pub(crate) fn import_source_identity_bindings_from_args(
     })
 }
 
+pub(crate) fn import_source_user_identity_bindings(
+    user_bindings: Vec<UserSourceIdentityBinding>,
+) -> Result<ImportSourceIdentityBindings, anyhow::Error> {
+    let mut seen_surfaces = BTreeSet::new();
+    let mut source_bindings = Vec::new();
+    for binding in &user_bindings {
+        reject_repeated_identity_binding_surface(&mut seen_surfaces, &binding.surface_id)?;
+        source_bindings.push(SourceIdentityBinding {
+            surface_id: binding.surface_id.clone(),
+            identity: String::new(),
+            owner: SourceIdentityOwner::User as i32,
+            accepted_identity: String::new(),
+        });
+    }
+
+    Ok(ImportSourceIdentityBindings {
+        replace_existing: !source_bindings.is_empty(),
+        source_bindings,
+        user_selections: user_bindings,
+    })
+}
+
 struct CliIdentityBinding {
     surface_id: String,
     identity: String,
@@ -1052,6 +1074,62 @@ pub(crate) fn identity_spec_inputs_for_add(
         return prompt_identity_spec_inputs(manifest);
     }
     collect_identity_spec_inputs_from_env(manifest, interactive_command)
+}
+
+pub(crate) fn prompt_required_identity_spec_inputs(
+    manifest: &IdentityManifest,
+) -> Result<Vec<IdentitySpecInputValue>, anyhow::Error> {
+    let mut values = Vec::new();
+    for input in &manifest.inputs {
+        match identity_spec_input_prompt_action(input, read_identity_spec_input_env(&input.key)) {
+            IdentitySpecInputPromptAction::Use(value) => values.push(IdentitySpecInputValue {
+                key: input.key.clone(),
+                value,
+            }),
+            IdentitySpecInputPromptAction::Skip => {}
+            IdentitySpecInputPromptAction::Prompt => match input.kind {
+                ManifestInputKind::Variable => {
+                    if let Some(variable) = prompt_variable(input)? {
+                        values.push(IdentitySpecInputValue {
+                            key: variable.key,
+                            value: variable.value,
+                        });
+                    }
+                }
+                ManifestInputKind::Secret => {
+                    if let Some(secret) = prompt_source_config_secret(input, None)? {
+                        values.push(IdentitySpecInputValue {
+                            key: secret.key,
+                            value: secret.value,
+                        });
+                    }
+                }
+            },
+        }
+    }
+    Ok(values)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum IdentitySpecInputPromptAction {
+    Use(String),
+    Prompt,
+    Skip,
+}
+
+fn identity_spec_input_prompt_action(
+    input: &ManifestInputSpec,
+    env_value: Option<String>,
+) -> IdentitySpecInputPromptAction {
+    if let Some(value) = env_value.filter(|value| !value.is_empty()) {
+        return IdentitySpecInputPromptAction::Use(value);
+    }
+    let default_resolves_in_manifest =
+        input.kind == ManifestInputKind::Variable && !input.default_value.is_empty();
+    if default_resolves_in_manifest || !input.required {
+        return IdentitySpecInputPromptAction::Skip;
+    }
+    IdentitySpecInputPromptAction::Prompt
 }
 
 pub(crate) fn prompt_identity_spec_inputs_for_import(
@@ -2096,8 +2174,16 @@ fn http_status_is_success(status: &str) -> bool {
 fn prompt_oauth_credential_inputs(
     oauth: &ManifestOAuthCredentialSpec,
 ) -> Result<Vec<OAuthCredentialInput>, anyhow::Error> {
+    prompt_oauth_credential_inputs_with_skip(oauth, |_| false)
+}
+
+fn prompt_oauth_credential_inputs_with_skip(
+    oauth: &ManifestOAuthCredentialSpec,
+    skip: impl Fn(&str) -> bool,
+) -> Result<Vec<OAuthCredentialInput>, anyhow::Error> {
     let mut values = Vec::new();
     if let Some(input_key) = oauth.client.id.input.as_deref()
+        && !skip(input_key)
         && let Some(value) = prompt_oauth_client_id(input_key, oauth.client.id.default.as_deref())?
     {
         values.push(OAuthCredentialInput {
@@ -2106,6 +2192,9 @@ fn prompt_oauth_credential_inputs(
         });
     }
     if let Some(secret) = oauth.client.secret.as_ref() {
+        if skip(&secret.input) {
+            return Ok(values);
+        }
         let value = prompt_oauth_client_secret(&secret.input)?;
         values.push(OAuthCredentialInput {
             key: secret.input.clone(),
@@ -2220,9 +2309,9 @@ mod tests {
     use super::{
         CredentialPromptMode, RedirectPromptAction, ValidationFollowUp, ValidationSeverityMode,
         apply_redirect_prompt_key, collect_inputs_with_hint, expected_oauth_redirect,
-        finalize_input_value, render_redirect_prompt_key_echo, resolve_prompt_hint,
-        shell_quote_arg, source_name_arg, submit_oauth_redirect_url, validate_oauth_redirect_url,
-        validation_follow_up,
+        finalize_input_value, identity_spec_input_prompt_action, render_redirect_prompt_key_echo,
+        resolve_prompt_hint, shell_quote_arg, source_name_arg, submit_oauth_redirect_url,
+        validate_oauth_redirect_url, validation_follow_up,
     };
 
     #[test]
@@ -2281,6 +2370,57 @@ mod tests {
 
         assert!(CredentialPromptMode::EnvFirst.reads_env_before_prompt(&input));
         assert!(!CredentialPromptMode::CredentialMethodFirst.reads_env_before_prompt(&input));
+    }
+
+    #[test]
+    fn required_identity_spec_input_prompt_action_uses_env_first() {
+        let input = ManifestInputSpec {
+            key: "GITHUB_OAUTH_CLIENT_ID".to_string(),
+            kind: ManifestInputKind::Variable,
+            required: true,
+            default_value: "default-client".to_string(),
+            hint: None,
+            credential: None,
+        };
+
+        assert_eq!(
+            identity_spec_input_prompt_action(&input, Some("env-client".to_string())),
+            super::IdentitySpecInputPromptAction::Use("env-client".to_string())
+        );
+    }
+
+    #[test]
+    fn required_identity_spec_input_prompt_action_skips_defaulted_variable() {
+        let input = ManifestInputSpec {
+            key: "GITHUB_OAUTH_CLIENT_ID".to_string(),
+            kind: ManifestInputKind::Variable,
+            required: true,
+            default_value: "default-client".to_string(),
+            hint: None,
+            credential: None,
+        };
+
+        assert_eq!(
+            identity_spec_input_prompt_action(&input, None),
+            super::IdentitySpecInputPromptAction::Skip
+        );
+    }
+
+    #[test]
+    fn required_identity_spec_input_prompt_action_prompts_missing_required_secret() {
+        let input = ManifestInputSpec {
+            key: "GITHUB_OAUTH_CLIENT_SECRET".to_string(),
+            kind: ManifestInputKind::Secret,
+            required: true,
+            default_value: String::new(),
+            hint: None,
+            credential: None,
+        };
+
+        assert_eq!(
+            identity_spec_input_prompt_action(&input, None),
+            super::IdentitySpecInputPromptAction::Prompt
+        );
     }
 
     fn secret_with_method(

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -435,7 +435,6 @@ pub(crate) fn import_source_user_identity_bindings(
             surface_id: binding.surface_id.clone(),
             identity: String::new(),
             owner: SourceIdentityOwner::User as i32,
-            accepted_identity: String::new(),
         });
     }
 
@@ -460,7 +459,9 @@ fn parse_cli_identity_binding(
         .ok_or_else(|| anyhow::anyhow!("{flag_name} must use SURFACE=IDENTITY"))?;
     let surface_id = non_empty_cli_identity_part(surface_id, flag_name, "surface")?;
     if selection.contains(':') {
-        bail!("{flag_name} must use SURFACE=IDENTITY");
+        return Err(anyhow::anyhow!(
+            "{flag_name} no longer accepts accepted identity ids; use SURFACE=IDENTITY"
+        ));
     }
     let identity = non_empty_cli_identity_part(selection, flag_name, "identity")?;
     Ok(CliIdentityBinding {

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -425,23 +425,16 @@ pub(crate) fn import_source_identity_bindings_from_args(
 }
 
 pub(crate) fn import_source_user_identity_bindings(
-    user_bindings: Vec<UserSourceIdentityBinding>,
+    user_bindings: Vec<SourceIdentityBinding>,
 ) -> Result<ImportSourceIdentityBindings, anyhow::Error> {
     let mut seen_surfaces = BTreeSet::new();
-    let mut source_bindings = Vec::new();
     for binding in &user_bindings {
         reject_repeated_identity_binding_surface(&mut seen_surfaces, &binding.surface_id)?;
-        source_bindings.push(SourceIdentityBinding {
-            surface_id: binding.surface_id.clone(),
-            identity: String::new(),
-            owner: SourceIdentityOwner::User as i32,
-        });
     }
 
     Ok(ImportSourceIdentityBindings {
-        replace_existing: !source_bindings.is_empty(),
-        source_bindings,
-        user_selections: user_bindings,
+        replace_existing: !user_bindings.is_empty(),
+        source_bindings: user_bindings,
     })
 }
 
@@ -2295,6 +2288,7 @@ mod tests {
     )]
 
     use coral_api::v1::ValidateSourceResponse;
+    use coral_api::v1::{IdentityOwner, SourceIdentityBinding};
     use coral_spec::{
         ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
         ManifestInputKind, ManifestInputSpec,
@@ -2348,6 +2342,25 @@ mod tests {
         assert_eq!(secrets.len(), 1);
         assert_eq!(secrets[0].key, "LINEAR_API_KEY");
         assert_eq!(secrets[0].value, "lin_token");
+    }
+
+    #[test]
+    fn prompted_user_identity_bindings_preserve_selected_identity() {
+        let bindings = super::import_source_user_identity_bindings(vec![SourceIdentityBinding {
+            surface_id: "rest".to_string(),
+            identity: "github-personal".to_string(),
+            owner: IdentityOwner::User as i32,
+        }])
+        .expect("prompted identity bindings should be valid");
+
+        assert!(bindings.replace_existing);
+        assert_eq!(bindings.source_bindings.len(), 1);
+        assert_eq!(bindings.source_bindings[0].surface_id, "rest");
+        assert_eq!(bindings.source_bindings[0].identity, "github-personal");
+        assert_eq!(
+            bindings.source_bindings[0].owner,
+            IdentityOwner::User as i32
+        );
     }
 
     #[test]

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -853,6 +853,113 @@ surfaces:
     server.shutdown().await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_file_imports_manifest_bundle_identity_specs() {
+    let server = MockServer::start().await;
+    let source_dir = tempdir().expect("source dir");
+    let openapi_file = source_dir.path().join("openapi.yaml");
+    std::fs::write(
+        &openapi_file,
+        r"
+openapi: 3.0.3
+paths: {}
+",
+    )
+    .expect("write descriptor");
+    let bundle_file = source_dir.path().join("github-bundle.yaml");
+    std::fs::write(
+        &bundle_file,
+        r"
+---
+kind: identity
+spec_version: 1
+name: github_oauth
+version: 0.1.0
+issuer: github
+type: oauth
+audience:
+  host: github.com
+inputs:
+  GITHUB_OAUTH_CLIENT_SECRET:
+    kind: secret
+    required: true
+oauth:
+  method:
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    endpoints:
+      authorization_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+    client:
+      id:
+        default: client-id
+      secret:
+        input: GITHUB_OAUTH_CLIENT_SECRET
+        transport: request_body
+---
+name: github_v4
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: openapi.yaml
+    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+          audience:
+            host: github.com
+",
+    )
+    .expect("write bundle");
+
+    server
+        .cmd()
+        .env("GITHUB_OAUTH_CLIENT_SECRET", "github-secret")
+        .args([
+            "source",
+            "add",
+            "--file",
+            bundle_file.to_str().expect("bundle path utf8"),
+        ])
+        .assert()
+        .success();
+
+    let requests = server.import_source_requests();
+    assert_eq!(requests.len(), 1, "expected one import_source call");
+    let request = &requests[0];
+    assert!(
+        request.manifest_yaml.contains("name: github_v4"),
+        "expected source document in import request: {}",
+        request.manifest_yaml
+    );
+    assert!(
+        !request.manifest_yaml.contains("kind: identity"),
+        "source import manifest should not include bundled identity docs: {}",
+        request.manifest_yaml
+    );
+    assert_eq!(request.identity_spec_manifest_yamls.len(), 1);
+    assert!(
+        request.identity_spec_manifest_yamls[0].contains("name: github_oauth"),
+        "expected bundled identity manifest yaml: {}",
+        request.identity_spec_manifest_yamls[0]
+    );
+    assert_eq!(request.identity_spec_inputs.len(), 1);
+    let input_group = &request.identity_spec_inputs[0];
+    assert_eq!(input_group.identity_spec_name, "github_oauth");
+    assert_eq!(input_group.input_values.len(), 1);
+    assert_eq!(
+        input_group.input_values[0].key,
+        "GITHUB_OAUTH_CLIENT_SECRET"
+    );
+    assert_eq!(input_group.input_values[0].value, "github-secret");
+
+    server.shutdown().await;
+}
+
 fn fixed_token_spec_yaml(name: &str) -> String {
     format!(
         r"

--- a/examples/github-v4-identity/README.md
+++ b/examples/github-v4-identity/README.md
@@ -1,0 +1,85 @@
+# GitHub DSL v4 Identity Example
+
+This example installs a preview DSL v4 GitHub source from a YAML stream that
+bundles:
+
+- `github_oauth`, a GitHub device-code OAuth identity spec with a default Coral
+  client ID.
+- `github_oauth_app`, a GitHub authorization-code OAuth identity spec for a
+  user-provided GitHub OAuth app.
+- `github_v4`, a DSL v4 OpenAPI source that binds its REST surface to one of
+  those identities.
+
+Use it to test bundled identity-spec import and user-owned source-surface
+identity binding flow.
+
+## Prerequisites
+
+- A GitHub account that can authorize the requested scopes.
+- A local build of Coral.
+- An isolated Coral config directory, so the test does not change your normal
+  Coral state.
+
+```shell
+export CORAL_CONFIG_DIR="$(mktemp -d)"
+cargo run -p coral-cli -- features enable dsl_v4
+```
+
+## Install The Example Source
+
+From the repository root, run:
+
+```shell
+cargo run -p coral-cli -- source add --interactive --file examples/github-v4-identity/github-v4-identity-bundle.yaml
+```
+
+Choose `github_oauth` when prompted to create an identity. Coral will show a
+GitHub device code and verification URL; complete that flow in your browser.
+
+The alternate `github_oauth_app` path is useful only if you want to test a
+custom GitHub OAuth app. Register the app with this callback URL before
+selecting it:
+
+```text
+http://127.0.0.1:53682/oauth/callback
+```
+
+## Smoke Test
+
+After install, verify that the identity specs, source, and generated projections
+are present:
+
+```shell
+cargo run -p coral-cli -- identity-spec list
+cargo run -p coral-cli -- identity list
+cargo run -p coral-cli -- source info github_v4 --verbose
+cargo run -p coral-cli -- sql "SELECT id, number, title, state FROM github_v4.repos_issues WHERE owner = 'octocat' AND repo = 'Hello-World' LIMIT 5"
+```
+
+You can also run the manifest's declared checks:
+
+```shell
+cargo run -p coral-cli -- source test github_v4
+```
+
+## Rebinding The Source
+
+Re-run the source add command to choose a different compatible identity for the
+same local user:
+
+```shell
+cargo run -p coral-cli -- source add --interactive --file examples/github-v4-identity/github-v4-identity-bundle.yaml
+```
+
+The source remains `github_v4`; Coral replaces the local user's selected
+identity for the `rest` surface.
+
+## Cleanup
+
+If you used the temporary `CORAL_CONFIG_DIR` above, remove that directory when
+you are done:
+
+```shell
+rm -rf "$CORAL_CONFIG_DIR"
+unset CORAL_CONFIG_DIR
+```

--- a/examples/github-v4-identity/github-v4-identity-bundle.yaml
+++ b/examples/github-v4-identity/github-v4-identity-bundle.yaml
@@ -1,0 +1,117 @@
+---
+kind: identity
+spec_version: 1
+name: github_oauth
+version: 0.1.0
+description: GitHub OAuth access token for GitHub Cloud REST APIs.
+issuer: github
+type: oauth
+audience:
+  host: github.com
+inputs:
+  GITHUB_OAUTH_CLIENT_ID:
+    kind: variable
+    default: Iv23liJHis6Bs8NO1DAI
+oauth:
+  method:
+    label: Connect with GitHub device code
+    description: Sign in to GitHub with a device code.
+    hint: |
+      Signs you in through GitHub, with no app setup or client secret needed.
+      Requests the `repo`, `read:org`, `read:user`, and `user:email` scopes.
+      To use your own GitHub app instead, install a separate identity spec for
+      that app's OAuth flow.
+    flow:
+      type: device_code
+    endpoints:
+      device_authorization_url: https://github.com/login/device/code
+      token_url: https://github.com/login/oauth/access_token
+    client:
+      id:
+        default: Iv23liJHis6Bs8NO1DAI
+        input: GITHUB_OAUTH_CLIENT_ID
+    scopes:
+      scope:
+        delimiter: space
+        values:
+          - repo
+          - read:org
+          - read:user
+          - user:email
+---
+kind: identity
+spec_version: 1
+name: github_oauth_app
+version: 0.1.0
+description: GitHub OAuth app access token for GitHub Cloud REST APIs.
+issuer: github
+type: oauth
+audience:
+  host: github.com
+inputs:
+  GITHUB_OAUTH_CLIENT_ID:
+    kind: variable
+    required: true
+  GITHUB_OAUTH_CLIENT_SECRET:
+    kind: secret
+    required: true
+oauth:
+  method:
+    label: Connect with GitHub OAuth app
+    description: Sign in through a GitHub OAuth app in your browser.
+    hint: |
+      Uses your own GitHub OAuth app. Register one with its Authorization
+      callback URL set to `http://127.0.0.1:53682/oauth/callback`, then enter
+      the app's Client ID and Client secret below. Requests the `repo`,
+      `read:org`, `read:user`, and `user:email` scopes.
+    flow:
+      type: authorization_code
+      pkce: required
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    redirect_uri_port_mode: fixed
+    endpoints:
+      authorization_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+    client:
+      id:
+        input: GITHUB_OAUTH_CLIENT_ID
+      secret:
+        input: GITHUB_OAUTH_CLIENT_SECRET
+        transport: request_body
+    scopes:
+      scope:
+        delimiter: space
+        values:
+          - repo
+          - read:org
+          - read:user
+          - user:email
+---
+name: github_v4
+version: 0.1.0
+dsl_version: 4
+description: GitHub Cloud REST API source using a resolved GitHub identity.
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://raw.githubusercontent.com/github/rest-api-description/9be34b1f355a4330ec7c04381dd081e4865ac820/descriptions/api.github.com/api.github.com.yaml
+    sha256: a7ad0985d8ae06726c499bee10fc69e5e99dbd237ff25cfcdf3a75547373da90
+    identity_requirements:
+      accepts:
+        - id: github-rest-read
+          identity_specs:
+            - github_oauth
+            - github_oauth_app
+          audience:
+            host: github.com
+    request_headers:
+      - name: X-GitHub-Api-Version
+        from: literal
+        value: "2022-11-28"
+      - name: User-Agent
+        from: literal
+        value: coral-dsl-v4
+test_queries:
+  - SELECT id, number, title, state FROM github_v4.repos_issues WHERE owner = 'octocat' AND repo = 'Hello-World' LIMIT 5
+  - SELECT id, number, title FROM github_v4.get_issue(owner => 'octocat', repo => 'Hello-World', issue_number => 1)
+  - SELECT id, number, title FROM github_v4.search_issues(q => 'repo:octocat/Hello-World is:issue') LIMIT 5


### PR DESCRIPTION
## Intent

Land `feat(cli): import source identity bundles` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-29-identity-docs...sauldhernandez/dsl-v4-identity-v2-30-github-identity-example
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
