### PR TITLE
feat(app): preserve public identity seams

### DIFF
--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -96,6 +96,10 @@ pub const CORAL_EPISODE_INTENT_MAX_CHARS: usize = 4096;
 /// Machine-readable reason for a configured source lookup miss.
 pub const CORAL_ERROR_REASON_SOURCE_NOT_FOUND: &str = "SOURCE_NOT_FOUND";
 
+/// Machine-readable reason for stale or missing DSL v4 materialized artifacts.
+pub const CORAL_ERROR_REASON_MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION: &str =
+    "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION";
+
 /// Reserved `ErrorInfo.metadata` key for a one-line error summary.
 pub const CORAL_ERROR_METADATA_SUMMARY: &str = "summary";
 

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -1,8 +1,11 @@
 //! Defines bootstrap and application-management errors for the local app.
 
+use std::collections::HashMap;
+
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_DETAIL, CORAL_ERROR_METADATA_HINT,
-    CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+    CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION,
+    CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
 };
 use coral_engine::{CoreError, StatusCode};
 use tonic::{Code, Status};
@@ -31,6 +34,16 @@ pub enum AppError {
     /// The request requires additional setup before it can succeed.
     #[error("failed precondition: {0}")]
     FailedPrecondition(String),
+    /// A DSL v4 source has missing or stale generated runtime artifacts.
+    #[error(
+        "failed precondition: source '{source_name}' has missing or incompatible DSL v4 materialized artifacts: {detail}. Re-add the source to regenerate them."
+    )]
+    MissingOrIncompatibleV4Materialization {
+        /// Source name whose installed artifacts failed validation.
+        source_name: String,
+        /// Specific materialization mismatch or missing-artifact detail.
+        detail: String,
+    },
     /// A known, installed source or related setup cannot be served until the
     /// user takes an explicit action.
     #[error("failed precondition: {0}")]
@@ -110,24 +123,58 @@ fn truncate_status_detail(detail: String) -> String {
     reason = "used directly as a map_err adapter across tonic service handlers"
 )]
 pub(crate) fn app_status(error: AppError) -> Status {
-    if matches!(error, AppError::SourceNotFound(_)) {
-        // The `reason` alone discriminates `SOURCE_NOT_FOUND` from other
-        // `Code::NotFound` causes (e.g. `io::ErrorKind::NotFound` raised
-        // when a manifest file is missing). The qualified name already
-        // appears in the truncated status message; we deliberately do
-        // not duplicate it into structured metadata so unbounded
-        // identifiers cannot push the `grpc-status-details-bin` trailer
-        // past the h2 `MAX_HEADER_LIST_SIZE` budget.
-        let details = vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
-            CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
-            CORAL_ERROR_DOMAIN,
-            std::collections::HashMap::new(),
-        ))];
-        return Status::with_error_details_vec(
-            Code::NotFound,
-            truncate_status_detail(error.to_string()),
-            details,
-        );
+    match &error {
+        AppError::SourceNotFound(_) => {
+            // The `reason` alone discriminates `SOURCE_NOT_FOUND` from other
+            // `Code::NotFound` causes (e.g. `io::ErrorKind::NotFound` raised
+            // when a manifest file is missing). The qualified name already
+            // appears in the truncated status message; we deliberately do
+            // not duplicate it into structured metadata so unbounded
+            // identifiers cannot push the `grpc-status-details-bin` trailer
+            // past the h2 `MAX_HEADER_LIST_SIZE` budget.
+            let details = vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+                CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+                CORAL_ERROR_DOMAIN,
+                HashMap::new(),
+            ))];
+            return Status::with_error_details_vec(
+                Code::NotFound,
+                truncate_status_detail(error.to_string()),
+                details,
+            );
+        }
+        AppError::MissingOrIncompatibleV4Materialization {
+            source_name,
+            detail,
+        } => {
+            let mut metadata = HashMap::new();
+            metadata.insert(
+                CORAL_ERROR_METADATA_SUMMARY.to_string(),
+                format!(
+                    "source '{source_name}' has missing or incompatible DSL v4 materialized artifacts"
+                ),
+            );
+            metadata.insert(
+                CORAL_ERROR_METADATA_DETAIL.to_string(),
+                truncate_status_detail(detail.clone()),
+            );
+            metadata.insert(
+                CORAL_ERROR_METADATA_HINT.to_string(),
+                "Re-add the source to regenerate them.".to_string(),
+            );
+            metadata.insert("source".to_string(), source_name.clone());
+            let details = vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+                CORAL_ERROR_REASON_MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION,
+                CORAL_ERROR_DOMAIN,
+                metadata,
+            ))];
+            return Status::with_error_details_vec(
+                Code::FailedPrecondition,
+                truncate_status_detail(error.to_string()),
+                details,
+            );
+        }
+        _ => {}
     }
     Status::new(app_code(&error), truncate_status_detail(error.to_string()))
 }
@@ -203,6 +250,7 @@ fn app_code(error: &AppError) -> Code {
         | AppError::IdentityNotFound(_) => Code::NotFound,
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
+        | AppError::MissingOrIncompatibleV4Materialization { .. }
         | AppError::SourceUnservable(_)
         | AppError::CredentialRefresh(_)
         | AppError::MissingConfigDir
@@ -271,6 +319,51 @@ mod tests {
             info.metadata.is_empty(),
             "SOURCE_NOT_FOUND must not carry unbounded identifier metadata: {:?}",
             info.metadata
+        );
+    }
+
+    #[test]
+    fn app_status_attaches_structured_reason_for_incompatible_materialization() {
+        let status = app_status(AppError::MissingOrIncompatibleV4Materialization {
+            source_name: "github_v4".to_string(),
+            detail: "semantic IR importer version mismatch for surface 'rest'".to_string(),
+        });
+        assert_eq!(status.code(), Code::FailedPrecondition);
+
+        let details = status.get_error_details_vec();
+        let info = details
+            .iter()
+            .find_map(|detail| match detail {
+                ErrorDetail::ErrorInfo(info) => Some(info),
+                _ => None,
+            })
+            .expect("materialization status must carry an ErrorInfo detail");
+        assert_eq!(
+            info.reason,
+            CORAL_ERROR_REASON_MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION
+        );
+        assert_eq!(info.domain, CORAL_ERROR_DOMAIN);
+        assert_eq!(
+            info.metadata.get("source").map(String::as_str),
+            Some("github_v4")
+        );
+        assert_eq!(
+            info.metadata
+                .get(CORAL_ERROR_METADATA_SUMMARY)
+                .map(String::as_str),
+            Some("source 'github_v4' has missing or incompatible DSL v4 materialized artifacts")
+        );
+        assert_eq!(
+            info.metadata
+                .get(CORAL_ERROR_METADATA_DETAIL)
+                .map(String::as_str),
+            Some("semantic IR importer version mismatch for surface 'rest'")
+        );
+        assert_eq!(
+            info.metadata
+                .get(CORAL_ERROR_METADATA_HINT)
+                .map(String::as_str),
+            Some("Re-add the source to regenerate them.")
         );
     }
 

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -31,16 +31,6 @@ pub enum AppError {
     /// The request requires additional setup before it can succeed.
     #[error("failed precondition: {0}")]
     FailedPrecondition(String),
-    /// A DSL v4 source has missing or stale generated runtime artifacts.
-    #[error(
-        "failed precondition: source '{source_name}' has missing or incompatible DSL v4 materialized artifacts: {detail}. Re-add the source to regenerate them."
-    )]
-    MissingOrIncompatibleV4Materialization {
-        /// Source name whose installed artifacts failed validation.
-        source_name: String,
-        /// Specific materialization mismatch or missing-artifact detail.
-        detail: String,
-    },
     /// A known, installed source or related setup cannot be served until the
     /// user takes an explicit action.
     #[error("failed precondition: {0}")]
@@ -213,7 +203,6 @@ fn app_code(error: &AppError) -> Code {
         | AppError::IdentityNotFound(_) => Code::NotFound,
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
-        | AppError::MissingOrIncompatibleV4Materialization { .. }
         | AppError::SourceUnservable(_)
         | AppError::CredentialRefresh(_)
         | AppError::MissingConfigDir

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1855,6 +1855,7 @@ audience:
     fn resolution_request(identity_name: &str) -> SourceIdentityResolutionRequest {
         SourceIdentityResolutionRequest {
             workspace_name: "default".to_string(),
+            request_principal: UserPrincipal::local(),
             user_id: Some("local".to_string()),
             source_name: "github".to_string(),
             surface_id: "rest".to_string(),

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -278,6 +278,13 @@ pub struct SourceIdentitySelectionRequest {
 pub struct SourceIdentityResolutionRequest {
     /// Workspace selected by the request.
     pub workspace_name: String,
+    /// User principal associated with the request that triggered identity
+    /// resolution.
+    ///
+    /// Providers should use [`Self::user_id`] to select user-owned identity
+    /// material. The request principal remains available for providers that
+    /// need to authorize access to workspace-owned material.
+    pub request_principal: UserPrincipal,
     /// Request user id selected by Coral for user-owned bindings.
     ///
     /// Workspace-owned bindings intentionally carry no request user id, so

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -44,9 +44,7 @@ use crate::source_artifacts::SourceArtifactStore;
 use crate::source_registry::{SourceRegistry, installed_source_from_record};
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
-use crate::sources::materialization::{
-    INCOMPATIBLE_MATERIALIZATION_MESSAGE_FRAGMENT, incompatible_materialization_error,
-};
+use crate::sources::materialization::incompatible_materialization_error;
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::{
     runtime_components_for_v4_source, runtime_relation_namespace,
@@ -1050,6 +1048,9 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::IdentityNotFound(_) => "IDENTITY_NOT_FOUND",
         AppError::InvalidInput(_) => "INVALID_INPUT",
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
+        AppError::MissingOrIncompatibleV4Materialization { .. } => {
+            "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION"
+        }
         AppError::SourceUnservable(_) => "SOURCE_UNSERVABLE",
         AppError::CredentialRefresh(_) => "CREDENTIAL_REFRESH",
         AppError::Unavailable(_) => "UNAVAILABLE",
@@ -1066,15 +1067,12 @@ fn app_error_type(error: &AppError) -> &'static str {
 }
 
 fn source_load_error_requires_fail_closed(error: &AppError) -> bool {
-    match error {
-        AppError::Credentials(CredentialsError::Unavailable(_)) | AppError::SourceUnservable(_) => {
-            true
-        }
-        AppError::FailedPrecondition(message) => {
-            message.contains(INCOMPATIBLE_MATERIALIZATION_MESSAGE_FRAGMENT)
-        }
-        _ => false,
-    }
+    matches!(
+        error,
+        AppError::Credentials(CredentialsError::Unavailable(_))
+            | AppError::MissingOrIncompatibleV4Materialization { .. }
+            | AppError::SourceUnservable(_)
+    )
 }
 
 fn core_error_type(error: &CoreError) -> String {
@@ -2197,7 +2195,10 @@ surfaces:
             .expect_err("missing materialization should fail closed");
 
         assert!(
-            matches!(&error, AppError::FailedPrecondition(message) if message.contains(INCOMPATIBLE_MATERIALIZATION_MESSAGE_FRAGMENT)),
+            matches!(
+                &error,
+                AppError::MissingOrIncompatibleV4Materialization { .. }
+            ),
             "unexpected error: {error:#}"
         );
     }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -44,7 +44,9 @@ use crate::source_artifacts::SourceArtifactStore;
 use crate::source_registry::{SourceRegistry, installed_source_from_record};
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
-use crate::sources::materialization::incompatible_materialization_error;
+use crate::sources::materialization::{
+    INCOMPATIBLE_MATERIALIZATION_MESSAGE_FRAGMENT, incompatible_materialization_error,
+};
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::{
     runtime_components_for_v4_source, runtime_relation_namespace,
@@ -397,11 +399,7 @@ impl QueryManager {
         for source in self.list_registry_sources(workspace_name)? {
             match self.load_query_source(workspace_name, &source) {
                 Ok(query_source) => query_sources.push(query_source),
-                Err(
-                    error @ (AppError::Credentials(CredentialsError::Unavailable(_))
-                    | AppError::MissingOrIncompatibleV4Materialization { .. }
-                    | AppError::SourceUnservable(_)),
-                ) => {
+                Err(error) if source_load_error_requires_fail_closed(&error) => {
                     return Err(error);
                 }
                 Err(error) => {
@@ -776,6 +774,7 @@ impl LazyRuntimeIdentitySelector {
             .identity_manager
             .resolve_source_identity(SourceIdentityResolutionRequest {
                 workspace_name: self.workspace_name.as_str().to_string(),
+                request_principal: self.request_principal.clone(),
                 user_id,
                 source_name: identity.source_name().to_string(),
                 surface_id: identity.surface_id().to_string(),
@@ -1051,9 +1050,6 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::IdentityNotFound(_) => "IDENTITY_NOT_FOUND",
         AppError::InvalidInput(_) => "INVALID_INPUT",
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
-        AppError::MissingOrIncompatibleV4Materialization { .. } => {
-            "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION"
-        }
         AppError::SourceUnservable(_) => "SOURCE_UNSERVABLE",
         AppError::CredentialRefresh(_) => "CREDENTIAL_REFRESH",
         AppError::Unavailable(_) => "UNAVAILABLE",
@@ -1066,6 +1062,18 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::TaskJoin(_) => "TASK_JOIN",
         AppError::Credentials(_) => "CREDENTIALS",
         AppError::MissingConfigDir => "MISSING_CONFIG_DIR",
+    }
+}
+
+fn source_load_error_requires_fail_closed(error: &AppError) -> bool {
+    match error {
+        AppError::Credentials(CredentialsError::Unavailable(_)) | AppError::SourceUnservable(_) => {
+            true
+        }
+        AppError::FailedPrecondition(message) => {
+            message.contains(INCOMPATIBLE_MATERIALIZATION_MESSAGE_FRAGMENT)
+        }
+        _ => false,
     }
 }
 
@@ -2189,10 +2197,7 @@ surfaces:
             .expect_err("missing materialization should fail closed");
 
         assert!(
-            matches!(
-                error,
-                AppError::MissingOrIncompatibleV4Materialization { .. }
-            ),
+            matches!(&error, AppError::FailedPrecondition(message) if message.contains(INCOMPATIBLE_MATERIALIZATION_MESSAGE_FRAGMENT)),
             "unexpected error: {error:#}"
         );
     }

--- a/crates/coral-app/src/source_management.rs
+++ b/crates/coral-app/src/source_management.rs
@@ -13,6 +13,14 @@ use crate::workspaces::WorkspaceName;
 
 /// Source import command accepted by [`SourceManagementHandle`].
 pub struct ImportManagedSourceCommand {
+    /// Optional workspace-local source name to install under.
+    ///
+    /// When set, [`SourceManagementHandle::import_source`] requires
+    /// [`Self::source_spec_id`] and preserves that authored source-spec id
+    /// while installing the source under this workspace-local name.
+    pub source_name: Option<String>,
+    /// Optional authored source-spec id declared by the manifest.
+    pub source_spec_id: Option<String>,
     /// Source manifest YAML to install into the workspace.
     pub manifest_yaml: String,
     /// Non-secret source variables.
@@ -24,6 +32,7 @@ pub struct ImportManagedSourceCommand {
 }
 
 /// Source installed or removed through [`SourceManagementHandle`].
+#[derive(Debug)]
 pub struct ManagedSource {
     /// Installed source name.
     pub name: String,
@@ -53,6 +62,19 @@ impl SourceManagementHandle {
         workspace_id: &str,
         command: ImportManagedSourceCommand,
     ) -> Result<ManagedSource, AppError> {
+        let source_name = command.source_name.clone();
+        let source_spec_id = command.source_spec_id.clone();
+        match (source_name, source_spec_id) {
+            (Some(source_name), Some(source_spec_id)) => {
+                return self.import_source_as(workspace_id, &source_name, &source_spec_id, command);
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                return Err(AppError::InvalidInput(
+                    "source_name and source_spec_id must be provided together".to_string(),
+                ));
+            }
+            (None, None) => {}
+        }
         let workspace_name = WorkspaceName::parse(workspace_id)?;
         let installed = self
             .sources
@@ -75,6 +97,20 @@ impl SourceManagementHandle {
         source_spec_id: &str,
         command: ImportManagedSourceCommand,
     ) -> Result<ManagedSource, AppError> {
+        if let Some(command_source_name) = &command.source_name
+            && command_source_name != source_name
+        {
+            return Err(AppError::InvalidInput(format!(
+                "command source_name '{command_source_name}' does not match requested source name '{source_name}'"
+            )));
+        }
+        if let Some(command_source_spec_id) = &command.source_spec_id
+            && command_source_spec_id != source_spec_id
+        {
+            return Err(AppError::InvalidInput(format!(
+                "command source_spec_id '{command_source_spec_id}' does not match requested source spec id '{source_spec_id}'"
+            )));
+        }
         let workspace_name = WorkspaceName::parse(workspace_id)?;
         let source_name = SourceName::parse(source_name)?;
         let source_spec_id = SourceName::parse(source_spec_id)?;
@@ -175,20 +211,23 @@ tables:
         .to_string()
     }
 
+    fn import_command() -> ImportManagedSourceCommand {
+        ImportManagedSourceCommand {
+            source_name: None,
+            source_spec_id: None,
+            manifest_yaml: manifest_without_secrets(),
+            variables: BTreeMap::new(),
+            identity_bindings: BTreeMap::new(),
+            replace_identity_bindings: false,
+        }
+    }
+
     #[test]
     fn import_source_uses_shared_source_lifecycle() {
         let (_temp, handle, config_store) = handle();
 
         let installed = handle
-            .import_source(
-                "default",
-                ImportManagedSourceCommand {
-                    manifest_yaml: manifest_without_secrets(),
-                    variables: BTreeMap::new(),
-                    identity_bindings: BTreeMap::new(),
-                    replace_identity_bindings: false,
-                },
-            )
+            .import_source("default", import_command())
             .expect("import source");
 
         assert_eq!(installed.name, "public_messages");
@@ -203,18 +242,47 @@ tables:
     }
 
     #[test]
+    fn import_source_accepts_optional_source_metadata() {
+        let (_temp, handle, config_store) = handle();
+        let mut command = import_command();
+        command.source_name = Some("public_messages".to_string());
+        command.source_spec_id = Some("public_messages".to_string());
+
+        let installed = handle
+            .import_source("default", command)
+            .expect("import source with metadata");
+
+        assert_eq!(installed.name, "public_messages");
+        let sources = SourceRegistry::list_workspace_sources(&config_store, "default")
+            .expect("workspace sources");
+        let [source] = sources.as_slice() else {
+            panic!("expected one source, got {sources:#?}");
+        };
+        assert_eq!(source.source_name, "public_messages");
+        assert_eq!(source.source_spec_id, None);
+    }
+
+    #[test]
+    fn import_source_rejects_partial_alias_metadata() {
+        let (_temp, handle, _config_store) = handle();
+        let mut command = import_command();
+        command.source_name = Some("team_messages".to_string());
+
+        let error = handle
+            .import_source("default", command)
+            .expect_err("partial alias metadata should fail");
+
+        assert!(
+            matches!(&error, AppError::InvalidInput(message) if message.contains("source_name and source_spec_id")),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
     fn delete_source_uses_shared_source_lifecycle() {
         let (_temp, handle, config_store) = handle();
         handle
-            .import_source(
-                "default",
-                ImportManagedSourceCommand {
-                    manifest_yaml: manifest_without_secrets(),
-                    variables: BTreeMap::new(),
-                    identity_bindings: BTreeMap::new(),
-                    replace_identity_bindings: false,
-                },
-            )
+            .import_source("default", import_command())
             .expect("import source");
 
         let removed = handle

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -534,14 +534,18 @@ fn expected_importer_version(surface_type: SurfaceType) -> &'static str {
     }
 }
 
+pub(crate) const INCOMPATIBLE_MATERIALIZATION_MESSAGE_FRAGMENT: &str =
+    "missing or incompatible DSL v4 materialized artifacts";
+
 pub(crate) fn incompatible_materialization_error(
     source_name: &SourceName,
     detail: impl AsRef<str>,
 ) -> AppError {
-    AppError::MissingOrIncompatibleV4Materialization {
-        source_name: source_name.to_string(),
-        detail: detail.as_ref().to_string(),
-    }
+    AppError::FailedPrecondition(format!(
+        "source '{}' has {INCOMPATIBLE_MATERIALIZATION_MESSAGE_FRAGMENT}: {}. Re-add the source to regenerate them.",
+        source_name,
+        detail.as_ref()
+    ))
 }
 
 fn write_materialization(

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -534,18 +534,14 @@ fn expected_importer_version(surface_type: SurfaceType) -> &'static str {
     }
 }
 
-pub(crate) const INCOMPATIBLE_MATERIALIZATION_MESSAGE_FRAGMENT: &str =
-    "missing or incompatible DSL v4 materialized artifacts";
-
 pub(crate) fn incompatible_materialization_error(
     source_name: &SourceName,
     detail: impl AsRef<str>,
 ) -> AppError {
-    AppError::FailedPrecondition(format!(
-        "source '{}' has {INCOMPATIBLE_MATERIALIZATION_MESSAGE_FRAGMENT}: {}. Re-add the source to regenerate them.",
-        source_name,
-        detail.as_ref()
-    ))
+    AppError::MissingOrIncompatibleV4Materialization {
+        source_name: source_name.to_string(),
+        detail: detail.as_ref().to_string(),
+    }
 }
 
 fn write_materialization(


### PR DESCRIPTION
## Intent

Land `feat(app): preserve public identity seams` as a focused DSL v4 identity layer.

## What it enables

- Provides the API, runtime, CLI, or documentation surface named by the title.
- Gives the next dependent layer a stable base while keeping review scope limited.

## Usage examples

Validate the layer after checkout:

```sh
make rust-checks
```

Inspect the layer against its base:

```sh
git diff sauldhernandez/dsl-v4-identity-v2-30-github-identity-example...sauldhernandez/dsl-v4-identity-v2-31-public-seam-compat
```

## Validation

- `make rust-checks`
- Path-patched downstream Rust workspace: `cargo check --workspace --all-targets --locked`
