### PR TITLE
feat(mcp): notify recipe tool list changes

### DIFF
--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -1,5 +1,7 @@
 //! RMCP server implementation for Coral's stdio MCP surface.
 
+use std::sync::{Arc, Mutex};
+
 use coral_api::v1::{
     CatalogItemKind as ProtoCatalogItemKind, DescribeTableRequest, DescribeTableResponse,
     ExecuteSqlRequest, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
@@ -78,6 +80,53 @@ struct EpisodeOpenedValue {
     instructions: &'static str,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum RecipeMcpToolSurfaceChange {
+    FirstObservation,
+    Unchanged,
+    Changed,
+}
+
+#[derive(Debug, PartialEq)]
+struct RecipeMcpToolSurface {
+    tools: Vec<Tool>,
+}
+
+#[derive(Debug)]
+enum RecipeMcpToolSurfaceTracker {
+    Unobserved,
+    Observed(RecipeMcpToolSurface),
+}
+
+impl RecipeMcpToolSurface {
+    fn from_recipes(recipes: &[Recipe]) -> Self {
+        let mut tools = recipes
+            .iter()
+            .flat_map(recipe_mcp_tools)
+            .collect::<Vec<_>>();
+        tools.sort_by(|left, right| left.name.cmp(&right.name));
+        Self { tools }
+    }
+}
+
+impl RecipeMcpToolSurfaceTracker {
+    fn observe(&mut self, surface: RecipeMcpToolSurface) -> RecipeMcpToolSurfaceChange {
+        match self {
+            Self::Unobserved => {
+                *self = Self::Observed(surface);
+                RecipeMcpToolSurfaceChange::FirstObservation
+            }
+            Self::Observed(previous) if *previous == surface => {
+                RecipeMcpToolSurfaceChange::Unchanged
+            }
+            Self::Observed(previous) => {
+                *previous = surface;
+                RecipeMcpToolSurfaceChange::Changed
+            }
+        }
+    }
+}
+
 fn serialize_tool_value(value: impl Serialize) -> Result<Value, tonic::Status> {
     serde_json::to_value(value).map_err(|error| tonic::Status::internal(error.to_string()))
 }
@@ -143,6 +192,7 @@ pub(crate) struct CoralMcpServer {
     feedback: FeedbackClient,
     episode: EpisodeClient,
     options: McpOptions,
+    observed_recipe_mcp_tool_surface: Arc<Mutex<RecipeMcpToolSurfaceTracker>>,
 }
 
 impl CoralMcpServer {
@@ -155,6 +205,9 @@ impl CoralMcpServer {
             feedback: app.feedback_client(),
             episode: app.episode_client(),
             options,
+            observed_recipe_mcp_tool_surface: Arc::new(Mutex::new(
+                RecipeMcpToolSurfaceTracker::Unobserved,
+            )),
         }
     }
 
@@ -178,6 +231,56 @@ impl CoralMcpServer {
             .await?
             .into_inner()
             .recipes)
+    }
+
+    fn observe_recipe_mcp_tool_surface(&self, recipes: &[Recipe]) -> RecipeMcpToolSurfaceChange {
+        let surface = RecipeMcpToolSurface::from_recipes(recipes);
+        let mut tracker = self
+            .observed_recipe_mcp_tool_surface
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        tracker.observe(surface)
+    }
+
+    async fn load_recipe_mcp_tools_and_notify_if_changed(
+        &self,
+        context: &RequestContext<RoleServer>,
+    ) -> Result<Vec<Recipe>, tonic::Status> {
+        let recipes = match self.load_recipe_mcp_tools().await {
+            Ok(recipes) => recipes,
+            Err(status) => {
+                tracing::warn!(
+                    detail = %status,
+                    "failed to refresh recipe MCP tool surface"
+                );
+                return Err(status);
+            }
+        };
+        if self.observe_recipe_mcp_tool_surface(&recipes) != RecipeMcpToolSurfaceChange::Changed {
+            return Ok(recipes);
+        }
+        if let Err(error) = context.peer.notify_tool_list_changed().await {
+            tracing::debug!(
+                detail = %error,
+                "failed to send MCP tool-list changed notification"
+            );
+        }
+        Ok(recipes)
+    }
+
+    async fn notify_if_recipe_mcp_tool_surface_changed(
+        &self,
+        context: &RequestContext<RoleServer>,
+    ) {
+        if self
+            .load_recipe_mcp_tools_and_notify_if_changed(context)
+            .await
+            .is_err()
+        {
+            // The refresh path already logged the status. Non-tool calls should
+            // keep serving their primary resource even if recipe inventory is
+            // temporarily unavailable.
+        }
     }
 
     async fn load_catalog(
@@ -792,6 +895,7 @@ impl ServerHandler for CoralMcpServer {
             ServerCapabilities::builder()
                 .enable_resources()
                 .enable_tools()
+                .enable_tool_list_changed()
                 .build(),
         )
         .with_server_info(Implementation::new("coral", env!("CARGO_PKG_VERSION")))
@@ -848,6 +952,7 @@ impl ServerHandler for CoralMcpServer {
                 .load_recipe_mcp_tools()
                 .await
                 .map_err(|status| status_to_error_data(&status))?;
+            self.observe_recipe_mcp_tool_surface(&recipes);
             let mut seen_tools = tools
                 .iter()
                 .map(|tool| tool.name.to_string())
@@ -865,9 +970,11 @@ impl ServerHandler for CoralMcpServer {
     async fn call_tool(
         &self,
         request: CallToolRequestParams,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
-        let recipe_mcp_tools = self.load_recipe_mcp_tools().await;
+        let recipe_mcp_tools = self
+            .load_recipe_mcp_tools_and_notify_if_changed(&context)
+            .await;
         let span =
             telemetry::call_tool_span(request.name.as_ref(), self.options.trace_parent.as_deref());
         let inject_episode_metadata = request.name.as_ref() != "open_episode";
@@ -895,8 +1002,10 @@ impl ServerHandler for CoralMcpServer {
     async fn list_resources(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, ErrorData> {
+        self.notify_if_recipe_mcp_tool_surface_changed(&context)
+            .await;
         let span = telemetry::list_resources_span(self.options.trace_parent.as_deref());
         telemetry::instrument_protocol(span, async {
             let (sources, visible_table_count, visible_function_count) = self
@@ -914,8 +1023,10 @@ impl ServerHandler for CoralMcpServer {
     async fn read_resource(
         &self,
         request: ReadResourceRequestParams,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, ErrorData> {
+        self.notify_if_recipe_mcp_tool_surface_changed(&context)
+            .await;
         let span = telemetry::read_resource_span(
             request.uri.as_str(),
             self.options.trace_parent.as_deref(),

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -6,11 +6,16 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
 
 use coral_api::recipe_mcp_tool_name;
 use coral_api::{
     CORAL_EPISODE_ID_MAX_LEN,
-    v1::{AddRecipeRequest, ImportSourceRequest, import_source_response},
+    v1::{AddRecipeRequest, ImportSourceRequest, RemoveRecipeRequest, import_source_response},
 };
 use coral_client::{
     AppClient, RecipeClient, SourceClient, default_workspace,
@@ -20,10 +25,11 @@ use jsonschema::JSONSchema;
 use rmcp::{
     ClientHandler, RoleClient, ServiceExt,
     model::{CallToolRequestParams, ReadResourceRequestParams, Tool},
-    service::RunningService,
+    service::{MaybeSendFuture, NotificationContext, RunningService},
 };
 use serde_json::{Map, Value, json};
 use tempfile::TempDir;
+use tokio::sync::Notify;
 use tonic::Request;
 
 use crate::{CoralMcpServer, McpOptions};
@@ -194,6 +200,7 @@ async fn add_demo_source(source_client: &mut SourceClient, manifest_yaml: String
 struct TestSession {
     source_client: SourceClient,
     recipe_client: RecipeClient,
+    client_handler: TestMcpClient,
     client: RunningService<RoleClient, TestMcpClient>,
     app_server: RunningServer,
     mcp_server_task: tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>,
@@ -203,6 +210,7 @@ impl TestSession {
     async fn shutdown(self) {
         let Self {
             client,
+            client_handler: _,
             app_server,
             mcp_server_task,
             ..
@@ -248,6 +256,7 @@ async fn start_session_with_options(temp: &TempDir, options: McpOptions) -> Test
     TestSession {
         source_client,
         recipe_client,
+        client_handler,
         client,
         app_server: server,
         mcp_server_task,
@@ -255,9 +264,41 @@ async fn start_session_with_options(temp: &TempDir, options: McpOptions) -> Test
 }
 
 #[derive(Clone, Default)]
-struct TestMcpClient;
+struct TestMcpClient {
+    tool_list_changed_count: Arc<AtomicUsize>,
+    tool_list_changed_notify: Arc<Notify>,
+}
 
-impl ClientHandler for TestMcpClient {}
+impl TestMcpClient {
+    fn tool_list_changed_count(&self) -> usize {
+        self.tool_list_changed_count.load(Ordering::SeqCst)
+    }
+
+    async fn wait_for_tool_list_changed_since(&self, previous: usize) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let notified = self.tool_list_changed_notify.notified();
+                if self.tool_list_changed_count() > previous {
+                    return;
+                }
+                notified.await;
+            }
+        })
+        .await
+        .expect("MCP client should receive tools/list_changed");
+    }
+}
+
+impl ClientHandler for TestMcpClient {
+    fn on_tool_list_changed(
+        &self,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl std::future::Future<Output = ()> + MaybeSendFuture + '_ {
+        self.tool_list_changed_count.fetch_add(1, Ordering::SeqCst);
+        self.tool_list_changed_notify.notify_waiters();
+        std::future::ready(())
+    }
+}
 
 fn text_content(result: &rmcp::model::ReadResourceResult) -> &str {
     match &result.contents[0] {
@@ -346,6 +387,36 @@ async fn add_demo_recipe(recipe_client: &mut RecipeClient, yaml: &str) {
         }))
         .await
         .expect("add recipe");
+}
+
+async fn remove_demo_recipe(recipe_client: &mut RecipeClient, name: &str) {
+    recipe_client
+        .remove_recipe(Request::new(RemoveRecipeRequest {
+            workspace: Some(default_workspace()),
+            name: name.to_string(),
+        }))
+        .await
+        .expect("remove recipe");
+}
+
+fn recipe_tool_yaml(name: &str) -> String {
+    format!(
+        r"
+kind: recipe
+name: {name}
+description: Demo MCP recipe.
+implementation:
+  kind: coral_sql
+  query: |
+    select 1 as id
+publish:
+  table_function:
+    schema: recipes
+    name: {name}
+  mcp:
+    name: {name}
+"
+    )
 }
 
 fn echo_recipe_tool_yaml(name: &str) -> String {
@@ -803,6 +874,17 @@ async fn mcp_recipe_tools_skip_stale_runtime_metadata() {
     )
     .expect("rewrite recipe yaml");
 
+    let previous_notifications = session.client_handler.tool_list_changed_count();
+    session
+        .client
+        .call_tool(CallToolRequestParams::new("list_catalog"))
+        .await
+        .expect("list catalog");
+    session
+        .client_handler
+        .wait_for_tool_list_changed_since(previous_notifications)
+        .await;
+
     let updated_tools = session
         .client
         .list_all_tools()
@@ -812,6 +894,79 @@ async fn mcp_recipe_tools_skip_stale_runtime_metadata() {
         updated_tools
             .iter()
             .all(|tool| tool.name != "recipe_stale_recipe_tool")
+    );
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_notifies_when_recipe_tool_surface_changes_after_add() {
+    let temp = TempDir::new().expect("temp dir");
+    let mut session = start_session(&temp).await;
+    let client = &session.client;
+
+    client.list_all_tools().await.expect("initial tools");
+    add_demo_recipe(
+        &mut session.recipe_client,
+        &recipe_tool_yaml("notified_mcp_recipe"),
+    )
+    .await;
+
+    let previous_notifications = session.client_handler.tool_list_changed_count();
+    client
+        .call_tool(CallToolRequestParams::new("list_catalog"))
+        .await
+        .expect("list catalog");
+    session
+        .client_handler
+        .wait_for_tool_list_changed_since(previous_notifications)
+        .await;
+
+    let tools_after_notification = client.list_all_tools().await.expect("tools after add");
+    assert!(
+        tools_after_notification
+            .iter()
+            .any(|tool| tool.name == "recipe_notified_mcp_recipe")
+    );
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_notifies_when_recipe_tool_surface_changes_after_remove() {
+    let temp = TempDir::new().expect("temp dir");
+    let mut session = start_session(&temp).await;
+    let client = &session.client;
+
+    add_demo_recipe(
+        &mut session.recipe_client,
+        &recipe_tool_yaml("removed_mcp_recipe"),
+    )
+    .await;
+    let tools_after_add = client.list_all_tools().await.expect("tools after add");
+    assert!(
+        tools_after_add
+            .iter()
+            .any(|tool| tool.name == "recipe_removed_mcp_recipe")
+    );
+
+    remove_demo_recipe(&mut session.recipe_client, "removed_mcp_recipe").await;
+
+    let previous_notifications = session.client_handler.tool_list_changed_count();
+    client
+        .call_tool(CallToolRequestParams::new("list_catalog"))
+        .await
+        .expect("list catalog");
+    session
+        .client_handler
+        .wait_for_tool_list_changed_since(previous_notifications)
+        .await;
+
+    let tools_after_remove = client.list_all_tools().await.expect("tools after remove");
+    assert!(
+        tools_after_remove
+            .iter()
+            .all(|tool| tool.name != "recipe_removed_mcp_recipe")
     );
 
     session.shutdown().await;

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -202,7 +202,7 @@ The agent should call `list_catalog`, `search_catalog`, or query `coral.tables` 
 
 Clients see the same database catalog and query results as `coral sql`. You set up sources with the CLI, then agents query Coral over MCP as SQL schemas and tables.
 
-Recipes that publish both `table_function` and `mcp` targets appear as additional MCP tools with a `recipe_` prefix. For example, `mcp.name: open_prs` is exposed as `recipe_open_prs`. Calling one of those tools executes the recipe through its published SQL table function, so it returns the same rows as `coral sql "select * from recipes.<name>(...)"`.
+Recipes that publish both `table_function` and `mcp` targets appear as additional MCP tools with a `recipe_` prefix. For example, `mcp.name: open_prs` is exposed as `recipe_open_prs`. Calling one of those tools executes the recipe through its published SQL table function, so it returns the same rows as `coral sql "select * from recipes.<name>(...)"`. When the recipe MCP tool surface changes, Coral advertises `notifications/tools/list_changed`; clients should refresh tools after receiving that notification.
 
 The `coral` system schema is part of that catalog. No-schema `list_catalog` and `coral://tables` include both configured source tables and Coral catalog tables: `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs`. Agents can also call `describe_table` and `list_columns` on those system tables.
 


### PR DESCRIPTION
## Summary

Adds dynamic MCP tool-list change notifications for recipe-backed MCP tools.

This sits on top of #1360. That PR exposes and executes recipe MCP tools. This PR adds the state tracking needed for Coral MCP to notice when the recipe tool surface changes and emit `notifications/tools/list_changed`.

## Design Notes

- The MCP server tracks the last observed recipe-derived tool surface.
- First observation does not notify; unchanged surfaces do not notify.
- A changed recipe tool surface triggers `notify_tool_list_changed`.
- Refresh happens on MCP interactions that already reach Coral, such as tool calls and resource reads/lists.
- Recipe loading errors are logged; non-tool resource calls continue serving their primary response when possible.

## Verification

- `cargo test -p coral-mcp --all-features mcp_` (12 MCP tests passed)
- Parent PR diff checked to confirm notification symbols are no longer present in #1360.