### PR TITLE
feat(spec): add OpenAPI 3.1 support for DSL v4 importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+* **spec:** import OpenAPI 3.1 documents in DSL v4 ([#1321](https://github.com/withcoral/coral/issues/1321))
+
 ## [0.4.3](https://github.com/withcoral/coral/compare/v0.4.2...v0.4.3) (2026-06-15)
 
 

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -1628,6 +1628,38 @@ components:
 "#
     }
 
+    fn v4_openapi_31_fixture() -> &'static str {
+        r"
+openapi: 3.1.0
+paths:
+  /repos/{owner}/{repo}/issues:
+    get:
+      operationId: issues/list-for-repo
+      parameters:
+        - {name: owner, in: path, required: true, schema: {type: string}}
+        - {name: repo, in: path, required: true, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type:
+                  - array
+                  - 'null'
+                items: {$ref: '#/components/schemas/issue'}
+components:
+  schemas:
+    issue:
+      type: object
+      properties:
+        id: {type: integer}
+        title:
+          type:
+            - string
+            - 'null'
+"
+    }
+
     fn manifest_v4_with_file_descriptor(openapi_file: &std::path::Path) -> String {
         format!(
             r#"
@@ -1975,6 +2007,44 @@ tables:
             .get_source_info(&default_workspace(), &source_name)
             .expect("installed v4 source should be usable");
         assert_eq!(info.name.as_str(), "github_v4_test");
+    }
+
+    #[test]
+    fn import_v4_openapi_31_source_writes_materialized_artifacts() {
+        let temp = TempDir::new().expect("temp dir");
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let openapi_file = descriptor_temp.path().join("github-openapi-31.yaml");
+        std::fs::write(&openapi_file, v4_openapi_31_fixture()).expect("write fixture");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+
+        let installed = manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_v4_with_file_descriptor(&openapi_file),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("import v4 OpenAPI 3.1 source");
+
+        assert_eq!(installed.name.as_str(), "github_v4_test");
+        let source_name = SourceName::parse("github_v4_test").expect("source");
+        let materialized = layout.v4_materialized_dir(&default_workspace(), &source_name);
+        assert!(materialized.join("fingerprint.yaml").exists());
+        assert!(materialized.join("projections.yaml").exists());
+        assert!(
+            materialized
+                .join("surfaces")
+                .join("rest")
+                .join("semantic-ir.yaml")
+                .exists()
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -814,3 +814,300 @@ paths:
     );
     assert_eq!(operation.output.cardinality, OutputCardinality::Unknown);
 }
+
+fn openapi_v4_manifest() -> V4SourceManifest {
+    parse_source_manifest_yaml(
+        r"
+name: openapi31
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest")
+    .as_v4()
+    .expect("v4")
+    .clone()
+}
+
+#[test]
+fn extracts_openapi_31_document_metadata() {
+    let metadata = openapi_document_metadata(
+        r"
+openapi: 3.1.0
+info:
+  title: Demo
+  description: OpenAPI 3.1 demo.
+servers:
+  - url: https://api.example.com/v1
+paths: {}
+"
+        .as_bytes(),
+    )
+    .expect("metadata");
+    assert_eq!(metadata.description.as_deref(), Some("OpenAPI 3.1 demo."));
+    assert_eq!(
+        metadata.server_url.as_deref(),
+        Some("https://api.example.com/v1")
+    );
+}
+
+#[test]
+fn rejects_unsupported_openapi_32_document() {
+    let error = openapi_document_metadata(
+        r"
+openapi: 3.2.0
+info:
+  title: Demo
+paths: {}
+"
+        .as_bytes(),
+    )
+    .expect_err("3.2 should be rejected");
+    assert!(
+        error.to_string().contains("unsupported version '3.2.0'"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn importer_accepts_openapi_31_documents() {
+    let manifest = openapi_v4_manifest();
+    let surface = manifest.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        &manifest,
+        surface,
+        r"
+openapi: 3.1.0
+paths:
+  /items/{id}:
+    get:
+      operationId: items/get
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: include_archived
+          in: query
+          schema:
+            type:
+              - boolean
+              - 'null'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  nickname:
+                    type:
+                      - string
+                      - 'null'
+"
+        .as_bytes(),
+    )
+    .expect("3.1 import");
+    let operation = ir.operations.first().expect("operation");
+    assert_eq!(operation.id, "items_get");
+
+    let types = ir
+        .types
+        .iter()
+        .map(|ty| (ty.id.as_str(), ty))
+        .collect::<BTreeMap<_, _>>();
+    let row = types
+        .get(operation.output.type_ref.as_str())
+        .expect("row type");
+    let IrTypeShape::Object { fields } = &row.shape else {
+        panic!("row imported as {:?}", row.shape);
+    };
+    let nickname = fields
+        .iter()
+        .find(|field| field.name == "nickname")
+        .expect("nickname field");
+    let nickname_type = types
+        .get(nickname.type_ref.as_str())
+        .expect("nickname type");
+    assert!(nickname_type.nullable);
+    assert!(matches!(
+        nickname_type.shape,
+        IrTypeShape::Scalar(IrScalarType::String)
+    ));
+
+    let include_archived = operation
+        .inputs
+        .iter()
+        .find(|input| input.name == "include_archived")
+        .expect("include_archived parameter");
+    assert_eq!(include_archived.data_type, IrScalarType::Boolean);
+}
+
+#[test]
+fn importer_classifies_openapi_31_wrapped_list_responses() {
+    let manifest = openapi_v4_manifest();
+    let surface = manifest.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        &manifest,
+        surface,
+        r"
+openapi: 3.1.0
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type:
+                      - array
+                      - 'null'
+                    items:
+                      $ref: '#/components/schemas/Item'
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        id:
+          type: string
+        note:
+          type:
+            - string
+            - 'null'
+"
+        .as_bytes(),
+    )
+    .expect("3.1 wrapped list import");
+    let operation = ir.operations.first().expect("operation");
+    assert_eq!(operation.output.cardinality, OutputCardinality::WrappedList);
+    assert_eq!(operation.output.row_path, vec!["data".to_string()]);
+
+    let catalog = generate_projection_catalog(&manifest, &[ir]).expect("catalog");
+    let projection = catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == "items_list")
+        .expect("projection");
+    assert_eq!(projection.name, "items");
+    assert!(matches!(projection.kind, ProjectionKind::Table));
+}
+
+#[test]
+fn importer_handles_openapi_31_array_response_items() {
+    let manifest = openapi_v4_manifest();
+    let surface = manifest.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        &manifest,
+        surface,
+        r"
+openapi: 3.1.0
+paths:
+  /widgets:
+    get:
+      operationId: widgets/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type:
+                  - array
+                  - 'null'
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+"
+        .as_bytes(),
+    )
+    .expect("3.1 array response import");
+    let operation = ir.operations.first().expect("operation");
+    assert_eq!(operation.output.cardinality, OutputCardinality::List);
+}
+
+#[test]
+fn importer_imports_object_schemas_without_explicit_type() {
+    let manifest = openapi_v4_manifest();
+    let surface = manifest.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        &manifest,
+        surface,
+        r"
+openapi: 3.1.0
+paths:
+  /records/{id}:
+    get:
+      operationId: records/get
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: {type: string}
+                  label:
+                    type:
+                      - string
+                      - 'null'
+"
+        .as_bytes(),
+    )
+    .expect("schema without explicit type imports");
+    let operation = ir.operations.first().expect("operation");
+    let row = ir
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type");
+    let IrTypeShape::Object { fields } = &row.shape else {
+        panic!("row imported as {:?}", row.shape);
+    };
+    assert_eq!(fields.len(), 2);
+}
+
+#[test]
+fn importer_rejects_unsupported_openapi_32_surface() {
+    let manifest = openapi_v4_manifest();
+    let surface = manifest.surfaces.first().expect("one surface");
+    let error = import_openapi_surface(
+        &manifest,
+        surface,
+        r"
+openapi: 3.2.0
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+"
+        .as_bytes(),
+    )
+    .expect_err("3.2 should be rejected");
+    assert!(
+        error.to_string().contains("unsupported version '3.2.0'"),
+        "unexpected error: {error}"
+    );
+}

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -21,6 +21,18 @@ pub(crate) fn json_schema_type_contains(schema: &Value, expected: &str) -> bool 
     }
 }
 
+pub(crate) fn json_schema_nullable(schema: &Value) -> bool {
+    schema
+        .get("nullable")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || schema_type_values(schema).contains(&"null")
+}
+
+pub(crate) fn json_schema_is_object_like(schema: &Value) -> bool {
+    json_schema_type_contains(schema, "object") || schema.get("type").is_none()
+}
+
 pub(crate) fn json_schema_type_display(schema: &Value) -> String {
     match schema.get("type") {
         Some(Value::String(value)) => value.clone(),
@@ -138,5 +150,36 @@ mod tests {
             json_schema_scalar_type(&json!({"format": "date-time"})),
             Some(IrScalarType::Timestamp)
         );
+    }
+
+    #[test]
+    fn nullable_detects_openapi_30_nullable_keyword() {
+        assert!(json_schema_nullable(
+            &json!({"type": "string", "nullable": true})
+        ));
+    }
+
+    #[test]
+    fn nullable_detects_openapi_31_type_arrays() {
+        assert!(json_schema_nullable(&json!({"type": ["string", "null"]})));
+    }
+
+    #[test]
+    fn nullable_rejects_non_nullable_schemas() {
+        assert!(!json_schema_nullable(&json!({"type": "string"})));
+    }
+
+    #[test]
+    fn object_like_treats_missing_type_as_object() {
+        assert!(json_schema_is_object_like(&json!({
+            "properties": {"id": {"type": "string"}}
+        })));
+    }
+
+    #[test]
+    fn object_like_accepts_openapi_31_object_type_arrays() {
+        assert!(json_schema_is_object_like(&json!({
+            "type": ["object", "null"]
+        })));
     }
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/document.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/document.rs
@@ -2,6 +2,8 @@ use serde_json::{Map, Value};
 
 use crate::{ManifestError, Result};
 
+use super::is_supported_openapi_version;
+
 pub fn normalize_source_document(bytes: &[u8]) -> Result<String> {
     let value: Value = serde_yaml::from_slice(bytes).map_err(ManifestError::parse_yaml)?;
     serde_yaml::to_string(&value).map_err(ManifestError::parse_yaml)
@@ -20,7 +22,7 @@ pub fn openapi_document_metadata(document_bytes: &[u8]) -> Result<OpenApiDocumen
         .get("openapi")
         .and_then(Value::as_str)
         .ok_or_else(|| ManifestError::validation("OpenAPI document is missing openapi version"))?;
-    if !openapi.starts_with("3.0.") {
+    if !is_supported_openapi_version(openapi) {
         return Err(ManifestError::validation(format!(
             "OpenAPI document uses unsupported version '{openapi}'"
         )));

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -8,6 +8,8 @@ use crate::v4::manifest::{V4SourceManifest, V4Surface};
 use crate::v4::{OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
 use crate::{ManifestError, Result};
 
+use super::is_supported_openapi_version;
+
 pub fn import_openapi_surface(
     manifest: &V4SourceManifest,
     surface: &V4Surface,
@@ -19,7 +21,7 @@ pub fn import_openapi_surface(
         .get("openapi")
         .and_then(Value::as_str)
         .ok_or_else(|| ManifestError::validation("OpenAPI document is missing openapi version"))?;
-    if !openapi.starts_with("3.0.") {
+    if !is_supported_openapi_version(openapi) {
         return Err(ManifestError::validation(format!(
             "OpenAPI document for surface '{}' uses unsupported version '{openapi}'",
             surface.id

--- a/crates/coral-spec/src/v4/surfaces/openapi/mod.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/mod.rs
@@ -6,3 +6,7 @@ mod schemas;
 
 pub use document::{OpenApiDocumentMetadata, normalize_source_document, openapi_document_metadata};
 pub use import::import_openapi_surface;
+
+pub(super) fn is_supported_openapi_version(version: &str) -> bool {
+    version.starts_with("3.0.") || version.starts_with("3.1.")
+}

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -5,6 +5,7 @@ use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{
     IrEntityCandidate, IrOperationOutput, OutputCardinality, RestResponseAttachment,
 };
+use crate::v4::surfaces::json_schema::{json_schema_is_object_like, json_schema_type_contains};
 
 use super::import::OpenApiImporter;
 
@@ -183,7 +184,7 @@ fn classify_response_schema(
     if schema == &Value::Null {
         return (OutputCardinality::None, Vec::new(), Value::Null, None);
     }
-    if schema.get("type").and_then(Value::as_str) == Some("array") {
+    if json_schema_type_contains(schema, "array") {
         let item = schema.get("items").cloned().unwrap_or(Value::Null);
         return (
             OutputCardinality::List,
@@ -194,12 +195,7 @@ fn classify_response_schema(
                 .map(entity_name_from_ref),
         );
     }
-    if schema
-        .get("type")
-        .and_then(Value::as_str)
-        .unwrap_or("object")
-        == "object"
-    {
+    if json_schema_is_object_like(schema) {
         if let Some((property_name, items)) = schema
             .get("properties")
             .and_then(Value::as_object)
@@ -235,7 +231,7 @@ fn wrapped_list_property(properties: &Map<String, Value>) -> Option<(&str, &Valu
         .find_map(|name| {
             properties
                 .get(*name)
-                .filter(|property| property.get("type").and_then(Value::as_str) == Some("array"))
+                .filter(|property| json_schema_type_contains(property, "array"))
                 .map(|property| (*name, property))
         })
         .or_else(|| single_array_payload_property(properties))
@@ -244,7 +240,7 @@ fn wrapped_list_property(properties: &Map<String, Value>) -> Option<(&str, &Valu
 fn single_array_payload_property(properties: &Map<String, Value>) -> Option<(&str, &Value)> {
     let array_properties = properties
         .iter()
-        .filter(|(_, property)| property.get("type").and_then(Value::as_str) == Some("array"))
+        .filter(|(_, property)| json_schema_type_contains(property, "array"))
         .filter(|(name, _)| !is_wrapper_metadata_property(name))
         .collect::<Vec<_>>();
     match array_properties.as_slice() {

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -5,7 +5,10 @@ use serde_json::{Map, Value};
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrField, IrType, IrTypeShape};
 use crate::v4::naming::normalize_identifier;
-use crate::v4::surfaces::json_schema::json_schema_scalar_type;
+use crate::v4::surfaces::json_schema::{
+    json_schema_is_object_like, json_schema_nullable, json_schema_scalar_type,
+    json_schema_type_contains,
+};
 
 use super::import::OpenApiImporter;
 
@@ -34,10 +37,7 @@ impl OpenApiImporter<'_> {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string();
-        let nullable = resolved
-            .get("nullable")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
+        let nullable = json_schema_nullable(&resolved);
         self.types.insert(
             type_id.clone(),
             IrType {
@@ -83,52 +83,43 @@ impl OpenApiImporter<'_> {
             }
         } else if let Some(scalar) = json_schema_scalar_type(&resolved) {
             IrTypeShape::Scalar(scalar)
-        } else {
-            match resolved
-                .get("type")
-                .and_then(Value::as_str)
-                .unwrap_or("object")
-            {
-                "object" => {
-                    if let Some(properties) = resolved.get("properties").and_then(Value::as_object)
-                    {
-                        let required = required_fields(&resolved);
-                        IrTypeShape::Object {
-                            fields: self.import_object_fields(
-                                properties,
-                                &required,
-                                &type_id,
-                                operation_id,
-                                diagnostics,
-                            ),
-                        }
-                    } else if let Some(additional) = resolved.get("additionalProperties") {
-                        if additional.as_bool() == Some(false) {
-                            IrTypeShape::Object { fields: Vec::new() }
-                        } else {
-                            let value_type_ref = self
-                                .import_schema(
-                                    additional,
-                                    &format!("{type_id}_value"),
-                                    operation_id,
-                                    diagnostics,
-                                )
-                                .unwrap_or_else(|| "json".to_string());
-                            IrTypeShape::Map { value_type_ref }
-                        }
-                    } else {
-                        IrTypeShape::Json
-                    }
+        } else if json_schema_is_object_like(&resolved) {
+            if let Some(properties) = resolved.get("properties").and_then(Value::as_object) {
+                let required = required_fields(&resolved);
+                IrTypeShape::Object {
+                    fields: self.import_object_fields(
+                        properties,
+                        &required,
+                        &type_id,
+                        operation_id,
+                        diagnostics,
+                    ),
                 }
-                "array" => {
-                    let item = resolved.get("items").unwrap_or(&Value::Null);
-                    let item_type_ref = self
-                        .import_schema(item, &format!("{type_id}_item"), operation_id, diagnostics)
+            } else if let Some(additional) = resolved.get("additionalProperties") {
+                if additional.as_bool() == Some(false) {
+                    IrTypeShape::Object { fields: Vec::new() }
+                } else {
+                    let value_type_ref = self
+                        .import_schema(
+                            additional,
+                            &format!("{type_id}_value"),
+                            operation_id,
+                            diagnostics,
+                        )
                         .unwrap_or_else(|| "json".to_string());
-                    IrTypeShape::List { item_type_ref }
+                    IrTypeShape::Map { value_type_ref }
                 }
-                _ => IrTypeShape::Json,
+            } else {
+                IrTypeShape::Json
             }
+        } else if json_schema_type_contains(&resolved, "array") {
+            let item = resolved.get("items").unwrap_or(&Value::Null);
+            let item_type_ref = self
+                .import_schema(item, &format!("{type_id}_item"), operation_id, diagnostics)
+                .unwrap_or_else(|| "json".to_string());
+            IrTypeShape::List { item_type_ref }
+        } else {
+            IrTypeShape::Json
         };
         self.types.insert(
             type_id.clone(),

--- a/docs/project/changelog.mdx
+++ b/docs/project/changelog.mdx
@@ -5,6 +5,12 @@ description: "Release notes for the Coral CLI, generated from [CHANGELOG.md](htt
 
 {/* AUTO-GENERATED — DO NOT EDIT. Run `make docs-generate` to update. */}
 
+## [Unreleased]
+
+### Features
+
+* **spec:** import OpenAPI 3.1 documents in DSL v4 ([#1321](https://github.com/withcoral/coral/issues/1321))
+
 ## [0.4.3](https://github.com/withcoral/coral/compare/v0.4.2...v0.4.3) (2026-06-15)
 
 


### PR DESCRIPTION
## Summary

- Accept OpenAPI **3.0.x** and **3.1.x** documents in the DSL v4 OpenAPI surface importer; reject 3.2+ for now.
- Handle OpenAPI 3.1 JSON Schema patterns used by the importer: nullable `type` arrays (e.g. `["string", "null"]`), object/array type arrays, and schemas without an explicit `type` when `properties` are present.
- Add unit/integration coverage in `coral-spec` and an end-to-end materialization test in `coral-app`.

Closes #1321.

## Test plan

- [x] `cargo test -p coral-spec v4::openapi --all-features` (21 tests)
- [x] `cargo test -p coral-app --lib sources::manager::tests::import_v4_openapi_31_source_writes_materialized_artifacts --all-features`
- [x] `cargo clippy -p coral-spec -p coral-app --all-targets --all-features --locked -- -D warnings`
- [x] `make docs-check`