### PR TITLE
refactor(spec): share JSON schema import helpers

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -662,6 +662,61 @@ paths:
 }
 
 #[test]
+fn importer_warns_for_openapi_all_of_property_conflicts() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: conflicting_all_of
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Combined'}
+components:
+  schemas:
+    Combined:
+      allOf:
+        - type: object
+          properties:
+            id: {type: string}
+        - type: object
+          properties:
+            id: {type: integer}
+"
+        .as_bytes(),
+    )
+    .expect("conflicting allOf imports with diagnostics");
+
+    let operation = ir.operations.first().expect("operation");
+    let codes = operation
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code.as_str())
+        .collect::<Vec<_>>();
+    assert!(codes.contains(&"OPENAPI_ALLOF_CONFLICT"), "{codes:?}");
+    assert_eq!(operation.output.type_ref, "json");
+}
+
+#[test]
 fn importer_preserves_non_string_parameter_defaults() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -86,25 +86,6 @@ pub(crate) fn with_resolved_json_schema<'a, T>(
     result
 }
 
-pub(crate) fn resolve_json_schema_refs<'a>(
-    root: &'a Value,
-    schema: &'a Value,
-    resolving_refs: &mut BTreeSet<String>,
-    depth: usize,
-    max_depth: usize,
-) -> Result<Value, JsonSchemaWalkError<'a>> {
-    with_resolved_json_schema(
-        root,
-        schema,
-        resolving_refs,
-        depth,
-        max_depth,
-        |resolved, resolving_refs, next_depth| {
-            resolve_json_schema_child_refs(root, resolved, resolving_refs, next_depth, max_depth)
-        },
-    )
-}
-
 pub(crate) fn resolve_json_schema_ref_with_siblings<'a>(
     root: &'a Value,
     schema: &'a Value,
@@ -235,60 +216,6 @@ fn resolve_json_schema_child_refs_allow_cycles<'a>(
                                 max_depth,
                             )
                             .map(|schema| (name.clone(), schema))
-                        })
-                        .collect::<Result<serde_json::Map<_, _>, _>>()?,
-                ),
-            );
-        }
-    }
-    Ok(Value::Object(resolved))
-}
-
-fn resolve_json_schema_child_refs<'a>(
-    root: &'a Value,
-    schema: &'a Value,
-    resolving_refs: &mut BTreeSet<String>,
-    depth: usize,
-    max_depth: usize,
-) -> Result<Value, JsonSchemaWalkError<'a>> {
-    let Some(object) = schema.as_object() else {
-        return Ok(schema.clone());
-    };
-
-    let mut resolved = object.clone();
-    for key in ["items", "additionalProperties", "not"] {
-        if let Some(value) = object.get(key).filter(|value| value.is_object()) {
-            resolved.insert(
-                key.to_string(),
-                resolve_json_schema_refs(root, value, resolving_refs, depth, max_depth)?,
-            );
-        }
-    }
-    for key in ["allOf", "anyOf", "oneOf"] {
-        if let Some(values) = object.get(key).and_then(Value::as_array) {
-            resolved.insert(
-                key.to_string(),
-                Value::Array(
-                    values
-                        .iter()
-                        .map(|value| {
-                            resolve_json_schema_refs(root, value, resolving_refs, depth, max_depth)
-                        })
-                        .collect::<Result<Vec<_>, _>>()?,
-                ),
-            );
-        }
-    }
-    for key in ["$defs", "definitions", "patternProperties", "properties"] {
-        if let Some(schemas) = object.get(key).and_then(Value::as_object) {
-            resolved.insert(
-                key.to_string(),
-                Value::Object(
-                    schemas
-                        .iter()
-                        .map(|(name, schema)| {
-                            resolve_json_schema_refs(root, schema, resolving_refs, depth, max_depth)
-                                .map(|schema| (name.clone(), schema))
                         })
                         .collect::<Result<serde_json::Map<_, _>, _>>()?,
                 ),
@@ -686,7 +613,7 @@ mod tests {
     }
 
     #[test]
-    fn resolved_schema_refs_resolves_schema_bearing_children() {
+    fn resolved_schema_ref_with_siblings_resolves_schema_bearing_children() {
         let root = json!({
             "$defs": {
                 "Value": {"type": "integer"}
@@ -705,7 +632,8 @@ mod tests {
         let filter = root.pointer("/properties/filter").expect("filter schema");
 
         let resolved =
-            resolve_json_schema_refs(&root, filter, &mut resolving_refs, 0, 8).expect("resolved");
+            resolve_json_schema_ref_with_siblings(&root, filter, &mut resolving_refs, 0, 8)
+                .expect("resolved");
 
         assert_eq!(
             resolved

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -10,6 +10,14 @@ pub(crate) enum RefError<'a> {
     NotFound(&'a str),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JsonSchemaWalkError<'a> {
+    ExternalRef(&'a str),
+    RefCycle(&'a str),
+    RefNotFound(&'a str),
+    DepthExceeded,
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct JsonObjectShape {
     pub(crate) properties: BTreeMap<String, Value>,
@@ -33,6 +41,126 @@ pub(crate) fn resolve_local_ref<'a>(
     }
     let pointer = reference.strip_prefix('#').unwrap_or(reference);
     root.pointer(pointer).ok_or(RefError::NotFound(reference))
+}
+
+pub(crate) fn with_resolved_json_schema<'a, T>(
+    root: &'a Value,
+    schema: &'a Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+    max_depth: usize,
+    visit: impl FnOnce(&'a Value, &mut BTreeSet<String>, usize) -> Result<T, JsonSchemaWalkError<'a>>,
+) -> Result<T, JsonSchemaWalkError<'a>> {
+    if depth > max_depth {
+        return Err(JsonSchemaWalkError::DepthExceeded);
+    }
+
+    let reference = schema.get("$ref").and_then(Value::as_str);
+    let guarded_reference = match reference {
+        Some(reference) if reference.starts_with("#/") => {
+            if !resolving_refs.insert(reference.to_string()) {
+                return Err(JsonSchemaWalkError::RefCycle(reference));
+            }
+            Some(reference)
+        }
+        _ => None,
+    };
+
+    let resolved = resolve_local_ref(root, schema).map_err(json_schema_walk_error_from_ref);
+    let next_depth = depth + 1;
+    let result = match resolved {
+        Ok(resolved) if resolved.get("$ref").is_some() => {
+            with_resolved_json_schema(root, resolved, resolving_refs, next_depth, max_depth, visit)
+        }
+        Ok(resolved) => visit(resolved, resolving_refs, next_depth),
+        Err(error) => Err(error),
+    };
+
+    if let Some(reference) = guarded_reference {
+        resolving_refs.remove(reference);
+    }
+
+    result
+}
+
+pub(crate) fn resolve_json_schema_refs<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+    max_depth: usize,
+) -> Result<Value, JsonSchemaWalkError<'a>> {
+    with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        max_depth,
+        |resolved, resolving_refs, next_depth| {
+            resolve_json_schema_child_refs(root, resolved, resolving_refs, next_depth, max_depth)
+        },
+    )
+}
+
+fn resolve_json_schema_child_refs<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+    max_depth: usize,
+) -> Result<Value, JsonSchemaWalkError<'a>> {
+    let Some(object) = schema.as_object() else {
+        return Ok(schema.clone());
+    };
+
+    let mut resolved = object.clone();
+    for key in ["items", "additionalProperties", "not"] {
+        if let Some(value) = object.get(key).filter(|value| value.is_object()) {
+            resolved.insert(
+                key.to_string(),
+                resolve_json_schema_refs(root, value, resolving_refs, depth, max_depth)?,
+            );
+        }
+    }
+    for key in ["allOf", "anyOf", "oneOf"] {
+        if let Some(values) = object.get(key).and_then(Value::as_array) {
+            resolved.insert(
+                key.to_string(),
+                Value::Array(
+                    values
+                        .iter()
+                        .map(|value| {
+                            resolve_json_schema_refs(root, value, resolving_refs, depth, max_depth)
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
+                ),
+            );
+        }
+    }
+    for key in ["$defs", "definitions", "patternProperties", "properties"] {
+        if let Some(schemas) = object.get(key).and_then(Value::as_object) {
+            resolved.insert(
+                key.to_string(),
+                Value::Object(
+                    schemas
+                        .iter()
+                        .map(|(name, schema)| {
+                            resolve_json_schema_refs(root, schema, resolving_refs, depth, max_depth)
+                                .map(|schema| (name.clone(), schema))
+                        })
+                        .collect::<Result<serde_json::Map<_, _>, _>>()?,
+                ),
+            );
+        }
+    }
+    Ok(Value::Object(resolved))
+}
+
+fn json_schema_walk_error_from_ref(error: RefError<'_>) -> JsonSchemaWalkError<'_> {
+    match error {
+        RefError::External(reference) => JsonSchemaWalkError::ExternalRef(reference),
+        RefError::NotFound(reference) => JsonSchemaWalkError::RefNotFound(reference),
+    }
 }
 
 pub(crate) fn direct_json_object_shape(schema: &Value) -> JsonObjectShape {
@@ -271,6 +399,8 @@ fn merge_json_schema_property_metadata(existing: &mut Value, candidate: &Value) 
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use serde_json::json;
 
     use super::*;
@@ -354,6 +484,61 @@ mod tests {
             resolve_local_ref(&root, &schema),
             Err(RefError::NotFound("#/$defs/Missing"))
         );
+    }
+
+    #[test]
+    fn resolved_schema_walk_keeps_ref_guard_during_visit() {
+        let root = json!({
+            "$defs": {
+                "Name": {"type": "string"}
+            }
+        });
+        let schema = json!({"$ref": "#/$defs/Name"});
+        let mut resolving_refs = BTreeSet::new();
+
+        let guard_was_active = with_resolved_json_schema(
+            &root,
+            &schema,
+            &mut resolving_refs,
+            0,
+            8,
+            |_schema, resolving_refs, _depth| Ok(resolving_refs.contains("#/$defs/Name")),
+        )
+        .expect("walk");
+
+        assert!(guard_was_active);
+        assert!(resolving_refs.is_empty());
+    }
+
+    #[test]
+    fn resolved_schema_refs_resolves_schema_bearing_children() {
+        let root = json!({
+            "$defs": {
+                "Value": {"type": "integer"}
+            },
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"$ref": "#/$defs/Value"}
+                    }
+                }
+            }
+        });
+        let mut resolving_refs = BTreeSet::new();
+        let filter = root.pointer("/properties/filter").expect("filter schema");
+
+        let resolved =
+            resolve_json_schema_refs(&root, filter, &mut resolving_refs, 0, 8).expect("resolved");
+
+        assert_eq!(
+            resolved
+                .pointer("/properties/value/type")
+                .and_then(Value::as_str),
+            Some("integer")
+        );
+        assert!(resolving_refs.is_empty());
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -4,6 +4,8 @@ use serde_json::Value;
 
 use crate::v4::ir::IrScalarType;
 
+const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RefError<'a> {
     External(&'a str),
@@ -18,15 +20,16 @@ pub(crate) enum JsonSchemaWalkError<'a> {
     DepthExceeded,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum JsonSchemaComparisonError {
+    PropertyConflict(String),
+    DepthExceeded,
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct JsonObjectShape {
     pub(crate) properties: BTreeMap<String, Value>,
     pub(crate) required: BTreeSet<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct JsonSchemaPropertyConflict {
-    pub(crate) property: String,
 }
 
 pub(crate) fn resolve_local_ref<'a>(
@@ -206,11 +209,11 @@ pub(crate) fn json_schema_default_to_string(value: &Value) -> String {
 pub(crate) fn merge_json_schema_properties_exact(
     target: &mut BTreeMap<String, Value>,
     source: BTreeMap<String, Value>,
-) -> Result<(), JsonSchemaPropertyConflict> {
+) -> Result<(), JsonSchemaComparisonError> {
     for (name, property) in source {
         if let Some(existing) = target.get(&name) {
             if existing != &property {
-                return Err(JsonSchemaPropertyConflict { property: name });
+                return Err(JsonSchemaComparisonError::PropertyConflict(name));
             }
         } else {
             target.insert(name, property);
@@ -222,11 +225,13 @@ pub(crate) fn merge_json_schema_properties_exact(
 pub(crate) fn merge_json_object_shape_annotation_insensitive(
     target: &mut JsonObjectShape,
     source: JsonObjectShape,
-) -> Result<(), JsonSchemaPropertyConflict> {
+    depth: usize,
+    max_depth: usize,
+) -> Result<(), JsonSchemaComparisonError> {
     for (name, property) in source.properties {
         if let Some(existing) = target.properties.get_mut(&name) {
-            if json_schema_property_schemas_conflict(existing, &property) {
-                return Err(JsonSchemaPropertyConflict { property: name });
+            if json_schema_property_schemas_conflict(existing, &property, depth, max_depth)? {
+                return Err(JsonSchemaComparisonError::PropertyConflict(name));
             }
             merge_json_schema_property_metadata(existing, &property);
         } else {
@@ -337,53 +342,84 @@ fn scalar_for_typeless_schema_format(schema: &Value) -> Option<IrScalarType> {
         })
 }
 
-fn json_schema_property_schemas_conflict(existing: &Value, candidate: &Value) -> bool {
-    schema_without_annotation_metadata(existing) != schema_without_annotation_metadata(candidate)
+fn json_schema_property_schemas_conflict(
+    existing: &Value,
+    candidate: &Value,
+    depth: usize,
+    max_depth: usize,
+) -> Result<bool, JsonSchemaComparisonError> {
+    let Ok(left) = schema_without_annotation_metadata(existing, depth, max_depth) else {
+        return Err(JsonSchemaComparisonError::DepthExceeded);
+    };
+    let Ok(right) = schema_without_annotation_metadata(candidate, depth, max_depth) else {
+        return Err(JsonSchemaComparisonError::DepthExceeded);
+    };
+    Ok(left != right)
 }
 
-fn schema_without_annotation_metadata(schema: &Value) -> Value {
-    schema_without_annotation_metadata_at_key(None, schema)
+fn schema_without_annotation_metadata<'a>(
+    schema: &Value,
+    depth: usize,
+    max_depth: usize,
+) -> Result<Value, JsonSchemaWalkError<'a>> {
+    schema_without_annotation_metadata_at_key(None, schema, depth, max_depth)
 }
 
-fn schema_without_annotation_metadata_at_key(key: Option<&str>, schema: &Value) -> Value {
-    const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
+fn schema_without_annotation_metadata_at_key<'a>(
+    key: Option<&str>,
+    schema: &Value,
+    depth: usize,
+    max_depth: usize,
+) -> Result<Value, JsonSchemaWalkError<'a>> {
+    // TODO: check depth against max_depth here!
+    if depth > max_depth {
+        return Err(JsonSchemaWalkError::DepthExceeded);
+    }
+    let next_depth = depth + 1;
+
     match schema {
         Value::Object(object) => {
             let is_schema_name_map = matches!(
                 key,
                 Some("$defs" | "definitions" | "patternProperties" | "properties")
             );
-            Value::Object(
-                object
-                    .iter()
-                    .filter(|(key, _value)| {
-                        is_schema_name_map || !ANNOTATION_KEYS.contains(&key.as_str())
-                    })
-                    .map(|(key, value)| {
-                        (
-                            key.clone(),
-                            schema_without_annotation_metadata_at_key(Some(key), value),
-                        )
-                    })
-                    .collect(),
-            )
+            let mut out = serde_json::Map::new();
+            for (key, value) in object.iter().filter(|(key, _value)| {
+                is_schema_name_map || !ANNOTATION_KEYS.contains(&key.as_str())
+            }) {
+                match schema_without_annotation_metadata_at_key(
+                    Some(key),
+                    value,
+                    next_depth,
+                    max_depth,
+                ) {
+                    Ok(x) => {
+                        out.insert(key.clone(), x);
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+            Ok(Value::Object(out))
         }
         Value::Array(values) => {
-            let mut values = values
-                .iter()
-                .map(|value| schema_without_annotation_metadata_at_key(None, value))
-                .collect::<Vec<_>>();
-            if key == Some("type") {
-                values.sort_by_key(Value::to_string);
+            let mut out = Vec::with_capacity(values.len());
+            for value in values {
+                match schema_without_annotation_metadata_at_key(None, value, next_depth, max_depth)
+                {
+                    Ok(x) => out.push(x),
+                    Err(err) => return Err(err),
+                }
             }
-            Value::Array(values)
+            if key == Some("type") {
+                out.sort_by_key(Value::to_string);
+            }
+            Ok(Value::Array(out))
         }
-        other => other.clone(),
+        other => Ok(other.clone()),
     }
 }
 
 fn merge_json_schema_property_metadata(existing: &mut Value, candidate: &Value) {
-    const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
     let (Some(existing), Some(candidate)) = (existing.as_object_mut(), candidate.as_object())
     else {
         return;
@@ -560,9 +596,9 @@ mod tests {
 
         assert_eq!(
             merge_json_schema_properties_exact(&mut target, source),
-            Err(JsonSchemaPropertyConflict {
-                property: "query".to_string()
-            })
+            Err(JsonSchemaComparisonError::PropertyConflict(
+                "query".to_string()
+            ))
         );
     }
 
@@ -588,7 +624,7 @@ mod tests {
             }
         }));
 
-        merge_json_object_shape_annotation_insensitive(&mut target, source).expect("merge");
+        merge_json_object_shape_annotation_insensitive(&mut target, source, 0, 100).expect("merge");
 
         let query = target.properties.get("query").expect("query property");
         assert_eq!(query.get("title").and_then(Value::as_str), Some("Query"));
@@ -597,6 +633,37 @@ mod tests {
             Some("Search query")
         );
         assert!(target.required.contains("query"));
+    }
+
+    #[test]
+    fn annotation_insensitive_object_shape_merge_reports_depth_exceeded() {
+        let mut target = direct_json_object_shape(&json!({
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string"}
+                    }
+                }
+            }
+        }));
+        let source = direct_json_object_shape(&json!({
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string"}
+                    }
+                }
+            }
+        }));
+
+        assert_eq!(
+            merge_json_object_shape_annotation_insensitive(&mut target, source, 0, 1),
+            Err(JsonSchemaComparisonError::DepthExceeded)
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -1,6 +1,106 @@
+use std::collections::{BTreeMap, BTreeSet};
+
 use serde_json::Value;
 
 use crate::v4::ir::IrScalarType;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RefError<'a> {
+    External(&'a str),
+    NotFound(&'a str),
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct JsonObjectShape {
+    pub(crate) properties: BTreeMap<String, Value>,
+    pub(crate) required: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct JsonSchemaPropertyConflict {
+    pub(crate) property: String,
+}
+
+pub(crate) fn resolve_local_ref<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+) -> Result<&'a Value, RefError<'a>> {
+    let Some(reference) = schema.get("$ref").and_then(Value::as_str) else {
+        return Ok(schema);
+    };
+    if !reference.starts_with("#/") {
+        return Err(RefError::External(reference));
+    }
+    let pointer = reference.strip_prefix('#').unwrap_or(reference);
+    root.pointer(pointer).ok_or(RefError::NotFound(reference))
+}
+
+pub(crate) fn direct_json_object_shape(schema: &Value) -> JsonObjectShape {
+    let Some(schema) = schema.as_object() else {
+        return JsonObjectShape::default();
+    };
+    let properties = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|properties| {
+            properties
+                .iter()
+                .map(|(name, property)| (name.clone(), property.clone()))
+                .collect()
+        })
+        .unwrap_or_default();
+    JsonObjectShape {
+        properties,
+        required: json_schema_required_fields(schema),
+    }
+}
+
+pub(crate) fn json_schema_required_fields(
+    schema: &serde_json::Map<String, Value>,
+) -> BTreeSet<String> {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(ToString::to_string)
+        .collect()
+}
+
+pub(crate) fn merge_json_schema_properties_exact(
+    target: &mut BTreeMap<String, Value>,
+    source: BTreeMap<String, Value>,
+) -> Result<(), JsonSchemaPropertyConflict> {
+    for (name, property) in source {
+        if let Some(existing) = target.get(&name) {
+            if existing != &property {
+                return Err(JsonSchemaPropertyConflict { property: name });
+            }
+        } else {
+            target.insert(name, property);
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn merge_json_object_shape_annotation_insensitive(
+    target: &mut JsonObjectShape,
+    source: JsonObjectShape,
+) -> Result<(), JsonSchemaPropertyConflict> {
+    for (name, property) in source.properties {
+        if let Some(existing) = target.properties.get_mut(&name) {
+            if json_schema_property_schemas_conflict(existing, &property) {
+                return Err(JsonSchemaPropertyConflict { property: name });
+            }
+            merge_json_schema_property_metadata(existing, &property);
+        } else {
+            target.properties.insert(name, property);
+        }
+    }
+    target.required.extend(source.required);
+    Ok(())
+}
 
 pub(crate) fn json_schema_scalar_type(schema: &Value) -> Option<IrScalarType> {
     json_schema_scalar_type_with_default(schema, None)
@@ -102,6 +202,66 @@ fn scalar_for_typeless_schema_format(schema: &Value) -> Option<IrScalarType> {
         })
 }
 
+fn json_schema_property_schemas_conflict(existing: &Value, candidate: &Value) -> bool {
+    schema_without_annotation_metadata(existing) != schema_without_annotation_metadata(candidate)
+}
+
+fn schema_without_annotation_metadata(schema: &Value) -> Value {
+    schema_without_annotation_metadata_at_key(None, schema)
+}
+
+fn schema_without_annotation_metadata_at_key(key: Option<&str>, schema: &Value) -> Value {
+    const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
+    match schema {
+        Value::Object(object) => {
+            let is_schema_name_map = matches!(
+                key,
+                Some("$defs" | "definitions" | "patternProperties" | "properties")
+            );
+            Value::Object(
+                object
+                    .iter()
+                    .filter(|(key, _value)| {
+                        is_schema_name_map || !ANNOTATION_KEYS.contains(&key.as_str())
+                    })
+                    .map(|(key, value)| {
+                        (
+                            key.clone(),
+                            schema_without_annotation_metadata_at_key(Some(key), value),
+                        )
+                    })
+                    .collect(),
+            )
+        }
+        Value::Array(values) => {
+            let mut values = values
+                .iter()
+                .map(|value| schema_without_annotation_metadata_at_key(None, value))
+                .collect::<Vec<_>>();
+            if key == Some("type") {
+                values.sort_by_key(Value::to_string);
+            }
+            Value::Array(values)
+        }
+        other => other.clone(),
+    }
+}
+
+fn merge_json_schema_property_metadata(existing: &mut Value, candidate: &Value) {
+    const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
+    let (Some(existing), Some(candidate)) = (existing.as_object_mut(), candidate.as_object())
+    else {
+        return;
+    };
+    for key in ANNOTATION_KEYS {
+        if !existing.contains_key(*key)
+            && let Some(value) = candidate.get(*key)
+        {
+            existing.insert((*key).to_string(), value.clone());
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
@@ -138,5 +298,112 @@ mod tests {
             json_schema_scalar_type(&json!({"format": "date-time"})),
             Some(IrScalarType::Timestamp)
         );
+    }
+
+    #[test]
+    fn resolve_local_ref_returns_input_without_ref() {
+        let root = json!({"$defs": {}});
+        let schema = json!({"type": "string"});
+
+        let resolved = resolve_local_ref(&root, &schema).expect("schema");
+
+        assert!(std::ptr::eq(
+            std::ptr::from_ref(resolved),
+            std::ptr::from_ref(&schema)
+        ));
+    }
+
+    #[test]
+    fn resolve_local_ref_returns_local_pointer_target() {
+        let root = json!({
+            "$defs": {
+                "Name": {"type": "string"}
+            }
+        });
+        let schema = json!({"$ref": "#/$defs/Name"});
+
+        let resolved = resolve_local_ref(&root, &schema).expect("schema");
+
+        assert_eq!(resolved, &json!({"type": "string"}));
+    }
+
+    #[test]
+    fn resolve_local_ref_rejects_external_refs() {
+        let root = json!({});
+        let schema = json!({"$ref": "https://example.com/schema.json#/Name"});
+
+        assert_eq!(
+            resolve_local_ref(&root, &schema),
+            Err(RefError::External("https://example.com/schema.json#/Name"))
+        );
+    }
+
+    #[test]
+    fn resolve_local_ref_reports_missing_refs() {
+        let root = json!({});
+        let schema = json!({"$ref": "#/$defs/Missing"});
+
+        assert_eq!(
+            resolve_local_ref(&root, &schema),
+            Err(RefError::NotFound("#/$defs/Missing"))
+        );
+    }
+
+    #[test]
+    fn exact_property_merge_reports_conflict() {
+        let mut target = direct_json_object_shape(&json!({
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"}
+            }
+        }))
+        .properties;
+        let source = direct_json_object_shape(&json!({
+            "type": "object",
+            "properties": {
+                "query": {"type": "integer"}
+            }
+        }))
+        .properties;
+
+        assert_eq!(
+            merge_json_schema_properties_exact(&mut target, source),
+            Err(JsonSchemaPropertyConflict {
+                property: "query".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn annotation_insensitive_object_shape_merge_keeps_metadata() {
+        let mut target = direct_json_object_shape(&json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": ["string", "null"],
+                    "title": "Query"
+                }
+            }
+        }));
+        let source = direct_json_object_shape(&json!({
+            "type": "object",
+            "required": ["query"],
+            "properties": {
+                "query": {
+                    "type": ["null", "string"],
+                    "description": "Search query"
+                }
+            }
+        }));
+
+        merge_json_object_shape_annotation_insensitive(&mut target, source).expect("merge");
+
+        let query = target.properties.get("query").expect("query property");
+        assert_eq!(query.get("title").and_then(Value::as_str), Some("Query"));
+        assert_eq!(
+            query.get("description").and_then(Value::as_str),
+            Some("Search query")
+        );
+        assert!(target.required.contains("query"));
     }
 }

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::v4::ir::IrScalarType;
 
-const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
+const ANNOTATION_KEYS: &[&str] = &["$comment", "default", "description", "examples", "title"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RefError<'a> {
@@ -103,6 +103,145 @@ pub(crate) fn resolve_json_schema_refs<'a>(
             resolve_json_schema_child_refs(root, resolved, resolving_refs, next_depth, max_depth)
         },
     )
+}
+
+pub(crate) fn resolve_json_schema_ref_with_siblings<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+    max_depth: usize,
+) -> Result<Value, JsonSchemaWalkError<'a>> {
+    with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        max_depth,
+        |resolved, resolving_refs, next_depth| {
+            let mut resolved = resolve_json_schema_child_refs_allow_cycles(
+                root,
+                resolved,
+                resolving_refs,
+                next_depth,
+                max_depth,
+            )?;
+            if let (Some(referrer), Some(resolved)) = (schema.as_object(), resolved.as_object_mut())
+            {
+                for (key, value) in referrer {
+                    if is_ref_site_metadata_key(key) {
+                        resolved.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+            Ok(resolved)
+        },
+    )
+}
+
+fn is_ref_site_metadata_key(key: &str) -> bool {
+    ANNOTATION_KEYS.contains(&key)
+}
+
+fn resolve_json_schema_refs_allow_cycles<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+    max_depth: usize,
+) -> Result<Value, JsonSchemaWalkError<'a>> {
+    match with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        max_depth,
+        |resolved, resolving_refs, next_depth| {
+            resolve_json_schema_child_refs_allow_cycles(
+                root,
+                resolved,
+                resolving_refs,
+                next_depth,
+                max_depth,
+            )
+        },
+    ) {
+        Ok(resolved) => Ok(resolved),
+        Err(JsonSchemaWalkError::RefCycle(_reference)) => Ok(schema.clone()),
+        Err(error) => Err(error),
+    }
+}
+
+fn resolve_json_schema_child_refs_allow_cycles<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+    max_depth: usize,
+) -> Result<Value, JsonSchemaWalkError<'a>> {
+    let Some(object) = schema.as_object() else {
+        return Ok(schema.clone());
+    };
+
+    let mut resolved = object.clone();
+    for key in ["items", "additionalProperties", "not"] {
+        if let Some(value) = object.get(key).filter(|value| value.is_object()) {
+            resolved.insert(
+                key.to_string(),
+                resolve_json_schema_refs_allow_cycles(
+                    root,
+                    value,
+                    resolving_refs,
+                    depth,
+                    max_depth,
+                )?,
+            );
+        }
+    }
+    for key in ["allOf", "anyOf", "oneOf"] {
+        if let Some(values) = object.get(key).and_then(Value::as_array) {
+            resolved.insert(
+                key.to_string(),
+                Value::Array(
+                    values
+                        .iter()
+                        .map(|value| {
+                            resolve_json_schema_refs_allow_cycles(
+                                root,
+                                value,
+                                resolving_refs,
+                                depth,
+                                max_depth,
+                            )
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
+                ),
+            );
+        }
+    }
+    for key in ["$defs", "definitions", "patternProperties", "properties"] {
+        if let Some(schemas) = object.get(key).and_then(Value::as_object) {
+            resolved.insert(
+                key.to_string(),
+                Value::Object(
+                    schemas
+                        .iter()
+                        .map(|(name, schema)| {
+                            resolve_json_schema_refs_allow_cycles(
+                                root,
+                                schema,
+                                resolving_refs,
+                                depth,
+                                max_depth,
+                            )
+                            .map(|schema| (name.clone(), schema))
+                        })
+                        .collect::<Result<serde_json::Map<_, _>, _>>()?,
+                ),
+            );
+        }
+    }
+    Ok(Value::Object(resolved))
 }
 
 fn resolve_json_schema_child_refs<'a>(

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -68,6 +68,13 @@ pub(crate) fn json_schema_required_fields(
         .collect()
 }
 
+pub(crate) fn json_schema_default_to_string(value: &Value) -> String {
+    match value {
+        Value::String(value) => value.clone(),
+        other => other.to_string(),
+    }
+}
+
 pub(crate) fn merge_json_schema_properties_exact(
     target: &mut BTreeMap<String, Value>,
     source: BTreeMap<String, Value>,
@@ -405,5 +412,16 @@ mod tests {
             Some("Search query")
         );
         assert!(target.required.contains("query"));
+    }
+
+    #[test]
+    fn default_to_string_preserves_string_values_and_serializes_other_json() {
+        assert_eq!(json_schema_default_to_string(&json!("text")), "text");
+        assert_eq!(json_schema_default_to_string(&json!(30)), "30");
+        assert_eq!(json_schema_default_to_string(&json!(true)), "true");
+        assert_eq!(
+            json_schema_default_to_string(&json!({"enabled": true})),
+            r#"{"enabled":true}"#
+        );
     }
 }

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -383,6 +383,121 @@ surfaces:
     }
 
     #[test]
+    fn imports_recursive_object_property_refs_as_json_inputs() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "search-items",
+                json!({
+                    "$defs": {
+                        "Node": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "children": {
+                                    "type": "array",
+                                    "items": {"$ref": "#/$defs/Node"}
+                                }
+                            }
+                        }
+                    },
+                    "type": "object",
+                    "properties": {
+                        "tree": {"$ref": "#/$defs/Node"}
+                    },
+                    "required": ["tree"]
+                }),
+                Some(json!({"type": "object", "properties": {}})),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "search_items");
+        assert!(operation.diagnostics.is_empty());
+
+        let tree = operation
+            .inputs
+            .iter()
+            .find(|input| input.name == "tree")
+            .expect("tree input");
+        assert_eq!(tree.data_type, IrScalarType::Json);
+        assert!(tree.required);
+    }
+
+    #[test]
+    fn property_level_input_schema_refs_keep_ref_site_metadata() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "search-items",
+                json!({
+                    "$defs": {
+                        "Limit": {"type": "integer"}
+                    },
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "$ref": "#/$defs/Limit",
+                            "default": 10,
+                            "description": "Page size"
+                        }
+                    }
+                }),
+                Some(json!({"type": "object", "properties": {}})),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "search_items");
+        assert!(operation.diagnostics.is_empty());
+
+        let limit = operation
+            .inputs
+            .iter()
+            .find(|input| input.name == "limit")
+            .expect("limit input");
+        assert_eq!(limit.data_type, IrScalarType::Integer);
+        assert_eq!(limit.default_value.as_deref(), Some("10"));
+        assert_eq!(limit.description, "Page size");
+    }
+
+    #[test]
+    fn property_level_input_schema_refs_ignore_ref_site_validation_siblings() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "search-items",
+                json!({
+                    "$defs": {
+                        "Limit": {"type": "integer"}
+                    },
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "$ref": "#/$defs/Limit",
+                            "type": "string",
+                            "default": 10
+                        }
+                    }
+                }),
+                Some(json!({"type": "object", "properties": {}})),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "search_items");
+        assert!(operation.diagnostics.is_empty());
+
+        let limit = operation
+            .inputs
+            .iter()
+            .find(|input| input.name == "limit")
+            .expect("limit input");
+        assert_eq!(limit.data_type, IrScalarType::Integer);
+        assert_eq!(limit.default_value.as_deref(), Some("10"));
+    }
+
+    #[test]
     fn unresolved_input_schema_refs_means_tool_is_not_exposed() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
@@ -556,6 +671,102 @@ surfaces:
             .expect("query input");
         assert_eq!(query.data_type, IrScalarType::String);
         assert!(query.required);
+    }
+
+    #[test]
+    fn imports_all_of_properties_with_equivalent_nested_refs() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "search-items",
+                json!({
+                    "$defs": {
+                        "Id": {"type": "string"}
+                    },
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "filter": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {"$ref": "#/$defs/Id"}
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "filter": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {"type": "string"}
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }),
+                Some(json!({"type": "object", "properties": {}})),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "search_items");
+        assert!(operation.diagnostics.is_empty());
+
+        let filter = operation
+            .inputs
+            .iter()
+            .find(|input| input.name == "filter")
+            .expect("filter input");
+        assert_eq!(filter.data_type, IrScalarType::Json);
+    }
+
+    #[test]
+    fn imports_all_of_properties_with_ref_site_default_metadata() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "search-items",
+                json!({
+                    "$defs": {
+                        "Limit": {"type": "integer"}
+                    },
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "limit": {
+                                    "$ref": "#/$defs/Limit",
+                                    "default": 10
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "limit": {"type": "integer"}
+                            }
+                        }
+                    ]
+                }),
+                Some(json!({"type": "object", "properties": {}})),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "search_items");
+        assert!(operation.diagnostics.is_empty());
+
+        let limit = operation
+            .inputs
+            .iter()
+            .find(|input| input.name == "limit")
+            .expect("limit input");
+        assert_eq!(limit.data_type, IrScalarType::Integer);
+        assert_eq!(limit.default_value.as_deref(), Some("10"));
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -346,6 +346,43 @@ surfaces:
     }
 
     #[test]
+    fn imports_property_level_input_schema_refs() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "search-items",
+                json!({
+                    "$defs": {
+                        "Query": {
+                            "type": "string",
+                            "description": "Search query"
+                        }
+                    },
+                    "type": "object",
+                    "properties": {
+                        "query": {"$ref": "#/$defs/Query"}
+                    },
+                    "required": ["query"]
+                }),
+                Some(json!({"type": "object", "properties": {}})),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "search_items");
+        assert!(operation.diagnostics.is_empty());
+
+        let query = operation
+            .inputs
+            .iter()
+            .find(|input| input.name == "query")
+            .expect("query input");
+        assert_eq!(query.data_type, IrScalarType::String);
+        assert!(query.required);
+        assert_eq!(query.description, "Search query");
+    }
+
+    #[test]
     fn unresolved_input_schema_refs_means_tool_is_not_exposed() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
@@ -370,6 +407,68 @@ surfaces:
             generate_projection_catalog(manifest().as_v4().expect("v4"), std::slice::from_ref(&ir))
                 .expect("projections");
         assert_eq!(projections.projections.len(), 0);
+    }
+
+    #[test]
+    fn recursive_input_schema_refs_mean_tool_is_not_exposed() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "search-items",
+                json!({
+                    "$defs": {
+                        "A": {
+                            "allOf": [
+                                {"$ref": "#/$defs/B"}
+                            ]
+                        },
+                        "B": {
+                            "allOf": [
+                                {"$ref": "#/$defs/A"}
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {"$ref": "#/$defs/A"}
+                    ]
+                }),
+                Some(json!({"type": "object", "properties": {}})),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        assert!(ir.operations.is_empty());
+        assert!(
+            ir.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "MCP_INPUT_SCHEMA_REF_UNSUPPORTED")
+        );
+    }
+
+    #[test]
+    fn missing_required_input_schema_properties_mean_tool_is_not_exposed() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "search-items",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "limit": {"type": "integer"}
+                    },
+                    "required": ["query"]
+                }),
+                Some(json!({"type": "object", "properties": {}})),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        assert!(ir.operations.is_empty());
+        assert!(
+            ir.diagnostics.iter().any(|diagnostic| {
+                diagnostic.code == "MCP_INPUT_SCHEMA_REQUIRED_PROPERTY_MISSING"
+            })
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
@@ -5,12 +5,15 @@ use serde_json::Value;
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
 use crate::v4::surfaces::json_schema::{
-    JsonObjectShape, RefError, direct_json_object_shape, json_schema_default_to_string,
-    json_schema_scalar_type, merge_json_object_shape_annotation_insensitive, resolve_local_ref,
+    JsonObjectShape, JsonSchemaWalkError, direct_json_object_shape, json_schema_default_to_string,
+    json_schema_scalar_type, merge_json_object_shape_annotation_insensitive,
+    resolve_json_schema_refs, with_resolved_json_schema,
 };
 
 use super::import::McpImporter;
 use super::model::McpToolDescriptor;
+
+const MAX_MCP_INPUT_SCHEMA_DEPTH: usize = 64;
 
 impl McpImporter<'_> {
     pub(super) fn import_inputs(
@@ -21,19 +24,33 @@ impl McpImporter<'_> {
     ) -> ImportedInputs {
         let mut resolving_refs = BTreeSet::new();
         let mut schema_complete = true;
-        let Some(shape) = input_object_shape(
-            &tool.input_schema,
-            &tool.input_schema,
-            &self.surface.id,
-            operation_id,
-            &mut resolving_refs,
-            diagnostics,
-            &mut schema_complete,
-        ) else {
-            return ImportedInputs {
-                inputs: Vec::new(),
-                schema_complete: false,
+        let shape = {
+            let mut context = InputSchemaContext {
+                surface_id: &self.surface.id,
+                operation_id,
+                diagnostics,
+                schema_complete: &mut schema_complete,
             };
+            let Some(shape) = input_object_shape(
+                &tool.input_schema,
+                &tool.input_schema,
+                &mut resolving_refs,
+                &mut context,
+                0,
+            ) else {
+                return ImportedInputs {
+                    inputs: Vec::new(),
+                    schema_complete: false,
+                };
+            };
+            if !validate_required_properties(&shape, &mut context) {
+                let schema_complete = *context.schema_complete;
+                return ImportedInputs {
+                    inputs: Vec::new(),
+                    schema_complete,
+                };
+            }
+            shape
         };
         let inputs = shape
             .properties
@@ -66,137 +83,170 @@ pub(super) struct ImportedInputs {
 fn input_object_shape(
     root: &Value,
     schema: &Value,
-    surface_id: &str,
-    operation_id: &str,
     resolving_refs: &mut BTreeSet<String>,
-    diagnostics: &mut Vec<Diagnostic>,
-    schema_complete: &mut bool,
+    context: &mut InputSchemaContext<'_, '_>,
+    depth: usize,
 ) -> Option<JsonObjectShape> {
-    let schema = resolve_input_schema_ref(
+    let result = with_resolved_json_schema(
         root,
         schema,
-        surface_id,
-        operation_id,
         resolving_refs,
-        diagnostics,
-        schema_complete,
-    )?;
+        depth,
+        MAX_MCP_INPUT_SCHEMA_DEPTH,
+        |schema, resolving_refs, next_depth| {
+            if schema.get("anyOf").is_some() || schema.get("oneOf").is_some() {
+                context.push_unsupported_composition();
+                return Ok(None);
+            }
 
-    if schema.get("anyOf").is_some() || schema.get("oneOf").is_some() {
-        *schema_complete = false;
-        diagnostics.push(Diagnostic::warning(
-            "MCP_INPUT_SCHEMA_COMPOSITION_UNSUPPORTED",
-            "MCP input schema uses anyOf/oneOf, which cannot be safely imported as SQL inputs",
-            surface_id.to_string(),
-            Some(operation_id.to_string()),
-        ));
-        return None;
-    }
-
-    let mut shape = direct_json_object_shape(schema);
-    if let Some(all_of) = schema.get("allOf").and_then(Value::as_array) {
-        for item in all_of {
-            let item_shape = input_object_shape(
+            let mut shape = direct_json_object_shape(schema);
+            if !resolve_input_property_schemas(
                 root,
-                item,
-                surface_id,
-                operation_id,
-                resolving_refs,
-                diagnostics,
-                schema_complete,
-            )?;
-            if !merge_input_object_shape(
                 &mut shape,
-                item_shape,
-                surface_id,
-                operation_id,
-                diagnostics,
-                schema_complete,
+                resolving_refs,
+                context,
+                next_depth,
             ) {
-                return None;
+                return Ok(None);
+            }
+
+            if let Some(all_of) = schema.get("allOf").and_then(Value::as_array) {
+                for item in all_of {
+                    let Some(item_shape) =
+                        input_object_shape(root, item, resolving_refs, context, next_depth)
+                    else {
+                        return Ok(None);
+                    };
+                    if !merge_input_object_shape(&mut shape, item_shape, context) {
+                        return Ok(None);
+                    }
+                }
+            }
+            Ok(Some(shape))
+        },
+    );
+    match result {
+        Ok(shape) => shape,
+        Err(error) => {
+            context.push_schema_walk_diagnostic(error);
+            None
+        }
+    }
+}
+
+fn resolve_input_property_schemas(
+    root: &Value,
+    shape: &mut JsonObjectShape,
+    resolving_refs: &mut BTreeSet<String>,
+    context: &mut InputSchemaContext<'_, '_>,
+    depth: usize,
+) -> bool {
+    for property in shape.properties.values_mut() {
+        match resolve_json_schema_refs(
+            root,
+            property,
+            resolving_refs,
+            depth,
+            MAX_MCP_INPUT_SCHEMA_DEPTH,
+        ) {
+            Ok(resolved) => *property = resolved,
+            Err(error) => {
+                context.push_schema_walk_diagnostic(error);
+                return false;
             }
         }
     }
-    Some(shape)
+    true
 }
 
-fn resolve_input_schema_ref<'a>(
-    root: &'a Value,
-    schema: &'a Value,
-    surface_id: &str,
-    operation_id: &str,
-    resolving_refs: &mut BTreeSet<String>,
-    diagnostics: &mut Vec<Diagnostic>,
-    schema_complete: &mut bool,
-) -> Option<&'a Value> {
-    let reference = schema.get("$ref").and_then(Value::as_str);
-    if let Some(reference) = reference
-        && reference.starts_with("#/")
-        && !resolving_refs.insert(reference.to_string())
-    {
-        *schema_complete = false;
-        diagnostics.push(Diagnostic::warning(
-            "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
-            format!("MCP input schema reference cycle includes '{reference}'"),
-            surface_id.to_string(),
-            Some(operation_id.to_string()),
-        ));
-        return None;
+fn validate_required_properties(
+    shape: &JsonObjectShape,
+    context: &mut InputSchemaContext<'_, '_>,
+) -> bool {
+    let missing = shape
+        .required
+        .iter()
+        .filter(|name| !shape.properties.contains_key(*name))
+        .cloned()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return true;
     }
-    let resolved = match resolve_local_ref(root, schema) {
-        Ok(resolved) => Some(resolved),
-        Err(RefError::External(reference)) => {
-            *schema_complete = false;
-            diagnostics.push(Diagnostic::warning(
-                "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
-                format!("MCP input schema external reference '{reference}' is unsupported"),
-                surface_id.to_string(),
-                Some(operation_id.to_string()),
-            ));
-            None
-        }
-        Err(RefError::NotFound(reference)) => {
-            *schema_complete = false;
-            diagnostics.push(Diagnostic::warning(
-                "MCP_INPUT_SCHEMA_REF_NOT_FOUND",
-                format!("MCP input schema reference '{reference}' was not found"),
-                surface_id.to_string(),
-                Some(operation_id.to_string()),
-            ));
-            None
-        }
-    };
-    if let Some(reference) = reference
-        && reference.starts_with("#/")
-    {
-        resolving_refs.remove(reference);
-    }
-    resolved
+    context.push_warning(
+        "MCP_INPUT_SCHEMA_REQUIRED_PROPERTY_MISSING",
+        format!(
+            "MCP input schema marks required properties that are not defined: {}",
+            missing.join(", ")
+        ),
+    );
+    false
 }
 
 fn merge_input_object_shape(
     target: &mut JsonObjectShape,
     source: JsonObjectShape,
-    surface_id: &str,
-    operation_id: &str,
-    diagnostics: &mut Vec<Diagnostic>,
-    schema_complete: &mut bool,
+    context: &mut InputSchemaContext<'_, '_>,
 ) -> bool {
     match merge_json_object_shape_annotation_insensitive(target, source) {
         Ok(()) => true,
         Err(conflict) => {
-            *schema_complete = false;
-            diagnostics.push(Diagnostic::warning(
+            context.push_warning(
                 "MCP_INPUT_SCHEMA_CONFLICT",
                 format!(
                     "MCP input schema defines conflicting property '{}'",
                     conflict.property
                 ),
-                surface_id.to_string(),
-                Some(operation_id.to_string()),
-            ));
+            );
             false
         }
+    }
+}
+
+struct InputSchemaContext<'a, 'b> {
+    surface_id: &'a str,
+    operation_id: &'a str,
+    diagnostics: &'b mut Vec<Diagnostic>,
+    schema_complete: &'b mut bool,
+}
+
+impl InputSchemaContext<'_, '_> {
+    fn push_unsupported_composition(&mut self) {
+        self.push_warning(
+            "MCP_INPUT_SCHEMA_COMPOSITION_UNSUPPORTED",
+            "MCP input schema uses anyOf/oneOf, which cannot be safely imported as SQL inputs",
+        );
+    }
+
+    fn push_schema_walk_diagnostic(&mut self, error: JsonSchemaWalkError<'_>) {
+        let (code, message) = match error {
+            JsonSchemaWalkError::ExternalRef(reference) => (
+                "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
+                format!("MCP input schema external reference '{reference}' is unsupported"),
+            ),
+            JsonSchemaWalkError::RefCycle(reference) => (
+                "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
+                format!("MCP input schema reference cycle includes '{reference}'"),
+            ),
+            JsonSchemaWalkError::RefNotFound(reference) => (
+                "MCP_INPUT_SCHEMA_REF_NOT_FOUND",
+                format!("MCP input schema reference '{reference}' was not found"),
+            ),
+            JsonSchemaWalkError::DepthExceeded => (
+                "MCP_INPUT_SCHEMA_DEPTH_EXCEEDED",
+                "MCP input schema exceeds the maximum supported nesting depth".to_string(),
+            ),
+        };
+        self.push_warning(code, message);
+    }
+
+    fn push_warning(&mut self, code: &'static str, message: impl Into<String>) {
+        *self.schema_complete = false;
+        self.diagnostics.push(Diagnostic::warning(
+            code,
+            message,
+            self.surface_id.to_string(),
+            Some(self.operation_id.to_string()),
+        ));
     }
 }
 

--- a/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
 use crate::v4::surfaces::json_schema::{
-    JsonObjectShape, RefError, direct_json_object_shape, json_schema_scalar_type,
-    merge_json_object_shape_annotation_insensitive, resolve_local_ref,
+    JsonObjectShape, RefError, direct_json_object_shape, json_schema_default_to_string,
+    json_schema_scalar_type, merge_json_object_shape_annotation_insensitive, resolve_local_ref,
 };
 
 use super::import::McpImporter;
@@ -46,7 +46,7 @@ impl McpImporter<'_> {
                     location: IrInputLocation::ToolArg,
                     required: shape.required.contains(name.as_str()),
                     data_type,
-                    default_value: property_default(property),
+                    default_value: property.get("default").map(json_schema_default_to_string),
                     description: schema_description(property),
                 }
             })
@@ -207,11 +207,4 @@ pub(super) fn schema_description(schema: &Value) -> String {
         .or_else(|| schema.get("title").and_then(Value::as_str))
         .unwrap_or_default()
         .to_string()
-}
-
-fn property_default(schema: &Value) -> Option<String> {
-    schema.get("default").map(|value| match value {
-        Value::String(text) => text.clone(),
-        other => other.to_string(),
-    })
 }

--- a/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
@@ -5,9 +5,10 @@ use serde_json::Value;
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
 use crate::v4::surfaces::json_schema::{
-    JsonObjectShape, JsonSchemaWalkError, direct_json_object_shape, json_schema_default_to_string,
-    json_schema_scalar_type, merge_json_object_shape_annotation_insensitive,
-    resolve_json_schema_refs, with_resolved_json_schema,
+    JsonObjectShape, JsonSchemaComparisonError, JsonSchemaWalkError, direct_json_object_shape,
+    json_schema_default_to_string, json_schema_scalar_type,
+    merge_json_object_shape_annotation_insensitive, resolve_json_schema_refs,
+    with_resolved_json_schema,
 };
 
 use super::import::McpImporter;
@@ -117,7 +118,13 @@ fn input_object_shape(
                     else {
                         return Ok(None);
                     };
-                    if !merge_input_object_shape(&mut shape, item_shape, context) {
+                    if !merge_input_object_shape(
+                        &mut shape,
+                        item_shape,
+                        context,
+                        depth,
+                        MAX_MCP_INPUT_SCHEMA_DEPTH,
+                    ) {
                         return Ok(None);
                     }
                 }
@@ -186,16 +193,22 @@ fn merge_input_object_shape(
     target: &mut JsonObjectShape,
     source: JsonObjectShape,
     context: &mut InputSchemaContext<'_, '_>,
+    depth: usize,
+    max_depth: usize,
 ) -> bool {
-    match merge_json_object_shape_annotation_insensitive(target, source) {
+    match merge_json_object_shape_annotation_insensitive(target, source, depth, max_depth) {
         Ok(()) => true,
-        Err(conflict) => {
+        Err(JsonSchemaComparisonError::PropertyConflict(property)) => {
             context.push_warning(
                 "MCP_INPUT_SCHEMA_CONFLICT",
-                format!(
-                    "MCP input schema defines conflicting property '{}'",
-                    conflict.property
-                ),
+                format!("MCP input schema defines conflicting property '{property}'"),
+            );
+            false
+        }
+        Err(JsonSchemaComparisonError::DepthExceeded) => {
+            context.push_warning(
+                "MCP_INPUT_SCHEMA_DEPTH_EXCEEDED",
+                "MCP input schema exceeds the maximum supported nesting depth",
             );
             false
         }

--- a/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
@@ -1,10 +1,13 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use serde_json::Value;
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
-use crate::v4::surfaces::json_schema::json_schema_scalar_type;
+use crate::v4::surfaces::json_schema::{
+    JsonObjectShape, RefError, direct_json_object_shape, json_schema_scalar_type,
+    merge_json_object_shape_annotation_insensitive, resolve_local_ref,
+};
 
 use super::import::McpImporter;
 use super::model::McpToolDescriptor;
@@ -60,12 +63,6 @@ pub(super) struct ImportedInputs {
     pub(super) schema_complete: bool,
 }
 
-#[derive(Default)]
-struct InputObjectShape {
-    properties: BTreeMap<String, Value>,
-    required: BTreeSet<String>,
-}
-
 fn input_object_shape(
     root: &Value,
     schema: &Value,
@@ -74,7 +71,7 @@ fn input_object_shape(
     resolving_refs: &mut BTreeSet<String>,
     diagnostics: &mut Vec<Diagnostic>,
     schema_complete: &mut bool,
-) -> Option<InputObjectShape> {
+) -> Option<JsonObjectShape> {
     let schema = resolve_input_schema_ref(
         root,
         schema,
@@ -96,7 +93,7 @@ fn input_object_shape(
         return None;
     }
 
-    let mut shape = direct_input_object_shape(schema);
+    let mut shape = direct_json_object_shape(schema);
     if let Some(all_of) = schema.get("allOf").and_then(Value::as_array) {
         for item in all_of {
             let item_shape = input_object_shape(
@@ -132,20 +129,11 @@ fn resolve_input_schema_ref<'a>(
     diagnostics: &mut Vec<Diagnostic>,
     schema_complete: &mut bool,
 ) -> Option<&'a Value> {
-    let Some(reference) = schema.get("$ref").and_then(Value::as_str) else {
-        return Some(schema);
-    };
-    if !reference.starts_with("#/") {
-        *schema_complete = false;
-        diagnostics.push(Diagnostic::warning(
-            "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
-            format!("MCP input schema external reference '{reference}' is unsupported"),
-            surface_id.to_string(),
-            Some(operation_id.to_string()),
-        ));
-        return None;
-    }
-    if !resolving_refs.insert(reference.to_string()) {
+    let reference = schema.get("$ref").and_then(Value::as_str);
+    if let Some(reference) = reference
+        && reference.starts_with("#/")
+        && !resolving_refs.insert(reference.to_string())
+    {
         *schema_complete = false;
         diagnostics.push(Diagnostic::warning(
             "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
@@ -155,139 +143,59 @@ fn resolve_input_schema_ref<'a>(
         ));
         return None;
     }
-    let pointer = reference.strip_prefix('#').unwrap_or(reference);
-    let resolved = root.pointer(pointer);
-    resolving_refs.remove(reference);
-    if let Some(resolved) = resolved {
-        Some(resolved)
-    } else {
-        *schema_complete = false;
-        diagnostics.push(Diagnostic::warning(
-            "MCP_INPUT_SCHEMA_REF_NOT_FOUND",
-            format!("MCP input schema reference '{reference}' was not found"),
-            surface_id.to_string(),
-            Some(operation_id.to_string()),
-        ));
-        None
-    }
-}
-
-fn direct_input_object_shape(schema: &Value) -> InputObjectShape {
-    let Some(schema) = schema.as_object() else {
-        return InputObjectShape::default();
+    let resolved = match resolve_local_ref(root, schema) {
+        Ok(resolved) => Some(resolved),
+        Err(RefError::External(reference)) => {
+            *schema_complete = false;
+            diagnostics.push(Diagnostic::warning(
+                "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
+                format!("MCP input schema external reference '{reference}' is unsupported"),
+                surface_id.to_string(),
+                Some(operation_id.to_string()),
+            ));
+            None
+        }
+        Err(RefError::NotFound(reference)) => {
+            *schema_complete = false;
+            diagnostics.push(Diagnostic::warning(
+                "MCP_INPUT_SCHEMA_REF_NOT_FOUND",
+                format!("MCP input schema reference '{reference}' was not found"),
+                surface_id.to_string(),
+                Some(operation_id.to_string()),
+            ));
+            None
+        }
     };
-    let required = schema
-        .get("required")
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(Value::as_str)
-                .map(str::to_string)
-                .collect::<BTreeSet<_>>()
-        })
-        .unwrap_or_default();
-    let properties = schema
-        .get("properties")
-        .and_then(Value::as_object)
-        .map(|properties| {
-            properties
-                .iter()
-                .map(|(name, property)| (name.clone(), property.clone()))
-                .collect()
-        })
-        .unwrap_or_default();
-    InputObjectShape {
-        properties,
-        required,
+    if let Some(reference) = reference
+        && reference.starts_with("#/")
+    {
+        resolving_refs.remove(reference);
     }
+    resolved
 }
 
 fn merge_input_object_shape(
-    target: &mut InputObjectShape,
-    source: InputObjectShape,
+    target: &mut JsonObjectShape,
+    source: JsonObjectShape,
     surface_id: &str,
     operation_id: &str,
     diagnostics: &mut Vec<Diagnostic>,
     schema_complete: &mut bool,
 ) -> bool {
-    for (name, property) in source.properties {
-        if let Some(existing) = target.properties.get_mut(&name) {
-            if input_property_schemas_conflict(existing, &property) {
-                *schema_complete = false;
-                diagnostics.push(Diagnostic::warning(
-                    "MCP_INPUT_SCHEMA_CONFLICT",
-                    format!("MCP input schema defines conflicting property '{name}'"),
-                    surface_id.to_string(),
-                    Some(operation_id.to_string()),
-                ));
-                return false;
-            }
-            merge_input_property_metadata(existing, &property);
-        } else {
-            target.properties.insert(name, property);
-        }
-    }
-    target.required.extend(source.required);
-    true
-}
-
-fn input_property_schemas_conflict(existing: &Value, candidate: &Value) -> bool {
-    schema_without_annotation_metadata(existing) != schema_without_annotation_metadata(candidate)
-}
-
-fn schema_without_annotation_metadata(schema: &Value) -> Value {
-    schema_without_annotation_metadata_at_key(None, schema)
-}
-
-fn schema_without_annotation_metadata_at_key(key: Option<&str>, schema: &Value) -> Value {
-    const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
-    match schema {
-        Value::Object(object) => {
-            let is_schema_name_map = matches!(
-                key,
-                Some("$defs" | "definitions" | "patternProperties" | "properties")
-            );
-            Value::Object(
-                object
-                    .iter()
-                    .filter(|(key, _value)| {
-                        is_schema_name_map || !ANNOTATION_KEYS.contains(&key.as_str())
-                    })
-                    .map(|(key, value)| {
-                        (
-                            key.clone(),
-                            schema_without_annotation_metadata_at_key(Some(key), value),
-                        )
-                    })
-                    .collect(),
-            )
-        }
-        Value::Array(values) => {
-            let mut values = values
-                .iter()
-                .map(|value| schema_without_annotation_metadata_at_key(None, value))
-                .collect::<Vec<_>>();
-            if key == Some("type") {
-                values.sort_by_key(Value::to_string);
-            }
-            Value::Array(values)
-        }
-        other => other.clone(),
-    }
-}
-
-fn merge_input_property_metadata(existing: &mut Value, candidate: &Value) {
-    const ANNOTATION_KEYS: &[&str] = &["$comment", "description", "examples", "title"];
-    let (Some(existing), Some(candidate)) = (existing.as_object_mut(), candidate.as_object())
-    else {
-        return;
-    };
-    for key in ANNOTATION_KEYS {
-        if !existing.contains_key(*key)
-            && let Some(value) = candidate.get(*key)
-        {
-            existing.insert((*key).to_string(), value.clone());
+    match merge_json_object_shape_annotation_insensitive(target, source) {
+        Ok(()) => true,
+        Err(conflict) => {
+            *schema_complete = false;
+            diagnostics.push(Diagnostic::warning(
+                "MCP_INPUT_SCHEMA_CONFLICT",
+                format!(
+                    "MCP input schema defines conflicting property '{}'",
+                    conflict.property
+                ),
+                surface_id.to_string(),
+                Some(operation_id.to_string()),
+            ));
+            false
         }
     }
 }

--- a/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
@@ -7,7 +7,7 @@ use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
 use crate::v4::surfaces::json_schema::{
     JsonObjectShape, JsonSchemaComparisonError, JsonSchemaWalkError, direct_json_object_shape,
     json_schema_default_to_string, json_schema_scalar_type,
-    merge_json_object_shape_annotation_insensitive, resolve_json_schema_refs,
+    merge_json_object_shape_annotation_insensitive, resolve_json_schema_ref_with_siblings,
     with_resolved_json_schema,
 };
 
@@ -149,7 +149,7 @@ fn resolve_input_property_schemas(
     depth: usize,
 ) -> bool {
     for property in shape.properties.values_mut() {
-        match resolve_json_schema_refs(
+        match resolve_json_schema_ref_with_siblings(
             root,
             property,
             resolving_refs,

--- a/crates/coral-spec/src/v4/surfaces/mcp/output_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/output_schema.rs
@@ -1,11 +1,11 @@
-use std::collections::BTreeSet;
-
 use serde_json::Value;
 
 use crate::v4::ir::{
     IrField, IrOperationOutput, IrScalarType, IrType, IrTypeShape, OutputCardinality,
 };
-use crate::v4::surfaces::json_schema::{json_schema_scalar_type, json_schema_type_contains};
+use crate::v4::surfaces::json_schema::{
+    json_schema_required_fields, json_schema_scalar_type, json_schema_type_contains,
+};
 
 use super::import::McpImporter;
 use super::input_schema::schema_description;
@@ -91,14 +91,8 @@ impl McpImporter<'_> {
             return;
         };
         let required = schema
-            .get("required")
-            .and_then(Value::as_array)
-            .map(|items| {
-                items
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .collect::<BTreeSet<_>>()
-            })
+            .as_object()
+            .map(json_schema_required_fields)
             .unwrap_or_default();
         let mut fields = properties
             .iter()

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrType, SemanticIr};
 use crate::v4::manifest::{V4SourceManifest, V4Surface};
+use crate::v4::surfaces::json_schema::{RefError, resolve_local_ref};
 use crate::v4::{OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
 use crate::{ManifestError, Result};
 
@@ -96,29 +97,26 @@ impl<'a> OpenApiImporter<'a> {
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Option<Value> {
-        let Some(reference) = value.get("$ref").and_then(Value::as_str) else {
-            return Some(value.clone());
-        };
-        if !reference.starts_with("#/") {
-            diagnostics.push(Diagnostic::warning(
-                "OPENAPI_EXTERNAL_REF_UNSUPPORTED",
-                format!("external reference '{reference}' is unsupported"),
-                self.surface.id.clone(),
-                Some(operation_id.to_string()),
-            ));
-            return None;
-        }
-        let pointer = reference.strip_prefix('#').unwrap_or(reference);
-        if let Some(target) = self.document.pointer(pointer) {
-            Some(target.clone())
-        } else {
-            diagnostics.push(Diagnostic::warning(
-                "OPENAPI_REF_NOT_FOUND",
-                format!("reference '{reference}' was not found"),
-                self.surface.id.clone(),
-                Some(operation_id.to_string()),
-            ));
-            None
+        match resolve_local_ref(self.document, value) {
+            Ok(resolved) => Some(resolved.clone()),
+            Err(RefError::External(reference)) => {
+                diagnostics.push(Diagnostic::warning(
+                    "OPENAPI_EXTERNAL_REF_UNSUPPORTED",
+                    format!("external reference '{reference}' is unsupported"),
+                    self.surface.id.clone(),
+                    Some(operation_id.to_string()),
+                ));
+                None
+            }
+            Err(RefError::NotFound(reference)) => {
+                diagnostics.push(Diagnostic::warning(
+                    "OPENAPI_REF_NOT_FOUND",
+                    format!("reference '{reference}' was not found"),
+                    self.surface.id.clone(),
+                    Some(operation_id.to_string()),
+                ));
+                None
+            }
         }
     }
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -9,7 +9,7 @@ use crate::v4::ir::{
 };
 use crate::v4::naming::normalize_identifier;
 use crate::v4::surfaces::json_schema::{
-    json_schema_scalar_type_or_string, json_schema_type_display,
+    json_schema_default_to_string, json_schema_scalar_type_or_string, json_schema_type_display,
 };
 use crate::{ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result};
 
@@ -160,7 +160,7 @@ impl OpenApiImporter<'_> {
                     location,
                     required: parameter_is_required(parameter_obj, location),
                     data_type: scalar,
-                    default_value: schema.get("default").map(openapi_default_to_string),
+                    default_value: schema.get("default").map(json_schema_default_to_string),
                     description: parameter_obj
                         .get("description")
                         .and_then(Value::as_str)
@@ -263,15 +263,6 @@ fn parameter_is_required(parameter_obj: &Map<String, Value>, location: IrInputLo
         .get("required")
         .and_then(Value::as_bool)
         .unwrap_or(false)
-}
-
-fn openapi_default_to_string(value: &Value) -> String {
-    match value {
-        Value::String(value) => value.clone(),
-        Value::Number(value) => value.to_string(),
-        Value::Bool(value) => value.to_string(),
-        Value::Null | Value::Array(_) | Value::Object(_) => value.to_string(),
-    }
 }
 
 fn detect_pagination(inputs: &[IrOperationInput]) -> PaginationSpec {

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -1,11 +1,14 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrField, IrType, IrTypeShape};
 use crate::v4::naming::normalize_identifier;
-use crate::v4::surfaces::json_schema::json_schema_scalar_type;
+use crate::v4::surfaces::json_schema::{
+    direct_json_object_shape, json_schema_required_fields, json_schema_scalar_type,
+    merge_json_schema_properties_exact,
+};
 
 use super::import::OpenApiImporter;
 
@@ -48,29 +51,26 @@ impl OpenApiImporter<'_> {
             },
         );
         let shape = if let Some(all_of) = resolved.get("allOf").and_then(Value::as_array) {
-            let mut merged = Map::new();
+            let mut merged = BTreeMap::new();
             for item in all_of {
                 let item = self.resolve_ref(item, operation_id, diagnostics)?;
-                if let Some(properties) = item.get("properties").and_then(Value::as_object) {
-                    for (name, property) in properties {
-                        if let Some(existing) = merged.get(name)
-                            && existing != property
-                        {
-                            diagnostics.push(Diagnostic::warning(
-                                "OPENAPI_ALLOF_CONFLICT",
-                                format!("allOf property '{name}' conflicts in operation '{operation_id}'"),
-                                self.surface.id.clone(),
-                                Some(operation_id.to_string()),
-                            ));
-                            return None;
-                        }
-                        merged.insert(name.clone(), property.clone());
-                    }
+                let properties = direct_json_object_shape(&item).properties;
+                if let Err(conflict) = merge_json_schema_properties_exact(&mut merged, properties) {
+                    diagnostics.push(Diagnostic::warning(
+                        "OPENAPI_ALLOF_CONFLICT",
+                        format!(
+                            "allOf property '{}' conflicts in operation '{operation_id}'",
+                            conflict.property
+                        ),
+                        self.surface.id.clone(),
+                        Some(operation_id.to_string()),
+                    ));
+                    return None;
                 }
             }
             IrTypeShape::Object {
                 fields: self.import_object_fields(
-                    &merged,
+                    merged.iter(),
                     &BTreeSet::new(),
                     &type_id,
                     operation_id,
@@ -92,10 +92,13 @@ impl OpenApiImporter<'_> {
                 "object" => {
                     if let Some(properties) = resolved.get("properties").and_then(Value::as_object)
                     {
-                        let required = required_fields(&resolved);
+                        let required = resolved
+                            .as_object()
+                            .map(json_schema_required_fields)
+                            .unwrap_or_default();
                         IrTypeShape::Object {
                             fields: self.import_object_fields(
-                                properties,
+                                properties.iter(),
                                 &required,
                                 &type_id,
                                 operation_id,
@@ -142,16 +145,15 @@ impl OpenApiImporter<'_> {
         Some(type_id)
     }
 
-    fn import_object_fields(
+    fn import_object_fields<'a>(
         &mut self,
-        properties: &Map<String, Value>,
+        properties: impl Iterator<Item = (&'a String, &'a Value)>,
         required: &BTreeSet<String>,
         parent_id: &str,
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Vec<IrField> {
         properties
-            .iter()
             .map(|(name, schema)| {
                 let type_ref = self
                     .import_schema(
@@ -189,17 +191,6 @@ impl OpenApiImporter<'_> {
             .unwrap_or_default()
             .to_string()
     }
-}
-
-fn required_fields(schema: &Value) -> BTreeSet<String> {
-    schema
-        .get("required")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(Value::as_str)
-        .map(ToString::to_string)
-        .collect()
 }
 
 fn enum_value(value: &Value) -> String {

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -6,8 +6,8 @@ use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrField, IrType, IrTypeShape};
 use crate::v4::naming::normalize_identifier;
 use crate::v4::surfaces::json_schema::{
-    direct_json_object_shape, json_schema_required_fields, json_schema_scalar_type,
-    merge_json_schema_properties_exact,
+    JsonSchemaComparisonError, direct_json_object_shape, json_schema_required_fields,
+    json_schema_scalar_type, merge_json_schema_properties_exact,
 };
 
 use super::import::OpenApiImporter;
@@ -55,17 +55,26 @@ impl OpenApiImporter<'_> {
             for item in all_of {
                 let item = self.resolve_ref(item, operation_id, diagnostics)?;
                 let properties = direct_json_object_shape(&item).properties;
-                if let Err(conflict) = merge_json_schema_properties_exact(&mut merged, properties) {
-                    diagnostics.push(Diagnostic::warning(
-                        "OPENAPI_ALLOF_CONFLICT",
-                        format!(
-                            "allOf property '{}' conflicts in operation '{operation_id}'",
-                            conflict.property
-                        ),
-                        self.surface.id.clone(),
-                        Some(operation_id.to_string()),
-                    ));
-                    return None;
+                match merge_json_schema_properties_exact(&mut merged, properties) {
+                    Ok(()) => {}
+                    Err(JsonSchemaComparisonError::PropertyConflict(property)) => {
+                        diagnostics.push(Diagnostic::warning(
+                            "OPENAPI_ALLOF_CONFLICT",
+                            format!("allOf property '{property}' conflicts in operation '{operation_id}'"),
+                            self.surface.id.clone(),
+                            Some(operation_id.to_string()),
+                        ));
+                        return None;
+                    }
+                    Err(JsonSchemaComparisonError::DepthExceeded) => {
+                        diagnostics.push(Diagnostic::warning(
+                            "OPENAPI_ALLOF_CONFLICT",
+                            format!("allOf schema exceeds maximum comparison depth in operation '{operation_id}'"),
+                            self.surface.id.clone(),
+                            Some(operation_id.to_string()),
+                        ));
+                        return None;
+                    }
                 }
             }
             IrTypeShape::Object {


### PR DESCRIPTION
Closes #1306, #1308

## Summary

- Add shared v4 JSON Schema helpers for local `$ref` resolution, object-shape/allOf property merging, required-field extraction, and default-value stringification.
- Refactor the OpenAPI and MCP import surfaces to use the shared helpers while preserving existing diagnostic codes and behavior.
- Add focused regression coverage for OpenAPI allOf property conflicts and shared default stringification.
- Added measures to avoid infinite recursion of schemas (#1306)

## Validation

- `make rust-checks`
