### PR TITLE
feat(engine): catalog recipe table functions

### DIFF
--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -180,6 +180,24 @@ impl CatalogDiscovery {
         pagination: Pagination,
         attribution: &QueryAttribution,
     ) -> Result<CatalogPage, QueryManagerError> {
+        Box::pin(self.list_catalog_inner(
+            workspace_name,
+            schema_name,
+            kind,
+            pagination,
+            attribution,
+        ))
+        .await
+    }
+
+    async fn list_catalog_inner(
+        &self,
+        workspace_name: &WorkspaceName,
+        schema_name: Option<&str>,
+        kind: Option<CatalogItemKind>,
+        pagination: Pagination,
+        attribution: &QueryAttribution,
+    ) -> Result<CatalogPage, QueryManagerError> {
         let catalog = self
             .queries
             .list_catalog(workspace_name, schema_name, attribution)
@@ -207,6 +225,15 @@ impl CatalogDiscovery {
     }
 
     pub(crate) async fn describe_table(
+        &self,
+        workspace_name: &WorkspaceName,
+        table_ref: CatalogTableRef<'_>,
+        attribution: &QueryAttribution,
+    ) -> Result<DescribeTableResult, QueryManagerError> {
+        Box::pin(self.describe_table_inner(workspace_name, table_ref, attribution)).await
+    }
+
+    async fn describe_table_inner(
         &self,
         workspace_name: &WorkspaceName,
         table_ref: CatalogTableRef<'_>,
@@ -281,6 +308,15 @@ impl CatalogDiscovery {
         query: SearchCatalogQuery<'_>,
         attribution: &QueryAttribution,
     ) -> Result<Page<CatalogSearchResult>, QueryManagerError> {
+        Box::pin(self.search_catalog_inner(workspace_name, query, attribution)).await
+    }
+
+    async fn search_catalog_inner(
+        &self,
+        workspace_name: &WorkspaceName,
+        query: SearchCatalogQuery<'_>,
+        attribution: &QueryAttribution,
+    ) -> Result<Page<CatalogSearchResult>, QueryManagerError> {
         let regex = compile_metadata_regex(query.pattern, query.ignore_case)
             .map_err(QueryManagerError::App)?;
         let matches = self
@@ -299,6 +335,15 @@ impl CatalogDiscovery {
     }
 
     pub(crate) async fn list_columns(
+        &self,
+        workspace_name: &WorkspaceName,
+        query: ListColumnsQuery<'_>,
+        attribution: &QueryAttribution,
+    ) -> Result<Option<Page<ColumnSearchResult>>, QueryManagerError> {
+        Box::pin(self.list_columns_inner(workspace_name, query, attribution)).await
+    }
+
+    async fn list_columns_inner(
         &self,
         workspace_name: &WorkspaceName,
         query: ListColumnsQuery<'_>,

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -11,10 +11,7 @@ use datafusion::error::{DataFusionError, Result};
 use datafusion::prelude::SessionContext;
 use serde::Serialize;
 
-use crate::backends::common::{
-    RegisteredTableFunctionArgument, RegisteredTableFunctionResultColumn,
-};
-use crate::backends::{RegisteredSource, RegisteredTableFunction};
+use crate::backends::RegisteredSource;
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
@@ -24,18 +21,49 @@ use crate::{
 /// Schema name for source metadata tables such as `coral.tables`.
 pub(crate) const SYSTEM_SCHEMA: &str = "coral";
 
+/// Catalog-only metadata for one SQL table-function surface.
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogTableFunction {
+    pub(crate) schema_name: String,
+    pub(crate) function_name: String,
+    pub(crate) description: String,
+    pub(crate) arguments: Vec<CatalogTableFunctionArgument>,
+    pub(crate) result_columns: Vec<CatalogTableFunctionResultColumn>,
+    pub(crate) kind: String,
+    pub(crate) search_limits_json: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogTableFunctionArgument {
+    pub(crate) name: String,
+    pub(crate) required: bool,
+    pub(crate) values: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogTableFunctionResultColumn {
+    pub(crate) name: String,
+    pub(crate) data_type: String,
+    pub(crate) nullable: bool,
+    pub(crate) description: String,
+}
+
 /// Register `coral.tables` and `coral.columns` for the active source set.
 ///
 /// # Errors
 ///
 /// Returns a `DataFusionError` if the catalog is missing or the metadata
 /// tables cannot be materialized.
-pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]) -> Result<()> {
+pub(crate) fn register(
+    ctx: &SessionContext,
+    active_sources: &[RegisteredSource],
+    extra_table_functions: &[CatalogTableFunction],
+) -> Result<()> {
     let tables_table = build_tables_table(active_sources)?;
     let columns_table = build_columns_table(active_sources)?;
     let filters_table = build_filters_table(active_sources)?;
     let inputs_table = build_inputs_table(active_sources)?;
-    let table_functions_table = build_table_functions_table(active_sources)?;
+    let table_functions_table = build_table_functions_table(active_sources, extra_table_functions)?;
 
     let mut meta_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
         HashMap::new();
@@ -59,7 +87,10 @@ pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]
     Ok(())
 }
 
-fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
+fn build_table_functions_table(
+    active_sources: &[RegisteredSource],
+    extra_table_functions: &[CatalogTableFunction],
+) -> Result<MemTable> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("schema_name", DataType::Utf8, false),
         Field::new("function_name", DataType::Utf8, false),
@@ -70,21 +101,15 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
         Field::new("search_limits_json", DataType::Utf8, true),
     ]));
 
-    let mut rows = active_sources
-        .iter()
-        .flat_map(|source| source.table_functions.iter())
-        .collect::<Vec<_>>();
-    rows.sort_by(|left, right| {
-        (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
-    });
+    let rows = catalog_table_functions(active_sources, extra_table_functions);
 
     let arguments_json = rows
         .iter()
-        .map(|row| table_function_arguments_json(row))
+        .map(table_function_arguments_json)
         .collect::<Result<Vec<_>>>()?;
     let result_columns_json = rows
         .iter()
-        .map(|row| table_function_result_columns_json(row))
+        .map(table_function_result_columns_json)
         .collect::<Result<Vec<_>>>()?;
 
     let batch = RecordBatch::try_new(
@@ -104,7 +129,7 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
     MemTable::try_new(schema, vec![vec![batch]])
 }
 
-fn table_function_arguments_json(row: &RegisteredTableFunction) -> Result<String> {
+fn table_function_arguments_json(row: &CatalogTableFunction) -> Result<String> {
     let arguments = row
         .arguments
         .iter()
@@ -113,7 +138,7 @@ fn table_function_arguments_json(row: &RegisteredTableFunction) -> Result<String
     serde_json::to_string(&arguments).map_err(|error| DataFusionError::External(Box::new(error)))
 }
 
-fn table_function_result_columns_json(row: &RegisteredTableFunction) -> Result<String> {
+fn table_function_result_columns_json(row: &CatalogTableFunction) -> Result<String> {
     let columns = row
         .result_columns
         .iter()
@@ -129,8 +154,8 @@ struct TableFunctionArgumentJson<'a> {
     values: &'a [String],
 }
 
-impl<'a> From<&'a RegisteredTableFunctionArgument> for TableFunctionArgumentJson<'a> {
-    fn from(argument: &'a RegisteredTableFunctionArgument) -> Self {
+impl<'a> From<&'a CatalogTableFunctionArgument> for TableFunctionArgumentJson<'a> {
+    fn from(argument: &'a CatalogTableFunctionArgument) -> Self {
         Self {
             name: &argument.name,
             required: argument.required,
@@ -148,8 +173,8 @@ struct TableFunctionResultColumnJson<'a> {
     description: &'a str,
 }
 
-impl<'a> From<&'a RegisteredTableFunctionResultColumn> for TableFunctionResultColumnJson<'a> {
-    fn from(column: &'a RegisteredTableFunctionResultColumn) -> Self {
+impl<'a> From<&'a CatalogTableFunctionResultColumn> for TableFunctionResultColumnJson<'a> {
+    fn from(column: &'a CatalogTableFunctionResultColumn) -> Self {
         Self {
             name: &column.name,
             data_type: &column.data_type,
@@ -513,25 +538,59 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
     tables
 }
 
-/// Collect typed source-scoped table function metadata for the active source set.
+/// Collect typed table function metadata for the active runtime.
 #[must_use]
 pub(crate) fn collect_table_functions(
     active_sources: &[RegisteredSource],
+    extra_table_functions: &[CatalogTableFunction],
 ) -> Vec<TableFunctionInfo> {
+    catalog_table_functions(active_sources, extra_table_functions)
+        .into_iter()
+        .map(|function| TableFunctionInfo {
+            schema_name: function.schema_name,
+            function_name: function.function_name,
+            description: function.description,
+            arguments: function
+                .arguments
+                .into_iter()
+                .map(|argument| TableFunctionArgumentInfo {
+                    name: argument.name,
+                    required: argument.required,
+                    values: argument.values,
+                })
+                .collect(),
+            result_columns: function
+                .result_columns
+                .into_iter()
+                .map(|column| TableFunctionResultColumnInfo {
+                    name: column.name,
+                    data_type: column.data_type,
+                    nullable: column.nullable,
+                    description: column.description,
+                })
+                .collect(),
+        })
+        .collect()
+}
+
+fn catalog_table_functions(
+    active_sources: &[RegisteredSource],
+    extra_table_functions: &[CatalogTableFunction],
+) -> Vec<CatalogTableFunction> {
     let mut functions = active_sources
         .iter()
         .flat_map(|source| {
             source
                 .table_functions
                 .iter()
-                .map(move |function| TableFunctionInfo {
+                .map(|function| CatalogTableFunction {
                     schema_name: function.schema_name.clone(),
                     function_name: function.function_name.clone(),
                     description: function.description.clone(),
                     arguments: function
                         .arguments
                         .iter()
-                        .map(|argument| TableFunctionArgumentInfo {
+                        .map(|argument| CatalogTableFunctionArgument {
                             name: argument.name.clone(),
                             required: argument.required,
                             values: argument.values.clone(),
@@ -540,15 +599,18 @@ pub(crate) fn collect_table_functions(
                     result_columns: function
                         .result_columns
                         .iter()
-                        .map(|column| TableFunctionResultColumnInfo {
+                        .map(|column| CatalogTableFunctionResultColumn {
                             name: column.name.clone(),
                             data_type: column.data_type.clone(),
                             nullable: column.nullable,
                             description: column.description.clone(),
                         })
                         .collect(),
+                    kind: function.kind.clone(),
+                    search_limits_json: function.search_limits_json.clone(),
                 })
         })
+        .chain(extra_table_functions.iter().cloned())
         .collect::<Vec<_>>();
     functions.sort_by(|left, right| {
         (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
@@ -949,22 +1011,25 @@ mod tests {
 
     #[test]
     fn collect_table_functions_preserves_registered_function_schema() {
-        let functions = collect_table_functions(&[RegisteredSource {
-            schema_name: "source_schema".to_string(),
-            tables: Vec::new(),
-            table_functions: vec![RegisteredTableFunction {
-                schema_name: "function_schema".to_string(),
-                function_name: "search".to_string(),
-                factory: Arc::new(StubSourceFunctionFactory::default()),
-                kind: "search".to_string(),
-                description: String::new(),
-                arguments: Vec::new(),
-                result_columns: Vec::new(),
-                arg_names: Vec::new(),
-                search_limits_json: None,
+        let functions = collect_table_functions(
+            &[RegisteredSource {
+                schema_name: "source_schema".to_string(),
+                tables: Vec::new(),
+                table_functions: vec![RegisteredTableFunction {
+                    schema_name: "function_schema".to_string(),
+                    function_name: "search".to_string(),
+                    factory: Arc::new(StubSourceFunctionFactory::default()),
+                    kind: "search".to_string(),
+                    description: String::new(),
+                    arguments: Vec::new(),
+                    result_columns: Vec::new(),
+                    arg_names: Vec::new(),
+                    search_limits_json: None,
+                }],
+                inputs: Vec::new(),
             }],
-            inputs: Vec::new(),
-        }]);
+            &[],
+        );
 
         assert_eq!(functions.len(), 1);
         assert_eq!(

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -29,6 +29,7 @@ use crate::runtime::json::register_json_support;
 use crate::runtime::pattern_validator::register_pattern_validator;
 use crate::runtime::query_planner::CoralQueryPlanner;
 use crate::runtime::recipe_functions::RecipeFunctionRegistry;
+use crate::runtime::recipes::published_table_functions;
 use crate::runtime::registry::{
     CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationFailure, register_sources,
 };
@@ -167,12 +168,15 @@ async fn build_registered_runtime(
         config.source_decorators,
     )
     .await?;
-    reject_duplicate_table_function_surfaces(&registration.active_sources, config.recipes)
+    let recipe_table_functions =
+        published_table_functions(config.recipes).map_err(|err| datafusion_to_core(&err, &[]))?;
+    reject_duplicate_table_function_surfaces(&registration.active_sources, &recipe_table_functions)
         .map_err(|err| datafusion_to_core(&err, &[]))?;
-    catalog::register(&ctx, &registration.active_sources)
+    catalog::register(&ctx, &registration.active_sources, &recipe_table_functions)
         .map_err(|err| datafusion_to_core(&err, &[]))?;
     let tables = catalog::collect_tables(&registration.active_sources);
-    let table_functions = catalog::collect_table_functions(&registration.active_sources);
+    let table_functions =
+        catalog::collect_table_functions(&registration.active_sources, &recipe_table_functions);
     let source_function_schemas = registration
         .active_sources
         .iter()
@@ -731,7 +735,7 @@ pub(crate) fn read_only_sql_options() -> SQLOptions {
 
 fn reject_duplicate_table_function_surfaces(
     active_sources: &[RegisteredSource],
-    recipes: &[RecipeRuntimeDefinition],
+    recipe_table_functions: &[catalog::CatalogTableFunction],
 ) -> Result<(), DataFusionError> {
     let mut source_functions = HashMap::new();
     for source in active_sources {
@@ -746,18 +750,11 @@ fn reject_duplicate_table_function_surfaces(
         }
     }
 
-    let mut recipe_functions = HashSet::new();
-    for recipe in recipes {
-        let publish = &recipe.publish.table_function;
-        let key = (publish.schema.as_str(), publish.name.as_str());
-        if !recipe_functions.insert(key) {
-            return Err(DataFusionError::Plan(format!(
-                "duplicate recipe table function {}.{}",
-                key.0, key.1
-            )));
-        }
-
-        if let Some(kind) = source_functions.get(&key) {
+    for function in recipe_table_functions {
+        if let Some(kind) = source_functions.get(&(
+            function.schema_name.as_str(),
+            function.function_name.as_str(),
+        )) {
             let existing = if *kind == "table" {
                 "table function".to_string()
             } else {
@@ -765,7 +762,7 @@ fn reject_duplicate_table_function_surfaces(
             };
             return Err(DataFusionError::Plan(format!(
                 "recipe table function {}.{} conflicts with existing {existing}",
-                key.0, key.1
+                function.schema_name, function.function_name
             )));
         }
     }

--- a/crates/coral-engine/src/runtime/recipes.rs
+++ b/crates/coral-engine/src/runtime/recipes.rs
@@ -1,6 +1,6 @@
-//! Recipe SQL parameter binding helpers.
+//! Recipe SQL parameter binding and catalog helpers.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr as _;
 use std::sync::Arc;
 
@@ -9,6 +9,9 @@ use datafusion::common::ScalarValue;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::Expr;
 
+use crate::runtime::catalog::{
+    CatalogTableFunction, CatalogTableFunctionArgument, CatalogTableFunctionResultColumn,
+};
 use crate::runtime::query::QueryRuntimeAdapter;
 use crate::runtime::query::parameter_scalar_value;
 use crate::{
@@ -49,6 +52,57 @@ pub(crate) async fn validate_recipe(
     query_runtime
         .validate_sql(recipe_sql(recipe), &params)
         .await
+}
+
+pub(crate) fn published_table_functions(
+    recipes: &[RecipeRuntimeDefinition],
+) -> Result<Vec<CatalogTableFunction>> {
+    let mut functions = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for recipe in recipes {
+        let publish = &recipe.publish.table_function;
+        let key = (publish.schema.as_str(), publish.name.as_str());
+        if !seen.insert(key) {
+            return Err(DataFusionError::Plan(format!(
+                "duplicate recipe table function {}.{}",
+                key.0, key.1
+            )));
+        }
+
+        recipe_arrow_schema(recipe)?;
+        functions.push(CatalogTableFunction {
+            schema_name: publish.schema.clone(),
+            function_name: publish.name.clone(),
+            kind: "recipe".to_string(),
+            description: publish_description(&publish.description, &recipe.description),
+            arguments: recipe
+                .arguments
+                .iter()
+                .map(|argument| CatalogTableFunctionArgument {
+                    name: argument.name.clone(),
+                    required: argument.required,
+                    values: Vec::new(),
+                })
+                .collect(),
+            result_columns: recipe
+                .result_columns
+                .iter()
+                .map(|column| CatalogTableFunctionResultColumn {
+                    name: column.name.clone(),
+                    data_type: column.data_type.clone(),
+                    nullable: column.nullable,
+                    description: column.description.clone(),
+                })
+                .collect(),
+            search_limits_json: None,
+        });
+    }
+
+    functions.sort_by(|left, right| {
+        (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
+    });
+    Ok(functions)
 }
 
 pub(crate) fn recipe_argument_values(
@@ -167,6 +221,14 @@ fn recipe_result_field(column: &RecipeRuntimeResultColumn) -> Result<Field> {
         ))
     })?;
     Ok(Field::new(&column.name, data_type, column.nullable))
+}
+
+fn publish_description(target_description: &str, recipe_description: &str) -> String {
+    if target_description.trim().is_empty() {
+        recipe_description.to_string()
+    } else {
+        target_description.to_string()
+    }
 }
 
 fn scalar_value_name(value: &ScalarValue) -> &'static str {

--- a/crates/coral-engine/tests/engine/recipe_tests.rs
+++ b/crates/coral-engine/tests/engine/recipe_tests.rs
@@ -579,3 +579,34 @@ async fn published_recipe_table_function_preserves_inner_limit() {
 
     assert_eq!(execution_to_rows(&execution), vec![json!({"count": 1})]);
 }
+
+#[tokio::test]
+async fn published_recipe_table_function_is_cataloged() {
+    let server = MockServer::start().await;
+    let source = search_source(&server, "catalog_recipe_search");
+    let runtime =
+        test_runtime().with_recipes(vec![published_review_queue_recipe("catalog_recipe_search")]);
+
+    let catalog = CoralQuery::list_catalog(&[source], runtime, Some("recipes"))
+        .await
+        .expect("catalog should include recipe function");
+
+    assert!(catalog.tables.is_empty());
+    assert_eq!(catalog.table_functions.len(), 1);
+    let function = catalog
+        .table_functions
+        .first()
+        .expect("recipe table function");
+    assert_eq!(function.schema_name, "recipes");
+    assert_eq!(function.function_name, "review_queue");
+    assert_eq!(function.arguments.len(), 2);
+    assert_eq!(function.result_columns.len(), 2);
+    assert_eq!(
+        function
+            .result_columns
+            .first()
+            .expect("title result column")
+            .name,
+        "title"
+    );
+}


### PR DESCRIPTION
## Summary

Recipe table functions now show up in Coral catalog discovery.

When a runtime is built with validated recipes, their published table-function surfaces are included alongside source table functions in:

- `coral.table_functions`
- `CoralQuery::list_catalog`
- catalog-backed MCP discovery output

This means a recipe that executes as `recipes.my_review_queue(...)` is also discoverable as a table function, with its argument metadata and inferred result columns.

## What Changed

- Adds catalog-only table-function metadata structs in `coral-engine` so source functions and recipe functions can be collected through one catalog path.
- Converts each validated recipe publish target into a `CatalogTableFunction` row with:
  - schema and function name
  - description
  - argument names and required flags
  - inferred result columns
  - `kind = "recipe"`
- Passes recipe catalog rows into `catalog::register`, so `coral.table_functions` includes recipes.
- Passes the same recipe catalog rows into `collect_table_functions`, so `list_catalog` returns recipes through the typed catalog API.
- Keeps duplicate recipe/source publish validation in the runtime build before catalog registration.
- Adds a regression test proving a published recipe table function is returned by `CoralQuery::list_catalog`.
- Moves the async size boundary into `CatalogDiscovery`, where catalog queries enter the heavier runtime/catalog path. The gRPC service remains a thin adapter.

## Behavior

Before this PR, recipe table functions could execute through SQL but were not represented in catalog discovery.

After this PR, the runtime catalog reports recipe table functions the same way it reports source table functions. Existing source table-function catalog behavior is unchanged.

## Validation

- `cargo test -p coral-engine --test engine recipe_tests::published_recipe_table_function_is_cataloged --all-features`
- `make rust-checks`