### PR TITLE
refactor(engine): share table-function call parsing

### DIFF
--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -11,4 +11,5 @@ pub(crate) mod query;
 pub(crate) mod query_planner;
 pub(crate) mod registry;
 pub(crate) mod schema_provider;
+pub(crate) mod scoped_table_functions;
 pub(crate) mod source_functions;

--- a/crates/coral-engine/src/runtime/scoped_table_functions.rs
+++ b/crates/coral-engine/src/runtime/scoped_table_functions.rs
@@ -1,0 +1,273 @@
+//! Shared parsing and argument lowering for Coral scoped table functions.
+
+use std::collections::{HashMap, HashSet};
+
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::common::{DFSchema, ScalarValue};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::Expr;
+use datafusion::logical_expr::planner::{RelationPlannerContext, RelationPlanning};
+use datafusion::logical_expr::sqlparser::ast::{
+    Expr as SqlExpr, FunctionArg, FunctionArgExpr, Ident, TableAlias, TableFactor,
+    TableFunctionArgs,
+};
+
+use crate::backends::RegisteredTableFunction;
+
+pub(crate) trait ScopedTableFunctionSignature {
+    fn display_name(&self) -> &str;
+    fn arg_names(&self) -> &[String];
+    fn contains(&self, name: &str) -> bool;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ScopedTableFunctionName {
+    pub(crate) schema: String,
+    pub(crate) function: String,
+}
+
+impl ScopedTableFunctionName {
+    pub(crate) fn from_manifest(function: &RegisteredTableFunction) -> Self {
+        Self {
+            schema: function.schema_name.clone(),
+            function: function.function_name.clone(),
+        }
+    }
+
+    fn from_sql(schema: Ident, function: Ident, context: &dyn RelationPlannerContext) -> Self {
+        Self {
+            schema: context.normalize_ident(schema),
+            function: context.normalize_ident(function),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ScopedTableFunctionCall {
+    pub(crate) lookup_key: ScopedTableFunctionName,
+    pub(crate) display_name: String,
+}
+
+impl ScopedTableFunctionCall {
+    pub(crate) fn parse(
+        relation: &TableFactor,
+        context: &dyn RelationPlannerContext,
+    ) -> Option<Self> {
+        let TableFactor::Table {
+            name,
+            args: Some(_),
+            ..
+        } = relation
+        else {
+            return None;
+        };
+
+        // Coral function surfaces are exactly `schema.function(...)`. Longer
+        // names belong to DataFusion's normal relation/function planner.
+        let [schema, function] = name.0.as_slice() else {
+            return None;
+        };
+
+        let schema = schema.as_ident()?.clone();
+        let function = function.as_ident()?.clone();
+        let display_name = qualified_name(&schema.value, &function.value);
+        let lookup_key = ScopedTableFunctionName::from_sql(schema, function, context);
+
+        Some(Self {
+            lookup_key,
+            display_name,
+        })
+    }
+
+    pub(crate) fn unknown_function_error(&self, kind: &str, hint: &str) -> DataFusionError {
+        DataFusionError::Plan(format!("unknown {kind} {}{}", self.display_name, hint))
+    }
+}
+
+pub(crate) fn find_placeholder(expr: &Expr) -> Option<String> {
+    let mut found = None;
+    expr.apply(|expr| {
+        if let Expr::Placeholder(placeholder) = expr {
+            found = Some(placeholder.id.clone());
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .expect("placeholder search never fails");
+    found
+}
+
+pub(crate) fn qualified_name(schema: &str, function: &str) -> String {
+    format!("{schema}.{function}")
+}
+
+pub(crate) fn original_relation(relation: TableFactor) -> RelationPlanning {
+    RelationPlanning::Original(Box::new(relation))
+}
+
+/// Takes ownership of a committed call's argument list and alias.
+///
+/// Shape-checking and destructuring are split on purpose:
+/// [`ScopedTableFunctionCall::parse`] inspects the relation by reference because
+/// the not-our-function fallthroughs must hand the relation back to
+/// `DataFusion` untouched. Only once the call is committed may the relation
+/// be consumed, which is what makes the `unreachable!` here truly so.
+pub(crate) fn call_parts(relation: TableFactor) -> (TableFunctionArgs, Option<TableAlias>) {
+    let TableFactor::Table {
+        args: Some(args),
+        alias,
+        ..
+    } = relation
+    else {
+        unreachable!("ScopedTableFunctionCall::parse only matches table function calls");
+    };
+    (args, alias)
+}
+
+/// Rejects table-factor modifiers Coral table-function planners do not support,
+/// so user-written SQL semantics are never silently dropped.
+///
+/// Destructures every field without `..` on purpose: a sqlparser upgrade that
+/// adds a new modifier must fail compilation here and force a decision, instead
+/// of executing while ignoring the modifier.
+pub(crate) fn reject_unsupported_modifiers(
+    call: &ScopedTableFunctionCall,
+    relation: &TableFactor,
+) -> Result<()> {
+    let TableFactor::Table {
+        name: _,
+        alias: _,
+        args: _,
+        with_hints,
+        version,
+        with_ordinality,
+        partitions,
+        json_path,
+        sample,
+        index_hints,
+    } = relation
+    else {
+        unreachable!("ScopedTableFunctionCall::parse only matches table relations");
+    };
+
+    let unsupported_modifiers = [
+        (*with_ordinality, "WITH ORDINALITY"),
+        (sample.is_some(), "TABLESAMPLE"),
+        (!with_hints.is_empty(), "table hints"),
+        (!index_hints.is_empty(), "index hints"),
+        (version.is_some(), "time-travel syntax"),
+        (!partitions.is_empty(), "PARTITION selection"),
+        (json_path.is_some(), "JSON path access"),
+    ];
+    for (present, modifier) in unsupported_modifiers {
+        if present {
+            return Err(DataFusionError::Plan(format!(
+                "table function {} does not support {modifier}",
+                call.display_name
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn reject_settings(
+    call: &ScopedTableFunctionCall,
+    args: &TableFunctionArgs,
+) -> Result<()> {
+    if args.settings.is_some() {
+        return Err(DataFusionError::Plan(format!(
+            "table function {} does not support SETTINGS",
+            call.display_name
+        )));
+    }
+    Ok(())
+}
+
+/// Lowers named call arguments into positional logical expressions in declared
+/// order. Missing optional args become NULL literals; each function binder
+/// interprets NULL according to its own argument rules.
+pub(crate) fn lower_named_args_to_positional_exprs(
+    function: &dyn ScopedTableFunctionSignature,
+    args: &TableFunctionArgs,
+    context: &mut dyn RelationPlannerContext,
+) -> Result<Vec<Expr>> {
+    let mut supplied = collect_named_args(function, args, context)?;
+
+    function
+        .arg_names()
+        .iter()
+        .map(|name| match supplied.remove(name) {
+            Some(sql_expr) => context.sql_to_expr(sql_expr, &DFSchema::empty()),
+            None => Ok(Expr::Literal(ScalarValue::Null, None)),
+        })
+        .collect()
+}
+
+fn collect_named_args(
+    function: &dyn ScopedTableFunctionSignature,
+    args: &TableFunctionArgs,
+    context: &dyn RelationPlannerContext,
+) -> Result<HashMap<String, SqlExpr>> {
+    let mut supplied = HashMap::new();
+    let mut seen = HashSet::new();
+
+    for arg in &args.args {
+        let FunctionArg::Named { name, arg, .. } = arg else {
+            return Err(non_named_arg_error(function, arg));
+        };
+        insert_named_arg(function, &mut supplied, &mut seen, name, arg, context)?;
+    }
+
+    Ok(supplied)
+}
+
+fn insert_named_arg(
+    function: &dyn ScopedTableFunctionSignature,
+    supplied: &mut HashMap<String, SqlExpr>,
+    seen: &mut HashSet<String>,
+    name: &Ident,
+    arg: &FunctionArgExpr,
+    context: &dyn RelationPlannerContext,
+) -> Result<()> {
+    let lookup_name = context.normalize_ident(name.clone());
+    if !seen.insert(lookup_name.clone()) {
+        return Err(DataFusionError::Plan(format!(
+            "{} duplicate argument '{}'",
+            function.display_name(),
+            name.value
+        )));
+    }
+    if !function.contains(&lookup_name) {
+        return Err(DataFusionError::Plan(format!(
+            "{} unknown argument '{}'",
+            function.display_name(),
+            name.value
+        )));
+    }
+    let FunctionArgExpr::Expr(sql_expr) = arg else {
+        return Err(DataFusionError::Plan(format!(
+            "{} argument '{}' does not support wildcard values",
+            function.display_name(),
+            name.value
+        )));
+    };
+    supplied.insert(lookup_name, sql_expr.clone());
+    Ok(())
+}
+
+fn non_named_arg_error(
+    function: &dyn ScopedTableFunctionSignature,
+    arg: &FunctionArg,
+) -> DataFusionError {
+    match arg {
+        FunctionArg::Unnamed(_) => DataFusionError::Plan(format!(
+            "{} requires named arguments",
+            function.display_name()
+        )),
+        FunctionArg::ExprNamed { .. } => DataFusionError::Plan(format!(
+            "{} requires identifier argument names",
+            function.display_name()
+        )),
+        FunctionArg::Named { .. } => unreachable!("named arguments are handled by the caller"),
+    }
+}

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -17,17 +17,14 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use datafusion::common::config::ConfigOptions;
-use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
-use datafusion::common::{DFSchema, DFSchemaRef, ScalarValue, TableReference};
+use datafusion::common::tree_node::Transformed;
+use datafusion::common::{DFSchema, DFSchemaRef, TableReference};
 use datafusion::datasource::provider_as_source;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::planner::{
     PlannedRelation, RelationPlanner, RelationPlannerContext, RelationPlanning,
 };
-use datafusion::logical_expr::sqlparser::ast::{
-    Expr as SqlExpr, FunctionArg, FunctionArgExpr, Ident, TableAlias, TableFactor,
-    TableFunctionArgs,
-};
+use datafusion::logical_expr::sqlparser::ast::TableFactor;
 use datafusion::logical_expr::{
     Expr, Extension, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNodeCore,
 };
@@ -35,10 +32,15 @@ use datafusion::optimizer::AnalyzerRule;
 use datafusion::prelude::SessionContext;
 
 use crate::backends::{RegisteredTableFunction, SourceFunctionProviderFactory};
+use crate::runtime::scoped_table_functions::{
+    ScopedTableFunctionCall, ScopedTableFunctionName, ScopedTableFunctionSignature, call_parts,
+    find_placeholder, lower_named_args_to_positional_exprs, original_relation, qualified_name,
+    reject_settings, reject_unsupported_modifiers,
+};
 
 #[derive(Debug)]
 pub(crate) struct SourceFunctionRegistry {
-    functions: HashMap<FunctionLookupKey, SourceFunction>,
+    functions: HashMap<ScopedTableFunctionName, SourceFunction>,
     source_schemas: HashSet<String>,
 }
 
@@ -50,7 +52,7 @@ impl SourceFunctionRegistry {
         let mut functions_by_name = HashMap::new();
 
         for function in functions {
-            let lookup_key = FunctionLookupKey::from_manifest(function);
+            let lookup_key = ScopedTableFunctionName::from_manifest(function);
             source_schemas.insert(lookup_key.schema.clone());
             functions_by_name.insert(lookup_key, SourceFunction::from_registered(function));
         }
@@ -74,11 +76,11 @@ impl SourceFunctionRegistry {
         Ok(())
     }
 
-    fn find(&self, call: &SourceFunctionCall) -> Option<&SourceFunction> {
+    fn find(&self, call: &ScopedTableFunctionCall) -> Option<&SourceFunction> {
         self.functions.get(&call.lookup_key)
     }
 
-    fn owns_schema(&self, call: &SourceFunctionCall) -> bool {
+    fn owns_schema(&self, call: &ScopedTableFunctionCall) -> bool {
         self.source_schemas.contains(&call.lookup_key.schema)
     }
 
@@ -106,14 +108,14 @@ impl RelationPlanner for SourceFunctionRegistry {
         relation: TableFactor,
         context: &mut dyn RelationPlannerContext,
     ) -> Result<RelationPlanning> {
-        let Some(call) = SourceFunctionCall::parse(&relation, context) else {
+        let Some(call) = ScopedTableFunctionCall::parse(&relation, context) else {
             return Ok(original_relation(relation));
         };
 
         let Some(function) = self.find(&call) else {
             if self.owns_schema(&call) {
                 let hint = self.available_functions_hint(&call.lookup_key.schema);
-                return Err(call.unknown_function_error(&hint));
+                return Err(call.unknown_function_error("source table function", &hint));
             }
             return Ok(original_relation(relation));
         };
@@ -171,67 +173,17 @@ impl SourceFunction {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct FunctionLookupKey {
-    schema: String,
-    function: String,
-}
-
-impl FunctionLookupKey {
-    fn from_manifest(function: &RegisteredTableFunction) -> Self {
-        Self {
-            schema: function.schema_name.clone(),
-            function: function.function_name.clone(),
-        }
+impl ScopedTableFunctionSignature for SourceFunction {
+    fn display_name(&self) -> &str {
+        &self.display_name
     }
 
-    fn from_sql(schema: Ident, function: Ident, context: &dyn RelationPlannerContext) -> Self {
-        Self {
-            schema: context.normalize_ident(schema),
-            function: context.normalize_ident(function),
-        }
-    }
-}
-
-#[derive(Debug)]
-struct SourceFunctionCall {
-    lookup_key: FunctionLookupKey,
-    display_name: String,
-}
-
-impl SourceFunctionCall {
-    fn parse(relation: &TableFactor, context: &dyn RelationPlannerContext) -> Option<Self> {
-        let TableFactor::Table {
-            name,
-            args: Some(_),
-            ..
-        } = relation
-        else {
-            return None;
-        };
-
-        // Coral source functions are exactly `source.function(...)`. Longer
-        // names belong to DataFusion's normal relation/function planner.
-        let [schema, function] = name.0.as_slice() else {
-            return None;
-        };
-
-        let schema = schema.as_ident()?.clone();
-        let function = function.as_ident()?.clone();
-        let display_name = qualified_name(&schema.value, &function.value);
-        let lookup_key = FunctionLookupKey::from_sql(schema, function, context);
-
-        Some(Self {
-            lookup_key,
-            display_name,
-        })
+    fn arg_names(&self) -> &[String] {
+        &self.arg_names
     }
 
-    fn unknown_function_error(&self, hint: &str) -> DataFusionError {
-        DataFusionError::Plan(format!(
-            "unknown source table function {}{}",
-            self.display_name, hint
-        ))
+    fn contains(&self, name: &str) -> bool {
+        self.contains(name)
     }
 }
 
@@ -300,19 +252,6 @@ impl SourceFunctionNode {
         )?
         .build()
     }
-}
-
-fn find_placeholder(expr: &Expr) -> Option<String> {
-    let mut found = None;
-    expr.apply(|expr| {
-        if let Expr::Placeholder(placeholder) = expr {
-            found = Some(placeholder.id.clone());
-            return Ok(TreeNodeRecursion::Stop);
-        }
-        Ok(TreeNodeRecursion::Continue)
-    })
-    .expect("placeholder search never fails");
-    found
 }
 
 // Node identity is the function name plus its argument expressions; `schema`
@@ -384,7 +323,7 @@ impl UserDefinedLogicalNodeCore for SourceFunctionNode {
         }
         // Plan rewrites (parameter substitution in particular) alias rewritten
         // expressions to preserve their display names. Arguments are
-        // positional here, so the alias carries no meaning — strip it before
+        // positional here, so the alias carries no meaning -- strip it before
         // binding sees the value.
         Ok(Self {
             args: exprs.into_iter().map(Expr::unalias).collect(),
@@ -404,7 +343,7 @@ pub(crate) struct SourceFunctionAnalyzerRule;
 impl AnalyzerRule for SourceFunctionAnalyzerRule {
     fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
         // Subquery plans live inside expressions, not in the plan's child
-        // list — a plain transform_up would never see a source-function call
+        // list -- a plain transform_up would never see a source-function call
         // written inside EXISTS/IN/scalar subqueries.
         plan.transform_up_with_subqueries(|plan| {
             let LogicalPlan::Extension(extension) = &plan else {
@@ -420,169 +359,5 @@ impl AnalyzerRule for SourceFunctionAnalyzerRule {
 
     fn name(&self) -> &'static str {
         "coral_source_functions"
-    }
-}
-
-fn qualified_name(schema: &str, function: &str) -> String {
-    format!("{schema}.{function}")
-}
-
-fn original_relation(relation: TableFactor) -> RelationPlanning {
-    RelationPlanning::Original(Box::new(relation))
-}
-
-/// Takes ownership of a committed call's argument list and alias.
-///
-/// Shape-checking and destructuring are split on purpose:
-/// [`SourceFunctionCall::parse`] inspects the relation by reference because
-/// the not-our-function fallthroughs must hand the relation back to
-/// `DataFusion` untouched. Only once the call is committed may the relation
-/// be consumed, which is what makes the `unreachable!` here truly so.
-fn call_parts(relation: TableFactor) -> (TableFunctionArgs, Option<TableAlias>) {
-    let TableFactor::Table {
-        args: Some(args),
-        alias,
-        ..
-    } = relation
-    else {
-        unreachable!("SourceFunctionCall::parse only matches table function calls");
-    };
-    (args, alias)
-}
-
-/// Rejects table-factor modifiers the source-function planner does not
-/// support, so user-written SQL semantics are never silently dropped.
-///
-/// Destructures every field without `..` on purpose: a sqlparser upgrade that
-/// adds a new modifier must fail compilation here and force a decision,
-/// instead of executing while ignoring the modifier.
-fn reject_unsupported_modifiers(call: &SourceFunctionCall, relation: &TableFactor) -> Result<()> {
-    let TableFactor::Table {
-        name: _,
-        alias: _,
-        args: _,
-        with_hints,
-        version,
-        with_ordinality,
-        partitions,
-        json_path,
-        sample,
-        index_hints,
-    } = relation
-    else {
-        unreachable!("SourceFunctionCall::parse only matches table relations");
-    };
-
-    let unsupported_modifiers = [
-        (*with_ordinality, "WITH ORDINALITY"),
-        (sample.is_some(), "TABLESAMPLE"),
-        (!with_hints.is_empty(), "table hints"),
-        (!index_hints.is_empty(), "index hints"),
-        (version.is_some(), "time-travel syntax"),
-        (!partitions.is_empty(), "PARTITION selection"),
-        (json_path.is_some(), "JSON path access"),
-    ];
-    for (present, modifier) in unsupported_modifiers {
-        if present {
-            return Err(DataFusionError::Plan(format!(
-                "source table function {} does not support {modifier}",
-                call.display_name
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn reject_settings(call: &SourceFunctionCall, args: &TableFunctionArgs) -> Result<()> {
-    if args.settings.is_some() {
-        return Err(DataFusionError::Plan(format!(
-            "source table function {} does not support SETTINGS",
-            call.display_name
-        )));
-    }
-    Ok(())
-}
-
-/// Lowers named call arguments into positional logical expressions in manifest
-/// order. Missing optional args become NULL literals; the backend binder
-/// treats NULL as absent and performs required-argument validation after that
-/// interpretation.
-fn lower_named_args_to_positional_exprs(
-    function: &SourceFunction,
-    args: &TableFunctionArgs,
-    context: &mut dyn RelationPlannerContext,
-) -> Result<Vec<Expr>> {
-    let mut supplied = collect_named_args(function, args, context)?;
-
-    function
-        .arg_names
-        .iter()
-        .map(|name| match supplied.remove(name) {
-            Some(sql_expr) => context.sql_to_expr(sql_expr, &DFSchema::empty()),
-            None => Ok(Expr::Literal(ScalarValue::Null, None)),
-        })
-        .collect()
-}
-
-fn collect_named_args(
-    function: &SourceFunction,
-    args: &TableFunctionArgs,
-    context: &dyn RelationPlannerContext,
-) -> Result<HashMap<String, SqlExpr>> {
-    let mut supplied = HashMap::new();
-    let mut seen = HashSet::new();
-
-    for arg in &args.args {
-        let FunctionArg::Named { name, arg, .. } = arg else {
-            return Err(non_named_arg_error(function, arg));
-        };
-        insert_named_arg(function, &mut supplied, &mut seen, name, arg, context)?;
-    }
-
-    Ok(supplied)
-}
-
-fn insert_named_arg(
-    function: &SourceFunction,
-    supplied: &mut HashMap<String, SqlExpr>,
-    seen: &mut HashSet<String>,
-    name: &Ident,
-    arg: &FunctionArgExpr,
-    context: &dyn RelationPlannerContext,
-) -> Result<()> {
-    let lookup_name = context.normalize_ident(name.clone());
-    if !seen.insert(lookup_name.clone()) {
-        return Err(DataFusionError::Plan(format!(
-            "{} duplicate argument '{}'",
-            function.display_name, name.value
-        )));
-    }
-    if !function.contains(&lookup_name) {
-        return Err(DataFusionError::Plan(format!(
-            "{} unknown argument '{}'",
-            function.display_name, name.value
-        )));
-    }
-    let FunctionArgExpr::Expr(sql_expr) = arg else {
-        return Err(DataFusionError::Plan(format!(
-            "{} argument '{}' does not support wildcard values",
-            function.display_name, name.value
-        )));
-    };
-    supplied.insert(lookup_name, sql_expr.clone());
-    Ok(())
-}
-
-fn non_named_arg_error(function: &SourceFunction, arg: &FunctionArg) -> DataFusionError {
-    match arg {
-        FunctionArg::Unnamed(_) => DataFusionError::Plan(format!(
-            "{} requires named arguments",
-            function.display_name
-        )),
-        FunctionArg::ExprNamed { .. } => DataFusionError::Plan(format!(
-            "{} requires identifier argument names",
-            function.display_name
-        )),
-        FunctionArg::Named { .. } => unreachable!("named arguments are handled by the caller"),
     }
 }


### PR DESCRIPTION
## Summary
- Move source-scoped table-function call parsing into `runtime::scoped_table_functions`.
- Keep existing source-function execution behavior the same.
- Leave catalog registration, public SQL shape, and source manifests unchanged.

## Why
Saved functions need the same source-qualified table-function call model as existing source functions. This PR extracts the reusable parser/name/signature types first, so later saved-function runtime work can use the same model instead of adding a parallel parser inside `source_functions`.

## Reviewer frame
This is a behavior-preserving refactor. Review this PR by checking that source table functions still parse, bind, and execute through the same source-function path after the shared call model moves out of `source_functions`.

## Product intent
This PR is the first mechanical step in the saved-functions stack. The product experience is illustrated here: https://coral-recipes-runtime.coral-1309.chatgpt-team.site

## What changed
- `SourceFunctionCall` became the shared `ScopedTableFunctionCall` type.
- `FunctionLookupKey` became `ScopedTableFunctionName`.
- `FunctionSignature` became `ScopedTableFunctionSignature`.
- `source_functions` now imports those shared types and keeps owning source-function planning/execution.

## Validation
- `make rust-checks` on PR4 after restacking PR1-PR4.
- Source table-function coverage included existing live/workspace tests and engine tests for source-scoped table-function parsing, binding, parameterized calls, and unsupported relation modifiers.
