### PR TITLE
feat(search): add universal search contracts

### DIFF
--- a/apps/docs/project/architecture.mdx
+++ b/apps/docs/project/architecture.mdx
@@ -68,6 +68,7 @@ The local server and core orchestrator.
 | Feedback persistence | Workspace-scoped blocked-agent feedback reports (`feedback/`) |
 | Query orchestration | Loads sources, builds the engine, executes SQL (`query/`) |
 | Catalog discovery | Lists/searches/describes query-visible tables and columns (`catalog/`) |
+| Universal Search | Owns the `SearchService` shell and app-domain search result contract (`search/`) |
 
 This is the largest crate. It ties `coral-spec` and `coral-engine` together and manages all persistent local state.
 
@@ -117,7 +118,7 @@ The shared gRPC contract.
 | Protobuf definitions | `proto/coral/v1/` transport contracts for Coral services and messages |
 | Generated bindings   | Tonic-generated Rust types and service traits                                          |
 
-All inter-crate communication between `coral-client` and `coral-app` goes through these generated types.
+All inter-crate communication between `coral-client` and `coral-app` goes through these generated types. The active service contracts include source management, query execution, catalog discovery, workspaces, feedback, episodes, traces, and Universal Search.
 
 ## Dependency graph
 

--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -5,6 +5,10 @@ fn main() {
     let mut config = tonic_prost_build::Config::new();
     config.protoc_executable(protoc);
     config.type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]");
+    config.type_attribute(
+        ".coral.v1.SearchProviderCoverage",
+        "#[expect(clippy::struct_excessive_bools, reason = \"generated coverage DTO intentionally carries independent booleans\")]",
+    );
     // Keep the generated oneof enum small enough for workspace clippy.
     config.boxed(".coral.v1.SourceCredentialMethod.method.oauth");
 
@@ -20,6 +24,7 @@ fn main() {
                 "proto/coral/v1/feedback.proto",
                 "proto/coral/v1/sources.proto",
                 "proto/coral/v1/query.proto",
+                "proto/coral/v1/search.proto",
                 "proto/coral/v1/traces.proto",
                 "proto/coral/v1/episode.proto",
             ],

--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -102,6 +102,26 @@ message TableFunctionResultColumn {
   string description = 4;
 }
 
+// Query-visible table-function semantic class.
+enum TableFunctionKind {
+  // Unknown function role.
+  TABLE_FUNCTION_KIND_UNSPECIFIED = 0;
+  // Generic row-returning provider operation.
+  TABLE_FUNCTION_KIND_TABLE = 1;
+  // Provider-native retrieval/search operation that returns ranked candidates.
+  TABLE_FUNCTION_KIND_SEARCH = 2;
+}
+
+// Bounded retrieval settings for search-like provider surfaces.
+message SearchLimits {
+  // Default candidate count used when the SQL call does not specify a limit.
+  uint32 default_top_k = 1;
+  // Maximum candidate count for one provider search call.
+  uint32 max_top_k = 2;
+  // Maximum number of provider search calls a single query may make.
+  uint32 max_calls_per_query = 3;
+}
+
 // A query-visible table function in one workspace.
 message TableFunction {
   // Workspace whose query catalog makes this function visible.
@@ -116,6 +136,10 @@ message TableFunction {
   repeated TableFunctionArgument arguments = 5;
   // Columns returned by the function.
   repeated TableFunctionResultColumn result_columns = 6;
+  // Function role. Search marks provider-native retrieval.
+  TableFunctionKind kind = 7;
+  // Provider search limit metadata, when declared by the source.
+  SearchLimits search_limits = 8;
 }
 
 // Catalog item kind filter for unified discovery.

--- a/crates/coral-api/proto/coral/v1/search.proto
+++ b/crates/coral-api/proto/coral/v1/search.proto
@@ -1,0 +1,228 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/catalog.proto";
+import "coral/v1/resources.proto";
+
+// Universal Search request for clue routing over Coral metadata and local memory.
+message SearchRequest {
+  // Workspace whose current search context should be inspected.
+  Workspace workspace = 1;
+  // User or agent clue to route to likely Coral surfaces. The server trims
+  // surrounding whitespace, rejects empty queries, and rejects queries longer
+  // than 512 bytes.
+  string query = 2;
+  // Optional maximum results. Zero applies the API default of 10. Non-zero
+  // values must be between 1 and 50 inclusive; larger values are rejected
+  // rather than clamped.
+  uint32 limit = 3;
+}
+
+// Universal Search response with typed, bounded routing hints.
+message SearchResponse {
+  // Ordered search hints.
+  repeated SearchResult results = 1;
+  // Provider coverage and error disclosure.
+  repeated SearchProviderStatus provider_statuses = 2;
+  // Result truncation metadata.
+  SearchResultTruncation truncation = 3;
+}
+
+// Result truncation metadata.
+message SearchResultTruncation {
+  // Whether more results were available than returned.
+  bool truncated = 1;
+  // Number of results returned in this response.
+  uint32 returned_count = 2;
+  // Applied maximum result count.
+  uint32 max_results = 3;
+  // Human-readable truncation note.
+  string note = 4;
+}
+
+// Backing provider status for a search response.
+message SearchProviderStatus {
+  // Provider name.
+  SearchProvider provider = 1;
+  // Provider state for this request.
+  SearchProviderState state = 2;
+  // Short coverage or error note.
+  string note = 3;
+  // Structured provider-local coverage for this request. Absent when the provider is not enabled or skipped.
+  SearchProviderCoverage coverage = 4;
+}
+
+// Structured provider-local coverage for one request.
+message SearchProviderCoverage {
+  // Units the provider considered eligible for this request.
+  uint32 eligible_units = 1;
+  // Units the provider actually searched for this request.
+  uint32 searched_units = 2;
+  // Units that failed while this provider ran.
+  uint32 failed_units = 3;
+  // Candidates returned by the provider before global fusion/truncation.
+  uint32 returned_count = 4;
+  // Whether the provider had more candidates than its local retrieval window.
+  bool has_more = 5;
+  // Whether the provider stopped because its maintenance/search budget expired.
+  bool budget_exhausted = 6;
+  // Whether the provider timed out.
+  bool timed_out = 7;
+  // Whether the provider served from stale or partially refreshed local state.
+  bool stale_index = 8;
+}
+
+// Universal Search backing providers.
+enum SearchProvider {
+  // Unknown provider.
+  SEARCH_PROVIDER_UNSPECIFIED = 0;
+  // Catalog metadata provider.
+  SEARCH_PROVIDER_CATALOG_METADATA = 1;
+  // Local observed-value provider.
+  SEARCH_PROVIDER_OBSERVED_VALUES = 2;
+  // Active provider-native fanout provider.
+  SEARCH_PROVIDER_NATIVE_FANOUT = 3;
+}
+
+// Provider state for one request.
+enum SearchProviderState {
+  // Unknown provider state.
+  SEARCH_PROVIDER_STATE_UNSPECIFIED = 0;
+  // Provider returned one or more results.
+  SEARCH_PROVIDER_STATE_RESULTS_FOUND = 1;
+  // Provider ran and returned no results.
+  SEARCH_PROVIDER_STATE_EMPTY = 2;
+  // Provider is not enabled.
+  SEARCH_PROVIDER_STATE_NOT_ENABLED = 3;
+  // Provider was skipped for this request.
+  SEARCH_PROVIDER_STATE_SKIPPED = 4;
+  // Provider returned partial results.
+  SEARCH_PROVIDER_STATE_PARTIAL = 5;
+  // Provider failed for this request.
+  SEARCH_PROVIDER_STATE_ERROR = 6;
+}
+
+// One typed Universal Search result.
+message SearchResult {
+  // Provider that produced this result.
+  SearchProvider provider = 1;
+  // Typed result payload.
+  oneof payload {
+    // Table or table-function metadata hit with search context.
+    CatalogMetadata catalog_metadata = 10;
+    // Column, filter, argument, or result-column hint.
+    ColumnHint column_hint = 11;
+    // Local observed-value hit. Reserved for the observed-value provider.
+    ObservedValue observed_value = 12;
+  }
+}
+
+// Table or table-function metadata hit with search-specific context.
+message CatalogMetadata {
+  // Matched catalog item.
+  CatalogItem item = 1;
+  // Metadata fields that matched the query.
+  repeated string matched_fields = 2;
+  // Compact table column hints for ordinary table hits.
+  SearchTableColumnPreview table_column_preview = 3;
+}
+
+// Compact column hints for an ordinary table metadata hit.
+message SearchTableColumnPreview {
+  // Total column count for the table before preview capping.
+  uint32 column_count = 1;
+  // Capped columns selected for query-writing orientation.
+  repeated SearchTableColumnPreviewColumn columns = 2;
+  // Number of table columns not included in the capped preview.
+  uint32 omitted_column_count = 3;
+}
+
+// One compact column hint in a table metadata hit preview.
+message SearchTableColumnPreviewColumn {
+  // Column name as exposed by the query engine.
+  string name = 1;
+  // The DataFusion/Arrow data type rendered as text.
+  string data_type = 2;
+  // Whether the column must be constrained before querying the table.
+  bool is_required_filter = 3;
+  // Human-readable column description.
+  string description = 4;
+  // Column metadata fields that matched the query.
+  repeated string matched_fields = 5;
+}
+
+// Surface kind for a column-style hint.
+enum SearchSurfaceKind {
+  // Unknown surface kind.
+  SEARCH_SURFACE_KIND_UNSPECIFIED = 0;
+  // Table surface.
+  SEARCH_SURFACE_KIND_TABLE = 1;
+  // Table-function surface.
+  SEARCH_SURFACE_KIND_TABLE_FUNCTION = 2;
+}
+
+// Role of a field-style hint on its owning surface.
+enum SearchFieldRole {
+  // Unknown field role.
+  SEARCH_FIELD_ROLE_UNSPECIFIED = 0;
+  // Ordinary table column.
+  SEARCH_FIELD_ROLE_TABLE_COLUMN = 1;
+  // Required or optional table filter.
+  SEARCH_FIELD_ROLE_TABLE_FILTER = 2;
+  // Table-function argument.
+  SEARCH_FIELD_ROLE_TABLE_FUNCTION_ARGUMENT = 3;
+  // Table-function result column.
+  SEARCH_FIELD_ROLE_TABLE_FUNCTION_RESULT_COLUMN = 4;
+}
+
+// A field-level hint that may hold or accept the query clue.
+message ColumnHint {
+  // Workspace that scopes this hint.
+  Workspace workspace = 1;
+  // Source schema that owns the surface.
+  string schema_name = 2;
+  // Table or table-function name.
+  string surface_name = 3;
+  // Whether the owning surface is a table or table function.
+  SearchSurfaceKind surface_kind = 4;
+  // Column, required filter, argument, or result-column name.
+  string name = 5;
+  // Data type when known.
+  string data_type = 6;
+  // Whether this field must be supplied or constrained.
+  bool required = 7;
+  // Human-readable field description.
+  string description = 8;
+  // Metadata fields that matched the query.
+  repeated string matched_fields = 9;
+  // How the field should be used when querying the owning surface.
+  SearchFieldRole field_role = 10;
+}
+
+// Local observed-value result.
+message ObservedValue {
+  // Matched observed value.
+  string value = 1;
+  // Source schema where the value was observed.
+  string schema_name = 2;
+  // Table or function where the value was observed.
+  string surface_name = 3;
+  // Column that produced the value.
+  string column_name = 4;
+  // Whether the owning surface is a table or table function.
+  SearchSurfaceKind surface_kind = 5;
+  // Field path where the value was observed.
+  string field_path = 6;
+  // Number of times this field/value pair has been observed.
+  uint64 observed_count = 7;
+  // RFC3339 timestamp when this field/value pair was most recently observed.
+  string last_observed_at = 8;
+}
+
+
+// Universal Search APIs.
+service SearchService {
+  // Routes a clue to typed Coral search hints.
+  rpc Search(SearchRequest) returns (SearchResponse);
+}

--- a/crates/coral-api/proto/coral/v1/search.proto
+++ b/crates/coral-api/proto/coral/v1/search.proto
@@ -178,26 +178,24 @@ enum SearchFieldRole {
 
 // A field-level hint that may hold or accept the query clue.
 message ColumnHint {
-  // Workspace that scopes this hint.
-  Workspace workspace = 1;
   // Source schema that owns the surface.
-  string schema_name = 2;
+  string schema_name = 1;
   // Table or table-function name.
-  string surface_name = 3;
+  string surface_name = 2;
   // Whether the owning surface is a table or table function.
-  SearchSurfaceKind surface_kind = 4;
+  SearchSurfaceKind surface_kind = 3;
   // Column, required filter, argument, or result-column name.
-  string name = 5;
+  string name = 4;
   // Data type when known.
-  string data_type = 6;
+  string data_type = 5;
   // Whether this field must be supplied or constrained.
-  bool required = 7;
+  bool required = 6;
   // Human-readable field description.
-  string description = 8;
+  string description = 7;
   // Metadata fields that matched the query.
-  repeated string matched_fields = 9;
+  repeated string matched_fields = 8;
   // How the field should be used when querying the owning surface.
-  SearchFieldRole field_role = 10;
+  SearchFieldRole field_role = 9;
 }
 
 // Local observed-value result.

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -55,6 +55,12 @@ pub const QUERY_RESPONSE_MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
 /// responses larger than tonic's 4 MB default.
 pub const CATALOG_RESPONSE_MAX_MESSAGE_SIZE: usize = QUERY_RESPONSE_MAX_MESSAGE_SIZE;
 
+/// Maximum gRPC message size for `SearchService` *responses*, in bytes.
+///
+/// Universal Search returns bounded metadata hints, but it may include table,
+/// table-function, and column descriptions for many installed sources.
+pub const SEARCH_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
+
 /// Maximum gRPC message size for `TraceService` *responses*, in bytes.
 ///
 /// Trace details can include large span attributes, which may exceed tonic's

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -315,17 +315,15 @@ impl ServerBuilder {
                     service: Some(TraceService::new(store.dir, store.retention)),
                 }
             });
-        start_server(
+        let managers = ServerManagers {
             source_manager,
             workspace_manager,
             query_manager,
             search_manager,
             feedback_manager,
             episode_store,
-            trace_components,
-            self.config.mode,
-        )
-        .await
+        };
+        start_server(managers, trace_components, self.config.mode).await
     }
 }
 
@@ -413,16 +411,28 @@ struct TraceServerComponents {
     local_trace_store_dir: Option<PathBuf>,
 }
 
-async fn start_server(
+struct ServerManagers {
     source_manager: SourceManager,
     workspace_manager: WorkspaceManager,
     query_manager: QueryManager,
     search_manager: SearchManager,
     feedback_manager: FeedbackManager,
     episode_store: EpisodeStore,
+}
+
+async fn start_server(
+    managers: ServerManagers,
     trace_components: TraceServerComponents,
     mode: ServerMode,
 ) -> Result<RunningServer, AppError> {
+    let ServerManagers {
+        source_manager,
+        workspace_manager,
+        query_manager,
+        search_manager,
+        feedback_manager,
+        episode_store,
+    } = managers;
     let TraceServerComponents {
         service: trace_service,
         local_trace_store_dir,
@@ -706,8 +716,8 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider, TraceServerComponents,
-        is_grpc_web_content_type, is_native_grpc_content_type, start_server,
+        ServerBuilder, ServerManagers, ServerMode, StaticAsset, StaticAssetsProvider,
+        TraceServerComponents, is_grpc_web_content_type, is_native_grpc_content_type, start_server,
     };
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::episode::store::EpisodeStore;
@@ -846,13 +856,16 @@ enabled = false
         );
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
-        let server = start_server(
+        let managers = ServerManagers {
             source_manager,
             workspace_manager,
             query_manager,
             search_manager,
             feedback_manager,
             episode_store,
+        };
+        let server = start_server(
+            managers,
             TraceServerComponents {
                 service: Some(trace_service),
                 local_trace_store_dir: None,
@@ -1239,13 +1252,16 @@ tables:
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
-        let running = start_server(
+        let managers = ServerManagers {
             source_manager,
             workspace_manager,
             query_manager,
             search_manager,
             feedback_manager,
             episode_store,
+        };
+        let running = start_server(
+            managers,
             TraceServerComponents::default(),
             ServerMode::NativeGrpc,
         )
@@ -1349,13 +1365,16 @@ tables:
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
-        let running = start_server(
+        let managers = ServerManagers {
             source_manager,
             workspace_manager,
             query_manager,
             search_manager,
             feedback_manager,
             episode_store,
+        };
+        let running = start_server(
+            managers,
             TraceServerComponents::default(),
             ServerMode::NativeGrpc,
         )
@@ -1459,13 +1478,16 @@ tables:
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
-        let running = start_server(
+        let managers = ServerManagers {
             source_manager,
             workspace_manager,
             query_manager,
             search_manager,
             feedback_manager,
             episode_store,
+        };
+        let running = start_server(
+            managers,
             TraceServerComponents::default(),
             ServerMode::NativeGrpc,
         )

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -18,12 +18,13 @@ use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::episode_service_server::EpisodeServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
+use coral_api::v1::search_service_server::SearchServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
 use coral_api::v1::trace_service_server::TraceServiceServer;
 use coral_api::v1::workspace_service_server::WorkspaceServiceServer;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
-    TRACE_RESPONSE_MAX_MESSAGE_SIZE,
+    SEARCH_RESPONSE_MAX_MESSAGE_SIZE, TRACE_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -51,6 +52,8 @@ use crate::feedback::publisher::{
 use crate::feedback::service::FeedbackService;
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
+use crate::search::manager::SearchManager;
+use crate::search::service::SearchService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
@@ -421,10 +424,12 @@ async fn start_server(
         service: trace_service,
         local_trace_store_dir,
     } = trace_components;
+    let search_manager = SearchManager::new(query_manager.config_store());
     let source_service = SourceService::new(source_manager, query_manager.clone());
     let workspace_service = WorkspaceService::new(workspace_manager);
     let catalog_service = CatalogService::new(query_manager.clone());
     let query_service = QueryService::new(query_manager);
+    let search_service = SearchService::new(search_manager);
     let feedback_service = FeedbackService::new(feedback_manager);
     let episode_service = EpisodeService::new(episode_store);
     let mut routes = Routes::default()
@@ -454,6 +459,10 @@ async fn start_server(
         .add_service(GrpcMethodAnnotatedService::new(
             QueryServiceServer::new(query_service)
                 .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
+        ))
+        .add_service(GrpcMethodAnnotatedService::new(
+            SearchServiceServer::new(search_service)
+                .max_encoding_message_size(SEARCH_RESPONSE_MAX_MESSAGE_SIZE),
         ));
     if let Some(trace_service) = trace_service {
         routes = routes.add_service(GrpcMethodAnnotatedService::new(

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -300,6 +300,7 @@ impl ServerBuilder {
             .query_runtime_context()
             .with_body_capture_max_bytes(body_capture_max_bytes);
 
+        let search_manager = SearchManager::new(config_store.clone());
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -318,6 +319,7 @@ impl ServerBuilder {
             source_manager,
             workspace_manager,
             query_manager,
+            search_manager,
             feedback_manager,
             episode_store,
             trace_components,
@@ -415,6 +417,7 @@ async fn start_server(
     source_manager: SourceManager,
     workspace_manager: WorkspaceManager,
     query_manager: QueryManager,
+    search_manager: SearchManager,
     feedback_manager: FeedbackManager,
     episode_store: EpisodeStore,
     trace_components: TraceServerComponents,
@@ -424,7 +427,6 @@ async fn start_server(
         service: trace_service,
         local_trace_store_dir,
     } = trace_components;
-    let search_manager = SearchManager::new(query_manager.config_store());
     let source_service = SourceService::new(source_manager, query_manager.clone());
     let workspace_service = WorkspaceService::new(workspace_manager);
     let catalog_service = CatalogService::new(query_manager.clone());
@@ -711,6 +713,7 @@ mod tests {
     use crate::episode::store::EpisodeStore;
     use crate::feedback::manager::FeedbackManager;
     use crate::query::manager::QueryManager;
+    use crate::search::manager::SearchManager;
     use crate::sources::manager::SourceManager;
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::telemetry::service::TraceService;
@@ -833,6 +836,7 @@ enabled = false
             layout.clone(),
             None,
         );
+        let search_manager = SearchManager::new(config_store.clone());
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -846,6 +850,7 @@ enabled = false
             source_manager,
             workspace_manager,
             query_manager,
+            search_manager,
             feedback_manager,
             episode_store,
             TraceServerComponents {
@@ -1223,6 +1228,7 @@ tables:
             layout.clone(),
             None,
         );
+        let search_manager = SearchManager::new(config_store.clone());
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -1237,6 +1243,7 @@ tables:
             source_manager,
             workspace_manager,
             query_manager,
+            search_manager,
             feedback_manager,
             episode_store,
             TraceServerComponents::default(),
@@ -1334,6 +1341,7 @@ tables:
             layout.clone(),
             None,
         );
+        let search_manager = SearchManager::new(config_store.clone());
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -1345,6 +1353,7 @@ tables:
             source_manager,
             workspace_manager,
             query_manager,
+            search_manager,
             feedback_manager,
             episode_store,
             TraceServerComponents::default(),
@@ -1442,6 +1451,7 @@ tables:
             layout.clone(),
             None,
         );
+        let search_manager = SearchManager::new(config_store.clone());
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -1453,6 +1463,7 @@ tables:
             source_manager,
             workspace_manager,
             query_manager,
+            search_manager,
             feedback_manager,
             episode_store,
             TraceServerComponents::default(),

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -50,6 +50,7 @@ pub mod features;
 mod feedback;
 mod identity;
 mod query;
+mod search;
 mod sources;
 mod state;
 mod storage;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -79,10 +79,6 @@ impl QueryManager {
         }
     }
 
-    pub(crate) fn config_store(&self) -> ConfigStore {
-        self.config_store.clone()
-    }
-
     pub(crate) async fn list_tables(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -79,6 +79,10 @@ impl QueryManager {
         }
     }
 
+    pub(crate) fn config_store(&self) -> ConfigStore {
+        self.config_store.clone()
+    }
+
     pub(crate) async fn list_tables(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -1,0 +1,63 @@
+//! App-level Universal Search manager.
+
+use crate::search::result::{
+    ProviderStatus, SearchManagerError, SearchProviderKind, SearchProviderState, SearchRequest,
+    SearchResponse, SearchTruncation,
+};
+use crate::state::ConfigStore;
+
+#[derive(Clone)]
+pub(crate) struct SearchManager {
+    config_store: ConfigStore,
+}
+
+impl SearchManager {
+    pub(crate) fn new(config_store: ConfigStore) -> Self {
+        Self { config_store }
+    }
+
+    pub(crate) fn search(
+        &self,
+        request: &SearchRequest,
+    ) -> Result<SearchResponse, SearchManagerError> {
+        {
+            let _state_lock = self.config_store.state_lock_shared()?;
+            let config = self.config_store.load_config_unlocked()?;
+            config.require_workspace(&request.workspace_name)?;
+        }
+        tracing::debug!(
+            workspace = %request.workspace_name,
+            query_len_bytes = request.query.len(),
+            limit = request.limit,
+            "running Universal Search shell without concrete providers"
+        );
+        Ok(SearchResponse {
+            provider_statuses: vec![
+                ProviderStatus {
+                    provider: SearchProviderKind::CatalogMetadata,
+                    state: SearchProviderState::NotEnabled,
+                    note: "catalog metadata search is not wired yet".to_string(),
+                    coverage: None,
+                },
+                ProviderStatus {
+                    provider: SearchProviderKind::ObservedValues,
+                    state: SearchProviderState::NotEnabled,
+                    note: "observed value search is not wired yet".to_string(),
+                    coverage: None,
+                },
+                ProviderStatus {
+                    provider: SearchProviderKind::NativeFanout,
+                    state: SearchProviderState::NotEnabled,
+                    note: "provider-native fanout is not wired yet".to_string(),
+                    coverage: None,
+                },
+            ],
+            truncation: SearchTruncation {
+                truncated: false,
+                returned_count: 0,
+                max_results: request.limit,
+                note: "no search providers are wired yet".to_string(),
+            },
+        })
+    }
+}

--- a/crates/coral-app/src/search/mod.rs
+++ b/crates/coral-app/src/search/mod.rs
@@ -1,0 +1,5 @@
+//! App-owned Universal Search orchestration.
+
+pub(crate) mod manager;
+pub(crate) mod result;
+pub(crate) mod service;

--- a/crates/coral-app/src/search/result.rs
+++ b/crates/coral-app/src/search/result.rs
@@ -1,0 +1,158 @@
+//! Transport-neutral Universal Search result models.
+
+use crate::bootstrap::AppError;
+use crate::workspaces::WorkspaceName;
+
+pub(crate) const DEFAULT_UNIVERSAL_SEARCH_LIMIT: u32 = 10;
+pub(crate) const MAX_UNIVERSAL_SEARCH_LIMIT: u32 = 50;
+const MAX_UNIVERSAL_SEARCH_QUERY_BYTES: usize = 512;
+
+#[derive(Debug)]
+pub(crate) enum SearchManagerError {
+    App(AppError),
+}
+
+impl From<AppError> for SearchManagerError {
+    fn from(error: AppError) -> Self {
+        Self::App(error)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SearchRequest {
+    pub(crate) workspace_name: WorkspaceName,
+    pub(crate) query: String,
+    pub(crate) limit: u32,
+}
+
+impl SearchRequest {
+    pub(crate) fn new(
+        workspace_name: WorkspaceName,
+        query: &str,
+        limit: u32,
+    ) -> Result<Self, SearchManagerError> {
+        let query = query.trim();
+        if query.is_empty() {
+            return Err(
+                AppError::InvalidInput("search query must not be empty".to_string()).into(),
+            );
+        }
+        if query.len() > MAX_UNIVERSAL_SEARCH_QUERY_BYTES {
+            return Err(AppError::InvalidInput(format!(
+                "search query must be at most {MAX_UNIVERSAL_SEARCH_QUERY_BYTES} bytes"
+            ))
+            .into());
+        }
+        let limit = normalized_search_limit(limit)?;
+        Ok(Self {
+            workspace_name,
+            query: query.to_string(),
+            limit,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SearchResponse {
+    pub(crate) provider_statuses: Vec<ProviderStatus>,
+    pub(crate) truncation: SearchTruncation,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SearchTruncation {
+    pub(crate) truncated: bool,
+    pub(crate) returned_count: u32,
+    pub(crate) max_results: u32,
+    pub(crate) note: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ProviderStatus {
+    pub(crate) provider: SearchProviderKind,
+    pub(crate) state: SearchProviderState,
+    pub(crate) note: String,
+    pub(crate) coverage: Option<ProviderCoverage>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SearchProviderKind {
+    CatalogMetadata,
+    ObservedValues,
+    NativeFanout,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SearchProviderState {
+    NotEnabled,
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "reserved for request-level provider gating in concrete provider PRs"
+        )
+    )]
+    Skipped,
+}
+
+#[derive(Debug, Clone, Default)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "provider coverage is a compact transport/domain status record"
+)]
+pub(crate) struct ProviderCoverage {
+    pub(crate) eligible_units: u32,
+    pub(crate) searched_units: u32,
+    pub(crate) failed_units: u32,
+    pub(crate) returned_count: u32,
+    pub(crate) has_more: bool,
+    pub(crate) budget_exhausted: bool,
+    pub(crate) timed_out: bool,
+    pub(crate) stale_index: bool,
+}
+
+fn normalized_search_limit(limit: u32) -> Result<u32, AppError> {
+    if limit == 0 {
+        return Ok(DEFAULT_UNIVERSAL_SEARCH_LIMIT);
+    }
+    if limit > MAX_UNIVERSAL_SEARCH_LIMIT {
+        return Err(AppError::InvalidInput(format!(
+            "search limit must be between 1 and {MAX_UNIVERSAL_SEARCH_LIMIT}"
+        )));
+    }
+    Ok(limit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DEFAULT_UNIVERSAL_SEARCH_LIMIT, MAX_UNIVERSAL_SEARCH_LIMIT,
+        MAX_UNIVERSAL_SEARCH_QUERY_BYTES, SearchRequest,
+    };
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn default_limit_applies_when_limit_is_zero() {
+        let request = SearchRequest::new(WorkspaceName::default(), "github issue", 0)
+            .expect("search request");
+
+        assert_eq!(request.limit, DEFAULT_UNIVERSAL_SEARCH_LIMIT);
+    }
+
+    #[test]
+    fn oversized_limit_is_rejected() {
+        SearchRequest::new(
+            WorkspaceName::default(),
+            "github issue",
+            MAX_UNIVERSAL_SEARCH_LIMIT + 1,
+        )
+        .expect_err("oversized limit should fail");
+    }
+
+    #[test]
+    fn oversized_query_is_rejected() {
+        let query = "x".repeat(MAX_UNIVERSAL_SEARCH_QUERY_BYTES + 1);
+
+        SearchRequest::new(WorkspaceName::default(), &query, 10)
+            .expect_err("oversized query should fail");
+    }
+}

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -1,0 +1,148 @@
+//! Implements the gRPC `SearchService`.
+
+use coral_api::v1::search_service_server::SearchService as SearchServiceApi;
+use coral_api::v1::{
+    SearchProvider as ProtoSearchProvider, SearchProviderCoverage, SearchProviderState,
+    SearchProviderStatus, SearchRequest as ProtoSearchRequest,
+    SearchResponse as ProtoSearchResponse, SearchResultTruncation,
+};
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::app_status;
+use crate::search::manager::SearchManager;
+use crate::search::result::{
+    ProviderCoverage, ProviderStatus, SearchManagerError, SearchProviderKind,
+    SearchProviderState as DomainProviderState, SearchRequest, SearchResponse,
+};
+use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto};
+
+#[derive(Clone)]
+pub(crate) struct SearchService {
+    search: SearchManager,
+}
+
+impl SearchService {
+    pub(crate) fn new(search_manager: SearchManager) -> Self {
+        Self {
+            search: search_manager,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl SearchServiceApi for SearchService {
+    async fn search(
+        &self,
+        request: Request<ProtoSearchRequest>,
+    ) -> Result<Response<ProtoSearchResponse>, Status> {
+        let span = grpc_span(&request);
+        let search = self.search.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let request = SearchRequest::new(workspace_name, &request.query, request.limit)
+                .map_err(search_status)?;
+            let response = search.search(&request).map_err(search_status)?;
+            Ok(Response::new(search_response_to_proto(response)))
+        })
+        .await
+    }
+}
+
+fn search_status(error: SearchManagerError) -> Status {
+    match error {
+        SearchManagerError::App(error) => app_status(error),
+    }
+}
+
+fn search_response_to_proto(response: SearchResponse) -> ProtoSearchResponse {
+    ProtoSearchResponse {
+        results: Vec::new(),
+        provider_statuses: response
+            .provider_statuses
+            .into_iter()
+            .map(provider_status_to_proto)
+            .collect(),
+        truncation: Some(SearchResultTruncation {
+            truncated: response.truncation.truncated,
+            returned_count: response.truncation.returned_count,
+            max_results: response.truncation.max_results,
+            note: response.truncation.note,
+        }),
+    }
+}
+
+fn provider_status_to_proto(status: ProviderStatus) -> SearchProviderStatus {
+    let coverage = if matches!(
+        status.state,
+        DomainProviderState::NotEnabled | DomainProviderState::Skipped
+    ) {
+        None
+    } else {
+        status.coverage.as_ref().map(provider_coverage_to_proto)
+    };
+    SearchProviderStatus {
+        provider: provider_kind_to_proto(status.provider) as i32,
+        state: provider_state_to_proto(status.state) as i32,
+        note: status.note,
+        coverage,
+    }
+}
+
+fn provider_kind_to_proto(provider: SearchProviderKind) -> ProtoSearchProvider {
+    match provider {
+        SearchProviderKind::CatalogMetadata => ProtoSearchProvider::CatalogMetadata,
+        SearchProviderKind::ObservedValues => ProtoSearchProvider::ObservedValues,
+        SearchProviderKind::NativeFanout => ProtoSearchProvider::NativeFanout,
+    }
+}
+
+fn provider_state_to_proto(state: DomainProviderState) -> SearchProviderState {
+    match state {
+        DomainProviderState::NotEnabled => SearchProviderState::NotEnabled,
+        DomainProviderState::Skipped => SearchProviderState::Skipped,
+    }
+}
+
+fn provider_coverage_to_proto(coverage: &ProviderCoverage) -> SearchProviderCoverage {
+    SearchProviderCoverage {
+        eligible_units: coverage.eligible_units,
+        searched_units: coverage.searched_units,
+        failed_units: coverage.failed_units,
+        returned_count: coverage.returned_count,
+        has_more: coverage.has_more,
+        budget_exhausted: coverage.budget_exhausted,
+        timed_out: coverage.timed_out,
+        stale_index: coverage.stale_index,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use coral_api::v1::SearchProviderState as ProtoSearchProviderState;
+
+    use super::provider_status_to_proto;
+    use crate::search::result::{
+        ProviderCoverage, ProviderStatus, SearchProviderKind,
+        SearchProviderState as DomainProviderState,
+    };
+
+    #[test]
+    fn skipped_provider_status_maps_without_coverage() {
+        let proto = provider_status_to_proto(ProviderStatus {
+            provider: SearchProviderKind::NativeFanout,
+            state: DomainProviderState::Skipped,
+            note: "not eligible for this request".to_string(),
+            coverage: Some(ProviderCoverage::default()),
+        });
+
+        assert_eq!(
+            ProtoSearchProviderState::try_from(proto.state).expect("provider state"),
+            ProtoSearchProviderState::Skipped
+        );
+        assert!(
+            proto.coverage.is_none(),
+            "skipped provider coverage should be absent"
+        );
+    }
+}

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -8,11 +8,12 @@ use coral_api::{
         CatalogItem as ProtoCatalogItem, CatalogSearchResult as ProtoCatalogSearchResult, Column,
         ColumnSearchResult as ProtoColumnSearchResult,
         DescribeTableResponse as ProtoDescribeTableResponse, PaginationResponse, QueryTestFailure,
-        QueryTestResult, QueryTestSuccess, Source, Table, TableFunction, TableFunctionArgument,
-        TableFunctionResultColumn, TableSummary, ValidateSourceResponse, Workspace, catalog_item,
-        query_test_result,
+        QueryTestResult, QueryTestSuccess, SearchLimits, Source, Table, TableFunction,
+        TableFunctionArgument, TableFunctionKind, TableFunctionResultColumn, TableSummary,
+        ValidateSourceResponse, Workspace, catalog_item, query_test_result,
     },
 };
+use coral_spec::{SearchLimitsSpec, SourceTableFunctionKind};
 use opentelemetry::propagation::Extractor;
 use opentelemetry::trace::Status as OtelStatus;
 use tonic::codegen::{Service, http};
@@ -337,10 +338,12 @@ pub(crate) fn table_function_to_proto(
     workspace_name: &WorkspaceName,
     function: coral_engine::TableFunctionInfo,
 ) -> TableFunction {
+    let schema_name = function.schema_name;
+    let function_name = function.function_name;
     TableFunction {
         workspace: Some(workspace_to_proto(workspace_name)),
-        schema_name: function.schema_name,
-        name: function.function_name,
+        schema_name,
+        name: function_name,
         description: function.description,
         arguments: function
             .arguments
@@ -361,6 +364,26 @@ pub(crate) fn table_function_to_proto(
                 description: column.description,
             })
             .collect(),
+        kind: table_function_kind_to_proto(function.kind) as i32,
+        search_limits: function.search_limits.as_ref().map(search_limits_to_proto),
+    }
+}
+
+fn table_function_kind_to_proto(kind: SourceTableFunctionKind) -> TableFunctionKind {
+    match kind {
+        SourceTableFunctionKind::Table => TableFunctionKind::Table,
+        SourceTableFunctionKind::Search => TableFunctionKind::Search,
+    }
+}
+
+fn search_limits_to_proto(limits: &SearchLimitsSpec) -> SearchLimits {
+    SearchLimits {
+        default_top_k: u32::try_from(limits.default_top_k)
+            .expect("validated search limits default_top_k fits u32"),
+        max_top_k: u32::try_from(limits.max_top_k)
+            .expect("validated search limits max_top_k fits u32"),
+        max_calls_per_query: u32::try_from(limits.max_calls_per_query)
+            .expect("validated search limits max_calls_per_query fits u32"),
     }
 }
 

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -522,6 +522,7 @@ mod tests {
         ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableFunctionInfo,
         TableInfo,
     };
+    use coral_spec::SourceTableFunctionKind;
 
     #[test]
     fn query_status_maps_app_errors() {
@@ -724,6 +725,8 @@ mod tests {
                 values: Vec::new(),
             }],
             result_columns: Vec::new(),
+            kind: SourceTableFunctionKind::Search,
+            search_limits: None,
         };
 
         let proto = table_function_to_proto(&workspace_name, function);

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -13,6 +13,8 @@ mod harness;
 mod oauth_refresh_tests;
 #[path = "grpc/resilience_tests.rs"]
 mod resilience_tests;
+#[path = "grpc/search_tests.rs"]
+mod search_tests;
 #[path = "grpc/server_lifecycle_tests.rs"]
 mod server_lifecycle_tests;
 #[path = "grpc/source_lifecycle_tests.rs"]

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -7,8 +7,8 @@ use coral_api::v1::{
     ValidateSourceResponse, catalog_item, import_source_response,
 };
 use coral_client::{
-    AppClient, CatalogClient, QueryClient, SourceClient, WorkspaceClient, batches_to_json_rows,
-    decode_execute_sql_response, default_workspace,
+    AppClient, CatalogClient, QueryClient, SearchClient, SourceClient, WorkspaceClient,
+    batches_to_json_rows, decode_execute_sql_response, default_workspace,
     local::{RunningServer, ServerBuilder},
 };
 use serde_json::{Value, json};
@@ -86,6 +86,10 @@ impl GrpcHarness {
 
     pub(crate) fn workspace_client(&self) -> WorkspaceClient {
         self.app.workspace_client()
+    }
+
+    pub(crate) fn search_client(&self) -> SearchClient {
+        self.app.search_client()
     }
 
     pub(crate) async fn import_source(
@@ -564,7 +568,7 @@ pub(crate) fn invalid_manifest_yaml() -> String {
     }))
 }
 
-fn manifest_yaml(value: &Value) -> String {
+pub(crate) fn manifest_yaml(value: &Value) -> String {
     serde_yaml::to_string(value).expect("serialize manifest yaml")
 }
 

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -1,0 +1,171 @@
+#![expect(
+    clippy::indexing_slicing,
+    reason = "proto regression assertions intentionally fail loudly in tests"
+)]
+
+use coral_api::v1::{
+    SearchProvider, SearchProviderState, SearchRequest, TableFunctionKind, ValidateSourceRequest,
+    Workspace,
+};
+use coral_client::default_workspace;
+use serde_json::json;
+use tonic::{Code, Request};
+
+use super::harness::{GrpcHarness, manifest_yaml};
+
+#[tokio::test]
+async fn search_service_returns_structured_shell_response() {
+    let harness = GrpcHarness::new().await;
+
+    let response = harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: "github issue".to_string(),
+            limit: 0,
+        }))
+        .await
+        .expect("search")
+        .into_inner();
+
+    assert!(response.results.is_empty());
+    let truncation = response.truncation.expect("truncation");
+    assert!(!truncation.truncated);
+    assert_eq!(truncation.returned_count, 0);
+    assert_eq!(truncation.max_results, 10);
+    assert_eq!(response.provider_statuses.len(), 3);
+    assert_eq!(
+        SearchProvider::try_from(response.provider_statuses[0].provider).expect("provider"),
+        SearchProvider::CatalogMetadata
+    );
+    assert_eq!(
+        SearchProviderState::try_from(response.provider_statuses[0].state).expect("state"),
+        SearchProviderState::NotEnabled
+    );
+    assert_eq!(
+        SearchProvider::try_from(response.provider_statuses[1].provider).expect("provider"),
+        SearchProvider::ObservedValues
+    );
+    assert_eq!(
+        SearchProviderState::try_from(response.provider_statuses[1].state).expect("state"),
+        SearchProviderState::NotEnabled
+    );
+    assert_eq!(
+        SearchProvider::try_from(response.provider_statuses[2].provider).expect("provider"),
+        SearchProvider::NativeFanout
+    );
+    assert_eq!(
+        SearchProviderState::try_from(response.provider_statuses[2].state).expect("state"),
+        SearchProviderState::NotEnabled
+    );
+    for status in &response.provider_statuses {
+        assert!(
+            status.coverage.is_none(),
+            "disabled provider coverage should be absent"
+        );
+    }
+}
+
+#[tokio::test]
+async fn search_service_rejects_unknown_workspace() {
+    let harness = GrpcHarness::new().await;
+
+    let status = harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(Workspace {
+                name: "missing".to_string(),
+            }),
+            query: "github issue".to_string(),
+            limit: 0,
+        }))
+        .await
+        .expect_err("unknown workspace should fail");
+
+    assert_eq!(status.code(), Code::NotFound);
+    assert!(
+        status.message().contains("workspace 'missing' not found"),
+        "expected workspace not found message, got: {}",
+        status.message()
+    );
+}
+
+#[tokio::test]
+async fn search_service_rejects_empty_query() {
+    let harness = GrpcHarness::new().await;
+
+    let status = harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: " ".to_string(),
+            limit: 0,
+        }))
+        .await
+        .expect_err("empty query should fail");
+
+    assert_eq!(status.code(), Code::InvalidArgument);
+    assert!(
+        status.message().contains("search query must not be empty"),
+        "unexpected message: {}",
+        status.message()
+    );
+}
+
+#[tokio::test]
+async fn table_function_proto_exposes_search_metadata() {
+    let harness = GrpcHarness::new().await;
+    let manifest = manifest_yaml(&json!({
+        "name": "searchable",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": "https://example.test",
+        "functions": [{
+            "name": "search_messages",
+            "kind": "search",
+            "description": "Search messages",
+            "args": [{
+                "name": "query",
+                "required": true,
+                "bind": { "arg": "query" }
+            }],
+            "request": {
+                "method": "GET",
+                "path": "/messages",
+                "query": [{ "name": "q", "from": "arg", "key": "query" }]
+            },
+            "response": { "rows_path": ["items"] },
+            "columns": [{ "name": "title", "type": "Utf8" }],
+            "search_limits": {
+                "default_top_k": 5,
+                "max_top_k": 20,
+                "max_calls_per_query": 2
+            }
+        }]
+    }));
+    harness
+        .import_source(manifest, Vec::new(), Vec::new())
+        .await;
+
+    let response = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "searchable".to_string(),
+        }))
+        .await
+        .expect("validate source")
+        .into_inner();
+
+    assert_eq!(response.table_functions.len(), 1);
+    let function = &response.table_functions[0];
+    assert_eq!(
+        TableFunctionKind::try_from(function.kind).expect("kind"),
+        TableFunctionKind::Search
+    );
+    let search_limits = function.search_limits.as_ref().expect("search limits");
+    assert_eq!(search_limits.default_top_k, 5);
+    assert_eq!(search_limits.max_top_k, 20);
+    assert_eq!(search_limits.max_calls_per_query, 2);
+}

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -5,10 +5,12 @@ use coral_api::v1::catalog_service_client::CatalogServiceClient;
 use coral_api::v1::episode_service_client::EpisodeServiceClient;
 use coral_api::v1::feedback_service_client::FeedbackServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
+use coral_api::v1::search_service_client::SearchServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
 use coral_api::v1::workspace_service_client::WorkspaceServiceClient;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
+    SEARCH_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint};
@@ -49,6 +51,9 @@ pub type CatalogClient = CatalogServiceClient<GrpcService>;
 /// Public SQL query gRPC client.
 pub type QueryClient = QueryServiceClient<GrpcService>;
 
+/// Public Universal Search gRPC client.
+pub type SearchClient = SearchServiceClient<GrpcService>;
+
 /// Public feedback-submission gRPC client.
 pub type FeedbackClient = FeedbackServiceClient<GrpcService>;
 
@@ -64,6 +69,7 @@ pub struct AppClient {
     workspace: WorkspaceClient,
     catalog: CatalogClient,
     query: QueryClient,
+    search: SearchClient,
     feedback: FeedbackClient,
     episode: EpisodeClient,
 }
@@ -88,6 +94,8 @@ impl AppClient {
             .max_decoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE);
         let query_client = QueryClient::new(grpc_service(channel.clone(), &grpc_endpoint))
             .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
+        let search_client = SearchClient::new(grpc_service(channel.clone(), &grpc_endpoint))
+            .max_decoding_message_size(SEARCH_RESPONSE_MAX_MESSAGE_SIZE);
         let feedback_client = FeedbackClient::new(grpc_service(channel.clone(), &grpc_endpoint));
         let episode_client = EpisodeClient::new(grpc_service(channel, &grpc_endpoint));
         Ok(Self {
@@ -95,6 +103,7 @@ impl AppClient {
             workspace: workspace_client,
             catalog: catalog_client,
             query: query_client,
+            search: search_client,
             feedback: feedback_client,
             episode: episode_client,
         })
@@ -122,6 +131,12 @@ impl AppClient {
     /// Returns a cloned query client.
     pub fn query_client(&self) -> QueryClient {
         self.query.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned Universal Search client.
+    pub fn search_client(&self) -> SearchClient {
+        self.search.clone()
     }
 
     #[must_use]

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -41,7 +41,7 @@ use serde_json::Value;
 
 pub use client::{
     AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, EpisodeClient, FeedbackClient, QueryClient,
-    SourceClient, WorkspaceClient, default_workspace, workspace,
+    SearchClient, SourceClient, WorkspaceClient, default_workspace, workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use propagation::with_episode_metadata;

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -7,7 +7,7 @@ use crate::{QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceInputR
 use async_trait::async_trait;
 use coral_spec::{
     ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
-    SearchLimitsSpec, SourceBackend, SourceTableFunctionSpec, TableCommon,
+    SearchLimitsSpec, SourceBackend, SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::datasource::TableProvider;
@@ -49,7 +49,7 @@ pub(crate) struct RegisteredTable {
     pub(crate) columns: Vec<RegisteredColumn>,
     pub(crate) filters: Vec<RegisteredFilter>,
     pub(crate) required_filters: Vec<String>,
-    pub(crate) search_limits_json: Option<String>,
+    pub(crate) search_limits: Option<SearchLimitsSpec>,
 }
 
 #[derive(Debug, Clone)]
@@ -57,11 +57,12 @@ pub(crate) struct RegisteredTableFunction {
     pub(crate) schema_name: String,
     pub(crate) function_name: String,
     pub(crate) factory: Arc<dyn SourceFunctionProviderFactory>,
-    pub(crate) kind: String,
+    pub(crate) kind: SourceTableFunctionKind,
     pub(crate) description: String,
     pub(crate) arguments: Vec<RegisteredTableFunctionArgument>,
     pub(crate) result_columns: Vec<RegisteredTableFunctionResultColumn>,
-    pub(crate) search_limits_json: Option<String>,
+    pub(crate) arg_names: Vec<String>,
+    pub(crate) search_limits: Option<SearchLimitsSpec>,
 }
 
 #[derive(Debug, Clone)]
@@ -323,7 +324,7 @@ pub(crate) fn build_registered_table(
         columns,
         filters: registered_filters_from_specs(&common.filters),
         required_filters,
-        search_limits_json: common.search_limits.as_ref().map(serialize_search_limits),
+        search_limits: common.search_limits.clone(),
     }
 }
 
@@ -356,16 +357,13 @@ pub(crate) fn build_registered_table_function(
         schema_name: schema_name.to_string(),
         function_name: function.name.clone(),
         factory,
-        kind: function.kind.as_str().to_string(),
+        kind: function.kind,
         description: function.description.clone(),
         arguments,
         result_columns,
-        search_limits_json: function.search_limits.as_ref().map(serialize_search_limits),
+        arg_names: function.args.iter().map(|arg| arg.name.clone()).collect(),
+        search_limits: function.search_limits.clone(),
     }
-}
-
-fn serialize_search_limits(limits: &SearchLimitsSpec) -> String {
-    serde_json::to_string(limits).expect("search limits json")
 }
 
 pub(crate) fn arrow_type_for_column(column: &ColumnSpec) -> DataType {

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -61,7 +61,6 @@ pub(crate) struct RegisteredTableFunction {
     pub(crate) description: String,
     pub(crate) arguments: Vec<RegisteredTableFunctionArgument>,
     pub(crate) result_columns: Vec<RegisteredTableFunctionResultColumn>,
-    pub(crate) arg_names: Vec<String>,
     pub(crate) search_limits: Option<SearchLimitsSpec>,
 }
 
@@ -361,7 +360,6 @@ pub(crate) fn build_registered_table_function(
         description: function.description.clone(),
         arguments,
         result_columns,
-        arg_names: function.args.iter().map(|arg| arg.name.clone()).collect(),
         search_limits: function.search_limits.clone(),
     }
 }

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -1,5 +1,7 @@
 //! Typed query-visible catalog metadata.
 
+use coral_spec::{SearchLimitsSpec, SourceTableFunctionKind};
+
 /// Describes one queryable column.
 #[derive(Debug, Clone)]
 pub struct ColumnInfo {
@@ -91,4 +93,8 @@ pub struct TableFunctionInfo {
     pub arguments: Vec<TableFunctionArgumentInfo>,
     /// Columns returned by the function.
     pub result_columns: Vec<TableFunctionResultColumnInfo>,
+    /// Function role. Search functions perform provider-native retrieval.
+    pub kind: SourceTableFunctionKind,
+    /// Provider search limit metadata, when declared by the source.
+    pub search_limits: Option<SearchLimitsSpec>,
 }

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -673,6 +673,8 @@ mod tests {
             description: String::new(),
             arguments: vec![],
             result_columns: vec![],
+            kind: coral_spec::SourceTableFunctionKind::Table,
+            search_limits: None,
         }
     }
 

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use coral_spec::ManifestInputKind;
+use coral_spec::{ManifestInputKind, SearchLimitsSpec};
 use datafusion::arrow::array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::datasource::MemTable;
@@ -86,6 +86,10 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
         .iter()
         .map(|row| table_function_result_columns_json(row))
         .collect::<Result<Vec<_>>>()?;
+    let search_limits_json = rows
+        .iter()
+        .map(|row| search_limits_json(row.search_limits.as_ref()))
+        .collect::<Result<Vec<_>>>()?;
 
     let batch = RecordBatch::try_new(
         schema.clone(),
@@ -96,7 +100,7 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
             utf8_column(arguments_json.iter().map(|value| Some(value.as_str()))),
             utf8_column(result_columns_json.iter().map(|value| Some(value.as_str()))),
             utf8_column(rows.iter().map(|row| Some(row.kind.as_str()))),
-            utf8_column(rows.iter().map(|row| row.search_limits_json.as_deref())),
+            utf8_column(search_limits_json.iter().map(|value| value.as_deref())),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
@@ -120,6 +124,15 @@ fn table_function_result_columns_json(row: &RegisteredTableFunction) -> Result<S
         .map(TableFunctionResultColumnJson::from)
         .collect::<Vec<_>>();
     serde_json::to_string(&columns).map_err(|error| DataFusionError::External(Box::new(error)))
+}
+
+fn search_limits_json(limits: Option<&SearchLimitsSpec>) -> Result<Option<String>> {
+    limits
+        .map(|limits| {
+            serde_json::to_string(limits)
+                .map_err(|error| DataFusionError::External(Box::new(error)))
+        })
+        .transpose()
 }
 
 #[derive(Serialize)]
@@ -547,6 +560,8 @@ pub(crate) fn collect_table_functions(
                             description: column.description.clone(),
                         })
                         .collect(),
+                    kind: function.kind,
+                    search_limits: function.search_limits.clone(),
                 })
         })
         .collect::<Vec<_>>();
@@ -562,7 +577,7 @@ struct CatalogTable {
     description: String,
     guide: String,
     required_filters: String,
-    search_limits_json: Option<String>,
+    search_limits: Option<SearchLimitsSpec>,
 }
 
 fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
@@ -583,7 +598,7 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
             description: table.description.to_string(),
             guide: table.guide.to_string(),
             required_filters: String::new(),
-            search_limits_json: None,
+            search_limits: None,
         })
         .chain(active_sources.iter().flat_map(|source| {
             source.tables.iter().map(move |table| CatalogTable {
@@ -592,7 +607,7 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
                 description: table.description.clone(),
                 guide: table.guide.clone(),
                 required_filters: table.required_filters.join(","),
-                search_limits_json: table.search_limits_json.clone(),
+                search_limits: table.search_limits.clone(),
             })
         }))
         .collect::<Vec<_>>();
@@ -600,6 +615,11 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
     rows.sort_by(|left, right| {
         (&left.schema_name, &left.table_name).cmp(&(&right.schema_name, &right.table_name))
     });
+
+    let search_limits_json = rows
+        .iter()
+        .map(|row| search_limits_json(row.search_limits.as_ref()))
+        .collect::<Result<Vec<_>>>()?;
 
     let batch = RecordBatch::try_new(
         schema.clone(),
@@ -609,7 +629,7 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
             utf8_column(rows.iter().map(|row| Some(row.description.as_str()))),
             utf8_column(rows.iter().map(|row| Some(row.guide.as_str()))),
             utf8_column(rows.iter().map(|row| Some(row.required_filters.as_str()))),
-            utf8_column(rows.iter().map(|row| row.search_limits_json.as_deref())),
+            utf8_column(search_limits_json.iter().map(|value| value.as_deref())),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
@@ -956,11 +976,12 @@ mod tests {
                 schema_name: "function_schema".to_string(),
                 function_name: "search".to_string(),
                 factory: Arc::new(StubSourceFunctionFactory::default()),
-                kind: "search".to_string(),
+                kind: coral_spec::SourceTableFunctionKind::Search,
                 description: String::new(),
                 arguments: Vec::new(),
                 result_columns: Vec::new(),
-                search_limits_json: None,
+                arg_names: Vec::new(),
+                search_limits: None,
             }],
             inputs: Vec::new(),
         }]);
@@ -971,6 +992,10 @@ mod tests {
                 .first()
                 .map(|function| function.schema_name.as_str()),
             Some("function_schema")
+        );
+        assert_eq!(
+            functions.first().map(|function| function.kind.as_str()),
+            Some("search")
         );
     }
 }

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -980,7 +980,6 @@ mod tests {
                 description: String::new(),
                 arguments: Vec::new(),
                 result_columns: Vec::new(),
-                arg_names: Vec::new(),
                 search_limits: None,
             }],
             inputs: Vec::new(),

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -345,6 +345,8 @@ mod tests {
             description: String::new(),
             arguments: vec![],
             result_columns: vec![],
+            kind: coral_spec::SourceTableFunctionKind::Table,
+            search_limits: None,
         }
     }
 

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -307,6 +307,52 @@ pub struct SearchLimitsSpec {
     pub max_calls_per_query: usize,
 }
 
+impl SearchLimitsSpec {
+    pub fn validate(&self, context: &str) -> Result<()> {
+        if self.default_top_k == 0 {
+            return Err(ManifestError::validation(format!(
+                "{context}.default_top_k must be > 0"
+            )));
+        }
+        if self.max_top_k == 0 {
+            return Err(ManifestError::validation(format!(
+                "{context}.max_top_k must be > 0"
+            )));
+        }
+        if self.max_top_k > MAX_SEARCH_TOP_K {
+            return Err(ManifestError::validation(format!(
+                "{context}.max_top_k must be <= {MAX_SEARCH_TOP_K}"
+            )));
+        }
+        if self.default_top_k > self.max_top_k {
+            return Err(ManifestError::validation(format!(
+                "{context}.default_top_k must be <= max_top_k"
+            )));
+        }
+        if self.max_calls_per_query == 0 {
+            return Err(ManifestError::validation(format!(
+                "{context}.max_calls_per_query must be > 0"
+            )));
+        }
+        if self.max_calls_per_query > MAX_SEARCH_CALLS_PER_QUERY {
+            return Err(ManifestError::validation(format!(
+                "{context}.max_calls_per_query must be <= {MAX_SEARCH_CALLS_PER_QUERY}"
+            )));
+        }
+        let Some(candidate_budget) = self.max_top_k.checked_mul(self.max_calls_per_query) else {
+            return Err(ManifestError::validation(format!(
+                "{context}.max_top_k * max_calls_per_query exceeds supported range"
+            )));
+        };
+        if candidate_budget > MAX_SEARCH_CANDIDATES_PER_QUERY {
+            return Err(ManifestError::validation(format!(
+                "{context}.max_top_k * max_calls_per_query must be <= {MAX_SEARCH_CANDIDATES_PER_QUERY}"
+            )));
+        }
+        Ok(())
+    }
+}
+
 /// Machine-readable path from a search candidate row to a detail table.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -4,8 +4,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::common::{
     BodySpec, ColumnSpec, DetailHintSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding,
-    MAX_SEARCH_CALLS_PER_QUERY, MAX_SEARCH_CANDIDATES_PER_QUERY, MAX_SEARCH_TOP_K, PaginationSpec,
-    RequestRouteSpec, RequestSpec, SearchLimitsSpec, SourceTableFunctionKind,
+    PaginationSpec, RequestRouteSpec, RequestSpec, SearchLimitsSpec, SourceTableFunctionKind,
     SourceTableFunctionSpec, ValueSourceSpec,
 };
 use crate::{ManifestError, ParsedTemplate, Result, TemplateNamespace};
@@ -370,57 +369,13 @@ fn validate_search_metadata(
         )));
     }
     if let Some(limits) = search_limits {
-        validate_search_limits(limits, &format!("{schema}.{table} search_limits"))?;
+        limits.validate(&format!("{schema}.{table} search_limits"))?;
     }
     validate_detail_hints(
         detail_hints,
         columns,
         &format!("{schema}.{table} detail_hints"),
     )
-}
-
-fn validate_search_limits(limits: &SearchLimitsSpec, context: &str) -> Result<()> {
-    if limits.default_top_k == 0 {
-        return Err(ManifestError::validation(format!(
-            "{context}.default_top_k must be > 0"
-        )));
-    }
-    if limits.max_top_k == 0 {
-        return Err(ManifestError::validation(format!(
-            "{context}.max_top_k must be > 0"
-        )));
-    }
-    if limits.max_top_k > MAX_SEARCH_TOP_K {
-        return Err(ManifestError::validation(format!(
-            "{context}.max_top_k must be <= {MAX_SEARCH_TOP_K}"
-        )));
-    }
-    if limits.default_top_k > limits.max_top_k {
-        return Err(ManifestError::validation(format!(
-            "{context}.default_top_k must be <= max_top_k"
-        )));
-    }
-    if limits.max_calls_per_query == 0 {
-        return Err(ManifestError::validation(format!(
-            "{context}.max_calls_per_query must be > 0"
-        )));
-    }
-    if limits.max_calls_per_query > MAX_SEARCH_CALLS_PER_QUERY {
-        return Err(ManifestError::validation(format!(
-            "{context}.max_calls_per_query must be <= {MAX_SEARCH_CALLS_PER_QUERY}"
-        )));
-    }
-    let Some(candidate_budget) = limits.max_top_k.checked_mul(limits.max_calls_per_query) else {
-        return Err(ManifestError::validation(format!(
-            "{context}.max_top_k * max_calls_per_query exceeds supported range"
-        )));
-    };
-    if candidate_budget > MAX_SEARCH_CANDIDATES_PER_QUERY {
-        return Err(ManifestError::validation(format!(
-            "{context}.max_top_k * max_calls_per_query must be <= {MAX_SEARCH_CANDIDATES_PER_QUERY}"
-        )));
-    }
-    Ok(())
 }
 
 fn validate_lookup_key_filters_compatible_with_search_limits(


### PR DESCRIPTION
## Summary

This is the bottom PR for the SQLite-only Universal Search stack. It adds the public contract and inert app/client wiring, without adding any storage backend, indexing, retrieval, MCP tool, or CLI entrypoint yet.

- Adds `SearchService` proto/messages with typed result payloads, provider status, coverage, and truncation metadata.
- Wires an app-level `SearchManager`/`SearchService` shell into the gRPC server and client.
- Keeps the inert shell behavior directly in `SearchManager`; there is no separate provider-orchestration engine layer until a later PR has real provider orchestration to own it.
- Reports explicit `NotEnabled` shell statuses for every declared provider: catalog metadata, observed values, and native fanout.
- Carries the public `Skipped` provider state through the app-domain enum and mapper for future request-level provider gating.
- Leaves provider coverage absent/null for `NotEnabled` and `Skipped` providers; enabled providers can return structured coverage.
- Exposes existing table-function `kind` and `search_limits` metadata through catalog proto responses, so `kind: search` functions can be returned as catalog metadata.
- Fails loudly if app/engine catalog metadata contains malformed `search_limits_json`, instead of silently omitting corrupted search-limit metadata.
- Documents the new `SearchService` contract and its current inert `NotEnabled` behavior in the architecture docs.
- Adds regression coverage for the shell response, disabled/skipped provider coverage absence, empty-query validation, table-function search metadata transport, and malformed search-limit metadata.

## Boundary

This PR declares the typed result payload contract but intentionally keeps the app shell result list empty. Catalog metadata and column hint payload mapping are exercised in #1423. `kind: search` functions are represented as catalog metadata table-function items, not as a separate `native_search_path` payload. Observed-value payload mapping will be covered with the observed-value provider PR, and active native fanout execution will get its own later provider/result contract.

## Why

This keeps the contract reviewable before the SQLite catalog/observed-value providers arrive. The service currently returns explicit not-wired-yet provider statuses rather than pretending search is implemented.

## Validation

- `cargo fmt --check`
- `cargo check -p coral-app --all-targets`
- `cargo test -p coral-app search:: --lib`

Earlier stack validation for this PR also included:

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/pakapica/src/withcoral/.cargo-target/universal-search-sqlite-pr1 cargo check --locked -p coral-app -p coral-client -p coral-api`
- `CARGO_TARGET_DIR=/Users/pakapica/src/withcoral/.cargo-target/universal-search-sqlite-pr1 cargo test --locked -p coral-app search::service::tests::skipped_provider_status_maps_without_coverage -- --nocapture`
- `CARGO_TARGET_DIR=/Users/pakapica/src/withcoral/.cargo-target/universal-search-sqlite-pr1 cargo test --locked -p coral-app transport::tests::table_function_to_proto_rejects_malformed_search_limits -- --nocapture`
- `CARGO_TARGET_DIR=/Users/pakapica/src/withcoral/.cargo-target/universal-search-sqlite-pr1 cargo test --locked -p coral-app search_tests -- --nocapture`
- `CARGO_TARGET_DIR=/Users/pakapica/src/withcoral/.cargo-target/universal-search-sqlite-pr1 cargo clippy --locked -p coral-app --all-targets -- -D warnings`
