### PR TITLE
feat(engine): surface query execution provenance

### DIFF
--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -209,8 +209,8 @@ mod tests {
     use arrow::datatypes::Schema;
     use arrow::record_batch::RecordBatch;
     use coral_engine::{
-        QueryResultObserver, QueryResultObserverError, RequestAuthenticator,
-        RequestAuthenticatorError,
+        QueryExecutionProvenance, QueryResultObserver, QueryResultObserverError,
+        RequestAuthenticator, RequestAuthenticatorError,
     };
     use reqwest::header::{HeaderName, HeaderValue};
 
@@ -250,6 +250,7 @@ mod tests {
             _sql: &str,
             _schema: &Schema,
             _batches: &[RecordBatch],
+            _provenance: &QueryExecutionProvenance,
         ) -> Result<(), QueryResultObserverError> {
             Ok(())
         }

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -10,7 +10,7 @@ use datafusion::datasource::TableProvider;
 use reqwest::header::{HeaderName, HeaderValue};
 
 use crate::CoreError;
-use crate::contracts::QuerySource;
+use crate::contracts::{QueryExecutionProvenance, QuerySource};
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
 /// One source's table providers keyed by manifest table name.
@@ -272,8 +272,8 @@ pub trait SourceInputResolver: Send + Sync + std::fmt::Debug {
 /// background workers when they should not delay the query response.
 ///
 /// Observers receive read-only references to the final SQL text, Arrow schema,
-/// and result batches; implementations must not rely on mutating the returned
-/// query result.
+/// result batches, and successful-execution provenance; implementations must
+/// not rely on mutating the returned query result.
 pub trait QueryResultObserver: Send + Sync {
     /// Stable observer name used in diagnostics.
     fn name(&self) -> &'static str;
@@ -290,6 +290,7 @@ pub trait QueryResultObserver: Send + Sync {
         sql: &str,
         schema: &Schema,
         batches: &[RecordBatch],
+        provenance: &QueryExecutionProvenance,
     ) -> Result<(), QueryResultObserverError>;
 }
 

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -12,9 +12,10 @@ pub use catalog::{
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
     DependentJoinConfig, DependentJoinSourceConfig, EffectiveDependentJoinConfig, MemorySize,
-    QueryExecution, QueryMemoryConfig, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
-    QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
-    RuntimeSourcePackage, SourceValidationReport,
+    QueryExecution, QueryExecutionProvenance, QueryMemoryConfig, QueryPlan, QueryRuntimeConfig,
+    QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure,
+    QueryTestResult, QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage,
+    SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -680,12 +680,17 @@ pub struct QueryExecution {
     arrow_schema: Arc<Schema>,
     batches: Vec<RecordBatch>,
     row_count: usize,
+    provenance: QueryExecutionProvenance,
 }
 
 impl QueryExecution {
     #[must_use]
-    /// Builds a validated fully materialized query result.
-    pub fn new(arrow_schema: Arc<Schema>, batches: Vec<RecordBatch>) -> Self {
+    /// Builds a validated fully materialized query result with successful-execution provenance.
+    pub fn new(
+        arrow_schema: Arc<Schema>,
+        batches: Vec<RecordBatch>,
+        mut provenance: QueryExecutionProvenance,
+    ) -> Self {
         let schema = arrow_schema
             .fields()
             .iter()
@@ -701,11 +706,13 @@ impl QueryExecution {
             })
             .collect();
         let row_count = batches.iter().map(RecordBatch::num_rows).sum();
+        provenance.set_row_count(row_count);
         Self {
             schema,
             arrow_schema,
             batches,
             row_count,
+            provenance,
         }
     }
 
@@ -731,6 +738,162 @@ impl QueryExecution {
     /// Returns the total number of rows across all batches.
     pub fn row_count(&self) -> usize {
         self.row_count
+    }
+
+    #[must_use]
+    /// Returns successful-execution provenance for this query result.
+    pub fn provenance(&self) -> &QueryExecutionProvenance {
+        &self.provenance
+    }
+}
+
+/// Successful-execution provenance for one query result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryExecutionProvenance {
+    sql: String,
+    sources: Vec<String>,
+    tables: Vec<QueryTableUsage>,
+    table_functions: Vec<QueryTableFunctionUsage>,
+    row_count: usize,
+}
+
+impl QueryExecutionProvenance {
+    #[must_use]
+    /// Builds one provenance entry for a planned query.
+    ///
+    /// [`QueryExecution::new`] stamps the final row count from the materialized
+    /// result batches.
+    pub fn new(
+        sql: impl Into<String>,
+        sources: Vec<String>,
+        tables: Vec<QueryTableUsage>,
+        table_functions: Vec<QueryTableFunctionUsage>,
+    ) -> Self {
+        Self {
+            sql: sql.into(),
+            sources,
+            tables,
+            table_functions,
+            row_count: 0,
+        }
+    }
+
+    #[must_use]
+    /// Returns the SQL text that was executed.
+    pub fn sql(&self) -> &str {
+        &self.sql
+    }
+
+    #[must_use]
+    /// Returns the installed source names used by the query.
+    pub fn sources(&self) -> &[String] {
+        &self.sources
+    }
+
+    #[must_use]
+    /// Returns source tables used by the query.
+    pub fn tables(&self) -> &[QueryTableUsage] {
+        &self.tables
+    }
+
+    #[must_use]
+    /// Returns source-scoped table functions used by the query.
+    pub fn table_functions(&self) -> &[QueryTableFunctionUsage] {
+        &self.table_functions
+    }
+
+    #[must_use]
+    /// Returns the total number of rows across all result batches.
+    pub fn row_count(&self) -> usize {
+        self.row_count
+    }
+
+    pub(crate) fn set_row_count(&mut self, row_count: usize) {
+        self.row_count = row_count;
+    }
+}
+
+/// One source table referenced by a successful query.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct QueryTableUsage {
+    source: String,
+    schema: String,
+    table: String,
+}
+
+impl QueryTableUsage {
+    #[must_use]
+    /// Builds one source table usage entry.
+    pub fn new(
+        source_name: impl Into<String>,
+        schema_name: impl Into<String>,
+        table_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            source: source_name.into(),
+            schema: schema_name.into(),
+            table: table_name.into(),
+        }
+    }
+
+    #[must_use]
+    /// Returns the installed source name that owns this table.
+    pub fn source_name(&self) -> &str {
+        &self.source
+    }
+
+    #[must_use]
+    /// Returns the SQL schema name for this table.
+    pub fn schema_name(&self) -> &str {
+        &self.schema
+    }
+
+    #[must_use]
+    /// Returns the table name within the SQL schema.
+    pub fn table_name(&self) -> &str {
+        &self.table
+    }
+}
+
+/// One source-scoped table function referenced by a successful query.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct QueryTableFunctionUsage {
+    source: String,
+    schema: String,
+    function: String,
+}
+
+impl QueryTableFunctionUsage {
+    #[must_use]
+    /// Builds one source-scoped table function usage entry.
+    pub fn new(
+        source_name: impl Into<String>,
+        schema_name: impl Into<String>,
+        function_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            source: source_name.into(),
+            schema: schema_name.into(),
+            function: function_name.into(),
+        }
+    }
+
+    #[must_use]
+    /// Returns the installed source name that owns this table function.
+    pub fn source_name(&self) -> &str {
+        &self.source
+    }
+
+    #[must_use]
+    /// Returns the SQL schema name for this table function.
+    pub fn schema_name(&self) -> &str {
+        &self.schema
+    }
+
+    #[must_use]
+    /// Returns the function name within the SQL schema.
+    pub fn function_name(&self) -> &str {
+        &self.function
     }
 }
 

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -68,8 +68,9 @@ pub use composition::{
 };
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
-    DescribeTableInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution, QueryMemoryConfig,
-    QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTestFailure,
+    DescribeTableInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution,
+    QueryExecutionProvenance, QueryMemoryConfig, QueryPlan, QueryRuntimeConfig,
+    QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure,
     QueryTestResult, QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage,
     SourceValidationReport, StatusCode, StructuredQueryError, TableFunctionArgumentInfo,
     TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -1,12 +1,15 @@
 //! Concrete `DataFusion` runtime assembly for the data plane.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
+use datafusion::common::TableReference;
+use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::displayable;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
 use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
@@ -29,11 +32,12 @@ use crate::runtime::query_planner::CoralQueryPlanner;
 use crate::runtime::registry::{
     CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationFailure, register_sources,
 };
-use crate::runtime::source_functions::SourceFunctionRegistry;
+use crate::runtime::source_functions::{SourceFunctionNode, SourceFunctionRegistry};
 use crate::{
     CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, MemorySize, QueryExecution,
-    QueryMemoryConfig, QueryPlan, QueryResultObserver, QueryResultObserverError,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceDecorator,
+    QueryExecutionProvenance, QueryMemoryConfig, QueryPlan, QueryResultObserver,
+    QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    QueryTableFunctionUsage, QueryTableUsage, RequestAuthenticator, SourceDecorator,
     SourceInputResolver, TableFunctionInfo, TableInfo,
 };
 
@@ -44,6 +48,7 @@ pub(crate) struct QueryRuntimeAdapter {
     tables: Vec<TableInfo>,
     table_functions: Vec<TableFunctionInfo>,
     failures: Vec<SourceRegistrationFailure>,
+    schema_to_source: HashMap<String, String>,
     query_result_observers: Vec<Arc<dyn QueryResultObserver>>,
 }
 
@@ -131,6 +136,7 @@ async fn build_runtime_inner(
         tables: primary.tables,
         table_functions: primary.table_functions,
         failures: primary.failures,
+        schema_to_source: schema_to_source_names(sources),
         query_result_observers: extensions.query_result_observers,
     })
 }
@@ -413,13 +419,22 @@ impl QueryRuntimeAdapter {
             .await
             .map_err(SqlExecutionFailure::Planning)?;
         let arrow_schema = Arc::new(df.schema().as_arrow().clone());
+        let provenance = self
+            .query_provenance(sql, df.logical_plan())
+            .map_err(SqlExecutionFailure::Planning)?;
         let batches = df
             .collect()
             .await
             .map_err(SqlExecutionFailure::Collection)?;
-        self.observe_query_result(sql, arrow_schema.as_ref(), &batches)
-            .map_err(SqlExecutionFailure::Observer)?;
-        Ok(QueryExecution::new(arrow_schema, batches))
+        let execution = QueryExecution::new(arrow_schema, batches, provenance);
+        self.observe_query_result(
+            sql,
+            execution.arrow_schema().as_ref(),
+            execution.batches(),
+            execution.provenance(),
+        )
+        .map_err(SqlExecutionFailure::Observer)?;
+        Ok(execution)
     }
 
     fn sql_execution_failure_to_core(&self, error: SqlExecutionFailure, sql: &str) -> CoreError {
@@ -451,13 +466,106 @@ impl QueryRuntimeAdapter {
         sql: &str,
         schema: &arrow::datatypes::Schema,
         batches: &[arrow::record_batch::RecordBatch],
+        provenance: &QueryExecutionProvenance,
     ) -> Result<(), CoreError> {
         for observer in &self.query_result_observers {
             observer
-                .observe_result(sql, schema, batches)
+                .observe_result(sql, schema, batches, provenance)
                 .map_err(|error| query_result_observer_error(observer.name(), &error))?;
         }
         Ok(())
+    }
+
+    fn query_provenance(
+        &self,
+        sql: &str,
+        plan: &LogicalPlan,
+    ) -> Result<QueryExecutionProvenance, DataFusionError> {
+        let mut tables = BTreeSet::new();
+        let mut table_functions = BTreeSet::new();
+        plan.apply_with_subqueries(|node| {
+            match node {
+                LogicalPlan::TableScan(scan) => {
+                    self.collect_table_scan_usage(&scan.table_name, &mut tables);
+                }
+                LogicalPlan::Extension(extension) => {
+                    if let Some(function) =
+                        extension.node.as_any().downcast_ref::<SourceFunctionNode>()
+                    {
+                        self.collect_table_function_usage(
+                            function.table_reference(),
+                            &mut table_functions,
+                        );
+                    }
+                }
+                _ => {}
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+
+        let mut sources = BTreeSet::new();
+        sources.extend(tables.iter().map(|usage| usage.source_name().to_string()));
+        sources.extend(
+            table_functions
+                .iter()
+                .map(|usage| usage.source_name().to_string()),
+        );
+
+        Ok(QueryExecutionProvenance::new(
+            sql,
+            sources.into_iter().collect(),
+            tables.into_iter().collect(),
+            table_functions.into_iter().collect(),
+        ))
+    }
+
+    fn collect_table_scan_usage(
+        &self,
+        table_reference: &TableReference,
+        tables: &mut BTreeSet<QueryTableUsage>,
+    ) {
+        let Some((schema_name, table_name)) = relation_parts(table_reference) else {
+            return;
+        };
+        if self
+            .tables
+            .iter()
+            .any(|table| table.schema_name == schema_name && table.table_name == table_name)
+        {
+            tables.insert(QueryTableUsage::new(
+                self.source_name_for_schema(schema_name),
+                schema_name,
+                table_name,
+            ));
+        }
+    }
+
+    fn collect_table_function_usage(
+        &self,
+        table_reference: &TableReference,
+        table_functions: &mut BTreeSet<QueryTableFunctionUsage>,
+    ) -> bool {
+        let Some((schema_name, function_name)) = relation_parts(table_reference) else {
+            return false;
+        };
+        if self.table_functions.iter().any(|function| {
+            function.schema_name == schema_name && function.function_name == function_name
+        }) {
+            table_functions.insert(QueryTableFunctionUsage::new(
+                self.source_name_for_schema(schema_name),
+                schema_name,
+                function_name,
+            ));
+            return true;
+        }
+        false
+    }
+
+    fn source_name_for_schema(&self, schema_name: &str) -> String {
+        self.schema_to_source
+            .get(schema_name)
+            .cloned()
+            .unwrap_or_else(|| schema_name.to_string())
     }
 
     pub(crate) async fn explain_sql(&self, sql: &str) -> Result<QueryPlan, CoreError> {
@@ -580,6 +688,24 @@ fn read_only_sql_options() -> SQLOptions {
         .with_allow_statements(false)
 }
 
+fn schema_to_source_names(sources: &[QuerySource]) -> HashMap<String, String> {
+    sources
+        .iter()
+        .flat_map(|source| {
+            let source_name = source.source_name().to_string();
+            source
+                .schema_names()
+                .into_iter()
+                .map(move |schema_name| (schema_name.to_string(), source_name.clone()))
+        })
+        .collect()
+}
+
+fn relation_parts(table_reference: &TableReference) -> Option<(&str, &str)> {
+    let schema_name = table_reference.schema()?;
+    Some((schema_name, table_reference.table()))
+}
+
 fn table_metadata_without_columns(table: &TableInfo) -> TableInfo {
     TableInfo {
         schema_name: table.schema_name.clone(),
@@ -638,6 +764,7 @@ mod tests {
             }],
             table_functions: Vec::new(),
             failures: Vec::new(),
+            schema_to_source: HashMap::from([("demo".to_string(), "demo".to_string())]),
             query_result_observers: Vec::new(),
         }
     }

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -277,6 +277,10 @@ impl SourceFunctionNode {
         self.args.iter().any(|arg| find_placeholder(arg).is_some())
     }
 
+    pub(crate) fn table_reference(&self) -> &TableReference {
+        &self.table_reference
+    }
+
     fn reject_unbound_parameters(&self) -> Result<()> {
         for (name, arg) in self.arg_names.iter().zip(&self.args) {
             if let Some(placeholder) = find_placeholder(arg) {

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -1180,6 +1180,42 @@ async fn source_scoped_table_function_builds_http_search_request() {
 }
 
 #[tokio::test]
+async fn execution_provenance_records_source_scoped_table_functions() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param("search_type", "hybrid"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("search", &server.uri()));
+    let sql = "SELECT title, score \
+               FROM search.search_issues(mode => 'hybrid', q => 'flaky cleanup repo:withcoral/coral')";
+    let execution = CoralQuery::execute_sql(&[source], test_runtime(), sql)
+        .await
+        .expect("query should succeed");
+
+    let provenance = execution.provenance();
+    assert_eq!(provenance.sql(), sql);
+    assert_eq!(provenance.sources(), ["search".to_string()]);
+    assert!(provenance.tables().is_empty());
+    assert_eq!(provenance.table_functions().len(), 1);
+    let function = &provenance.table_functions()[0];
+    assert_eq!(function.source_name(), "search");
+    assert_eq!(function.schema_name(), "search");
+    assert_eq!(function.function_name(), "search_issues");
+    assert_eq!(provenance.row_count(), 1);
+}
+
+#[tokio::test]
 async fn validate_source_accepts_function_only_http_source_and_runs_queries() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))

--- a/crates/coral-engine/tests/engine/query_result_observer_tests.rs
+++ b/crates/coral-engine/tests/engine/query_result_observer_tests.rs
@@ -4,8 +4,8 @@ use std::sync::{Arc, Mutex};
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use coral_engine::{
-    CoralQuery, CoreError, EngineExtensions, QueryResultObserver, QueryResultObserverError,
-    QueryRuntimeConfig, QueryRuntimeContext, StatusCode,
+    CoralQuery, CoreError, EngineExtensions, QueryExecutionProvenance, QueryResultObserver,
+    QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext, StatusCode,
 };
 use serde_json::{Value, json};
 
@@ -19,9 +19,23 @@ struct ObservedQuery {
     rows: Vec<Value>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ObservedProvenance {
+    sql: String,
+    sources: Vec<String>,
+    tables: Vec<(String, String, String)>,
+    table_functions: Vec<(String, String, String)>,
+    row_count: usize,
+}
+
 #[derive(Debug, Default)]
 struct RecordingObserver {
     calls: Mutex<Vec<ObservedQuery>>,
+}
+
+#[derive(Debug, Default)]
+struct ProvenanceObserver {
+    calls: Mutex<Vec<ObservedProvenance>>,
 }
 
 impl RecordingObserver {
@@ -30,6 +44,47 @@ impl RecordingObserver {
             .lock()
             .expect("observer calls lock should not be poisoned")
             .clone()
+    }
+}
+
+impl ProvenanceObserver {
+    fn calls(&self) -> Vec<ObservedProvenance> {
+        self.calls
+            .lock()
+            .expect("observer calls lock should not be poisoned")
+            .clone()
+    }
+}
+
+impl From<&QueryExecutionProvenance> for ObservedProvenance {
+    fn from(provenance: &QueryExecutionProvenance) -> Self {
+        Self {
+            sql: provenance.sql().to_string(),
+            sources: provenance.sources().to_vec(),
+            tables: provenance
+                .tables()
+                .iter()
+                .map(|table| {
+                    (
+                        table.source_name().to_string(),
+                        table.schema_name().to_string(),
+                        table.table_name().to_string(),
+                    )
+                })
+                .collect(),
+            table_functions: provenance
+                .table_functions()
+                .iter()
+                .map(|function| {
+                    (
+                        function.source_name().to_string(),
+                        function.schema_name().to_string(),
+                        function.function_name().to_string(),
+                    )
+                })
+                .collect(),
+            row_count: provenance.row_count(),
+        }
     }
 }
 
@@ -43,6 +98,7 @@ impl QueryResultObserver for RecordingObserver {
         sql: &str,
         schema: &Schema,
         batches: &[RecordBatch],
+        _provenance: &QueryExecutionProvenance,
     ) -> Result<(), QueryResultObserverError> {
         self.calls
             .lock()
@@ -65,6 +121,30 @@ impl QueryResultObserver for RecordingObserver {
     }
 }
 
+impl QueryResultObserver for ProvenanceObserver {
+    fn name(&self) -> &'static str {
+        "provenance"
+    }
+
+    fn observe_result(
+        &self,
+        _sql: &str,
+        _schema: &Schema,
+        _batches: &[RecordBatch],
+        provenance: &QueryExecutionProvenance,
+    ) -> Result<(), QueryResultObserverError> {
+        self.calls
+            .lock()
+            .map_err(|_err| {
+                QueryResultObserverError::failed_precondition(
+                    "observer calls lock should not be poisoned",
+                )
+            })?
+            .push(ObservedProvenance::from(provenance));
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 struct FailingObserver;
 
@@ -78,11 +158,40 @@ impl QueryResultObserver for FailingObserver {
         _sql: &str,
         _schema: &Schema,
         _batches: &[RecordBatch],
+        _provenance: &QueryExecutionProvenance,
     ) -> Result<(), QueryResultObserverError> {
         Err(QueryResultObserverError::failed_precondition(
             "expected benchmark state is missing",
         ))
     }
+}
+
+#[tokio::test]
+async fn execution_and_observer_include_table_provenance() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
+    let source = build_source(jsonl_manifest("observer_provenance", temp.path()));
+    let observer = Arc::new(ProvenanceObserver::default());
+    let runtime = runtime_with_observer(observer.clone());
+    let sql = "SELECT id FROM observer_provenance.users WHERE id >= 2 ORDER BY id";
+
+    let execution = CoralQuery::execute_sql(&[source], runtime, sql)
+        .await
+        .expect("query should succeed");
+
+    let expected = ObservedProvenance {
+        sql: sql.to_string(),
+        sources: vec!["observer_provenance".to_string()],
+        tables: vec![(
+            "observer_provenance".to_string(),
+            "observer_provenance".to_string(),
+            "users".to_string(),
+        )],
+        table_functions: Vec::new(),
+        row_count: 2,
+    };
+    assert_eq!(ObservedProvenance::from(execution.provenance()), expected);
+    assert_eq!(observer.calls(), vec![expected]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
RFC step 1: make successful query executions carry the information needed for MCP few-shot history.

This adds `QueryExecutionProvenance` to successful query results and passes it through `QueryResultObserver`. Provenance includes the executed SQL, source names, tables, table functions, and final row count, with table/table-function usage derived from the planned query and row count stamped after result materialization.

This PR only wires in-memory execution metadata; it does not persist query history or change MCP output.