### PR TITLE
feat(engine): support named query parameters

### DIFF
--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -12,9 +12,9 @@ pub use catalog::{
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
     DependentJoinConfig, DependentJoinSourceConfig, EffectiveDependentJoinConfig, MemorySize,
-    QueryExecution, QueryMemoryConfig, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
-    QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
-    RuntimeSourcePackage, SourceValidationReport,
+    QueryExecution, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTestFailure, QueryTestResult,
+    QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -379,6 +379,7 @@ pub type QueryParameters = BTreeMap<String, QueryParameterValue>;
 /// through `DataFusion` parameter substitution, so no quoting or escaping
 /// rules apply anywhere in the request path.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum QueryParameterValue {
     /// UTF-8 string value.
     String(String),

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -369,6 +369,29 @@ impl QueryRuntimeContext {
     }
 }
 
+/// Named SQL query parameters, keyed by parameter name without the `$`
+/// prefix: binding `owner` supplies `$owner` in the statement.
+pub type QueryParameters = BTreeMap<String, QueryParameterValue>;
+
+/// Value bound to one named SQL query parameter (`$name`).
+///
+/// Values are data, never SQL text: they bind into the planned statement
+/// through `DataFusion` parameter substitution, so no quoting or escaping
+/// rules apply anywhere in the request path.
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryParameterValue {
+    /// UTF-8 string value.
+    String(String),
+    /// 64-bit signed integer value.
+    Integer(i64),
+    /// 64-bit floating point value.
+    Float(f64),
+    /// Boolean value.
+    Boolean(bool),
+    /// SQL NULL.
+    Null,
+}
+
 /// Owned runtime-build inputs needed while compiling and registering sources.
 #[derive(Default)]
 pub struct QueryRuntimeConfig {

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -381,16 +381,14 @@ pub type QueryParameters = BTreeMap<String, QueryParameterValue>;
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum QueryParameterValue {
-    /// UTF-8 string value.
-    String(String),
-    /// 64-bit signed integer value.
-    Integer(i64),
-    /// 64-bit floating point value.
-    Float(f64),
-    /// Boolean value.
-    Boolean(bool),
-    /// SQL NULL.
-    Null,
+    /// UTF-8 string value, or a typed string NULL.
+    String(Option<String>),
+    /// 64-bit signed integer value, or a typed integer NULL.
+    Integer(Option<i64>),
+    /// 64-bit floating point value, or a typed float NULL.
+    Float(Option<f64>),
+    /// Boolean value, or a typed boolean NULL.
+    Boolean(Option<bool>),
 }
 
 /// Owned runtime-build inputs needed while compiling and registering sources.

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -69,10 +69,10 @@ pub use composition::{
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
     DescribeTableInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution, QueryMemoryConfig,
-    QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTestFailure,
-    QueryTestResult, QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage,
-    SourceValidationReport, StatusCode, StructuredQueryError, TableFunctionArgumentInfo,
-    TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
+    QueryParameterValue, QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
+    QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
+    RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
+    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// High-level query operations for the local query engine.
@@ -154,13 +154,30 @@ impl CoralQuery {
         runtime: QueryRuntimeConfig,
         sql: &str,
     ) -> Result<QueryExecution, CoreError> {
+        Self::execute_sql_with_params(sources, runtime, sql, QueryParameters::new()).await
+    }
+
+    /// Executes one `SQL` statement with named query parameter values bound
+    /// into its `$name` placeholders.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the SQL is empty, if source compilation fails,
+    /// if a supplied parameter is not referenced by the statement, or if the
+    /// runtime cannot execute the statement.
+    pub async fn execute_sql_with_params(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        sql: &str,
+        params: QueryParameters,
+    ) -> Result<QueryExecution, CoreError> {
         if sql.trim().is_empty() {
             return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
         }
 
         runtime::query::build_runtime(sources, runtime)
             .await?
-            .execute_sql(sql)
+            .execute_sql(sql, &params)
             .await
     }
 
@@ -178,13 +195,30 @@ impl CoralQuery {
         runtime: QueryRuntimeConfig,
         sql: &str,
     ) -> Result<QueryPlan, CoreError> {
+        Self::explain_sql_with_params(sources, runtime, sql, QueryParameters::new()).await
+    }
+
+    /// Explains one `SQL` statement with named query parameter values bound
+    /// into its `$name` placeholders before planning output is rendered.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the SQL is empty, if source compilation fails,
+    /// if a supplied parameter is not referenced by the statement, or if the
+    /// query engine cannot explain the statement.
+    pub async fn explain_sql_with_params(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        sql: &str,
+        params: QueryParameters,
+    ) -> Result<QueryPlan, CoreError> {
         if sql.trim().is_empty() {
             return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
         }
 
         runtime::query::build_runtime(sources, runtime)
             .await?
-            .explain_sql(sql)
+            .explain_sql(sql, &params)
             .await
     }
 
@@ -234,7 +268,10 @@ impl CoralQuery {
 
         let mut query_tests = Vec::with_capacity(test_queries.len());
         for sql in test_queries {
-            match query_runtime.execute_sql(sql).await {
+            match query_runtime
+                .execute_sql(sql, &QueryParameters::new())
+                .await
+            {
                 Ok(execution) => query_tests.push(QueryTestResult::success(
                     sql.clone(),
                     execution.row_count() as u64,

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -11,4 +11,5 @@ pub(crate) mod query;
 pub(crate) mod query_planner;
 pub(crate) mod registry;
 pub(crate) mod schema_provider;
+pub(crate) mod scoped_table_functions;
 pub(crate) mod source_functions;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -577,11 +577,10 @@ fn reject_unknown_parameters(
 
 fn parameter_scalar_value(value: &QueryParameterValue) -> ScalarValue {
     match value {
-        QueryParameterValue::String(value) => ScalarValue::Utf8(Some(value.clone())),
-        QueryParameterValue::Integer(value) => ScalarValue::Int64(Some(*value)),
-        QueryParameterValue::Float(value) => ScalarValue::Float64(Some(*value)),
-        QueryParameterValue::Boolean(value) => ScalarValue::Boolean(Some(*value)),
-        QueryParameterValue::Null => ScalarValue::Null,
+        QueryParameterValue::String(value) => ScalarValue::Utf8(value.clone()),
+        QueryParameterValue::Integer(value) => ScalarValue::Int64(*value),
+        QueryParameterValue::Float(value) => ScalarValue::Float64(*value),
+        QueryParameterValue::Boolean(value) => ScalarValue::Boolean(*value),
     }
 }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -3,10 +3,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use datafusion::common::ScalarValue;
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::displayable;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
 use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
@@ -32,7 +34,8 @@ use crate::runtime::registry::{
 use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
     CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, MemorySize, QueryExecution,
-    QueryMemoryConfig, QueryPlan, QueryResultObserver, QueryResultObserverError,
+    QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan, QueryResultObserver,
+    QueryResultObserverError,
     QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceDecorator,
     SourceInputResolver, TableFunctionInfo, TableInfo,
 };
@@ -358,8 +361,12 @@ impl QueryRuntimeAdapter {
             .find(|failure| failure.schema_name == source_name)
     }
 
-    pub(crate) async fn execute_sql(&self, sql: &str) -> Result<QueryExecution, CoreError> {
-        match self.execute_sql_once(&self.ctx, sql).await {
+    pub(crate) async fn execute_sql(
+        &self,
+        sql: &str,
+        params: &QueryParameters,
+    ) -> Result<QueryExecution, CoreError> {
+        match self.execute_sql_once(&self.ctx, sql, params).await {
             Ok(execution) => Ok(execution),
             Err(SqlExecutionFailure::Collection(error)) => {
                 // Resolver-row overflow is a dependent-join buffering limit, not
@@ -388,7 +395,7 @@ impl QueryRuntimeAdapter {
                     .get_or_build_without_dependent_join()
                     .await?;
 
-                match self.execute_sql_once(&fallback.ctx, sql).await {
+                match self.execute_sql_once(&fallback.ctx, sql, params).await {
                     Ok(execution) => Ok(execution),
                     Err(error) => {
                         if is_missing_required_filter_failure(&error) {
@@ -407,11 +414,13 @@ impl QueryRuntimeAdapter {
         &self,
         ctx: &SessionContext,
         sql: &str,
+        params: &QueryParameters,
     ) -> Result<QueryExecution, SqlExecutionFailure> {
         let df = ctx
             .sql_with_options(sql, read_only_sql_options())
             .await
             .map_err(SqlExecutionFailure::Planning)?;
+        let df = apply_query_parameters(df, params).map_err(SqlExecutionFailure::Planning)?;
         let arrow_schema = Arc::new(df.schema().as_arrow().clone());
         let batches = df
             .collect()
@@ -460,8 +469,12 @@ impl QueryRuntimeAdapter {
         Ok(())
     }
 
-    pub(crate) async fn explain_sql(&self, sql: &str) -> Result<QueryPlan, CoreError> {
-        let df = self.sql_dataframe(sql).await?;
+    pub(crate) async fn explain_sql(
+        &self,
+        sql: &str,
+        params: &QueryParameters,
+    ) -> Result<QueryPlan, CoreError> {
+        let df = self.sql_dataframe(sql, params).await?;
         let unoptimized_logical_plan = df.logical_plan().display_indent_schema().to_string();
         let (session_state, logical_plan) = df.into_parts();
         let optimized_logical_plan = session_state
@@ -486,8 +499,13 @@ impl QueryRuntimeAdapter {
         ))
     }
 
-    async fn sql_dataframe(&self, sql: &str) -> Result<DataFrame, CoreError> {
-        self.ctx
+    async fn sql_dataframe(
+        &self,
+        sql: &str,
+        params: &QueryParameters,
+    ) -> Result<DataFrame, CoreError> {
+        let df = self
+            .ctx
             .sql_with_options(sql, read_only_sql_options())
             .await
             .map_err(|err| {
@@ -497,7 +515,74 @@ impl QueryRuntimeAdapter {
                     &self.table_functions,
                     Some(sql),
                 )
-            })
+            })?;
+        apply_query_parameters(df, params).map_err(|err| {
+            datafusion_to_core_with_sql_and_table_functions(
+                &err,
+                &self.tables,
+                &self.table_functions,
+                Some(sql),
+            )
+        })
+    }
+}
+
+/// Binds named query parameter values into a planned statement.
+///
+/// Rejects parameters the statement never references, then substitutes the
+/// values into the logical plan via `DataFusion` parameter binding — values
+/// stay data and are never rendered into SQL text.
+fn apply_query_parameters(
+    df: DataFrame,
+    params: &QueryParameters,
+) -> Result<DataFrame, DataFusionError> {
+    if params.is_empty() {
+        return Ok(df);
+    }
+    reject_unknown_parameters(df.logical_plan(), params)?;
+    let values: Vec<(String, ScalarValue)> = params
+        .iter()
+        .map(|(name, value)| (name.clone(), parameter_scalar_value(value)))
+        .collect();
+    df.with_param_values(values)
+}
+
+fn reject_unknown_parameters(
+    plan: &LogicalPlan,
+    params: &QueryParameters,
+) -> Result<(), DataFusionError> {
+    let referenced = plan.get_parameter_names()?;
+    let mut unknown: Vec<&str> = params
+        .keys()
+        .map(String::as_str)
+        .filter(|name| !referenced.contains(&format!("${name}")))
+        .collect();
+    if unknown.is_empty() {
+        return Ok(());
+    }
+    unknown.sort_unstable();
+
+    let mut placeholders: Vec<&str> = referenced.iter().map(String::as_str).collect();
+    placeholders.sort_unstable();
+    let placeholder_hint = if placeholders.is_empty() {
+        "the statement has no parameter placeholders".to_string()
+    } else {
+        format!("the statement references: {}", placeholders.join(", "))
+    };
+
+    Err(DataFusionError::Plan(format!(
+        "unknown query parameter(s): {}; {placeholder_hint}",
+        unknown.join(", ")
+    )))
+}
+
+fn parameter_scalar_value(value: &QueryParameterValue) -> ScalarValue {
+    match value {
+        QueryParameterValue::String(value) => ScalarValue::Utf8(Some(value.clone())),
+        QueryParameterValue::Integer(value) => ScalarValue::Int64(Some(*value)),
+        QueryParameterValue::Float(value) => ScalarValue::Float64(Some(*value)),
+        QueryParameterValue::Boolean(value) => ScalarValue::Boolean(Some(*value)),
+        QueryParameterValue::Null => ScalarValue::Null,
     }
 }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -35,9 +35,8 @@ use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
     CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, MemorySize, QueryExecution,
     QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan, QueryResultObserver,
-    QueryResultObserverError,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceDecorator,
-    SourceInputResolver, TableFunctionInfo, TableInfo,
+    QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    RequestAuthenticator, SourceDecorator, SourceInputResolver, TableFunctionInfo, TableInfo,
 };
 
 pub(crate) struct QueryRuntimeAdapter {

--- a/crates/coral-engine/src/runtime/scoped_table_functions.rs
+++ b/crates/coral-engine/src/runtime/scoped_table_functions.rs
@@ -1,0 +1,273 @@
+//! Shared parsing and argument lowering for Coral scoped table functions.
+
+use std::collections::{HashMap, HashSet};
+
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::common::{DFSchema, ScalarValue};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::Expr;
+use datafusion::logical_expr::planner::{RelationPlannerContext, RelationPlanning};
+use datafusion::logical_expr::sqlparser::ast::{
+    Expr as SqlExpr, FunctionArg, FunctionArgExpr, Ident, TableAlias, TableFactor,
+    TableFunctionArgs,
+};
+
+use crate::backends::RegisteredTableFunction;
+
+pub(crate) trait ScopedTableFunctionSignature {
+    fn display_name(&self) -> &str;
+    fn arg_names(&self) -> &[String];
+    fn contains(&self, name: &str) -> bool;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ScopedTableFunctionName {
+    pub(crate) schema: String,
+    pub(crate) function: String,
+}
+
+impl ScopedTableFunctionName {
+    pub(crate) fn from_manifest(function: &RegisteredTableFunction) -> Self {
+        Self {
+            schema: function.schema_name.clone(),
+            function: function.function_name.clone(),
+        }
+    }
+
+    fn from_sql(schema: Ident, function: Ident, context: &dyn RelationPlannerContext) -> Self {
+        Self {
+            schema: context.normalize_ident(schema),
+            function: context.normalize_ident(function),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ScopedTableFunctionCall {
+    pub(crate) lookup_key: ScopedTableFunctionName,
+    pub(crate) display_name: String,
+}
+
+impl ScopedTableFunctionCall {
+    pub(crate) fn parse(
+        relation: &TableFactor,
+        context: &dyn RelationPlannerContext,
+    ) -> Option<Self> {
+        let TableFactor::Table {
+            name,
+            args: Some(_),
+            ..
+        } = relation
+        else {
+            return None;
+        };
+
+        // Coral function surfaces are exactly `schema.function(...)`. Longer
+        // names belong to DataFusion's normal relation/function planner.
+        let [schema, function] = name.0.as_slice() else {
+            return None;
+        };
+
+        let schema = schema.as_ident()?.clone();
+        let function = function.as_ident()?.clone();
+        let display_name = qualified_name(&schema.value, &function.value);
+        let lookup_key = ScopedTableFunctionName::from_sql(schema, function, context);
+
+        Some(Self {
+            lookup_key,
+            display_name,
+        })
+    }
+
+    pub(crate) fn unknown_function_error(&self, kind: &str, hint: &str) -> DataFusionError {
+        DataFusionError::Plan(format!("unknown {kind} {}{}", self.display_name, hint))
+    }
+}
+
+pub(crate) fn find_placeholder(expr: &Expr) -> Option<String> {
+    let mut found = None;
+    expr.apply(|expr| {
+        if let Expr::Placeholder(placeholder) = expr {
+            found = Some(placeholder.id.clone());
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .expect("placeholder search never fails");
+    found
+}
+
+pub(crate) fn qualified_name(schema: &str, function: &str) -> String {
+    format!("{schema}.{function}")
+}
+
+pub(crate) fn original_relation(relation: TableFactor) -> RelationPlanning {
+    RelationPlanning::Original(Box::new(relation))
+}
+
+/// Takes ownership of a committed call's argument list and alias.
+///
+/// Shape-checking and destructuring are split on purpose:
+/// [`ScopedTableFunctionCall::parse`] inspects the relation by reference because
+/// the not-our-function fallthroughs must hand the relation back to
+/// `DataFusion` untouched. Only once the call is committed may the relation
+/// be consumed, which is what makes the `unreachable!` here truly so.
+pub(crate) fn call_parts(relation: TableFactor) -> (TableFunctionArgs, Option<TableAlias>) {
+    let TableFactor::Table {
+        args: Some(args),
+        alias,
+        ..
+    } = relation
+    else {
+        unreachable!("ScopedTableFunctionCall::parse only matches table function calls");
+    };
+    (args, alias)
+}
+
+/// Rejects table-factor modifiers Coral table-function planners do not support,
+/// so user-written SQL semantics are never silently dropped.
+///
+/// Destructures every field without `..` on purpose: a sqlparser upgrade that
+/// adds a new modifier must fail compilation here and force a decision, instead
+/// of executing while ignoring the modifier.
+pub(crate) fn reject_unsupported_modifiers(
+    call: &ScopedTableFunctionCall,
+    relation: &TableFactor,
+) -> Result<()> {
+    let TableFactor::Table {
+        name: _,
+        alias: _,
+        args: _,
+        with_hints,
+        version,
+        with_ordinality,
+        partitions,
+        json_path,
+        sample,
+        index_hints,
+    } = relation
+    else {
+        unreachable!("ScopedTableFunctionCall::parse only matches table relations");
+    };
+
+    let unsupported_modifiers = [
+        (*with_ordinality, "WITH ORDINALITY"),
+        (sample.is_some(), "TABLESAMPLE"),
+        (!with_hints.is_empty(), "table hints"),
+        (!index_hints.is_empty(), "index hints"),
+        (version.is_some(), "time-travel syntax"),
+        (!partitions.is_empty(), "PARTITION selection"),
+        (json_path.is_some(), "JSON path access"),
+    ];
+    for (present, modifier) in unsupported_modifiers {
+        if present {
+            return Err(DataFusionError::Plan(format!(
+                "table function {} does not support {modifier}",
+                call.display_name
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn reject_settings(
+    call: &ScopedTableFunctionCall,
+    args: &TableFunctionArgs,
+) -> Result<()> {
+    if args.settings.is_some() {
+        return Err(DataFusionError::Plan(format!(
+            "table function {} does not support SETTINGS",
+            call.display_name
+        )));
+    }
+    Ok(())
+}
+
+/// Lowers named call arguments into positional logical expressions in declared
+/// order. Missing optional args become NULL literals; each function binder
+/// interprets NULL according to its own argument rules.
+pub(crate) fn lower_named_args_to_positional_exprs(
+    function: &dyn ScopedTableFunctionSignature,
+    args: &TableFunctionArgs,
+    context: &mut dyn RelationPlannerContext,
+) -> Result<Vec<Expr>> {
+    let mut supplied = collect_named_args(function, args, context)?;
+
+    function
+        .arg_names()
+        .iter()
+        .map(|name| match supplied.remove(name) {
+            Some(sql_expr) => context.sql_to_expr(sql_expr, &DFSchema::empty()),
+            None => Ok(Expr::Literal(ScalarValue::Null, None)),
+        })
+        .collect()
+}
+
+fn collect_named_args(
+    function: &dyn ScopedTableFunctionSignature,
+    args: &TableFunctionArgs,
+    context: &dyn RelationPlannerContext,
+) -> Result<HashMap<String, SqlExpr>> {
+    let mut supplied = HashMap::new();
+    let mut seen = HashSet::new();
+
+    for arg in &args.args {
+        let FunctionArg::Named { name, arg, .. } = arg else {
+            return Err(non_named_arg_error(function, arg));
+        };
+        insert_named_arg(function, &mut supplied, &mut seen, name, arg, context)?;
+    }
+
+    Ok(supplied)
+}
+
+fn insert_named_arg(
+    function: &dyn ScopedTableFunctionSignature,
+    supplied: &mut HashMap<String, SqlExpr>,
+    seen: &mut HashSet<String>,
+    name: &Ident,
+    arg: &FunctionArgExpr,
+    context: &dyn RelationPlannerContext,
+) -> Result<()> {
+    let lookup_name = context.normalize_ident(name.clone());
+    if !seen.insert(lookup_name.clone()) {
+        return Err(DataFusionError::Plan(format!(
+            "{} duplicate argument '{}'",
+            function.display_name(),
+            name.value
+        )));
+    }
+    if !function.contains(&lookup_name) {
+        return Err(DataFusionError::Plan(format!(
+            "{} unknown argument '{}'",
+            function.display_name(),
+            name.value
+        )));
+    }
+    let FunctionArgExpr::Expr(sql_expr) = arg else {
+        return Err(DataFusionError::Plan(format!(
+            "{} argument '{}' does not support wildcard values",
+            function.display_name(),
+            name.value
+        )));
+    };
+    supplied.insert(lookup_name, sql_expr.clone());
+    Ok(())
+}
+
+fn non_named_arg_error(
+    function: &dyn ScopedTableFunctionSignature,
+    arg: &FunctionArg,
+) -> DataFusionError {
+    match arg {
+        FunctionArg::Unnamed(_) => DataFusionError::Plan(format!(
+            "{} requires named arguments",
+            function.display_name()
+        )),
+        FunctionArg::ExprNamed { .. } => DataFusionError::Plan(format!(
+            "{} requires identifier argument names",
+            function.display_name()
+        )),
+        FunctionArg::Named { .. } => unreachable!("named arguments are handled by the caller"),
+    }
+}

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -17,17 +17,14 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use datafusion::common::config::ConfigOptions;
-use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
-use datafusion::common::{DFSchema, DFSchemaRef, ScalarValue, TableReference};
+use datafusion::common::tree_node::Transformed;
+use datafusion::common::{DFSchema, DFSchemaRef, TableReference};
 use datafusion::datasource::provider_as_source;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::planner::{
     PlannedRelation, RelationPlanner, RelationPlannerContext, RelationPlanning,
 };
-use datafusion::logical_expr::sqlparser::ast::{
-    Expr as SqlExpr, FunctionArg, FunctionArgExpr, Ident, TableAlias, TableFactor,
-    TableFunctionArgs,
-};
+use datafusion::logical_expr::sqlparser::ast::TableFactor;
 use datafusion::logical_expr::{
     Expr, Extension, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNodeCore,
 };
@@ -35,10 +32,15 @@ use datafusion::optimizer::AnalyzerRule;
 use datafusion::prelude::SessionContext;
 
 use crate::backends::{RegisteredTableFunction, SourceFunctionProviderFactory};
+use crate::runtime::scoped_table_functions::{
+    ScopedTableFunctionCall, ScopedTableFunctionName, ScopedTableFunctionSignature, call_parts,
+    find_placeholder, lower_named_args_to_positional_exprs, original_relation, qualified_name,
+    reject_settings, reject_unsupported_modifiers,
+};
 
 #[derive(Debug)]
 pub(crate) struct SourceFunctionRegistry {
-    functions: HashMap<FunctionLookupKey, SourceFunction>,
+    functions: HashMap<ScopedTableFunctionName, SourceFunction>,
     source_schemas: HashSet<String>,
 }
 
@@ -50,7 +52,7 @@ impl SourceFunctionRegistry {
         let mut functions_by_name = HashMap::new();
 
         for function in functions {
-            let lookup_key = FunctionLookupKey::from_manifest(function);
+            let lookup_key = ScopedTableFunctionName::from_manifest(function);
             source_schemas.insert(lookup_key.schema.clone());
             functions_by_name.insert(lookup_key, SourceFunction::from_registered(function));
         }
@@ -74,11 +76,11 @@ impl SourceFunctionRegistry {
         Ok(())
     }
 
-    fn find(&self, call: &SourceFunctionCall) -> Option<&SourceFunction> {
+    fn find(&self, call: &ScopedTableFunctionCall) -> Option<&SourceFunction> {
         self.functions.get(&call.lookup_key)
     }
 
-    fn owns_schema(&self, call: &SourceFunctionCall) -> bool {
+    fn owns_schema(&self, call: &ScopedTableFunctionCall) -> bool {
         self.source_schemas.contains(&call.lookup_key.schema)
     }
 
@@ -106,14 +108,14 @@ impl RelationPlanner for SourceFunctionRegistry {
         relation: TableFactor,
         context: &mut dyn RelationPlannerContext,
     ) -> Result<RelationPlanning> {
-        let Some(call) = SourceFunctionCall::parse(&relation, context) else {
+        let Some(call) = ScopedTableFunctionCall::parse(&relation, context) else {
             return Ok(original_relation(relation));
         };
 
         let Some(function) = self.find(&call) else {
             if self.owns_schema(&call) {
                 let hint = self.available_functions_hint(&call.lookup_key.schema);
-                return Err(call.unknown_function_error(&hint));
+                return Err(call.unknown_function_error("source table function", &hint));
             }
             return Ok(original_relation(relation));
         };
@@ -171,67 +173,17 @@ impl SourceFunction {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct FunctionLookupKey {
-    schema: String,
-    function: String,
-}
-
-impl FunctionLookupKey {
-    fn from_manifest(function: &RegisteredTableFunction) -> Self {
-        Self {
-            schema: function.schema_name.clone(),
-            function: function.function_name.clone(),
-        }
+impl ScopedTableFunctionSignature for SourceFunction {
+    fn display_name(&self) -> &str {
+        &self.display_name
     }
 
-    fn from_sql(schema: Ident, function: Ident, context: &dyn RelationPlannerContext) -> Self {
-        Self {
-            schema: context.normalize_ident(schema),
-            function: context.normalize_ident(function),
-        }
-    }
-}
-
-#[derive(Debug)]
-struct SourceFunctionCall {
-    lookup_key: FunctionLookupKey,
-    display_name: String,
-}
-
-impl SourceFunctionCall {
-    fn parse(relation: &TableFactor, context: &dyn RelationPlannerContext) -> Option<Self> {
-        let TableFactor::Table {
-            name,
-            args: Some(_),
-            ..
-        } = relation
-        else {
-            return None;
-        };
-
-        // Coral source functions are exactly `source.function(...)`. Longer
-        // names belong to DataFusion's normal relation/function planner.
-        let [schema, function] = name.0.as_slice() else {
-            return None;
-        };
-
-        let schema = schema.as_ident()?.clone();
-        let function = function.as_ident()?.clone();
-        let display_name = qualified_name(&schema.value, &function.value);
-        let lookup_key = FunctionLookupKey::from_sql(schema, function, context);
-
-        Some(Self {
-            lookup_key,
-            display_name,
-        })
+    fn arg_names(&self) -> &[String] {
+        &self.arg_names
     }
 
-    fn unknown_function_error(&self, hint: &str) -> DataFusionError {
-        DataFusionError::Plan(format!(
-            "unknown source table function {}{}",
-            self.display_name, hint
-        ))
+    fn contains(&self, name: &str) -> bool {
+        self.contains(name)
     }
 }
 
@@ -300,19 +252,6 @@ impl SourceFunctionNode {
         )?
         .build()
     }
-}
-
-fn find_placeholder(expr: &Expr) -> Option<String> {
-    let mut found = None;
-    expr.apply(|expr| {
-        if let Expr::Placeholder(placeholder) = expr {
-            found = Some(placeholder.id.clone());
-            return Ok(TreeNodeRecursion::Stop);
-        }
-        Ok(TreeNodeRecursion::Continue)
-    })
-    .expect("placeholder search never fails");
-    found
 }
 
 // Node identity is the function name plus its argument expressions; `schema`
@@ -384,7 +323,7 @@ impl UserDefinedLogicalNodeCore for SourceFunctionNode {
         }
         // Plan rewrites (parameter substitution in particular) alias rewritten
         // expressions to preserve their display names. Arguments are
-        // positional here, so the alias carries no meaning — strip it before
+        // positional here, so the alias carries no meaning -- strip it before
         // binding sees the value.
         Ok(Self {
             args: exprs.into_iter().map(Expr::unalias).collect(),
@@ -404,7 +343,7 @@ pub(crate) struct SourceFunctionAnalyzerRule;
 impl AnalyzerRule for SourceFunctionAnalyzerRule {
     fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
         // Subquery plans live inside expressions, not in the plan's child
-        // list — a plain transform_up would never see a source-function call
+        // list -- a plain transform_up would never see a source-function call
         // written inside EXISTS/IN/scalar subqueries.
         plan.transform_up_with_subqueries(|plan| {
             let LogicalPlan::Extension(extension) = &plan else {
@@ -420,169 +359,5 @@ impl AnalyzerRule for SourceFunctionAnalyzerRule {
 
     fn name(&self) -> &'static str {
         "coral_source_functions"
-    }
-}
-
-fn qualified_name(schema: &str, function: &str) -> String {
-    format!("{schema}.{function}")
-}
-
-fn original_relation(relation: TableFactor) -> RelationPlanning {
-    RelationPlanning::Original(Box::new(relation))
-}
-
-/// Takes ownership of a committed call's argument list and alias.
-///
-/// Shape-checking and destructuring are split on purpose:
-/// [`SourceFunctionCall::parse`] inspects the relation by reference because
-/// the not-our-function fallthroughs must hand the relation back to
-/// `DataFusion` untouched. Only once the call is committed may the relation
-/// be consumed, which is what makes the `unreachable!` here truly so.
-fn call_parts(relation: TableFactor) -> (TableFunctionArgs, Option<TableAlias>) {
-    let TableFactor::Table {
-        args: Some(args),
-        alias,
-        ..
-    } = relation
-    else {
-        unreachable!("SourceFunctionCall::parse only matches table function calls");
-    };
-    (args, alias)
-}
-
-/// Rejects table-factor modifiers the source-function planner does not
-/// support, so user-written SQL semantics are never silently dropped.
-///
-/// Destructures every field without `..` on purpose: a sqlparser upgrade that
-/// adds a new modifier must fail compilation here and force a decision,
-/// instead of executing while ignoring the modifier.
-fn reject_unsupported_modifiers(call: &SourceFunctionCall, relation: &TableFactor) -> Result<()> {
-    let TableFactor::Table {
-        name: _,
-        alias: _,
-        args: _,
-        with_hints,
-        version,
-        with_ordinality,
-        partitions,
-        json_path,
-        sample,
-        index_hints,
-    } = relation
-    else {
-        unreachable!("SourceFunctionCall::parse only matches table relations");
-    };
-
-    let unsupported_modifiers = [
-        (*with_ordinality, "WITH ORDINALITY"),
-        (sample.is_some(), "TABLESAMPLE"),
-        (!with_hints.is_empty(), "table hints"),
-        (!index_hints.is_empty(), "index hints"),
-        (version.is_some(), "time-travel syntax"),
-        (!partitions.is_empty(), "PARTITION selection"),
-        (json_path.is_some(), "JSON path access"),
-    ];
-    for (present, modifier) in unsupported_modifiers {
-        if present {
-            return Err(DataFusionError::Plan(format!(
-                "source table function {} does not support {modifier}",
-                call.display_name
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn reject_settings(call: &SourceFunctionCall, args: &TableFunctionArgs) -> Result<()> {
-    if args.settings.is_some() {
-        return Err(DataFusionError::Plan(format!(
-            "source table function {} does not support SETTINGS",
-            call.display_name
-        )));
-    }
-    Ok(())
-}
-
-/// Lowers named call arguments into positional logical expressions in manifest
-/// order. Missing optional args become NULL literals; the backend binder
-/// treats NULL as absent and performs required-argument validation after that
-/// interpretation.
-fn lower_named_args_to_positional_exprs(
-    function: &SourceFunction,
-    args: &TableFunctionArgs,
-    context: &mut dyn RelationPlannerContext,
-) -> Result<Vec<Expr>> {
-    let mut supplied = collect_named_args(function, args, context)?;
-
-    function
-        .arg_names
-        .iter()
-        .map(|name| match supplied.remove(name) {
-            Some(sql_expr) => context.sql_to_expr(sql_expr, &DFSchema::empty()),
-            None => Ok(Expr::Literal(ScalarValue::Null, None)),
-        })
-        .collect()
-}
-
-fn collect_named_args(
-    function: &SourceFunction,
-    args: &TableFunctionArgs,
-    context: &dyn RelationPlannerContext,
-) -> Result<HashMap<String, SqlExpr>> {
-    let mut supplied = HashMap::new();
-    let mut seen = HashSet::new();
-
-    for arg in &args.args {
-        let FunctionArg::Named { name, arg, .. } = arg else {
-            return Err(non_named_arg_error(function, arg));
-        };
-        insert_named_arg(function, &mut supplied, &mut seen, name, arg, context)?;
-    }
-
-    Ok(supplied)
-}
-
-fn insert_named_arg(
-    function: &SourceFunction,
-    supplied: &mut HashMap<String, SqlExpr>,
-    seen: &mut HashSet<String>,
-    name: &Ident,
-    arg: &FunctionArgExpr,
-    context: &dyn RelationPlannerContext,
-) -> Result<()> {
-    let lookup_name = context.normalize_ident(name.clone());
-    if !seen.insert(lookup_name.clone()) {
-        return Err(DataFusionError::Plan(format!(
-            "{} duplicate argument '{}'",
-            function.display_name, name.value
-        )));
-    }
-    if !function.contains(&lookup_name) {
-        return Err(DataFusionError::Plan(format!(
-            "{} unknown argument '{}'",
-            function.display_name, name.value
-        )));
-    }
-    let FunctionArgExpr::Expr(sql_expr) = arg else {
-        return Err(DataFusionError::Plan(format!(
-            "{} argument '{}' does not support wildcard values",
-            function.display_name, name.value
-        )));
-    };
-    supplied.insert(lookup_name, sql_expr.clone());
-    Ok(())
-}
-
-fn non_named_arg_error(function: &SourceFunction, arg: &FunctionArg) -> DataFusionError {
-    match arg {
-        FunctionArg::Unnamed(_) => DataFusionError::Plan(format!(
-            "{} requires named arguments",
-            function.display_name
-        )),
-        FunctionArg::ExprNamed { .. } => DataFusionError::Plan(format!(
-            "{} requires identifier argument names",
-            function.display_name
-        )),
-        FunctionArg::Named { .. } => unreachable!("named arguments are handled by the caller"),
     }
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -3126,7 +3126,7 @@ async fn legacy_json_body_array_form_still_works() {
 fn string_param(name: &str, value: &str) -> (String, QueryParameterValue) {
     (
         name.to_string(),
-        QueryParameterValue::String(value.to_string()),
+        QueryParameterValue::String(Some(value.to_string())),
     )
 }
 
@@ -3275,7 +3275,7 @@ async fn null_query_parameter_is_treated_as_omitted_optional_argument() {
     let source = build_source(search_function_manifest("null_param_search", &server.uri()));
     let params = QueryParameters::from([
         string_param("q", "flaky cleanup repo:withcoral/coral"),
-        ("mode".to_string(), QueryParameterValue::Null),
+        ("mode".to_string(), QueryParameterValue::String(None)),
     ]);
 
     let rows = execution_to_rows(
@@ -3302,7 +3302,7 @@ async fn null_query_parameter_is_treated_as_omitted_optional_argument() {
 async fn null_query_parameter_for_required_argument_fails() {
     let server = MockServer::start().await;
     let source = build_source(search_function_manifest("null_required", &server.uri()));
-    let params = QueryParameters::from([("q".to_string(), QueryParameterValue::Null)]);
+    let params = QueryParameters::from([("q".to_string(), QueryParameterValue::String(None))]);
 
     let error = CoralQuery::execute_sql_with_params(
         &[source],
@@ -3324,9 +3324,12 @@ async fn null_query_parameter_for_required_argument_fails() {
 #[tokio::test]
 async fn query_parameters_bind_typed_scalar_values() {
     let params = QueryParameters::from([
-        ("count".to_string(), QueryParameterValue::Integer(7)),
-        ("score".to_string(), QueryParameterValue::Float(9.5)),
-        ("enabled".to_string(), QueryParameterValue::Boolean(true)),
+        ("count".to_string(), QueryParameterValue::Integer(Some(7))),
+        ("score".to_string(), QueryParameterValue::Float(Some(9.5))),
+        (
+            "enabled".to_string(),
+            QueryParameterValue::Boolean(Some(true)),
+        ),
     ]);
 
     let rows = execution_to_rows(

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -9,8 +9,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use coral_engine::{
-    CoralQuery, CoreError, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext,
-    RequestAuthenticator, RequestAuthenticatorError, StatusCode,
+    CoralQuery, CoreError, EngineExtensions, QueryParameterValue, QueryParameters,
+    QueryRuntimeConfig, QueryRuntimeContext, RequestAuthenticator, RequestAuthenticatorError,
+    StatusCode,
 };
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use serde_json::{Value, json};
@@ -3120,4 +3121,204 @@ async fn legacy_json_body_array_form_still_works() {
     );
 
     assert_eq!(rows, users_rows());
+}
+
+fn string_param(name: &str, value: &str) -> (String, QueryParameterValue) {
+    (
+        name.to_string(),
+        QueryParameterValue::String(value.to_string()),
+    )
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_binds_query_parameters() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param("search_type", "hybrid"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("param_search", &server.uri()));
+    let params = QueryParameters::from([
+        string_param("q", "flaky cleanup repo:withcoral/coral"),
+        string_param("mode", "hybrid"),
+    ]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[source],
+            test_runtime(),
+            "SELECT title, score FROM param_search.search_issues(q => $q, mode => $mode)",
+            params,
+        )
+        .await
+        .expect("parameterized source function call should bind and execute"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_rejects_unbound_parameter() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("unbound_search", &server.uri()));
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM unbound_search.search_issues(q => $q)",
+    )
+    .await
+    .expect_err("an unbound parameter in a source function call should fail");
+
+    assert!(
+        error.to_string().contains(
+            "unbound_search.search_issues argument 'q' is bound to parameter $q, \
+             but no value was provided for it"
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn query_parameters_reject_unknown_names() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("strict_params", &server.uri()));
+    let params = QueryParameters::from([string_param("typo", "hybrid")]);
+
+    let error = CoralQuery::execute_sql_with_params(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM strict_params.search_issues(q => $q)",
+        params,
+    )
+    .await
+    .expect_err("parameters the statement never references should fail");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("unknown query parameter(s): typo"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        message.contains("the statement references: $q"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn null_query_parameter_is_treated_as_omitted_optional_argument() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param_is_missing("search_type"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("null_param_search", &server.uri()));
+    let params = QueryParameters::from([
+        string_param("q", "flaky cleanup repo:withcoral/coral"),
+        ("mode".to_string(), QueryParameterValue::Null),
+    ]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[source],
+            test_runtime(),
+            "SELECT title, score FROM null_param_search.search_issues(q => $q, mode => $mode)",
+            params,
+        )
+        .await
+        .expect("null parameter for an optional argument should be omitted"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn null_query_parameter_for_required_argument_fails() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("null_required", &server.uri()));
+    let params = QueryParameters::from([("q".to_string(), QueryParameterValue::Null)]);
+
+    let error = CoralQuery::execute_sql_with_params(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM null_required.search_issues(q => $q)",
+        params,
+    )
+    .await
+    .expect_err("null parameter for a required argument should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("null_required.search_issues missing required argument(s): q"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn query_parameters_bind_in_where_clauses() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "cleanup"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [
+                { "title": "Flaky workspace cleanup", "score": 9.5 },
+                { "title": "Unrelated issue", "score": 1.0 }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("where_params", &server.uri()));
+    let params = QueryParameters::from([
+        string_param("q", "cleanup"),
+        string_param("title", "Flaky workspace cleanup"),
+    ]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[source],
+            test_runtime(),
+            "SELECT title FROM where_params.search_issues(q => $q) WHERE title = $title",
+            params,
+        )
+        .await
+        .expect("parameters should bind in both call arguments and WHERE clauses"),
+    );
+
+    assert_eq!(rows, vec![json!({ "title": "Flaky workspace cleanup" })]);
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -3174,6 +3174,40 @@ async fn source_scoped_table_function_binds_query_parameters() {
 }
 
 #[tokio::test]
+async fn explain_sql_binds_query_parameters() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest(
+        "explain_param_search",
+        &server.uri(),
+    ));
+    let params = QueryParameters::from([
+        string_param("q", "flaky cleanup repo:withcoral/coral"),
+        string_param("mode", "hybrid"),
+    ]);
+
+    let plan = CoralQuery::explain_sql_with_params(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM explain_param_search.search_issues(q => $q, mode => $mode)",
+        params,
+    )
+    .await
+    .expect("parameterized source function call should explain after binding");
+
+    assert!(
+        plan.unoptimized_logical_plan()
+            .contains("explain_param_search.search_issues"),
+        "unexpected unoptimized plan: {}",
+        plan.unoptimized_logical_plan()
+    );
+    assert!(
+        plan.physical_plan().contains("Exec"),
+        "unexpected physical plan: {}",
+        plan.physical_plan()
+    );
+}
+
+#[tokio::test]
 async fn source_scoped_table_function_rejects_unbound_parameter() {
     let server = MockServer::start().await;
     let source = build_source(search_function_manifest("unbound_search", &server.uri()));
@@ -3284,6 +3318,36 @@ async fn null_query_parameter_for_required_argument_fails() {
             .to_string()
             .contains("null_required.search_issues missing required argument(s): q"),
         "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn query_parameters_bind_typed_scalar_values() {
+    let params = QueryParameters::from([
+        ("count".to_string(), QueryParameterValue::Integer(7)),
+        ("score".to_string(), QueryParameterValue::Float(9.5)),
+        ("enabled".to_string(), QueryParameterValue::Boolean(true)),
+    ]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[],
+            test_runtime(),
+            "SELECT $count AS count, $score AS score, $enabled AS enabled \
+             WHERE $count = 7 AND $score > 9.0 AND $enabled",
+            params,
+        )
+        .await
+        .expect("integer, float, and boolean parameters should bind"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "count": 7,
+            "score": 9.5,
+            "enabled": true
+        })]
     );
 }
 


### PR DESCRIPTION
## Summary
- Add typed named SQL parameter values to the engine query API.
- Bind those values through DataFusion after SQL relation planning and before execution or explain-plan optimization.
- Preserve existing literal source table-function calls while allowing parameterized calls such as `github.search_issues(q => $query, mode => $mode)`.

## Why
Saved-function SQL needs to execute with bound arguments. This PR adds the generic engine support first, so later saved-function PRs can pass validated arguments through the normal query path.

## Reviewer frame
This is an engine execution-surface change. The important checks are:
- named params bind as typed values
- source table-function argument validation still runs for literal calls
- parameterized source table-function calls reach the same bound-argument model as literal calls
- params are carried through explain and dependent-join fallback paths
- no app, CLI, MCP, or saved-function lifecycle surface is introduced here

## Product intent
This PR is part of the saved-functions stack. The product experience is illustrated here: https://coral-recipes-runtime.coral-1309.chatgpt-team.site

## Validation
- `make rust-checks` on PR4 after restacking PR1-PR4.
- Relevant tests include `query_parameters_bind_typed_scalar_values`, `explain_sql_binds_query_parameters`, and source-scoped table-function parameter binding coverage.
