### PR TITLE
chore(github): simplify CODEOWNERS ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,41 +1,22 @@
-# Default: no new path should silently bypass review.
-* @withcoral/core-maintainers
-
 # Ownership policy, CI, release, build, and repo automation.
-/.github/ @withcoral/repo-ops
+/.github/ @withcoral/core-maintainers
 /.github/CODEOWNERS @withcoral/core-maintainers
-/release-please-config.json @withcoral/repo-ops
-/.release-please-manifest.json @withcoral/repo-ops
-/Makefile @withcoral/repo-ops
-/rust-toolchain.toml @withcoral/repo-ops
+/release-please-config.json @withcoral/core-maintainers
+/.release-please-manifest.json @withcoral/core-maintainers
+/Makefile @withcoral/core-maintainers
+/rust-toolchain.toml @withcoral/core-maintainers
 /Cargo.toml @withcoral/core-maintainers
 /Cargo.lock @withcoral/core-maintainers
-/scripts/ @withcoral/repo-ops
-/xtask/ @withcoral/repo-ops
-/xtask/src/docs/ @withcoral/repo-ops @withcoral/docs
 
 # Project docs.
-AGENTS.md @withcoral/core-maintainers
 /CONTRIBUTING.md @withcoral/core-maintainers
-/SECURITY.md @withcoral/core-maintainers
+/LICENSE @withcoral/core-maintainers
 /README.md @withcoral/core-maintainers
+/SECURITY.md @withcoral/core-maintainers
+AGENTS.md @withcoral/core-maintainers
 
-# Docs.
+# User docs.
 /docs/ @withcoral/docs
 
-# Crates.
-/crates/auth/aws/ @withcoral/sources
-/crates/coral-api/ @withcoral/runtime
-/crates/coral-app/ @withcoral/runtime
-/crates/coral-client/ @withcoral/runtime
-/crates/coral-cli/ @withcoral/cli
-/crates/coral-engine/ @withcoral/engine
-/crates/coral-mcp/ @withcoral/mcp
-/crates/coral-spec/ @withcoral/sources
-
 # Sources
-/sources/ @withcoral/sources
 /sources/community/ @jsummerfield
-
-# UI
-/ui/ @withcoral/ui

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,6 @@
   `xtask/src/sources.rs`, performance checks live in `xtask/src/perf.rs`, and
   skill export lives in `xtask/src/skills.rs`. Release signing and
   notarization automation lives in `xtask/src/release.rs`.
-  `@withcoral/repo-ops` owns the whole tree; add narrower owners only for the
-  workflow-specific paths they actually maintain.
 - `make docs-check` intentionally skips the aggregate community source catalog.
   Any PR may leave that generated page stale so unrelated changes do not fail
   on aggregate community catalog drift; keep docs freshness strict for bundled


### PR DESCRIPTION
## Summary

- Simplify CODEOWNERS by removing the global fallback owner and granular crate/UI/source owner entries.
- Route repo automation and top-level metadata ownership through core maintainers where CODEOWNERS still declares ownership.
- Remove the stale AGENTS.md guidance that referenced `@withcoral/repo-ops` ownership.

## Verification

- `git diff --cached --check`
- CODEOWNERS line-shape check: every active row has an owner token.
- `rg -n "repo-ops" AGENTS.md .github/CODEOWNERS` returned no matches.
- Runtime checks not run; this is GitHub metadata and agent guidance only.
