### PR TITLE
ci(reef): add Chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,55 @@
+name: "Chromatic"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/chromatic.yml"
+      - "reef/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/chromatic.yml"
+      - "reef/**"
+
+permissions:
+  contents: read
+
+jobs:
+  chromatic:
+    name: Run Chromatic
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    defaults:
+      run:
+        working-directory: reef
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: reef/.node-version
+          package-manager-cache: false
+
+      - name: Setup Node with trusted npm cache
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: reef/.node-version
+          cache: npm
+          cache-dependency-path: reef/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Chromatic
+        run: npm exec -- chromatic
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## Summary

Says on the tin. Restoring the chromatic deployment on CI; this won't run from forked PR -- can change in the future if needed.

## Test plan

Branch off this PR, create a new PR, check chromatic runs to completion.

<img width="517" height="169" alt="image" src="https://github.com/user-attachments/assets/d5072b81-5a09-43c7-a364-8a4bfb33cb86" />

Test PR: #1383  https://6a3cfca9530ba1e4c7574952-gvbhpmxhvz.chromatic.com/?path=/docs/wax-animations-pulse--docs