### PR TITLE
feat(reef): wire sources route actions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -74,6 +74,7 @@ jobs:
               - 'apps/ui/**'
             reef-checks:
               - '.github/workflows/validate.yml'
+              - 'crates/coral-api/proto/**'
               - 'apps/reef/**'
               # Reef re-exports the desktop IPC bridge types, so a change there
               # can break the reef type-check.

--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -339,7 +339,8 @@ describe('Architectural Tests', () => {
 
       expect(routeConfig).toContain("layout('routes/app-shell.tsx', [")
       expect(routeConfig).toContain("index('routes/index.tsx')")
-      expect(routeConfig).toContain("route('sources', 'routes/sources.tsx')")
+      expect(routeConfig).toContain("route('sources', 'routes/sources.tsx', [")
+      expect(routeConfig).toContain("route(':sourceName', 'routes/source-detail.tsx')")
       expect(routeConfig).toContain("route('traces', 'routes/traces.tsx')")
       // Settings is gated to the desktop build, but the route entry is still present.
       expect(routeConfig).toContain("route('settings', 'routes/settings.tsx')")
@@ -347,7 +348,7 @@ describe('Architectural Tests', () => {
       // Structural check: every route is nested inside the layout, and settings
       // keeps its desktop-only conditional spread.
       expect(routeConfig).toMatch(
-        /layout\(\s*'routes\/app-shell\.tsx',\s*\[\s*index\('routes\/index\.tsx'\),\s*route\('sources', 'routes\/sources\.tsx'\),\s*route\('traces', 'routes\/traces\.tsx'\),\s*\.\.\.\(\s*isDesktopApp\s*\?\s*\[route\('settings', 'routes\/settings\.tsx'\)\]\s*:\s*\[\]\),?\s*\]\s*\)/,
+        /layout\(\s*'routes\/app-shell\.tsx',\s*\[\s*index\('routes\/index\.tsx'\),\s*route\('sources', 'routes\/sources\.tsx',\s*\[\s*route\(':sourceName', 'routes\/source-detail\.tsx'\),?\s*\]\),\s*route\('traces', 'routes\/traces\.tsx'\),\s*\.\.\.\(\s*isDesktopApp\s*\?\s*\[route\('settings', 'routes\/settings\.tsx'\)\]\s*:\s*\[\]\),?\s*\]\s*\)/,
       )
     })
 

--- a/apps/reef/app/lib/constants.ts
+++ b/apps/reef/app/lib/constants.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_DEV_CORAL_ENDPOINT = 'http://127.0.0.1:1457'
+export const DEFAULT_DEV_CORAL_PORT = '1457'
+export const WORKSPACE = { name: 'default' } as const

--- a/apps/reef/app/lib/coral-clients.ts
+++ b/apps/reef/app/lib/coral-clients.ts
@@ -7,5 +7,3 @@ import { getCoralTransport } from './coral-runtime'
 export function getSourceClient(): Promise<Client<typeof SourceService>> {
   return getCoralTransport().then((transport) => createClient(SourceService, transport))
 }
-
-export const WORKSPACE = { name: 'default' } as const

--- a/apps/reef/app/lib/coral-request.server.ts
+++ b/apps/reef/app/lib/coral-request.server.ts
@@ -1,0 +1,27 @@
+import { createClient } from '@connectrpc/connect'
+import { createGrpcWebTransport } from '@connectrpc/connect-web'
+
+import { SourceService } from '@/generated/coral/v1/sources_pb'
+
+import { DEFAULT_DEV_CORAL_ENDPOINT } from './constants'
+import { isLocalDevOrigin, trimTrailingSlash } from './utils'
+
+export function sourceClientForRequest(request: Request) {
+  return createClient(
+    SourceService,
+    createGrpcWebTransport({ baseUrl: coralEndpointForRequest(request) }),
+  )
+}
+
+export function coralEndpointForRequest(request: Request): string {
+  const configured = process.env.CORAL_ENDPOINT?.trim()
+  if (configured) return trimTrailingSlash(configured)
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('CORAL_ENDPOINT must be set in production')
+  }
+
+  const url = new URL(request.url)
+  if (isLocalDevOrigin(url)) return DEFAULT_DEV_CORAL_ENDPOINT
+  return url.origin
+}

--- a/apps/reef/app/lib/sources.ts
+++ b/apps/reef/app/lib/sources.ts
@@ -13,7 +13,8 @@ import {
   type SourceInfo,
 } from '@/generated/coral/v1/sources_pb'
 
-import { getSourceClient, WORKSPACE } from './coral-clients'
+import { getSourceClient } from './coral-clients'
+import { WORKSPACE } from './constants'
 
 export type SourceOriginLabel = 'bundled' | 'imported' | 'unknown'
 
@@ -23,6 +24,8 @@ export interface CatalogEntry {
   version: string
   installed: boolean
   origin: SourceOriginLabel
+  info?: SourceInfo
+  source?: Source
 }
 
 export interface ResolvedSourceInfo {
@@ -41,6 +44,32 @@ export function originLabel(origin: SourceOrigin): SourceOriginLabel {
   return 'unknown'
 }
 
+export function catalogEntries(discovered: SourceInfo[], installed: Source[]): CatalogEntry[] {
+  const entries = new Map<string, CatalogEntry>()
+  for (const info of discovered) {
+    entries.set(info.name, toCatalogEntry(info))
+  }
+  for (const source of installed) {
+    const existing = entries.get(source.name)
+    if (existing) {
+      existing.installed = true
+      const installedOrigin = originLabel(source.origin)
+      if (installedOrigin !== 'unknown') existing.origin = installedOrigin
+      existing.version = source.version || existing.version
+      continue
+    }
+    entries.set(source.name, {
+      description:
+        source.origin === SourceOrigin.IMPORTED ? 'Imported source' : 'Configured source',
+      installed: true,
+      name: source.name,
+      origin: originLabel(source.origin),
+      version: source.version,
+    })
+  }
+  return [...entries.values()]
+}
+
 function toCatalogEntry(s: SourceInfo): CatalogEntry {
   return {
     name: s.name,
@@ -48,6 +77,7 @@ function toCatalogEntry(s: SourceInfo): CatalogEntry {
     version: s.version,
     installed: s.installed,
     origin: originLabel(s.origin),
+    info: s,
   }
 }
 

--- a/apps/reef/app/lib/utils.ts
+++ b/apps/reef/app/lib/utils.ts
@@ -1,0 +1,16 @@
+import { DEFAULT_DEV_CORAL_PORT } from './constants'
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function isLocalDevOrigin(url: URL): boolean {
+  return (
+    (url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
+    url.port !== DEFAULT_DEV_CORAL_PORT
+  )
+}
+
+export function trimTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value
+}

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -7,7 +7,7 @@ const isDesktopApp = process.env.CORAL_DESKTOP_APP === '1'
 export default [
   layout('routes/app-shell.tsx', [
     index('routes/index.tsx'),
-    route('sources', 'routes/sources.tsx'),
+    route('sources', 'routes/sources.tsx', [route(':sourceName', 'routes/source-detail.tsx')]),
     route('traces', 'routes/traces.tsx'),
     ...(isDesktopApp ? [route('settings', 'routes/settings.tsx')] : []),
   ]),

--- a/apps/reef/app/routes/source-detail.tsx
+++ b/apps/reef/app/routes/source-detail.tsx
@@ -1,0 +1,109 @@
+import { create } from '@bufbuild/protobuf'
+import { useNavigate } from 'react-router'
+
+import type { Route } from './+types/source-detail'
+import { action as sourcesAction, type SourcesActionData } from './sources-action'
+
+import {
+  GetSourceInfoRequestSchema,
+  GetSourceRequestSchema,
+  type Source,
+  type SourceInfo,
+} from '@/generated/coral/v1/sources_pb'
+import { SourceDetailDialog } from '@/views/sources/source-detail'
+import { sourceClientForRequest } from '@/lib/coral-request.server'
+import { WORKSPACE } from '@/lib/constants'
+import { originLabel, type CatalogEntry } from '@/lib/sources'
+import { errorMessage } from '@/lib/utils'
+
+interface SourceDetailRouteData {
+  entry: CatalogEntry
+  loadError: string | null
+}
+
+export async function loader({
+  params,
+  request,
+}: Route.LoaderArgs): Promise<SourceDetailRouteData> {
+  const name = params.sourceName
+  if (!name) {
+    return {
+      entry: sourceDetailEntry('', null, null),
+      loadError: 'Missing source name',
+    }
+  }
+
+  const sourceClient = sourceClientForRequest(request)
+  const [sourceResult, infoResult] = await Promise.allSettled([
+    getInstalledSource(sourceClient, name),
+    getSourceInfo(sourceClient, name),
+  ])
+  const info = infoResult.status === 'fulfilled' ? infoResult.value : null
+
+  const source = sourceResult.status === 'fulfilled' ? sourceResult.value : null
+  const loadError =
+    !source && (!info || info.installed) && sourceResult.status === 'rejected'
+      ? errorMessage(sourceResult.reason)
+      : null
+
+  return {
+    entry: sourceDetailEntry(name, source, info),
+    loadError,
+  }
+}
+
+export async function action(args: Route.ActionArgs): Promise<SourcesActionData | Response> {
+  return sourcesAction(args)
+}
+
+export default function SourceDetailRoute({ params }: Route.ComponentProps) {
+  const navigate = useNavigate()
+  const name = params.sourceName ?? null
+
+  return (
+    <SourceDetailDialog
+      name={name}
+      open
+      onOpenChange={(open) => {
+        if (!open) navigate('/sources')
+      }}
+      onRemoved={() => navigate('/sources')}
+    />
+  )
+}
+
+async function getSourceInfo(
+  sourceClient: ReturnType<typeof sourceClientForRequest>,
+  name: string,
+): Promise<SourceInfo> {
+  const response = await sourceClient.getSourceInfo(
+    create(GetSourceInfoRequestSchema, { name, workspace: WORKSPACE }),
+  )
+  if (!response.sourceInfo) throw new Error(`Source info for ${name} was not found`)
+  return response.sourceInfo
+}
+
+async function getInstalledSource(
+  sourceClient: ReturnType<typeof sourceClientForRequest>,
+  name: string,
+): Promise<Source> {
+  const response = await sourceClient.getSource(
+    create(GetSourceRequestSchema, { name, workspace: WORKSPACE }),
+  )
+  if (!response.source) throw new Error(`Source ${name} was not found`)
+  return response.source
+}
+
+function sourceDetailEntry(name: string, source: Source | null, info: SourceInfo | null) {
+  const origin = source ? originLabel(source.origin) : info ? originLabel(info.origin) : 'unknown'
+  return {
+    description:
+      info?.description ?? (origin === 'imported' ? 'Imported source' : 'Configured source'),
+    info: info ?? undefined,
+    installed: source ? true : (info?.installed ?? false),
+    name: source?.name || info?.name || name,
+    origin,
+    source: source ?? undefined,
+    version: source?.version || info?.version || '',
+  } satisfies CatalogEntry
+}

--- a/apps/reef/app/routes/sources-action.server.test.ts
+++ b/apps/reef/app/routes/sources-action.server.test.ts
@@ -1,0 +1,85 @@
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it } from 'vitest'
+
+import {
+  OAuthCredentialMethodSchema,
+  SourceCredentialMethodSchema,
+  SourceCredentialSchema,
+  SourceConfigCredentialMethodSchema,
+  SourceInfoSchema,
+  SourceInputSpecSchema,
+  SourceOrigin,
+  SourceSchema,
+  SourceSecretInputSchema,
+} from '@/generated/coral/v1/sources_pb'
+
+import { editBindingsFromForm } from './sources-action'
+
+const source = create(SourceSchema, {
+  name: 'github',
+  origin: SourceOrigin.BUNDLED,
+  secrets: [{ key: 'token' }],
+})
+
+const oauthMethod = create(SourceCredentialMethodSchema, {
+  label: 'OAuth',
+  method: {
+    case: 'oauth',
+    value: create(OAuthCredentialMethodSchema, {
+      redirectUri: 'http://127.0.0.1/callback',
+    }),
+  },
+})
+
+const sourceConfigMethod = create(SourceCredentialMethodSchema, {
+  label: 'Paste token',
+  method: {
+    case: 'sourceConfig',
+    value: create(SourceConfigCredentialMethodSchema),
+  },
+})
+
+const sourceInfo = create(SourceInfoSchema, {
+  inputs: [
+    create(SourceInputSpecSchema, {
+      key: 'token',
+      input: {
+        case: 'secret',
+        value: create(SourceSecretInputSchema, {
+          credential: create(SourceCredentialSchema, {
+            methods: [oauthMethod, sourceConfigMethod],
+          }),
+        }),
+      },
+    }),
+  ],
+})
+
+describe('editBindingsFromForm', () => {
+  it('keeps legacy edit secret submissions when no credential method is posted', () => {
+    const formData = new FormData()
+    formData.set('sec:token', 'new-secret')
+
+    expect(editBindingsFromForm(source, sourceInfo, formData)).toEqual([
+      { key: 'token', secret: true, value: 'new-secret' },
+    ])
+  })
+
+  it('does not map an OAuth-selected edit secret field to a source secret binding', () => {
+    const formData = new FormData()
+    formData.set('method:token', '0')
+    formData.set('sec:token', 'should-not-submit')
+
+    expect(editBindingsFromForm(source, sourceInfo, formData)).toEqual([])
+  })
+
+  it('still maps source-config-selected edit secrets to source secret bindings', () => {
+    const formData = new FormData()
+    formData.set('method:token', '1')
+    formData.set('sec:token', 'new-secret')
+
+    expect(editBindingsFromForm(source, sourceInfo, formData)).toEqual([
+      { key: 'token', secret: true, value: 'new-secret' },
+    ])
+  })
+})

--- a/apps/reef/app/routes/sources-action.ts
+++ b/apps/reef/app/routes/sources-action.ts
@@ -1,0 +1,222 @@
+import { create } from '@bufbuild/protobuf'
+import { redirect } from 'react-router'
+
+import {
+  CreateBundledSourceRequestSchema,
+  DeleteSourceRequestSchema,
+  GetSourceInfoRequestSchema,
+  GetSourceRequestSchema,
+  type Source,
+  type SourceInfo,
+  type SourceInputSpec,
+} from '@/generated/coral/v1/sources_pb'
+import { sourceClientForRequest } from '@/lib/coral-request.server'
+import { WORKSPACE } from '@/lib/constants'
+import { type InstallInput, originLabel } from '@/lib/sources'
+import { errorMessage } from '@/lib/utils'
+
+export type SourceActionIntent = 'delete' | 'edit' | 'install'
+
+export type SourcesActionData =
+  | {
+      intent: SourceActionIntent
+      message: string
+      name: string
+      status: 'error'
+    }
+  | undefined
+
+export async function action({
+  request,
+}: {
+  request: Request
+}): Promise<SourcesActionData | Response> {
+  const formData = await request.formData()
+  const intent = formValue(formData, '_intent')
+  const name = formValue(formData, 'name')
+  if (!name) return actionError('install', '', 'Missing source name')
+
+  const sourceClient = sourceClientForRequest(request)
+  try {
+    if (intent === 'install') {
+      const info = await getSourceInfo(sourceClient, name)
+      if (info.installed && originLabel(info.origin) !== 'bundled') {
+        return actionError('install', name, "Imported sources can't be installed here yet")
+      }
+      if (firstOAuthMethodInput(info, formData)) {
+        return actionError('install', name, 'OAuth install is not available in this shell yet')
+      }
+      const missing = firstMissingRequiredInput(info, formData)
+      if (missing) return actionError('install', name, `${missing} is required`)
+      await createBundledSource(sourceClient, name, installBindingsFromForm(info, formData))
+      return redirect('/sources')
+    }
+    if (intent === 'edit') {
+      const source = await getInstalledSource(sourceClient, name)
+      if (originLabel(source.origin) !== 'bundled') {
+        return actionError('edit', name, "Imported sources can't be edited here yet")
+      }
+      const info = await getSourceInfo(sourceClient, name).catch(() => null)
+      await createBundledSource(sourceClient, name, editBindingsFromForm(source, info, formData))
+      return redirect('/sources')
+    }
+    if (intent === 'delete') {
+      await sourceClient.deleteSource(
+        create(DeleteSourceRequestSchema, { name, workspace: WORKSPACE }),
+      )
+      return redirect('/sources')
+    }
+    return actionError('install', name, 'Unknown source action')
+  } catch (error) {
+    return actionError(
+      intent === 'edit' || intent === 'delete' ? intent : 'install',
+      name,
+      errorMessage(error),
+    )
+  }
+}
+
+export function installBindingsFromForm(info: SourceInfo, formData: FormData): InstallInput[] {
+  const bindings: InstallInput[] = []
+  for (const input of info.inputs) {
+    if (input.input.case === 'variable') {
+      const value = formValue(formData, `var:${input.key}`, input.input.value.defaultValue)
+      if (value.length > 0) bindings.push({ key: input.key, secret: false, value })
+      continue
+    }
+    if (input.input.case !== 'secret') continue
+    const methodIndex = Number(formValue(formData, `method:${input.key}`, '0'))
+    const method = input.input.value.credential?.methods[methodIndex]
+    if (method?.method.case === 'oauth') continue
+    const value = formValue(formData, `sec:${input.key}`)
+    if (value.length > 0) bindings.push({ key: input.key, secret: true, value })
+  }
+  return bindings
+}
+
+export function editBindingsFromForm(
+  source: Source,
+  info: SourceInfo | null,
+  formData: FormData,
+): InstallInput[] {
+  if (!info) return bindingsFromInstalledSource(source, formData)
+  const bindings: InstallInput[] = []
+  const variables = new Map(source.variables.map((variable) => [variable.key, variable.value]))
+  for (const input of info.inputs) {
+    if (input.input.case === 'variable') {
+      const existingValue = variables.get(input.key) ?? input.input.value.defaultValue
+      const value = formValue(formData, `var:${input.key}`, existingValue)
+      if (value.length > 0) bindings.push({ key: input.key, secret: false, value })
+      continue
+    }
+    if (input.input.case !== 'secret') continue
+    const method = submittedCredentialMethod(input, formData)
+    if (method?.method.case === 'oauth') continue
+    const value = formValue(formData, `sec:${input.key}`)
+    if (value.length > 0) bindings.push({ key: input.key, secret: true, value })
+  }
+  return bindings
+}
+
+export function firstMissingRequiredInput(info: SourceInfo, formData: FormData): string | null {
+  for (const input of info.inputs) {
+    if (!input.required) continue
+    if (input.input.case === 'variable') {
+      const value = formValue(formData, `var:${input.key}`, input.input.value.defaultValue)
+      if (value.length === 0) return input.key
+      continue
+    }
+    if (input.input.case !== 'secret') continue
+    const methodIndex = Number(formValue(formData, `method:${input.key}`, '0'))
+    const method = input.input.value.credential?.methods[methodIndex]
+    if (!method || method.method.case === 'sourceConfig') {
+      if (formValue(formData, `sec:${input.key}`).length === 0) return input.key
+    }
+  }
+  return null
+}
+
+export function firstOAuthMethodInput(info: SourceInfo, formData: FormData): string | null {
+  for (const input of info.inputs) {
+    if (input.input.case !== 'secret') continue
+    const methodIndex = Number(formValue(formData, `method:${input.key}`, '0'))
+    const method = input.input.value.credential?.methods[methodIndex]
+    if (method?.method.case === 'oauth') return input.key
+  }
+  return null
+}
+
+function bindingsFromInstalledSource(source: Source, formData: FormData): InstallInput[] {
+  const bindings: InstallInput[] = source.variables.map((variable) => ({
+    key: variable.key,
+    secret: false,
+    value: formValue(formData, `var:${variable.key}`, variable.value),
+  }))
+  for (const secret of source.secrets) {
+    const value = formValue(formData, `sec:${secret.key}`)
+    if (value.length > 0) bindings.push({ key: secret.key, secret: true, value })
+  }
+  return bindings
+}
+
+function submittedCredentialMethod(input: SourceInputSpec, formData: FormData) {
+  if (input.input.case !== 'secret') return undefined
+  const submittedMethod = formData.get(`method:${input.key}`)
+  if (typeof submittedMethod !== 'string') return undefined
+  const methodIndex = Number(submittedMethod)
+  if (!Number.isInteger(methodIndex) || methodIndex < 0) return undefined
+  return input.input.value.credential?.methods[methodIndex]
+}
+
+async function getSourceInfo(
+  sourceClient: ReturnType<typeof sourceClientForRequest>,
+  name: string,
+) {
+  const response = await sourceClient.getSourceInfo(
+    create(GetSourceInfoRequestSchema, { name, workspace: WORKSPACE }),
+  )
+  if (!response.sourceInfo) throw new Error(`Source info for ${name} was not found`)
+  return response.sourceInfo
+}
+
+async function getInstalledSource(
+  sourceClient: ReturnType<typeof sourceClientForRequest>,
+  name: string,
+) {
+  const response = await sourceClient.getSource(
+    create(GetSourceRequestSchema, { name, workspace: WORKSPACE }),
+  )
+  if (!response.source) throw new Error(`Source ${name} was not found`)
+  return response.source
+}
+
+async function createBundledSource(
+  sourceClient: ReturnType<typeof sourceClientForRequest>,
+  name: string,
+  bindings: InstallInput[],
+) {
+  const response = await sourceClient.createBundledSource(
+    create(CreateBundledSourceRequestSchema, {
+      name,
+      workspace: WORKSPACE,
+      variables: bindings
+        .filter((binding) => !binding.secret)
+        .map((binding) => ({ key: binding.key, value: binding.value })),
+      secrets: bindings
+        .filter((binding) => binding.secret)
+        .map((binding) => ({ key: binding.key, value: binding.value })),
+    }),
+  )
+  if (!response.source) throw new Error(`Coral did not return installed source ${name}`)
+  return response.source
+}
+
+function actionError(intent: SourceActionIntent, name: string, message: string): SourcesActionData {
+  return { intent, message, name, status: 'error' }
+}
+
+function formValue(formData: FormData, key: string, defaultValue = ''): string {
+  const value = formData.get(key)
+  if (typeof value !== 'string') return defaultValue.trim()
+  return value.trim()
+}

--- a/apps/reef/app/routes/sources-loader.ts
+++ b/apps/reef/app/routes/sources-loader.ts
@@ -1,0 +1,38 @@
+import { create } from '@bufbuild/protobuf'
+
+import type { Route } from './+types/sources'
+
+import {
+  DiscoverSourcesRequestSchema,
+  ListSourcesRequestSchema,
+} from '@/generated/coral/v1/sources_pb'
+import { WORKSPACE } from '@/lib/constants'
+import { sourceClientForRequest } from '@/lib/coral-request.server'
+import { catalogEntries, type CatalogEntry } from '@/lib/sources'
+import { errorMessage } from '@/lib/utils'
+
+export interface SourcesRouteData {
+  entries: CatalogEntry[]
+  loadError: string | null
+}
+
+export async function loader({ request }: Route.LoaderArgs): Promise<SourcesRouteData> {
+  return loadSourcesRouteData(request)
+}
+
+export async function loadSourcesRouteData(request: Request): Promise<SourcesRouteData> {
+  try {
+    return { entries: await listCatalogForRequest(request), loadError: null }
+  } catch (error) {
+    return { entries: [], loadError: errorMessage(error) }
+  }
+}
+
+export async function listCatalogForRequest(request: Request): Promise<CatalogEntry[]> {
+  const sourceClient = sourceClientForRequest(request)
+  const [discovered, installed] = await Promise.all([
+    sourceClient.discoverSources(create(DiscoverSourcesRequestSchema, { workspace: WORKSPACE })),
+    sourceClient.listSources(create(ListSourcesRequestSchema, { workspace: WORKSPACE })),
+  ])
+  return catalogEntries(discovered.sources, installed.sources)
+}

--- a/apps/reef/app/routes/sources.tsx
+++ b/apps/reef/app/routes/sources.tsx
@@ -1,5 +1,39 @@
+import { Outlet, type ShouldRevalidateFunctionArgs } from 'react-router'
+
 import { SourcesIndex } from '@/views/sources/sources-index'
 
+export { action } from './sources-action'
+export { loader } from './sources-loader'
+
+export function shouldRevalidate({
+  currentUrl,
+  defaultShouldRevalidate,
+  formMethod,
+  nextUrl,
+}: ShouldRevalidateFunctionArgs) {
+  if (formMethod && formMethod !== 'GET') return defaultShouldRevalidate
+  if (
+    currentUrl.pathname !== nextUrl.pathname &&
+    isSourcesDetailNavigation(currentUrl.pathname, nextUrl.pathname)
+  ) {
+    return false
+  }
+  return defaultShouldRevalidate
+}
+
+function isSourcesDetailNavigation(currentPath: string, nextPath: string) {
+  const sourcesPath = '/sources'
+  const sourceDetailPath = /^\/sources\/[^/]+$/
+  const currentIsSources = currentPath === sourcesPath || sourceDetailPath.test(currentPath)
+  const nextIsSources = nextPath === sourcesPath || sourceDetailPath.test(nextPath)
+  return currentIsSources && nextIsSources
+}
+
 export default function SourcesRoute() {
-  return <SourcesIndex />
+  return (
+    <>
+      <SourcesIndex />
+      <Outlet />
+    </>
+  )
 }


### PR DESCRIPTION
Add the `sources` route, with loader and actions.  
The view shows nothing yet, but the data is there.  
  
\-----  
Constraint: Keep this branch as route/data plumbing plus an empty page shell so the UI implementation can review separately.

Rejected: Include source cards and dialogs here | That would make the lower PR too large and mix routing/data with UI implementation.

Confidence: high

Scope-risk: moderate

Directive: Keep full source-page rendering, OAuth UI, provider assets, and toast polish in the upstack implementation branch.

Tested: npm run check --prefix reef; npm run typecheck --prefix reef; npm test --prefix reef -- --run --project unit app/lib/source-form.test.ts; npm test --prefix reef -- --run --project architecture