### PR TITLE
feat(reef): use route data for sources page

### DIFF
--- a/apps/reef/app/lib/sources.ts
+++ b/apps/reef/app/lib/sources.ts
@@ -1,22 +1,76 @@
-import { create } from '@bufbuild/protobuf'
-
 import {
-  CreateBundledSourceRequestSchema,
-  CreateBundledSourceWithOAuthRequestSchema,
-  DeleteSourceRequestSchema,
-  DiscoverSourcesRequestSchema,
-  GetSourceInfoRequestSchema,
-  GetSourceRequestSchema,
   SourceOrigin,
-  type OAuthCredentialRetrieval,
+  type OAuthCredentialMethod,
   type Source,
+  type SourceCredentialMethod,
   type SourceInfo,
+  type SourceInputSpec,
 } from '@/generated/coral/v1/sources_pb'
 
-import { getSourceClient } from './coral-clients'
-import { WORKSPACE } from './constants'
-
 export type SourceOriginLabel = 'bundled' | 'imported' | 'unknown'
+
+export interface CatalogSourceBinding {
+  key: string
+  value: string
+}
+
+export interface CatalogSource {
+  name: string
+  origin: SourceOriginLabel
+  secrets: CatalogSourceBinding[]
+  variables: CatalogSourceBinding[]
+  version: string
+}
+
+export interface CatalogSourceInputSpec {
+  hint: string
+  input:
+    | {
+        case: 'variable'
+        value: {
+          defaultValue: string
+        }
+      }
+    | {
+        case: 'secret'
+        value: {
+          credential?: {
+            methods: CatalogSourceCredentialMethod[]
+          }
+        }
+      }
+    | { case: undefined; value?: undefined }
+  key: string
+  required: boolean
+}
+
+export interface CatalogSourceCredentialMethod {
+  description: string
+  hint: string
+  label: string
+  method:
+    | {
+        case: 'sourceConfig'
+        value: Record<string, never>
+      }
+    | {
+        case: 'oauth'
+        value: CatalogOAuthCredentialMethod
+      }
+    | { case: undefined; value?: undefined }
+}
+
+export interface CatalogOAuthCredentialMethod {
+  client?: {
+    id?: {
+      defaultValue: string
+      input: string
+    }
+    secret?: {
+      input: string
+    }
+  }
+}
 
 export interface CatalogEntry {
   name: string
@@ -24,18 +78,8 @@ export interface CatalogEntry {
   version: string
   installed: boolean
   origin: SourceOriginLabel
-  info?: SourceInfo
-  source?: Source
-}
-
-export interface ResolvedSourceInfo {
-  info: SourceInfo
-}
-
-export interface InstallInput {
-  key: string
-  value: string
-  secret: boolean
+  inputSpecs?: CatalogSourceInputSpec[]
+  source?: CatalogSource
 }
 
 export function originLabel(origin: SourceOrigin): SourceOriginLabel {
@@ -70,6 +114,20 @@ export function catalogEntries(discovered: SourceInfo[], installed: Source[]): C
   return [...entries.values()]
 }
 
+export function toCatalogSource(source: Source): CatalogSource {
+  return {
+    name: source.name,
+    origin: originLabel(source.origin),
+    secrets: source.secrets.map(({ key, value }) => ({ key, value })),
+    variables: source.variables.map(({ key, value }) => ({ key, value })),
+    version: source.version,
+  }
+}
+
+export function toCatalogSourceInputSpecs(info: SourceInfo): CatalogSourceInputSpec[] {
+  return info.inputs.map(toCatalogSourceInputSpec)
+}
+
 function toCatalogEntry(s: SourceInfo): CatalogEntry {
   return {
     name: s.name,
@@ -77,116 +135,96 @@ function toCatalogEntry(s: SourceInfo): CatalogEntry {
     version: s.version,
     installed: s.installed,
     origin: originLabel(s.origin),
-    info: s,
+    inputSpecs: toCatalogSourceInputSpecs(s),
   }
 }
 
-export async function discoverBundled(): Promise<CatalogEntry[]> {
-  const sourceClient = await getSourceClient()
-  const resp = await sourceClient.discoverSources(
-    create(DiscoverSourcesRequestSchema, { workspace: WORKSPACE }),
-  )
-  return resp.sources.map(toCatalogEntry)
-}
-
-export async function getSourceInfo(name: string): Promise<ResolvedSourceInfo> {
-  const sourceClient = await getSourceClient()
-  const resp = await sourceClient.getSourceInfo(
-    create(GetSourceInfoRequestSchema, { workspace: WORKSPACE, name }),
-  )
-  if (!resp.sourceInfo) {
-    throw new Error(`source '${name}' has no info`)
+function toCatalogSourceInputSpec(input: SourceInputSpec): CatalogSourceInputSpec {
+  const base = {
+    hint: input.hint,
+    key: input.key,
+    required: input.required,
   }
-  return { info: resp.sourceInfo }
-}
-
-export async function getInstalledSource(name: string): Promise<Source> {
-  const sourceClient = await getSourceClient()
-  const resp = await sourceClient.getSource(
-    create(GetSourceRequestSchema, { workspace: WORKSPACE, name }),
-  )
-  if (!resp.source) throw new Error(`source '${name}' not found`)
-  return resp.source
-}
-
-export async function deleteSource(name: string): Promise<void> {
-  const sourceClient = await getSourceClient()
-  await sourceClient.deleteSource(create(DeleteSourceRequestSchema, { workspace: WORKSPACE, name }))
-}
-
-function splitBindings(inputs: InstallInput[]) {
-  const variables = inputs.filter((i) => !i.secret).map((i) => ({ key: i.key, value: i.value }))
-  const secrets = inputs.filter((i) => i.secret).map((i) => ({ key: i.key, value: i.value }))
-  return { variables, secrets }
-}
-
-export async function createBundledSource(name: string, inputs: InstallInput[]): Promise<Source> {
-  const sourceClient = await getSourceClient()
-  const { variables, secrets } = splitBindings(inputs)
-  const resp = await sourceClient.createBundledSource(
-    create(CreateBundledSourceRequestSchema, {
-      workspace: WORKSPACE,
-      name,
-      variables,
-      secrets,
-    }),
-  )
-  if (!resp.source) throw new Error(`createBundledSource returned no source`)
-  return resp.source
-}
-
-export interface OAuthFlowCallbacks {
-  onAuthorization?: (event: {
-    inputKey: string
-    authorizationUrl: string
-    expiresInSeconds: bigint
-    userCode: string
-    verificationUri: string
-    verificationUriComplete: string
-  }) => void
-  onCompleted?: (event: { inputKey: string; metadata: Map<string, string> }) => void
-}
-
-/** Run the bundled-source OAuth install stream and deliver progress events. */
-export async function createBundledSourceWithOAuth(
-  name: string,
-  inputs: InstallInput[],
-  oauthRetrievals: OAuthCredentialRetrieval[],
-  callbacks: OAuthFlowCallbacks = {},
-): Promise<Source> {
-  const sourceClient = await getSourceClient()
-  const { variables, secrets } = splitBindings(inputs)
-  const stream = sourceClient.createBundledSourceWithOAuth(
-    create(CreateBundledSourceWithOAuthRequestSchema, {
-      workspace: WORKSPACE,
-      name,
-      variables,
-      secrets,
-      oauthCredentialRetrievals: oauthRetrievals,
-    }),
-  )
-  for await (const response of stream) {
-    const event = response.event
-    if (event.case === 'source') return event.value
-    if (event.case === 'oauthAuthorization') {
-      callbacks.onAuthorization?.({
-        inputKey: event.value.inputKey,
-        authorizationUrl: event.value.authorizationUrl,
-        expiresInSeconds: event.value.expiresInSeconds,
-        userCode: event.value.userCode,
-        verificationUri: event.value.verificationUri,
-        verificationUriComplete: event.value.verificationUriComplete,
-      })
-      // Keep the device-code prompt visible if a fast backend streams the
-      // completion event immediately after authorization starts.
-      if (event.value.userCode) {
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-      }
-    } else if (event.case === 'oauthCompleted') {
-      const metadata = new Map<string, string>()
-      for (const item of event.value.metadata) metadata.set(item.key, item.value)
-      callbacks.onCompleted?.({ inputKey: event.value.inputKey, metadata })
+  if (input.input.case === 'variable') {
+    return {
+      ...base,
+      input: {
+        case: 'variable',
+        value: {
+          defaultValue: input.input.value.defaultValue,
+        },
+      },
     }
   }
-  throw new Error(`install stream ended without a source event`)
+  if (input.input.case === 'secret') {
+    return {
+      ...base,
+      input: {
+        case: 'secret',
+        value: {
+          credential: input.input.value.credential
+            ? {
+                methods: input.input.value.credential.methods.map(toCatalogCredentialMethod),
+              }
+            : undefined,
+        },
+      },
+    }
+  }
+  return {
+    ...base,
+    input: { case: undefined },
+  }
+}
+
+function toCatalogCredentialMethod(method: SourceCredentialMethod): CatalogSourceCredentialMethod {
+  const base = {
+    description: method.description,
+    hint: method.hint,
+    label: method.label,
+  }
+  if (method.method.case === 'sourceConfig') {
+    return {
+      ...base,
+      method: {
+        case: 'sourceConfig',
+        value: {},
+      },
+    }
+  }
+  if (method.method.case === 'oauth') {
+    return {
+      ...base,
+      method: {
+        case: 'oauth',
+        value: toCatalogOAuthCredentialMethod(method.method.value),
+      },
+    }
+  }
+  return {
+    ...base,
+    method: { case: undefined },
+  }
+}
+
+function toCatalogOAuthCredentialMethod(
+  method: OAuthCredentialMethod,
+): CatalogOAuthCredentialMethod {
+  return {
+    client: method.client
+      ? {
+          id: method.client.id
+            ? {
+                defaultValue: method.client.id.defaultValue,
+                input: method.client.id.input,
+              }
+            : undefined,
+          secret: method.client.secret
+            ? {
+                input: method.client.secret.input,
+              }
+            : undefined,
+        }
+      : undefined,
+  }
 }

--- a/apps/reef/app/routes/index.tsx
+++ b/apps/reef/app/routes/index.tsx
@@ -1,5 +1,10 @@
+import type { Route } from './+types/index'
+
 import { SourcesIndex } from '@/views/sources/sources-index'
 
-export default function AppIndex() {
-  return <SourcesIndex />
+export { action } from './sources-action'
+export { loader } from './sources-loader'
+
+export default function AppIndex({ loaderData }: Route.ComponentProps) {
+  return <SourcesIndex entries={loaderData.entries} loadError={loaderData.loadError} />
 }

--- a/apps/reef/app/routes/source-detail.tsx
+++ b/apps/reef/app/routes/source-detail.tsx
@@ -1,5 +1,4 @@
 import { create } from '@bufbuild/protobuf'
-import { useNavigate } from 'react-router'
 
 import type { Route } from './+types/source-detail'
 import { action as sourcesAction, type SourcesActionData } from './sources-action'
@@ -10,10 +9,15 @@ import {
   type Source,
   type SourceInfo,
 } from '@/generated/coral/v1/sources_pb'
-import { SourceDetailDialog } from '@/views/sources/source-detail'
+import { SourceDetailView } from '@/views/sources/source-detail'
 import { sourceClientForRequest } from '@/lib/coral-request.server'
 import { WORKSPACE } from '@/lib/constants'
-import { originLabel, type CatalogEntry } from '@/lib/sources'
+import {
+  originLabel,
+  toCatalogSource,
+  toCatalogSourceInputSpecs,
+  type CatalogEntry,
+} from '@/lib/sources'
 import { errorMessage } from '@/lib/utils'
 
 interface SourceDetailRouteData {
@@ -56,20 +60,8 @@ export async function action(args: Route.ActionArgs): Promise<SourcesActionData 
   return sourcesAction(args)
 }
 
-export default function SourceDetailRoute({ params }: Route.ComponentProps) {
-  const navigate = useNavigate()
-  const name = params.sourceName ?? null
-
-  return (
-    <SourceDetailDialog
-      name={name}
-      open
-      onOpenChange={(open) => {
-        if (!open) navigate('/sources')
-      }}
-      onRemoved={() => navigate('/sources')}
-    />
-  )
+export default function SourceDetailRoute({ actionData, loaderData }: Route.ComponentProps) {
+  return <SourceDetailView actionData={actionData} loaderData={loaderData} />
 }
 
 async function getSourceInfo(
@@ -99,11 +91,11 @@ function sourceDetailEntry(name: string, source: Source | null, info: SourceInfo
   return {
     description:
       info?.description ?? (origin === 'imported' ? 'Imported source' : 'Configured source'),
-    info: info ?? undefined,
+    inputSpecs: info ? toCatalogSourceInputSpecs(info) : undefined,
     installed: source ? true : (info?.installed ?? false),
     name: source?.name || info?.name || name,
     origin,
-    source: source ?? undefined,
+    source: source ? toCatalogSource(source) : undefined,
     version: source?.version || info?.version || '',
   } satisfies CatalogEntry
 }

--- a/apps/reef/app/routes/sources-action.ts
+++ b/apps/reef/app/routes/sources-action.ts
@@ -12,7 +12,7 @@ import {
 } from '@/generated/coral/v1/sources_pb'
 import { sourceClientForRequest } from '@/lib/coral-request.server'
 import { WORKSPACE } from '@/lib/constants'
-import { type InstallInput, originLabel } from '@/lib/sources'
+import { originLabel } from '@/lib/sources'
 import { errorMessage } from '@/lib/utils'
 
 export type SourceActionIntent = 'delete' | 'edit' | 'install'
@@ -25,6 +25,12 @@ export type SourcesActionData =
       status: 'error'
     }
   | undefined
+
+interface InstallInput {
+  key: string
+  value: string
+  secret: boolean
+}
 
 export async function action({
   request,

--- a/apps/reef/app/routes/sources.test.ts
+++ b/apps/reef/app/routes/sources.test.ts
@@ -1,0 +1,44 @@
+import type { ShouldRevalidateFunctionArgs } from 'react-router'
+import { describe, expect, it } from 'vitest'
+
+import { shouldRevalidate } from './sources'
+
+function revalidationArgs(
+  overrides: Partial<ShouldRevalidateFunctionArgs>,
+): ShouldRevalidateFunctionArgs {
+  return {
+    currentParams: {},
+    currentUrl: new URL('http://localhost/sources'),
+    defaultShouldRevalidate: true,
+    nextParams: {},
+    nextUrl: new URL('http://localhost/sources/github'),
+    ...overrides,
+  }
+}
+
+describe('sources shouldRevalidate', () => {
+  it('skips parent catalog reloads for normal source detail navigation', () => {
+    expect(
+      shouldRevalidate(
+        revalidationArgs({
+          currentUrl: new URL('http://localhost/sources'),
+          defaultShouldRevalidate: true,
+          nextUrl: new URL('http://localhost/sources/github'),
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('revalidates the catalog after source mutations even when the action redirects to /sources', () => {
+    expect(
+      shouldRevalidate(
+        revalidationArgs({
+          currentUrl: new URL('http://localhost/sources/github'),
+          defaultShouldRevalidate: false,
+          formMethod: 'POST',
+          nextUrl: new URL('http://localhost/sources'),
+        }),
+      ),
+    ).toBe(true)
+  })
+})

--- a/apps/reef/app/routes/sources.tsx
+++ b/apps/reef/app/routes/sources.tsx
@@ -1,5 +1,7 @@
 import { Outlet, type ShouldRevalidateFunctionArgs } from 'react-router'
 
+import type { Route } from './+types/sources'
+
 import { SourcesIndex } from '@/views/sources/sources-index'
 
 export { action } from './sources-action'
@@ -11,7 +13,7 @@ export function shouldRevalidate({
   formMethod,
   nextUrl,
 }: ShouldRevalidateFunctionArgs) {
-  if (formMethod && formMethod !== 'GET') return defaultShouldRevalidate
+  if (formMethod && formMethod.toUpperCase() !== 'GET') return true
   if (
     currentUrl.pathname !== nextUrl.pathname &&
     isSourcesDetailNavigation(currentUrl.pathname, nextUrl.pathname)
@@ -29,10 +31,10 @@ function isSourcesDetailNavigation(currentPath: string, nextPath: string) {
   return currentIsSources && nextIsSources
 }
 
-export default function SourcesRoute() {
+export default function SourcesRoute({ loaderData }: Route.ComponentProps) {
   return (
     <>
-      <SourcesIndex />
+      <SourcesIndex entries={loaderData.entries} loadError={loaderData.loadError} />
       <Outlet />
     </>
   )

--- a/apps/reef/app/views/sources/source-detail.test.tsx
+++ b/apps/reef/app/views/sources/source-detail.test.tsx
@@ -1,0 +1,38 @@
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { SourceDetailView } from './source-detail'
+
+describe('SourceDetailView', () => {
+  it('renders the source dialog from route data passed by the adapter', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          element: (
+            <SourceDetailView
+              actionData={undefined}
+              loaderData={{
+                entry: {
+                  description: 'Query GitHub data.',
+                  installed: false,
+                  name: 'github',
+                  origin: 'bundled',
+                  version: '1.0.0',
+                },
+                loadError: null,
+              }}
+            />
+          ),
+          path: '/sources/:sourceName',
+        },
+      ],
+      { initialEntries: ['/sources/github'] },
+    )
+
+    const screen = await render(<RouterProvider router={router} />)
+
+    await expect.element(screen.getByRole('dialog')).toBeVisible()
+    await expect.element(screen.getByRole('button', { name: 'Add source' })).toBeVisible()
+  })
+})

--- a/apps/reef/app/views/sources/source-detail.tsx
+++ b/apps/reef/app/views/sources/source-detail.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-
-import type { Source, SourceInfo, SourceInputSpec } from '@/generated/coral/v1/sources_pb'
+import { useEffect, useMemo, useState } from 'react'
+import { Form, useActionData, useNavigate, useNavigation } from 'react-router'
 
 import { Container as ButtonContainer } from '@/wax/components/button/container'
 import { Icon as ButtonIcon } from '@/wax/components/button/icon'
@@ -8,49 +7,95 @@ import { Text as ButtonText } from '@/wax/components/button/text'
 import { Dialog } from '@/wax/components'
 import { Icon } from '@/wax/components/icon'
 import { TextInput } from '@/wax/components/inputs/text'
-import { addToast } from '@/wax/components/toast'
 import { Typography } from '@/wax/components/typography'
 
-import {
-  createBundledSource,
-  deleteSource,
-  getInstalledSource,
-  getSourceInfo,
-  originLabel,
-  type InstallInput,
-  type SourceOriginLabel,
+import type {
+  CatalogEntry,
+  CatalogSource,
+  CatalogSourceInputSpec,
+  SourceOriginLabel,
 } from '@/lib/sources'
+import type { action as sourceDetailAction } from '@/routes/source-detail'
+import type { SourcesActionData } from '@/routes/sources-action'
 
 import { ProviderLogo } from './provider-logo'
 import * as styles from './source-detail.css'
+import { SourceInstallDialog } from './source-install'
 
 const SECRET_PLACEHOLDER = '••••••••'
 
 const IMPORTED_EDIT_NOTICE =
   "Imported sources can't be edited here yet — re-import the source spec to change its credentials."
 
+export function SourceDetailView({
+  actionData,
+  loaderData,
+}: {
+  actionData: SourcesActionData | undefined
+  loaderData: {
+    entry: CatalogEntry
+    loadError: string | null
+  }
+}) {
+  const navigate = useNavigate()
+  const navigation = useNavigation()
+  const actionError = actionData?.status === 'error' ? actionData : null
+  const pendingIntent = formValue(navigation.formData, '_intent')
+  const pendingName = formValue(navigation.formData, 'name')
+  const entry = loaderData.entry
+
+  if (!entry.installed) {
+    return (
+      <SourceInstallDialog
+        actionError={
+          actionError && actionError.intent === 'install' && actionError.name === entry.name
+            ? actionError.message
+            : loaderData.loadError
+        }
+        entry={entry}
+        open
+        onOpenChange={(open) => {
+          if (!open) navigate('/sources')
+        }}
+        submitting={pendingName === entry.name && pendingIntent === 'install'}
+      />
+    )
+  }
+
+  return (
+    <SourceDetailDialog
+      entry={entry}
+      loadError={loaderData.loadError}
+      open
+      onOpenChange={(open) => {
+        if (!open) navigate('/sources')
+      }}
+    />
+  )
+}
+
 export function SourceDetailDialog({
-  name,
+  entry,
+  loadError,
   open,
   onOpenChange,
-  onRemoved,
 }: {
-  name: string | null
+  entry: CatalogEntry | null
+  loadError: string | null
   open: boolean
   onOpenChange: (open: boolean) => void
-  onRemoved: (name: string) => void
 }) {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Backdrop />
         <Dialog.Popup size="l">
-          {name ? (
+          {entry ? (
             <SourceDetailDialogContent
-              key={name}
-              name={name}
+              key={entry.name}
+              entry={entry}
+              loadError={loadError}
               onClose={() => onOpenChange(false)}
-              onRemoved={onRemoved}
             />
           ) : null}
         </Dialog.Popup>
@@ -60,68 +105,33 @@ export function SourceDetailDialog({
 }
 
 function SourceDetailDialogContent({
-  name,
+  entry,
+  loadError,
   onClose,
-  onRemoved,
 }: {
-  name: string
+  entry: CatalogEntry
+  loadError: string | null
   onClose: () => void
-  onRemoved: (name: string) => void
 }) {
-  const [source, setSource] = useState<Source | null>(null)
-  const [sourceInfo, setSourceInfo] = useState<SourceInfo | null>(null)
-  const [loadError, setLoadError] = useState<string | null>(null)
   const [confirmingRemove, setConfirmingRemove] = useState(false)
-  const [deleting, setDeleting] = useState(false)
   const [drafts, setDrafts] = useState<Record<string, string>>({})
-  const [saving, setSaving] = useState(false)
+  const { actionError, pendingIntent, removeError } = useSourceDetailActionState(entry, loadError)
 
-  const refresh = useCallback(async () => {
-    // getSourceInfo no longer depends on the installed origin, so fetch both in
-    // parallel. Source info is best-effort (imported sources may not have it).
-    const [installedResult, infoResult] = await Promise.allSettled([
-      getInstalledSource(name),
-      getSourceInfo(name),
-    ])
-
-    if (installedResult.status === 'rejected') {
-      const reason = installedResult.reason
-      setSource(null)
-      setSourceInfo(null)
-      setLoadError(reason instanceof Error ? reason.message : String(reason))
-      return
-    }
-
-    setSource(installedResult.value)
-    setSourceInfo(infoResult.status === 'fulfilled' ? infoResult.value.info : null)
-    setDrafts({})
-    setLoadError(null)
-  }, [name])
+  const source = entry.source ?? null
+  const inputSpecs = entry.inputSpecs
+  const deleting = pendingIntent === 'delete'
+  const saving = pendingIntent === 'edit'
+  const editable = source ? source.origin === 'bundled' : false
 
   useEffect(() => {
-    void refresh()
-  }, [refresh])
-
-  const onDelete = useCallback(async () => {
-    setDeleting(true)
-    try {
-      await deleteSource(name)
-      addToast('success', { title: `Removed ${name}` })
-      setConfirmingRemove(false)
-      onRemoved(name)
-    } catch (e) {
-      addToast('error', { title: e instanceof Error ? e.message : String(e) })
-      setDeleting(false)
-    }
-  }, [name, onRemoved])
-
-  const editable = source ? originLabel(source.origin) === 'bundled' : false
+    if (removeError) setConfirmingRemove(true)
+  }, [removeError])
 
   const hasChanges = useMemo(() => {
     if (!source) return false
-    if (sourceInfo) {
+    if (inputSpecs) {
       const variables = new Map(source.variables.map((v) => [v.key, v.value]))
-      for (const input of sourceInfo.inputs) {
+      for (const input of inputSpecs) {
         if (input.input.case === 'variable') {
           const draft = drafts[`var:${input.key}`]
           const current = variables.get(input.key) ?? input.input.value.defaultValue ?? ''
@@ -142,158 +152,117 @@ function SourceDetailDialogContent({
       if (draft !== undefined && draft.trim().length > 0) return true
     }
     return false
-  }, [drafts, source, sourceInfo])
+  }, [drafts, source, inputSpecs])
 
-  async function save() {
-    if (!source) return
-    setSaving(true)
-    try {
-      const bindings: InstallInput[] = []
-      if (sourceInfo) {
-        const variables = new Map(source.variables.map((v) => [v.key, v.value]))
-        for (const input of sourceInfo.inputs) {
-          if (input.input.case === 'variable') {
-            const value = (
-              drafts[`var:${input.key}`] ??
-              variables.get(input.key) ??
-              input.input.value.defaultValue ??
-              ''
-            ).trim()
-            if (value.length > 0) bindings.push({ key: input.key, value, secret: false })
-            continue
-          }
-          if (input.input.case !== 'secret') continue
-          const draft = drafts[`sec:${input.key}`]
-          if (draft === undefined) continue
-          const trimmed = draft.trim()
-          if (trimmed.length > 0) {
-            bindings.push({ key: input.key, value: trimmed, secret: true })
-          }
-        }
-      } else {
-        bindings.push(
-          ...source.variables.map((v) => ({
-            key: v.key,
-            value: drafts[`var:${v.key}`] ?? v.value,
-            secret: false,
-          })),
-        )
-        for (const s of source.secrets) {
-          const draft = drafts[`sec:${s.key}`]
-          if (draft === undefined) continue
-          const trimmed = draft.trim()
-          if (trimmed.length > 0) {
-            bindings.push({ key: s.key, value: trimmed, secret: true })
-          }
-        }
-      }
-      await createBundledSource(name, bindings)
-      onClose()
-      addToast('success', { title: `Updated ${name}` })
-    } catch (e) {
-      addToast('error', { title: e instanceof Error ? e.message : String(e) })
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  const origin = source ? originLabel(source.origin) : null
+  const origin = source ? source.origin : entry.origin
 
   return (
     <>
-      <div className={styles.header}>
-        <ProviderLogo name={name} size="large" />
-        <div className={styles.headerText}>
-          <Dialog.Title className={styles.headerTitleRow}>
-            <Typography.HeadingMedium as="span" className={styles.headerTitle}>
-              {name}
-            </Typography.HeadingMedium>
-            {origin ? <span className={styles.headerPill}>{originBadgeLabel(origin)}</span> : null}
-          </Dialog.Title>
-          <Dialog.Description render={<div />}>
-            <Typography.BodySmall variant="secondary">
-              {source?.version ? `v${source.version}` : 'Configured source'}
-            </Typography.BodySmall>
-          </Dialog.Description>
+      <Form method="post">
+        <input type="hidden" name="_intent" value="edit" />
+        <input type="hidden" name="name" value={entry.name} />
+
+        <div className={styles.header}>
+          <ProviderLogo name={entry.name} size="large" />
+          <div className={styles.headerText}>
+            <Dialog.Title className={styles.headerTitleRow}>
+              <Typography.HeadingMedium as="span" className={styles.headerTitle}>
+                {entry.name}
+              </Typography.HeadingMedium>
+              {origin ? (
+                <span className={styles.headerPill}>{originBadgeLabel(origin)}</span>
+              ) : null}
+            </Dialog.Title>
+            <Dialog.Description render={<div />}>
+              <Typography.BodySmall variant="secondary">
+                {source?.version || entry.version
+                  ? `v${source?.version || entry.version}`
+                  : 'Configured source'}
+              </Typography.BodySmall>
+            </Dialog.Description>
+          </div>
         </div>
-      </div>
 
-      {loadError ? (
-        <div className={styles.alertError}>
-          <Icon name="CircleAlert" size="14" color="inherit" />
-          <Typography.BodySmall>{loadError}</Typography.BodySmall>
-        </div>
-      ) : null}
+        {!source ? (
+          <div className={styles.alertError}>
+            <Icon name="CircleAlert" size="14" color="inherit" />
+            <Typography.BodySmall>Installed source details are unavailable.</Typography.BodySmall>
+          </div>
+        ) : null}
 
-      {!source && !loadError ? (
-        <Typography.BodySmall variant="tertiary">Loading…</Typography.BodySmall>
-      ) : !source ? null : sourceInfo ? (
-        <SourceInfoBindings
-          disabled={!editable || saving || deleting}
-          drafts={drafts}
-          editable={editable}
-          onSecretBlur={(key) => {
-            const draftKey = `sec:${key}`
-            if (drafts[draftKey] !== '') return
-            setDrafts((previous) => {
-              const next = { ...previous }
-              delete next[draftKey]
-              return next
-            })
-          }}
-          onSecretFocus={(key) => {
-            const draftKey = `sec:${key}`
-            if (drafts[draftKey] !== undefined) return
-            setDrafts((previous) => ({ ...previous, [draftKey]: '' }))
-          }}
-          onValueChange={(key, value, secret) =>
-            setDrafts((previous) => ({ ...previous, [`${secret ? 'sec' : 'var'}:${key}`]: value }))
-          }
-          source={source}
-          sourceInfo={sourceInfo}
-        />
-      ) : source.variables.length === 0 && source.secrets.length === 0 ? (
-        <section className={styles.section}>
-          <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
-          <Typography.BodySmall variant="tertiary">No bindings recorded.</Typography.BodySmall>
-        </section>
-      ) : (
-        <FallbackBindings
-          disabled={!editable || saving || deleting}
-          drafts={drafts}
-          editable={editable}
-          onValueChange={(draftKey, value) =>
-            setDrafts((previous) => ({ ...previous, [draftKey]: value }))
-          }
-          source={source}
-        />
-      )}
+        {actionError ? (
+          <div className={styles.alertError}>
+            <Icon name="CircleAlert" size="14" color="inherit" />
+            <Typography.BodySmall>{actionError}</Typography.BodySmall>
+          </div>
+        ) : null}
 
-      <Dialog.Actions>
-        <ButtonContainer
-          variant="bare"
-          size="32"
-          onClick={() => setConfirmingRemove(true)}
-          disabled={saving || deleting}
-        >
-          <ButtonText>Remove</ButtonText>
-        </ButtonContainer>
-        {editable && hasChanges ? (
-          <ButtonContainer
-            variant="primary"
-            size="32"
-            onClick={() => void save()}
-            disabled={saving}
-          >
-            {saving ? <ButtonIcon name="Loader" /> : null}
-            <ButtonText>{saving ? 'Saving…' : 'Save changes'}</ButtonText>
-          </ButtonContainer>
+        {!source ? null : inputSpecs ? (
+          <SourceInputBindings
+            disabled={!editable || saving || deleting}
+            drafts={drafts}
+            editable={editable}
+            inputSpecs={inputSpecs}
+            onSecretBlur={(key) => {
+              const draftKey = `sec:${key}`
+              if (drafts[draftKey] !== '') return
+              setDrafts((previous) => {
+                const next = { ...previous }
+                delete next[draftKey]
+                return next
+              })
+            }}
+            onSecretFocus={(key) => {
+              const draftKey = `sec:${key}`
+              if (drafts[draftKey] !== undefined) return
+              setDrafts((previous) => ({ ...previous, [draftKey]: '' }))
+            }}
+            onValueChange={(key, value, secret) =>
+              setDrafts((previous) => ({
+                ...previous,
+                [`${secret ? 'sec' : 'var'}:${key}`]: value,
+              }))
+            }
+            source={source}
+          />
+        ) : source.variables.length === 0 && source.secrets.length === 0 ? (
+          <section className={styles.section}>
+            <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
+            <Typography.BodySmall variant="tertiary">No bindings recorded.</Typography.BodySmall>
+          </section>
         ) : (
-          <ButtonContainer variant="primary" size="32" onClick={onClose}>
-            <ButtonText>Close</ButtonText>
-          </ButtonContainer>
+          <InstalledBindings
+            disabled={!editable || saving || deleting}
+            drafts={drafts}
+            editable={editable}
+            onValueChange={(draftKey, value) =>
+              setDrafts((previous) => ({ ...previous, [draftKey]: value }))
+            }
+            source={source}
+          />
         )}
-      </Dialog.Actions>
+
+        <Dialog.Actions>
+          <ButtonContainer
+            variant="bare"
+            size="32"
+            onClick={() => setConfirmingRemove(true)}
+            disabled={!source || saving || deleting}
+          >
+            <ButtonText>Remove</ButtonText>
+          </ButtonContainer>
+          {editable && hasChanges ? (
+            <ButtonContainer variant="primary" size="32" type="submit" disabled={saving}>
+              {saving ? <ButtonIcon name="Loader" /> : null}
+              <ButtonText>{saving ? 'Saving…' : 'Save changes'}</ButtonText>
+            </ButtonContainer>
+          ) : (
+            <ButtonContainer variant="primary" size="32" onClick={onClose}>
+              <ButtonText>Close</ButtonText>
+            </ButtonContainer>
+          )}
+        </Dialog.Actions>
+      </Form>
 
       <Dialog.Root open={confirmingRemove} onOpenChange={(open) => setConfirmingRemove(open)}>
         <Dialog.Portal>
@@ -301,9 +270,9 @@ function SourceDetailDialogContent({
           <Dialog.Popup size="m">
             <RemoveConfirmation
               deleting={deleting}
-              name={name}
+              error={removeError}
+              name={entry.name}
               onCancel={() => setConfirmingRemove(false)}
-              onDelete={onDelete}
             />
           </Dialog.Popup>
         </Dialog.Portal>
@@ -314,17 +283,20 @@ function SourceDetailDialogContent({
 
 function RemoveConfirmation({
   deleting,
+  error,
   name,
   onCancel,
-  onDelete,
 }: {
   deleting: boolean
+  error?: string | null
   name: string
   onCancel: () => void
-  onDelete: () => void
 }) {
   return (
-    <>
+    <Form method="post">
+      <input type="hidden" name="_intent" value="delete" />
+      <input type="hidden" name="name" value={name} />
+
       <div className={styles.removeConfirmText}>
         <Dialog.Title>Remove {name}?</Dialog.Title>
         <Dialog.Description>
@@ -332,25 +304,26 @@ function RemoveConfirmation({
           reinstall later, but you'll need to re-supply any secrets.
         </Dialog.Description>
       </div>
+      {error ? (
+        <div className={styles.alertError}>
+          <Icon name="CircleAlert" size="14" color="inherit" />
+          <Typography.BodySmall>{error}</Typography.BodySmall>
+        </div>
+      ) : null}
       <Dialog.Actions className={styles.removeConfirmActions}>
         <ButtonContainer variant="secondary" size="32" onClick={onCancel} disabled={deleting}>
           <ButtonText>Cancel</ButtonText>
         </ButtonContainer>
-        <ButtonContainer
-          variant="destructive"
-          size="32"
-          onClick={() => void onDelete()}
-          disabled={deleting}
-        >
+        <ButtonContainer variant="destructive" size="32" type="submit" disabled={deleting}>
           {deleting ? <ButtonIcon name="Loader" /> : null}
           <ButtonText>{deleting ? 'Removing…' : 'Remove'}</ButtonText>
         </ButtonContainer>
       </Dialog.Actions>
-    </>
+    </Form>
   )
 }
 
-function FallbackBindings({
+function InstalledBindings({
   disabled,
   drafts,
   editable,
@@ -361,7 +334,7 @@ function FallbackBindings({
   drafts: Record<string, string>
   editable: boolean
   onValueChange: (draftKey: string, value: string) => void
-  source: Source
+  source: CatalogSource
 }) {
   return (
     <section className={styles.section}>
@@ -376,6 +349,7 @@ function FallbackBindings({
             <div key={draftKey} className={styles.fieldItem}>
               <Typography.Body className={styles.fieldLabel}>{v.key}</Typography.Body>
               <TextInput
+                name={draftKey}
                 value={drafts[draftKey] ?? v.value}
                 onChange={(value) => onValueChange(draftKey, value)}
                 placeholder={v.key}
@@ -389,6 +363,7 @@ function FallbackBindings({
           return (
             <div key={draftKey} className={styles.fieldItem}>
               <Typography.Body className={styles.fieldLabel}>{s.key}</Typography.Body>
+              <input type="hidden" name={draftKey} value={drafts[draftKey] ?? ''} />
               <TextInput
                 type="password"
                 value={drafts[draftKey] ?? ''}
@@ -404,29 +379,57 @@ function FallbackBindings({
   )
 }
 
-function SourceInfoBindings({
+function useSourceDetailActionState(entry: CatalogEntry, loadError: string | null) {
+  const actionData = useActionData<typeof sourceDetailAction>()
+  const navigation = useNavigation()
+  const actionError = actionData?.status === 'error' ? actionData : null
+  const pendingIntent = formValue(navigation.formData, '_intent')
+  const pendingName = formValue(navigation.formData, 'name')
+
+  return {
+    actionError:
+      actionError && actionError.intent === 'edit' && actionError.name === entry.name
+        ? actionError.message
+        : loadError,
+    pendingIntent:
+      pendingName === entry.name && (pendingIntent === 'delete' || pendingIntent === 'edit')
+        ? pendingIntent
+        : null,
+    removeError:
+      actionError && actionError.intent === 'delete' && actionError.name === entry.name
+        ? actionError.message
+        : null,
+  }
+}
+
+function formValue(formData: FormData | undefined, key: string): string | null {
+  const value = formData?.get(key)
+  return typeof value === 'string' ? value : null
+}
+
+function SourceInputBindings({
   disabled,
   drafts,
   editable,
+  inputSpecs,
   onSecretBlur,
   onSecretFocus,
   onValueChange,
   source,
-  sourceInfo,
 }: {
   disabled: boolean
   drafts: Record<string, string>
   editable: boolean
+  inputSpecs: CatalogSourceInputSpec[]
   onSecretBlur: (key: string) => void
   onSecretFocus: (key: string) => void
   onValueChange: (key: string, value: string, secret: boolean) => void
-  source: Source
-  sourceInfo: SourceInfo
+  source: CatalogSource
 }) {
   const variables = useMemo(() => new Map(source.variables.map((v) => [v.key, v.value])), [source])
   const configuredSecrets = useMemo(() => new Set(source.secrets.map((s) => s.key)), [source])
 
-  if (sourceInfo.inputs.length === 0) {
+  if (inputSpecs.length === 0) {
     return (
       <section className={styles.section}>
         <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
@@ -442,7 +445,7 @@ function SourceInfoBindings({
         <Typography.BodySmall variant="tertiary">{IMPORTED_EDIT_NOTICE}</Typography.BodySmall>
       ) : null}
       <div className={styles.fieldGroup}>
-        {sourceInfo.inputs.map((input) => (
+        {inputSpecs.map((input) => (
           <SourceInfoInputRow
             key={input.key}
             configuredSecret={configuredSecrets.has(input.key)}
@@ -473,7 +476,7 @@ function SourceInfoInputRow({
   configuredSecret: boolean
   disabled: boolean
   draft: string | undefined
-  input: SourceInputSpec
+  input: CatalogSourceInputSpec
   onSecretBlur: (key: string) => void
   onSecretFocus: (key: string) => void
   onValueChange: (key: string, value: string, secret: boolean) => void
@@ -484,6 +487,7 @@ function SourceInfoInputRow({
     return (
       <Field input={input}>
         <TextInput
+          name={`var:${input.key}`}
           value={draft ?? resolved}
           onChange={(next) => onValueChange(input.key, next, false)}
           placeholder={resolved || input.key}
@@ -497,6 +501,7 @@ function SourceInfoInputRow({
 
   return (
     <Field input={input}>
+      <input type="hidden" name={`sec:${input.key}`} value={draft ?? ''} />
       <TextInput
         type="password"
         value={draft ?? (configuredSecret ? SECRET_PLACEHOLDER : '')}
@@ -510,7 +515,7 @@ function SourceInfoInputRow({
   )
 }
 
-function Field({ input, children }: { input: SourceInputSpec; children: React.ReactNode }) {
+function Field({ input, children }: { input: CatalogSourceInputSpec; children: React.ReactNode }) {
   return (
     <div className={styles.fieldItem}>
       <Typography.Body className={styles.fieldLabel}>{input.key}</Typography.Body>

--- a/apps/reef/app/views/sources/source-install.tsx
+++ b/apps/reef/app/views/sources/source-install.tsx
@@ -1,13 +1,6 @@
-import { create } from '@bufbuild/protobuf'
 import classNames from 'classnames'
-import { useEffect, useMemo, useState } from 'react'
-
-import {
-  OAuthCredentialRetrievalSchema,
-  type OAuthCredentialMethod,
-  type SourceCredentialMethod,
-  type SourceInputSpec,
-} from '@/generated/coral/v1/sources_pb'
+import { useMemo, useState } from 'react'
+import { Form } from 'react-router'
 
 import { Container as ButtonContainer } from '@/wax/components/button/container'
 import { Icon as ButtonIcon } from '@/wax/components/button/icon'
@@ -15,60 +8,48 @@ import { Text as ButtonText } from '@/wax/components/button/text'
 import { Dialog } from '@/wax/components'
 import { Icon } from '@/wax/components/icon'
 import { TextInput } from '@/wax/components/inputs/text'
-import { addToast } from '@/wax/components/toast'
 import { Typography } from '@/wax/components/typography'
 
 import { Markdown } from '@/components/markdown'
-import {
-  createBundledSource,
-  createBundledSourceWithOAuth,
-  getSourceInfo,
-  type InstallInput,
-  type ResolvedSourceInfo,
+import type {
+  CatalogEntry,
+  CatalogOAuthCredentialMethod,
+  CatalogSourceCredentialMethod,
+  CatalogSourceInputSpec,
 } from '@/lib/sources'
 import { toSentenceCase } from '@/utils/to-sentence-case'
 
 import { ProviderLogo } from './provider-logo'
 import * as styles from './source-install.css'
 
-type InstallProgress =
-  | { kind: 'idle' }
-  | { kind: 'busy' }
-  | {
-      kind: 'awaiting-oauth'
-      inputKey: string
-      authorizationUrl: string
-      userCode: string
-      verificationUri: string
-      verificationUriComplete: string
-    }
-  | { kind: 'oauth-completed'; inputKey: string }
-
 function formatFieldName(key: string): string {
   return toSentenceCase(key.replace(/_/g, ' '))
 }
 
 export function SourceInstallDialog({
-  name,
+  actionError,
+  entry,
   open,
   onOpenChange,
-  onInstalled,
+  submitting,
 }: {
-  name: string | null
+  actionError?: string | null
+  entry: CatalogEntry | null
   open: boolean
   onOpenChange: (open: boolean) => void
-  onInstalled: (name: string) => void
+  submitting?: boolean
 }) {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Backdrop />
         <Dialog.Popup size="l">
-          {name ? (
+          {entry ? (
             <SourceInstallDialogContent
-              name={name}
+              actionError={actionError}
+              entry={entry}
               onCancel={() => onOpenChange(false)}
-              onInstalled={onInstalled}
+              submitting={submitting ?? false}
             />
           ) : null}
         </Dialog.Popup>
@@ -78,39 +59,27 @@ export function SourceInstallDialog({
 }
 
 function SourceInstallDialogContent({
-  name,
+  actionError,
+  entry,
   onCancel,
-  onInstalled,
+  submitting,
 }: {
-  name: string
+  actionError?: string | null
+  entry: CatalogEntry
   onCancel: () => void
-  onInstalled: (name: string) => void
+  submitting: boolean
 }) {
-  const [resolved, setResolved] = useState<ResolvedSourceInfo | null>(null)
-  const [loadError, setLoadError] = useState<string | null>(null)
   const [values, setValues] = useState<Record<string, string>>({})
   const [methodChoices, setMethodChoices] = useState<Record<string, number>>({})
-  const [progress, setProgress] = useState<InstallProgress>({ kind: 'idle' })
-  const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
-    let cancelled = false
-    getSourceInfo(name)
-      .then((info) => !cancelled && setResolved(info))
-      .catch((e) => !cancelled && setLoadError(e instanceof Error ? e.message : String(e)))
-    return () => {
-      cancelled = true
-    }
-  }, [name])
+  const inputSpecs = entry.inputSpecs
+  const inputs: CatalogSourceInputSpec[] = inputSpecs ?? []
 
-  const inputs: SourceInputSpec[] = resolved?.info.inputs ?? []
-  const busy = progress.kind !== 'idle'
-
-  const effectiveChoice = (input: SourceInputSpec): number => methodChoices[input.key] ?? 0
+  const effectiveChoice = (input: CatalogSourceInputSpec): number => methodChoices[input.key] ?? 0
 
   const canSubmit = useMemo(() => {
-    if (!resolved) return false
-    return resolved.info.inputs.every((input) => {
+    if (!inputSpecs) return false
+    return inputSpecs.every((input) => {
       if (!input.required) return true
       const choice = methodChoices[input.key] ?? 0
       if (input.input.case === 'variable') {
@@ -128,172 +97,75 @@ function SourceInstallDialogContent({
       }
       return true
     })
-  }, [resolved, values, methodChoices])
-
-  async function submit() {
-    if (!resolved) return
-    setError(null)
-    setProgress({ kind: 'busy' })
-
-    try {
-      const bindings: InstallInput[] = []
-      const retrievalProtos = []
-
-      for (const input of inputs) {
-        if (input.input.case === 'variable') {
-          const value = (values[input.key] ?? input.input.value.defaultValue ?? '').trim()
-          if (value.length > 0) bindings.push({ key: input.key, value, secret: false })
-          continue
-        }
-        if (input.input.case !== 'secret') continue
-
-        const method = input.input.value.credential?.methods[effectiveChoice(input)]
-        if (!method || method.method.case === 'sourceConfig') {
-          const value = (values[input.key] ?? '').trim()
-          if (value.length > 0) bindings.push({ key: input.key, value, secret: true })
-          continue
-        }
-        if (method.method.case === 'oauth') {
-          retrievalProtos.push(
-            create(OAuthCredentialRetrievalSchema, {
-              inputKey: input.key,
-              methodIndex: effectiveChoice(input),
-              credentialInputs: oauthCredentialInputs(method.method.value, values),
-            }),
-          )
-        }
-      }
-
-      const callbacks = {
-        onAuthorization: (event: {
-          inputKey: string
-          authorizationUrl: string
-          userCode: string
-          verificationUri: string
-          verificationUriComplete: string
-        }) => {
-          setProgress({
-            kind: 'awaiting-oauth',
-            inputKey: event.inputKey,
-            authorizationUrl: event.authorizationUrl,
-            userCode: event.userCode,
-            verificationUri: event.verificationUri,
-            verificationUriComplete: event.verificationUriComplete,
-          })
-          window.open(event.authorizationUrl, '_blank', 'noopener,noreferrer')
-        },
-        onCompleted: (event: { inputKey: string }) => {
-          setProgress({ kind: 'oauth-completed', inputKey: event.inputKey })
-        },
-      }
-
-      if (retrievalProtos.length === 0) {
-        await createBundledSource(name, bindings)
-      } else {
-        await createBundledSourceWithOAuth(name, bindings, retrievalProtos, callbacks)
-      }
-
-      addToast('neutral', {
-        title: `Configured ${name}`,
-        description: 'Credentials were saved but not verified.',
-      })
-      onInstalled(name)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-      setProgress({ kind: 'idle' })
-    }
-  }
+  }, [inputSpecs, values, methodChoices])
 
   return (
-    <>
+    <Form method="post">
+      <input type="hidden" name="_intent" value="install" />
+      <input type="hidden" name="name" value={entry.name} />
+
       <div className={styles.header}>
-        <ProviderLogo name={name} size="large" />
+        <ProviderLogo name={entry.name} size="large" />
         <div className={styles.headerText}>
           <Dialog.Title className={styles.headerTitleRow}>
             <Typography.HeadingMedium as="span" className={styles.headerTitle}>
-              {name}
+              {entry.name}
             </Typography.HeadingMedium>
             <span className={styles.headerPill}>Core</span>
           </Dialog.Title>
           <Dialog.Description render={<div />}>
-            <Markdown>{resolved?.info.description ?? 'Officially supported by Coral.'}</Markdown>
+            <Markdown>{entry.description}</Markdown>
           </Dialog.Description>
         </div>
       </div>
 
-      {loadError ? (
+      {!inputSpecs ? (
         <div className={classNames(styles.alertBox, styles.alertError)}>
           <Icon color="inherit" name="CircleAlert" size="14" />
-          <Typography.BodySmall>{loadError}</Typography.BodySmall>
+          <Typography.BodySmall>Source metadata is unavailable.</Typography.BodySmall>
+        </div>
+      ) : inputs.length === 0 ? (
+        <Typography.BodySmall variant="tertiary">
+          No configuration needed — click Add source to install.
+        </Typography.BodySmall>
+      ) : (
+        <div className={styles.fieldGroup}>
+          {inputs.map((input) => (
+            <InputRow
+              key={input.key}
+              input={input}
+              methodIndex={effectiveChoice(input)}
+              values={values}
+              disabled={submitting}
+              onValueChange={(key, value) => setValues((p) => ({ ...p, [key]: value }))}
+              onMethodChange={(key, index) => setMethodChoices((p) => ({ ...p, [key]: index }))}
+            />
+          ))}
+        </div>
+      )}
+
+      {actionError ? (
+        <div className={classNames(styles.alertBox, styles.alertError)}>
+          <Icon color="inherit" name="CircleAlert" size="14" />
+          <Typography.BodySmall>{actionError}</Typography.BodySmall>
         </div>
       ) : null}
 
-      {resolved === null && !loadError ? (
-        <Typography.BodySmall variant="tertiary">Loading…</Typography.BodySmall>
-      ) : !resolved ? null : (
-        <>
-          {inputs.length === 0 ? (
-            <Typography.BodySmall variant="tertiary">
-              No configuration needed — click Add source to install.
-            </Typography.BodySmall>
-          ) : (
-            <div className={styles.fieldGroup}>
-              {inputs.map((input) => (
-                <InputRow
-                  key={input.key}
-                  input={input}
-                  methodIndex={effectiveChoice(input)}
-                  values={values}
-                  disabled={busy}
-                  onValueChange={(key, value) => setValues((p) => ({ ...p, [key]: value }))}
-                  onMethodChange={(key, index) => setMethodChoices((p) => ({ ...p, [key]: index }))}
-                />
-              ))}
-            </div>
-          )}
-
-          {progress.kind === 'awaiting-oauth' ? (
-            <OAuthProgress
-              authorizationUrl={progress.authorizationUrl}
-              inputKey={progress.inputKey}
-              userCode={progress.userCode}
-              verificationUri={progress.verificationUri}
-              verificationUriComplete={progress.verificationUriComplete}
-            />
-          ) : null}
-          {progress.kind === 'oauth-completed' ? (
-            <div className={styles.oauthBox}>
-              <Icon name="CircleCheck" size="16" color="success" />
-              <Typography.BodySmall variant="primary">
-                {progress.inputKey} authorized. Finishing install…
-              </Typography.BodySmall>
-            </div>
-          ) : null}
-
-          {error ? (
-            <div className={classNames(styles.alertBox, styles.alertError)}>
-              <Icon color="inherit" name="CircleAlert" size="14" />
-              <Typography.BodySmall>{error}</Typography.BodySmall>
-            </div>
-          ) : null}
-
-          <Dialog.Actions>
-            <ButtonContainer disabled={busy} onClick={onCancel} size="32" variant="bare">
-              <ButtonText>Cancel</ButtonText>
-            </ButtonContainer>
-            <ButtonContainer
-              disabled={busy || !canSubmit}
-              onClick={() => void submit()}
-              size="32"
-              variant="primary"
-            >
-              {busy ? <ButtonIcon name="Loader" /> : null}
-              <ButtonText>{busyLabel(progress)}</ButtonText>
-            </ButtonContainer>
-          </Dialog.Actions>
-        </>
-      )}
-    </>
+      <Dialog.Actions>
+        <ButtonContainer disabled={submitting} onClick={onCancel} size="32" variant="bare">
+          <ButtonText>Cancel</ButtonText>
+        </ButtonContainer>
+        <ButtonContainer
+          disabled={submitting || !canSubmit}
+          size="32"
+          type="submit"
+          variant="primary"
+        >
+          {submitting ? <ButtonIcon name="Loader" /> : null}
+          <ButtonText>{submitting ? 'Adding…' : 'Add source'}</ButtonText>
+        </ButtonContainer>
+      </Dialog.Actions>
+    </Form>
   )
 }
 
@@ -305,7 +177,7 @@ function InputRow({
   onValueChange,
   onMethodChange,
 }: {
-  input: SourceInputSpec
+  input: CatalogSourceInputSpec
   methodIndex: number
   values: Record<string, string>
   disabled: boolean
@@ -317,6 +189,7 @@ function InputRow({
     return (
       <Field input={input}>
         <TextInput
+          name={`var:${input.key}`}
           value={values[input.key] ?? def}
           onChange={(value) => onValueChange(input.key, value)}
           placeholder={def || formatFieldName(input.key)}
@@ -334,6 +207,10 @@ function InputRow({
 
   return (
     <Field input={input} fullWidth={methods.length > 1 || isOAuth(selected)}>
+      {methods.length > 0 ? (
+        <input type="hidden" name={`method:${input.key}`} value={methodIndex} />
+      ) : null}
+
       {methods.length > 1 ? (
         <div className={styles.methodTabs}>
           {methods.map((m, i) => (
@@ -353,6 +230,7 @@ function InputRow({
 
       {!selected || selected.method.case === 'sourceConfig' ? (
         <TextInput
+          name={`sec:${input.key}`}
           type="password"
           value={values[input.key] ?? ''}
           onChange={(value) => onValueChange(input.key, value)}
@@ -376,7 +254,7 @@ function Field({
   children,
   fullWidth,
 }: {
-  input: SourceInputSpec
+  input: CatalogSourceInputSpec
   children: React.ReactNode
   fullWidth?: boolean
 }) {
@@ -395,7 +273,7 @@ function OAuthFields({
   disabled,
   onValueChange,
 }: {
-  oauth: OAuthCredentialMethod
+  oauth: CatalogOAuthCredentialMethod
   values: Record<string, string>
   disabled: boolean
   onValueChange: (key: string, value: string) => void
@@ -404,7 +282,7 @@ function OAuthFields({
   if (fields.length === 0) {
     return (
       <Typography.BodySmall variant="secondary">
-        Click Add source to open your browser and complete sign-in.
+        OAuth installation will be handled by the route action.
       </Typography.BodySmall>
     )
   }
@@ -426,64 +304,14 @@ function OAuthFields({
   )
 }
 
-function OAuthProgress({
-  authorizationUrl,
-  inputKey,
-  userCode,
-  verificationUri,
-  verificationUriComplete,
-}: {
-  authorizationUrl: string
-  inputKey: string
-  userCode: string
-  verificationUri: string
-  verificationUriComplete: string
-}) {
-  const link = verificationUriComplete || authorizationUrl
-  const displayUri = verificationUri || authorizationUrl
-
-  return (
-    <div className={styles.oauthBox}>
-      <Icon name="Loader" size="16" color="secondary" />
-      <div>
-        <Typography.BodySmall variant="primary">
-          Waiting for {formatFieldName(inputKey)} authorization in your browser…
-        </Typography.BodySmall>
-        {userCode ? (
-          <>
-            <Typography.BodySmall variant="secondary">
-              Enter code <code className={styles.oauthCode}>{userCode}</code> at{' '}
-              <a href={link} target="_blank" rel="noopener noreferrer">
-                {displayUri}
-              </a>
-              .
-            </Typography.BodySmall>
-            <Typography.BodySmall variant="tertiary">
-              If the new tab didn't open, use the link above.
-            </Typography.BodySmall>
-          </>
-        ) : (
-          <Typography.BodySmall variant="tertiary">
-            If the new tab didn't open,{' '}
-            <a href={authorizationUrl} target="_blank" rel="noopener noreferrer">
-              click here to open it
-            </a>
-            .
-          </Typography.BodySmall>
-        )}
-      </div>
-    </div>
-  )
-}
-
-function methodLabel(method: SourceCredentialMethod, index: number): string {
+function methodLabel(method: CatalogSourceCredentialMethod, index: number): string {
   if (method.label) return method.label
   if (method.method.case === 'sourceConfig') return 'Paste token'
   if (method.method.case === 'oauth') return 'OAuth'
   return `Method ${index + 1}`
 }
 
-function isOAuth(method: SourceCredentialMethod | undefined): boolean {
+function isOAuth(method: CatalogSourceCredentialMethod | undefined): boolean {
   return method?.method.case === 'oauth'
 }
 
@@ -494,7 +322,7 @@ interface OAuthInput {
   required: boolean
 }
 
-function oauthInputs(oauth: OAuthCredentialMethod): OAuthInput[] {
+function oauthInputs(oauth: CatalogOAuthCredentialMethod): OAuthInput[] {
   const out: OAuthInput[] = []
   const id = oauth.client?.id
   if (id?.input) {
@@ -512,24 +340,12 @@ function oauthInputs(oauth: OAuthCredentialMethod): OAuthInput[] {
   return out
 }
 
-function oauthMethodReady(oauth: OAuthCredentialMethod, values: Record<string, string>): boolean {
-  return oauthInputs(oauth)
-    .filter((input) => input.required)
-    .every(({ key }) => (values[key] ?? '').trim().length > 0)
-}
-
-function oauthCredentialInputs(
-  oauth: OAuthCredentialMethod,
+function oauthMethodReady(
+  oauth: CatalogOAuthCredentialMethod,
   values: Record<string, string>,
-): { key: string; value: string }[] {
-  return oauthInputs(oauth)
-    .map(({ key }) => ({ key, value: (values[key] ?? '').trim() }))
-    .filter((entry) => entry.value.length > 0)
-}
-
-function busyLabel(progress: InstallProgress): string {
-  if (progress.kind === 'busy') return 'Adding…'
-  if (progress.kind === 'awaiting-oauth') return 'Awaiting OAuth…'
-  if (progress.kind === 'oauth-completed') return 'Finishing…'
-  return 'Add source'
+): boolean {
+  return oauthInputs(oauth).every((input) => {
+    if (!input.required) return true
+    return (values[input.key] ?? input.defaultValue ?? '').trim().length > 0
+  })
 }

--- a/apps/reef/app/views/sources/sources-index.test.tsx
+++ b/apps/reef/app/views/sources/sources-index.test.tsx
@@ -1,0 +1,55 @@
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type { CatalogEntry } from '@/lib/sources'
+
+import { SourcesIndex } from './sources-index'
+
+function renderSourcesIndex(entries: CatalogEntry[]) {
+  const router = createMemoryRouter(
+    [
+      {
+        element: <SourcesIndex entries={entries} />,
+        path: '/',
+      },
+    ],
+    { initialEntries: ['/'] },
+  )
+
+  return render(<RouterProvider router={router} />)
+}
+
+describe('SourcesIndex', () => {
+  it('routes installable sources through the source detail route', async () => {
+    const screen = await renderSourcesIndex([
+      {
+        description: 'Query GitHub data.',
+        installed: false,
+        name: 'github',
+        origin: 'bundled',
+        version: '1.0.0',
+      },
+    ])
+
+    await expect
+      .element(screen.getByRole('link', { name: /github/i }))
+      .toHaveAttribute('href', '/sources/github')
+  })
+
+  it('encodes source names before routing through the source detail route', async () => {
+    const screen = await renderSourcesIndex([
+      {
+        description: 'Reserved URL characters should stay inside the source name.',
+        installed: false,
+        name: 'foo?bar',
+        origin: 'imported',
+        version: '1.0.0',
+      },
+    ])
+
+    await expect
+      .element(screen.getByRole('link', { name: /foo\?bar/i }))
+      .toHaveAttribute('href', '/sources/foo%3Fbar')
+  })
+})

--- a/apps/reef/app/views/sources/sources-index.tsx
+++ b/apps/reef/app/views/sources/sources-index.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useRevalidator } from 'react-router'
 
 import { Button, Card, ScrollArea } from '@/wax/components'
 import { Icon } from '@/wax/components/icon'
@@ -8,22 +9,23 @@ import { Typography } from '@/wax/components/typography'
 import { EmptyPage } from '@/components/empty-page'
 import { ErrorBanner } from '@/components/error-banner'
 import { SOURCE_CATEGORY_ORDER, getCategoryForSource } from '@/lib/source-categories'
-import { discoverBundled, type CatalogEntry } from '@/lib/sources'
+import type { CatalogEntry } from '@/lib/sources'
 
 import { ProviderLogo } from './provider-logo'
-import { SourceDetailDialog } from './source-detail'
-import { SourceInstallDialog } from './source-install'
 import * as styles from './sources-index.css'
 
 type IndexEntry = CatalogEntry
 
-export function SourcesIndex() {
-  const [bundled, setBundled] = useState<CatalogEntry[] | null>(null)
-  const [error, setError] = useState<string | null>(null)
+export function SourcesIndex({
+  entries,
+  loadError = null,
+}: {
+  entries: CatalogEntry[]
+  loadError?: string | null
+}) {
   const [search, setSearch] = useState('')
-  const [installingName, setInstallingName] = useState<string | null>(null)
-  const [detailName, setDetailName] = useState<string | null>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
+  const revalidator = useRevalidator()
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -39,24 +41,11 @@ export function SourcesIndex() {
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [])
 
-  const refresh = useCallback(async () => {
-    try {
-      setBundled(await discoverBundled())
-      setError(null)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    }
-  }, [])
-
-  useEffect(() => {
-    void refresh()
-  }, [refresh])
-
-  const loading = bundled === null && !error
+  const loading = revalidator.state === 'loading' && entries.length === 0 && !loadError
 
   const allEntries = useMemo<IndexEntry[]>(
-    () => (bundled ?? []).toSorted((a, b) => a.name.localeCompare(b.name)),
-    [bundled],
+    () => entries.toSorted((a, b) => a.name.localeCompare(b.name)),
+    [entries],
   )
 
   const filtered = useMemo(() => {
@@ -92,125 +81,88 @@ export function SourcesIndex() {
     return ordered
   }, [filtered])
 
-  const onPick = (entry: IndexEntry) => {
-    if (entry.installed) {
-      setDetailName(entry.name)
-    } else {
-      setInstallingName(entry.name)
-    }
-  }
-
-  const onInstalled = useCallback(() => {
-    setInstallingName(null)
-    void refresh()
-  }, [refresh])
-
-  const onRemoved = useCallback(() => {
-    setDetailName(null)
-    void refresh()
-  }, [refresh])
-
   return (
-    <>
-      <section className={styles.root} aria-label="Coral sources">
-        <div className={styles.header}>
-          <div className={styles.headerInner}>
-            <div className={styles.headerText}>
-              <Typography.HeadingLarge as="h1">Sources</Typography.HeadingLarge>
-              <Typography.Body variant="secondary">
-                Manage sources for this workspace
-              </Typography.Body>
-            </div>
-
-            <div className={styles.searchBar}>
-              <TextInput
-                ref={searchInputRef}
-                value={search}
-                onChange={setSearch}
-                placeholder="Search sources…"
-                icon="Search"
-              />
-            </div>
+    <section className={styles.root} aria-label="Coral sources">
+      <div className={styles.header}>
+        <div className={styles.headerInner}>
+          <div className={styles.headerText}>
+            <Typography.HeadingLarge as="h1">Sources</Typography.HeadingLarge>
+            <Typography.Body variant="secondary">
+              Connect external systems to query their data from Coral. Click a source to install or
+              inspect it.
+            </Typography.Body>
           </div>
-        </div>
 
-        {error ? (
-          <div className={styles.statusPanel}>
-            <ErrorBanner
-              title="Couldn't load sources"
-              message={error}
-              onRetry={() => window.location.reload()}
+          <div className={styles.searchBar}>
+            <TextInput
+              ref={searchInputRef}
+              value={search}
+              onChange={setSearch}
+              placeholder="Search sources…"
+              icon="Search"
             />
           </div>
-        ) : null}
+        </div>
+      </div>
 
-        <ScrollArea.Container className={styles.resultsScroll} constrainWidth fillContent>
-          <div className={styles.resultsContent}>
-            {loading ? (
-              <div className={styles.loadingState}>
-                <Icon name="Loader" size="16" color="tertiary" className={styles.spinAnimation} />
-                <Typography.BodySmall variant="tertiary">Loading sources…</Typography.BodySmall>
-              </div>
-            ) : null}
+      {loadError ? (
+        <div className={styles.statusPanel}>
+          <ErrorBanner
+            title="Couldn't load sources"
+            message={loadError}
+            onRetry={() => revalidator.revalidate()}
+          />
+        </div>
+      ) : null}
 
-            {!loading && !error && allEntries.length === 0 ? (
-              <EmptyPage
-                description="Check the Coral build for a populated catalog."
-                iconName="Plug"
-                title="No sources available"
-              />
-            ) : null}
+      <ScrollArea.Container className={styles.resultsScroll} constrainWidth fillContent>
+        <div className={styles.resultsContent}>
+          {loading ? (
+            <div className={styles.loadingState}>
+              <Icon name="Loader" size="16" color="tertiary" className={styles.spinAnimation} />
+              <Typography.BodySmall variant="tertiary">Loading sources…</Typography.BodySmall>
+            </div>
+          ) : null}
 
-            {connected.length > 0 ? (
-              <Section title="Configured" count={connected.length}>
-                <SourceCardList entries={connected} onPick={onPick} />
-              </Section>
-            ) : null}
+          {!loading && !loadError && allEntries.length === 0 ? (
+            <EmptyPage
+              description="Check the Coral build for a populated catalog."
+              iconName="Plug"
+              title="No sources available"
+            />
+          ) : null}
 
-            {sections.map((section) => (
-              <Section key={section.key} title={section.label} count={section.entries.length}>
-                <SourceCardList entries={section.entries} onPick={onPick} />
-              </Section>
-            ))}
+          {connected.length > 0 ? (
+            <Section title="Configured" count={connected.length}>
+              <SourceCardList entries={connected} />
+            </Section>
+          ) : null}
 
-            {connected.length === 0 &&
-            sections.length === 0 &&
-            !loading &&
-            !error &&
-            allEntries.length > 0 ? (
-              <EmptyPage
-                action={
-                  <Button.TextButton onClick={() => setSearch('')} variant="secondary">
-                    Clear search
-                  </Button.TextButton>
-                }
-                description="Try adjusting your search."
-                iconName="Search"
-                title="No matching sources"
-              />
-            ) : null}
-          </div>
-        </ScrollArea.Container>
-      </section>
+          {sections.map((section) => (
+            <Section key={section.key} title={section.label} count={section.entries.length}>
+              <SourceCardList entries={section.entries} />
+            </Section>
+          ))}
 
-      <SourceInstallDialog
-        name={installingName}
-        open={installingName !== null}
-        onOpenChange={(open) => {
-          if (!open) setInstallingName(null)
-        }}
-        onInstalled={onInstalled}
-      />
-
-      <SourceDetailDialog
-        name={detailName}
-        open={detailName !== null}
-        onOpenChange={(open) => {
-          if (!open) setDetailName(null)
-        }}
-        onRemoved={onRemoved}
-      />
-    </>
+          {connected.length === 0 &&
+          sections.length === 0 &&
+          !loading &&
+          !loadError &&
+          allEntries.length > 0 ? (
+            <EmptyPage
+              action={
+                <Button.TextButton onClick={() => setSearch('')} variant="secondary">
+                  Clear search
+                </Button.TextButton>
+              }
+              description="Try adjusting your search."
+              iconName="Search"
+              title="No matching sources"
+            />
+          ) : null}
+        </div>
+      </ScrollArea.Container>
+    </section>
   )
 }
 
@@ -234,24 +186,20 @@ function Section({
   )
 }
 
-function SourceCardList({
-  entries,
-  onPick,
-}: {
-  entries: IndexEntry[]
-  onPick: (entry: IndexEntry) => void
-}) {
+function SourceCardList({ entries }: { entries: IndexEntry[] }) {
   return (
     <Card.List>
       {entries.map((entry) => (
         <Card.Item key={sourceCardId(entry)}>
           <Card.Card
-            as="button"
+            as={Link}
             description={entry.description}
             headerPill={sourceOriginPill(entry)}
             icon={<ProviderLogo name={entry.name} size="small" />}
-            onClick={() => onPick(entry)}
+            prefetch="intent"
+            preventScrollReset
             title={entry.name}
+            to={`/sources/${encodeURIComponent(entry.name)}`}
           />
         </Card.Item>
       ))}

--- a/apps/reef/vite.config.ts
+++ b/apps/reef/vite.config.ts
@@ -1,29 +1,38 @@
 import { reactRouter } from '@react-router/dev/vite'
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin'
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv, type ProxyOptions } from 'vite'
 
-// Under the desktop dev harness (apps/desktop/scripts/dev.mjs) the sidecar binds
-// this fixed port. Proxying the same-origin `/__coral__` prefix to it keeps the
-// gRPC-web client same-origin in dev — no CORS — mirroring the packaged app://
-// proxy. Must match GRPC_PATH_PREFIX in apps/desktop/src/main/app-renderer.ts.
-// Absent when Reef runs standalone, so no proxy is added there.
-const sidecarPort = process.env.CORAL_DEV_SIDECAR_PORT
-const coralProxy = sidecarPort
-  ? {
-      '/__coral__': {
-        target: `http://127.0.0.1:${sidecarPort}`,
-        changeOrigin: true,
-        rewrite: (path: string) => path.replace(/^\/__coral__/, ''),
-      },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const coralEndpoint = env.CORAL_ENDPOINT?.trim() || 'http://127.0.0.1:1457'
+
+  // Under the desktop dev harness (apps/desktop/scripts/dev.mjs) the sidecar binds
+  // this fixed port. Proxying the same-origin `/__coral__` prefix to it keeps the
+  // gRPC-web client same-origin in dev — no CORS — mirroring the packaged app://
+  // proxy. Must match GRPC_PATH_PREFIX in apps/desktop/src/main/app-renderer.ts.
+  const sidecarPort = env.CORAL_DEV_SIDECAR_PORT?.trim()
+  const proxy: Record<string, string | ProxyOptions> = {
+    '/coral.v1': {
+      changeOrigin: true,
+      target: coralEndpoint,
+    },
+  }
+
+  if (sidecarPort) {
+    proxy['/__coral__'] = {
+      target: `http://127.0.0.1:${sidecarPort}`,
+      changeOrigin: true,
+      rewrite: (path: string) => path.replace(/^\/__coral__/, ''),
     }
-  : undefined
+  }
 
-export default defineConfig({
-  plugins: [vanillaExtractPlugin(), reactRouter()],
-  resolve: {
-    tsconfigPaths: true,
-  },
-  server: {
-    proxy: coralProxy,
-  },
+  return {
+    plugins: [vanillaExtractPlugin(), reactRouter()],
+    resolve: {
+      tsconfigPaths: true,
+    },
+    server: {
+      proxy,
+    },
+  }
 })


### PR DESCRIPTION
## Summary

- Move the Reef sources page onto route loader/action data flow instead of view-local source fetching and mutations.
- Use URL-backed `/sources/:sourceName` navigation for installable source setup and installed source detail/edit/remove flows.
- Keep source catalog shaping in `lib/sources` while route modules own Coral gRPC-web reads and writes.
- Adapt source cards to the downstack polymorphic `CardList as={Link}` API so route props stay in the sources view rather than on WAX card items.

## Why

The sources UI needs to work with React Router's data APIs so route loaders/actions can drive refreshes, pending states, errors, and desktop/server rendering consistently. Keeping route behavior in route modules also keeps the reusable WAX card primitives router-agnostic.

## Validation

- `npm run check --prefix apps/reef`
- `npm run typecheck --prefix apps/reef`
- `npm test --prefix apps/reef -- sources-index`
- `npm test --prefix apps/reef`
- `npm run build --prefix apps/reef`
