### PR TITLE
feat(engine): validate saved function SQL definitions

### DIFF
--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -4,6 +4,7 @@ mod catalog;
 mod error;
 mod query;
 mod query_error;
+mod saved_functions;
 
 pub use catalog::{
     CatalogInfo, ColumnInfo, DescribeTableInfo, TableFunctionArgumentInfo, TableFunctionInfo,
@@ -17,6 +18,10 @@ pub use query::{
     QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
+pub use saved_functions::{
+    SavedFunctionRuntimeArgument, SavedFunctionRuntimeArgumentType, SavedFunctionRuntimeDefinition,
+    SavedFunctionRuntimeImplementation,
+};
 
 #[cfg(test)]
 pub(crate) use query_error::UNKNOWN_COLUMN_REASON;

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -391,6 +391,30 @@ pub enum QueryParameterValue {
     Boolean(Option<bool>),
 }
 
+impl QueryParameterValue {
+    /// Returns whether this parameter value is a typed SQL NULL.
+    #[must_use]
+    pub(crate) fn is_null(&self) -> bool {
+        match self {
+            Self::String(value) => value.is_none(),
+            Self::Integer(value) => value.is_none(),
+            Self::Float(value) => value.is_none(),
+            Self::Boolean(value) => value.is_none(),
+        }
+    }
+
+    /// Returns the scalar type name used in validation diagnostics.
+    #[must_use]
+    pub(crate) fn type_name(&self) -> &'static str {
+        match self {
+            Self::String(_) => "string",
+            Self::Integer(_) => "integer",
+            Self::Float(_) => "float",
+            Self::Boolean(_) => "boolean",
+        }
+    }
+}
+
 /// Owned runtime-build inputs needed while compiling and registering sources.
 #[derive(Default)]
 pub struct QueryRuntimeConfig {

--- a/crates/coral-engine/src/contracts/saved_functions.rs
+++ b/crates/coral-engine/src/contracts/saved_functions.rs
@@ -1,0 +1,85 @@
+//! Engine runtime saved function contracts supplied by the app layer.
+//!
+//! These are not the user-authored saved function file format. The app/spec layers
+//! parse and validate authored saved functions, then supply these runtime definitions
+//! to the engine for planning and execution.
+
+use crate::QueryParameterValue;
+
+/// One validated saved function made available to the query runtime.
+#[derive(Debug, Clone)]
+pub struct SavedFunctionRuntimeDefinition {
+    /// Stable saved function id within one workspace.
+    pub name: String,
+    /// Typed arguments accepted by the saved function.
+    pub arguments: Vec<SavedFunctionRuntimeArgument>,
+    /// Executable saved function implementation.
+    pub implementation: SavedFunctionRuntimeImplementation,
+}
+
+/// One typed saved function argument.
+#[derive(Debug, Clone)]
+pub struct SavedFunctionRuntimeArgument {
+    /// Argument name.
+    pub name: String,
+    /// Scalar argument type.
+    pub data_type: SavedFunctionRuntimeArgumentType,
+    /// Whether callers must provide this argument.
+    pub required: bool,
+}
+
+/// Scalar argument types supported by v1 saved function execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SavedFunctionRuntimeArgumentType {
+    /// UTF-8 string.
+    String,
+    /// Signed 64-bit integer.
+    Integer,
+    /// Boolean.
+    Boolean,
+}
+
+impl SavedFunctionRuntimeArgumentType {
+    /// Returns the argument type name used in validation diagnostics.
+    #[must_use]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::String => "string",
+            Self::Integer => "integer",
+            Self::Boolean => "boolean",
+        }
+    }
+
+    /// Returns whether a query parameter value can satisfy this saved function argument type.
+    #[must_use]
+    pub(crate) fn accepts(self, value: &QueryParameterValue) -> bool {
+        matches!(
+            (self, value),
+            (Self::String, QueryParameterValue::String(_))
+                | (Self::Integer, QueryParameterValue::Integer(_))
+                | (Self::Boolean, QueryParameterValue::Boolean(_))
+        )
+    }
+
+    /// Builds a typed SQL NULL for this argument type.
+    #[must_use]
+    pub(crate) fn typed_null_value(self) -> QueryParameterValue {
+        match self {
+            Self::String => QueryParameterValue::String(None),
+            Self::Integer => QueryParameterValue::Integer(None),
+            Self::Boolean => QueryParameterValue::Boolean(None),
+        }
+    }
+}
+
+/// Executable saved function implementation.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum SavedFunctionRuntimeImplementation {
+    /// Read-only Coral SQL using `DataFusion` value parameters like `$argument`.
+    CoralSql {
+        /// SQL query executed by Coral after typed argument binding.
+        query: String,
+    },
+}

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -71,8 +71,10 @@ pub use contracts::{
     DescribeTableInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution, QueryMemoryConfig,
     QueryParameterValue, QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
     QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
-    RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
-    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
+    RuntimeSourcePackage, SavedFunctionRuntimeArgument, SavedFunctionRuntimeArgumentType,
+    SavedFunctionRuntimeDefinition, SavedFunctionRuntimeImplementation, SourceValidationReport,
+    StatusCode, StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
+    TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// High-level query operations for the local query engine.
@@ -179,6 +181,28 @@ impl CoralQuery {
             .await?
             .execute_sql(sql, &params)
             .await
+    }
+
+    /// Validates one saved function against the selected sources using one concrete invocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if source compilation fails, if saved function argument
+    /// values cannot be bound, if the saved function SQL cannot plan against the
+    /// selected sources, or if the validation invocation cannot execute.
+    pub async fn validate_saved_function(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        saved_function: SavedFunctionRuntimeDefinition,
+        arguments: QueryParameters,
+    ) -> Result<std::sync::Arc<arrow::datatypes::Schema>, CoreError> {
+        let query_runtime = runtime::query::build_runtime(sources, runtime).await?;
+        runtime::saved_functions::validate_saved_function(
+            &query_runtime,
+            &saved_function,
+            &arguments,
+        )
+        .await
     }
 
     /// Explains one `SQL` statement with logical and physical plan renderings.

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod pattern_validator;
 pub(crate) mod query;
 pub(crate) mod query_planner;
 pub(crate) mod registry;
+pub(crate) mod saved_functions;
 pub(crate) mod schema_provider;
 pub(crate) mod scoped_table_functions;
 pub(crate) mod source_functions;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -365,6 +365,32 @@ impl QueryRuntimeAdapter {
         sql: &str,
         params: &QueryParameters,
     ) -> Result<QueryExecution, CoreError> {
+        self.execute_sql_with_fallback(sql, params).await
+    }
+
+    pub(crate) async fn infer_sql_schema(
+        &self,
+        sql: &str,
+        params: &QueryParameters,
+    ) -> Result<Arc<arrow::datatypes::Schema>, CoreError> {
+        let df = self.sql_dataframe(sql, params).await?;
+        let (session_state, logical_plan) = df.into_parts();
+        let analyzed_plan = session_state.optimize(&logical_plan).map_err(|err| {
+            datafusion_to_core_with_sql_and_table_functions(
+                &err,
+                &self.tables,
+                &self.table_functions,
+                Some(sql),
+            )
+        })?;
+        Ok(Arc::new(analyzed_plan.schema().as_arrow().clone()))
+    }
+
+    async fn execute_sql_with_fallback(
+        &self,
+        sql: &str,
+        params: &QueryParameters,
+    ) -> Result<QueryExecution, CoreError> {
         match self.execute_sql_once(&self.ctx, sql, params).await {
             Ok(execution) => Ok(execution),
             Err(SqlExecutionFailure::Collection(error)) => {

--- a/crates/coral-engine/src/runtime/saved_functions.rs
+++ b/crates/coral-engine/src/runtime/saved_functions.rs
@@ -1,0 +1,118 @@
+//! Saved function SQL parameter binding helpers.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use arrow::datatypes::Schema;
+
+use crate::runtime::query::QueryRuntimeAdapter;
+use crate::{
+    CoreError, QueryParameters, SavedFunctionRuntimeArgument, SavedFunctionRuntimeDefinition,
+    SavedFunctionRuntimeImplementation,
+};
+
+fn saved_function_sql(saved_function: &SavedFunctionRuntimeDefinition) -> &str {
+    let SavedFunctionRuntimeImplementation::CoralSql { query } = &saved_function.implementation;
+    query
+}
+
+pub(crate) async fn validate_saved_function(
+    query_runtime: &QueryRuntimeAdapter,
+    saved_function: &SavedFunctionRuntimeDefinition,
+    arguments: &QueryParameters,
+) -> Result<Arc<Schema>, CoreError> {
+    let params =
+        SavedFunctionArgumentBinding::new(saved_function, arguments).into_query_params()?;
+    query_runtime
+        .infer_sql_schema(saved_function_sql(saved_function), &params)
+        .await
+}
+
+struct SavedFunctionArgumentBinding<'a> {
+    saved_function: &'a SavedFunctionRuntimeDefinition,
+    arguments: &'a QueryParameters,
+}
+
+impl<'a> SavedFunctionArgumentBinding<'a> {
+    fn new(
+        saved_function: &'a SavedFunctionRuntimeDefinition,
+        arguments: &'a QueryParameters,
+    ) -> Self {
+        Self {
+            saved_function,
+            arguments,
+        }
+    }
+
+    fn into_query_params(self) -> Result<QueryParameters, CoreError> {
+        self.reject_duplicate_argument_definitions()?;
+        self.reject_unknown_arguments()?;
+
+        let mut params = self.arguments.clone();
+        for argument in &self.saved_function.arguments {
+            self.bind_argument(argument, &mut params)?;
+        }
+        Ok(params)
+    }
+
+    fn reject_duplicate_argument_definitions(&self) -> Result<(), CoreError> {
+        let mut seen = BTreeSet::new();
+        for argument in &self.saved_function.arguments {
+            if !seen.insert(argument.name.as_str()) {
+                return Err(CoreError::InvalidInput(format!(
+                    "saved_function '{}' argument '{}' is declared more than once",
+                    self.saved_function.name, argument.name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn reject_unknown_arguments(&self) -> Result<(), CoreError> {
+        if let Some(argument_name) = self.arguments.keys().find(|argument_name| {
+            self.saved_function
+                .arguments
+                .iter()
+                .all(|argument| argument.name != **argument_name)
+        }) {
+            return Err(CoreError::InvalidInput(format!(
+                "saved_function '{}' received unknown argument '{}'",
+                self.saved_function.name, argument_name
+            )));
+        }
+        Ok(())
+    }
+
+    fn bind_argument(
+        &self,
+        argument: &SavedFunctionRuntimeArgument,
+        params: &mut QueryParameters,
+    ) -> Result<(), CoreError> {
+        match params.get(&argument.name) {
+            Some(value) if !argument.data_type.accepts(value) => {
+                Err(CoreError::InvalidInput(format!(
+                    "saved_function '{}' argument '{}' expected {}, got {}",
+                    self.saved_function.name,
+                    argument.name,
+                    argument.data_type.as_str(),
+                    value.type_name()
+                )))
+            }
+            Some(value) if argument.required && value.is_null() => {
+                Err(CoreError::InvalidInput(format!(
+                    "saved_function '{}' argument '{}' is required and cannot be null",
+                    self.saved_function.name, argument.name
+                )))
+            }
+            Some(_) => Ok(()),
+            None if argument.required => Err(CoreError::InvalidInput(format!(
+                "saved_function '{}' is missing required argument '{}'",
+                self.saved_function.name, argument.name
+            ))),
+            None => {
+                params.insert(argument.name.clone(), argument.data_type.typed_null_value());
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/coral-engine/tests/engine.rs
+++ b/crates/coral-engine/tests/engine.rs
@@ -29,6 +29,8 @@ mod parquet_tests;
 mod pattern_error_tests;
 #[path = "engine/query_result_observer_tests.rs"]
 mod query_result_observer_tests;
+#[path = "engine/saved_function_tests.rs"]
+mod saved_function_tests;
 #[path = "engine/structured_error_tests.rs"]
 mod structured_error_tests;
 #[path = "engine/test_source_tests.rs"]

--- a/crates/coral-engine/tests/engine/saved_function_tests.rs
+++ b/crates/coral-engine/tests/engine/saved_function_tests.rs
@@ -1,0 +1,276 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
+use coral_engine::{
+    CoralQuery, EngineExtensions, QueryParameterValue, QueryResultObserver,
+    QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext,
+    SavedFunctionRuntimeArgument, SavedFunctionRuntimeArgumentType, SavedFunctionRuntimeDefinition,
+    SavedFunctionRuntimeImplementation, StatusCode,
+};
+use serde_json::{Value, json};
+
+use crate::harness::{build_source, dir_url, test_runtime, write_jsonl_file};
+
+#[derive(Debug, Default)]
+struct RowCountObserver {
+    row_counts: Mutex<Vec<usize>>,
+}
+
+impl RowCountObserver {
+    fn row_counts(&self) -> Vec<usize> {
+        self.row_counts
+            .lock()
+            .expect("observer row count lock should not be poisoned")
+            .clone()
+    }
+}
+
+impl QueryResultObserver for RowCountObserver {
+    fn name(&self) -> &'static str {
+        "row_count"
+    }
+
+    fn observe_result(
+        &self,
+        _sql: &str,
+        _schema: &Schema,
+        batches: &[RecordBatch],
+    ) -> Result<(), QueryResultObserverError> {
+        self.row_counts
+            .lock()
+            .map_err(|_err| {
+                QueryResultObserverError::failed_precondition(
+                    "observer row count lock should not be poisoned",
+                )
+            })?
+            .push(batches.iter().map(RecordBatch::num_rows).sum());
+        Ok(())
+    }
+}
+
+fn events_manifest(name: &str, dir: &Path) -> Value {
+    json!({
+        "name": name,
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "file",
+        "tables": [{
+            "name": "events",
+            "description": "Event rows",
+            "format": "jsonl",
+            "source": {
+                "location": dir_url(dir),
+                "glob": "**/*.jsonl"
+            },
+            "columns": [
+                { "name": "id", "type": "Int64" }
+            ]
+        }]
+    })
+}
+
+fn min_id_saved_function(source_name: &str) -> SavedFunctionRuntimeDefinition {
+    SavedFunctionRuntimeDefinition {
+        name: "min_id_events".to_string(),
+        arguments: vec![SavedFunctionRuntimeArgument {
+            name: "min_id".to_string(),
+            data_type: SavedFunctionRuntimeArgumentType::Integer,
+            required: true,
+        }],
+        implementation: SavedFunctionRuntimeImplementation::CoralSql {
+            query: format!("select id from {source_name}.events where id >= $min_id order by id"),
+        },
+    }
+}
+
+fn events_saved_function(source_name: &str) -> SavedFunctionRuntimeDefinition {
+    SavedFunctionRuntimeDefinition {
+        name: "events".to_string(),
+        arguments: Vec::new(),
+        implementation: SavedFunctionRuntimeImplementation::CoralSql {
+            query: format!("select id from {source_name}.events order by id"),
+        },
+    }
+}
+
+fn optional_label_saved_function() -> SavedFunctionRuntimeDefinition {
+    SavedFunctionRuntimeDefinition {
+        name: "optional_label".to_string(),
+        arguments: vec![SavedFunctionRuntimeArgument {
+            name: "label".to_string(),
+            data_type: SavedFunctionRuntimeArgumentType::String,
+            required: false,
+        }],
+        implementation: SavedFunctionRuntimeImplementation::CoralSql {
+            query: "select $label as label".to_string(),
+        },
+    }
+}
+
+fn runtime_with_observer(observer: Arc<dyn QueryResultObserver>) -> QueryRuntimeConfig {
+    let mut extensions = EngineExtensions::default();
+    extensions.query_result_observers.push(observer);
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions)
+}
+
+#[tokio::test]
+async fn validate_saved_function_preserves_optional_null_argument_type() {
+    let schema = CoralQuery::validate_saved_function(
+        &[],
+        test_runtime(),
+        optional_label_saved_function(),
+        BTreeMap::new(),
+    )
+    .await
+    .expect("saved_function schema should infer typed null argument");
+
+    let field = schema.fields().first().expect("label field");
+    assert_eq!(field.name(), "label");
+    assert_eq!(field.data_type(), &arrow::datatypes::DataType::Utf8);
+}
+
+#[tokio::test]
+async fn validate_saved_function_returns_schema_from_explicit_validation_args() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "events.jsonl",
+        &[json!({"id": 1}), json!({"id": 2})],
+    );
+    let source = build_source(events_manifest("schema_saved_function_events", temp.path()));
+
+    let schema = CoralQuery::validate_saved_function(
+        &[source],
+        test_runtime(),
+        min_id_saved_function("schema_saved_function_events"),
+        BTreeMap::from([("min_id".to_string(), QueryParameterValue::Integer(Some(1)))]),
+    )
+    .await
+    .expect("saved_function schema should infer");
+
+    let field = schema.fields().first().expect("id field");
+    assert_eq!(field.name(), "id");
+    assert_eq!(field.data_type(), &arrow::datatypes::DataType::Int64);
+}
+
+#[tokio::test]
+async fn validate_saved_function_does_not_collect_rows() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "events.jsonl",
+        &[json!({"id": 1}), json!({"id": 2})],
+    );
+    let source = build_source(events_manifest("validation_limit_events", temp.path()));
+    let observer = Arc::new(RowCountObserver::default());
+
+    let schema = CoralQuery::validate_saved_function(
+        &[source],
+        runtime_with_observer(observer.clone()),
+        events_saved_function("validation_limit_events"),
+        BTreeMap::new(),
+    )
+    .await
+    .expect("saved_function validation should infer schema without collection");
+
+    assert_eq!(schema.fields().len(), 1);
+    assert_eq!(observer.row_counts(), Vec::<usize>::new());
+}
+
+#[tokio::test]
+async fn validate_saved_function_rejects_missing_validation_args() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_jsonl_file(temp.path(), "events.jsonl", &[json!({"id": 1})]);
+    let source = build_source(events_manifest(
+        "missing_arg_saved_function_events",
+        temp.path(),
+    ));
+
+    let error = CoralQuery::validate_saved_function(
+        &[source],
+        test_runtime(),
+        min_id_saved_function("missing_arg_saved_function_events"),
+        BTreeMap::new(),
+    )
+    .await
+    .expect_err("missing validation args should fail");
+
+    assert_eq!(error.status_code(), StatusCode::InvalidArgument);
+    assert!(
+        error
+            .to_string()
+            .contains("saved_function 'min_id_events' is missing required argument 'min_id'"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn validate_saved_function_rejects_invalid_argument_values() {
+    let cases = [
+        (
+            "unknown supplied arg",
+            min_id_saved_function("invalid_arg_saved_function_events"),
+            BTreeMap::from([(
+                "not_declared".to_string(),
+                QueryParameterValue::Integer(Some(1)),
+            )]),
+            "saved_function 'min_id_events' received unknown argument 'not_declared'",
+        ),
+        (
+            "required null arg",
+            min_id_saved_function("invalid_arg_saved_function_events"),
+            BTreeMap::from([("min_id".to_string(), QueryParameterValue::Integer(None))]),
+            "saved_function 'min_id_events' argument 'min_id' is required and cannot be null",
+        ),
+        (
+            "wrong arg type",
+            min_id_saved_function("invalid_arg_saved_function_events"),
+            BTreeMap::from([(
+                "min_id".to_string(),
+                QueryParameterValue::String(Some("1".to_string())),
+            )]),
+            "saved_function 'min_id_events' argument 'min_id' expected integer, got string",
+        ),
+    ];
+
+    for (name, saved_function, arguments, expected_message) in cases {
+        let Err(error) =
+            CoralQuery::validate_saved_function(&[], test_runtime(), saved_function, arguments)
+                .await
+        else {
+            panic!("{name} should fail");
+        };
+
+        assert_eq!(error.status_code(), StatusCode::InvalidArgument, "{name}");
+        assert!(
+            error.to_string().contains(expected_message),
+            "{name}: unexpected error: {error}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn validate_saved_function_rejects_duplicate_runtime_argument_names() {
+    let mut saved_function = optional_label_saved_function();
+    saved_function.arguments.push(SavedFunctionRuntimeArgument {
+        name: "label".to_string(),
+        data_type: SavedFunctionRuntimeArgumentType::String,
+        required: false,
+    });
+
+    let error =
+        CoralQuery::validate_saved_function(&[], test_runtime(), saved_function, BTreeMap::new())
+            .await
+            .expect_err("duplicate saved_function runtime arguments should fail");
+
+    assert_eq!(error.status_code(), StatusCode::InvalidArgument);
+    assert!(
+        error.to_string().contains(
+            "saved_function 'optional_label' argument 'label' is declared more than once"
+        ),
+        "unexpected error: {error}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add engine runtime contracts for saved-function SQL validation.
- Add `CoralQuery::validate_saved_function`, which builds a normal query runtime, binds saved-function args through named query parameters, and returns the inferred Arrow schema.
- Add fail-closed saved-function argument validation for missing required args, duplicate arg definitions, unknown supplied args, required nulls, and type mismatches.

## Reviewer frame
This PR is engine-only. It proves this invariant:

```text
selected sources + saved-function SQL + concrete validation args
  -> plan through the normal query runtime
  -> infer the result schema
```

The app lifecycle, inventory, SQL table-function registration, catalog rows, CLI, MCP, and bundled saved functions come later.

## Ownership / boundaries
`coral-engine` owns this because the invariant is runtime/query-shaped: given selected sources, a SQL implementation, and concrete validation args, can Coral plan the saved function enough to know its result schema?

## Notes
- This PR does not install saved functions.
- This PR does not expose a public saved-function table-function surface.
- This PR does not add catalog rows.
- This PR does not add CLI or MCP surfaces.

## Validation
- `cargo test -p coral-engine saved_function -- --nocapture`
- `make rust-checks` on PR4 after restacking PR1-PR4.
