### PR TITLE
feat(cli): pass trace-backed query examples to MCP

### DIFF
--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -578,7 +578,7 @@ async fn run_app_command(
                     episodes_enabled: features.enabled(coral_app::features::Feature::Episodes),
                     trace_parent: ctx.and_then(|ctx| ctx.trace_parent.clone()),
                     source_names,
-                    query_examples: Vec::new(),
+                    query_examples,
                 },
             ))
             .await

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -44,6 +44,7 @@ use tempfile as _;
 /// gRPC-Web surface.
 #[cfg(feature = "embedded-ui")]
 const DEFAULT_SERVER_PORT: u16 = 1457;
+const MCP_INITIAL_QUERY_EXAMPLE_LIMIT: usize = 5;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -562,15 +563,39 @@ async fn run_app_command(
             let features = coral_app::features::FeatureStore::discover(None)
                 .and_then(|store| store.load_with_overrides(feature_overrides))
                 .map_err(anyhow::Error::from)?;
-            let source_names = match coral_app::bootstrap::default_workspace_source_names() {
-                Ok(source_names) => source_names,
-                Err(error) => {
-                    eprintln!(
-                        "warning: failed to load source names for MCP initialize instructions: {error}"
-                    );
-                    Vec::new()
-                }
-            };
+            let (source_names, query_examples) =
+                match coral_app::bootstrap::default_workspace_mcp_startup_context(
+                    MCP_INITIAL_QUERY_EXAMPLE_LIMIT,
+                ) {
+                    Ok(context) => (
+                        context.source_names().to_vec(),
+                        context
+                            .query_history()
+                            .iter()
+                            .map(|entry| {
+                                coral_mcp::McpQueryExample::new(entry.sql())
+                                    .with_sources(entry.sources().iter().cloned())
+                                    .with_row_count(entry.row_count())
+                            })
+                            .collect(),
+                    ),
+                    Err(error) => {
+                        eprintln!(
+                            "warning: failed to load MCP startup context for initialize instructions: {error}"
+                        );
+                        let source_names =
+                            match coral_app::bootstrap::default_workspace_source_names() {
+                                Ok(source_names) => source_names,
+                                Err(error) => {
+                                    eprintln!(
+                                        "warning: failed to load source names for MCP initialize instructions: {error}"
+                                    );
+                                    Vec::new()
+                                }
+                            };
+                        (source_names, Vec::new())
+                    }
+                };
             Box::pin(coral_mcp::run_stdio_with_client(
                 app,
                 coral_mcp::McpOptions {

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -10,10 +10,14 @@
 
 mod harness;
 
+use std::path::Path;
 use std::process::{Command as StdCommand, Stdio};
 use std::time::Duration;
 use std::{fs, io};
 
+use coral_api::v1::{ExecuteSqlRequest, ImportSourceRequest, import_source_response};
+use coral_app::{ServerBuilder, shutdown_tracing};
+use coral_client::{AppClient, default_workspace};
 use harness::MockServer;
 use jsonschema::JSONSchema;
 use rmcp::{
@@ -28,6 +32,7 @@ use tokio::{
     process::{ChildStdin, ChildStdout, Command},
     time::timeout,
 };
+use tonic::Request;
 
 const RAW_JSONRPC_RESPONSE_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -78,6 +83,68 @@ async fn start_mcp_client_with_args(
     )?;
     let client = ().serve(transport).await?;
     Ok(client)
+}
+
+fn write_real_fixture_manifest(root: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let source_dir = root.join("fixture-source");
+    let data_dir = root.join("fixture-data");
+    fs::create_dir_all(&source_dir)?;
+    fs::create_dir_all(&data_dir)?;
+    fs::write(
+        data_dir.join("messages.jsonl"),
+        r#"{"type":"user","sessionId":"s1","text":"hello"}
+{"type":"assistant","sessionId":"s1","text":"world"}
+"#,
+    )?;
+    Ok(format!(
+        r#"
+name: local_messages
+version: 0.1.0
+dsl_version: 3
+backend: file
+tables:
+  - name: messages
+    description: Fixture messages
+    format: jsonl
+    source:
+      location: file://{}/
+      glob: "**/*.jsonl"
+    columns:
+      - name: type
+        type: Utf8
+      - name: sessionId
+        type: Utf8
+      - name: text
+        type: Utf8
+"#,
+        data_dir.display()
+    ))
+}
+
+async fn import_real_fixture_source(
+    app: &AppClient,
+    manifest_yaml: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut source_client = app.source_client();
+    let mut stream = source_client
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml,
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await?
+        .into_inner();
+    stream
+        .message()
+        .await?
+        .and_then(|response| match response.event {
+            Some(import_source_response::Event::Source(source)) => Some(source),
+            _ => None,
+        })
+        .expect("import source response");
+    Ok(())
 }
 
 fn text_content(result: &rmcp::model::ReadResourceResult) -> &str {
@@ -277,6 +344,94 @@ origin = "bundled"
         child.wait().await?;
     }
     server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_initialize_includes_trace_backed_query_examples()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::TempDir::new()?;
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir)?;
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"
+[credentials]
+storage = "file"
+"#,
+    )?;
+    let server = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .with_noop_feedback_uploads()
+        .start()
+        .await?;
+    let app = AppClient::connect(server.endpoint_uri()).await?;
+    import_real_fixture_source(&app, write_real_fixture_manifest(temp.path())?).await?;
+    let sql = "SELECT text FROM local_messages.messages ORDER BY text";
+    app.query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: sql.to_string(),
+        }))
+        .await?;
+    shutdown_tracing();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_coral"))
+        .arg("mcp-stdio")
+        .env("CORAL_ENDPOINT", server.endpoint_uri())
+        .env("CORAL_CONFIG_DIR", &config_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()?;
+    let mut stdin = child.stdin.take().expect("mcp stdio stdin");
+    let stdout = child.stdout.take().expect("mcp stdio stdout");
+    let mut stdout = BufReader::new(stdout);
+
+    write_jsonrpc_message(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "coral-cli-query-history-init-test",
+                    "version": "0.0.0"
+                }
+            }
+        }),
+    )
+    .await?;
+    let initialize = read_jsonrpc_response(&mut stdout, 1).await?;
+    let instructions = initialize
+        .pointer("/result/instructions")
+        .and_then(Value::as_str)
+        .expect("initialize response should include instructions");
+    assert!(
+        instructions.contains("Connected Coral sources: local_messages."),
+        "initialize instructions should include connected source names: {instructions}"
+    );
+    assert!(
+        instructions.contains("Recent successful Coral SQL examples"),
+        "initialize instructions should include query examples heading: {instructions}"
+    );
+    assert!(
+        instructions.contains(&format!(
+            "1. sources: local_messages; row_count: 2\n```sql\n{sql}\n```"
+        )),
+        "initialize instructions should include the traced query metadata and SQL: {instructions}"
+    );
+
+    drop(stdin);
+    if timeout(Duration::from_secs(5), child.wait()).await.is_err() {
+        child.start_kill()?;
+        child.wait().await?;
+    }
+    server.shutdown().await?;
     Ok(())
 }
 


### PR DESCRIPTION
RFC step 4: wire `coral mcp-stdio` to the app-owned MCP startup context.

The CLI now calls `coral_app::bootstrap::default_workspace_mcp_startup_context(...)` before starting `coral-mcp`, maps trace-backed query history into `McpQueryExample`, and passes those examples through `McpOptions`. If the richer startup context cannot be loaded, startup falls back to the previous source-names-only behavior.

Adds an end-to-end MCP stdio test that imports a real fixture source, executes a query, flushes tracing, starts `coral mcp-stdio`, and asserts that `initialize` includes the source name, row count, and SQL example.