### PR TITLE
feat(mcp)!: support multiple SQL queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ dependencies = [
  "coral-app",
  "coral-client",
  "coral-telemetry",
+ "futures",
  "jsonschema",
  "opentelemetry",
  "regex",

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -891,11 +891,21 @@ async fn assert_sql_tool(
     let sql = structured_tool_content(
         client,
         CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-            "sql": "SELECT text FROM local_messages.messages ORDER BY text"
+            "queries": ["SELECT text FROM local_messages.messages ORDER BY text"]
         }))),
     )
     .await?;
-    assert_eq!(sql["rows"][0]["text"], "hello");
+    assert_eq!(sql["successful"], true);
+    assert_eq!(sql["total_count"], 1);
+    assert_eq!(sql["success_count"], 1);
+    assert_eq!(sql["error_count"], 0);
+    assert_eq!(sql["results"][0]["index"], 0);
+    assert_eq!(
+        sql["results"][0]["sql"],
+        "SELECT text FROM local_messages.messages ORDER BY text"
+    );
+    assert_eq!(sql["results"][0]["status"], "success");
+    assert_eq!(sql["results"][0]["rows"][0]["text"], "hello");
     Ok(())
 }
 
@@ -904,18 +914,14 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
     let server = MockServer::start().await;
     let client = start_mcp_client(&server).await?;
 
-    let invalid_sql = client
+    client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
                 "sql": "DELETE FROM local_messages.messages"
             }))),
         )
-        .await?;
-    assert_eq!(invalid_sql.is_error, Some(true));
-    assert_eq!(
-        invalid_sql.structured_content.expect("structured content")["error"]["summary"],
-        "Query request is invalid"
-    );
+        .await
+        .expect_err("legacy sql argument should fail before execution");
 
     let catalog = client
         .call_tool(CallToolRequestParams::new("list_catalog"))

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -910,6 +910,51 @@ async fn assert_sql_tool(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_sql_executes_multiple_queries() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client(&server).await?;
+
+    let first_sql = "SELECT 1 AS value";
+    let second_sql = "SELECT 2 AS value";
+    let sql = structured_tool_content(
+        &client,
+        CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+            "queries": [first_sql, second_sql]
+        }))),
+    )
+    .await?;
+    assert_eq!(sql["successful"], true);
+    assert_eq!(sql["total_count"], 2);
+    assert_eq!(sql["success_count"], 2);
+    assert_eq!(sql["error_count"], 0);
+    assert_eq!(sql["results"][0]["index"], 0);
+    assert_eq!(sql["results"][0]["sql"], first_sql);
+    assert_eq!(sql["results"][0]["rows"][0]["value"], "1");
+    assert_eq!(sql["results"][1]["index"], 1);
+    assert_eq!(sql["results"][1]["sql"], second_sql);
+    assert_eq!(sql["results"][1]["rows"][0]["value"], "1");
+
+    let requests = server.execute_sql_requests();
+    assert_eq!(requests.len(), 2);
+    let mut captured_sql = requests
+        .iter()
+        .map(|request| {
+            assert_eq!(
+                request.workspace.as_ref().expect("workspace").name,
+                "default"
+            );
+            request.sql.as_str()
+        })
+        .collect::<Vec<_>>();
+    captured_sql.sort_unstable();
+    assert_eq!(captured_sql, vec![first_sql, second_sql]);
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
     let client = start_mcp_client(&server).await?;

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -968,6 +968,30 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
         .await
         .expect_err("legacy sql argument should fail before execution");
 
+    let invalid_sql = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "queries": ["DELETE FROM local_messages.messages"]
+            }))),
+        )
+        .await?;
+    assert_eq!(invalid_sql.is_error, Some(true));
+    let invalid_value = invalid_sql.structured_content.expect("structured content");
+    assert_eq!(invalid_value["successful"], false);
+    assert_eq!(invalid_value["total_count"], 1);
+    assert_eq!(invalid_value["success_count"], 0);
+    assert_eq!(invalid_value["error_count"], 1);
+    assert_eq!(invalid_value["results"][0]["index"], 0);
+    assert_eq!(invalid_value["results"][0]["status"], "error");
+    assert_eq!(
+        invalid_value["results"][0]["error"]["summary"],
+        "Query request is invalid"
+    );
+    assert_eq!(
+        invalid_value["results"][0]["error"]["grpc_code"],
+        "InvalidArgument"
+    );
+
     let catalog = client
         .call_tool(CallToolRequestParams::new("list_catalog"))
         .await?;

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
+futures.workspace = true
 regex.workspace = true
 rmcp.workspace = true
 serde.workspace = true

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -6,7 +6,7 @@
 
 Treat Coral like a read-only SQL database. The MCP discovery tools are catalog helpers, not replacement APIs. Inspect tables, parameterized table functions, and columns first, then answer with set-based SQL.
 
-Prefer one SQL statement with `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions over fetching rows and combining them in the agent. Use `CROSS JOIN` explicitly when the query needs every combination of rows from two relations. Call table functions from `FROM` with named arguments, for example `github.search_issues(q => 'repo:withcoral/coral deploy failure')`.
+Prefer one SQL statement with `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions when one statement can answer the question. Use `CROSS JOIN` explicitly when the query needs every combination of rows from two relations. When independent reads need different result shapes, call the `sql` tool once with multiple entries in its required `queries[]` argument. Call table functions from `FROM` with named arguments, for example `github.search_issues(q => 'repo:withcoral/coral deploy failure')`.
 
 ```sql
 -- List visible tables, descriptions, and required filters
@@ -64,7 +64,8 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 
 ## Query Guidance
 
-- Result values of type `Int64`/`BIGINT`, `UInt64`, and `Decimal*` are returned as JSON strings, not JSON numbers, so exact values survive JSON parsing in clients that decode numbers as IEEE-754 doubles. The declared column type is unchanged; read these values as strings.
+- The `sql` tool takes `queries[]` and returns an aggregate object with `successful`, `total_count`, `success_count`, `error_count`, and ordered `results[]`. Success items contain `rows`; error items contain structured Coral error fields. The legacy single `sql` argument is not supported.
+- Result values of type `Int64`/`BIGINT`, `UInt64`, and `Decimal*` are returned as JSON strings inside success-item `rows`, not JSON numbers, so exact values survive JSON parsing in clients that decode numbers as IEEE-754 doubles. The declared column type is unchanged; read these values as strings.
 - Use each table's `sql_reference` from `list_catalog` or `coral://tables` in `FROM` and `JOIN` clauses, for example `slack.messages`.
 - Use each table function's `sql_call_example` from `list_catalog` or `search_catalog`, filling in the required arguments before querying it.
 - Do not quote the whole `schema.table` string. Write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -35,8 +35,8 @@ use crate::{
         guide_resource_content, initial_instructions, list_catalog_arguments, list_catalog_tool,
         list_catalog_value, list_columns_arguments, list_columns_tool, list_columns_value,
         open_episode_arguments, open_episode_tool, optional_episode_id_argument,
-        required_string_argument, search_catalog_arguments, search_catalog_tool,
-        search_catalog_value, sql_tool, status_to_error_data, tables_resource,
+        required_queries_argument, required_string_argument, search_catalog_arguments,
+        search_catalog_tool, search_catalog_value, sql_tool, status_to_error_data, tables_resource,
         tables_resource_content, tool_error_from_status, tool_error_result,
         with_episode_id_argument,
     },
@@ -58,7 +58,19 @@ enum ToolCallOutcome {
 }
 
 #[derive(Serialize)]
-struct SqlRowsValue {
+struct SqlQueriesValue {
+    successful: bool,
+    total_count: usize,
+    success_count: usize,
+    error_count: usize,
+    results: Vec<SqlQueryResultValue>,
+}
+
+#[derive(Serialize)]
+struct SqlQueryResultValue {
+    index: usize,
+    sql: String,
+    status: &'static str,
     rows: Vec<Value>,
 }
 
@@ -319,12 +331,27 @@ impl CoralMcpServer {
             .map_err(|error| tonic::Status::internal(error.to_string()))
     }
 
-    async fn execute_sql_value(
-        &self,
-        request: Request<ExecuteSqlRequest>,
-    ) -> Result<Value, tonic::Status> {
-        serialize_tool_value(SqlRowsValue {
-            rows: self.query_rows(request).await?,
+    async fn execute_sql_value(&self, queries: Vec<String>) -> Result<Value, tonic::Status> {
+        let total_count = queries.len();
+        let mut results = Vec::with_capacity(total_count);
+        for (index, sql) in queries.into_iter().enumerate() {
+            let request = Request::new(ExecuteSqlRequest {
+                workspace: Some(default_workspace()),
+                sql: sql.clone(),
+            });
+            results.push(SqlQueryResultValue {
+                index,
+                sql,
+                status: "success",
+                rows: self.query_rows(request).await?,
+            });
+        }
+        serialize_tool_value(SqlQueriesValue {
+            successful: true,
+            total_count,
+            success_count: total_count,
+            error_count: 0,
+            results,
         })
     }
 
@@ -461,14 +488,10 @@ impl CoralMcpServer {
     ) -> Result<ToolCallOutcome, ErrorData> {
         match request.name.as_ref() {
             "sql" => {
-                let sql = required_string_argument(request.arguments.as_ref(), "sql")?;
-                let request = Request::new(ExecuteSqlRequest {
-                    workspace: Some(default_workspace()),
-                    sql,
-                });
+                let queries = required_queries_argument(request.arguments.as_ref(), "queries")?;
                 Ok(ToolCallOutcome::from_value_result(
                     "Query",
-                    self.execute_sql_value(request).await,
+                    self.execute_sql_value(queries).await,
                 ))
             }
             "list_catalog" => {

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -11,6 +11,7 @@ use coral_client::{
     batches_to_json_rows_json_safe_numbers, decode_execute_sql_response, default_workspace,
     with_episode_metadata,
 };
+use futures::{StreamExt, stream};
 use rmcp::{
     ErrorData, ServerHandler,
     model::{
@@ -48,6 +49,7 @@ const LIST_CATALOG_COUNT_LIMIT: u32 = 1;
 const CATALOG_KIND_ALL: ProtoCatalogItemKind = ProtoCatalogItemKind::Unspecified;
 const CATALOG_KIND_TABLE: ProtoCatalogItemKind = ProtoCatalogItemKind::Table;
 const CATALOG_KIND_TABLE_FUNCTION: ProtoCatalogItemKind = ProtoCatalogItemKind::TableFunction;
+const MAX_CONCURRENT_SQL_QUERIES: usize = 10;
 
 enum ToolCallOutcome {
     Success(Value),
@@ -72,6 +74,11 @@ struct SqlQueryResultValue {
     sql: String,
     status: &'static str,
     rows: Vec<Value>,
+}
+
+struct SqlQueryInput {
+    index: usize,
+    sql: String,
 }
 
 #[derive(Serialize)]
@@ -320,10 +327,9 @@ impl CoralMcpServer {
     }
 
     async fn query_rows(
-        &self,
+        mut query_client: QueryClient,
         request: Request<ExecuteSqlRequest>,
     ) -> Result<Vec<Value>, tonic::Status> {
-        let mut query_client = self.query.clone();
         let response = query_client.execute_sql(request).await?.into_inner();
         let result = decode_execute_sql_response(&response)
             .map_err(|error| tonic::Status::internal(error.to_string()))?;
@@ -331,21 +337,47 @@ impl CoralMcpServer {
             .map_err(|error| tonic::Status::internal(error.to_string()))
     }
 
+    async fn execute_sql_query(
+        query_client: QueryClient,
+        input: SqlQueryInput,
+    ) -> Result<SqlQueryResultValue, tonic::Status> {
+        let request = Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: input.sql.clone(),
+        });
+        Ok(SqlQueryResultValue {
+            index: input.index,
+            sql: input.sql,
+            status: "success",
+            rows: Self::query_rows(query_client, request).await?,
+        })
+    }
+
+    async fn execute_sql_queries(
+        &self,
+        inputs: Vec<SqlQueryInput>,
+    ) -> Result<Vec<SqlQueryResultValue>, tonic::Status> {
+        let mut results = stream::iter(inputs.into_iter().map(|input| {
+            let query_client = self.query.clone();
+            Self::execute_sql_query(query_client, input)
+        }))
+        .buffer_unordered(MAX_CONCURRENT_SQL_QUERIES)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+        results.sort_by_key(|result| result.index);
+        Ok(results)
+    }
+
     async fn execute_sql_value(&self, queries: Vec<String>) -> Result<Value, tonic::Status> {
         let total_count = queries.len();
-        let mut results = Vec::with_capacity(total_count);
-        for (index, sql) in queries.into_iter().enumerate() {
-            let request = Request::new(ExecuteSqlRequest {
-                workspace: Some(default_workspace()),
-                sql: sql.clone(),
-            });
-            results.push(SqlQueryResultValue {
-                index,
-                sql,
-                status: "success",
-                rows: self.query_rows(request).await?,
-            });
-        }
+        let inputs = queries
+            .into_iter()
+            .enumerate()
+            .map(|(index, sql)| SqlQueryInput { index, sql })
+            .collect::<Vec<_>>();
+        let results = self.execute_sql_queries(inputs).await?;
         serialize_tool_value(SqlQueriesValue {
             successful: true,
             total_count,

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -31,15 +31,15 @@ use tonic::{
 use crate::{
     McpOptions,
     surface::{
-        CatalogToolKind, ToolDescriptionContext, build_tool_result, describe_table_arguments,
-        describe_table_tool, describe_table_value, feedback_tool, guide_resource,
-        guide_resource_content, initial_instructions, list_catalog_arguments, list_catalog_tool,
-        list_catalog_value, list_columns_arguments, list_columns_tool, list_columns_value,
-        open_episode_arguments, open_episode_tool, optional_episode_id_argument,
-        required_queries_argument, required_string_argument, search_catalog_arguments,
-        search_catalog_tool, search_catalog_value, sql_tool, status_to_error_data, tables_resource,
-        tables_resource_content, tool_error_from_status, tool_error_result,
-        with_episode_id_argument,
+        CatalogToolKind, ToolDescriptionContext, build_tool_result, build_tool_result_with_error,
+        describe_table_arguments, describe_table_tool, describe_table_value, feedback_tool,
+        guide_resource, guide_resource_content, initial_instructions, list_catalog_arguments,
+        list_catalog_tool, list_catalog_value, list_columns_arguments, list_columns_tool,
+        list_columns_value, open_episode_arguments, open_episode_tool,
+        optional_episode_id_argument, required_queries_argument, required_string_argument,
+        search_catalog_arguments, search_catalog_tool, search_catalog_value, sql_tool,
+        status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
+        tool_error_result, tool_error_value, with_episode_id_argument,
     },
     telemetry,
 };
@@ -53,6 +53,10 @@ const MAX_CONCURRENT_SQL_QUERIES: usize = 10;
 
 enum ToolCallOutcome {
     Success(Value),
+    SqlAggregate {
+        value: Value,
+        has_errors: bool,
+    },
     ToolError {
         operation: &'static str,
         status: tonic::Status,
@@ -73,7 +77,10 @@ struct SqlQueryResultValue {
     index: usize,
     sql: String,
     status: &'static str,
-    rows: Vec<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rows: Option<Vec<Value>>,
 }
 
 struct SqlQueryInput {
@@ -340,23 +347,33 @@ impl CoralMcpServer {
     async fn execute_sql_query(
         query_client: QueryClient,
         input: SqlQueryInput,
-    ) -> Result<SqlQueryResultValue, tonic::Status> {
+    ) -> SqlQueryResultValue {
         let request = Request::new(ExecuteSqlRequest {
             workspace: Some(default_workspace()),
             sql: input.sql.clone(),
         });
-        Ok(SqlQueryResultValue {
-            index: input.index,
-            sql: input.sql,
-            status: "success",
-            rows: Self::query_rows(query_client, request).await?,
-        })
+        match Self::query_rows(query_client, request).await {
+            Ok(rows) => SqlQueryResultValue {
+                index: input.index,
+                sql: input.sql,
+                status: "success",
+                error: None,
+                rows: Some(rows),
+            },
+            Err(status) => {
+                let error = tool_error_from_status("Query", &status);
+                SqlQueryResultValue {
+                    index: input.index,
+                    sql: input.sql,
+                    status: "error",
+                    error: Some(tool_error_value(&error)),
+                    rows: None,
+                }
+            }
+        }
     }
 
-    async fn execute_sql_queries(
-        &self,
-        inputs: Vec<SqlQueryInput>,
-    ) -> Result<Vec<SqlQueryResultValue>, tonic::Status> {
+    async fn execute_sql_queries(&self, inputs: Vec<SqlQueryInput>) -> Vec<SqlQueryResultValue> {
         let mut results = stream::iter(inputs.into_iter().map(|input| {
             let query_client = self.query.clone();
             Self::execute_sql_query(query_client, input)
@@ -365,26 +382,36 @@ impl CoralMcpServer {
         .collect::<Vec<_>>()
         .await
         .into_iter()
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Vec<_>>();
         results.sort_by_key(|result| result.index);
-        Ok(results)
+        results
     }
 
-    async fn execute_sql_value(&self, queries: Vec<String>) -> Result<Value, tonic::Status> {
+    async fn execute_sql_value(
+        &self,
+        queries: Vec<String>,
+    ) -> Result<(Value, bool), tonic::Status> {
         let total_count = queries.len();
         let inputs = queries
             .into_iter()
             .enumerate()
             .map(|(index, sql)| SqlQueryInput { index, sql })
             .collect::<Vec<_>>();
-        let results = self.execute_sql_queries(inputs).await?;
+        let results = self.execute_sql_queries(inputs).await;
+        let success_count = results
+            .iter()
+            .filter(|result| result.status == "success")
+            .count();
+        let error_count = total_count - success_count;
+        let has_errors = error_count > 0;
         serialize_tool_value(SqlQueriesValue {
-            successful: true,
+            successful: !has_errors,
             total_count,
-            success_count: total_count,
-            error_count: 0,
+            success_count,
+            error_count,
             results,
         })
+        .map(|value| (value, has_errors))
     }
 
     async fn open_episode(
@@ -521,10 +548,11 @@ impl CoralMcpServer {
         match request.name.as_ref() {
             "sql" => {
                 let queries = required_queries_argument(request.arguments.as_ref(), "queries")?;
-                Ok(ToolCallOutcome::from_value_result(
-                    "Query",
-                    self.execute_sql_value(queries).await,
-                ))
+                let (value, has_errors) = self
+                    .execute_sql_value(queries)
+                    .await
+                    .map_err(|status| status_to_error_data(&status))?;
+                Ok(ToolCallOutcome::SqlAggregate { value, has_errors })
             }
             "list_catalog" => {
                 self.list_catalog_tool_result(request.arguments.as_ref())
@@ -793,6 +821,11 @@ fn finish_tool_call(
     match outcome {
         Ok(ToolCallOutcome::Success(value)) => {
             let result = build_tool_result(value);
+            telemetry::record_protocol_result(span, &result);
+            result
+        }
+        Ok(ToolCallOutcome::SqlAggregate { value, has_errors }) => {
+            let result = build_tool_result_with_error(value, has_errors);
             telemetry::record_protocol_result(span, &result);
             result
         }

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -33,22 +33,8 @@ pub(crate) fn tool_error_result(error: ToolError) -> CallToolResult {
         write!(text, "\nHint: {hint}").expect("writing to String cannot fail");
     }
 
-    let metadata = error
-        .metadata
-        .iter()
-        .map(|(key, value)| (key.clone(), Value::String(value.clone())))
-        .collect::<Map<_, _>>();
-
     let structured = serde_json::to_value(StructuredToolErrorValue {
-        error: ToolErrorValue {
-            summary: &error.summary,
-            detail: &error.detail,
-            hint: error.hint.as_deref(),
-            grpc_code: &error.grpc_code,
-            reason: error.reason.as_deref(),
-            retryable: error.retryable,
-            metadata: Value::Object(metadata),
-        },
+        error: tool_error_value_struct(&error),
     })
     .expect("tool error value serializes");
     let mut result = CallToolResult::structured_error(structured);
@@ -56,8 +42,29 @@ pub(crate) fn tool_error_result(error: ToolError) -> CallToolResult {
     result
 }
 
+pub(crate) fn tool_error_value(error: &ToolError) -> Value {
+    serde_json::to_value(tool_error_value_struct(error)).expect("tool error value serializes")
+}
+
+fn tool_error_value_struct(error: &ToolError) -> ToolErrorValue<'_> {
+    let metadata = error
+        .metadata
+        .iter()
+        .map(|(key, value)| (key.clone(), Value::String(value.clone())))
+        .collect::<Map<_, _>>();
+    ToolErrorValue {
+        summary: &error.summary,
+        detail: &error.detail,
+        hint: error.hint.as_deref(),
+        grpc_code: &error.grpc_code,
+        reason: error.reason.as_deref(),
+        retryable: error.retryable,
+        metadata: Value::Object(metadata),
+    }
+}
+
 pub(crate) fn tool_error_from_status(operation: &str, status: &tonic::Status) -> ToolError {
-    let grpc_code = status.code().to_string();
+    let grpc_code = format!("{:?}", status.code());
 
     match decode_status_error(status) {
         DecodedStatusError::Structured(error) => ToolError {
@@ -118,7 +125,7 @@ pub(crate) fn status_to_error_data(status: &tonic::Status) -> ErrorData {
         DecodedStatusError::Structured(error) => {
             let data = serde_json::to_value(StatusErrorDataValue {
                 detail: &error.detail,
-                grpc_code: status.code().to_string(),
+                grpc_code: format!("{:?}", status.code()),
                 reason: &error.reason,
                 retryable: error.retryable,
                 metadata: &error.metadata,
@@ -318,10 +325,7 @@ mod tests {
         let result = tool_error_result(error);
         let json = result.structured_content.expect("structured content");
         assert_eq!(json["error"]["retryable"], false);
-        assert_eq!(
-            json["error"]["grpc_code"],
-            Code::FailedPrecondition.to_string()
-        );
+        assert_eq!(json["error"]["grpc_code"], "FailedPrecondition");
         assert_eq!(json["error"]["reason"], "PROVIDER_REQUEST_FAILED");
         assert_eq!(json["error"]["metadata"]["retryable"], "true");
         assert_eq!(json["error"]["metadata"]["grpc_code"], "Ok");

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -22,6 +22,6 @@ pub(crate) use tools::{
     CatalogToolKind, ToolDescriptionContext, build_tool_result, describe_table_arguments,
     describe_table_tool, feedback_tool, list_catalog_arguments, list_catalog_tool,
     list_columns_arguments, list_columns_tool, open_episode_arguments, open_episode_tool,
-    optional_episode_id_argument, required_string_argument, search_catalog_arguments,
-    search_catalog_tool, sql_tool, with_episode_id_argument,
+    optional_episode_id_argument, required_queries_argument, required_string_argument,
+    search_catalog_arguments, search_catalog_tool, sql_tool, with_episode_id_argument,
 };

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -12,16 +12,19 @@ pub(crate) use catalog::{
     describe_table_value, list_catalog_value, list_columns_value, search_catalog_value,
 };
 pub(crate) use discovery::{Pagination, parse_pagination, parse_pagination_with_limits};
-pub(crate) use errors::{status_to_error_data, tool_error_from_status, tool_error_result};
+pub(crate) use errors::{
+    status_to_error_data, tool_error_from_status, tool_error_result, tool_error_value,
+};
 pub(crate) use resources::{
     guide_resource, guide_resource_content, initial_instructions, tables_resource,
     tables_resource_content,
 };
 pub(crate) use source_names::connected_source_names_text;
 pub(crate) use tools::{
-    CatalogToolKind, ToolDescriptionContext, build_tool_result, describe_table_arguments,
-    describe_table_tool, feedback_tool, list_catalog_arguments, list_catalog_tool,
-    list_columns_arguments, list_columns_tool, open_episode_arguments, open_episode_tool,
-    optional_episode_id_argument, required_queries_argument, required_string_argument,
-    search_catalog_arguments, search_catalog_tool, sql_tool, with_episode_id_argument,
+    CatalogToolKind, ToolDescriptionContext, build_tool_result, build_tool_result_with_error,
+    describe_table_arguments, describe_table_tool, feedback_tool, list_catalog_arguments,
+    list_catalog_tool, list_columns_arguments, list_columns_tool, open_episode_arguments,
+    open_episode_tool, optional_episode_id_argument, required_queries_argument,
+    required_string_argument, search_catalog_arguments, search_catalog_tool, sql_tool,
+    with_episode_id_argument,
 };

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -14,6 +14,7 @@ use super::{
 
 const EPISODE_ID_ARGUMENT_DESCRIPTION: &str = "Optional episode id returned by open_episode. Pass it on subsequent Coral tool calls for the same task so Coral can attribute the call to that episode.";
 const EPISODE_ID_JSON_SCHEMA_PATTERN: &str = "^[!-~]+$";
+pub(crate) const MAX_SQL_QUERIES: usize = 10;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ToolDescriptionContext {
@@ -90,15 +91,22 @@ pub(crate) fn sql_tool(context: &ToolDescriptionContext) -> Tool {
         sql_tool_description(context),
         json_object_schema(&json!({
             "type": "object",
-            "required": ["sql"],
+            "required": ["queries"],
             "properties": {
-                "sql": {
-                    "type": "string",
-                    "description": "One read-only SQL statement to execute against the Coral database and its configured connected source schemas."
+                "queries": {
+                    "type": "array",
+                    "description": "One or more independent read-only SQL statements to execute against the Coral database and its configured connected source schemas.",
+                    "minItems": 1,
+                    "maxItems": MAX_SQL_QUERIES,
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
                 }
             }
         })),
     )
+    .with_raw_output_schema(sql_output_schema())
     .with_annotations(
         ToolAnnotations::with_title("Run SQL")
             .read_only(true)
@@ -106,6 +114,50 @@ pub(crate) fn sql_tool(context: &ToolDescriptionContext) -> Tool {
             .idempotent(true)
             .open_world(true),
     )
+}
+
+pub(crate) fn required_queries_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+) -> Result<Vec<String>, ErrorData> {
+    let values = arguments
+        .and_then(|arguments| arguments.get(key))
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            ErrorData::invalid_params(format!("missing array argument '{key}'"), None)
+        })?;
+    if values.is_empty() {
+        return Err(ErrorData::invalid_params(
+            format!("argument '{key}' must contain at least one query"),
+            None,
+        ));
+    }
+    if values.len() > MAX_SQL_QUERIES {
+        return Err(ErrorData::invalid_params(
+            format!("argument '{key}' must contain at most {MAX_SQL_QUERIES} queries"),
+            None,
+        ));
+    }
+
+    values
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let query = value.as_str().ok_or_else(|| {
+                ErrorData::invalid_params(
+                    format!("argument '{key}' item {index} must be a string"),
+                    None,
+                )
+            })?;
+            if query.trim().is_empty() {
+                return Err(ErrorData::invalid_params(
+                    format!("argument '{key}' item {index} must not be blank"),
+                    None,
+                ));
+            }
+            Ok(query.to_string())
+        })
+        .collect()
 }
 
 pub(crate) fn list_catalog_tool(context: &ToolDescriptionContext) -> Tool {
@@ -496,16 +548,54 @@ pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorDat
 fn sql_tool_description(context: &ToolDescriptionContext) -> String {
     if context.visible_table_count == 0 {
         format!(
-            "Execute read-only SQL against the Coral database. {} No user tables are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first.",
+            "Execute one or more independent read-only SQL statements against the Coral database. {} No user tables are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first.",
             context.connected_sources_sentence()
         )
     } else {
         format!(
-            "Execute read-only SQL against the Coral database across connected Coral sources/schemas. {} {} table(s) are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first. Use JOIN, CROSS JOIN, CTEs, subqueries, and aggregates to combine tables in one statement.",
+            "Execute one or more independent read-only SQL statements against the Coral database across connected Coral sources/schemas. {} {} table(s) are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first. Use JOIN, CROSS JOIN, CTEs, subqueries, and aggregates to combine tables in one statement when one statement can answer the question.",
             context.connected_sources_sentence(),
             context.visible_table_count
         )
     }
+}
+
+fn sql_output_schema() -> Arc<Map<String, Value>> {
+    json_object_schema(&json!({
+        "type": "object",
+        "required": ["successful", "total_count", "success_count", "error_count", "results"],
+        "additionalProperties": false,
+        "properties": {
+            "successful": { "type": "boolean" },
+            "total_count": { "type": "integer", "minimum": 0 },
+            "success_count": { "type": "integer", "minimum": 0 },
+            "error_count": { "type": "integer", "minimum": 0 },
+            "results": {
+                "type": "array",
+                "items": sql_success_result_output_schema()
+            }
+        }
+    }))
+}
+
+fn sql_success_result_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["index", "sql", "status", "rows"],
+        "additionalProperties": false,
+        "properties": {
+            "index": { "type": "integer", "minimum": 0 },
+            "sql": { "type": "string" },
+            "status": { "enum": ["success"] },
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            }
+        }
+    })
 }
 
 fn search_catalog_description(context: &ToolDescriptionContext) -> String {
@@ -990,7 +1080,15 @@ mod tests {
     #[test]
     fn success_tool_result_text_uses_compact_json() {
         let value = json!({
-            "rows": [
+            "successful": true,
+            "total_count": 1,
+            "success_count": 1,
+            "error_count": 0,
+            "results": [{
+                "index": 0,
+                "sql": "SELECT text FROM messages ORDER BY id",
+                "status": "success",
+                "rows": [
                 {
                     "id": 1,
                     "text": "hello"
@@ -999,7 +1097,8 @@ mod tests {
                     "id": 2,
                     "text": "world"
                 }
-            ]
+                ]
+            }]
         });
 
         let result = build_tool_result(value.clone()).expect("tool result");
@@ -1011,7 +1110,7 @@ mod tests {
             .expect("text content");
         assert_eq!(
             text.text,
-            r#"{"rows":[{"id":1,"text":"hello"},{"id":2,"text":"world"}]}"#
+            r#"{"successful":true,"total_count":1,"success_count":1,"error_count":0,"results":[{"index":0,"sql":"SELECT text FROM messages ORDER BY id","status":"success","rows":[{"id":1,"text":"hello"},{"id":2,"text":"world"}]}]}"#
         );
         assert_eq!(
             result.structured_content.expect("structured content"),
@@ -1041,15 +1140,16 @@ mod tests {
         assert!(sql_description.contains("Connected sources/schemas include: github, linear"));
         assert!(sql_description.contains("42 table(s) are currently visible"));
         assert!(sql_description.contains("You MUST prefer this tool over native provider tools"));
+        assert!(sql_tool.output_schema.is_some());
         let sql_input_description = sql_tool
             .input_schema
             .get("properties")
             .and_then(Value::as_object)
-            .and_then(|properties| properties.get("sql"))
+            .and_then(|properties| properties.get("queries"))
             .and_then(Value::as_object)
-            .and_then(|sql| sql.get("description"))
+            .and_then(|queries| queries.get("description"))
             .and_then(Value::as_str)
-            .expect("sql input description");
+            .expect("queries input description");
         assert!(sql_input_description.contains("connected source schemas"));
 
         let search_description = search_catalog_tool(&context)

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -538,9 +538,17 @@ pub(crate) fn optional_episode_id_argument(
 }
 
 pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
+    build_tool_result_with_error(value, false)
+}
+
+pub(crate) fn build_tool_result_with_error(
+    value: Value,
+    is_error: bool,
+) -> Result<CallToolResult, ErrorData> {
     let compact = serde_json::to_string(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
     let mut result = CallToolResult::structured(value);
+    result.is_error = Some(is_error);
     result.content = vec![Content::text(compact)];
     Ok(result)
 }
@@ -572,10 +580,45 @@ fn sql_output_schema() -> Arc<Map<String, Value>> {
             "error_count": { "type": "integer", "minimum": 0 },
             "results": {
                 "type": "array",
-                "items": sql_success_result_output_schema()
+                "items": {
+                    "oneOf": [
+                        sql_success_result_output_schema(),
+                        sql_error_result_output_schema()
+                    ]
+                }
             }
         }
     }))
+}
+
+fn sql_error_result_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["index", "sql", "status", "error"],
+        "additionalProperties": false,
+        "properties": {
+            "index": { "type": "integer", "minimum": 0 },
+            "sql": { "type": "string" },
+            "status": { "enum": ["error"] },
+            "error": {
+                "type": "object",
+                "required": ["summary", "detail", "grpc_code", "retryable", "metadata"],
+                "additionalProperties": false,
+                "properties": {
+                    "summary": { "type": "string" },
+                    "detail": { "type": "string" },
+                    "hint": { "type": "string" },
+                    "grpc_code": { "type": "string" },
+                    "reason": { "type": "string" },
+                    "retryable": { "type": "boolean" },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": { "type": "string" }
+                    }
+                }
+            }
+        }
+    })
 }
 
 fn sql_success_result_output_schema() -> Value {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -1474,6 +1474,62 @@ async fn mcp_feedback_tool_is_disabled_by_default() {
 }
 
 #[tokio::test]
+async fn mcp_sql_executes_multiple_queries_in_input_order() {
+    let temp = TempDir::new().expect("temp dir");
+    let manifest_path = write_fixture_manifest(temp.path());
+    let manifest_yaml = fs::read_to_string(&manifest_path).expect("read manifest");
+    let mut session = start_session(&temp).await;
+    let client = &session.client;
+
+    add_demo_source(&mut session.source_client, manifest_yaml).await;
+    let tools = client.list_all_tools().await.expect("tools");
+    let sql_tool = tool_by_name(&tools, "sql");
+
+    let first_sql = "SELECT text FROM local_messages.messages ORDER BY text LIMIT 1";
+    let second_sql = "SELECT COUNT(*) AS message_count FROM local_messages.messages";
+    let third_sql = "SELECT text FROM local_messages.messages ORDER BY text DESC LIMIT 1";
+    let sql = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "queries": [first_sql, second_sql, third_sql]
+            }))),
+        )
+        .await
+        .expect("multi-query sql");
+    assert_eq!(sql.is_error, Some(false));
+
+    let text = sql.content[0]
+        .as_text()
+        .expect("text content")
+        .text
+        .as_str();
+    let sql_value = sql.structured_content.expect("structured content");
+    assert_eq!(
+        serde_json::to_string(&sql_value).expect("compact json"),
+        text
+    );
+    assert_eq!(sql_value["successful"], true);
+    assert_eq!(sql_value["total_count"], 3);
+    assert_eq!(sql_value["success_count"], 3);
+    assert_eq!(sql_value["error_count"], 0);
+    assert_eq!(sql_value["results"][0]["index"], 0);
+    assert_eq!(sql_value["results"][0]["sql"], first_sql);
+    assert_eq!(sql_value["results"][0]["status"], "success");
+    assert_eq!(sql_result_rows(&sql_value, 0)[0]["text"], "hello");
+    assert_eq!(sql_value["results"][1]["index"], 1);
+    assert_eq!(sql_value["results"][1]["sql"], second_sql);
+    assert_eq!(sql_value["results"][1]["status"], "success");
+    assert_eq!(sql_result_rows(&sql_value, 1)[0]["message_count"], "2");
+    assert_eq!(sql_value["results"][2]["index"], 2);
+    assert_eq!(sql_value["results"][2]["sql"], third_sql);
+    assert_eq!(sql_value["results"][2]["status"], "success");
+    assert_eq!(sql_result_rows(&sql_value, 2)[0]["text"], "world");
+    assert_matches_output_schema(sql_tool, &sql_value);
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
 async fn mcp_tool_error_does_not_end_session() {
     let temp = TempDir::new().expect("temp dir");
     let manifest_path = write_fixture_manifest(temp.path());

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -324,6 +324,10 @@ fn assert_matches_output_schema(tool: &Tool, value: &Value) {
     }
 }
 
+fn sql_result_rows(value: &Value, index: usize) -> &Value {
+    &value["results"][index]["rows"]
+}
+
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,
@@ -427,7 +431,7 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
     let sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "SELECT 1 AS ok",
+                "queries": ["SELECT 1 AS ok"],
                 "episode_id": child_episode_id
             }))),
         )
@@ -435,14 +439,14 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
         .expect("tagged sql");
     assert_eq!(sql.is_error, Some(false));
     assert_eq!(
-        sql.structured_content.expect("sql structured")["rows"][0]["ok"],
+        sql_result_rows(&sql.structured_content.expect("sql structured"), 0)[0]["ok"],
         "1"
     );
 
     let invalid_episode_id = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "SELECT 1",
+                "queries": ["SELECT 1"],
                 "episode_id": "has space"
             }))),
         )
@@ -562,12 +566,12 @@ async fn mcp_catalog_helpers_expose_coral_system_tables_from_sql_catalog() {
     let sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "SELECT table_name FROM coral.tables WHERE schema_name = 'coral' ORDER BY table_name"
+                "queries": ["SELECT table_name FROM coral.tables WHERE schema_name = 'coral' ORDER BY table_name"]
             }))),
         )
         .await
         .expect("sql system catalog");
-    let sql_rows = sql.structured_content.as_ref().expect("structured sql")["rows"]
+    let sql_rows = sql_result_rows(sql.structured_content.as_ref().expect("structured sql"), 0)
         .as_array()
         .expect("sql rows");
     assert_eq!(
@@ -672,6 +676,14 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .expect("sql description")
             .contains("No connected user sources are currently configured")
     );
+    let sql_tool = tool_by_name(&initial_tools, "sql");
+    let sql_properties = tool_input_properties(sql_tool);
+    assert!(sql_properties.contains_key("queries"));
+    assert!(!sql_properties.contains_key("sql"));
+    assert_eq!(sql_tool.input_schema["required"], json!(["queries"]));
+    assert_eq!(sql_properties["queries"]["minItems"], json!(1));
+    assert_eq!(sql_properties["queries"]["maxItems"], json!(10));
+    assert!(sql_tool.output_schema.is_some());
     for tool in &initial_tools {
         let Some(output_schema) = &tool.output_schema else {
             continue;
@@ -1470,25 +1482,44 @@ async fn mcp_tool_error_does_not_end_session() {
     let client = &session.client;
 
     add_demo_source(&mut session.source_client, manifest_yaml).await;
+    let tools = client.list_all_tools().await.expect("tools");
+    let sql_tool = tool_by_name(&tools, "sql");
 
     let sql = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "queries": ["SELECT text FROM local_messages.messages ORDER BY text"]
+            }))),
+        )
+        .await
+        .expect("sql");
+    let sql_value = sql.structured_content.expect("structured content");
+    assert_eq!(sql_value["successful"], true);
+    assert_eq!(sql_value["total_count"], 1);
+    assert_eq!(sql_value["success_count"], 1);
+    assert_eq!(sql_value["error_count"], 0);
+    assert_eq!(sql_value["results"][0]["index"], 0);
+    assert_eq!(
+        sql_value["results"][0]["sql"],
+        "SELECT text FROM local_messages.messages ORDER BY text"
+    );
+    assert_eq!(sql_result_rows(&sql_value, 0)[0]["text"], "hello");
+    assert_matches_output_schema(sql_tool, &sql_value);
+    assert_eq!(sql.is_error, Some(false));
+
+    client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
                 "sql": "SELECT text FROM local_messages.messages ORDER BY text"
             }))),
         )
         .await
-        .expect("sql");
-    assert_eq!(
-        sql.structured_content.expect("structured content")["rows"][0]["text"],
-        "hello"
-    );
-    assert_eq!(sql.is_error, Some(false));
+        .expect_err("legacy sql argument should fail before execution");
 
     let invalid_sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "DELETE FROM local_messages.messages"
+                "queries": ["DELETE FROM local_messages.messages"]
             }))),
         )
         .await
@@ -1542,14 +1573,15 @@ async fn mcp_sql_returns_large_int64_as_string() {
     let sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "SELECT CAST(-8504475857937456387 AS BIGINT) AS user_id"
+                "queries": ["SELECT CAST(-8504475857937456387 AS BIGINT) AS user_id"]
             }))),
         )
         .await
         .expect("sql");
     assert_eq!(sql.is_error, Some(false));
 
-    let rows = &sql.structured_content.expect("structured content")["rows"];
+    let sql_value = sql.structured_content.expect("structured content");
+    let rows = sql_result_rows(&sql_value, 0);
     assert_eq!(
         rows[0]["user_id"],
         Value::String("-8504475857937456387".to_string()),

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -1530,6 +1530,10 @@ async fn mcp_sql_executes_multiple_queries_in_input_order() {
 }
 
 #[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Session-continuity coverage intentionally keeps success, partial failure, all failure, and follow-up call assertions together."
+)]
 async fn mcp_tool_error_does_not_end_session() {
     let temp = TempDir::new().expect("temp dir");
     let manifest_path = write_fixture_manifest(temp.path());
@@ -1572,26 +1576,72 @@ async fn mcp_tool_error_does_not_end_session() {
         .await
         .expect_err("legacy sql argument should fail before execution");
 
-    let invalid_sql = client
+    let mixed_sql = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "queries": [
+                    "SELECT text FROM local_messages.messages ORDER BY text LIMIT 1",
+                    "DELETE FROM local_messages.messages",
+                    "SELECT text FROM local_messages.messages ORDER BY text DESC LIMIT 1"
+                ]
+            }))),
+        )
+        .await
+        .expect("partially failing sql still returns tool result");
+    assert_eq!(mixed_sql.is_error, Some(true));
+    let mixed_text = mixed_sql.content[0]
+        .as_text()
+        .expect("text content")
+        .text
+        .as_str();
+    let mixed_value = mixed_sql.structured_content.expect("structured content");
+    assert_eq!(
+        serde_json::to_string(&mixed_value).expect("compact json"),
+        mixed_text
+    );
+    assert_eq!(mixed_value["successful"], false);
+    assert_eq!(mixed_value["total_count"], 3);
+    assert_eq!(mixed_value["success_count"], 2);
+    assert_eq!(mixed_value["error_count"], 1);
+    assert_eq!(mixed_value["results"][0]["status"], "success");
+    assert_eq!(sql_result_rows(&mixed_value, 0)[0]["text"], "hello");
+    assert_eq!(mixed_value["results"][1]["index"], 1);
+    assert_eq!(mixed_value["results"][1]["status"], "error");
+    assert_eq!(
+        mixed_value["results"][1]["error"]["summary"],
+        "Query request is invalid"
+    );
+    assert_eq!(
+        mixed_value["results"][1]["error"]["grpc_code"],
+        "InvalidArgument"
+    );
+    assert_eq!(mixed_value["results"][1]["error"]["retryable"], false);
+    assert!(mixed_value["results"][1]["error"]["metadata"].is_object());
+    assert_eq!(mixed_value["results"][2]["status"], "success");
+    assert_eq!(sql_result_rows(&mixed_value, 2)[0]["text"], "world");
+    assert_matches_output_schema(sql_tool, &mixed_value);
+
+    let all_invalid_sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
                 "queries": ["DELETE FROM local_messages.messages"]
             }))),
         )
         .await
-        .expect("failing sql still returns tool result");
-    assert_eq!(invalid_sql.is_error, Some(true));
+        .expect("failing sql still returns aggregate tool result");
+    assert_eq!(all_invalid_sql.is_error, Some(true));
+    let all_invalid_value = all_invalid_sql
+        .structured_content
+        .expect("structured content");
+    assert_eq!(all_invalid_value["successful"], false);
+    assert_eq!(all_invalid_value["success_count"], 0);
+    assert_eq!(all_invalid_value["error_count"], 1);
+    assert_eq!(all_invalid_value["results"][0]["status"], "error");
     assert_eq!(
-        invalid_sql.structured_content.expect("structured content")["error"]["summary"],
+        all_invalid_value["results"][0]["error"]["summary"],
         "Query request is invalid"
     );
-    assert!(
-        invalid_sql.content[0]
-            .as_text()
-            .expect("text content")
-            .text
-            .contains("Detail:")
-    );
+    assert_matches_output_schema(sql_tool, &all_invalid_value);
 
     let catalog_after_error = client
         .call_tool(
@@ -1613,6 +1663,48 @@ async fn mcp_tool_error_does_not_end_session() {
         "local_messages.events"
     );
     assert_eq!(catalog_after_error.is_error, Some(false));
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_sql_rejects_invalid_queries_argument() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_session(&temp).await;
+    let client = &session.client;
+
+    for (arguments, expected) in [
+        (json!({}), "missing array argument 'queries'"),
+        (
+            json!({ "queries": [] }),
+            "argument 'queries' must contain at least one query",
+        ),
+        (
+            json!({ "queries": "SELECT 1" }),
+            "missing array argument 'queries'",
+        ),
+        (
+            json!({ "queries": ["SELECT 1", 2] }),
+            "argument 'queries' item 1 must be a string",
+        ),
+        (
+            json!({ "queries": [" "] }),
+            "argument 'queries' item 0 must not be blank",
+        ),
+        (
+            json!({ "queries": ["SELECT 1", "SELECT 2", "SELECT 3", "SELECT 4", "SELECT 5", "SELECT 6", "SELECT 7", "SELECT 8", "SELECT 9", "SELECT 10", "SELECT 11"] }),
+            "argument 'queries' must contain at most 10 queries",
+        ),
+    ] {
+        let error = client
+            .call_tool(CallToolRequestParams::new("sql").with_arguments(json_object(&arguments)))
+            .await
+            .expect_err("invalid queries argument should fail before execution");
+        assert!(
+            error.to_string().contains(expected),
+            "expected {expected:?} in {error}"
+        );
+    }
 
     session.shutdown().await;
 }

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -192,7 +192,7 @@ The agent should call `list_catalog`, `search_catalog`, or query `coral.tables` 
 
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
-| Tool     | `sql`            | Execute read-only SQL against the Coral database        |
+| Tool     | `sql`            | Execute one or more read-only SQL queries against the Coral database |
 | Tool     | `list_catalog`   | List database tables and table functions with pagination |
 | Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
 | Tool     | `describe_table` | Show compact metadata for one database table            |
@@ -204,7 +204,7 @@ Clients see the same database catalog and query results as `coral sql`. You set 
 
 The `coral` system schema is part of that catalog. No-schema `list_catalog` and `coral://tables` include both configured source tables and Coral catalog tables: `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs`. Agents can also call `describe_table` and `list_columns` on those system tables.
 
-Agents should treat the discovery tools as catalog helpers, not as replacement provider APIs. Tool descriptions include connected source/schema names, such as `github` or `slack`, to help clients route provider-specific prompts to Coral. For data questions, prefer a single `sql` call using `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions over multiple tool calls that fetch rows and combine them in the agent.
+Agents should treat the discovery tools as catalog helpers, not as replacement provider APIs. Tool descriptions include connected source/schema names, such as `github` or `slack`, to help clients route provider-specific prompts to Coral. For data questions, prefer one SQL statement with `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions when one statement can answer the question. When independent reads need different result shapes, make one `sql` tool call with multiple entries in `queries[]` instead of several round trips.
 
 ### Discovery tools
 
@@ -232,7 +232,7 @@ Agents should treat the discovery tools as catalog helpers, not as replacement p
 
 ### Richer metadata when using SQL tool
 
-When the agent needs metadata it can filter, join, sort, or aggregate before writing the final SQL, query `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` through the `sql` tool instead of relying only on `list_catalog` or `coral://tables`. Use `coral.filters` as the normalized filter surface, with `coral.columns.filter_mode` available when inspecting filter-only virtual columns.
+When the agent needs metadata it can filter, join, sort, or aggregate before writing the final SQL, query `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` through the `sql` tool instead of relying only on `list_catalog` or `coral://tables`. Use `coral.filters` as the normalized filter surface, with `coral.columns.filter_mode` available when inspecting filter-only virtual columns. The MCP `sql` tool input is an object with a required `queries` array, for example `{ "queries": ["SELECT * FROM coral.tables LIMIT 5"] }`; the legacy single `sql` string argument is not supported.
 
 ### Searching a provider's data
 
@@ -240,7 +240,41 @@ Some sources expose native search endpoints (for example, GitHub issue search) a
 
 ## Query result format
 
-The `sql` tool returns rows as a JSON array of objects. To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
+The `sql` tool returns an aggregate object with counters and ordered per-query results:
+
+```json
+{
+  "successful": false,
+  "total_count": 2,
+  "success_count": 1,
+  "error_count": 1,
+  "results": [
+    {
+      "index": 0,
+      "sql": "SELECT 1 AS ok",
+      "status": "success",
+      "rows": [{ "ok": "1" }]
+    },
+    {
+      "index": 1,
+      "sql": "DELETE FROM local_messages.messages",
+      "status": "error",
+      "error": {
+        "summary": "Query request is invalid",
+        "detail": "...",
+        "hint": "...",
+        "grpc_code": "InvalidArgument",
+        "retryable": false,
+        "metadata": {}
+      }
+    }
+  ]
+}
+```
+
+Each validated query runs independently. Success items contain `rows`; error items contain a structured Coral error. The top-level MCP `is_error` flag is true whenever `error_count > 0`, but the MCP session stays open and successful rows remain available next to failures.
+
+Rows are JSON arrays of objects under each success result item. To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
 
 - `Int64` (`BIGINT`) and `UInt64`
 - `Decimal32`, `Decimal64`, `Decimal128`, and `Decimal256`


### PR DESCRIPTION
[Ticket](https://cloud.humanlayer.com/artifacts/019eff6d-97ad-79f8-9c84-4f0a8a27cf85) | [Research](https://cloud.humanlayer.com/artifacts/019eff81-d97e-703b-9918-bd6d0bc5cad3) | [Design discussion](https://cloud.humanlayer.com/artifacts/019eff89-9b0a-7a5a-8e25-c4686ec69828) | [Structure outline](https://cloud.humanlayer.com/artifacts/019effe7-8d48-7cda-876e-803c9bf22e3a) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/019f009b-3c73-7746-a857-09382969d011)

## What problems was I solving

The MCP `sql` tool only accepted one SQL statement per tool call and returned one root `{ "rows": [...] }` object. Agents that needed several independent reads with different result shapes had to make several MCP round trips, even when those reads belonged to one user request.

This PR makes that workflow first-class by changing the MCP `sql` tool to a required `queries[]` contract and returning a stable aggregate envelope with ordered per-query results. It is a breaking MCP tool contract change: the legacy single `sql` argument and legacy root `{ rows }` output shape are intentionally removed.

The implementation also fixes partial-failure behavior for this aggregate path. Once the input array validates, each query runs independently; successful rows remain available next to failed queries, failed items carry Coral's structured error fields, and top-level MCP `is_error` is set when any item fails without ending the MCP session.

## What user-facing changes did I ship

- [crates/coral-mcp/src/surface/tools.rs](https://github.com/withcoral/coral/pull/1392/files#diff-cffd5d109cee28edde990cbb908d24e729feafc727d2a89075f55d8c399414f1R88) - the advertised MCP `sql` tool now requires `queries: string[]`, enforces 1-10 non-blank query strings, removes the legacy `sql` input, and advertises an aggregate output schema.
- [crates/coral-mcp/src/server.rs](https://github.com/withcoral/coral/pull/1392/files#diff-a03a1c6e7bc4c2e410d8cdd6c98ec97b2734d200e293f6a49fc5b36a84c8792cR376) - one `sql` tool call executes validated queries with bounded concurrency, preserves input ordering in `results[]`, and returns aggregate counters.
- [crates/coral-mcp/src/server.rs](https://github.com/withcoral/coral/pull/1392/files#diff-a03a1c6e7bc4c2e410d8cdd6c98ec97b2734d200e293f6a49fc5b36a84c8792cR347) - per-query backend failures become structured result items while successes keep their JSON-safe `rows` payloads.
- [crates/coral-mcp/src/guide_template.md](https://github.com/withcoral/coral/pull/1392/files#diff-34a9963fa5b0ff28c1a0663803dec5af8b884d381f105426191e54e9ce199a6fR9) - embedded MCP guidance tells agents when to batch independent reads with `queries[]` while still preferring one set-based SQL statement when possible.
- [docs/guides/use-coral-over-mcp.mdx](https://github.com/withcoral/coral/pull/1392/files#diff-c6f5b4c7280c2f1e3ee66549197cbfd604473a81b3a4b8f0cba4aa0c86f0b03dR235) - public MCP docs describe the required `queries` array, aggregate result format, partial errors, and session continuity behavior.

## How I implemented it

### MCP Contract

- [crates/coral-mcp/src/surface/tools.rs](https://github.com/withcoral/coral/pull/1392/files#diff-cffd5d109cee28edde990cbb908d24e729feafc727d2a89075f55d8c399414f1R88) - changed `sql_tool()` from a required `sql` string to a required `queries` array with `minItems: 1`, `maxItems: 10`, and string items.
- [crates/coral-mcp/src/surface/tools.rs](https://github.com/withcoral/coral/pull/1392/files#diff-cffd5d109cee28edde990cbb908d24e729feafc727d2a89075f55d8c399414f1R119) - added `required_queries_argument()` so missing, empty, oversized, non-array, non-string, and blank values fail as MCP `invalid_params` before any backend query is executed.
- [crates/coral-mcp/src/surface/tools.rs](https://github.com/withcoral/coral/pull/1392/files#diff-cffd5d109cee28edde990cbb908d24e729feafc727d2a89075f55d8c399414f1R571) - added an aggregate output schema with top-level counters plus success/error result variants.
- [crates/coral-mcp/src/surface/mod.rs](https://github.com/withcoral/coral/pull/1392/files#diff-9628895beab2391cbcc5dbff5a31b06caddeca5abe6816415cd2659e5d9e4466) - re-exported the new argument validator and aggregate result helpers needed by the server.

### MCP Execution

- [crates/coral-mcp/src/server.rs](https://github.com/withcoral/coral/pull/1392/files#diff-a03a1c6e7bc4c2e410d8cdd6c98ec97b2734d200e293f6a49fc5b36a84c8792cR52) - introduced the aggregate SQL value structs and `MAX_CONCURRENT_SQL_QUERIES = 10` for bounded fan-out.
- [crates/coral-mcp/src/server.rs](https://github.com/withcoral/coral/pull/1392/files#diff-a03a1c6e7bc4c2e410d8cdd6c98ec97b2734d200e293f6a49fc5b36a84c8792cR336) - kept Arrow IPC decode and JSON-safe row rendering in the same shared `query_rows()` path so successful aggregate rows preserve existing behavior.
- [crates/coral-mcp/src/server.rs](https://github.com/withcoral/coral/pull/1392/files#diff-a03a1c6e7bc4c2e410d8cdd6c98ec97b2734d200e293f6a49fc5b36a84c8792cR376) - executes each indexed query through a cloned `QueryClient`, uses `buffer_unordered(10)`, then sorts by `index` before serialization.
- [crates/coral-mcp/src/server.rs](https://github.com/withcoral/coral/pull/1392/files#diff-a03a1c6e7bc4c2e410d8cdd6c98ec97b2734d200e293f6a49fc5b36a84c8792cR390) - computes `successful`, `total_count`, `success_count`, and `error_count` from the collected results.
- [crates/coral-mcp/src/server.rs](https://github.com/withcoral/coral/pull/1392/files#diff-a03a1c6e7bc4c2e410d8cdd6c98ec97b2734d200e293f6a49fc5b36a84c8792cR827) - routes the aggregate through `build_tool_result_with_error()` so MCP `is_error` reflects whether any query failed.
- [crates/coral-mcp/Cargo.toml](https://github.com/withcoral/coral/pull/1392/files#diff-ef5ac2fb64b8e8b0b10f5ea7bba0abd5ba0fcb231226adf46ff863b03b1f0b9aR13) and [Cargo.lock](https://github.com/withcoral/coral/pull/1392/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) - add the workspace `futures` dependency used for bounded stream concurrency.

### Error Shape

- [crates/coral-mcp/src/surface/errors.rs](https://github.com/withcoral/coral/pull/1392/files#diff-4d5acd33186336281401e8a090d7c4142bc2c77352e57dd63355108fe96b5021R45) - factored structured tool-error serialization into `tool_error_value()` so SQL result items can embed the same fields as existing top-level tool errors.
- [crates/coral-mcp/src/surface/errors.rs](https://github.com/withcoral/coral/pull/1392/files#diff-4d5acd33186336281401e8a090d7c4142bc2c77352e57dd63355108fe96b5021R67) - normalizes `grpc_code` strings to the enum-style names used by the new aggregate error assertions, such as `InvalidArgument`.

### Tests

- [crates/coral-mcp/src/tests.rs](https://github.com/withcoral/coral/pull/1392/files#diff-38a4ab53eb9c18806bcd5ba279470f2bba4c97cb56e0ceec1d86b60bd8de929eR1477) - added in-process MCP coverage for multiple successful queries returning in input order.
- [crates/coral-mcp/src/tests.rs](https://github.com/withcoral/coral/pull/1392/files#diff-38a4ab53eb9c18806bcd5ba279470f2bba4c97cb56e0ceec1d86b60bd8de929eR1537) - expanded session-continuity coverage to include a legacy-argument rejection, partial failure, all failure, output-schema validation, and a later catalog call.
- [crates/coral-mcp/src/tests.rs](https://github.com/withcoral/coral/pull/1392/files#diff-38a4ab53eb9c18806bcd5ba279470f2bba4c97cb56e0ceec1d86b60bd8de929eR1671) - added invalid `queries` argument coverage for every validation branch.
- [crates/coral-mcp/src/tests.rs](https://github.com/withcoral/coral/pull/1392/files#diff-38a4ab53eb9c18806bcd5ba279470f2bba4c97cb56e0ceec1d86b60bd8de929eR1716) - moved the large-`Int64` JSON-safe numeric assertion under `results[0].rows`.
- [crates/coral-cli/tests/mcp.rs](https://github.com/withcoral/coral/pull/1392/files#diff-95eab225e2dc855a085b457ca9b0ce55dfd6883392f4d38ca5de160532d1d4d5R913) - added CLI-launched stdio MCP coverage that one tool call produces two backend `ExecuteSqlRequest`s.
- [crates/coral-cli/tests/mcp.rs](https://github.com/withcoral/coral/pull/1392/files#diff-95eab225e2dc855a085b457ca9b0ce55dfd6883392f4d38ca5de160532d1d4d5R958) - updated stdio MCP error coverage to assert aggregate error items and continued session usability.

### Docs and Guidance

- [crates/coral-mcp/src/guide_template.md](https://github.com/withcoral/coral/pull/1392/files#diff-34a9963fa5b0ff28c1a0663803dec5af8b884d381f105426191e54e9ce199a6fR67) - documents the aggregate counters, ordered `results[]`, success rows, structured error items, and removal of the legacy single `sql` argument in the embedded guide.
- [docs/guides/use-coral-over-mcp.mdx](https://github.com/withcoral/coral/pull/1392/files#diff-c6f5b4c7280c2f1e3ee66549197cbfd604473a81b3a4b8f0cba4aa0c86f0b03dR207) - updates user guidance to prefer one SQL statement when it fits, and one multi-entry `queries[]` call when independent reads need different result shapes.
- [docs/guides/use-coral-over-mcp.mdx](https://github.com/withcoral/coral/pull/1392/files#diff-c6f5b4c7280c2f1e3ee66549197cbfd604473a81b3a4b8f0cba4aa0c86f0b03dR241) - replaces the old root rows result description with a full aggregate JSON example and partial-failure explanation.

## Deviations from the plan

No `*plan*.md` artifact exists for this task, so there was no formal plan file to compare against.

### Implemented as planned
- Compared with the available structure outline, the implementation follows the outlined phases: aggregate `queries[]` contract, bounded ordered execution, per-query errors, test updates, and docs updates.
- The direct `coral sql` CLI, protobuf API, app query service, and engine execution semantics remain unchanged as intended.

### Deviations/surprises
- No material deviations found. The notable implementation detail is the `grpc_code` string normalization in `crates/coral-mcp/src/surface/errors.rs`, which supports the new aggregate error assertions and keeps structured error fields consistent.

### Additions not in plan
- No extra product behavior beyond the structure outline. This PR description and walkthrough are review artifacts only.

### Items planned but not implemented
- None apparent from the structure outline. The manual verification checklist remains reviewer-facing; the automated checks recorded there are included below.

## How to verify it

### Manual Testing
- [ ] Check out the branch:
  ```bash
  git fetch origin
  git switch support-multiple-sql-queries-in-mcp-tool
  git pull --ff-only
  ```
- [ ] Start an MCP client against Coral and inspect `tools/list`; the `sql` tool should advertise required `queries`, no legacy `sql` property, and an aggregate output schema.
- [ ] Call the MCP `sql` tool with multiple successful entries, for example `{ "queries": ["SELECT 1 AS one", "SELECT 2 AS two"] }`; expect `successful: true`, `total_count: 2`, ordered `results[]`, and rows under each success item.
- [ ] Call the MCP `sql` tool with one valid read and one invalid/write statement; expect `is_error: true`, successful rows preserved next to a structured error item, and the MCP session still able to run another tool call.
- [ ] Confirm the direct `coral sql` CLI command still uses its existing one-statement interface.

### Automated Tests
```bash
cargo test -p coral-mcp mcp_sql_executes_multiple_queries_in_input_order
cargo test -p coral-mcp mcp_tool_error_does_not_end_session
cargo test -p coral-mcp mcp_sql_rejects_invalid_queries_argument
cargo test -p coral-mcp mcp_sql_returns_large_int64_as_string
cargo test -p coral-cli --test mcp mcp_stdio_sql_executes_multiple_queries
cargo test -p coral-cli --test mcp mcp_stdio_tool_errors_do_not_end_the_session
make rust-checks
make docs-check
```

## Description for the changelog

Breaking: the MCP `sql` tool now requires `queries[]` and returns an aggregate per-query result envelope with structured partial errors.
