### PR TITLE
feat(mcp)!: support SQL query batches

### DIFF
--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -31,7 +31,9 @@ use coral_api::v1::{
     create_bundled_source_with_o_auth_response, import_source_response,
     source_input_spec::Input as ProtoSourceInput,
 };
-use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
+use coral_api::{
+    CORAL_EPISODE_ID_METADATA_KEY, CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -593,6 +595,7 @@ fn list_catalog_response(request: &ListCatalogRequest) -> ListCatalogResponse {
 #[derive(Default)]
 struct Captured {
     execute_sql: Mutex<Vec<ExecuteSqlRequest>>,
+    execute_sql_episode_ids: Mutex<Vec<Option<String>>>,
     list_catalog: Mutex<Vec<ListCatalogRequest>>,
     search_catalog: Mutex<Vec<SearchCatalogRequest>>,
     describe_table: Mutex<Vec<DescribeTableRequest>>,
@@ -635,12 +638,22 @@ impl QueryService for MockQueryService {
         &self,
         request: Request<ExecuteSqlRequest>,
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
+        let episode_id = request
+            .metadata()
+            .get(CORAL_EPISODE_ID_METADATA_KEY)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
         let request = request.into_inner();
         self.captured
             .execute_sql
             .lock()
             .expect("execute_sql capture")
             .push(request.clone());
+        self.captured
+            .execute_sql_episode_ids
+            .lock()
+            .expect("execute_sql episode id capture")
+            .push(episode_id);
         let sql = request.sql;
         if sql
             .trim_start()
@@ -1065,6 +1078,14 @@ impl MockServer {
             .execute_sql
             .lock()
             .expect("execute_sql capture")
+            .clone()
+    }
+
+    pub(crate) fn execute_sql_episode_ids(&self) -> Vec<Option<String>> {
+        self.captured
+            .execute_sql_episode_ids
+            .lock()
+            .expect("execute_sql episode id capture")
             .clone()
     }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -209,6 +209,24 @@ fn mock_sql_response(sql: &str) -> ExecuteSqlResponse {
         return mock_coral_tables_response();
     }
 
+    if sql.contains("'first'") || sql.contains("'second'") {
+        let label = if sql.contains("'first'") {
+            "first"
+        } else {
+            "second"
+        };
+        let schema = Schema::new(vec![Field::new("label", DataType::Utf8, false)]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![Arc::new(StringArray::from(vec![label]))],
+        )
+        .expect("build label batch");
+        return ExecuteSqlResponse {
+            arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[batch]).expect("encode arrow ipc"),
+            row_count: 1,
+        };
+    }
+
     let (schema, batch, row_count) = if sql.contains("local_messages.messages") {
         let schema = Schema::new(vec![Field::new("text", DataType::Utf8, false)]);
         let batch = RecordBatch::try_new(

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -953,14 +953,16 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
         "tool errors should not include text fallback content"
     );
     let mixed_sql = mixed_sql.structured_content.expect("structured content");
-    assert_eq!(mixed_sql["total_count"], 2);
-    assert_eq!(mixed_sql["success_count"], 1);
-    assert_eq!(mixed_sql["error_count"], 1);
-    assert_eq!(mixed_sql["results"][0]["status"], "success");
-    assert_eq!(mixed_sql["results"][0]["rows"][0]["text"], "hello");
-    assert_eq!(mixed_sql["results"][1]["status"], "error");
+    assert_eq!(mixed_sql["error"]["reason"], "SQL_BATCH_PARTIAL_FAILURE");
+    let mixed_sql_batch = &mixed_sql["data"];
+    assert_eq!(mixed_sql_batch["total_count"], 2);
+    assert_eq!(mixed_sql_batch["success_count"], 1);
+    assert_eq!(mixed_sql_batch["error_count"], 1);
+    assert_eq!(mixed_sql_batch["results"][0]["status"], "success");
+    assert_eq!(mixed_sql_batch["results"][0]["rows"][0]["text"], "hello");
+    assert_eq!(mixed_sql_batch["results"][1]["status"], "error");
     assert_eq!(
-        mixed_sql["results"][1]["error"]["summary"],
+        mixed_sql_batch["results"][1]["error"]["summary"],
         "Query request is invalid"
     );
 
@@ -1016,6 +1018,40 @@ async fn mcp_stdio_sql_batch_records_each_execute_sql_request()
         requests
             .iter()
             .any(|request| request.sql == "SELECT 'second' AS label")
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_sql_batch_propagates_episode_id_to_each_query()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client_with_args(&server, &["--enable-episodes"]).await?;
+
+    let sql = structured_tool_content(
+        &client,
+        CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+            "queries": [
+                "SELECT 'first' AS label",
+                "SELECT 'second' AS label"
+            ],
+            "episode_id": "ep_batch"
+        }))),
+    )
+    .await?;
+    assert_eq!(sql["total_count"], 2);
+    assert_eq!(sql["success_count"], 2);
+
+    let episode_ids = server.execute_sql_episode_ids();
+    assert_eq!(episode_ids.len(), 2);
+    assert!(
+        episode_ids
+            .iter()
+            .all(|episode_id| episode_id.as_deref() == Some("ep_batch")),
+        "expected every batch query to carry coral-episode-id, got {episode_ids:?}"
     );
 
     client.cancel().await?;

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -982,7 +982,7 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn mcp_stdio_sql_batch_records_execute_sql_requests_in_order()
+async fn mcp_stdio_sql_batch_records_each_execute_sql_request()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
     let client = start_mcp_client(&server).await?;

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -102,6 +102,10 @@ async fn structured_tool_content(
 ) -> Result<Value, Box<dyn std::error::Error>> {
     let result = client.call_tool(request).await?;
     assert_eq!(result.is_error, Some(false));
+    assert!(
+        result.content.is_empty(),
+        "tool results should not duplicate structured payloads as text content"
+    );
     Ok(result.structured_content.expect("structured content"))
 }
 
@@ -944,6 +948,10 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
         )
         .await?;
     assert_eq!(mixed_sql.is_error, Some(true));
+    assert!(
+        mixed_sql.content.is_empty(),
+        "tool errors should not include text fallback content"
+    );
     let mixed_sql = mixed_sql.structured_content.expect("structured content");
     assert_eq!(mixed_sql["total_count"], 2);
     assert_eq!(mixed_sql["success_count"], 1);
@@ -962,6 +970,7 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
         .call_tool(CallToolRequestParams::new("list_catalog"))
         .await?;
     assert_eq!(catalog.is_error, Some(false));
+    assert!(catalog.content.is_empty());
     assert_eq!(
         catalog.structured_content.expect("structured content")["items"][0]["name"],
         "local_messages.events"

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -933,18 +933,30 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
     let server = MockServer::start().await;
     let client = start_mcp_client(&server).await?;
 
-    let invalid_sql = client
+    let mixed_sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "queries": ["DELETE FROM local_messages.messages"]
+                "queries": [
+                    "SELECT text FROM local_messages.messages ORDER BY text",
+                    "DELETE FROM local_messages.messages"
+                ]
             }))),
         )
         .await?;
-    assert_eq!(invalid_sql.is_error, Some(true));
+    assert_eq!(mixed_sql.is_error, Some(true));
+    let mixed_sql = mixed_sql.structured_content.expect("structured content");
+    assert_eq!(mixed_sql["total_count"], 2);
+    assert_eq!(mixed_sql["success_count"], 1);
+    assert_eq!(mixed_sql["error_count"], 1);
+    assert_eq!(mixed_sql["results"][0]["status"], "success");
+    assert_eq!(mixed_sql["results"][0]["rows"][0]["text"], "hello");
+    assert_eq!(mixed_sql["results"][1]["status"], "error");
     assert_eq!(
-        invalid_sql.structured_content.expect("structured content")["error"]["summary"],
+        mixed_sql["results"][1]["error"]["summary"],
         "Query request is invalid"
     );
+
+    assert_eq!(server.execute_sql_requests().len(), 2);
 
     let catalog = client
         .call_tool(CallToolRequestParams::new("list_catalog"))

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -189,6 +189,31 @@ fn assert_raw_tools_list_contract(response: &Value) {
             )
         });
     }
+    let sql_tool = tools
+        .iter()
+        .find(|tool| tool.get("name").and_then(Value::as_str) == Some("sql"))
+        .expect("sql tool should be advertised");
+    let sql_properties = sql_tool
+        .pointer("/inputSchema/properties")
+        .and_then(Value::as_object)
+        .expect("sql input properties");
+    assert!(!sql_properties.contains_key("sql"));
+    assert_eq!(
+        sql_tool.pointer("/inputSchema/required/0"),
+        Some(&json!("queries"))
+    );
+    assert_eq!(
+        sql_tool.pointer("/inputSchema/properties/queries/minItems"),
+        Some(&json!(1))
+    );
+    assert_eq!(
+        sql_tool.pointer("/inputSchema/properties/queries/maxItems"),
+        Some(&json!(10))
+    );
+    assert_eq!(
+        sql_tool.pointer("/outputSchema/type"),
+        Some(&json!("object"))
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -891,11 +916,15 @@ async fn assert_sql_tool(
     let sql = structured_tool_content(
         client,
         CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-            "sql": "SELECT text FROM local_messages.messages ORDER BY text"
+            "queries": ["SELECT text FROM local_messages.messages ORDER BY text"]
         }))),
     )
     .await?;
-    assert_eq!(sql["rows"][0]["text"], "hello");
+    assert_eq!(sql["total_count"], 1);
+    assert_eq!(sql["success_count"], 1);
+    assert_eq!(sql["error_count"], 0);
+    assert_eq!(sql["results"][0]["status"], "success");
+    assert_eq!(sql["results"][0]["rows"][0]["text"], "hello");
     Ok(())
 }
 
@@ -907,7 +936,7 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
     let invalid_sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "DELETE FROM local_messages.messages"
+                "queries": ["DELETE FROM local_messages.messages"]
             }))),
         )
         .await?;
@@ -924,6 +953,30 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
     assert_eq!(
         catalog.structured_content.expect("structured content")["items"][0]["name"],
         "local_messages.events"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_sql_rejects_malformed_queries_before_backend_dispatch()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client(&server).await?;
+
+    client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "queries": []
+            }))),
+        )
+        .await
+        .expect_err("empty queries should fail as invalid params");
+    assert!(
+        server.execute_sql_requests().is_empty(),
+        "malformed queries must not reach backend"
     );
 
     client.cancel().await?;

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -961,6 +961,48 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_sql_batch_records_execute_sql_requests_in_order()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client(&server).await?;
+
+    let sql = structured_tool_content(
+        &client,
+        CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+            "queries": [
+                "SELECT 'first' AS label",
+                "SELECT 'second' AS label"
+            ]
+        }))),
+    )
+    .await?;
+    assert_eq!(sql["total_count"], 2);
+    assert_eq!(sql["success_count"], 2);
+    assert_eq!(sql["error_count"], 0);
+    assert_eq!(sql["results"][0]["index"], 0);
+    assert_eq!(sql["results"][0]["rows"][0]["label"], "first");
+    assert_eq!(sql["results"][1]["index"], 1);
+    assert_eq!(sql["results"][1]["rows"][0]["label"], "second");
+
+    let requests = server.execute_sql_requests();
+    assert_eq!(requests.len(), 2);
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.sql == "SELECT 'first' AS label")
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.sql == "SELECT 'second' AS label")
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn mcp_stdio_sql_rejects_malformed_queries_before_backend_dispatch()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -38,7 +38,7 @@ use crate::{
         optional_episode_id_argument, required_string_argument, search_catalog_arguments,
         search_catalog_tool, search_catalog_value, sql_arguments, sql_tool, status_to_error_data,
         tables_resource, tables_resource_content, tool_error_from_status, tool_error_result,
-        tool_error_with_data_result, with_episode_id_argument,
+        with_episode_id_argument,
     },
     telemetry,
 };
@@ -782,14 +782,17 @@ fn finish_tool_call(
                 Ok(value) => value,
                 Err(status) => {
                     telemetry::record_tonic_status(span, &status);
-                    return Ok(tool_error_result(tool_error_from_status("Query", &status)));
+                    return Ok(tool_error_result(
+                        tool_error_from_status("Query", &status),
+                        None,
+                    ));
                 }
             };
             if batch.has_errors() {
                 telemetry::record_sql_batch_partial_failure(span);
-                Ok(tool_error_with_data_result(
+                Ok(tool_error_result(
                     batch.partial_failure_error(),
-                    serialized,
+                    Some(serialized),
                 ))
             } else {
                 telemetry::record_success(span);
@@ -798,9 +801,10 @@ fn finish_tool_call(
         }
         Ok(ToolCallOutcome::ToolError { operation, status }) => {
             telemetry::record_tonic_status(span, &status);
-            Ok(tool_error_result(tool_error_from_status(
-                operation, &status,
-            )))
+            Ok(tool_error_result(
+                tool_error_from_status(operation, &status),
+                None,
+            ))
         }
         Err(error) => {
             telemetry::record_protocol_error(span, &error);

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -1,10 +1,5 @@
 //! RMCP server implementation for Coral's stdio MCP surface.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicUsize, Ordering},
-};
-
 use coral_api::v1::{
     CatalogItemKind as ProtoCatalogItemKind, DescribeTableRequest, DescribeTableResponse,
     ExecuteSqlRequest, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
@@ -358,27 +353,16 @@ impl CoralMcpServer {
         queries: Vec<String>,
     ) -> Result<SqlBatchValue, tonic::Status> {
         let mut tasks = tokio::task::JoinSet::new();
-        let next_to_submit = Arc::new(AtomicUsize::new(0));
-        let submission_notify = Arc::new(tokio::sync::Notify::new());
         for (index, sql) in queries.into_iter().enumerate() {
             let server = self.clone();
-            let next_to_submit = Arc::clone(&next_to_submit);
-            let submission_notify = Arc::clone(&submission_notify);
-            tasks.spawn(async move {
-                while next_to_submit.load(Ordering::Acquire) != index {
-                    submission_notify.notified().await;
-                }
-                next_to_submit.fetch_add(1, Ordering::AcqRel);
-                submission_notify.notify_waiters();
-                server.execute_one_sql_query(index, sql).await
-            });
+            tasks.spawn(async move { server.execute_one_sql_query(index, sql).await });
         }
 
         let mut results = Vec::new();
         while let Some(joined) = tasks.join_next().await {
             results.push(joined.map_err(|error| tonic::Status::internal(error.to_string()))?);
         }
-        SqlBatchValue::from_unordered(results)
+        Ok(SqlBatchValue::from_unordered(results))
     }
 
     async fn open_episode(
@@ -809,11 +793,7 @@ fn finish_tool_call(
                 Ok(build_tool_result(payload.value))
             }
             ToolPayloadStatus::Error => {
-                telemetry::record_tool_payload_error(
-                    span,
-                    "sql_batch_partial_failure",
-                    "One or more SQL queries failed",
-                );
+                telemetry::record_sql_batch_partial_failure(span);
                 let mut result = CallToolResult::structured_error(payload.value);
                 result.content = Vec::new();
                 Ok(result)

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -38,7 +38,7 @@ use crate::{
         optional_episode_id_argument, required_string_argument, search_catalog_arguments,
         search_catalog_tool, search_catalog_value, sql_arguments, sql_tool, status_to_error_data,
         tables_resource, tables_resource_content, tool_error_from_status, tool_error_result,
-        with_episode_id_argument,
+        tool_error_with_data_result, with_episode_id_argument,
     },
     telemetry,
 };
@@ -50,21 +50,12 @@ const CATALOG_KIND_TABLE: ProtoCatalogItemKind = ProtoCatalogItemKind::Table;
 const CATALOG_KIND_TABLE_FUNCTION: ProtoCatalogItemKind = ProtoCatalogItemKind::TableFunction;
 
 enum ToolCallOutcome {
-    Payload(ToolPayload),
+    Payload(Value),
+    SqlBatch(SqlBatchValue),
     ToolError {
         operation: &'static str,
         status: tonic::Status,
     },
-}
-
-struct ToolPayload {
-    value: Value,
-    status: ToolPayloadStatus,
-}
-
-enum ToolPayloadStatus {
-    Success,
-    Error,
 }
 
 #[derive(Serialize)]
@@ -88,18 +79,12 @@ fn serialize_tool_value(value: impl Serialize) -> Result<Value, tonic::Status> {
 
 impl ToolCallOutcome {
     fn success(value: Value) -> Self {
-        Self::Payload(ToolPayload {
-            value,
-            status: ToolPayloadStatus::Success,
-        })
+        Self::Payload(value)
     }
 
     fn from_value_result(operation: &'static str, result: Result<Value, tonic::Status>) -> Self {
         match result {
-            Ok(value) => Self::Payload(ToolPayload {
-                value,
-                status: ToolPayloadStatus::Success,
-            }),
+            Ok(value) => Self::Payload(value),
             Err(status) => Self::ToolError { operation, status },
         }
     }
@@ -351,11 +336,19 @@ impl CoralMcpServer {
     async fn execute_sql_batch(
         &self,
         queries: Vec<String>,
+        episode_id_metadata: Option<MetadataValue<Ascii>>,
     ) -> Result<SqlBatchValue, tonic::Status> {
         let mut tasks = tokio::task::JoinSet::new();
         for (index, sql) in queries.into_iter().enumerate() {
             let server = self.clone();
-            tasks.spawn(async move { server.execute_one_sql_query(index, sql).await });
+            let episode_id_metadata = episode_id_metadata.clone();
+            tasks.spawn(async move {
+                with_episode_metadata(
+                    episode_id_metadata,
+                    server.execute_one_sql_query(index, sql),
+                )
+                .await
+            });
         }
 
         let mut results = Vec::new();
@@ -495,27 +488,16 @@ impl CoralMcpServer {
         &self,
         request: CallToolRequestParams,
         span: &tracing::Span,
+        episode_id_metadata: Option<MetadataValue<Ascii>>,
     ) -> Result<ToolCallOutcome, ErrorData> {
         match request.name.as_ref() {
             "sql" => {
                 let arguments = sql_arguments(request.arguments.as_ref())?;
-                match self.execute_sql_batch(arguments.queries).await {
-                    Ok(batch) => {
-                        let status = if batch.has_errors() {
-                            ToolPayloadStatus::Error
-                        } else {
-                            ToolPayloadStatus::Success
-                        };
-                        match serialize_tool_value(batch) {
-                            Ok(value) => {
-                                Ok(ToolCallOutcome::Payload(ToolPayload { value, status }))
-                            }
-                            Err(status) => Ok(ToolCallOutcome::ToolError {
-                                operation: "Query",
-                                status,
-                            }),
-                        }
-                    }
+                match self
+                    .execute_sql_batch(arguments.queries, episode_id_metadata)
+                    .await
+                {
+                    Ok(batch) => Ok(ToolCallOutcome::SqlBatch(batch)),
                     Err(status) => Ok(ToolCallOutcome::ToolError {
                         operation: "Query",
                         status,
@@ -706,9 +688,13 @@ impl ServerHandler for CoralMcpServer {
                 let episode_id_metadata = inject_episode_metadata
                     .then(|| episode_tag.into_metadata())
                     .flatten();
+                let dispatch_episode_id_metadata = episode_id_metadata.clone();
                 telemetry::instrument(
                     span.clone(),
-                    with_episode_metadata(episode_id_metadata, self.dispatch_tool(request, &span)),
+                    with_episode_metadata(
+                        episode_id_metadata,
+                        self.dispatch_tool(request, &span, dispatch_episode_id_metadata),
+                    ),
                 )
                 .await
             }
@@ -787,18 +773,29 @@ fn finish_tool_call(
     outcome: Result<ToolCallOutcome, ErrorData>,
 ) -> Result<CallToolResult, ErrorData> {
     match outcome {
-        Ok(ToolCallOutcome::Payload(payload)) => match payload.status {
-            ToolPayloadStatus::Success => {
-                telemetry::record_success(span);
-                Ok(build_tool_result(payload.value))
-            }
-            ToolPayloadStatus::Error => {
+        Ok(ToolCallOutcome::Payload(value)) => {
+            telemetry::record_success(span);
+            Ok(build_tool_result(value))
+        }
+        Ok(ToolCallOutcome::SqlBatch(batch)) => {
+            let serialized = match serialize_tool_value(&batch) {
+                Ok(value) => value,
+                Err(status) => {
+                    telemetry::record_tonic_status(span, &status);
+                    return Ok(tool_error_result(tool_error_from_status("Query", &status)));
+                }
+            };
+            if batch.has_errors() {
                 telemetry::record_sql_batch_partial_failure(span);
-                let mut result = CallToolResult::structured_error(payload.value);
-                result.content = Vec::new();
-                Ok(result)
+                Ok(tool_error_with_data_result(
+                    batch.partial_failure_error(),
+                    serialized,
+                ))
+            } else {
+                telemetry::record_success(span);
+                Ok(build_tool_result(serialized))
             }
-        },
+        }
         Ok(ToolCallOutcome::ToolError { operation, status }) => {
             telemetry::record_tonic_status(span, &status);
             Ok(tool_error_result(tool_error_from_status(

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -806,7 +806,7 @@ fn finish_tool_call(
         Ok(ToolCallOutcome::Payload(payload)) => match payload.status {
             ToolPayloadStatus::Success => {
                 telemetry::record_success(span);
-                build_tool_result(payload.value)
+                Ok(build_tool_result(payload.value))
             }
             ToolPayloadStatus::Error => {
                 telemetry::record_tool_payload_error(
@@ -814,7 +814,9 @@ fn finish_tool_call(
                     "sql_batch_partial_failure",
                     "One or more SQL queries failed",
                 );
-                Ok(CallToolResult::structured_error(payload.value))
+                let mut result = CallToolResult::structured_error(payload.value);
+                result.content = Vec::new();
+                Ok(result)
             }
         },
         Ok(ToolCallOutcome::ToolError { operation, status }) => {

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -1,5 +1,10 @@
 //! RMCP server implementation for Coral's stdio MCP surface.
 
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
 use coral_api::v1::{
     CatalogItemKind as ProtoCatalogItemKind, DescribeTableRequest, DescribeTableResponse,
     ExecuteSqlRequest, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
@@ -314,19 +319,51 @@ impl CoralMcpServer {
             .map_err(|error| tonic::Status::internal(error.to_string()))
     }
 
-    async fn execute_sql_batch_value(&self, queries: Vec<String>) -> Result<Value, tonic::Status> {
-        let mut results = Vec::with_capacity(queries.len());
+    async fn execute_one_sql_query(
+        &self,
+        index: usize,
+        sql: String,
+    ) -> Result<SqlQueryResultValue, tonic::Status> {
+        let request = Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql,
+        });
+        Ok(SqlQueryResultValue::Success {
+            index,
+            rows: self.query_rows(request).await?,
+        })
+    }
+
+    async fn execute_sql_batch(
+        &self,
+        queries: Vec<String>,
+    ) -> Result<SqlBatchValue, tonic::Status> {
+        let mut tasks = tokio::task::JoinSet::new();
+        let next_to_submit = Arc::new(AtomicUsize::new(0));
+        let submission_notify = Arc::new(tokio::sync::Notify::new());
         for (index, sql) in queries.into_iter().enumerate() {
-            let request = Request::new(ExecuteSqlRequest {
-                workspace: Some(default_workspace()),
-                sql,
-            });
-            results.push(SqlQueryResultValue::Success {
-                index,
-                rows: self.query_rows(request).await?,
+            let server = self.clone();
+            let next_to_submit = Arc::clone(&next_to_submit);
+            let submission_notify = Arc::clone(&submission_notify);
+            tasks.spawn(async move {
+                while next_to_submit.load(Ordering::Acquire) != index {
+                    submission_notify.notified().await;
+                }
+                next_to_submit.fetch_add(1, Ordering::AcqRel);
+                submission_notify.notify_waiters();
+                server.execute_one_sql_query(index, sql).await
             });
         }
-        serialize_tool_value(SqlBatchValue::from_successes(results))
+
+        let mut results = Vec::new();
+        while let Some(joined) = tasks.join_next().await {
+            results.push(joined.map_err(|error| tonic::Status::internal(error.to_string()))??);
+        }
+        SqlBatchValue::from_unordered(results)
+    }
+
+    async fn execute_sql_batch_value(&self, queries: Vec<String>) -> Result<Value, tonic::Status> {
+        serialize_tool_value(self.execute_sql_batch(queries).await?)
     }
 
     async fn open_episode(

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -30,14 +30,14 @@ use tonic::{
 use crate::{
     McpOptions,
     surface::{
-        CatalogToolKind, ToolDescriptionContext, build_tool_result, describe_table_arguments,
-        describe_table_tool, describe_table_value, feedback_tool, guide_resource,
-        guide_resource_content, initial_instructions, list_catalog_arguments, list_catalog_tool,
-        list_catalog_value, list_columns_arguments, list_columns_tool, list_columns_value,
-        open_episode_arguments, open_episode_tool, optional_episode_id_argument,
-        required_string_argument, search_catalog_arguments, search_catalog_tool,
-        search_catalog_value, sql_tool, status_to_error_data, tables_resource,
-        tables_resource_content, tool_error_from_status, tool_error_result,
+        CatalogToolKind, SqlBatchValue, SqlQueryResultValue, ToolDescriptionContext,
+        build_tool_result, describe_table_arguments, describe_table_tool, describe_table_value,
+        feedback_tool, guide_resource, guide_resource_content, initial_instructions,
+        list_catalog_arguments, list_catalog_tool, list_catalog_value, list_columns_arguments,
+        list_columns_tool, list_columns_value, open_episode_arguments, open_episode_tool,
+        optional_episode_id_argument, required_string_argument, search_catalog_arguments,
+        search_catalog_tool, search_catalog_value, sql_arguments, sql_tool, status_to_error_data,
+        tables_resource, tables_resource_content, tool_error_from_status, tool_error_result,
         with_episode_id_argument,
     },
     telemetry,
@@ -55,11 +55,6 @@ enum ToolCallOutcome {
         operation: &'static str,
         status: tonic::Status,
     },
-}
-
-#[derive(Serialize)]
-struct SqlRowsValue {
-    rows: Vec<Value>,
 }
 
 #[derive(Serialize)]
@@ -319,13 +314,19 @@ impl CoralMcpServer {
             .map_err(|error| tonic::Status::internal(error.to_string()))
     }
 
-    async fn execute_sql_value(
-        &self,
-        request: Request<ExecuteSqlRequest>,
-    ) -> Result<Value, tonic::Status> {
-        serialize_tool_value(SqlRowsValue {
-            rows: self.query_rows(request).await?,
-        })
+    async fn execute_sql_batch_value(&self, queries: Vec<String>) -> Result<Value, tonic::Status> {
+        let mut results = Vec::with_capacity(queries.len());
+        for (index, sql) in queries.into_iter().enumerate() {
+            let request = Request::new(ExecuteSqlRequest {
+                workspace: Some(default_workspace()),
+                sql,
+            });
+            results.push(SqlQueryResultValue::Success {
+                index,
+                rows: self.query_rows(request).await?,
+            });
+        }
+        serialize_tool_value(SqlBatchValue::from_successes(results))
     }
 
     async fn open_episode(
@@ -461,14 +462,10 @@ impl CoralMcpServer {
     ) -> Result<ToolCallOutcome, ErrorData> {
         match request.name.as_ref() {
             "sql" => {
-                let sql = required_string_argument(request.arguments.as_ref(), "sql")?;
-                let request = Request::new(ExecuteSqlRequest {
-                    workspace: Some(default_workspace()),
-                    sql,
-                });
+                let arguments = sql_arguments(request.arguments.as_ref())?;
                 Ok(ToolCallOutcome::from_value_result(
                     "Query",
-                    self.execute_sql_value(request).await,
+                    self.execute_sql_batch_value(arguments.queries).await,
                 ))
             }
             "list_catalog" => {

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -55,11 +55,21 @@ const CATALOG_KIND_TABLE: ProtoCatalogItemKind = ProtoCatalogItemKind::Table;
 const CATALOG_KIND_TABLE_FUNCTION: ProtoCatalogItemKind = ProtoCatalogItemKind::TableFunction;
 
 enum ToolCallOutcome {
-    Success(Value),
+    Payload(ToolPayload),
     ToolError {
         operation: &'static str,
         status: tonic::Status,
     },
+}
+
+struct ToolPayload {
+    value: Value,
+    status: ToolPayloadStatus,
+}
+
+enum ToolPayloadStatus {
+    Success,
+    Error,
 }
 
 #[derive(Serialize)]
@@ -82,9 +92,19 @@ fn serialize_tool_value(value: impl Serialize) -> Result<Value, tonic::Status> {
 }
 
 impl ToolCallOutcome {
+    fn success(value: Value) -> Self {
+        Self::Payload(ToolPayload {
+            value,
+            status: ToolPayloadStatus::Success,
+        })
+    }
+
     fn from_value_result(operation: &'static str, result: Result<Value, tonic::Status>) -> Self {
         match result {
-            Ok(value) => Self::Success(value),
+            Ok(value) => Self::Payload(ToolPayload {
+                value,
+                status: ToolPayloadStatus::Success,
+            }),
             Err(status) => Self::ToolError { operation, status },
         }
     }
@@ -319,19 +339,18 @@ impl CoralMcpServer {
             .map_err(|error| tonic::Status::internal(error.to_string()))
     }
 
-    async fn execute_one_sql_query(
-        &self,
-        index: usize,
-        sql: String,
-    ) -> Result<SqlQueryResultValue, tonic::Status> {
+    async fn execute_one_sql_query(&self, index: usize, sql: String) -> SqlQueryResultValue {
         let request = Request::new(ExecuteSqlRequest {
             workspace: Some(default_workspace()),
             sql,
         });
-        Ok(SqlQueryResultValue::Success {
-            index,
-            rows: self.query_rows(request).await?,
-        })
+        match self.query_rows(request).await {
+            Ok(rows) => SqlQueryResultValue::Success { index, rows },
+            Err(status) => SqlQueryResultValue::Error {
+                index,
+                error: tool_error_from_status("Query", &status),
+            },
+        }
     }
 
     async fn execute_sql_batch(
@@ -357,13 +376,9 @@ impl CoralMcpServer {
 
         let mut results = Vec::new();
         while let Some(joined) = tasks.join_next().await {
-            results.push(joined.map_err(|error| tonic::Status::internal(error.to_string()))??);
+            results.push(joined.map_err(|error| tonic::Status::internal(error.to_string()))?);
         }
         SqlBatchValue::from_unordered(results)
-    }
-
-    async fn execute_sql_batch_value(&self, queries: Vec<String>) -> Result<Value, tonic::Status> {
-        serialize_tool_value(self.execute_sql_batch(queries).await?)
     }
 
     async fn open_episode(
@@ -436,7 +451,7 @@ impl CoralMcpServer {
             .await
             .map(|response| search_catalog_value(&response.into_inner()))
         {
-            Ok(value) => Ok(ToolCallOutcome::Success(value)),
+            Ok(value) => Ok(ToolCallOutcome::success(value)),
             Err(status) if status.code() == tonic::Code::InvalidArgument => {
                 Err(status_to_error_data(&status))
             }
@@ -480,7 +495,7 @@ impl CoralMcpServer {
             .load_table_description(&arguments.schema, &arguments.table)
             .await
         {
-            Ok(response) => Ok(ToolCallOutcome::Success(describe_table_value(
+            Ok(response) => Ok(ToolCallOutcome::success(describe_table_value(
                 &arguments.schema,
                 &arguments.table,
                 &response,
@@ -500,10 +515,28 @@ impl CoralMcpServer {
         match request.name.as_ref() {
             "sql" => {
                 let arguments = sql_arguments(request.arguments.as_ref())?;
-                Ok(ToolCallOutcome::from_value_result(
-                    "Query",
-                    self.execute_sql_batch_value(arguments.queries).await,
-                ))
+                match self.execute_sql_batch(arguments.queries).await {
+                    Ok(batch) => {
+                        let status = if batch.has_errors() {
+                            ToolPayloadStatus::Error
+                        } else {
+                            ToolPayloadStatus::Success
+                        };
+                        match serialize_tool_value(batch) {
+                            Ok(value) => {
+                                Ok(ToolCallOutcome::Payload(ToolPayload { value, status }))
+                            }
+                            Err(status) => Ok(ToolCallOutcome::ToolError {
+                                operation: "Query",
+                                status,
+                            }),
+                        }
+                    }
+                    Err(status) => Ok(ToolCallOutcome::ToolError {
+                        operation: "Query",
+                        status,
+                    }),
+                }
             }
             "list_catalog" => {
                 self.list_catalog_tool_result(request.arguments.as_ref())
@@ -530,7 +563,7 @@ impl CoralMcpServer {
                         telemetry::record_episode_id(span, &episode.episode_id);
                         serialize_tool_value(episode)
                     }) {
-                    Ok(value) => Ok(ToolCallOutcome::Success(value)),
+                    Ok(value) => Ok(ToolCallOutcome::success(value)),
                     Err(status) if status.code() == tonic::Code::InvalidArgument => {
                         Err(status_to_error_data(&status))
                     }
@@ -579,7 +612,7 @@ impl CoralMcpServer {
             }))
             .await
         {
-            Ok(response) => Ok(ToolCallOutcome::Success(list_columns_value(
+            Ok(response) => Ok(ToolCallOutcome::success(list_columns_value(
                 &arguments.schema,
                 &arguments.table,
                 &response.into_inner(),
@@ -592,7 +625,7 @@ impl CoralMcpServer {
                     .load_table_description(&arguments.schema, &arguments.table)
                     .await
                 {
-                    Ok(response) => Ok(ToolCallOutcome::Success(describe_table_value(
+                    Ok(response) => Ok(ToolCallOutcome::success(describe_table_value(
                         &arguments.schema,
                         &arguments.table,
                         &response,
@@ -770,11 +803,20 @@ fn finish_tool_call(
     outcome: Result<ToolCallOutcome, ErrorData>,
 ) -> Result<CallToolResult, ErrorData> {
     match outcome {
-        Ok(ToolCallOutcome::Success(value)) => {
-            let result = build_tool_result(value);
-            telemetry::record_protocol_result(span, &result);
-            result
-        }
+        Ok(ToolCallOutcome::Payload(payload)) => match payload.status {
+            ToolPayloadStatus::Success => {
+                telemetry::record_success(span);
+                build_tool_result(payload.value)
+            }
+            ToolPayloadStatus::Error => {
+                telemetry::record_tool_payload_error(
+                    span,
+                    "sql_batch_partial_failure",
+                    "One or more SQL queries failed",
+                );
+                Ok(CallToolResult::structured_error(payload.value))
+            }
+        },
         Ok(ToolCallOutcome::ToolError { operation, status }) => {
             telemetry::record_tonic_status(span, &status);
             Ok(tool_error_result(tool_error_from_status(

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -1,6 +1,7 @@
 use coral_client::{DecodedStatusError, decode_status_error};
 use rmcp::{ErrorData, model::CallToolResult};
 use serde::Serialize;
+use serde_json::{Value, json};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize)]
@@ -22,6 +23,31 @@ pub(crate) fn tool_error_result(error: ToolError) -> CallToolResult {
     let mut result = CallToolResult::structured_error(structured);
     result.content = Vec::new();
     result
+}
+
+pub(crate) fn tool_error_with_data_result(error: ToolError, data: Value) -> CallToolResult {
+    let structured = serde_json::to_value(StructuredToolErrorWithDataValue { error, data })
+        .expect("tool error with data value serializes");
+    let mut result = CallToolResult::structured_error(structured);
+    result.content = Vec::new();
+    result
+}
+
+pub(crate) fn tool_error_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["summary", "detail", "grpc_code", "retryable", "metadata"],
+        "additionalProperties": false,
+        "properties": {
+            "summary": { "type": "string" },
+            "detail": { "type": "string" },
+            "hint": { "type": "string" },
+            "grpc_code": { "type": "string" },
+            "reason": { "type": "string" },
+            "retryable": { "type": "boolean" },
+            "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
+        }
+    })
 }
 
 pub(crate) fn tool_error_from_status(operation: &str, status: &tonic::Status) -> ToolError {
@@ -115,6 +141,12 @@ struct StructuredToolErrorValue {
 }
 
 #[derive(Serialize)]
+struct StructuredToolErrorWithDataValue {
+    error: ToolError,
+    data: Value,
+}
+
+#[derive(Serialize)]
 struct StatusErrorDataValue<'a> {
     detail: &'a str,
     grpc_code: String,
@@ -141,7 +173,10 @@ mod tests {
 
     use coral_client::CORAL_ERROR_DOMAIN;
 
-    use super::{ToolError, status_to_error_data, tool_error_from_status, tool_error_result};
+    use super::{
+        ToolError, status_to_error_data, tool_error_from_status, tool_error_result,
+        tool_error_with_data_result,
+    };
 
     #[test]
     fn tool_error_result_includes_structured_error_payload() {
@@ -159,6 +194,28 @@ mod tests {
         let json = result.structured_content.expect("structured content");
         assert_eq!(json["error"]["grpc_code"], "InvalidArgument");
         assert_eq!(json["error"]["retryable"], false);
+    }
+
+    #[test]
+    fn tool_error_with_data_result_keeps_canonical_error_envelope() {
+        let result = tool_error_with_data_result(
+            ToolError {
+                summary: "One or more SQL queries failed".to_string(),
+                detail: "Inspect `data.results` for per-query successes and errors.".to_string(),
+                hint: None,
+                grpc_code: "Unknown".to_string(),
+                reason: Some("SQL_BATCH_PARTIAL_FAILURE".to_string()),
+                retryable: false,
+                metadata: HashMap::new(),
+            },
+            serde_json::json!({ "total_count": 2, "results": [] }),
+        );
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content.is_empty());
+        let json = result.structured_content.expect("structured content");
+        assert_eq!(json["error"]["reason"], "SQL_BATCH_PARTIAL_FAILURE");
+        assert_eq!(json["data"]["total_count"], 2);
     }
 
     #[test]
@@ -196,8 +253,9 @@ mod tests {
         })
         .expect("tool error serializes");
 
-        assert!(json["hint"].is_null());
-        assert!(json["reason"].is_null());
+        let object = json.as_object().expect("tool error object");
+        assert!(!object.contains_key("hint"));
+        assert!(!object.contains_key("reason"));
         assert_eq!(
             json["metadata"].as_object().expect("metadata object").len(),
             0

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -17,17 +17,9 @@ pub(crate) struct ToolError {
     pub(crate) metadata: HashMap<String, String>,
 }
 
-pub(crate) fn tool_error_result(error: ToolError) -> CallToolResult {
-    let structured = serde_json::to_value(StructuredToolErrorValue { error })
+pub(crate) fn tool_error_result(error: ToolError, data: Option<Value>) -> CallToolResult {
+    let structured = serde_json::to_value(StructuredToolErrorValue { error, data })
         .expect("tool error value serializes");
-    let mut result = CallToolResult::structured_error(structured);
-    result.content = Vec::new();
-    result
-}
-
-pub(crate) fn tool_error_with_data_result(error: ToolError, data: Value) -> CallToolResult {
-    let structured = serde_json::to_value(StructuredToolErrorWithDataValue { error, data })
-        .expect("tool error with data value serializes");
     let mut result = CallToolResult::structured_error(structured);
     result.content = Vec::new();
     result
@@ -138,12 +130,8 @@ pub(crate) fn status_to_error_data(status: &tonic::Status) -> ErrorData {
 #[derive(Serialize)]
 struct StructuredToolErrorValue {
     error: ToolError,
-}
-
-#[derive(Serialize)]
-struct StructuredToolErrorWithDataValue {
-    error: ToolError,
-    data: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
 }
 
 #[derive(Serialize)]
@@ -173,32 +161,38 @@ mod tests {
 
     use coral_client::CORAL_ERROR_DOMAIN;
 
-    use super::{
-        ToolError, status_to_error_data, tool_error_from_status, tool_error_result,
-        tool_error_with_data_result,
-    };
+    use super::{ToolError, status_to_error_data, tool_error_from_status, tool_error_result};
 
     #[test]
     fn tool_error_result_includes_structured_error_payload() {
-        let result = tool_error_result(ToolError {
-            summary: "Query failed".to_string(),
-            detail: "planner error".to_string(),
-            hint: Some("Retry with valid SQL.".to_string()),
-            grpc_code: "InvalidArgument".to_string(),
-            reason: None,
-            retryable: false,
-            metadata: HashMap::new(),
-        });
+        let result = tool_error_result(
+            ToolError {
+                summary: "Query failed".to_string(),
+                detail: "planner error".to_string(),
+                hint: Some("Retry with valid SQL.".to_string()),
+                grpc_code: "InvalidArgument".to_string(),
+                reason: None,
+                retryable: false,
+                metadata: HashMap::new(),
+            },
+            None,
+        );
         assert_eq!(result.is_error, Some(true));
         assert!(result.content.is_empty());
         let json = result.structured_content.expect("structured content");
         assert_eq!(json["error"]["grpc_code"], "InvalidArgument");
         assert_eq!(json["error"]["retryable"], false);
+        assert!(
+            json.as_object()
+                .expect("structured object")
+                .get("data")
+                .is_none()
+        );
     }
 
     #[test]
-    fn tool_error_with_data_result_keeps_canonical_error_envelope() {
-        let result = tool_error_with_data_result(
+    fn tool_error_result_can_include_data_in_canonical_error_envelope() {
+        let result = tool_error_result(
             ToolError {
                 summary: "One or more SQL queries failed".to_string(),
                 detail: "Inspect `data.results` for per-query successes and errors.".to_string(),
@@ -208,7 +202,7 @@ mod tests {
                 retryable: false,
                 metadata: HashMap::new(),
             },
-            serde_json::json!({ "total_count": 2, "results": [] }),
+            Some(serde_json::json!({ "total_count": 2, "results": [] })),
         );
 
         assert_eq!(result.is_error, Some(true));
@@ -322,7 +316,7 @@ mod tests {
             false,
         );
         let error = tool_error_from_status("Query", &status);
-        let result = tool_error_result(error);
+        let result = tool_error_result(error, None);
         let json = result.structured_content.expect("structured content");
         assert_eq!(json["error"]["reason"], "PROVIDER_REQUEST_FAILED");
         assert_eq!(json["error"]["retryable"], false);
@@ -347,7 +341,7 @@ mod tests {
         );
         let error = tool_error_from_status("Query", &status);
         assert!(error.retryable);
-        let result = tool_error_result(error);
+        let result = tool_error_result(error, None);
         assert_eq!(
             result.structured_content.expect("structured content")["error"]["retryable"],
             true
@@ -372,7 +366,7 @@ mod tests {
             false,
         );
         let error = tool_error_from_status("Query", &status);
-        let result = tool_error_result(error);
+        let result = tool_error_result(error, None);
         let json = result.structured_content.expect("structured content");
         assert_eq!(json["error"]["retryable"], false);
         assert_eq!(

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -1,29 +1,25 @@
-use std::collections::HashMap;
-use std::fmt::Write as _;
-
 use coral_client::{DecodedStatusError, decode_status_error};
 use rmcp::{
     ErrorData,
     model::{CallToolResult, Content},
 };
 use serde::Serialize;
-use serde_json::{Map, Value};
+use std::collections::HashMap;
+use std::fmt::Write as _;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct ToolError {
     pub(crate) summary: String,
     pub(crate) detail: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) hint: Option<String>,
     pub(crate) grpc_code: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) reason: Option<String>,
     pub(crate) retryable: bool,
     pub(crate) metadata: HashMap<String, String>,
 }
 
-#[expect(
-    clippy::needless_pass_by_value,
-    reason = "callers always pass an owned ToolError that is not used after this call"
-)]
 pub(crate) fn tool_error_result(error: ToolError) -> CallToolResult {
     let mut text = format!("Error: {}", error.summary);
     if !error.detail.is_empty() {
@@ -33,24 +29,8 @@ pub(crate) fn tool_error_result(error: ToolError) -> CallToolResult {
         write!(text, "\nHint: {hint}").expect("writing to String cannot fail");
     }
 
-    let metadata = error
-        .metadata
-        .iter()
-        .map(|(key, value)| (key.clone(), Value::String(value.clone())))
-        .collect::<Map<_, _>>();
-
-    let structured = serde_json::to_value(StructuredToolErrorValue {
-        error: ToolErrorValue {
-            summary: &error.summary,
-            detail: &error.detail,
-            hint: error.hint.as_deref(),
-            grpc_code: &error.grpc_code,
-            reason: error.reason.as_deref(),
-            retryable: error.retryable,
-            metadata: Value::Object(metadata),
-        },
-    })
-    .expect("tool error value serializes");
+    let structured = serde_json::to_value(StructuredToolErrorValue { error })
+        .expect("tool error value serializes");
     let mut result = CallToolResult::structured_error(structured);
     result.content = vec![Content::text(text)];
     result
@@ -142,21 +122,8 @@ pub(crate) fn status_to_error_data(status: &tonic::Status) -> ErrorData {
 }
 
 #[derive(Serialize)]
-struct StructuredToolErrorValue<'a> {
-    error: ToolErrorValue<'a>,
-}
-
-#[derive(Serialize)]
-struct ToolErrorValue<'a> {
-    summary: &'a str,
-    detail: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    hint: Option<&'a str>,
-    grpc_code: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    reason: Option<&'a str>,
-    retryable: bool,
-    metadata: Value,
+struct StructuredToolErrorValue {
+    error: ToolError,
 }
 
 #[derive(Serialize)]
@@ -203,6 +170,49 @@ mod tests {
         let json = result.structured_content.expect("structured content");
         assert_eq!(json["error"]["grpc_code"], "InvalidArgument");
         assert_eq!(json["error"]["retryable"], false);
+    }
+
+    #[test]
+    fn tool_error_serializes_directly_with_structured_vocabulary() {
+        let json = serde_json::to_value(ToolError {
+            summary: "Query failed".to_string(),
+            detail: "planner error".to_string(),
+            hint: Some("Retry with valid SQL.".to_string()),
+            grpc_code: "InvalidArgument".to_string(),
+            reason: Some("INVALID_SQL".to_string()),
+            retryable: false,
+            metadata: HashMap::from([("schema".to_string(), "local".to_string())]),
+        })
+        .expect("tool error serializes");
+
+        assert_eq!(json["summary"], "Query failed");
+        assert_eq!(json["detail"], "planner error");
+        assert_eq!(json["hint"], "Retry with valid SQL.");
+        assert_eq!(json["grpc_code"], "InvalidArgument");
+        assert_eq!(json["reason"], "INVALID_SQL");
+        assert_eq!(json["retryable"], false);
+        assert_eq!(json["metadata"]["schema"], "local");
+    }
+
+    #[test]
+    fn tool_error_direct_serialization_skips_absent_optional_fields() {
+        let json = serde_json::to_value(ToolError {
+            summary: "Query request is invalid".to_string(),
+            detail: "DML not supported".to_string(),
+            hint: None,
+            grpc_code: "InvalidArgument".to_string(),
+            reason: None,
+            retryable: false,
+            metadata: HashMap::new(),
+        })
+        .expect("tool error serializes");
+
+        assert!(json["hint"].is_null());
+        assert!(json["reason"].is_null());
+        assert_eq!(
+            json["metadata"].as_object().expect("metadata object").len(),
+            0
+        );
     }
 
     fn build_coral_status(reason: &str, metadata: Vec<(&str, &str)>, retryable: bool) -> Status {

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -1,11 +1,7 @@
 use coral_client::{DecodedStatusError, decode_status_error};
-use rmcp::{
-    ErrorData,
-    model::{CallToolResult, Content},
-};
+use rmcp::{ErrorData, model::CallToolResult};
 use serde::Serialize;
 use std::collections::HashMap;
-use std::fmt::Write as _;
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct ToolError {
@@ -21,18 +17,10 @@ pub(crate) struct ToolError {
 }
 
 pub(crate) fn tool_error_result(error: ToolError) -> CallToolResult {
-    let mut text = format!("Error: {}", error.summary);
-    if !error.detail.is_empty() {
-        write!(text, "\nDetail: {}", error.detail).expect("writing to String cannot fail");
-    }
-    if let Some(hint) = &error.hint {
-        write!(text, "\nHint: {hint}").expect("writing to String cannot fail");
-    }
-
     let structured = serde_json::to_value(StructuredToolErrorValue { error })
         .expect("tool error value serializes");
     let mut result = CallToolResult::structured_error(structured);
-    result.content = vec![Content::text(text)];
+    result.content = Vec::new();
     result
 }
 
@@ -167,6 +155,7 @@ mod tests {
             metadata: HashMap::new(),
         });
         assert_eq!(result.is_error, Some(true));
+        assert!(result.content.is_empty());
         let json = result.structured_content.expect("structured content");
         assert_eq!(json["error"]["grpc_code"], "InvalidArgument");
         assert_eq!(json["error"]["retryable"], false);

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use catalog::{
 pub(crate) use discovery::{Pagination, parse_pagination, parse_pagination_with_limits};
 pub(crate) use errors::{
     ToolError, status_to_error_data, tool_error_from_status, tool_error_output_schema,
-    tool_error_result, tool_error_with_data_result,
+    tool_error_result,
 };
 pub(crate) use resources::{
     guide_resource, guide_resource_content, initial_instructions, tables_resource,

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -4,6 +4,7 @@ mod catalog;
 mod discovery;
 mod errors;
 mod resources;
+mod schema;
 mod source_names;
 mod sql;
 mod tools;
@@ -14,7 +15,8 @@ pub(crate) use catalog::{
 };
 pub(crate) use discovery::{Pagination, parse_pagination, parse_pagination_with_limits};
 pub(crate) use errors::{
-    ToolError, status_to_error_data, tool_error_from_status, tool_error_result,
+    ToolError, status_to_error_data, tool_error_from_status, tool_error_output_schema,
+    tool_error_result, tool_error_with_data_result,
 };
 pub(crate) use resources::{
     guide_resource, guide_resource_content, initial_instructions, tables_resource,

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -13,7 +13,9 @@ pub(crate) use catalog::{
     describe_table_value, list_catalog_value, list_columns_value, search_catalog_value,
 };
 pub(crate) use discovery::{Pagination, parse_pagination, parse_pagination_with_limits};
-pub(crate) use errors::{status_to_error_data, tool_error_from_status, tool_error_result};
+pub(crate) use errors::{
+    ToolError, status_to_error_data, tool_error_from_status, tool_error_result,
+};
 pub(crate) use resources::{
     guide_resource, guide_resource_content, initial_instructions, tables_resource,
     tables_resource_content,

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -5,6 +5,7 @@ mod discovery;
 mod errors;
 mod resources;
 mod source_names;
+mod sql;
 mod tools;
 mod values;
 
@@ -18,6 +19,9 @@ pub(crate) use resources::{
     tables_resource_content,
 };
 pub(crate) use source_names::connected_source_names_text;
+pub(crate) use sql::{
+    SqlBatchValue, SqlQueryResultValue, sql_arguments, sql_input_schema, sql_output_schema,
+};
 pub(crate) use tools::{
     CatalogToolKind, ToolDescriptionContext, build_tool_result, describe_table_arguments,
     describe_table_tool, feedback_tool, list_catalog_arguments, list_catalog_tool,

--- a/crates/coral-mcp/src/surface/schema.rs
+++ b/crates/coral-mcp/src/surface/schema.rs
@@ -1,0 +1,12 @@
+use std::sync::Arc;
+
+use serde_json::{Map, Value};
+
+pub(crate) fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
+    Arc::new(
+        value
+            .as_object()
+            .cloned()
+            .expect("tool schemas should be JSON objects"),
+    )
+}

--- a/crates/coral-mcp/src/surface/sql.rs
+++ b/crates/coral-mcp/src/surface/sql.rs
@@ -30,30 +30,23 @@ pub(crate) enum SqlQueryResultValue {
 }
 
 impl SqlBatchValue {
-    pub(crate) fn from_unordered(
-        mut results: Vec<SqlQueryResultValue>,
-    ) -> Result<Self, tonic::Status> {
+    pub(crate) fn from_unordered(mut results: Vec<SqlQueryResultValue>) -> Self {
         results.sort_by_key(SqlQueryResultValue::index);
 
         for (expected_index, result) in results.iter().enumerate() {
-            let actual_index = result.index();
-            if actual_index != expected_index {
-                return Err(tonic::Status::internal(format!(
-                    "SQL batch result index mismatch: expected {expected_index}, found {actual_index}"
-                )));
-            }
+            debug_assert_eq!(result.index(), expected_index);
         }
 
         let success_count = results
             .iter()
             .filter(|result| matches!(result, SqlQueryResultValue::Success { .. }))
             .count();
-        Ok(Self {
+        Self {
             total_count: results.len(),
             success_count,
             error_count: results.len() - success_count,
             results,
-        })
+        }
     }
 
     pub(crate) fn has_errors(&self) -> bool {

--- a/crates/coral-mcp/src/surface/sql.rs
+++ b/crates/coral-mcp/src/surface/sql.rs
@@ -1,12 +1,13 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use rmcp::ErrorData;
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 
-use super::ToolError;
+use super::{ToolError, schema::json_object_schema, tool_error_output_schema};
 
 pub(crate) const MAX_SQL_BATCH_QUERIES: usize = 10;
+const MAX_SQL_BATCH_RESULT_INDEX: usize = MAX_SQL_BATCH_QUERIES - 1;
 
 pub(crate) struct SqlArguments {
     pub(crate) queries: Vec<String>,
@@ -52,12 +53,35 @@ impl SqlBatchValue {
     pub(crate) fn has_errors(&self) -> bool {
         self.error_count > 0
     }
+
+    pub(crate) fn partial_failure_error(&self) -> ToolError {
+        ToolError {
+            summary: "One or more SQL queries failed".to_string(),
+            detail: "Inspect `data.results` for per-query successes and errors.".to_string(),
+            hint: None,
+            grpc_code: tonic::Code::Unknown.to_string(),
+            reason: Some("SQL_BATCH_PARTIAL_FAILURE".to_string()),
+            retryable: self.results.iter().any(SqlQueryResultValue::is_retryable),
+            metadata: HashMap::from([
+                ("total_count".to_string(), self.total_count.to_string()),
+                ("success_count".to_string(), self.success_count.to_string()),
+                ("error_count".to_string(), self.error_count.to_string()),
+            ]),
+        }
+    }
 }
 
 impl SqlQueryResultValue {
     fn index(&self) -> usize {
         match self {
             Self::Success { index, .. } | Self::Error { index, .. } => *index,
+        }
+    }
+
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::Success { .. } => false,
+            Self::Error { error, .. } => error.retryable,
         }
     }
 }
@@ -116,7 +140,8 @@ pub(crate) fn sql_input_schema() -> Arc<Map<String, Value>> {
                 "maxItems": MAX_SQL_BATCH_QUERIES,
                 "items": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "pattern": r"\S"
                 }
             }
         }
@@ -124,7 +149,30 @@ pub(crate) fn sql_input_schema() -> Arc<Map<String, Value>> {
 }
 
 pub(crate) fn sql_output_schema() -> Arc<Map<String, Value>> {
+    let result_index_max = MAX_SQL_BATCH_RESULT_INDEX;
     json_object_schema(&json!({
+        "type": "object",
+        "oneOf": [
+            { "$ref": "#/$defs/sql_batch" },
+            {
+                "type": "object",
+                "required": ["error", "data"],
+                "additionalProperties": false,
+                "properties": {
+                    "error": { "$ref": "#/$defs/tool_error" },
+                    "data": { "$ref": "#/$defs/sql_batch" }
+                }
+            }
+        ],
+        "$defs": {
+            "sql_batch": sql_batch_output_schema(result_index_max),
+            "tool_error": tool_error_output_schema()
+        }
+    }))
+}
+
+fn sql_batch_output_schema(result_index_max: usize) -> Value {
+    json!({
         "type": "object",
         "required": ["total_count", "success_count", "error_count", "results"],
         "additionalProperties": false,
@@ -143,7 +191,7 @@ pub(crate) fn sql_output_schema() -> Arc<Map<String, Value>> {
                             "required": ["index", "status", "rows"],
                             "additionalProperties": false,
                             "properties": {
-                                "index": { "type": "integer", "minimum": 0, "maximum": 9 },
+                                "index": { "type": "integer", "minimum": 0, "maximum": result_index_max },
                                 "status": { "const": "success" },
                                 "rows": { "type": "array", "items": { "type": "object" } }
                             }
@@ -153,39 +201,14 @@ pub(crate) fn sql_output_schema() -> Arc<Map<String, Value>> {
                             "required": ["index", "status", "error"],
                             "additionalProperties": false,
                             "properties": {
-                                "index": { "type": "integer", "minimum": 0, "maximum": 9 },
+                                "index": { "type": "integer", "minimum": 0, "maximum": result_index_max },
                                 "status": { "const": "error" },
-                                "error": { "$ref": "#/$defs/sql_query_error" }
+                                "error": { "$ref": "#/$defs/tool_error" }
                             }
                         }
                     ]
                 }
             }
         },
-        "$defs": {
-            "sql_query_error": {
-                "type": "object",
-                "required": ["summary", "detail", "grpc_code", "retryable", "metadata"],
-                "additionalProperties": false,
-                "properties": {
-                    "summary": { "type": "string" },
-                    "detail": { "type": "string" },
-                    "hint": { "type": "string" },
-                    "grpc_code": { "type": "string" },
-                    "reason": { "type": "string" },
-                    "retryable": { "type": "boolean" },
-                    "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
-                }
-            }
-        }
-    }))
-}
-
-fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
-    Arc::new(
-        value
-            .as_object()
-            .cloned()
-            .expect("tool schemas should be JSON objects"),
-    )
+    })
 }

--- a/crates/coral-mcp/src/surface/sql.rs
+++ b/crates/coral-mcp/src/surface/sql.rs
@@ -34,6 +34,31 @@ impl SqlBatchValue {
             results,
         }
     }
+
+    pub(crate) fn from_unordered(
+        mut results: Vec<SqlQueryResultValue>,
+    ) -> Result<Self, tonic::Status> {
+        results.sort_by_key(SqlQueryResultValue::index);
+
+        for (expected_index, result) in results.iter().enumerate() {
+            let actual_index = result.index();
+            if actual_index != expected_index {
+                return Err(tonic::Status::internal(format!(
+                    "SQL batch result index mismatch: expected {expected_index}, found {actual_index}"
+                )));
+            }
+        }
+
+        Ok(Self::from_successes(results))
+    }
+}
+
+impl SqlQueryResultValue {
+    fn index(&self) -> usize {
+        match self {
+            Self::Success { index, .. } => *index,
+        }
+    }
 }
 
 pub(crate) fn sql_arguments(

--- a/crates/coral-mcp/src/surface/sql.rs
+++ b/crates/coral-mcp/src/surface/sql.rs
@@ -4,6 +4,8 @@ use rmcp::ErrorData;
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 
+use super::ToolError;
+
 pub(crate) const MAX_SQL_BATCH_QUERIES: usize = 10;
 
 pub(crate) struct SqlArguments {
@@ -23,18 +25,11 @@ pub(crate) struct SqlBatchValue {
 pub(crate) enum SqlQueryResultValue {
     #[serde(rename = "success")]
     Success { index: usize, rows: Vec<Value> },
+    #[serde(rename = "error")]
+    Error { index: usize, error: ToolError },
 }
 
 impl SqlBatchValue {
-    pub(crate) fn from_successes(results: Vec<SqlQueryResultValue>) -> Self {
-        Self {
-            total_count: results.len(),
-            success_count: results.len(),
-            error_count: 0,
-            results,
-        }
-    }
-
     pub(crate) fn from_unordered(
         mut results: Vec<SqlQueryResultValue>,
     ) -> Result<Self, tonic::Status> {
@@ -49,14 +44,27 @@ impl SqlBatchValue {
             }
         }
 
-        Ok(Self::from_successes(results))
+        let success_count = results
+            .iter()
+            .filter(|result| matches!(result, SqlQueryResultValue::Success { .. }))
+            .count();
+        Ok(Self {
+            total_count: results.len(),
+            success_count,
+            error_count: results.len() - success_count,
+            results,
+        })
+    }
+
+    pub(crate) fn has_errors(&self) -> bool {
+        self.error_count > 0
     }
 }
 
 impl SqlQueryResultValue {
     fn index(&self) -> usize {
         match self {
-            Self::Success { index, .. } => *index,
+            Self::Success { index, .. } | Self::Error { index, .. } => *index,
         }
     }
 }
@@ -136,14 +144,44 @@ pub(crate) fn sql_output_schema() -> Arc<Map<String, Value>> {
                 "minItems": 1,
                 "maxItems": MAX_SQL_BATCH_QUERIES,
                 "items": {
-                    "type": "object",
-                    "required": ["index", "status", "rows"],
-                    "additionalProperties": false,
-                    "properties": {
-                        "index": { "type": "integer", "minimum": 0, "maximum": 9 },
-                        "status": { "const": "success" },
-                        "rows": { "type": "array", "items": { "type": "object" } }
-                    }
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "required": ["index", "status", "rows"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "index": { "type": "integer", "minimum": 0, "maximum": 9 },
+                                "status": { "const": "success" },
+                                "rows": { "type": "array", "items": { "type": "object" } }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "required": ["index", "status", "error"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "index": { "type": "integer", "minimum": 0, "maximum": 9 },
+                                "status": { "const": "error" },
+                                "error": { "$ref": "#/$defs/sql_query_error" }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "$defs": {
+            "sql_query_error": {
+                "type": "object",
+                "required": ["summary", "detail", "grpc_code", "retryable", "metadata"],
+                "additionalProperties": false,
+                "properties": {
+                    "summary": { "type": "string" },
+                    "detail": { "type": "string" },
+                    "hint": { "type": "string" },
+                    "grpc_code": { "type": "string" },
+                    "reason": { "type": "string" },
+                    "retryable": { "type": "boolean" },
+                    "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
                 }
             }
         }

--- a/crates/coral-mcp/src/surface/sql.rs
+++ b/crates/coral-mcp/src/surface/sql.rs
@@ -1,0 +1,135 @@
+use std::sync::Arc;
+
+use rmcp::ErrorData;
+use serde::Serialize;
+use serde_json::{Map, Value, json};
+
+pub(crate) const MAX_SQL_BATCH_QUERIES: usize = 10;
+
+pub(crate) struct SqlArguments {
+    pub(crate) queries: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct SqlBatchValue {
+    total_count: usize,
+    success_count: usize,
+    error_count: usize,
+    results: Vec<SqlQueryResultValue>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status")]
+pub(crate) enum SqlQueryResultValue {
+    #[serde(rename = "success")]
+    Success { index: usize, rows: Vec<Value> },
+}
+
+impl SqlBatchValue {
+    pub(crate) fn from_successes(results: Vec<SqlQueryResultValue>) -> Self {
+        Self {
+            total_count: results.len(),
+            success_count: results.len(),
+            error_count: 0,
+            results,
+        }
+    }
+}
+
+pub(crate) fn sql_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<SqlArguments, ErrorData> {
+    let queries = arguments
+        .and_then(|arguments| arguments.get("queries"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| ErrorData::invalid_params("argument 'queries' must be an array", None))?;
+    if queries.is_empty() {
+        return Err(ErrorData::invalid_params(
+            "argument 'queries' must contain at least 1 query",
+            None,
+        ));
+    }
+    if queries.len() > MAX_SQL_BATCH_QUERIES {
+        return Err(ErrorData::invalid_params(
+            format!("argument 'queries' must contain at most {MAX_SQL_BATCH_QUERIES} queries"),
+            None,
+        ));
+    }
+    let queries = queries
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let query = value.as_str().ok_or_else(|| {
+                ErrorData::invalid_params(
+                    format!("argument 'queries[{index}]' must be a string"),
+                    None,
+                )
+            })?;
+            let query = query.trim();
+            if query.is_empty() {
+                return Err(ErrorData::invalid_params(
+                    format!("argument 'queries[{index}]' must not be empty"),
+                    None,
+                ));
+            }
+            Ok(query.to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(SqlArguments { queries })
+}
+
+pub(crate) fn sql_input_schema() -> Arc<Map<String, Value>> {
+    json_object_schema(&json!({
+        "type": "object",
+        "required": ["queries"],
+        "properties": {
+            "queries": {
+                "type": "array",
+                "description": "One to ten independent read-only SQL statements to execute against Coral. Entries must not depend on one another's rows, errors, or side effects.",
+                "minItems": 1,
+                "maxItems": MAX_SQL_BATCH_QUERIES,
+                "items": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        }
+    }))
+}
+
+pub(crate) fn sql_output_schema() -> Arc<Map<String, Value>> {
+    json_object_schema(&json!({
+        "type": "object",
+        "required": ["total_count", "success_count", "error_count", "results"],
+        "additionalProperties": false,
+        "properties": {
+            "total_count": { "type": "integer", "minimum": 1, "maximum": MAX_SQL_BATCH_QUERIES },
+            "success_count": { "type": "integer", "minimum": 0, "maximum": MAX_SQL_BATCH_QUERIES },
+            "error_count": { "type": "integer", "minimum": 0, "maximum": MAX_SQL_BATCH_QUERIES },
+            "results": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": MAX_SQL_BATCH_QUERIES,
+                "items": {
+                    "type": "object",
+                    "required": ["index", "status", "rows"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "index": { "type": "integer", "minimum": 0, "maximum": 9 },
+                        "status": { "const": "success" },
+                        "rows": { "type": "array", "items": { "type": "object" } }
+                    }
+                }
+            }
+        }
+    }))
+}
+
+fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
+    Arc::new(
+        value
+            .as_object()
+            .cloned()
+            .expect("tool schemas should be JSON objects"),
+    )
+}

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -10,7 +10,7 @@ use coral_api::{CORAL_EPISODE_ID_MAX_LEN, CORAL_EPISODE_INTENT_MAX_CHARS};
 
 use super::{
     Pagination, connected_source_names_text, parse_pagination, parse_pagination_with_limits,
-    sql_input_schema, sql_output_schema,
+    schema::json_object_schema, sql_input_schema, sql_output_schema,
 };
 
 const EPISODE_ID_ARGUMENT_DESCRIPTION: &str = "Optional episode id returned by open_episode. Pass it on subsequent Coral tool calls for the same task so Coral can attribute the call to that episode.";
@@ -953,15 +953,6 @@ fn optional_bool_argument(
     value.as_bool().ok_or_else(|| {
         ErrorData::invalid_params(format!("argument '{key}' must be a boolean"), None)
     })
-}
-
-fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
-    Arc::new(
-        value
-            .as_object()
-            .cloned()
-            .expect("tool schemas should be JSON objects"),
-    )
 }
 
 #[cfg(test)]

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -10,6 +10,7 @@ use coral_api::{CORAL_EPISODE_ID_MAX_LEN, CORAL_EPISODE_INTENT_MAX_CHARS};
 
 use super::{
     Pagination, connected_source_names_text, parse_pagination, parse_pagination_with_limits,
+    sql_input_schema, sql_output_schema,
 };
 
 const EPISODE_ID_ARGUMENT_DESCRIPTION: &str = "Optional episode id returned by open_episode. Pass it on subsequent Coral tool calls for the same task so Coral can attribute the call to that episode.";
@@ -85,27 +86,15 @@ pub(crate) struct OpenEpisodeArguments {
 }
 
 pub(crate) fn sql_tool(context: &ToolDescriptionContext) -> Tool {
-    Tool::new(
-        "sql",
-        sql_tool_description(context),
-        json_object_schema(&json!({
-            "type": "object",
-            "required": ["sql"],
-            "properties": {
-                "sql": {
-                    "type": "string",
-                    "description": "One read-only SQL statement to execute against the Coral database and its configured connected source schemas."
-                }
-            }
-        })),
-    )
-    .with_annotations(
-        ToolAnnotations::with_title("Run SQL")
-            .read_only(true)
-            .destructive(false)
-            .idempotent(true)
-            .open_world(true),
-    )
+    Tool::new("sql", sql_tool_description(context), sql_input_schema())
+        .with_raw_output_schema(sql_output_schema())
+        .with_annotations(
+            ToolAnnotations::with_title("Run SQL")
+                .read_only(true)
+                .destructive(false)
+                .idempotent(true)
+                .open_world(true),
+        )
 }
 
 pub(crate) fn list_catalog_tool(context: &ToolDescriptionContext) -> Tool {
@@ -496,12 +485,12 @@ pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorDat
 fn sql_tool_description(context: &ToolDescriptionContext) -> String {
     if context.visible_table_count == 0 {
         format!(
-            "Execute read-only SQL against the Coral database. {} No user tables are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first.",
+            "Execute 1 to 10 independent read-only SQL queries against the Coral database using queries[]. Each entry must be independent and must not depend on another entry's rows, errors, or side effects. {} No user tables are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first.",
             context.connected_sources_sentence()
         )
     } else {
         format!(
-            "Execute read-only SQL against the Coral database across connected Coral sources/schemas. {} {} table(s) are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first. Use JOIN, CROSS JOIN, CTEs, subqueries, and aggregates to combine tables in one statement.",
+            "Execute 1 to 10 independent read-only SQL queries against the Coral database across connected Coral sources/schemas using queries[]. Each entry must be independent and must not depend on another entry's rows, errors, or side effects. {} {} table(s) are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first. Use JOIN, CROSS JOIN, CTEs, subqueries, and aggregates inside one query when work is dependent.",
             context.connected_sources_sentence(),
             context.visible_table_count
         )
@@ -1045,12 +1034,20 @@ mod tests {
             .input_schema
             .get("properties")
             .and_then(Value::as_object)
-            .and_then(|properties| properties.get("sql"))
+            .and_then(|properties| {
+                assert!(!properties.contains_key("sql"));
+                properties.get("queries")
+            })
             .and_then(Value::as_object)
-            .and_then(|sql| sql.get("description"))
+            .and_then(|queries| {
+                assert_eq!(queries.get("minItems"), Some(&json!(1)));
+                assert_eq!(queries.get("maxItems"), Some(&json!(10)));
+                queries.get("description")
+            })
             .and_then(Value::as_str)
-            .expect("sql input description");
-        assert!(sql_input_description.contains("connected source schemas"));
+            .expect("queries input description");
+        assert!(sql_input_description.contains("independent"));
+        assert!(sql_tool.output_schema.is_some());
 
         let search_description = search_catalog_tool(&context)
             .description

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rmcp::{
     ErrorData,
-    model::{CallToolResult, Content, Tool, ToolAnnotations},
+    model::{CallToolResult, Tool, ToolAnnotations},
 };
 use serde_json::{Map, Value, json};
 
@@ -474,12 +474,10 @@ pub(crate) fn optional_episode_id_argument(
     Ok(Some(value.to_string()))
 }
 
-pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
-    let compact = serde_json::to_string(&value)
-        .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+pub(crate) fn build_tool_result(value: Value) -> CallToolResult {
     let mut result = CallToolResult::structured(value);
-    result.content = vec![Content::text(compact)];
-    Ok(result)
+    result.content = Vec::new();
+    result
 }
 
 fn sql_tool_description(context: &ToolDescriptionContext) -> String {
@@ -977,7 +975,7 @@ mod tests {
     };
 
     #[test]
-    fn success_tool_result_text_uses_compact_json() {
+    fn success_tool_result_uses_structured_content_only() {
         let value = json!({
             "rows": [
                 {
@@ -991,17 +989,9 @@ mod tests {
             ]
         });
 
-        let result = build_tool_result(value.clone()).expect("tool result");
+        let result = build_tool_result(value.clone());
 
-        let text = result
-            .content
-            .first()
-            .and_then(|content| content.as_text())
-            .expect("text content");
-        assert_eq!(
-            text.text,
-            r#"{"rows":[{"id":1,"text":"hello"},{"id":2,"text":"world"}]}"#
-        );
+        assert!(result.content.is_empty());
         assert_eq!(
             result.structured_content.expect("structured content"),
             value

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -117,12 +117,12 @@ pub(crate) fn record_tonic_status(span: &tracing::Span, status: &tonic::Status) 
     }
 }
 
-pub(crate) fn record_tool_payload_error(
-    span: &tracing::Span,
-    error_type: &str,
-    message: impl std::fmt::Display,
-) {
-    record_error(span, error_type, message);
+pub(crate) fn record_sql_batch_partial_failure(span: &tracing::Span) {
+    record_error(
+        span,
+        "sql_batch_partial_failure",
+        "One or more SQL queries failed",
+    );
 }
 
 pub(crate) fn record_success(span: &tracing::Span) {

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -117,6 +117,14 @@ pub(crate) fn record_tonic_status(span: &tracing::Span, status: &tonic::Status) 
     }
 }
 
+pub(crate) fn record_tool_payload_error(
+    span: &tracing::Span,
+    error_type: &str,
+    message: impl std::fmt::Display,
+) {
+    record_error(span, error_type, message);
+}
+
 pub(crate) fn record_success(span: &tracing::Span) {
     span.record("status", "ok");
     span.set_status(OtelStatus::Ok);

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -1484,6 +1484,8 @@ async fn mcp_sql_executes_successful_batch_in_input_order() {
     let mut session = start_session(&temp).await;
     add_demo_source(&mut session.source_client, manifest_yaml).await;
     let client = &session.client;
+    let tools = client.list_all_tools().await.expect("tools");
+    let sql_tool = tool_by_name(&tools, "sql");
 
     let sql = client
         .call_tool(
@@ -1498,6 +1500,7 @@ async fn mcp_sql_executes_successful_batch_in_input_order() {
         .expect("batched sql");
     assert_eq!(sql.is_error, Some(false));
     let sql = sql.structured_content.expect("sql structured");
+    assert_matches_output_schema(sql_tool, &sql);
     assert_eq!(sql["total_count"], 2);
     assert_eq!(sql["success_count"], 2);
     assert_eq!(sql["error_count"], 0);
@@ -1520,6 +1523,8 @@ async fn mcp_tool_error_does_not_end_session() {
     let client = &session.client;
 
     add_demo_source(&mut session.source_client, manifest_yaml).await;
+    let tools = client.list_all_tools().await.expect("tools");
+    let sql_tool = tool_by_name(&tools, "sql");
 
     let sql = client
         .call_tool(
@@ -1548,6 +1553,7 @@ async fn mcp_tool_error_does_not_end_session() {
         .expect("mixed sql still returns tool result");
     assert_eq!(mixed_sql.is_error, Some(true));
     let mixed_sql = mixed_sql.structured_content.expect("structured content");
+    assert_matches_output_schema(sql_tool, &mixed_sql);
     assert_eq!(mixed_sql["total_count"], 2);
     assert_eq!(mixed_sql["success_count"], 1);
     assert_eq!(mixed_sql["error_count"], 1);

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -1552,16 +1552,19 @@ async fn mcp_tool_error_does_not_end_session() {
         .await
         .expect("mixed sql still returns tool result");
     assert_eq!(mixed_sql.is_error, Some(true));
+    assert_structured_content_only(&mixed_sql);
     let mixed_sql = mixed_sql.structured_content.expect("structured content");
     assert_matches_output_schema(sql_tool, &mixed_sql);
-    assert_eq!(mixed_sql["total_count"], 2);
-    assert_eq!(mixed_sql["success_count"], 1);
-    assert_eq!(mixed_sql["error_count"], 1);
-    assert_eq!(mixed_sql["results"][0]["status"], "success");
-    assert_eq!(mixed_sql["results"][0]["rows"][0]["text"], "hello");
-    assert_eq!(mixed_sql["results"][1]["status"], "error");
+    assert_eq!(mixed_sql["error"]["reason"], "SQL_BATCH_PARTIAL_FAILURE");
+    let mixed_sql_batch = &mixed_sql["data"];
+    assert_eq!(mixed_sql_batch["total_count"], 2);
+    assert_eq!(mixed_sql_batch["success_count"], 1);
+    assert_eq!(mixed_sql_batch["error_count"], 1);
+    assert_eq!(mixed_sql_batch["results"][0]["status"], "success");
+    assert_eq!(mixed_sql_batch["results"][0]["rows"][0]["text"], "hello");
+    assert_eq!(mixed_sql_batch["results"][1]["status"], "error");
     assert_eq!(
-        mixed_sql["results"][1]["error"]["summary"],
+        mixed_sql_batch["results"][1]["error"]["summary"],
         "Query request is invalid"
     );
 

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -427,7 +427,7 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
     let sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "SELECT 1 AS ok",
+                "queries": ["SELECT 1 AS ok"],
                 "episode_id": child_episode_id
             }))),
         )
@@ -435,14 +435,14 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
         .expect("tagged sql");
     assert_eq!(sql.is_error, Some(false));
     assert_eq!(
-        sql.structured_content.expect("sql structured")["rows"][0]["ok"],
+        sql.structured_content.expect("sql structured")["results"][0]["rows"][0]["ok"],
         "1"
     );
 
     let invalid_episode_id = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "SELECT 1",
+                "queries": ["SELECT 1"],
                 "episode_id": "has space"
             }))),
         )
@@ -562,12 +562,12 @@ async fn mcp_catalog_helpers_expose_coral_system_tables_from_sql_catalog() {
     let sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "SELECT table_name FROM coral.tables WHERE schema_name = 'coral' ORDER BY table_name"
+                "queries": ["SELECT table_name FROM coral.tables WHERE schema_name = 'coral' ORDER BY table_name"]
             }))),
         )
         .await
         .expect("sql system catalog");
-    let sql_rows = sql.structured_content.as_ref().expect("structured sql")["rows"]
+    let sql_rows = sql.structured_content.as_ref().expect("structured sql")["results"][0]["rows"]
         .as_array()
         .expect("sql rows");
     assert_eq!(
@@ -1474,13 +1474,13 @@ async fn mcp_tool_error_does_not_end_session() {
     let sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "SELECT text FROM local_messages.messages ORDER BY text"
+                "queries": ["SELECT text FROM local_messages.messages ORDER BY text"]
             }))),
         )
         .await
         .expect("sql");
     assert_eq!(
-        sql.structured_content.expect("structured content")["rows"][0]["text"],
+        sql.structured_content.expect("structured content")["results"][0]["rows"][0]["text"],
         "hello"
     );
     assert_eq!(sql.is_error, Some(false));
@@ -1488,7 +1488,7 @@ async fn mcp_tool_error_does_not_end_session() {
     let invalid_sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "DELETE FROM local_messages.messages"
+                "queries": ["DELETE FROM local_messages.messages"]
             }))),
         )
         .await
@@ -1542,14 +1542,14 @@ async fn mcp_sql_returns_large_int64_as_string() {
     let sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "SELECT CAST(-8504475857937456387 AS BIGINT) AS user_id"
+                "queries": ["SELECT CAST(-8504475857937456387 AS BIGINT) AS user_id"]
             }))),
         )
         .await
         .expect("sql");
     assert_eq!(sql.is_error, Some(false));
 
-    let rows = &sql.structured_content.expect("structured content")["rows"];
+    let rows = &sql.structured_content.expect("structured content")["results"][0]["rows"];
     assert_eq!(
         rows[0]["user_id"],
         Value::String("-8504475857937456387".to_string()),

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -1520,25 +1520,28 @@ async fn mcp_tool_error_does_not_end_session() {
     );
     assert_eq!(sql.is_error, Some(false));
 
-    let invalid_sql = client
+    let mixed_sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "queries": ["DELETE FROM local_messages.messages"]
+                "queries": [
+                    "SELECT text FROM local_messages.messages WHERE text = 'hello'",
+                    "DELETE FROM local_messages.messages"
+                ]
             }))),
         )
         .await
-        .expect("failing sql still returns tool result");
-    assert_eq!(invalid_sql.is_error, Some(true));
+        .expect("mixed sql still returns tool result");
+    assert_eq!(mixed_sql.is_error, Some(true));
+    let mixed_sql = mixed_sql.structured_content.expect("structured content");
+    assert_eq!(mixed_sql["total_count"], 2);
+    assert_eq!(mixed_sql["success_count"], 1);
+    assert_eq!(mixed_sql["error_count"], 1);
+    assert_eq!(mixed_sql["results"][0]["status"], "success");
+    assert_eq!(mixed_sql["results"][0]["rows"][0]["text"], "hello");
+    assert_eq!(mixed_sql["results"][1]["status"], "error");
     assert_eq!(
-        invalid_sql.structured_content.expect("structured content")["error"]["summary"],
+        mixed_sql["results"][1]["error"]["summary"],
         "Query request is invalid"
-    );
-    assert!(
-        invalid_sql.content[0]
-            .as_text()
-            .expect("text content")
-            .text
-            .contains("Detail:")
     );
 
     let catalog_after_error = client

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -1462,6 +1462,41 @@ async fn mcp_feedback_tool_is_disabled_by_default() {
 }
 
 #[tokio::test]
+async fn mcp_sql_executes_successful_batch_in_input_order() {
+    let temp = TempDir::new().expect("temp dir");
+    let manifest_path = write_fixture_manifest(temp.path());
+    let manifest_yaml = fs::read_to_string(&manifest_path).expect("read manifest");
+    let mut session = start_session(&temp).await;
+    add_demo_source(&mut session.source_client, manifest_yaml).await;
+    let client = &session.client;
+
+    let sql = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "queries": [
+                    "SELECT text FROM local_messages.messages WHERE text = 'world'",
+                    "SELECT text FROM local_messages.messages WHERE text = 'hello'"
+                ]
+            }))),
+        )
+        .await
+        .expect("batched sql");
+    assert_eq!(sql.is_error, Some(false));
+    let sql = sql.structured_content.expect("sql structured");
+    assert_eq!(sql["total_count"], 2);
+    assert_eq!(sql["success_count"], 2);
+    assert_eq!(sql["error_count"], 0);
+    assert_eq!(sql["results"][0]["index"], 0);
+    assert_eq!(sql["results"][0]["status"], "success");
+    assert_eq!(sql["results"][0]["rows"][0]["text"], "world");
+    assert_eq!(sql["results"][1]["index"], 1);
+    assert_eq!(sql["results"][1]["status"], "success");
+    assert_eq!(sql["results"][1]["rows"][0]["text"], "hello");
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
 async fn mcp_tool_error_does_not_end_session() {
     let temp = TempDir::new().expect("temp dir");
     let manifest_path = write_fixture_manifest(temp.path());

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -18,7 +18,7 @@ use coral_client::{
 use jsonschema::JSONSchema;
 use rmcp::{
     RoleClient, ServiceExt,
-    model::{CallToolRequestParams, ReadResourceRequestParams, Tool},
+    model::{CallToolRequestParams, CallToolResult, ReadResourceRequestParams, Tool},
     service::RunningService,
 };
 use serde_json::{Map, Value, json};
@@ -324,6 +324,17 @@ fn assert_matches_output_schema(tool: &Tool, value: &Value) {
     }
 }
 
+fn assert_structured_content_only(result: &CallToolResult) {
+    assert!(
+        result.content.is_empty(),
+        "tool results should not duplicate structured payloads as text content"
+    );
+    assert!(
+        result.structured_content.is_some(),
+        "tool result should expose structured_content"
+    );
+}
+
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,
@@ -389,6 +400,7 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
         .await
         .expect("open root episode");
     assert_eq!(root.is_error, Some(false));
+    assert_structured_content_only(&root);
     let root = root.structured_content.expect("root structured content");
     assert_matches_output_schema(open_episode_tool, &root);
     let root_episode_id = root["episode_id"]
@@ -415,6 +427,7 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
         .await
         .expect("open child episode");
     assert_eq!(child.is_error, Some(false));
+    assert_structured_content_only(&child);
     let child = child.structured_content.expect("child structured content");
     assert_matches_output_schema(open_episode_tool, &child);
     let child_episode_id = child["episode_id"]
@@ -434,6 +447,7 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
         .await
         .expect("tagged sql");
     assert_eq!(sql.is_error, Some(false));
+    assert_structured_content_only(&sql);
     assert_eq!(
         sql.structured_content.expect("sql structured")["results"][0]["rows"][0]["ok"],
         "1"
@@ -567,6 +581,7 @@ async fn mcp_catalog_helpers_expose_coral_system_tables_from_sql_catalog() {
         )
         .await
         .expect("sql system catalog");
+    assert_structured_content_only(&sql);
     let sql_rows = sql.structured_content.as_ref().expect("structured sql")["results"][0]["rows"]
         .as_array()
         .expect("sql rows");
@@ -586,9 +601,9 @@ async fn mcp_catalog_helpers_expose_coral_system_tables_from_sql_catalog() {
             }))),
         )
         .await
-        .expect("list system catalog")
-        .structured_content
-        .expect("structured catalog");
+        .expect("list system catalog");
+    assert_structured_content_only(&catalog);
+    let catalog = catalog.structured_content.expect("structured catalog");
     assert_eq!(catalog["total"], expected_tables.len());
     assert_eq!(
         catalog["items"]

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -251,23 +251,21 @@ Each entry must be one independent read-only SQL statement. Coral starts entries
 
 `queries` must contain 1 to 10 non-blank strings. Missing `queries`, an empty array, more than 10 entries, non-string entries, and blank strings are MCP argument errors and do not dispatch any SQL.
 
-
-
 ### Searching a provider's data
 
 Some sources expose native search endpoints (for example, GitHub issue search) as table functions with `kind = 'search'`. Prefer these over scanning a regular table when the agent needs ranked, query-driven results. They return provider-ranked candidates, so agents should preserve any returned rank columns and use the returned ids plus catalog-described tables to fetch full detail rows when the search result itself is incomplete.
 
 ## Query result format
 
-MCP tool results use `structured_content` as the only payload channel. The `content` array is empty for successful tool results and structured tool errors, so clients should not parse text content for rows or errors.
+MCP tool results use `structuredContent` for rows and errors. The `content` array is empty for successful tool results and structured tool errors, so clients should not parse text content.
 
-The `sql` tool returns one structured batch envelope:
+When every query succeeds, the `sql` tool returns one structured batch envelope:
 
 ```json
 {
   "total_count": 2,
-  "success_count": 1,
-  "error_count": 1,
+  "success_count": 2,
+  "error_count": 0,
   "results": [
     {
       "index": 0,
@@ -276,20 +274,56 @@ The `sql` tool returns one structured batch envelope:
     },
     {
       "index": 1,
-      "status": "error",
-      "error": {
-        "summary": "Query request is invalid",
-        "detail": "DML not supported: DELETE",
-        "grpc_code": "InvalidArgument",
-        "retryable": false,
-        "metadata": {}
-      }
+      "status": "success",
+      "rows": [{ "column_name": "title", "data_type": "Utf8" }]
     }
   ]
 }
 ```
 
-`results` is ordered to match `queries`, and each item includes its zero-based `index`. Successful items have `status: "success"` and `rows`. Failed items have `status: "error"` and an `error` object. A batch with any failed item sets the MCP tool result error indicator while still returning the full structured batch for partial-success inspection.
+`results` is ordered to match `queries`, and each item includes its zero-based `index`. Successful items have `status: "success"` and `rows`.
+
+A batch with any failed query sets the MCP tool result error indicator, keeps the top-level structured error shape, and returns the ordered batch under `data`:
+
+```json
+{
+  "error": {
+    "summary": "One or more SQL queries failed",
+    "detail": "Inspect `data.results` for per-query successes and errors.",
+    "grpc_code": "Unknown",
+    "reason": "SQL_BATCH_PARTIAL_FAILURE",
+    "retryable": false,
+    "metadata": {
+      "total_count": "2",
+      "success_count": "1",
+      "error_count": "1"
+    }
+  },
+  "data": {
+    "total_count": 2,
+    "success_count": 1,
+    "error_count": 1,
+    "results": [
+      {
+        "index": 0,
+        "status": "success",
+        "rows": [{ "table_name": "pulls" }]
+      },
+      {
+        "index": 1,
+        "status": "error",
+        "error": {
+          "summary": "Query request is invalid",
+          "detail": "DML not supported: DELETE",
+          "grpc_code": "InvalidArgument",
+          "retryable": false,
+          "metadata": {}
+        }
+      }
+    ]
+  }
+}
+```
 
 Successful SQL rows are JSON objects. To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
 

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -259,7 +259,7 @@ Some sources expose native search endpoints (for example, GitHub issue search) a
 
 MCP tool results use `structuredContent` for rows and errors. The `content` array is empty for successful tool results and structured tool errors, so clients should not parse text content.
 
-When every query succeeds, the `sql` tool returns one structured batch envelope:
+When every query succeeds, the `sql` tool returns one ordered batch:
 
 ```json
 {
@@ -281,60 +281,11 @@ When every query succeeds, the `sql` tool returns one structured batch envelope:
 }
 ```
 
-`results` is ordered to match `queries`, and each item includes its zero-based `index`. Successful items have `status: "success"` and `rows`.
+`results` is ordered to match `queries`, and each item includes its zero-based `index`.
 
-A batch with any failed query sets the MCP tool result error indicator, keeps the top-level structured error shape, and returns the ordered batch under `data`:
+If any query fails, the MCP tool result is marked as an error. The top-level `error` describes the batch failure, and `data` contains the same ordered batch with successful items and per-query error items.
 
-```json
-{
-  "error": {
-    "summary": "One or more SQL queries failed",
-    "detail": "Inspect `data.results` for per-query successes and errors.",
-    "grpc_code": "Unknown",
-    "reason": "SQL_BATCH_PARTIAL_FAILURE",
-    "retryable": false,
-    "metadata": {
-      "total_count": "2",
-      "success_count": "1",
-      "error_count": "1"
-    }
-  },
-  "data": {
-    "total_count": 2,
-    "success_count": 1,
-    "error_count": 1,
-    "results": [
-      {
-        "index": 0,
-        "status": "success",
-        "rows": [{ "table_name": "pulls" }]
-      },
-      {
-        "index": 1,
-        "status": "error",
-        "error": {
-          "summary": "Query request is invalid",
-          "detail": "DML not supported: DELETE",
-          "grpc_code": "InvalidArgument",
-          "retryable": false,
-          "metadata": {}
-        }
-      }
-    ]
-  }
-}
-```
-
-Successful SQL rows are JSON objects. To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
-
-- `Int64` (`BIGINT`) and `UInt64`
-- `Decimal32`, `Decimal64`, `Decimal128`, and `Decimal256`
-
-This applies wherever these types appear, including nested inside `Struct`, `List`, and `Map` columns. The column's declared SQL type does not change — `describe_table`, `list_columns`, and `coral.columns` still report `Int64` or `Decimal(p, s)`; only the JSON encoding of the value is a string. A `BIGINT` `user_id`, for example, comes back as `{ "user_id": "-8504475857937456387" }`.
-
-Coral does this because MCP uses JSON-RPC, and many clients — JavaScript/TypeScript `JSON.parse` and most MCP hosts — decode JSON numbers as IEEE-754 doubles. Values beyond 2^53 silently lose precision when read as a number.
-
-The CLI is unaffected: `coral sql --format json` keeps emitting these types as JSON numbers.
+Successful SQL rows are JSON objects. In MCP results, precision-sensitive numeric values such as `Int64`, `UInt64`, and decimals are encoded as JSON strings to avoid precision loss in JSON clients. The CLI is unaffected: `coral sql --format json` keeps emitting these types as JSON numbers.
 
 ## Troubleshooting
 

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -192,7 +192,7 @@ The agent should call `list_catalog`, `search_catalog`, or query `coral.tables` 
 
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
-| Tool     | `sql`            | Execute read-only SQL against the Coral database        |
+| Tool     | `sql`            | Execute 1 to 10 independent read-only SQL queries against the Coral database |
 | Tool     | `list_catalog`   | List database tables and table functions with pagination |
 | Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
 | Tool     | `describe_table` | Show compact metadata for one database table            |
@@ -204,7 +204,7 @@ Clients see the same database catalog and query results as `coral sql`. You set 
 
 The `coral` system schema is part of that catalog. No-schema `list_catalog` and `coral://tables` include both configured source tables and Coral catalog tables: `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs`. Agents can also call `describe_table` and `list_columns` on those system tables.
 
-Agents should treat the discovery tools as catalog helpers, not as replacement provider APIs. Tool descriptions include connected source/schema names, such as `github` or `slack`, to help clients route provider-specific prompts to Coral. For data questions, prefer a single `sql` call using `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions over multiple tool calls that fetch rows and combine them in the agent.
+Agents should treat the discovery tools as catalog helpers, not as replacement provider APIs. Tool descriptions include connected source/schema names, such as `github` or `slack`, to help clients route provider-specific prompts to Coral. For dependent data questions, prefer one SQL statement using `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions. For several independent questions, use one `sql` tool call with multiple `queries[]` entries.
 
 ### Discovery tools
 
@@ -234,13 +234,66 @@ Agents should treat the discovery tools as catalog helpers, not as replacement p
 
 When the agent needs metadata it can filter, join, sort, or aggregate before writing the final SQL, query `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` through the `sql` tool instead of relying only on `list_catalog` or `coral://tables`. Use `coral.filters` as the normalized filter surface, with `coral.columns.filter_mode` available when inspecting filter-only virtual columns.
 
+### SQL tool input
+
+The `sql` tool accepts a required `queries` array, not a top-level `sql` string:
+
+```json
+{
+  "queries": [
+    "SELECT table_name FROM coral.tables WHERE schema_name = 'github' ORDER BY table_name",
+    "SELECT column_name, data_type FROM coral.columns WHERE schema_name = 'github' AND table_name = 'pulls' ORDER BY ordinal_position"
+  ]
+}
+```
+
+Each entry must be one independent read-only SQL statement. Coral starts entries concurrently, so a later entry must not depend on rows, errors, or side effects from an earlier entry. If the work is dependent, combine it into one SQL statement or make separate tool calls after inspecting each result.
+
+`queries` must contain 1 to 10 non-blank strings. Missing `queries`, an empty array, more than 10 entries, non-string entries, and blank strings are MCP argument errors and do not dispatch any SQL.
+
+<Note>
+This is a breaking MCP contract change: update existing calls from `sql: "SELECT ..."` to `queries: ["SELECT ..."]`.
+</Note>
+
 ### Searching a provider's data
 
 Some sources expose native search endpoints (for example, GitHub issue search) as table functions with `kind = 'search'`. Prefer these over scanning a regular table when the agent needs ranked, query-driven results. They return provider-ranked candidates, so agents should preserve any returned rank columns and use the returned ids plus catalog-described tables to fetch full detail rows when the search result itself is incomplete.
 
 ## Query result format
 
-The `sql` tool returns rows as a JSON array of objects. To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
+MCP tool results use `structured_content` as the only payload channel. The `content` array is empty for successful tool results and structured tool errors, so clients should not parse text content for rows or errors.
+
+The `sql` tool returns one structured batch envelope:
+
+```json
+{
+  "total_count": 2,
+  "success_count": 1,
+  "error_count": 1,
+  "results": [
+    {
+      "index": 0,
+      "status": "success",
+      "rows": [{ "table_name": "pulls" }]
+    },
+    {
+      "index": 1,
+      "status": "error",
+      "error": {
+        "summary": "Query request is invalid",
+        "detail": "DML not supported: DELETE",
+        "grpc_code": "InvalidArgument",
+        "retryable": false,
+        "metadata": {}
+      }
+    }
+  ]
+}
+```
+
+`results` is ordered to match `queries`, and each item includes its zero-based `index`. Successful items have `status: "success"` and `rows`. Failed items have `status: "error"` and an `error` object. A batch with any failed item sets the MCP tool result error indicator while still returning the full structured batch for partial-success inspection.
+
+Successful SQL rows are JSON objects. To preserve exact values across JSON parsers, Coral encodes precision-sensitive numeric types as JSON **strings** rather than JSON numbers:
 
 - `Int64` (`BIGINT`) and `UInt64`
 - `Decimal32`, `Decimal64`, `Decimal128`, and `Decimal256`

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -251,9 +251,7 @@ Each entry must be one independent read-only SQL statement. Coral starts entries
 
 `queries` must contain 1 to 10 non-blank strings. Missing `queries`, an empty array, more than 10 entries, non-string entries, and blank strings are MCP argument errors and do not dispatch any SQL.
 
-<Note>
-This is a breaking MCP contract change: update existing calls from `sql: "SELECT ..."` to `queries: ["SELECT ..."]`.
-</Note>
+
 
 ### Searching a provider's data
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -246,7 +246,7 @@ By default, this server exposes:
 
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
-| Tool     | `sql`            | Execute 1 to 10 independent read-only SQL queries against the Coral database |
+| Tool     | `sql`            | MCP tool that executes 1 to 10 independent read-only SQL queries against the Coral database |
 | Tool     | `list_catalog`   | List database tables and table functions with pagination |
 | Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
 | Tool     | `describe_table` | Show compact metadata for one database table            |

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -246,7 +246,7 @@ By default, this server exposes:
 
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
-| Tool     | `sql`            | MCP tool that executes 1 to 10 independent read-only SQL queries against the Coral database |
+| Tool     | `sql`            | Execute read-only SQL against the Coral database        |
 | Tool     | `list_catalog`   | List database tables and table functions with pagination |
 | Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
 | Tool     | `describe_table` | Show compact metadata for one database table            |
@@ -261,7 +261,7 @@ Catalog helpers include the `coral` system schema, so `list_catalog`,
 `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and
 `coral.inputs`.
 
-For the `sql` tool's `queries: ["..."]` contract and MCP structured result-format details, see [Use Coral over MCP](/guides/use-coral-over-mcp).
+For client setup and MCP result-format details, see [Use Coral over MCP](/guides/use-coral-over-mcp).
 
 ## `coral completion <SHELL>`
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -246,7 +246,7 @@ By default, this server exposes:
 
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
-| Tool     | `sql`            | Execute read-only SQL against the Coral database        |
+| Tool     | `sql`            | Execute 1 to 10 independent read-only SQL queries against the Coral database |
 | Tool     | `list_catalog`   | List database tables and table functions with pagination |
 | Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
 | Tool     | `describe_table` | Show compact metadata for one database table            |
@@ -261,7 +261,7 @@ Catalog helpers include the `coral` system schema, so `list_catalog`,
 `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and
 `coral.inputs`.
 
-For client setup and MCP result-format details, see [Use Coral over MCP](/guides/use-coral-over-mcp).
+For the `sql` tool's `queries: ["..."]` contract and MCP structured result-format details, see [Use Coral over MCP](/guides/use-coral-over-mcp).
 
 ## `coral completion <SHELL>`
 


### PR DESCRIPTION
The MCP `sql` tool could only accept one top-level SQL string, so agents that needed several independent Coral queries had to issue repeated tool calls, preserve ordering themselves, and recover from partial failures outside Coral. This PR moves that orchestration into the MCP adapter with a bounded `queries[]` batch contract and deterministic ordered results.

This is also a contract cleanup. MCP SQL results now use structured output as the authoritative machine-readable surface, and mixed-success batches use the same canonical tool-error envelope as other Coral MCP errors.

**Breaking MCP change:** existing MCP clients must update calls from `sql: "SELECT ..."` to `queries: ["SELECT ..."]`, and raw MCP clients should read results from `structuredContent`.

## What changed

- Adds a required `queries[]` input for the MCP `sql` tool, bounded from 1 to 10 non-blank SQL strings.
- Executes independent SQL queries concurrently while returning results in input order.
- Returns successful batches as the SQL batch object directly.
- Returns mixed-success batches as a canonical structured tool error with top-level `error` and the ordered SQL batch under `data`.
- Preserves episode metadata across every parallel backend SQL request without adding a new dependency.
- Keeps per-query errors on the existing `ToolError` vocabulary and shares the same schema helper between top-level and per-query errors.
- Updates the MCP guide for the new `queries[]`, `structuredContent`, and partial-failure contracts.

## Review follow-up

- Replaced the generic tool payload abstraction with an explicit SQL batch outcome in the MCP server.
- Added the `{ error, data }` partial-failure result shape instead of treating the batch itself as the top-level successful payload.
- Moved reusable JSON-schema object handling into a shared surface helper.
- Added input-schema `pattern` validation to match runtime non-blank SQL validation.
- Added coverage proving a batch `episode_id` reaches every backend SQL request.
- Avoided adding `futures`; each spawned query is wrapped in the existing episode-metadata scope.

## How to verify

```bash
cargo test -p coral-mcp
cargo test -p coral-cli --features cli-test-server --test mcp
make docs-check
make rust-checks
```

These passed locally before pushing the branch.

