### PR TITLE
feat(app): read and select MCP startup query history

### DIFF
--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -1,6 +1,6 @@
 //! Internal bootstrap seam for assembling the local server runtime.
 
-use std::path::PathBuf;
+use std::{cmp::Reverse, collections::HashSet, path::PathBuf};
 
 mod consts;
 mod env;
@@ -8,6 +8,9 @@ mod error;
 mod server;
 
 use crate::state::{AppStateLayout, ConfigStore};
+use crate::telemetry::{
+    TelemetryConfig, TraceQueryHistoryEntry, TraceQueryTableFunctionUsage, TraceQueryTableUsage,
+};
 use crate::workspaces::WorkspaceName;
 
 #[cfg(test)]
@@ -38,4 +41,368 @@ pub fn default_workspace_source_names() -> Result<Vec<String>, AppError> {
     let layout = discover_app_state_layout(None)?;
     layout.ensure()?;
     ConfigStore::new(layout).list_workspace_source_names(&WorkspaceName::default())
+}
+
+/// Startup context loaded from local state for default-workspace MCP sessions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DefaultWorkspaceMcpStartupContext {
+    source_names: Vec<String>,
+    query_history: Vec<McpQueryHistoryEntry>,
+}
+
+impl DefaultWorkspaceMcpStartupContext {
+    /// Installed source names in the default workspace.
+    #[must_use]
+    pub fn source_names(&self) -> &[String] {
+        &self.source_names
+    }
+
+    /// Trace-backed successful query examples.
+    #[must_use]
+    pub fn query_history(&self) -> &[McpQueryHistoryEntry] {
+        &self.query_history
+    }
+}
+
+/// One successful query-history entry for MCP startup context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpQueryHistoryEntry {
+    sql: String,
+    sources: Vec<String>,
+    tables: Vec<McpQueryTableUsage>,
+    table_functions: Vec<McpQueryTableFunctionUsage>,
+    row_count: u64,
+}
+
+impl McpQueryHistoryEntry {
+    /// SQL text recorded on the query span.
+    #[must_use]
+    pub fn sql(&self) -> &str {
+        &self.sql
+    }
+
+    /// Installed source names used by this query.
+    #[must_use]
+    pub fn sources(&self) -> &[String] {
+        &self.sources
+    }
+
+    /// Source-scoped tables used by this query.
+    #[must_use]
+    pub fn tables(&self) -> &[McpQueryTableUsage] {
+        &self.tables
+    }
+
+    /// Source-scoped table functions used by this query.
+    #[must_use]
+    pub fn table_functions(&self) -> &[McpQueryTableFunctionUsage] {
+        &self.table_functions
+    }
+
+    /// Number of rows returned by the successful query.
+    #[must_use]
+    pub fn row_count(&self) -> u64 {
+        self.row_count
+    }
+
+    fn from_trace(entry: TraceQueryHistoryEntry) -> Self {
+        Self {
+            sql: entry.sql,
+            sources: entry.sources,
+            tables: entry
+                .tables
+                .into_iter()
+                .map(McpQueryTableUsage::from_trace)
+                .collect(),
+            table_functions: entry
+                .table_functions
+                .into_iter()
+                .map(McpQueryTableFunctionUsage::from_trace)
+                .collect(),
+            row_count: entry.row_count,
+        }
+    }
+}
+
+/// Source-scoped table usage in an MCP startup query-history entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpQueryTableUsage {
+    source: String,
+    schema: String,
+    table: String,
+}
+
+impl McpQueryTableUsage {
+    /// Installed source name that owns the table.
+    #[must_use]
+    pub fn source_name(&self) -> &str {
+        &self.source
+    }
+
+    /// SQL schema name used in the query.
+    #[must_use]
+    pub fn schema_name(&self) -> &str {
+        &self.schema
+    }
+
+    /// SQL table name used in the query.
+    #[must_use]
+    pub fn table_name(&self) -> &str {
+        &self.table
+    }
+
+    fn from_trace(usage: TraceQueryTableUsage) -> Self {
+        Self {
+            source: usage.source,
+            schema: usage.schema,
+            table: usage.table,
+        }
+    }
+}
+
+/// Source-scoped table-function usage in an MCP startup query-history entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpQueryTableFunctionUsage {
+    source: String,
+    schema: String,
+    function: String,
+}
+
+impl McpQueryTableFunctionUsage {
+    /// Installed source name that owns the table function.
+    #[must_use]
+    pub fn source_name(&self) -> &str {
+        &self.source
+    }
+
+    /// SQL schema name used in the query.
+    #[must_use]
+    pub fn schema_name(&self) -> &str {
+        &self.schema
+    }
+
+    /// SQL table-function name used in the query.
+    #[must_use]
+    pub fn function_name(&self) -> &str {
+        &self.function
+    }
+
+    fn from_trace(usage: TraceQueryTableFunctionUsage) -> Self {
+        Self {
+            source: usage.source,
+            schema: usage.schema,
+            function: usage.function,
+        }
+    }
+}
+
+/// Loads default-workspace source names and trace-backed query history without
+/// starting the local server.
+///
+/// # Errors
+///
+/// Returns [`AppError`] when local app state, config, or trace history cannot
+/// be read. Older trace records that do not carry query provenance are ignored.
+pub fn default_workspace_mcp_startup_context(
+    query_history_limit: usize,
+) -> Result<DefaultWorkspaceMcpStartupContext, AppError> {
+    let layout = discover_app_state_layout(None)?;
+    layout.ensure()?;
+    let source_names =
+        ConfigStore::new(layout.clone()).list_workspace_source_names(&WorkspaceName::default())?;
+    let telemetry_config = TelemetryConfig::load(&layout)?;
+    let query_history = if telemetry_config.trace_history.enabled {
+        let query_history = crate::telemetry::list_local_query_history(
+            layout.local_trace_store_dir(),
+            telemetry_config.trace_history.retention(),
+        )
+        .map_err(|error| {
+            AppError::FailedPrecondition(format!(
+                "failed to read trace-backed query history: {error}"
+            ))
+        })?
+        .into_iter()
+        .map(McpQueryHistoryEntry::from_trace)
+        .collect::<Vec<_>>();
+        select_mcp_query_history(query_history, query_history_limit)
+    } else {
+        Vec::new()
+    };
+
+    Ok(DefaultWorkspaceMcpStartupContext {
+        source_names,
+        query_history,
+    })
+}
+
+fn select_mcp_query_history(
+    mut query_history: Vec<McpQueryHistoryEntry>,
+    limit: usize,
+) -> Vec<McpQueryHistoryEntry> {
+    if limit == 0 {
+        return Vec::new();
+    }
+
+    query_history.retain(|entry| entry.row_count > 0);
+    query_history.sort_by_key(|entry| Reverse(query_history_sort_key(entry)));
+    if query_history.len() <= limit {
+        return query_history;
+    }
+
+    greedily_select_query_history(query_history, limit)
+}
+
+fn query_history_sort_key(entry: &McpQueryHistoryEntry) -> (usize, usize, usize) {
+    (
+        unique_source_count(&entry.sources),
+        entry.tables.len(),
+        entry.table_functions.len(),
+    )
+}
+
+fn unique_source_count(sources: &[String]) -> usize {
+    sources.iter().collect::<HashSet<_>>().len()
+}
+
+fn greedily_select_query_history(
+    mut remaining: Vec<McpQueryHistoryEntry>,
+    limit: usize,
+) -> Vec<McpQueryHistoryEntry> {
+    let mut selected = Vec::new();
+    let mut selected_sources = HashSet::new();
+
+    while selected.len() < limit && !remaining.is_empty() {
+        let mut best_position = 0;
+        let mut best_new_sources = 0;
+        for (position, entry) in remaining.iter().enumerate() {
+            let new_sources = new_source_count(&entry.sources, &selected_sources);
+            if new_sources > best_new_sources {
+                best_position = position;
+                best_new_sources = new_sources;
+            }
+        }
+
+        let entry = remaining.remove(best_position);
+        for source in &entry.sources {
+            selected_sources.insert(source.clone());
+        }
+        selected.push(entry);
+    }
+
+    selected
+}
+
+fn new_source_count(sources: &[String], selected_sources: &HashSet<String>) -> usize {
+    sources
+        .iter()
+        .filter(|source| !selected_sources.contains(*source))
+        .collect::<HashSet<_>>()
+        .len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        McpQueryHistoryEntry, McpQueryTableFunctionUsage, McpQueryTableUsage,
+        select_mcp_query_history,
+    };
+
+    #[test]
+    fn query_history_selection_filters_empty_results_and_sorts_by_complexity() {
+        let selected = select_mcp_query_history(
+            vec![
+                history_entry("zero_rows", &["sentry"], 10, 10, 0),
+                history_entry("one_table", &["github"], 1, 0, 1),
+                history_entry("two_sources", &["slack", "linear"], 0, 0, 1),
+                history_entry("two_tables", &["github"], 2, 0, 1),
+                history_entry("two_tables_one_function", &["github"], 2, 1, 1),
+            ],
+            10,
+        );
+
+        assert_eq!(
+            sqls(&selected),
+            [
+                "two_sources",
+                "two_tables_one_function",
+                "two_tables",
+                "one_table",
+            ]
+        );
+    }
+
+    #[test]
+    fn query_history_selection_keeps_top_ranked_query_even_when_not_globally_optimal() {
+        let selected = select_mcp_query_history(
+            vec![
+                history_entry("wide_but_overlapping", &["a", "b", "c"], 3, 0, 1),
+                history_entry("covers_e", &["b", "c", "e"], 1, 0, 1),
+                history_entry("covers_d", &["a", "d"], 0, 0, 1),
+            ],
+            2,
+        );
+
+        assert_eq!(sqls(&selected), ["wide_but_overlapping", "covers_e"]);
+    }
+
+    #[test]
+    fn query_history_selection_favors_new_sources_after_top_ranked_query() {
+        let selected = select_mcp_query_history(
+            vec![
+                history_entry("top_ranked", &["a", "b"], 2, 0, 1),
+                history_entry("overlap_next_ranked", &["a", "b"], 1, 0, 1),
+                history_entry("uncovered_lower_ranked", &["c"], 0, 0, 1),
+            ],
+            2,
+        );
+
+        assert_eq!(sqls(&selected), ["top_ranked", "uncovered_lower_ranked"]);
+    }
+
+    #[test]
+    fn query_history_selection_breaks_coverage_ties_by_sorted_order() {
+        let selected = select_mcp_query_history(
+            vec![
+                history_entry("first", &["a"], 1, 0, 1),
+                history_entry("second", &["b"], 0, 0, 1),
+                history_entry("third", &["c"], 0, 0, 1),
+            ],
+            2,
+        );
+
+        assert_eq!(sqls(&selected), ["first", "second"]);
+    }
+
+    fn history_entry(
+        sql: &str,
+        sources: &[&str],
+        table_count: usize,
+        table_function_count: usize,
+        row_count: u64,
+    ) -> McpQueryHistoryEntry {
+        let table_source = sources.first().copied().unwrap_or("source");
+        McpQueryHistoryEntry {
+            sql: sql.to_string(),
+            sources: sources.iter().map(|source| (*source).to_string()).collect(),
+            tables: (0..table_count)
+                .map(|index| McpQueryTableUsage {
+                    source: table_source.to_string(),
+                    schema: "schema".to_string(),
+                    table: format!("table_{index}"),
+                })
+                .collect(),
+            table_functions: (0..table_function_count)
+                .map(|index| McpQueryTableFunctionUsage {
+                    source: table_source.to_string(),
+                    schema: "schema".to_string(),
+                    function: format!("function_{index}"),
+                })
+                .collect(),
+            row_count,
+        }
+    }
+
+    fn sqls(entries: &[McpQueryHistoryEntry]) -> Vec<&str> {
+        entries.iter().map(McpQueryHistoryEntry::sql).collect()
+    }
 }

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -14,6 +14,7 @@ use opentelemetry::{Array as OtelArray, KeyValue, Value as OtelValue};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::trace::{SpanData, SpanExporter};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue, json};
 use tokio::task;
@@ -447,6 +448,38 @@ pub(crate) struct TraceDetailRecord {
     pub(crate) spans: Vec<TraceSpanRecord>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TraceQueryHistoryEntry {
+    pub(crate) trace_id: String,
+    pub(crate) span_id: String,
+    pub(crate) sql: String,
+    pub(crate) sources: Vec<String>,
+    pub(crate) tables: Vec<TraceQueryTableUsage>,
+    pub(crate) table_functions: Vec<TraceQueryTableFunctionUsage>,
+    pub(crate) row_count: u64,
+    pub(crate) end_time_unix_nanos: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct TraceQueryTableUsage {
+    #[serde(rename = "source_name")]
+    pub(crate) source: String,
+    #[serde(rename = "schema_name")]
+    pub(crate) schema: String,
+    #[serde(rename = "table_name")]
+    pub(crate) table: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct TraceQueryTableFunctionUsage {
+    #[serde(rename = "source_name")]
+    pub(crate) source: String,
+    #[serde(rename = "schema_name")]
+    pub(crate) schema: String,
+    #[serde(rename = "function_name")]
+    pub(crate) function: String,
+}
+
 struct TraceAggregate {
     trace_id: String,
     start_time_unix_nanos: i64,
@@ -492,6 +525,17 @@ struct TraceListAggregate {
 #[derive(Debug, Deserialize)]
 struct TraceSpanIdentityRecord {
     trace_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct TraceQueryHistorySpanRecord {
+    trace_id: String,
+    span_id: String,
+    name: String,
+    #[serde(default)]
+    status: StoredTraceStatus,
+    end_time_unix_nanos: i64,
+    attributes_json: String,
 }
 
 impl TraceStore {
@@ -623,6 +667,36 @@ impl TraceStore {
 
         let summary = summary_from_spans(trace_id, &spans);
         Ok(TraceDetailRecord { summary, spans })
+    }
+
+    pub(crate) fn list_query_history_sync(
+        &self,
+    ) -> Result<Vec<TraceQueryHistoryEntry>, TraceStoreError> {
+        self.prune_expired()?;
+        let files = self.jsonl_files_by_modified()?;
+        let mut entries_by_span = HashMap::new();
+
+        for file in files.iter().rev() {
+            for span in read_query_history_spans_file(&file.path)? {
+                let key = (span.trace_id.clone(), span.span_id.clone());
+                if entries_by_span.contains_key(&key) {
+                    continue;
+                }
+                if let Some(entry) = query_history_entry_from_span(&span) {
+                    entries_by_span.insert(key, entry);
+                }
+            }
+        }
+
+        let mut entries = entries_by_span.into_values().collect::<Vec<_>>();
+        entries.sort_by(|left, right| {
+            right
+                .end_time_unix_nanos
+                .cmp(&left.end_time_unix_nanos)
+                .then_with(|| left.trace_id.cmp(&right.trace_id))
+                .then_with(|| left.span_id.cmp(&right.span_id))
+        });
+        Ok(entries)
     }
 
     fn prune_expired(&self) -> Result<(), TraceStoreError> {
@@ -1036,6 +1110,49 @@ fn read_trace_spans_file(
     Ok(spans_by_id.into_values().collect())
 }
 
+fn read_query_history_spans_file(
+    path: &Path,
+) -> Result<Vec<TraceQueryHistorySpanRecord>, TraceStoreError> {
+    let file = File::open(path).map_err(|source| TraceStoreError::OpenFile {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut reader = BufReader::new(file);
+    let mut spans_by_id = HashMap::new();
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let bytes_read =
+            reader
+                .read_line(&mut line)
+                .map_err(|source| TraceStoreError::ReadFile {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        let complete_line = line.ends_with('\n');
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.trim().is_empty() || !trimmed.contains(r#""name":"coral.query""#) {
+            continue;
+        }
+
+        match serde_json::from_str::<TraceQueryHistorySpanRecord>(trimmed) {
+            Ok(span) if span.name == "coral.query" => {
+                spans_by_id.insert((span.trace_id.clone(), span.span_id.clone()), span);
+            }
+            Ok(_span) => {}
+            Err(_) if !complete_line => break,
+            Err(_) => {}
+        }
+    }
+
+    Ok(spans_by_id.into_values().collect())
+}
+
 fn summary_from_spans(trace_id: &str, spans: &[TraceSpanRecord]) -> TraceSummaryRecord {
     let start_time_unix_nanos = spans
         .iter()
@@ -1253,6 +1370,64 @@ fn attr_u64(attributes: &JsonValue, key: &str) -> Option<u64> {
             .as_u64()
             .or_else(|| value.as_i64().and_then(|value| u64::try_from(value).ok())),
         JsonValue::String(value) => value.parse().ok(),
+        _ => None,
+    }
+}
+
+fn query_history_entry_from_span(
+    span: &TraceQueryHistorySpanRecord,
+) -> Option<TraceQueryHistoryEntry> {
+    let attributes = parse_attributes(&span.attributes_json)?;
+    let status = status_from_attributes(Some(&attributes)).unwrap_or(span.status);
+    if status != StoredTraceStatus::Ok {
+        return None;
+    }
+    let sql = attr_string(&attributes, "sql")?;
+    if sql.trim().is_empty() {
+        return None;
+    }
+    let row_count = attr_u64(&attributes, "row_count")?;
+    let sources = attr_string_array(&attributes, super::QUERY_TRACE_SOURCES_ATTR)?;
+    let tables =
+        attr_json_vec::<TraceQueryTableUsage>(&attributes, super::QUERY_TRACE_TABLES_ATTR)?;
+    let table_functions = attr_json_vec::<TraceQueryTableFunctionUsage>(
+        &attributes,
+        super::QUERY_TRACE_TABLE_FUNCTIONS_ATTR,
+    )?;
+
+    Some(TraceQueryHistoryEntry {
+        trace_id: span.trace_id.clone(),
+        span_id: span.span_id.clone(),
+        sql,
+        sources,
+        tables,
+        table_functions,
+        row_count,
+        end_time_unix_nanos: span.end_time_unix_nanos,
+    })
+}
+
+fn attr_string_array(attributes: &JsonValue, key: &str) -> Option<Vec<String>> {
+    match attributes.get(key)? {
+        JsonValue::Array(values) => values.iter().map(attr_array_string_value).collect(),
+        JsonValue::String(value) => serde_json::from_str(value).ok(),
+        _ => None,
+    }
+}
+
+fn attr_array_string_value(value: &JsonValue) -> Option<String> {
+    match value {
+        JsonValue::String(value) => Some(value.clone()),
+        JsonValue::Number(value) => Some(value.to_string()),
+        JsonValue::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn attr_json_vec<T: DeserializeOwned>(attributes: &JsonValue, key: &str) -> Option<Vec<T>> {
+    match attributes.get(key)? {
+        JsonValue::Array(values) => serde_json::from_value(JsonValue::Array(values.clone())).ok(),
+        JsonValue::String(value) => serde_json::from_str(value).ok(),
         _ => None,
     }
 }
@@ -1572,6 +1747,52 @@ mod tests {
         assert_eq!(summary.status, StoredTraceStatus::Ok);
         assert_eq!(summary.row_count, 1);
         assert!(summary.row_count_recorded);
+    }
+
+    #[test]
+    fn query_history_reads_successful_query_provenance_leniently() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+
+        let mut legacy_record = trace_record("legacy-trace", "legacy-span");
+        legacy_record.attributes_json =
+            r#"{"sql":"SELECT old","status":"ok","row_count":1}"#.to_string();
+
+        let mut malformed_record = trace_record("malformed-trace", "malformed-span");
+        malformed_record.attributes_json =
+            query_history_attributes("SELECT malformed", "not-json", "[]", "[]", 1);
+
+        let mut valid_record = trace_record("valid-trace", "valid-span");
+        valid_record.end_time_unix_nanos = 42;
+        valid_record.attributes_json = query_history_attributes(
+            "SELECT title FROM github.issues",
+            r#"["github"]"#,
+            r#"[{"source_name":"github","schema_name":"github","table_name":"issues"}]"#,
+            r#"[{"source_name":"github","schema_name":"github","function_name":"search_issues"}]"#,
+            15,
+        );
+
+        let path = dir.join(timestamped_jsonl_path(SystemTime::now()));
+        write_record_file_lines(&path, &[legacy_record, malformed_record, valid_record]);
+
+        let history = TraceStore::new(dir)
+            .list_query_history_sync()
+            .expect("query history");
+
+        assert_eq!(history.len(), 1);
+        let entry = history.first().expect("history entry");
+        assert_eq!(entry.sql, "SELECT title FROM github.issues");
+        assert_eq!(entry.sources, ["github"]);
+        assert_eq!(entry.row_count, 15);
+        assert_eq!(entry.tables.len(), 1);
+        let table = entry.tables.first().expect("table usage");
+        assert_eq!(table.source, "github");
+        assert_eq!(table.schema, "github");
+        assert_eq!(table.table, "issues");
+        assert_eq!(entry.table_functions.len(), 1);
+        let table_function = entry.table_functions.first().expect("table function usage");
+        assert_eq!(table_function.function, "search_issues");
     }
 
     #[test]
@@ -2119,5 +2340,31 @@ mod tests {
             trace_state: String::new(),
             is_remote: false,
         }
+    }
+
+    fn query_history_attributes(
+        sql: &str,
+        sources_json: &str,
+        tables_json: &str,
+        table_functions_json: &str,
+        row_count: u64,
+    ) -> String {
+        let mut attributes = serde_json::Map::new();
+        attributes.insert("sql".to_string(), json!(sql));
+        attributes.insert("status".to_string(), json!("ok"));
+        attributes.insert("row_count".to_string(), json!(row_count));
+        attributes.insert(
+            crate::telemetry::QUERY_TRACE_SOURCES_ATTR.to_string(),
+            json!(sources_json),
+        );
+        attributes.insert(
+            crate::telemetry::QUERY_TRACE_TABLES_ATTR.to_string(),
+            json!(tables_json),
+        );
+        attributes.insert(
+            crate::telemetry::QUERY_TRACE_TABLE_FUNCTIONS_ATTR.to_string(),
+            json!(table_functions_json),
+        );
+        serde_json::Value::Object(attributes).to_string()
     }
 }

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -34,6 +34,9 @@ pub(crate) mod service;
 use crate::bootstrap::AppError;
 pub use config::TelemetryConfig;
 use config::{DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER};
+pub(crate) use local_store::{
+    TraceQueryHistoryEntry, TraceQueryTableFunctionUsage, TraceQueryTableUsage, TraceStoreError,
+};
 
 static INIT: OnceLock<Result<TracingInitState, String>> = OnceLock::new();
 static PROVIDER: Mutex<Option<SdkTracerProvider>> = Mutex::new(None);

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -313,6 +313,13 @@ fn add_local_trace_exporter(
     Ok(builder.with_span_processor(BatchSpanProcessor::builder(exporter).build()))
 }
 
+pub(crate) fn list_local_query_history(
+    dir: PathBuf,
+    retention: Duration,
+) -> Result<Vec<TraceQueryHistoryEntry>, TraceStoreError> {
+    local_store::TraceStore::with_retention(dir, retention).list_query_history_sync()
+}
+
 fn build_otlp_logger_provider(
     resource: &Resource,
     endpoint: &str,


### PR DESCRIPTION
RFC step 2 follow-up: read successful query history from local traces and expose selected entries for default-workspace MCP startup context.

This adds a lenient trace-store reader that skips older trace records without query provenance, then extends `default_workspace_mcp_startup_context(...)` to return installed source names plus selected successful query examples. Selection drops zero-row results, ranks richer queries first, and greedily improves source coverage up to the configured limit.

Depends on #1389 for recording provenance on successful query spans. Storage remains the existing local trace store.