### PR TITLE
feat(app): add SQLite app storage abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "prost",
  "regex",
  "reqwest 0.13.3",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1383,6 +1384,7 @@ dependencies = [
  "opentelemetry",
  "regex",
  "rmcp",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -2509,6 +2511,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,6 +2851,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -3458,6 +3481,17 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -4735,6 +4769,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5966,6 +6014,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ export CORAL_CONFIG_DIR=/path/to/coral-config
 Important files include:
 
 - `config.toml` for installed-source metadata and non-secret variables
+- `state.sqlite3` for Coral-owned internal state, such as local feedback reports and episode metadata
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -23,6 +23,7 @@ opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -9,6 +9,7 @@ use tonic::{Code, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::credentials::CredentialsError;
+use crate::storage::app::AppStorageError;
 
 /// Errors surfaced by the local application layer.
 #[derive(Debug, thiserror::Error)]
@@ -65,6 +66,12 @@ pub enum AppError {
     /// Credential material access failed.
     #[error(transparent)]
     Credentials(#[from] CredentialsError),
+    /// Configured application storage backend is not available.
+    #[error("unsupported app storage backend '{0}'")]
+    UnsupportedAppStorageBackend(String),
+    /// Application storage failed.
+    #[error("app storage: {0}")]
+    AppStorage(String),
     /// The Coral config directory could not be discovered from defaults.
     #[error("failed to determine Coral config directory")]
     MissingConfigDir,
@@ -200,9 +207,8 @@ fn app_code(error: &AppError) -> Code {
         | AppError::MissingOrIncompatibleV4Materialization { .. }
         | AppError::CredentialRefresh(_)
         | AppError::MissingConfigDir
-        | AppError::Credentials(CredentialsError::Parse(_) | CredentialsError::Unavailable(_)) => {
-            Code::FailedPrecondition
-        }
+        | AppError::Credentials(CredentialsError::Parse(_) | CredentialsError::Unavailable(_))
+        | AppError::UnsupportedAppStorageBackend(_) => Code::FailedPrecondition,
         AppError::Unavailable(_) => Code::Unavailable,
         AppError::Io(error) if error.kind() == std::io::ErrorKind::NotFound => Code::NotFound,
         AppError::Io(_)
@@ -213,7 +219,19 @@ fn app_code(error: &AppError) -> Code {
         | AppError::Json(_)
         | AppError::Transport(_)
         | AppError::TaskJoin(_)
-        | AppError::Credentials(_) => Code::Internal,
+        | AppError::Credentials(_)
+        | AppError::AppStorage(_) => Code::Internal,
+    }
+}
+
+impl From<AppStorageError> for AppError {
+    fn from(error: AppStorageError) -> Self {
+        match error {
+            AppStorageError::UnsupportedBackend { backend } => {
+                Self::UnsupportedAppStorageBackend(backend)
+            }
+            error => Self::AppStorage(error.to_string()),
+        }
     }
 }
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -763,6 +763,93 @@ enabled = false
     }
 
     #[tokio::test]
+    async fn server_uses_configured_sqlite_app_storage_path() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("mkdir config");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            r#"
+version = 1
+
+[trace_history]
+enabled = false
+
+[storage]
+sqlite_path = "db/app-state.sqlite3"
+"#,
+        )
+        .expect("write config");
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+        let workspace = WorkspaceName::default();
+        let legacy_episode_path = layout.episodes_file(&workspace);
+        std::fs::create_dir_all(legacy_episode_path.parent().expect("episode parent"))
+            .expect("mkdir episodes");
+        std::fs::write(
+            &legacy_episode_path,
+            r#"{"id":"ep_legacy_configured","workspace":"default","intent":"legacy configured db import","parent_episode_id":null,"created_at_unix_nanos":321}
+"#,
+        )
+        .expect("write legacy episode");
+        let legacy_feedback_path = layout.feedback_reports_file(&workspace);
+        std::fs::create_dir_all(legacy_feedback_path.parent().expect("feedback parent"))
+            .expect("mkdir feedback");
+        std::fs::write(
+            &legacy_feedback_path,
+            r#"{"id":"fb_legacy_configured","workspace":"default","created_at":"2026-06-26T00:00:00Z","trying_to_do":"trying configured","tried":"tried configured","stuck":"stuck configured"}
+"#,
+        )
+        .expect("write legacy feedback");
+
+        let server = ServerBuilder::new()
+            .with_config_dir(config_dir.clone())
+            .start()
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut episode_client = EpisodeServiceClient::new(channel);
+
+        episode_client
+            .open_episode(Request::new(OpenEpisodeRequest {
+                workspace: Some(default_workspace()),
+                episode_id: "ep_configured_storage".to_string(),
+                intent: "persist into configured sqlite path".to_string(),
+                parent_episode_id: String::new(),
+            }))
+            .await
+            .expect("OpenEpisode is served");
+
+        let configured_database = layout.config_dir().join("db/app-state.sqlite3");
+        assert!(configured_database.exists());
+        assert!(
+            !layout.app_database_file().exists(),
+            "server should not create the default app database when sqlite_path is configured"
+        );
+        let app_store = AppStore::sqlite(configured_database).expect("sqlite app store");
+        let episode = app_store
+            .test_read_episode(WorkspaceName::default().as_str(), "ep_configured_storage")
+            .expect("read episode")
+            .expect("episode id should be persisted");
+        assert_eq!(episode.intent, "persist into configured sqlite path");
+        let legacy_episode = app_store
+            .test_read_episode(workspace.as_str(), "ep_legacy_configured")
+            .expect("read legacy episode")
+            .expect("legacy episode should be imported into configured database");
+        assert_eq!(legacy_episode.intent, "legacy configured db import");
+        let feedback = app_store
+            .test_read_feedback_reports(workspace.as_str())
+            .expect("read legacy feedback");
+        assert_eq!(feedback.len(), 1);
+        assert_eq!(feedback[0].id, "fb_legacy_configured");
+        assert_eq!(feedback[0].stuck, "stuck configured");
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
     async fn trace_service_lists_empty_store() {
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -53,6 +53,7 @@ use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
+use crate::storage::app::{AppStorageConfig, AppStore};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
@@ -261,6 +262,8 @@ impl ServerBuilder {
             internal_trace_store_dir.clone(),
         )?;
         let config_store = ConfigStore::new(layout.clone());
+        let app_storage_config = AppStorageConfig::load(&layout)?;
+        let app_store = AppStore::open(&layout, &app_storage_config)?;
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
@@ -271,8 +274,8 @@ impl ServerBuilder {
             layout.clone(),
         );
         let feedback_manager =
-            FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
-        let episode_store = EpisodeStore::new(layout.clone());
+            FeedbackManager::with_publisher(app_store.clone(), self.config.feedback_publisher);
+        let episode_store = EpisodeStore::new(app_store);
         let body_capture_max_bytes = telemetry_config
             .trace_history
             .http_body_recording_max_bytes();
@@ -657,9 +660,11 @@ mod tests {
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::episode::store::EpisodeStore;
     use crate::feedback::manager::FeedbackManager;
+    use crate::feedback::publisher::NoopFeedbackPublisher;
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
     use crate::state::{AppStateLayout, ConfigStore};
+    use crate::storage::app::AppStore;
     use crate::telemetry::service::TraceService;
     use crate::transport::workspace_to_proto;
     use crate::workspaces::WorkspaceName;
@@ -746,15 +751,14 @@ enabled = false
             .await
             .expect("OpenEpisode is served regardless of the episodes feature");
 
-        // The handler ran the full path through to the per-workspace episode log.
+        // The handler ran the full path through to the configured app store.
         let layout = AppStateLayout::discover(Some(config_dir)).expect("layout");
-        let raw = std::fs::read_to_string(layout.episodes_file(&WorkspaceName::default()))
-            .expect("episode file should exist");
-        assert!(raw.contains("ep_smoke"), "episode id should be persisted");
-        assert!(
-            raw.contains("find the HR onboarding form"),
-            "intent should be persisted"
-        );
+        let app_store = AppStore::sqlite(layout.app_database_file()).expect("sqlite app store");
+        let episode = app_store
+            .test_read_episode(WorkspaceName::default().as_str(), "ep_smoke")
+            .expect("read episode")
+            .expect("episode id should be persisted");
+        assert_eq!(episode.intent, "find the HR onboarding form");
         server.shutdown().await.expect("shutdown");
     }
 
@@ -772,8 +776,10 @@ enabled = false
             credential_manager.clone(),
             layout.clone(),
         );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
+        let app_store = AppStore::sqlite(layout.app_database_file()).expect("sqlite app store");
+        let feedback_manager =
+            FeedbackManager::with_publisher(app_store.clone(), Arc::new(NoopFeedbackPublisher));
+        let episode_store = EpisodeStore::new(app_store);
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -1152,8 +1158,10 @@ tables:
             credential_manager.clone(),
             layout.clone(),
         );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
+        let app_store = AppStore::sqlite(layout.app_database_file()).expect("sqlite app store");
+        let feedback_manager =
+            FeedbackManager::with_publisher(app_store.clone(), Arc::new(NoopFeedbackPublisher));
+        let episode_store = EpisodeStore::new(app_store);
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -1256,8 +1264,10 @@ tables:
             credential_manager.clone(),
             layout.clone(),
         );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
+        let app_store = AppStore::sqlite(layout.app_database_file()).expect("sqlite app store");
+        let feedback_manager =
+            FeedbackManager::with_publisher(app_store.clone(), Arc::new(NoopFeedbackPublisher));
+        let episode_store = EpisodeStore::new(app_store);
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -1357,8 +1367,10 @@ tables:
             credential_manager.clone(),
             layout.clone(),
         );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
+        let app_store = AppStore::sqlite(layout.app_database_file()).expect("sqlite app store");
+        let feedback_manager =
+            FeedbackManager::with_publisher(app_store.clone(), Arc::new(NoopFeedbackPublisher));
+        let episode_store = EpisodeStore::new(app_store);
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,

--- a/crates/coral-app/src/episode/service.rs
+++ b/crates/coral-app/src/episode/service.rs
@@ -90,7 +90,7 @@ fn open_episode_status(error: &EpisodeStoreError) -> Status {
     match error {
         EpisodeStoreError::Conflict { .. } => Status::failed_precondition(error.to_string()),
         EpisodeStoreError::InvalidIntent { .. } => Status::invalid_argument(error.to_string()),
-        EpisodeStoreError::Io(_) | EpisodeStoreError::Serde(_) => {
+        EpisodeStoreError::Io(_) | EpisodeStoreError::Serde(_) | EpisodeStoreError::Storage(_) => {
             warn!(%error, "failed to persist episode");
             Status::internal("failed to persist episode")
         }
@@ -99,8 +99,6 @@ fn open_episode_status(error: &EpisodeStoreError) -> Status {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
     use coral_api::v1::{OpenEpisodeRequest, Workspace};
     use tempfile::TempDir;
     use tonic::{Code, Request};
@@ -108,14 +106,16 @@ mod tests {
     use super::super::store::EpisodeStore;
     use super::{EpisodeService, EpisodeServiceApi};
     use crate::state::AppStateLayout;
+    use crate::storage::app::AppStore;
     use crate::workspaces::WorkspaceName;
 
-    fn service() -> (TempDir, AppStateLayout, EpisodeService) {
+    fn service() -> (TempDir, AppStore, EpisodeService) {
         let dir = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(dir.path().join("coral-config")))
             .expect("layout should resolve");
-        let service = EpisodeService::new(EpisodeStore::new(layout.clone()));
-        (dir, layout, service)
+        let app_store = AppStore::sqlite(layout.app_database_file()).expect("sqlite app store");
+        let service = EpisodeService::new(EpisodeStore::new(app_store.clone()));
+        (dir, app_store, service)
     }
 
     fn request(
@@ -136,7 +136,7 @@ mod tests {
 
     #[tokio::test]
     async fn open_episode_persists_record() {
-        let (_dir, layout, service) = service();
+        let (_dir, app_store, service) = service();
         service
             .open_episode(request(
                 Some("acme"),
@@ -148,17 +148,16 @@ mod tests {
             .expect("open episode");
 
         let workspace = WorkspaceName::parse("acme").expect("workspace");
-        let raw = fs::read_to_string(layout.episodes_file(&workspace)).expect("episode file");
-        let records: Vec<_> = raw.lines().filter(|line| !line.trim().is_empty()).collect();
-        assert_eq!(records.len(), 1);
-        let record = records.first().expect("one record");
-        assert!(record.contains("ep_1"));
-        assert!(record.contains("find the HR onboarding form"));
+        let record = app_store
+            .test_read_episode(workspace.as_str(), "ep_1")
+            .expect("read episode")
+            .expect("episode persisted");
+        assert_eq!(record.intent, "find the HR onboarding form");
     }
 
     #[tokio::test]
     async fn open_child_episode_records_parent() {
-        let (_dir, layout, service) = service();
+        let (_dir, app_store, service) = service();
         service
             .open_episode(request(Some("acme"), "parent_ep", "root task", None))
             .await
@@ -174,13 +173,16 @@ mod tests {
             .expect("open child");
 
         let workspace = WorkspaceName::parse("acme").expect("workspace");
-        let raw = fs::read_to_string(layout.episodes_file(&workspace)).expect("episode file");
-        assert!(raw.contains(r#""parent_episode_id":"parent_ep""#));
+        let record = app_store
+            .test_read_episode(workspace.as_str(), "child_ep")
+            .expect("read episode")
+            .expect("child persisted");
+        assert_eq!(record.parent_episode_id.as_deref(), Some("parent_ep"));
     }
 
     #[tokio::test]
     async fn reopen_identical_is_ok() {
-        let (_dir, _layout, service) = service();
+        let (_dir, _app_store, service) = service();
         service
             .open_episode(request(Some("acme"), "ep_1", "same intent", None))
             .await
@@ -193,7 +195,7 @@ mod tests {
 
     #[tokio::test]
     async fn reopen_with_different_intent_conflicts() {
-        let (_dir, _layout, service) = service();
+        let (_dir, _app_store, service) = service();
         service
             .open_episode(request(Some("acme"), "ep_1", "intent A", None))
             .await
@@ -207,7 +209,7 @@ mod tests {
 
     #[tokio::test]
     async fn missing_workspace_is_invalid_argument() {
-        let (_dir, _layout, service) = service();
+        let (_dir, _app_store, service) = service();
         let status = service
             .open_episode(request(None, "ep_1", "intent", None))
             .await
@@ -217,7 +219,7 @@ mod tests {
 
     #[tokio::test]
     async fn blank_episode_id_is_invalid_argument() {
-        let (_dir, _layout, service) = service();
+        let (_dir, _app_store, service) = service();
         let status = service
             .open_episode(request(Some("acme"), "   ", "intent", None))
             .await
@@ -227,7 +229,7 @@ mod tests {
 
     #[tokio::test]
     async fn non_ascii_episode_id_is_invalid_argument() {
-        let (_dir, _layout, service) = service();
+        let (_dir, _app_store, service) = service();
         // A non-ASCII id cannot round-trip as the `coral-episode-id` metadata
         // value, so the boundary rejects it before it reaches the store.
         let status = service

--- a/crates/coral-app/src/episode/store.rs
+++ b/crates/coral-app/src/episode/store.rs
@@ -1,27 +1,20 @@
-//! Per-workspace, append-only episode store.
+//! Per-workspace episode store.
 //!
 //! Persists `{ episode_id -> intent, parent }` for an episode (one task-attempt),
-//! written once by `OpenEpisode` into the per-workspace episode log resolved by
-//! [`AppStateLayout`]: a private (0600), locked JSONL append, bounded by a
+//! written once by `OpenEpisode` into app storage. Writes are bounded by a
 //! per-workspace **byte ceiling with oldest-out eviction** — when a new record
-//! would exceed the limit, the oldest records are dropped to make room, so the log
-//! keeps the most recent episodes within budget (a byte-bounded FIFO; no time
-//! component). The idempotency scan already reads every record, so eviction folds
-//! into the same pass. The always-registered `OpenEpisode` route makes an unbounded
-//! log a real fill-the-disk surface, which this prevents. JSONL→Parquet compaction
-//! and the queryable `coral.episodes` surface land in a later PR.
+//! would exceed the limit, the oldest records are dropped to make room, so storage
+//! keeps the most recent episodes within budget. The always-registered
+//! `OpenEpisode` route makes an unbounded store a real fill-the-disk surface,
+//! which this prevents. Queryable `coral.episodes` lands in a later PR.
 
-use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
-use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use coral_api::CORAL_EPISODE_INTENT_MAX_CHARS;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use super::EpisodeId;
-use crate::state::AppStateLayout;
-use crate::storage::fs::{self as storage_fs, FileLock};
+use crate::storage::app::{AppStorageError, AppStore, OpenEpisodeResult, StoredEpisode};
 use crate::workspaces::WorkspaceName;
 
 /// Per-workspace byte ceiling on the raw log. A new record that would push the log
@@ -45,10 +38,8 @@ pub(crate) struct Episode {
     pub(crate) created_at_unix_nanos: u128,
 }
 
-/// On-disk JSONL shape for an [`Episode`]. The workspace is also encoded in the
-/// per-workspace file path; it is persisted here too so each record is
-/// self-describing.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Stable serialization shape for byte-budget accounting.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct PersistedEpisode {
     id: String,
     workspace: String,
@@ -72,12 +63,16 @@ impl PersistedEpisode {
             created_at_unix_nanos: episode.created_at_unix_nanos,
         }
     }
+
+    fn record_bytes(&self) -> Result<u64, EpisodeStoreError> {
+        Ok(serde_json::to_vec(self)?.len() as u64 + 1)
+    }
 }
 
 /// Errors from the episode store.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum EpisodeStoreError {
-    /// Filesystem error reading or writing the store.
+    /// Filesystem error reading legacy test fixtures or writing the store.
     #[error("episode store io: {0}")]
     Io(#[from] std::io::Error),
     /// JSON (de)serialization error.
@@ -95,22 +90,24 @@ pub(crate) enum EpisodeStoreError {
         /// The configured maximum intent length, in characters.
         max: usize,
     },
+    /// The app storage backend failed.
+    #[error(transparent)]
+    Storage(#[from] AppStorageError),
 }
 
-/// Append-only, per-workspace JSONL episode store, bounded by a byte ceiling with
-/// oldest-out eviction. Paths and the shared state lock are resolved through
-/// [`AppStateLayout`].
+/// Per-workspace episode repository, bounded by a byte ceiling with oldest-out
+/// eviction. Durable writes go through [`AppStore`].
 #[derive(Clone)]
 pub(crate) struct EpisodeStore {
-    layout: AppStateLayout,
+    store: AppStore,
     max_bytes: u64,
 }
 
 impl EpisodeStore {
-    /// Creates a store that persists under `layout` with the default byte ceiling.
-    pub(crate) fn new(layout: AppStateLayout) -> Self {
+    /// Creates a store that persists through `store` with the default byte ceiling.
+    pub(crate) fn new(store: AppStore) -> Self {
         Self {
-            layout,
+            store,
             max_bytes: MAX_EPISODE_BYTES_PER_WORKSPACE,
         }
     }
@@ -137,12 +134,11 @@ impl EpisodeStore {
     /// reused in practice and the guarantee holds for all real callers.
     ///
     /// A new record is appended within the per-workspace byte ceiling: if it would
-    /// push the log over, the oldest records are evicted to make room (the log is a
-    /// byte-bounded FIFO; the newest record is always kept). The shared state lock is
-    /// held across read-then-write so the idempotency check and the
-    /// evict-and-append are atomic against concurrent opens. Intent may be PII, so
-    /// the log is written 0600. The id is already validated ([`EpisodeId`]); intent
-    /// is checked here as a safety net for callers that bypass the service boundary.
+    /// push storage over budget, the oldest records are evicted to make room (a
+    /// byte-bounded FIFO; the newest record is always kept). The idempotency check
+    /// and evict-and-insert happen in one app-storage unit of work. The id is
+    /// already validated ([`EpisodeId`]); intent is checked here as a safety net for
+    /// callers that bypass the service boundary.
     pub(crate) fn open_episode(&self, episode: &Episode) -> Result<(), EpisodeStoreError> {
         // Normalize intent once so surrounding whitespace never becomes part of the
         // immutable key — a retry with an accidental trailing space must stay
@@ -153,34 +149,53 @@ impl EpisodeStore {
                 max: CORAL_EPISODE_INTENT_MAX_CHARS,
             });
         }
-        let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        let path = self.layout.episodes_file(&episode.workspace);
-
-        // One read serves both the idempotency check and eviction (file order is
-        // chronological — oldest first).
-        let records = read_all_records(&path)?;
-        if let Some(existing) = records
-            .iter()
-            .rfind(|record| record.id == episode.id.as_str())
-        {
-            return if existing.intent == intent
-                && existing.parent_episode_id.as_deref()
-                    == episode.parent_episode_id.as_ref().map(EpisodeId::as_str)
-            {
+        let persisted = PersistedEpisode::from_episode(episode, intent);
+        let stored = StoredEpisode {
+            workspace: persisted.workspace.clone(),
+            id: persisted.id.clone(),
+            intent: persisted.intent.clone(),
+            parent_episode_id: persisted.parent_episode_id.clone(),
+            created_at_unix_nanos: i64::try_from(persisted.created_at_unix_nanos).map_err(
+                |_error| AppStorageError::ValueOutOfRange {
+                    field: "created_at_unix_nanos",
+                    value: persisted.created_at_unix_nanos.to_string(),
+                },
+            )?,
+            record_bytes: persisted.record_bytes()?,
+        };
+        let mut uow = self.store.begin_write()?;
+        let result = {
+            let mut episodes = uow.episodes();
+            episodes.open_episode(&stored, self.max_bytes)?
+        };
+        match result {
+            OpenEpisodeResult::Opened | OpenEpisodeResult::AlreadyOpen => {
+                uow.commit()?;
                 Ok(())
-            } else {
-                Err(EpisodeStoreError::Conflict {
-                    episode_id: episode.id.as_str().to_string(),
-                })
-            };
+            }
+            OpenEpisodeResult::Conflict => Err(EpisodeStoreError::Conflict {
+                episode_id: episode.id.as_str().to_string(),
+            }),
         }
+    }
 
-        append_within_budget(
-            &path,
-            records,
-            PersistedEpisode::from_episode(episode, intent),
-            self.max_bytes,
-        )
+    #[cfg(test)]
+    fn read_episode(
+        &self,
+        workspace: &WorkspaceName,
+        episode_id: &str,
+    ) -> Result<Option<StoredEpisode>, AppStorageError> {
+        self.store.test_read_episode(workspace.as_str(), episode_id)
+    }
+
+    #[cfg(test)]
+    fn count_episodes(&self, workspace: &WorkspaceName) -> Result<usize, AppStorageError> {
+        self.store.test_count_episodes(workspace.as_str())
+    }
+
+    #[cfg(test)]
+    fn episode_bytes(&self, workspace: &WorkspaceName) -> Result<u64, AppStorageError> {
+        self.store.test_episode_bytes(workspace.as_str())
     }
 }
 
@@ -191,182 +206,31 @@ pub(crate) fn now_unix_nanos() -> u128 {
         .map_or(0, |elapsed| elapsed.as_nanos())
 }
 
-/// Parses every intact record in `contents`, in file order, skipping blank lines
-/// and torn records.
-///
-/// Splits on newlines so a torn record is skipped whether the crash broke JSON *or*
-/// UTF-8 (a crash can truncate a multi-byte intent mid-character) — one torn write
-/// must never brick reads for the workspace. An unacknowledged torn write is simply
-/// re-appended when the client retries `OpenEpisode`.
-fn parse_records(contents: &[u8]) -> impl Iterator<Item = PersistedEpisode> + '_ {
-    contents
-        .split(|&byte| byte == b'\n')
-        .filter_map(|raw_line| {
-            let Ok(line) = std::str::from_utf8(raw_line) else {
-                tracing::warn!("skipping episode record with invalid UTF-8 (likely a torn write)");
-                return None;
-            };
-            if line.trim().is_empty() {
-                return None;
-            }
-            match serde_json::from_str::<PersistedEpisode>(line) {
-                Ok(record) => Some(record),
-                Err(error) => {
-                    tracing::warn!(%error, "skipping unparsable episode record");
-                    None
-                }
-            }
-        })
-}
-
-/// Reads every intact record in `path`, in file order (empty if the log is absent).
-fn read_all_records(path: &Path) -> Result<Vec<PersistedEpisode>, EpisodeStoreError> {
-    let contents = match std::fs::read(path) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(error) => return Err(error.into()),
-    };
-    Ok(parse_records(&contents).collect())
-}
-
-/// Appends `record` to `path`, evicting the oldest records first if needed to keep
-/// the log within `max_bytes`. `existing` is the current log in file order (oldest
-/// first). The newest record is always kept, even if it alone exceeds `max_bytes`.
-fn append_within_budget(
-    path: &Path,
-    existing: Vec<PersistedEpisode>,
-    record: PersistedEpisode,
-    max_bytes: u64,
-) -> Result<(), EpisodeStoreError> {
-    let line_len = serde_json::to_vec(&record)?.len() as u64 + 1;
-    // Fast path: it fits on top of what's already on disk. `file_len` counts physical
-    // bytes (so any torn-record bytes are included conservatively); add the separator
-    // newline `append_record` will prepend when the file lacks a trailing one, so a
-    // torn-tailed file at the boundary doesn't slip one byte over the ceiling.
-    let leading = u64::from(file_needs_leading_newline(path)?);
-    if file_len(path)?
-        .saturating_add(line_len)
-        .saturating_add(leading)
-        <= max_bytes
-    {
-        return append_record(path, &record);
-    }
-
-    // Over budget: rebuild the log keeping the newest records (and always `record`)
-    // that fit, dropping the oldest. Rewriting also compacts away torn records.
-    let mut kept = existing;
-    kept.push(record);
-    let encoded: Vec<Vec<u8>> = kept
-        .iter()
-        .map(serde_json::to_vec)
-        .collect::<Result<_, _>>()?;
-    let record_count = encoded.len();
-    let mut total: u64 = encoded.iter().map(|line| line.len() as u64 + 1).sum();
-    // Drop oldest (front) records until within budget, but never the newest (last).
-    let mut dropped = 0;
-    for line in &encoded {
-        if total <= max_bytes || dropped + 1 >= record_count {
-            break;
-        }
-        total -= line.len() as u64 + 1;
-        dropped += 1;
-    }
-    let mut bytes = Vec::new();
-    for line in encoded.iter().skip(dropped) {
-        bytes.extend_from_slice(line);
-        bytes.push(b'\n');
-    }
-    // `write_atomic` (temp-file + rename) does not create the parent dir, so ensure
-    // it for the first-ever write. Crash-safe, so a crash mid-eviction never
-    // truncates the log.
-    if let Some(parent) = path.parent() {
-        storage_fs::ensure_dir(parent)?;
-    }
-    storage_fs::write_atomic(path, &bytes)?;
-    Ok(())
-}
-
-/// Current on-disk size of `path` in bytes, or 0 if the log does not exist yet.
-fn file_len(path: &Path) -> Result<u64, EpisodeStoreError> {
-    match std::fs::metadata(path) {
-        Ok(metadata) => Ok(metadata.len()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(0),
-        Err(error) => Err(error.into()),
-    }
-}
-
-/// Appends one record to `path` as a private (0600) JSONL line.
-fn append_record(path: &Path, record: &PersistedEpisode) -> Result<(), EpisodeStoreError> {
-    let encoded = serde_json::to_vec(record)?;
-    let mut bytes = Vec::with_capacity(encoded.len() + 2);
-    // A prior torn append can leave the file without a trailing newline; start this
-    // record on its own line so the incomplete one stays separately skippable
-    // instead of merging with (and corrupting) this record.
-    if file_needs_leading_newline(path)? {
-        bytes.push(b'\n');
-    }
-    bytes.extend_from_slice(&encoded);
-    bytes.push(b'\n');
-    storage_fs::append_file_private(path, &bytes)?;
-    Ok(())
-}
-
-/// Returns the most recent record for `episode_id` in `path`, if any. Test-only:
-/// production reads go through [`read_all_records`].
-#[cfg(test)]
-fn read_episode(
-    path: &Path,
-    episode_id: &str,
-) -> Result<Option<PersistedEpisode>, EpisodeStoreError> {
-    Ok(read_all_records(path)?
-        .into_iter()
-        .rfind(|record| record.id == episode_id))
-}
-
-/// Whether an append to `path` must start with a newline: the file exists, is
-/// non-empty, and does not already end in one (e.g. after a torn append). Keeps
-/// an incomplete trailing record on its own line so it never merges with the
-/// next record.
-fn file_needs_leading_newline(path: &Path) -> Result<bool, EpisodeStoreError> {
-    let mut file = match File::open(path) {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(error.into()),
-    };
-    if file.seek(SeekFrom::End(0))? == 0 {
-        return Ok(false);
-    }
-    file.seek(SeekFrom::End(-1))?;
-    let mut last = [0_u8; 1];
-    file.read_exact(&mut last)?;
-    Ok(last[0] != b'\n')
-}
-
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
     use tempfile::TempDir;
 
     use super::{
         CORAL_EPISODE_INTENT_MAX_CHARS, Episode, EpisodeId, EpisodeStore, EpisodeStoreError,
-        PersistedEpisode, now_unix_nanos, read_episode,
+        PersistedEpisode, now_unix_nanos,
     };
     use crate::state::AppStateLayout;
+    use crate::storage::app::AppStore;
     use crate::workspaces::WorkspaceName;
 
     /// On-disk byte size of one record (serialized JSON + newline), for sizing the
     /// byte ceiling in eviction tests.
     fn record_bytes(workspace: &WorkspaceName, id: &str, intent: &str) -> u64 {
         let record = PersistedEpisode::from_episode(&episode(workspace, id, intent, None), intent);
-        serde_json::to_vec(&record).expect("serialize").len() as u64 + 1
+        record.record_bytes().expect("record bytes")
     }
 
-    fn layout() -> (TempDir, AppStateLayout) {
+    fn store() -> (TempDir, EpisodeStore) {
         let dir = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(dir.path().join("coral-config")))
             .expect("layout should resolve");
-        (dir, layout)
+        let app_store = AppStore::sqlite(layout.app_database_file()).expect("sqlite app store");
+        (dir, EpisodeStore::new(app_store))
     }
 
     fn episode(workspace: &WorkspaceName, id: &str, intent: &str, parent: Option<&str>) -> Episode {
@@ -381,8 +245,7 @@ mod tests {
 
     #[test]
     fn open_rejects_blank_and_overlong_intent() {
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout);
+        let (_dir, store) = store();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         let blank = store
             .open_episode(&episode(&workspace, "ep_blank", "   ", None))
@@ -397,8 +260,7 @@ mod tests {
 
     #[test]
     fn intent_whitespace_is_normalized_and_does_not_fork_the_key() {
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout.clone());
+        let (_dir, store) = store();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         store
             .open_episode(&episode(&workspace, "ep_1", "find the form", None))
@@ -407,119 +269,55 @@ mod tests {
         store
             .open_episode(&episode(&workspace, "ep_1", "  find the form  ", None))
             .expect("whitespace-only difference is idempotent");
-        let read = read_episode(&layout.episodes_file(&workspace), "ep_1")
+        let read = store
+            .read_episode(&workspace, "ep_1")
             .expect("read")
             .expect("present");
         assert_eq!(read.intent, "find the form", "stored intent is normalized");
-        let lines = fs::read_to_string(layout.episodes_file(&workspace))
-            .expect("read file")
-            .lines()
-            .filter(|line| !line.trim().is_empty())
-            .count();
         assert_eq!(
-            lines, 1,
-            "whitespace-only difference must not append a record"
+            store.count_episodes(&workspace).expect("count"),
+            1,
+            "whitespace-only difference must not insert a second record"
         );
     }
 
     #[test]
-    fn read_tolerates_a_torn_trailing_record() {
-        use std::io::Write as _;
-
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout.clone());
-        let workspace = WorkspaceName::parse("acme").expect("workspace");
-        let path = layout.episodes_file(&workspace);
-        store
-            .open_episode(&episode(&workspace, "ep_1", "first intent", None))
-            .expect("open");
-        // Simulate a crash mid-append: a complete record followed by a torn line
-        // with no trailing newline.
-        fs::OpenOptions::new()
-            .append(true)
-            .open(&path)
-            .expect("open for append")
-            .write_all(b"{\"id\":\"ep_2\",\"workspace\":\"acme\"")
-            .expect("write torn record");
-        // The torn line is skipped, not fatal.
-        let read = read_episode(&path, "ep_1")
-            .expect("read tolerates the torn tail")
-            .expect("ep_1 present");
-        assert_eq!(read.intent, "first intent");
-        // The next append starts on a fresh line (no merge), so the new record is
-        // readable and the torn one stays isolated.
-        store
-            .open_episode(&episode(&workspace, "ep_2", "second intent", None))
-            .expect("open after torn tail");
-        let recovered = read_episode(&path, "ep_2")
-            .expect("read")
-            .expect("ep_2 present after recovery");
-        assert_eq!(recovered.intent, "second intent");
-    }
-
-    #[test]
-    fn read_tolerates_a_torn_record_with_invalid_utf8() {
-        use std::io::Write as _;
-
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout.clone());
-        let workspace = WorkspaceName::parse("acme").expect("workspace");
-        let path = layout.episodes_file(&workspace);
-        store
-            .open_episode(&episode(&workspace, "ep_1", "first intent", None))
-            .expect("open");
-        // A crash can truncate a multi-byte (non-ASCII) intent mid-character,
-        // leaving invalid UTF-8 at the tail — `{` then the first two bytes of a
-        // 4-byte emoji.
-        fs::OpenOptions::new()
-            .append(true)
-            .open(&path)
-            .expect("open for append")
-            .write_all(&[b'{', 0xF0, 0x9F])
-            .expect("write torn invalid-utf8 record");
-        let read = read_episode(&path, "ep_1")
-            .expect("read tolerates an invalid-UTF-8 tail")
-            .expect("ep_1 present");
-        assert_eq!(read.intent, "first intent");
-    }
-
-    #[test]
     fn open_then_read_round_trips() {
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout.clone());
+        let (_dir, store) = store();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         let ep = episode(&workspace, "ep_1", "find the HR onboarding form", None);
         store.open_episode(&ep).expect("open");
-        let read = read_episode(&layout.episodes_file(&workspace), "ep_1")
+        let read = store
+            .read_episode(&workspace, "ep_1")
             .expect("read")
             .expect("episode should be present");
         assert_eq!(read.id, "ep_1");
         assert_eq!(read.workspace, "acme");
         assert_eq!(read.intent, "find the HR onboarding form");
         assert_eq!(read.parent_episode_id, None);
-        assert_eq!(read.created_at_unix_nanos, ep.created_at_unix_nanos);
+        assert_eq!(
+            read.created_at_unix_nanos,
+            i64::try_from(ep.created_at_unix_nanos).expect("timestamp")
+        );
     }
 
     #[test]
     fn reopen_identical_is_idempotent() {
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout.clone());
+        let (_dir, store) = store();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         let ep = episode(&workspace, "ep_1", "same intent", None);
         store.open_episode(&ep).expect("first open");
         store.open_episode(&ep).expect("idempotent reopen");
-        let lines = fs::read_to_string(layout.episodes_file(&workspace))
-            .expect("read file")
-            .lines()
-            .filter(|line| !line.trim().is_empty())
-            .count();
-        assert_eq!(lines, 1, "idempotent reopen must not append a duplicate");
+        assert_eq!(
+            store.count_episodes(&workspace).expect("count"),
+            1,
+            "idempotent reopen must not insert a duplicate"
+        );
     }
 
     #[test]
     fn reopen_with_different_intent_conflicts() {
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout);
+        let (_dir, store) = store();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         store
             .open_episode(&episode(&workspace, "ep_1", "intent A", None))
@@ -532,15 +330,15 @@ mod tests {
 
     #[test]
     fn open_child_round_trips_parent() {
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout.clone());
+        let (_dir, store) = store();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         store
             .open_episode(&episode(&workspace, "root_ep", "root task", None))
             .expect("open root");
         let child = episode(&workspace, "child_ep", "sub task", Some("root_ep"));
         store.open_episode(&child).expect("open child");
-        let read = read_episode(&layout.episodes_file(&workspace), "child_ep")
+        let read = store
+            .read_episode(&workspace, "child_ep")
             .expect("read")
             .expect("child should be present");
         assert_eq!(
@@ -553,29 +351,23 @@ mod tests {
 
     #[test]
     fn reopen_child_with_identical_parent_is_idempotent() {
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout.clone());
+        let (_dir, store) = store();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         let child = episode(&workspace, "child_ep", "sub task", Some("root_ep"));
         store.open_episode(&child).expect("first open");
         store
             .open_episode(&child)
             .expect("identical reopen (same id/intent/parent) is idempotent");
-        let lines = fs::read_to_string(layout.episodes_file(&workspace))
-            .expect("read file")
-            .lines()
-            .filter(|line| !line.trim().is_empty())
-            .count();
         assert_eq!(
-            lines, 1,
-            "reopening with an identical parent must not append a duplicate"
+            store.count_episodes(&workspace).expect("count"),
+            1,
+            "reopening with an identical parent must not insert a duplicate"
         );
     }
 
     #[test]
     fn reopen_same_intent_different_parent_conflicts() {
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout);
+        let (_dir, store) = store();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         store
             .open_episode(&episode(
@@ -601,8 +393,7 @@ mod tests {
 
     #[test]
     fn same_id_in_different_workspaces_is_isolated() {
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout.clone());
+        let (_dir, store) = store();
         let acme = WorkspaceName::parse("acme").expect("workspace");
         let globex = WorkspaceName::parse("globex").expect("workspace");
         store
@@ -613,54 +404,47 @@ mod tests {
             .open_episode(&episode(&globex, "ep_1", "in globex", None))
             .expect("globex");
         assert_eq!(
-            read_episode(&layout.episodes_file(&acme), "ep_1")
-                .unwrap()
-                .unwrap()
-                .intent,
+            store.read_episode(&acme, "ep_1").unwrap().unwrap().intent,
             "in acme"
         );
         assert_eq!(
-            read_episode(&layout.episodes_file(&globex), "ep_1")
-                .unwrap()
-                .unwrap()
-                .intent,
+            store.read_episode(&globex, "ep_1").unwrap().unwrap().intent,
             "in globex"
         );
     }
 
     #[test]
     fn open_evicts_oldest_to_stay_under_the_byte_ceiling() {
-        let (_dir, layout) = layout();
+        let (_dir, store) = store();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         // Size the ceiling to hold exactly two records (ids and intent are uniform, so
         // every record serializes to the same length).
         let one = record_bytes(&workspace, "ep_0", "task");
-        let store = EpisodeStore::new(layout.clone()).with_max_bytes(one * 2);
+        let store = store.with_max_bytes(one * 2);
         for id in ["ep_1", "ep_2", "ep_3"] {
             store
                 .open_episode(&episode(&workspace, id, "task", None))
                 .expect("open");
         }
 
-        let path = layout.episodes_file(&workspace);
         assert!(
-            read_episode(&path, "ep_1").unwrap().is_none(),
+            store.read_episode(&workspace, "ep_1").unwrap().is_none(),
             "the oldest record must be evicted"
         );
-        assert!(read_episode(&path, "ep_2").unwrap().is_some());
-        assert!(read_episode(&path, "ep_3").unwrap().is_some());
+        assert!(store.read_episode(&workspace, "ep_2").unwrap().is_some());
+        assert!(store.read_episode(&workspace, "ep_3").unwrap().is_some());
         assert!(
-            fs::metadata(&path).unwrap().len() <= one * 2,
-            "the log must stay within the byte ceiling"
+            store.episode_bytes(&workspace).unwrap() <= one * 2,
+            "the episode rows must stay within the byte ceiling"
         );
     }
 
     #[test]
     fn the_newest_record_is_kept_even_when_it_alone_exceeds_the_ceiling() {
-        let (_dir, layout) = layout();
+        let (_dir, store) = store();
         // A ceiling smaller than any record: each open evicts everything older, so the
-        // log always holds exactly the most recent episode — never rejects.
-        let store = EpisodeStore::new(layout.clone()).with_max_bytes(1);
+        // store always holds exactly the most recent episode — never rejects.
+        let store = store.with_max_bytes(1);
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         store
             .open_episode(&episode(&workspace, "ep_1", "first", None))
@@ -669,24 +453,26 @@ mod tests {
             .open_episode(&episode(&workspace, "ep_2", "second", None))
             .expect("second evicts first, never rejects");
 
-        let path = layout.episodes_file(&workspace);
-        assert!(read_episode(&path, "ep_1").unwrap().is_none());
+        assert!(store.read_episode(&workspace, "ep_1").unwrap().is_none());
         assert_eq!(
-            read_episode(&path, "ep_2").unwrap().unwrap().intent,
+            store
+                .read_episode(&workspace, "ep_2")
+                .unwrap()
+                .unwrap()
+                .intent,
             "second"
         );
-        let lines = fs::read_to_string(&path)
-            .unwrap()
-            .lines()
-            .filter(|line| !line.trim().is_empty())
-            .count();
-        assert_eq!(lines, 1, "only the newest record remains");
+        assert_eq!(
+            store.count_episodes(&workspace).expect("count"),
+            1,
+            "only the newest record remains"
+        );
     }
 
     #[test]
     fn reopening_an_evicted_id_is_a_fresh_episode() {
-        let (_dir, layout) = layout();
-        let store = EpisodeStore::new(layout.clone()).with_max_bytes(1);
+        let (_dir, store) = store();
+        let store = store.with_max_bytes(1);
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         store
             .open_episode(&episode(&workspace, "ep_1", "old intent", None))
@@ -700,50 +486,19 @@ mod tests {
         store
             .open_episode(&episode(&workspace, "ep_1", "new intent", None))
             .expect("evicted id is reusable");
-        let read = read_episode(&layout.episodes_file(&workspace), "ep_1")
+        let read = store
+            .read_episode(&workspace, "ep_1")
             .unwrap()
             .expect("present");
         assert_eq!(read.intent, "new intent");
     }
 
     #[test]
-    fn byte_ceiling_holds_when_the_log_has_a_torn_tail() {
-        // Regression: the fast-path budget must account for the separator newline
-        // `append_record` prepends to a file with no trailing newline, or a torn-tailed
-        // file sitting at the boundary slips one byte over the ceiling.
-        let (_dir, layout) = layout();
-        let workspace = WorkspaceName::parse("acme").expect("workspace");
-        let one = record_bytes(&workspace, "ep_1", "task");
-        let path = layout.episodes_file(&workspace);
-
-        // Seed a single valid record with NO trailing newline (a torn tail), so its
-        // on-disk size is `one - 1`.
-        let seed = serde_json::to_vec(&PersistedEpisode::from_episode(
-            &episode(&workspace, "ep_1", "task", None),
-            "task",
-        ))
-        .expect("serialize");
-        fs::create_dir_all(path.parent().unwrap()).expect("mkdir");
-        fs::write(&path, &seed).expect("seed torn-tail log");
-
-        // Ceiling = exactly the torn record + one new record. The old fast path would
-        // append (adding a leading newline) and land at `2*one`, one over.
-        let store = EpisodeStore::new(layout).with_max_bytes(2 * one - 1);
-        store
-            .open_episode(&episode(&workspace, "ep_2", "task", None))
-            .expect("open within budget");
-        assert!(
-            fs::metadata(&path).unwrap().len() < 2 * one,
-            "the log must not exceed the ceiling even when it had a torn tail"
-        );
-    }
-
-    #[test]
     fn eviction_preserves_idempotency_for_surviving_records() {
-        let (_dir, layout) = layout();
+        let (_dir, store) = store();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         let one = record_bytes(&workspace, "ep_0", "task");
-        let store = EpisodeStore::new(layout.clone()).with_max_bytes(one * 2);
+        let store = store.with_max_bytes(one * 2);
         for id in ["ep_1", "ep_2", "ep_3"] {
             store
                 .open_episode(&episode(&workspace, id, "task", None))

--- a/crates/coral-app/src/feedback/manager.rs
+++ b/crates/coral-app/src/feedback/manager.rs
@@ -1,15 +1,11 @@
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use serde::Serialize;
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
 use crate::feedback::publisher::FeedbackPublisher;
-#[cfg(test)]
-use crate::feedback::publisher::NoopFeedbackPublisher;
-use crate::state::AppStateLayout;
-use crate::storage::fs::{self as storage_fs, FileLock};
+use crate::storage::app::{AppStore, StoredFeedbackReport};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug, Clone)]
@@ -55,33 +51,15 @@ impl FeedbackUpload {
     }
 }
 
-#[derive(Debug, Serialize)]
-struct PersistedFeedbackReport<'a> {
-    id: &'a str,
-    workspace: &'a str,
-    created_at: String,
-    trying_to_do: &'a str,
-    tried: &'a str,
-    stuck: &'a str,
-}
-
 #[derive(Clone)]
 pub(crate) struct FeedbackManager {
-    layout: AppStateLayout,
+    store: AppStore,
     publisher: Arc<dyn FeedbackPublisher>,
 }
 
 impl FeedbackManager {
-    #[cfg(test)]
-    pub(crate) fn new(layout: AppStateLayout) -> Self {
-        Self::with_publisher(layout, Arc::new(NoopFeedbackPublisher))
-    }
-
-    pub(crate) fn with_publisher(
-        layout: AppStateLayout,
-        publisher: Arc<dyn FeedbackPublisher>,
-    ) -> Self {
-        Self { layout, publisher }
+    pub(crate) fn with_publisher(store: AppStore, publisher: Arc<dyn FeedbackPublisher>) -> Self {
+        Self { store, publisher }
     }
 
     pub(crate) fn submit_feedback(
@@ -113,19 +91,20 @@ impl FeedbackManager {
     }
 
     fn append_report(&self, report: &FeedbackReport) -> Result<(), AppError> {
-        let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        let file = self.layout.feedback_reports_file(&report.workspace);
-        let persisted = PersistedFeedbackReport {
-            id: &report.id,
-            workspace: report.workspace.as_str(),
-            created_at: report.created_at.to_rfc3339(),
-            trying_to_do: &report.trying_to_do,
-            tried: &report.tried,
-            stuck: &report.stuck,
+        let persisted = StoredFeedbackReport {
+            id: report.id.clone(),
+            workspace: report.workspace.as_str().to_string(),
+            created_at_rfc3339: report.created_at.to_rfc3339(),
+            trying_to_do: report.trying_to_do.clone(),
+            tried: report.tried.clone(),
+            stuck: report.stuck.clone(),
         };
-        let mut line = serde_json::to_vec(&persisted)?;
-        line.push(b'\n');
-        storage_fs::append_file_private(&file, &line)?;
+        let mut uow = self.store.begin_write()?;
+        {
+            let mut feedback = uow.feedback();
+            feedback.append_report(&persisted)?;
+        }
+        uow.commit()?;
         Ok(())
     }
 }
@@ -142,28 +121,30 @@ fn required_text(field: &str, value: &str) -> Result<String, AppError> {
 
 #[cfg(test)]
 mod tests {
-    #![expect(
-        clippy::indexing_slicing,
-        reason = "JSONL shape assertions intentionally fail loudly in tests"
-    )]
+    use std::{sync::Arc, time::Duration};
 
-    use std::{fs, sync::Arc, time::Duration};
-
-    use serde_json::Value;
     use tempfile::TempDir;
 
     use super::{FeedbackManager, FeedbackReport, FeedbackUpload};
-    use crate::feedback::publisher::FeedbackPublisher;
+    use crate::feedback::publisher::{FeedbackPublisher, NoopFeedbackPublisher};
     use crate::state::AppStateLayout;
+    use crate::storage::app::AppStore;
     use crate::workspaces::WorkspaceName;
 
-    #[tokio::test]
-    async fn submit_feedback_appends_workspace_jsonl_record() {
+    fn manager() -> (TempDir, AppStore, FeedbackManager) {
         let temp = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
             .expect("layout should resolve");
+        let store = AppStore::sqlite(layout.app_database_file()).expect("sqlite app store");
+        let manager =
+            FeedbackManager::with_publisher(store.clone(), Arc::new(NoopFeedbackPublisher));
+        (temp, store, manager)
+    }
+
+    #[tokio::test]
+    async fn submit_feedback_appends_workspace_record() {
+        let (_temp, store, manager) = manager();
         let workspace = WorkspaceName::default();
-        let manager = FeedbackManager::new(layout.clone());
 
         let submission = manager
             .submit_feedback(&workspace, " trying ", " tried ", " stuck ")
@@ -172,30 +153,26 @@ mod tests {
 
         assert_eq!(report.workspace.as_str(), "default");
         assert_eq!(report.trying_to_do, "trying");
-        let raw = fs::read_to_string(layout.feedback_reports_file(&workspace))
-            .expect("feedback file should exist");
-        let lines = raw.lines().collect::<Vec<_>>();
-        assert_eq!(lines.len(), 1);
-        let value: Value = serde_json::from_str(lines[0]).expect("jsonl record should parse");
-        assert_eq!(value["id"], report.id);
-        assert_eq!(value["workspace"], "default");
-        assert_eq!(value["trying_to_do"], "trying");
-        assert_eq!(value["tried"], "tried");
-        assert_eq!(value["stuck"], "stuck");
+        let reports = store
+            .test_read_feedback_reports(workspace.as_str())
+            .expect("read feedback reports");
+        assert_eq!(reports.len(), 1);
+        let persisted = reports.first().expect("one report");
+        assert_eq!(persisted.id, report.id);
+        assert_eq!(persisted.workspace, "default");
+        assert_eq!(persisted.trying_to_do, "trying");
+        assert_eq!(persisted.tried, "tried");
+        assert_eq!(persisted.stuck, "stuck");
         assert!(
-            value["created_at"]
-                .as_str()
-                .is_some_and(|value| !value.is_empty())
+            !persisted.created_at_rfc3339.is_empty(),
+            "created_at should be persisted"
         );
     }
 
     #[tokio::test]
     async fn submit_feedback_rejects_blank_fields_before_persisting() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
-            .expect("layout should resolve");
+        let (_temp, store, manager) = manager();
         let workspace = WorkspaceName::default();
-        let manager = FeedbackManager::new(layout.clone());
 
         let error = manager
             .submit_feedback(&workspace, "trying", " ", "stuck")
@@ -206,7 +183,12 @@ mod tests {
                 .to_string()
                 .contains("missing string argument 'tried'")
         );
-        assert!(!layout.feedback_reports_file(&workspace).exists());
+        assert!(
+            store
+                .test_read_feedback_reports(workspace.as_str())
+                .expect("read feedback reports")
+                .is_empty()
+        );
     }
 
     #[tokio::test]
@@ -214,10 +196,11 @@ mod tests {
         let temp = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
             .expect("layout should resolve");
+        let store = AppStore::sqlite(layout.app_database_file()).expect("sqlite app store");
         let workspace = WorkspaceName::default();
         let (started_tx, mut started_rx) = tokio::sync::mpsc::unbounded_channel();
         let manager = FeedbackManager::with_publisher(
-            layout.clone(),
+            store.clone(),
             Arc::new(PendingFeedbackPublisher {
                 started: started_tx,
             }),
@@ -232,7 +215,13 @@ mod tests {
             .await
             .expect("hosted publish task should start")
             .expect("hosted publish task should signal start");
-        assert!(layout.feedback_reports_file(&workspace).exists());
+        assert_eq!(
+            store
+                .test_read_feedback_reports(workspace.as_str())
+                .expect("read feedback reports")
+                .len(),
+            1
+        );
     }
 
     struct PendingFeedbackPublisher {

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -11,13 +11,16 @@
 //! # Main Internal Areas
 //!
 //! - [`ServerBuilder`] starts the local application server with filesystem
-//!   config, managed source resources, and plaintext credential material storage.
+//!   config, database-backed internal app storage, managed source resources, and
+//!   credential material storage.
 //! - [`RunningServer`] owns the running local gRPC server task.
 //! - [`AppError`] is the transport-neutral application error type used during
 //!   bootstrap and management operations.
 //! - `sources/` owns managed-source lifecycle and the reviewable installed
 //!   source contract.
 //! - `state/` owns persisted config-dir layout and config storage.
+//! - `storage/` owns app-storage abstractions and concrete local storage
+//!   backends.
 //! - `credentials/` owns credential-set identity and credential material
 //!   persistence.
 //! - `query/` owns query-time source loading and `coral-engine`

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -564,6 +564,8 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::Transport(_) => "TRANSPORT",
         AppError::TaskJoin(_) => "TASK_JOIN",
         AppError::Credentials(_) => "CREDENTIALS",
+        AppError::UnsupportedAppStorageBackend(_) => "UNSUPPORTED_APP_STORAGE_BACKEND",
+        AppError::AppStorage(_) => "APP_STORAGE",
         AppError::MissingConfigDir => "MISSING_CONFIG_DIR",
     }
 }

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -82,18 +82,18 @@ impl AppStateLayout {
         self.workspace_dir(workspace_name).join("sources")
     }
 
-    #[cfg(test)]
     pub(crate) fn feedback_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.workspace_dir(workspace_name).join("feedback")
     }
 
-    #[cfg(test)]
+    /// Legacy per-workspace feedback report path used for one-way import into
+    /// app storage.
     pub(crate) fn feedback_reports_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.feedback_dir(workspace_name).join("reports.jsonl")
     }
 
-    /// Legacy per-workspace episode log path kept for layout regression tests.
-    #[cfg(test)]
+    /// Legacy per-workspace episode log path used for one-way import into app
+    /// storage.
     pub(crate) fn episodes_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.workspace_dir(workspace_name)
             .join("episodes")

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -66,6 +66,10 @@ impl AppStateLayout {
         self.config_dir.join("telemetry").join("traces")
     }
 
+    pub(crate) fn app_database_file(&self) -> PathBuf {
+        self.config_dir.join("state.sqlite3")
+    }
+
     pub(crate) fn workspaces_root(&self) -> PathBuf {
         self.config_dir.join("workspaces")
     }
@@ -78,17 +82,18 @@ impl AppStateLayout {
         self.workspace_dir(workspace_name).join("sources")
     }
 
+    #[cfg(test)]
     pub(crate) fn feedback_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.workspace_dir(workspace_name).join("feedback")
     }
 
+    #[cfg(test)]
     pub(crate) fn feedback_reports_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.feedback_dir(workspace_name).join("reports.jsonl")
     }
 
-    /// Per-workspace episode log (JSONL) for experimental trajectory memory. The
-    /// episode store appends `OpenEpisode` records here; indexing and retrieval
-    /// land in a later PR.
+    /// Legacy per-workspace episode log path kept for layout regression tests.
+    #[cfg(test)]
     pub(crate) fn episodes_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.workspace_dir(workspace_name)
             .join("episodes")
@@ -209,6 +214,7 @@ mod tests {
         let source_name = SourceName::parse("github").expect("source");
 
         assert_eq!(layout.config_file(), config_dir.join("config.toml"));
+        assert_eq!(layout.app_database_file(), config_dir.join("state.sqlite3"));
         assert_eq!(
             layout.manifest_file(&workspace_name, &source_name),
             config_dir

--- a/crates/coral-app/src/storage/app/config.rs
+++ b/crates/coral-app/src/storage/app/config.rs
@@ -1,0 +1,172 @@
+//! App storage backend configuration loaded from `config.toml`.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use super::AppStorageError;
+use crate::state::AppStateLayout;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AppStorageBackend {
+    #[default]
+    Sqlite,
+    Postgres,
+}
+
+impl AppStorageBackend {
+    pub(crate) fn as_config_value(self) -> &'static str {
+        match self {
+            Self::Sqlite => "sqlite",
+            Self::Postgres => "postgres",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AppStorageConfig {
+    pub(crate) backend: AppStorageBackend,
+    sqlite_path: Option<PathBuf>,
+}
+
+impl AppStorageConfig {
+    pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, AppStorageError> {
+        let raw = match std::fs::read_to_string(layout.config_file()) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self::default());
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let file = toml::from_str::<AppStorageConfigFile>(&raw)?;
+        Ok(Self {
+            backend: file.storage.backend,
+            sqlite_path: file.storage.sqlite_path,
+        })
+    }
+
+    pub(crate) fn sqlite_path(&self, layout: &AppStateLayout) -> PathBuf {
+        match &self.sqlite_path {
+            Some(path) if path.is_absolute() => path.clone(),
+            Some(path) => layout.config_dir().join(path),
+            None => layout.app_database_file(),
+        }
+    }
+}
+
+impl Default for AppStorageConfig {
+    fn default() -> Self {
+        Self {
+            backend: AppStorageBackend::Sqlite,
+            sqlite_path: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AppStorageConfigFile {
+    #[serde(default)]
+    storage: AppStorageConfigSection,
+}
+
+#[derive(Debug, Deserialize)]
+struct AppStorageConfigSection {
+    #[serde(default)]
+    backend: AppStorageBackend,
+    #[serde(default, alias = "path")]
+    sqlite_path: Option<PathBuf>,
+}
+
+impl Default for AppStorageConfigSection {
+    fn default() -> Self {
+        Self {
+            backend: AppStorageBackend::Sqlite,
+            sqlite_path: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::{AppStorageBackend, AppStorageConfig};
+    use crate::state::AppStateLayout;
+
+    #[test]
+    fn defaults_to_sqlite_at_layout_database_file() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+
+        let config = AppStorageConfig::load(&layout).expect("load default");
+
+        assert_eq!(config.backend, AppStorageBackend::Sqlite);
+        assert_eq!(config.sqlite_path(&layout), layout.app_database_file());
+    }
+
+    #[test]
+    fn parses_sqlite_storage_config() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        std::fs::create_dir_all(layout.config_dir()).expect("mkdir");
+        std::fs::write(
+            layout.config_file(),
+            r#"
+version = 1
+
+[storage]
+backend = "sqlite"
+sqlite_path = "/tmp/coral-test.sqlite3"
+"#,
+        )
+        .expect("write config");
+
+        let config = AppStorageConfig::load(&layout).expect("load config");
+
+        assert_eq!(config.backend, AppStorageBackend::Sqlite);
+        assert_eq!(
+            config.sqlite_path(&layout),
+            std::path::PathBuf::from("/tmp/coral-test.sqlite3")
+        );
+    }
+
+    #[test]
+    fn resolves_relative_sqlite_path_under_config_dir() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        std::fs::create_dir_all(layout.config_dir()).expect("mkdir");
+        std::fs::write(
+            layout.config_file(),
+            r#"
+[storage]
+sqlite_path = "db/coral.sqlite3"
+"#,
+        )
+        .expect("write config");
+
+        let config = AppStorageConfig::load(&layout).expect("load config");
+
+        assert_eq!(
+            config.sqlite_path(&layout),
+            layout.config_dir().join("db/coral.sqlite3")
+        );
+    }
+
+    #[test]
+    fn accepts_postgres_as_future_backend_without_sqlite_path() {
+        let file = toml::from_str::<super::AppStorageConfigFile>(
+            r#"
+[storage]
+backend = "postgres"
+"#,
+        )
+        .expect("parse config");
+
+        assert_eq!(file.storage.backend, AppStorageBackend::Postgres);
+        assert_eq!(file.storage.sqlite_path, None);
+    }
+}

--- a/crates/coral-app/src/storage/app/legacy.rs
+++ b/crates/coral-app/src/storage/app/legacy.rs
@@ -1,0 +1,243 @@
+use std::fs::{self, File};
+use std::io::{BufRead as _, BufReader};
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use super::{AppStorageError, AppStore, StoredEpisode, StoredFeedbackReport};
+use crate::state::AppStateLayout;
+use crate::workspaces::WorkspaceName;
+
+const LEGACY_JSONL_IMPORT: &str = "legacy_jsonl_import";
+
+#[derive(Debug, Deserialize, Serialize)]
+struct LegacyEpisode {
+    id: String,
+    workspace: String,
+    intent: String,
+    parent_episode_id: Option<String>,
+    created_at_unix_nanos: u128,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyFeedbackReport {
+    id: String,
+    created_at: String,
+    trying_to_do: String,
+    tried: String,
+    stuck: String,
+}
+
+pub(super) fn migrate_jsonl(
+    store: &AppStore,
+    layout: &AppStateLayout,
+) -> Result<(), AppStorageError> {
+    if store.migration_applied(LEGACY_JSONL_IMPORT)? {
+        return Ok(());
+    }
+
+    let workspaces = legacy_workspace_names(layout)?;
+    let mut uow = store.begin_write()?;
+    for workspace in workspaces {
+        import_episodes(&mut uow.episodes(), layout, &workspace)?;
+        import_feedback_reports(&mut uow.feedback(), layout, &workspace)?;
+    }
+    uow.mark_migration_applied(LEGACY_JSONL_IMPORT)?;
+    uow.commit()
+}
+
+fn legacy_workspace_names(layout: &AppStateLayout) -> Result<Vec<WorkspaceName>, AppStorageError> {
+    let entries = match fs::read_dir(layout.workspaces_root()) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.into()),
+    };
+
+    let mut workspaces = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let raw_name = entry.file_name();
+        let Some(name) = raw_name.to_str() else {
+            warn!(path = %entry.path().display(), "skipping legacy app-storage workspace with non-UTF-8 name");
+            continue;
+        };
+        match WorkspaceName::parse(name) {
+            Ok(workspace) => workspaces.push(workspace),
+            Err(error) => {
+                warn!(workspace = name, %error, "skipping legacy app-storage workspace with invalid name");
+            }
+        }
+    }
+    workspaces.sort();
+    Ok(workspaces)
+}
+
+fn import_episodes(
+    episodes: &mut super::EpisodeRepository<'_>,
+    layout: &AppStateLayout,
+    workspace: &WorkspaceName,
+) -> Result<(), AppStorageError> {
+    let path = layout.episodes_file(workspace);
+    stream_jsonl::<LegacyEpisode>(&path, "episode", |legacy| {
+        let Some(record) = stored_episode(legacy, workspace)? else {
+            return Ok(());
+        };
+        episodes.import_episode(&record)
+    })
+}
+
+fn stored_episode(
+    legacy: LegacyEpisode,
+    workspace: &WorkspaceName,
+) -> Result<Option<StoredEpisode>, AppStorageError> {
+    let created_at_unix_nanos = match i64::try_from(legacy.created_at_unix_nanos).map_err(
+        |_error| AppStorageError::ValueOutOfRange {
+            field: "created_at_unix_nanos",
+            value: legacy.created_at_unix_nanos.to_string(),
+        },
+    ) {
+        Ok(created_at) => created_at,
+        Err(error) => {
+            warn!(episode_id = %legacy.id, workspace = workspace.as_str(), %error, "skipping legacy episode with out-of-range timestamp");
+            return Ok(None);
+        }
+    };
+    let record_for_size = LegacyEpisode {
+        workspace: workspace.as_str().to_string(),
+        ..legacy
+    };
+    Ok(Some(StoredEpisode {
+        workspace: record_for_size.workspace.clone(),
+        id: record_for_size.id.clone(),
+        intent: record_for_size.intent.clone(),
+        parent_episode_id: record_for_size.parent_episode_id.clone(),
+        created_at_unix_nanos,
+        record_bytes: serde_json::to_vec(&record_for_size)?.len() as u64 + 1,
+    }))
+}
+
+fn import_feedback_reports(
+    feedback: &mut super::FeedbackRepository<'_>,
+    layout: &AppStateLayout,
+    workspace: &WorkspaceName,
+) -> Result<(), AppStorageError> {
+    let path = layout.feedback_reports_file(workspace);
+    stream_jsonl::<LegacyFeedbackReport>(&path, "feedback report", |legacy| {
+        let record = StoredFeedbackReport {
+            id: legacy.id,
+            workspace: workspace.as_str().to_string(),
+            created_at_rfc3339: legacy.created_at,
+            trying_to_do: legacy.trying_to_do,
+            tried: legacy.tried,
+            stuck: legacy.stuck,
+        };
+        feedback.import_report(&record)
+    })
+}
+
+fn stream_jsonl<T>(
+    path: &Path,
+    kind: &'static str,
+    mut visit: impl FnMut(T) -> Result<(), AppStorageError>,
+) -> Result<(), AppStorageError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let mut reader = BufReader::new(file);
+    let mut raw_line = Vec::new();
+    loop {
+        raw_line.clear();
+        if reader.read_until(b'\n', &mut raw_line)? == 0 {
+            break;
+        }
+        if raw_line.ends_with(b"\n") {
+            raw_line.pop();
+        }
+        if raw_line.ends_with(b"\r") {
+            raw_line.pop();
+        }
+        let Ok(line) = std::str::from_utf8(&raw_line) else {
+            warn!(path = %path.display(), "skipping legacy {kind} record with invalid UTF-8");
+            continue;
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<T>(line) {
+            Ok(record) => visit(record)?,
+            Err(error) => {
+                warn!(path = %path.display(), %error, "skipping unparsable legacy {kind} record");
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::migrate_jsonl;
+    use crate::state::AppStateLayout;
+    use crate::storage::app::{AppStore, StoredFeedbackReport};
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn imports_legacy_episode_and_feedback_jsonl_once() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        let workspace = WorkspaceName::default();
+        let episode_path = layout.episodes_file(&workspace);
+        let feedback_path = layout.feedback_reports_file(&workspace);
+        std::fs::create_dir_all(episode_path.parent().expect("episode parent")).expect("mkdir");
+        std::fs::create_dir_all(feedback_path.parent().expect("feedback parent")).expect("mkdir");
+        std::fs::write(
+            &episode_path,
+            r#"{"id":"ep_legacy","workspace":"default","intent":"legacy task","parent_episode_id":null,"created_at_unix_nanos":123}
+{"id":"broken"
+"#,
+        )
+        .expect("write legacy episodes");
+        std::fs::write(
+            &feedback_path,
+            r#"{"id":"fb_legacy","workspace":"default","created_at":"2026-06-26T00:00:00Z","trying_to_do":"trying","tried":"tried","stuck":"stuck"}
+"#,
+        )
+        .expect("write legacy feedback");
+
+        let store = AppStore::sqlite(layout.app_database_file()).expect("sqlite store");
+        migrate_jsonl(&store, &layout).expect("first migration");
+        migrate_jsonl(&store, &layout).expect("second migration is skipped");
+
+        let episode = store
+            .test_read_episode("default", "ep_legacy")
+            .expect("read episode")
+            .expect("episode imported");
+        assert_eq!(episode.intent, "legacy task");
+        assert_eq!(episode.created_at_unix_nanos, 123);
+        let feedback = store
+            .test_read_feedback_reports("default")
+            .expect("read feedback");
+        assert_eq!(
+            feedback,
+            vec![StoredFeedbackReport {
+                id: "fb_legacy".to_string(),
+                workspace: "default".to_string(),
+                created_at_rfc3339: "2026-06-26T00:00:00Z".to_string(),
+                trying_to_do: "trying".to_string(),
+                tried: "tried".to_string(),
+                stuck: "stuck".to_string(),
+            }]
+        );
+    }
+}

--- a/crates/coral-app/src/storage/app/mod.rs
+++ b/crates/coral-app/src/storage/app/mod.rs
@@ -1,0 +1,222 @@
+//! Application-owned durable storage.
+//!
+//! This module is the storage boundary for internal app state that should be
+//! database-backed. Callers work through a unit of work and domain repositories;
+//! backend-specific code stays below this layer.
+
+use std::fmt;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::state::AppStateLayout;
+
+pub(crate) mod config;
+mod sqlite;
+
+pub(crate) use config::{AppStorageBackend, AppStorageConfig};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AppStorageError {
+    #[error("app storage io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("app storage config: {0}")]
+    Config(#[from] toml::de::Error),
+    #[error("app storage sqlite: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("app storage mutex poisoned")]
+    Poisoned,
+    #[error("unsupported app storage backend '{backend}'")]
+    UnsupportedBackend { backend: String },
+    #[error("app storage value '{field}' is out of range: {value}")]
+    ValueOutOfRange { field: &'static str, value: String },
+    #[error("app storage is corrupt: {0}")]
+    Corrupt(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StoredEpisode {
+    pub(crate) workspace: String,
+    pub(crate) id: String,
+    pub(crate) intent: String,
+    pub(crate) parent_episode_id: Option<String>,
+    pub(crate) created_at_unix_nanos: i64,
+    pub(crate) record_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OpenEpisodeResult {
+    Opened,
+    AlreadyOpen,
+    Conflict,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StoredFeedbackReport {
+    pub(crate) id: String,
+    pub(crate) workspace: String,
+    pub(crate) created_at_rfc3339: String,
+    pub(crate) trying_to_do: String,
+    pub(crate) tried: String,
+    pub(crate) stuck: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct AppStore {
+    backend: Arc<dyn AppStoreBackend>,
+}
+
+impl AppStore {
+    pub(crate) fn open(
+        layout: &AppStateLayout,
+        config: &AppStorageConfig,
+    ) -> Result<Self, AppStorageError> {
+        match config.backend {
+            AppStorageBackend::Sqlite => Self::sqlite(config.sqlite_path(layout)),
+            AppStorageBackend::Postgres => Err(AppStorageError::UnsupportedBackend {
+                backend: AppStorageBackend::Postgres.as_config_value().to_string(),
+            }),
+        }
+    }
+
+    pub(crate) fn sqlite(path: PathBuf) -> Result<Self, AppStorageError> {
+        Ok(Self {
+            backend: Arc::new(sqlite::SqliteAppStore::open(path)?),
+        })
+    }
+
+    pub(crate) fn begin_write(&self) -> Result<AppWriteUnitOfWork<'_>, AppStorageError> {
+        Ok(AppWriteUnitOfWork {
+            transaction: Some(self.backend.begin_write()?),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_read_episode(
+        &self,
+        workspace: &str,
+        episode_id: &str,
+    ) -> Result<Option<StoredEpisode>, AppStorageError> {
+        self.backend.test_read_episode(workspace, episode_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_count_episodes(&self, workspace: &str) -> Result<usize, AppStorageError> {
+        self.backend.test_count_episodes(workspace)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_episode_bytes(&self, workspace: &str) -> Result<u64, AppStorageError> {
+        self.backend.test_episode_bytes(workspace)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_read_feedback_reports(
+        &self,
+        workspace: &str,
+    ) -> Result<Vec<StoredFeedbackReport>, AppStorageError> {
+        self.backend.test_read_feedback_reports(workspace)
+    }
+}
+
+impl fmt::Debug for AppStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("AppStore").finish_non_exhaustive()
+    }
+}
+
+pub(crate) struct AppWriteUnitOfWork<'a> {
+    transaction: Option<Box<dyn AppStoreWriteTransaction + 'a>>,
+}
+
+impl<'a> AppWriteUnitOfWork<'a> {
+    pub(crate) fn episodes(&mut self) -> EpisodeRepository<'_> {
+        EpisodeRepository {
+            transaction: self.transaction(),
+        }
+    }
+
+    pub(crate) fn feedback(&mut self) -> FeedbackRepository<'_> {
+        FeedbackRepository {
+            transaction: self.transaction(),
+        }
+    }
+
+    pub(crate) fn commit(mut self) -> Result<(), AppStorageError> {
+        let transaction = self
+            .transaction
+            .take()
+            .expect("unit of work transaction is present until commit");
+        transaction.commit()
+    }
+
+    fn transaction(&mut self) -> &mut (dyn AppStoreWriteTransaction + 'a) {
+        self.transaction
+            .as_deref_mut()
+            .expect("unit of work transaction is present until commit")
+    }
+}
+
+pub(crate) struct EpisodeRepository<'a> {
+    transaction: &'a mut dyn AppStoreWriteTransaction,
+}
+
+impl EpisodeRepository<'_> {
+    pub(crate) fn open_episode(
+        &mut self,
+        episode: &StoredEpisode,
+        max_bytes: u64,
+    ) -> Result<OpenEpisodeResult, AppStorageError> {
+        self.transaction.open_episode(episode, max_bytes)
+    }
+}
+
+pub(crate) struct FeedbackRepository<'a> {
+    transaction: &'a mut dyn AppStoreWriteTransaction,
+}
+
+impl FeedbackRepository<'_> {
+    pub(crate) fn append_report(
+        &mut self,
+        report: &StoredFeedbackReport,
+    ) -> Result<(), AppStorageError> {
+        self.transaction.append_feedback_report(report)
+    }
+}
+
+trait AppStoreBackend: Send + Sync {
+    fn begin_write(&self) -> Result<Box<dyn AppStoreWriteTransaction + '_>, AppStorageError>;
+
+    #[cfg(test)]
+    fn test_read_episode(
+        &self,
+        workspace: &str,
+        episode_id: &str,
+    ) -> Result<Option<StoredEpisode>, AppStorageError>;
+
+    #[cfg(test)]
+    fn test_count_episodes(&self, workspace: &str) -> Result<usize, AppStorageError>;
+
+    #[cfg(test)]
+    fn test_episode_bytes(&self, workspace: &str) -> Result<u64, AppStorageError>;
+
+    #[cfg(test)]
+    fn test_read_feedback_reports(
+        &self,
+        workspace: &str,
+    ) -> Result<Vec<StoredFeedbackReport>, AppStorageError>;
+}
+
+trait AppStoreWriteTransaction {
+    fn open_episode(
+        &mut self,
+        episode: &StoredEpisode,
+        max_bytes: u64,
+    ) -> Result<OpenEpisodeResult, AppStorageError>;
+
+    fn append_feedback_report(
+        &mut self,
+        report: &StoredFeedbackReport,
+    ) -> Result<(), AppStorageError>;
+
+    fn commit(self: Box<Self>) -> Result<(), AppStorageError>;
+}

--- a/crates/coral-app/src/storage/app/mod.rs
+++ b/crates/coral-app/src/storage/app/mod.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use crate::state::AppStateLayout;
 
 pub(crate) mod config;
+mod legacy;
 mod sqlite;
 
 pub(crate) use config::{AppStorageBackend, AppStorageConfig};
@@ -23,6 +24,8 @@ pub(crate) enum AppStorageError {
     Config(#[from] toml::de::Error),
     #[error("app storage sqlite: {0}")]
     Sqlite(#[from] rusqlite::Error),
+    #[error("app storage json: {0}")]
+    Json(#[from] serde_json::Error),
     #[error("app storage mutex poisoned")]
     Poisoned,
     #[error("unsupported app storage backend '{backend}'")]
@@ -70,12 +73,14 @@ impl AppStore {
         layout: &AppStateLayout,
         config: &AppStorageConfig,
     ) -> Result<Self, AppStorageError> {
-        match config.backend {
-            AppStorageBackend::Sqlite => Self::sqlite(config.sqlite_path(layout)),
+        let store = match config.backend {
+            AppStorageBackend::Sqlite => Self::sqlite(config.sqlite_path(layout))?,
             AppStorageBackend::Postgres => Err(AppStorageError::UnsupportedBackend {
                 backend: AppStorageBackend::Postgres.as_config_value().to_string(),
-            }),
-        }
+            })?,
+        };
+        legacy::migrate_jsonl(&store, layout)?;
+        Ok(store)
     }
 
     pub(crate) fn sqlite(path: PathBuf) -> Result<Self, AppStorageError> {
@@ -88,6 +93,10 @@ impl AppStore {
         Ok(AppWriteUnitOfWork {
             transaction: Some(self.backend.begin_write()?),
         })
+    }
+
+    fn migration_applied(&self, name: &str) -> Result<bool, AppStorageError> {
+        self.backend.migration_applied(name)
     }
 
     #[cfg(test)]
@@ -149,6 +158,10 @@ impl<'a> AppWriteUnitOfWork<'a> {
         transaction.commit()
     }
 
+    fn mark_migration_applied(&mut self, name: &str) -> Result<(), AppStorageError> {
+        self.transaction().mark_migration_applied(name)
+    }
+
     fn transaction(&mut self) -> &mut (dyn AppStoreWriteTransaction + 'a) {
         self.transaction
             .as_deref_mut()
@@ -168,6 +181,10 @@ impl EpisodeRepository<'_> {
     ) -> Result<OpenEpisodeResult, AppStorageError> {
         self.transaction.open_episode(episode, max_bytes)
     }
+
+    fn import_episode(&mut self, episode: &StoredEpisode) -> Result<(), AppStorageError> {
+        self.transaction.import_episode(episode)
+    }
 }
 
 pub(crate) struct FeedbackRepository<'a> {
@@ -181,10 +198,16 @@ impl FeedbackRepository<'_> {
     ) -> Result<(), AppStorageError> {
         self.transaction.append_feedback_report(report)
     }
+
+    fn import_report(&mut self, report: &StoredFeedbackReport) -> Result<(), AppStorageError> {
+        self.transaction.import_feedback_report(report)
+    }
 }
 
 trait AppStoreBackend: Send + Sync {
     fn begin_write(&self) -> Result<Box<dyn AppStoreWriteTransaction + '_>, AppStorageError>;
+
+    fn migration_applied(&self, name: &str) -> Result<bool, AppStorageError>;
 
     #[cfg(test)]
     fn test_read_episode(
@@ -213,10 +236,19 @@ trait AppStoreWriteTransaction {
         max_bytes: u64,
     ) -> Result<OpenEpisodeResult, AppStorageError>;
 
+    fn import_episode(&mut self, episode: &StoredEpisode) -> Result<(), AppStorageError>;
+
     fn append_feedback_report(
         &mut self,
         report: &StoredFeedbackReport,
     ) -> Result<(), AppStorageError>;
+
+    fn import_feedback_report(
+        &mut self,
+        report: &StoredFeedbackReport,
+    ) -> Result<(), AppStorageError>;
+
+    fn mark_migration_applied(&mut self, name: &str) -> Result<(), AppStorageError>;
 
     fn commit(self: Box<Self>) -> Result<(), AppStorageError>;
 }

--- a/crates/coral-app/src/storage/app/sqlite.rs
+++ b/crates/coral-app/src/storage/app/sqlite.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
 
@@ -8,10 +8,16 @@ use super::{
     AppStorageError, AppStoreBackend, AppStoreWriteTransaction, OpenEpisodeResult, StoredEpisode,
     StoredFeedbackReport,
 };
+use crate::storage::fs as storage_fs;
 
 const SCHEMA: &str = r"
 CREATE TABLE IF NOT EXISTS app_schema_migrations (
     version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS app_data_migrations (
+    name TEXT PRIMARY KEY,
     applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 
@@ -42,15 +48,14 @@ INSERT OR IGNORE INTO app_schema_migrations (version) VALUES (1);
 ";
 
 pub(super) struct SqliteAppStore {
+    path: PathBuf,
     connection: Mutex<Connection>,
 }
 
 impl SqliteAppStore {
     pub(super) fn open(path: PathBuf) -> Result<Self, AppStorageError> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let connection = Connection::open(path)?;
+        storage_fs::ensure_file_private(&path)?;
+        let connection = Connection::open(&path)?;
         connection.busy_timeout(Duration::from_secs(5))?;
         connection.execute_batch(
             r"
@@ -60,7 +65,9 @@ PRAGMA synchronous = NORMAL;
 ",
         )?;
         connection.execute_batch(SCHEMA)?;
+        set_sqlite_file_permissions(&path)?;
         Ok(Self {
+            path,
             connection: Mutex::new(connection),
         })
     }
@@ -77,9 +84,15 @@ impl AppStoreBackend for SqliteAppStore {
         let connection = self.lock()?;
         connection.execute_batch("BEGIN IMMEDIATE")?;
         Ok(Box::new(SqliteWriteTransaction {
+            path: self.path.clone(),
             connection,
             completed: false,
         }))
+    }
+
+    fn migration_applied(&self, name: &str) -> Result<bool, AppStorageError> {
+        let connection = self.lock()?;
+        migration_applied(&connection, name)
     }
 
     #[cfg(test)]
@@ -141,6 +154,7 @@ ORDER BY rowid ASC
 }
 
 struct SqliteWriteTransaction<'a> {
+    path: PathBuf,
     connection: MutexGuard<'a, Connection>,
     completed: bool,
 }
@@ -185,6 +199,30 @@ INSERT INTO episodes (
         Ok(OpenEpisodeResult::Opened)
     }
 
+    fn import_episode(&mut self, episode: &StoredEpisode) -> Result<(), AppStorageError> {
+        self.connection.execute(
+            r"
+INSERT OR IGNORE INTO episodes (
+    workspace,
+    episode_id,
+    intent,
+    parent_episode_id,
+    created_at_unix_nanos,
+    record_bytes
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+",
+            params![
+                episode.workspace.as_str(),
+                episode.id.as_str(),
+                episode.intent.as_str(),
+                episode.parent_episode_id.as_deref(),
+                episode.created_at_unix_nanos,
+                sqlite_i64("record_bytes", episode.record_bytes)?
+            ],
+        )?;
+        Ok(())
+    }
+
     fn append_feedback_report(
         &mut self,
         report: &StoredFeedbackReport,
@@ -212,8 +250,44 @@ INSERT INTO feedback_reports (
         Ok(())
     }
 
+    fn import_feedback_report(
+        &mut self,
+        report: &StoredFeedbackReport,
+    ) -> Result<(), AppStorageError> {
+        self.connection.execute(
+            r"
+INSERT OR IGNORE INTO feedback_reports (
+    workspace,
+    report_id,
+    created_at,
+    trying_to_do,
+    tried,
+    stuck
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+",
+            params![
+                report.workspace.as_str(),
+                report.id.as_str(),
+                report.created_at_rfc3339.as_str(),
+                report.trying_to_do.as_str(),
+                report.tried.as_str(),
+                report.stuck.as_str()
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn mark_migration_applied(&mut self, name: &str) -> Result<(), AppStorageError> {
+        self.connection.execute(
+            "INSERT OR IGNORE INTO app_data_migrations (name) VALUES (?1)",
+            params![name],
+        )?;
+        Ok(())
+    }
+
     fn commit(mut self: Box<Self>) -> Result<(), AppStorageError> {
         self.connection.execute_batch("COMMIT")?;
+        set_sqlite_file_permissions(&self.path)?;
         self.completed = true;
         Ok(())
     }
@@ -262,6 +336,18 @@ WHERE workspace = ?1 AND episode_id = ?2
         )
         .optional()?;
     row.map(stored_episode).transpose()
+}
+
+fn migration_applied(connection: &Connection, name: &str) -> Result<bool, AppStorageError> {
+    let present = connection
+        .query_row(
+            "SELECT 1 FROM app_data_migrations WHERE name = ?1",
+            params![name],
+            |_row| Ok(()),
+        )
+        .optional()?
+        .is_some();
+    Ok(present)
 }
 
 fn stored_episode(row: SqlEpisodeRow) -> Result<StoredEpisode, AppStorageError> {
@@ -334,4 +420,114 @@ fn sqlite_i64(field: &'static str, value: u64) -> Result<i64, AppStorageError> {
         field,
         value: value.to_string(),
     })
+}
+
+fn set_sqlite_file_permissions(path: &Path) -> Result<(), AppStorageError> {
+    storage_fs::set_file_permissions_private_if_exists(path)?;
+    for sidecar in sqlite_sidecar_paths(path) {
+        storage_fs::set_file_permissions_private_if_exists(&sidecar)?;
+    }
+    Ok(())
+}
+
+fn sqlite_sidecar_paths(path: &Path) -> [PathBuf; 2] {
+    [
+        sqlite_sidecar_path(path, "-wal"),
+        sqlite_sidecar_path(path, "-shm"),
+    ]
+}
+
+fn sqlite_sidecar_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut raw = path.as_os_str().to_os_string();
+    raw.push(suffix);
+    PathBuf::from(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
+    #[cfg(unix)]
+    #[test]
+    fn creates_database_and_wal_sidecars_with_private_permissions() {
+        let temp = TempDir::new().expect("temp dir");
+        let database = temp.path().join("nested").join("state.sqlite3");
+        let store = SqliteAppStore::open(database.clone()).expect("sqlite app store");
+        append_feedback_report(&store, "feedback-1");
+
+        assert_eq!(mode(database.parent().expect("database parent")), 0o700);
+        assert_eq!(mode(&database), 0o600);
+        for sidecar in sqlite_sidecar_paths(&database) {
+            assert!(
+                sidecar.exists(),
+                "sidecar should exist: {}",
+                sidecar.display()
+            );
+            assert_eq!(mode(&sidecar), 0o600, "sidecar: {}", sidecar.display());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tightens_existing_database_and_wal_sidecar_permissions() {
+        let temp = TempDir::new().expect("temp dir");
+        let database = temp.path().join("state.sqlite3");
+        std::fs::write(&database, b"").expect("precreate database");
+        set_mode(&database, 0o666);
+
+        let store = SqliteAppStore::open(database.clone()).expect("sqlite app store");
+        assert_eq!(mode(&database), 0o600);
+        append_feedback_report(&store, "feedback-1");
+
+        set_mode(&database, 0o666);
+        for sidecar in sqlite_sidecar_paths(&database) {
+            assert!(
+                sidecar.exists(),
+                "sidecar should exist before loosening: {}",
+                sidecar.display()
+            );
+            set_mode(&sidecar, 0o666);
+        }
+        append_feedback_report(&store, "feedback-2");
+
+        assert_eq!(mode(&database), 0o600);
+        for sidecar in sqlite_sidecar_paths(&database) {
+            assert_eq!(mode(&sidecar), 0o600, "sidecar: {}", sidecar.display());
+        }
+    }
+
+    #[cfg(unix)]
+    fn append_feedback_report(store: &SqliteAppStore, id: &str) {
+        let mut transaction = store.begin_write().expect("begin write");
+        transaction
+            .append_feedback_report(&StoredFeedbackReport {
+                id: id.to_string(),
+                workspace: "default".to_string(),
+                created_at_rfc3339: "2026-06-26T00:00:00Z".to_string(),
+                trying_to_do: "trying".to_string(),
+                tried: "tried".to_string(),
+                stuck: "stuck".to_string(),
+            })
+            .expect("append feedback");
+        transaction.commit().expect("commit");
+    }
+
+    #[cfg(unix)]
+    fn set_mode(path: &Path, mode: u32) {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+            .expect("set permissions");
+    }
+
+    #[cfg(unix)]
+    fn mode(path: &Path) -> u32 {
+        std::fs::metadata(path)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777
+    }
 }

--- a/crates/coral-app/src/storage/app/sqlite.rs
+++ b/crates/coral-app/src/storage/app/sqlite.rs
@@ -1,0 +1,337 @@
+use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard};
+use std::time::Duration;
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use super::{
+    AppStorageError, AppStoreBackend, AppStoreWriteTransaction, OpenEpisodeResult, StoredEpisode,
+    StoredFeedbackReport,
+};
+
+const SCHEMA: &str = r"
+CREATE TABLE IF NOT EXISTS app_schema_migrations (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS episodes (
+    workspace TEXT NOT NULL,
+    episode_id TEXT NOT NULL,
+    intent TEXT NOT NULL,
+    parent_episode_id TEXT,
+    created_at_unix_nanos INTEGER NOT NULL,
+    record_bytes INTEGER NOT NULL CHECK (record_bytes >= 0),
+    PRIMARY KEY (workspace, episode_id)
+);
+
+CREATE TABLE IF NOT EXISTS feedback_reports (
+    workspace TEXT NOT NULL,
+    report_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    trying_to_do TEXT NOT NULL,
+    tried TEXT NOT NULL,
+    stuck TEXT NOT NULL,
+    PRIMARY KEY (workspace, report_id)
+);
+
+CREATE INDEX IF NOT EXISTS feedback_reports_workspace_created_idx
+    ON feedback_reports (workspace, created_at, report_id);
+
+INSERT OR IGNORE INTO app_schema_migrations (version) VALUES (1);
+";
+
+pub(super) struct SqliteAppStore {
+    connection: Mutex<Connection>,
+}
+
+impl SqliteAppStore {
+    pub(super) fn open(path: PathBuf) -> Result<Self, AppStorageError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let connection = Connection::open(path)?;
+        connection.busy_timeout(Duration::from_secs(5))?;
+        connection.execute_batch(
+            r"
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+",
+        )?;
+        connection.execute_batch(SCHEMA)?;
+        Ok(Self {
+            connection: Mutex::new(connection),
+        })
+    }
+
+    fn lock(&self) -> Result<MutexGuard<'_, Connection>, AppStorageError> {
+        self.connection
+            .lock()
+            .map_err(|_error| AppStorageError::Poisoned)
+    }
+}
+
+impl AppStoreBackend for SqliteAppStore {
+    fn begin_write(&self) -> Result<Box<dyn AppStoreWriteTransaction + '_>, AppStorageError> {
+        let connection = self.lock()?;
+        connection.execute_batch("BEGIN IMMEDIATE")?;
+        Ok(Box::new(SqliteWriteTransaction {
+            connection,
+            completed: false,
+        }))
+    }
+
+    #[cfg(test)]
+    fn test_read_episode(
+        &self,
+        workspace: &str,
+        episode_id: &str,
+    ) -> Result<Option<StoredEpisode>, AppStorageError> {
+        let connection = self.lock()?;
+        select_episode(&connection, workspace, episode_id)
+    }
+
+    #[cfg(test)]
+    fn test_count_episodes(&self, workspace: &str) -> Result<usize, AppStorageError> {
+        let connection = self.lock()?;
+        let count = connection.query_row(
+            "SELECT COUNT(*) FROM episodes WHERE workspace = ?1",
+            params![workspace],
+            |row| row.get::<_, i64>(0),
+        )?;
+        usize::try_from(count).map_err(|_error| AppStorageError::ValueOutOfRange {
+            field: "episode_count",
+            value: count.to_string(),
+        })
+    }
+
+    #[cfg(test)]
+    fn test_episode_bytes(&self, workspace: &str) -> Result<u64, AppStorageError> {
+        let connection = self.lock()?;
+        episode_bytes(&connection, workspace)
+    }
+
+    #[cfg(test)]
+    fn test_read_feedback_reports(
+        &self,
+        workspace: &str,
+    ) -> Result<Vec<StoredFeedbackReport>, AppStorageError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            r"
+SELECT report_id, workspace, created_at, trying_to_do, tried, stuck
+FROM feedback_reports
+WHERE workspace = ?1
+ORDER BY rowid ASC
+",
+        )?;
+        let rows = statement.query_map(params![workspace], |row| {
+            Ok(StoredFeedbackReport {
+                id: row.get(0)?,
+                workspace: row.get(1)?,
+                created_at_rfc3339: row.get(2)?,
+                trying_to_do: row.get(3)?,
+                tried: row.get(4)?,
+                stuck: row.get(5)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+}
+
+struct SqliteWriteTransaction<'a> {
+    connection: MutexGuard<'a, Connection>,
+    completed: bool,
+}
+
+impl AppStoreWriteTransaction for SqliteWriteTransaction<'_> {
+    fn open_episode(
+        &mut self,
+        episode: &StoredEpisode,
+        max_bytes: u64,
+    ) -> Result<OpenEpisodeResult, AppStorageError> {
+        if let Some(existing) = select_episode(&self.connection, &episode.workspace, &episode.id)? {
+            return if existing.intent == episode.intent
+                && existing.parent_episode_id == episode.parent_episode_id
+            {
+                Ok(OpenEpisodeResult::AlreadyOpen)
+            } else {
+                Ok(OpenEpisodeResult::Conflict)
+            };
+        }
+
+        self.connection.execute(
+            r"
+INSERT INTO episodes (
+    workspace,
+    episode_id,
+    intent,
+    parent_episode_id,
+    created_at_unix_nanos,
+    record_bytes
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+",
+            params![
+                episode.workspace.as_str(),
+                episode.id.as_str(),
+                episode.intent.as_str(),
+                episode.parent_episode_id.as_deref(),
+                episode.created_at_unix_nanos,
+                sqlite_i64("record_bytes", episode.record_bytes)?
+            ],
+        )?;
+        prune_episodes(&self.connection, &episode.workspace, max_bytes)?;
+        Ok(OpenEpisodeResult::Opened)
+    }
+
+    fn append_feedback_report(
+        &mut self,
+        report: &StoredFeedbackReport,
+    ) -> Result<(), AppStorageError> {
+        self.connection.execute(
+            r"
+INSERT INTO feedback_reports (
+    workspace,
+    report_id,
+    created_at,
+    trying_to_do,
+    tried,
+    stuck
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+",
+            params![
+                report.workspace.as_str(),
+                report.id.as_str(),
+                report.created_at_rfc3339.as_str(),
+                report.trying_to_do.as_str(),
+                report.tried.as_str(),
+                report.stuck.as_str()
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn commit(mut self: Box<Self>) -> Result<(), AppStorageError> {
+        self.connection.execute_batch("COMMIT")?;
+        self.completed = true;
+        Ok(())
+    }
+}
+
+impl Drop for SqliteWriteTransaction<'_> {
+    fn drop(&mut self) {
+        if !self.completed {
+            drop(self.connection.execute_batch("ROLLBACK"));
+        }
+    }
+}
+
+struct SqlEpisodeRow {
+    workspace: String,
+    id: String,
+    intent: String,
+    parent_episode_id: Option<String>,
+    created_at_unix_nanos: i64,
+    record_bytes: i64,
+}
+
+fn select_episode(
+    connection: &Connection,
+    workspace: &str,
+    episode_id: &str,
+) -> Result<Option<StoredEpisode>, AppStorageError> {
+    let row = connection
+        .query_row(
+            r"
+SELECT workspace, episode_id, intent, parent_episode_id, created_at_unix_nanos, record_bytes
+FROM episodes
+WHERE workspace = ?1 AND episode_id = ?2
+",
+            params![workspace, episode_id],
+            |row| {
+                Ok(SqlEpisodeRow {
+                    workspace: row.get(0)?,
+                    id: row.get(1)?,
+                    intent: row.get(2)?,
+                    parent_episode_id: row.get(3)?,
+                    created_at_unix_nanos: row.get(4)?,
+                    record_bytes: row.get(5)?,
+                })
+            },
+        )
+        .optional()?;
+    row.map(stored_episode).transpose()
+}
+
+fn stored_episode(row: SqlEpisodeRow) -> Result<StoredEpisode, AppStorageError> {
+    let record_bytes = u64::try_from(row.record_bytes).map_err(|_error| {
+        AppStorageError::Corrupt(format!(
+            "episode '{}' in workspace '{}' has negative record_bytes",
+            row.id, row.workspace
+        ))
+    })?;
+    Ok(StoredEpisode {
+        workspace: row.workspace,
+        id: row.id,
+        intent: row.intent,
+        parent_episode_id: row.parent_episode_id,
+        created_at_unix_nanos: row.created_at_unix_nanos,
+        record_bytes,
+    })
+}
+
+fn prune_episodes(
+    connection: &Connection,
+    workspace: &str,
+    max_bytes: u64,
+) -> Result<(), AppStorageError> {
+    let mut total = sqlite_i64("episode_bytes", episode_bytes(connection, workspace)?)?;
+    let max_bytes = sqlite_i64("max_bytes", max_bytes)?;
+    if total <= max_bytes {
+        return Ok(());
+    }
+
+    let mut statement = connection.prepare(
+        r"
+SELECT rowid, record_bytes
+FROM episodes
+WHERE workspace = ?1
+ORDER BY rowid ASC
+",
+    )?;
+    let rows = statement
+        .query_map(params![workspace], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    let row_count = rows.len();
+    for (index, (rowid, record_bytes)) in rows.into_iter().enumerate() {
+        if total <= max_bytes || index + 1 >= row_count {
+            break;
+        }
+        connection.execute("DELETE FROM episodes WHERE rowid = ?1", params![rowid])?;
+        total = total.saturating_sub(record_bytes);
+    }
+    Ok(())
+}
+
+fn episode_bytes(connection: &Connection, workspace: &str) -> Result<u64, AppStorageError> {
+    let bytes = connection.query_row(
+        "SELECT COALESCE(SUM(record_bytes), 0) FROM episodes WHERE workspace = ?1",
+        params![workspace],
+        |row| row.get::<_, i64>(0),
+    )?;
+    u64::try_from(bytes).map_err(|_error| {
+        AppStorageError::Corrupt(format!(
+            "workspace '{workspace}' has negative episode byte total"
+        ))
+    })
+}
+
+fn sqlite_i64(field: &'static str, value: u64) -> Result<i64, AppStorageError> {
+    i64::try_from(value).map_err(|_error| AppStorageError::ValueOutOfRange {
+        field,
+        value: value.to_string(),
+    })
+}

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -33,6 +33,32 @@ pub(crate) fn create_new_file_private(path: &Path) -> io::Result<File> {
     open_create_new_file_private(path)
 }
 
+pub(crate) fn ensure_file_private(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        ensure_dir(parent)?;
+    }
+    match open_create_new_file_private(path) {
+        Ok(file) => {
+            drop(file);
+            sync_parent(path);
+            Ok(())
+        }
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            set_file_permissions_private_if_exists(path)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+pub(crate) fn set_file_permissions_private_if_exists(path: &Path) -> io::Result<()> {
+    match fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => set_file_permissions_private(path),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
 /// Write to a temp file then rename to avoid partial writes on crash.
 pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
     let temp_path = temp_path_for(path);
@@ -45,11 +71,7 @@ pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
 pub(crate) fn replace_atomic(from: &Path, to: &Path) -> io::Result<()> {
     rename_with_fallback(from, to)?;
 
-    if let Some(parent) = to.parent()
-        && let Ok(dir) = fs::File::open(parent)
-    {
-        drop(dir.sync_all());
-    }
+    sync_parent(to);
 
     Ok(())
 }
@@ -103,6 +125,14 @@ fn open_lock_file(path: &Path) -> io::Result<File> {
         .read(true)
         .write(true)
         .open(path)
+}
+
+fn sync_parent(path: &Path) {
+    if let Some(parent) = path.parent()
+        && let Ok(dir) = fs::File::open(parent)
+    {
+        drop(dir.sync_all());
+    }
 }
 
 #[cfg(unix)]

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -1,7 +1,7 @@
 //! Filesystem helpers for private directories, atomic writes, and file locks.
 
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, Write as _};
+use std::io;
 use std::path::{Path, PathBuf};
 
 use fs2::FileExt;
@@ -39,27 +39,6 @@ pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
     write_file_private(&temp_path, bytes)?;
     replace_atomic(&temp_path, path)?;
     set_file_permissions_private(path)?;
-    Ok(())
-}
-
-pub(crate) fn append_file_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    if let Some(parent) = path.parent() {
-        ensure_dir(parent)?;
-    }
-    let mut file = open_append_file_private(path)?;
-    set_file_permissions_private(path)?;
-    file.write_all(bytes)?;
-    file.sync_all()?;
-    // Best-effort: try to durably link the (possibly freshly created) file into
-    // its directory so a crash is less likely to lose it. Like `replace_atomic`,
-    // the parent-directory fsync is best-effort — opening or fsyncing a directory
-    // is not portable (e.g. it fails on Windows), so a failure here is ignored
-    // rather than surfaced.
-    if let Some(parent) = path.parent()
-        && let Ok(dir) = fs::File::open(parent)
-    {
-        drop(dir.sync_all());
-    }
     Ok(())
 }
 
@@ -124,22 +103,6 @@ fn open_lock_file(path: &Path) -> io::Result<File> {
         .read(true)
         .write(true)
         .open(path)
-}
-
-#[cfg(unix)]
-fn open_append_file_private(path: &Path) -> io::Result<File> {
-    use std::os::unix::fs::OpenOptionsExt;
-
-    OpenOptions::new()
-        .create(true)
-        .append(true)
-        .mode(0o600)
-        .open(path)
-}
-
-#[cfg(not(unix))]
-fn open_append_file_private(path: &Path) -> io::Result<File> {
-    OpenOptions::new().create(true).append(true).open(path)
 }
 
 #[cfg(unix)]

--- a/crates/coral-app/src/storage/mod.rs
+++ b/crates/coral-app/src/storage/mod.rs
@@ -1,3 +1,4 @@
 //! Shared filesystem helpers for local persistence.
 
+pub(crate) mod app;
 pub(crate) mod fs;

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -29,5 +29,6 @@ coral-telemetry.workspace = true
 [dev-dependencies]
 coral-app.workspace = true
 jsonschema.workspace = true
+rusqlite.workspace = true
 tempfile.workspace = true
 tonic-types.workspace = true

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -21,6 +21,7 @@ use rmcp::{
     model::{CallToolRequestParams, ReadResourceRequestParams, Tool},
     service::RunningService,
 };
+use rusqlite::Connection;
 use serde_json::{Map, Value, json};
 use tempfile::TempDir;
 use tonic::Request;
@@ -243,6 +244,72 @@ async fn start_session_with_options(temp: &TempDir, options: McpOptions) -> Test
         app_server: server,
         mcp_server_task,
     }
+}
+
+fn app_database_path(temp: &TempDir) -> PathBuf {
+    temp.path().join("coral-config/state.sqlite3")
+}
+
+fn open_app_database(temp: &TempDir) -> Connection {
+    Connection::open(app_database_path(temp)).expect("open app storage database")
+}
+
+fn read_episode_records(temp: &TempDir) -> Vec<Value> {
+    let connection = open_app_database(temp);
+    let mut statement = connection
+        .prepare(
+            r"
+SELECT episode_id, workspace, intent, parent_episode_id
+FROM episodes
+ORDER BY rowid ASC
+",
+        )
+        .expect("prepare episode record query");
+    let rows = statement
+        .query_map([], |row| {
+            Ok(json!({
+                "id": row.get::<_, String>(0)?,
+                "workspace": row.get::<_, String>(1)?,
+                "intent": row.get::<_, String>(2)?,
+                "parent_episode_id": row.get::<_, Option<String>>(3)?,
+            }))
+        })
+        .expect("query episode records");
+    rows.collect::<Result<Vec<_>, _>>()
+        .expect("read episode records")
+}
+
+fn count_episode_records(temp: &TempDir) -> i64 {
+    open_app_database(temp)
+        .query_row("SELECT COUNT(*) FROM episodes", [], |row| row.get(0))
+        .expect("count episode records")
+}
+
+fn read_feedback_records(temp: &TempDir) -> Vec<Value> {
+    let connection = open_app_database(temp);
+    let mut statement = connection
+        .prepare(
+            r"
+SELECT report_id, workspace, created_at, trying_to_do, tried, stuck
+FROM feedback_reports
+ORDER BY rowid ASC
+",
+        )
+        .expect("prepare feedback record query");
+    let rows = statement
+        .query_map([], |row| {
+            Ok(json!({
+                "id": row.get::<_, String>(0)?,
+                "workspace": row.get::<_, String>(1)?,
+                "created_at": row.get::<_, String>(2)?,
+                "trying_to_do": row.get::<_, String>(3)?,
+                "tried": row.get::<_, String>(4)?,
+                "stuck": row.get::<_, String>(5)?,
+            }))
+        })
+        .expect("query feedback records");
+    rows.collect::<Result<Vec<_>, _>>()
+        .expect("read feedback records")
 }
 
 fn text_content(result: &rmcp::model::ReadResourceResult) -> &str {
@@ -469,14 +536,7 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
             .contains("argument 'episode_id' must be graphic ASCII")
     );
 
-    let episodes_path = temp
-        .path()
-        .join("coral-config/workspaces/default/episodes/episodes.jsonl");
-    let raw = fs::read_to_string(&episodes_path).expect("episode file should exist");
-    let records = raw
-        .lines()
-        .map(|line| serde_json::from_str::<Value>(line).expect("episode JSONL should parse"))
-        .collect::<Vec<_>>();
+    let records = read_episode_records(&temp);
     assert_eq!(records.len(), 2);
     let root_record = records
         .iter()
@@ -506,8 +566,7 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
             .to_string()
             .contains("missing string argument 'intent'")
     );
-    let raw_after_error = fs::read_to_string(&episodes_path).expect("episode file should exist");
-    assert_eq!(raw_after_error.lines().count(), 2);
+    assert_eq!(count_episode_records(&temp), 2);
 
     session.shutdown().await;
 }
@@ -542,12 +601,7 @@ async fn mcp_episode_tool_is_disabled_by_default() {
             .to_string()
             .contains("tool 'open_episode' not found")
     );
-    assert!(
-        !temp
-            .path()
-            .join("coral-config/workspaces/default/episodes/episodes.jsonl")
-            .exists()
-    );
+    assert_eq!(count_episode_records(&temp), 0);
 
     session.shutdown().await;
 }
@@ -1334,14 +1388,9 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
     assert_eq!(structured["message"], "Feedback report stored.");
     assert!(structured.get("upload").is_none());
 
-    let raw = fs::read_to_string(
-        temp.path()
-            .join("coral-config/workspaces/default/feedback/reports.jsonl"),
-    )
-    .expect("feedback file should exist");
-    let records = raw.lines().collect::<Vec<_>>();
+    let records = read_feedback_records(&temp);
     assert_eq!(records.len(), 1);
-    let record: Value = serde_json::from_str(records[0]).expect("feedback JSONL should parse");
+    let record = records.first().expect("feedback record");
     assert_eq!(record["id"], structured["feedback_id"]);
     assert_eq!(record["workspace"], "default");
     assert_eq!(record["trying_to_do"], "Fix failing tests");
@@ -1370,12 +1419,7 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             .contains("missing string argument 'tried'")
     );
 
-    let raw_after_error = fs::read_to_string(
-        temp.path()
-            .join("coral-config/workspaces/default/feedback/reports.jsonl"),
-    )
-    .expect("feedback file should still exist");
-    assert_eq!(raw_after_error.lines().count(), 1);
+    assert_eq!(read_feedback_records(&temp).len(), 1);
 
     session.shutdown().await;
 }
@@ -1451,12 +1495,7 @@ async fn mcp_feedback_tool_is_disabled_by_default() {
         .await
         .expect_err("feedback should not be exposed by default");
     assert!(feedback.to_string().contains("tool 'feedback' not found"));
-    assert!(
-        !temp
-            .path()
-            .join("coral-config/workspaces/default/feedback/reports.jsonl")
-            .exists()
-    );
+    assert!(read_feedback_records(&temp).is_empty());
 
     session.shutdown().await;
 }

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -222,6 +222,7 @@ On Windows, the default local state path is
 Important files include:
 
 - `config.toml` for installed-source metadata, non-secret variables, and runtime settings. See [Configuration](/reference/configuration).
+- `state.sqlite3` for Coral-owned internal state, such as local feedback reports and episode metadata.
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -11,9 +11,23 @@ Coral writes source installation state to `config.toml` when you run commands su
 
 This state includes installed-source metadata and non-secret source variables. Source secrets are stored separately within the same local trust boundary.
 
+Coral-owned internal state, such as local feedback reports and episode metadata, is stored in the configured app storage backend. The default backend is SQLite at `state.sqlite3` in the local state directory.
+
 <Note>
   Prefer the `coral source` commands for source state instead of editing workspace entries manually.
 </Note>
+
+## App storage
+
+Application storage is configured under `[storage]`.
+
+```toml
+[storage]
+backend = "sqlite"
+sqlite_path = "/path/to/coral-state.sqlite3"
+```
+
+`backend` defaults to `sqlite`, and `sqlite_path` defaults to `state.sqlite3` in the local state directory. Relative `sqlite_path` values are resolved from the local state directory. `postgres` is reserved for a future backend; current builds fail at startup if it is selected.
 
 ## Runtime features
 


### PR DESCRIPTION
## Intent

Move Coral-owned internal app state off ad hoc JSONL files and behind a DB-first storage boundary. This PR implements the SQLite backend now while leaving the repository/UoW abstraction in place for a future Postgres backend selected by config.

This intentionally does not migrate source install metadata, source artifacts, or credentials. Those remain in `config.toml`, workspace files, and credential storage.

## What it enables

- Feedback reports and episode metadata are persisted through `AppStore` repositories instead of direct file writes.
- App storage is selected from `[storage]` config, with SQLite as the default and Postgres reserved for a later implementation.
- Future backend swaps can be contained below the `AppStore`/UoW boundary instead of changing feedback or episode call sites.
- MCP and app tests now assert SQLite-backed persistence behavior.

## Usage examples

Default local SQLite storage:

```toml
[storage]
backend = "sqlite"
```

Custom SQLite path:

```toml
[storage]
backend = "sqlite"
sqlite_path = "db/coral.sqlite3"
```

Relative `sqlite_path` values resolve under Coral's local state directory. Selecting `postgres` parses but fails at startup until the backend is implemented.

## Validation

- `cargo test --locked -p coral-app --all-features storage::app::config`
- `CARGO_TARGET_DIR=/private/tmp/coral-storage-target CARGO_BUILD_RUSTC_WRAPPER= make rust-checks`

Final Rust gate result: 1308 tests passed; nextest reported 1 leaky test, non-failing.