### PR TITLE
fix(mcp): stop duplicating structured tool content

### DIFF
--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -102,6 +102,10 @@ async fn structured_tool_content(
 ) -> Result<Value, Box<dyn std::error::Error>> {
     let result = client.call_tool(request).await?;
     assert_eq!(result.is_error, Some(false));
+    assert!(
+        result.content.is_empty(),
+        "tool results should not duplicate structured payloads as text content"
+    );
     Ok(result.structured_content.expect("structured content"))
 }
 
@@ -912,6 +916,10 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
         )
         .await?;
     assert_eq!(invalid_sql.is_error, Some(true));
+    assert!(
+        invalid_sql.content.is_empty(),
+        "tool errors should not include text fallback content"
+    );
     assert_eq!(
         invalid_sql.structured_content.expect("structured content")["error"]["summary"],
         "Query request is invalid"
@@ -921,6 +929,7 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
         .call_tool(CallToolRequestParams::new("list_catalog"))
         .await?;
     assert_eq!(catalog.is_error, Some(false));
+    assert!(catalog.content.is_empty());
     assert_eq!(
         catalog.structured_content.expect("structured content")["items"][0]["name"],
         "local_messages.events"

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -738,8 +738,8 @@ fn finish_tool_call(
     match outcome {
         Ok(ToolCallOutcome::Success(value)) => {
             let result = build_tool_result(value);
-            telemetry::record_protocol_result(span, &result);
-            result
+            telemetry::record_success(span);
+            Ok(result)
         }
         Ok(ToolCallOutcome::ToolError { operation, status }) => {
             telemetry::record_tonic_status(span, &status);

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -1,58 +1,27 @@
 use std::collections::HashMap;
-use std::fmt::Write as _;
 
 use coral_client::{DecodedStatusError, decode_status_error};
-use rmcp::{
-    ErrorData,
-    model::{CallToolResult, Content},
-};
+use rmcp::{ErrorData, model::CallToolResult};
 use serde::Serialize;
-use serde_json::{Map, Value};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct ToolError {
     pub(crate) summary: String,
     pub(crate) detail: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) hint: Option<String>,
     pub(crate) grpc_code: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) reason: Option<String>,
     pub(crate) retryable: bool,
     pub(crate) metadata: HashMap<String, String>,
 }
 
-#[expect(
-    clippy::needless_pass_by_value,
-    reason = "callers always pass an owned ToolError that is not used after this call"
-)]
 pub(crate) fn tool_error_result(error: ToolError) -> CallToolResult {
-    let mut text = format!("Error: {}", error.summary);
-    if !error.detail.is_empty() {
-        write!(text, "\nDetail: {}", error.detail).expect("writing to String cannot fail");
-    }
-    if let Some(hint) = &error.hint {
-        write!(text, "\nHint: {hint}").expect("writing to String cannot fail");
-    }
-
-    let metadata = error
-        .metadata
-        .iter()
-        .map(|(key, value)| (key.clone(), Value::String(value.clone())))
-        .collect::<Map<_, _>>();
-
-    let structured = serde_json::to_value(StructuredToolErrorValue {
-        error: ToolErrorValue {
-            summary: &error.summary,
-            detail: &error.detail,
-            hint: error.hint.as_deref(),
-            grpc_code: &error.grpc_code,
-            reason: error.reason.as_deref(),
-            retryable: error.retryable,
-            metadata: Value::Object(metadata),
-        },
-    })
-    .expect("tool error value serializes");
+    let structured = serde_json::to_value(StructuredToolErrorValue { error })
+        .expect("tool error value serializes");
     let mut result = CallToolResult::structured_error(structured);
-    result.content = vec![Content::text(text)];
+    result.content = Vec::new();
     result
 }
 
@@ -142,21 +111,8 @@ pub(crate) fn status_to_error_data(status: &tonic::Status) -> ErrorData {
 }
 
 #[derive(Serialize)]
-struct StructuredToolErrorValue<'a> {
-    error: ToolErrorValue<'a>,
-}
-
-#[derive(Serialize)]
-struct ToolErrorValue<'a> {
-    summary: &'a str,
-    detail: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    hint: Option<&'a str>,
-    grpc_code: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    reason: Option<&'a str>,
-    retryable: bool,
-    metadata: Value,
+struct StructuredToolErrorValue {
+    error: ToolError,
 }
 
 #[derive(Serialize)]
@@ -200,6 +156,7 @@ mod tests {
             metadata: HashMap::new(),
         });
         assert_eq!(result.is_error, Some(true));
+        assert!(result.content.is_empty());
         let json = result.structured_content.expect("structured content");
         assert_eq!(json["error"]["grpc_code"], "InvalidArgument");
         assert_eq!(json["error"]["retryable"], false);

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rmcp::{
     ErrorData,
-    model::{CallToolResult, Content, Tool, ToolAnnotations},
+    model::{CallToolResult, Tool, ToolAnnotations},
 };
 use serde_json::{Map, Value, json};
 
@@ -485,12 +485,10 @@ pub(crate) fn optional_episode_id_argument(
     Ok(Some(value.to_string()))
 }
 
-pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
-    let compact = serde_json::to_string(&value)
-        .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+pub(crate) fn build_tool_result(value: Value) -> CallToolResult {
     let mut result = CallToolResult::structured(value);
-    result.content = vec![Content::text(compact)];
-    Ok(result)
+    result.content = Vec::new();
+    result
 }
 
 fn sql_tool_description(context: &ToolDescriptionContext) -> String {
@@ -988,7 +986,7 @@ mod tests {
     };
 
     #[test]
-    fn success_tool_result_text_uses_compact_json() {
+    fn success_tool_result_uses_structured_content_only() {
         let value = json!({
             "rows": [
                 {
@@ -1002,17 +1000,9 @@ mod tests {
             ]
         });
 
-        let result = build_tool_result(value.clone()).expect("tool result");
+        let result = build_tool_result(value.clone());
 
-        let text = result
-            .content
-            .first()
-            .and_then(|content| content.as_text())
-            .expect("text content");
-        assert_eq!(
-            text.text,
-            r#"{"rows":[{"id":1,"text":"hello"},{"id":2,"text":"world"}]}"#
-        );
+        assert!(result.content.is_empty());
         assert_eq!(
             result.structured_content.expect("structured content"),
             value

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -18,7 +18,7 @@ use coral_client::{
 use jsonschema::JSONSchema;
 use rmcp::{
     RoleClient, ServiceExt,
-    model::{CallToolRequestParams, ReadResourceRequestParams, Tool},
+    model::{CallToolRequestParams, CallToolResult, ReadResourceRequestParams, Tool},
     service::RunningService,
 };
 use serde_json::{Map, Value, json};
@@ -324,6 +324,17 @@ fn assert_matches_output_schema(tool: &Tool, value: &Value) {
     }
 }
 
+fn assert_structured_content_only(result: &CallToolResult) {
+    assert!(
+        result.content.is_empty(),
+        "tool results should not duplicate structured payloads as text content"
+    );
+    assert!(
+        result.structured_content.is_some(),
+        "tool result should expose structured_content"
+    );
+}
+
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,
@@ -389,6 +400,7 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
         .await
         .expect("open root episode");
     assert_eq!(root.is_error, Some(false));
+    assert_structured_content_only(&root);
     let root = root.structured_content.expect("root structured content");
     assert_matches_output_schema(open_episode_tool, &root);
     let root_episode_id = root["episode_id"]
@@ -415,6 +427,7 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
         .await
         .expect("open child episode");
     assert_eq!(child.is_error, Some(false));
+    assert_structured_content_only(&child);
     let child = child.structured_content.expect("child structured content");
     assert_matches_output_schema(open_episode_tool, &child);
     let child_episode_id = child["episode_id"]
@@ -434,6 +447,7 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
         .await
         .expect("tagged sql");
     assert_eq!(sql.is_error, Some(false));
+    assert_structured_content_only(&sql);
     assert_eq!(
         sql.structured_content.expect("sql structured")["rows"][0]["ok"],
         "1"
@@ -1479,6 +1493,7 @@ async fn mcp_tool_error_does_not_end_session() {
         )
         .await
         .expect("sql");
+    assert_structured_content_only(&sql);
     assert_eq!(
         sql.structured_content.expect("structured content")["rows"][0]["text"],
         "hello"
@@ -1494,16 +1509,10 @@ async fn mcp_tool_error_does_not_end_session() {
         .await
         .expect("failing sql still returns tool result");
     assert_eq!(invalid_sql.is_error, Some(true));
+    assert_structured_content_only(&invalid_sql);
     assert_eq!(
         invalid_sql.structured_content.expect("structured content")["error"]["summary"],
         "Query request is invalid"
-    );
-    assert!(
-        invalid_sql.content[0]
-            .as_text()
-            .expect("text content")
-            .text
-            .contains("Detail:")
     );
 
     let catalog_after_error = client


### PR DESCRIPTION
## What problem this fixes

MCP tool calls were returning the same machine-readable payload twice: once as `structured_content` and again as JSON or formatted text in `content`. That makes clients pay for and parse duplicate response data, and it creates ambiguity about which channel is authoritative.

This PR keeps `structured_content` as the single payload channel for Coral MCP tool successes and structured tool errors while preserving the existing single-query `sql` tool contract.

## What changed

- Clear text `content` for structured success tool results.
- Clear text `content` for structured tool errors.
- Keep structured error fields serializable directly through the shared `ToolError` shape.
- Update MCP and stdio tests to assert structured-only tool responses.

## What this intentionally does not change

- Does not add SQL query batching.
- Does not change the MCP `sql` input from `sql` to `queries`.
- Does not change CLI SQL behavior.

## Verification

- `cargo test -p coral-mcp`
- `cargo test -p coral-cli --features cli-test-server --test mcp`
- `make rust-checks`
- `$HOME/.agents/skills/autoreview/scripts/autoreview --mode local --prompt "...scope baseline..."`
