### PR TITLE
feat(mcp): segment episodes from per-call intent (store-only)

### DIFF
--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -109,14 +109,6 @@ fn assert_tool_advertises_intent(tool: &rmcp::model::Tool) {
     );
 }
 
-fn assert_tool_omits_intent(tool: &rmcp::model::Tool) {
-    assert!(
-        !tool_input_properties(tool).contains_key("intent"),
-        "tool '{}' should not advertise intent by default",
-        tool.name
-    );
-}
-
 async fn structured_tool_content(
     client: &RunningService<RoleClient, ()>,
     request: CallToolRequestParams,
@@ -342,7 +334,7 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .contains("3 table(s) and 0 table function(s) are currently visible")
     );
     for tool in &tools {
-        assert_tool_omits_intent(tool);
+        assert_tool_advertises_intent(tool);
     }
     let catalog_requests = server.list_catalog_requests();
     let count_request = catalog_requests
@@ -408,7 +400,7 @@ async fn mcp_stdio_enable_feedback_flag_lists_feedback_tool()
         ]
     );
     for tool in &tools {
-        assert_tool_omits_intent(tool);
+        assert_tool_advertises_intent(tool);
     }
 
     client.cancel().await?;

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -14,6 +14,7 @@ use std::process::{Command as StdCommand, Stdio};
 use std::time::Duration;
 use std::{fs, io};
 
+use coral_api::CORAL_EPISODE_INTENT_MAX_CHARS;
 use harness::MockServer;
 use jsonschema::JSONSchema;
 use rmcp::{
@@ -94,6 +95,18 @@ fn tool_input_properties(tool: &rmcp::model::Tool) -> &Map<String, Value> {
         .get("properties")
         .and_then(Value::as_object)
         .unwrap_or_else(|| panic!("tool '{}' should advertise input properties", tool.name))
+}
+
+fn assert_tool_advertises_intent(tool: &rmcp::model::Tool) {
+    let intent_schema = tool_input_properties(tool)
+        .get("intent")
+        .unwrap_or_else(|| panic!("tool '{}' should advertise optional intent", tool.name));
+    assert_eq!(intent_schema["type"], json!("string"));
+    assert_eq!(intent_schema["minLength"], json!(1));
+    assert_eq!(
+        intent_schema["maxLength"],
+        json!(CORAL_EPISODE_INTENT_MAX_CHARS)
+    );
 }
 
 async fn structured_tool_content(
@@ -320,6 +333,9 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .expect("search_catalog description")
             .contains("3 table(s) and 0 table function(s) are currently visible")
     );
+    for tool in &tools {
+        assert_tool_advertises_intent(tool);
+    }
     let catalog_requests = server.list_catalog_requests();
     let count_request = catalog_requests
         .last()
@@ -383,6 +399,9 @@ async fn mcp_stdio_enable_feedback_flag_lists_feedback_tool()
             "feedback"
         ]
     );
+    for tool in &tools {
+        assert_tool_advertises_intent(tool);
+    }
 
     client.cancel().await?;
     server.shutdown().await;
@@ -414,6 +433,7 @@ async fn mcp_stdio_enable_episodes_flag_lists_open_episode_tool()
         .iter()
         .filter(|tool| tool.name.as_ref() != "open_episode")
     {
+        assert_tool_advertises_intent(tool);
         assert!(
             tool_input_properties(tool).contains_key("episode_id"),
             "tool '{}' should advertise optional episode_id",
@@ -424,6 +444,7 @@ async fn mcp_stdio_enable_episodes_flag_lists_open_episode_tool()
         .iter()
         .find(|tool| tool.name.as_ref() == "open_episode")
         .expect("open_episode tool should be listed");
+    assert_tool_advertises_intent(open_episode);
     assert!(
         tool_input_properties(open_episode).contains_key("parent_episode_id"),
         "open_episode should accept an optional parent_episode_id"

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -109,6 +109,14 @@ fn assert_tool_advertises_intent(tool: &rmcp::model::Tool) {
     );
 }
 
+fn assert_tool_omits_intent(tool: &rmcp::model::Tool) {
+    assert!(
+        !tool_input_properties(tool).contains_key("intent"),
+        "tool '{}' should not advertise intent by default",
+        tool.name
+    );
+}
+
 async fn structured_tool_content(
     client: &RunningService<RoleClient, ()>,
     request: CallToolRequestParams,
@@ -334,7 +342,7 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .contains("3 table(s) and 0 table function(s) are currently visible")
     );
     for tool in &tools {
-        assert_tool_advertises_intent(tool);
+        assert_tool_omits_intent(tool);
     }
     let catalog_requests = server.list_catalog_requests();
     let count_request = catalog_requests
@@ -400,7 +408,7 @@ async fn mcp_stdio_enable_feedback_flag_lists_feedback_tool()
         ]
     );
     for tool in &tools {
-        assert_tool_advertises_intent(tool);
+        assert_tool_omits_intent(tool);
     }
 
     client.cancel().await?;

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -373,12 +373,11 @@ impl CoralMcpServer {
     ///    `ep_<uuid>`, makes it current, and opens it via `OpenEpisode`;
     /// 3. else (no intent) reuse the current episode if one exists, otherwise no tag.
     ///
-    /// Intent is used only to drive segmentation and reaches the store via `OpenEpisode` — it is
-    /// never recorded on the span (store-only; spans carry just the opaque `episode.id`).
     async fn resolve_episode_metadata(
         &self,
         name: &str,
         arguments: Option<&Map<String, Value>>,
+        intent: Option<&str>,
         span: &tracing::Span,
     ) -> Result<Option<MetadataValue<Ascii>>, ErrorData> {
         if !self.options.episodes_enabled {
@@ -390,11 +389,6 @@ impl CoralMcpServer {
         if name == "open_episode" {
             return Ok(None);
         }
-        let intent = if self.tool_accepts_optional_intent(name) {
-            optional_intent_argument(arguments, "intent")?
-        } else {
-            None
-        };
 
         // Option B: an explicit episode id wins; do not segment.
         if let Some(explicit) = explicit_episode_id {
@@ -412,7 +406,7 @@ impl CoralMcpServer {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             match intent {
                 Some(intent) => {
-                    let normalized = normalize_intent(&intent);
+                    let normalized = normalize_intent(intent);
                     match current.as_ref() {
                         Some(existing) if existing.normalized_intent == normalized => {
                             EpisodeResolution::Reuse(existing.episode_id.clone())
@@ -423,7 +417,10 @@ impl CoralMcpServer {
                                 normalized_intent: normalized,
                                 episode_id: episode_id.clone(),
                             });
-                            EpisodeResolution::Open { episode_id, intent }
+                            EpisodeResolution::Open {
+                                episode_id,
+                                intent: intent.to_string(),
+                            }
                         }
                     }
                 }
@@ -441,10 +438,7 @@ impl CoralMcpServer {
                 // Segmented episodes are roots (lineage comes from explicit open_episode). Best
                 // effort: a failed open must not fail the user's data call — log and still tag, so
                 // attribution telemetry stays meaningful and we honor "open once per intent".
-                if let Err(status) = self
-                    .open_episode_request(&episode_id, &intent, None)
-                    .await
-                {
+                if let Err(status) = self.open_episode_request(&episode_id, &intent, None).await {
                     tracing::warn!(
                         error = %status,
                         episode_id = %episode_id,
@@ -597,6 +591,7 @@ impl CoralMcpServer {
             }
             "open_episode" if self.options.episodes_enabled => {
                 let arguments = open_episode_arguments(request.arguments.as_ref())?;
+                telemetry::record_tool_intent(span, &arguments.intent);
                 match self
                     .open_episode(&arguments.intent, arguments.parent_episode_id.as_deref())
                     .await
@@ -729,21 +724,21 @@ impl ServerHandler for CoralMcpServer {
                 search_catalog_tool(&tool_context),
                 describe_table_tool(),
                 list_columns_tool(),
-            ];
+            ]
+            .into_iter()
+            .map(with_intent_argument)
+            .collect::<Vec<_>>();
             if self.options.episodes_enabled {
-                // `intent` (segmentation input) and `episode_id` (explicit attribution) are only
-                // advertised when episodes are on. `open_episode` already declares its own `intent`.
-                tools = tools
-                    .into_iter()
-                    .map(with_intent_argument)
-                    .map(with_episode_id_argument)
-                    .collect();
+                // `episode_id` is explicit attribution and is only useful when episodes are on.
+                // Regular tools always advertise `intent`; with episodes enabled, intent also
+                // drives automatic episode segmentation.
+                tools = tools.into_iter().map(with_episode_id_argument).collect();
                 tools.push(open_episode_tool());
             }
             if self.options.feedback_enabled {
-                let mut feedback = feedback_tool();
+                let mut feedback = with_intent_argument(feedback_tool());
                 if self.options.episodes_enabled {
-                    feedback = with_episode_id_argument(with_intent_argument(feedback));
+                    feedback = with_episode_id_argument(feedback);
                 }
                 tools.push(feedback);
             }
@@ -759,8 +754,21 @@ impl ServerHandler for CoralMcpServer {
     ) -> Result<CallToolResult, ErrorData> {
         let span =
             telemetry::call_tool_span(request.name.as_ref(), self.options.trace_parent.as_deref());
+        let tool_intent = if self.tool_accepts_optional_intent(request.name.as_ref()) {
+            optional_intent_argument(request.arguments.as_ref(), "intent")?
+        } else {
+            None
+        };
+        if let Some(intent) = tool_intent.as_deref() {
+            telemetry::record_tool_intent(&span, intent);
+        }
         let outcome = match self
-            .resolve_episode_metadata(request.name.as_ref(), request.arguments.as_ref(), &span)
+            .resolve_episode_metadata(
+                request.name.as_ref(),
+                request.arguments.as_ref(),
+                tool_intent.as_deref(),
+                &span,
+            )
             .await
         {
             Ok(episode_id_metadata) => {

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -35,10 +35,10 @@ use crate::{
         guide_resource_content, initial_instructions, list_catalog_arguments, list_catalog_tool,
         list_catalog_value, list_columns_arguments, list_columns_tool, list_columns_value,
         open_episode_arguments, open_episode_tool, optional_episode_id_argument,
-        required_string_argument, search_catalog_arguments, search_catalog_tool,
-        search_catalog_value, sql_tool, status_to_error_data, tables_resource,
+        optional_intent_argument, required_string_argument, search_catalog_arguments,
+        search_catalog_tool, search_catalog_value, sql_tool, status_to_error_data, tables_resource,
         tables_resource_content, tool_error_from_status, tool_error_result,
-        with_episode_id_argument,
+        with_episode_id_argument, with_intent_argument,
     },
     telemetry,
 };
@@ -489,6 +489,7 @@ impl CoralMcpServer {
             }
             "open_episode" if self.options.episodes_enabled => {
                 let arguments = open_episode_arguments(request.arguments.as_ref())?;
+                telemetry::record_tool_intent(span, &arguments.intent);
                 match self
                     .open_episode(&arguments.intent, arguments.parent_episode_id.as_deref())
                     .await
@@ -621,13 +622,16 @@ impl ServerHandler for CoralMcpServer {
                 search_catalog_tool(&tool_context),
                 describe_table_tool(),
                 list_columns_tool(),
-            ];
+            ]
+            .into_iter()
+            .map(with_intent_argument)
+            .collect::<Vec<_>>();
             if self.options.episodes_enabled {
                 tools = tools.into_iter().map(with_episode_id_argument).collect();
                 tools.push(open_episode_tool());
             }
             if self.options.feedback_enabled {
-                let feedback = feedback_tool();
+                let feedback = with_intent_argument(feedback_tool());
                 let feedback = if self.options.episodes_enabled {
                     with_episode_id_argument(feedback)
                 } else {
@@ -648,9 +652,17 @@ impl ServerHandler for CoralMcpServer {
         let span =
             telemetry::call_tool_span(request.name.as_ref(), self.options.trace_parent.as_deref());
         let inject_episode_metadata = request.name.as_ref() != "open_episode";
+        let tool_intent = if self.tool_accepts_optional_intent(request.name.as_ref()) {
+            optional_intent_argument(request.arguments.as_ref(), "intent")
+        } else {
+            Ok(None)
+        };
         let episode_tag = EpisodeTag::from_tool_request(&self.options, request.arguments.as_ref());
-        let outcome = match episode_tag {
-            Ok(episode_tag) => {
+        let outcome = match (tool_intent, episode_tag) {
+            (Ok(tool_intent), Ok(episode_tag)) => {
+                if let Some(intent) = tool_intent.as_deref() {
+                    telemetry::record_tool_intent(&span, intent);
+                }
                 episode_tag.record_telemetry(&span);
                 let episode_id_metadata = inject_episode_metadata
                     .then(|| episode_tag.into_metadata())
@@ -661,7 +673,7 @@ impl ServerHandler for CoralMcpServer {
                 )
                 .await
             }
-            Err(error) => Err(error),
+            (Err(error), _) | (_, Err(error)) => Err(error),
         };
         finish_tool_call(&span, outcome)
     }
@@ -728,6 +740,15 @@ impl ServerHandler for CoralMcpServer {
             }
         })
         .await
+    }
+}
+
+impl CoralMcpServer {
+    fn tool_accepts_optional_intent(&self, tool_name: &str) -> bool {
+        matches!(
+            tool_name,
+            "sql" | "list_catalog" | "search_catalog" | "describe_table" | "list_columns"
+        ) || (tool_name == "feedback" && self.options.feedback_enabled)
     }
 }
 

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -1,5 +1,7 @@
 //! RMCP server implementation for Coral's stdio MCP surface.
 
+use std::sync::{Arc, Mutex};
+
 use coral_api::v1::{
     CatalogItemKind as ProtoCatalogItemKind, DescribeTableRequest, DescribeTableResponse,
     ExecuteSqlRequest, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
@@ -90,47 +92,40 @@ impl ToolCallOutcome {
     }
 }
 
-#[derive(Debug, Default)]
-struct EpisodeTag {
-    episode_id: Option<String>,
-    episode_id_metadata: Option<MetadataValue<Ascii>>,
+/// The episode a session is currently attributing intent-bearing tool calls to.
+///
+/// Held per MCP session and mutated only inside the synchronous critical section of
+/// [`CoralMcpServer::resolve_episode_metadata`]. `normalized_intent` is the segmentation key —
+/// a call whose normalized intent matches reuses `episode_id`; a change mints a new one.
+#[derive(Clone, Debug)]
+struct CurrentEpisode {
+    normalized_intent: String,
+    episode_id: String,
 }
 
-impl EpisodeTag {
-    fn from_tool_request(
-        options: &McpOptions,
-        arguments: Option<&Map<String, Value>>,
-    ) -> Result<Self, ErrorData> {
-        if !options.episodes_enabled {
-            return Ok(Self::default());
-        }
-        let episode_id = optional_episode_id_argument(arguments, "episode_id")?;
-        let episode_id_metadata = episode_id
-            .as_deref()
-            .map(|episode_id| {
-                episode_id.parse().map_err(|error| {
-                    ErrorData::invalid_params(
-                        format!("argument 'episode_id' is not valid metadata: {error}"),
-                        None,
-                    )
-                })
-            })
-            .transpose()?;
-        Ok(Self {
-            episode_id,
-            episode_id_metadata,
-        })
-    }
+/// Outcome of the segmentation decision; computed under the lock, acted on after it is dropped.
+enum EpisodeResolution {
+    /// No attribution: episodes off, `open_episode`, or no intent and no current episode.
+    Untagged,
+    /// Tag with an already-known episode id; no `OpenEpisode` RPC needed.
+    Reuse(String),
+    /// A new id was minted and made current; `OpenEpisode(id, intent)` must be issued.
+    Open { episode_id: String, intent: String },
+}
 
-    fn record_telemetry(&self, span: &tracing::Span) {
-        if let Some(episode_id) = self.episode_id.as_deref() {
-            telemetry::record_episode_id(span, episode_id);
-        }
-    }
+/// Normalize intent for boundary detection: trim and collapse internal ASCII whitespace runs to a
+/// single space. Case-sensitive — a v1 heuristic; fuzzy/embedding matching is a separate issue.
+fn normalize_intent(intent: &str) -> String {
+    intent.split_whitespace().collect::<Vec<_>>().join(" ")
+}
 
-    fn into_metadata(self) -> Option<MetadataValue<Ascii>> {
-        self.episode_id_metadata
-    }
+fn episode_id_to_metadata(episode_id: &str) -> Result<MetadataValue<Ascii>, ErrorData> {
+    episode_id.parse().map_err(|error| {
+        ErrorData::invalid_params(
+            format!("argument 'episode_id' is not valid metadata: {error}"),
+            None,
+        )
+    })
 }
 
 #[derive(Clone)]
@@ -142,6 +137,10 @@ pub(crate) struct CoralMcpServer {
     episode: EpisodeClient,
     startup_context: McpStartupContext,
     options: McpOptions,
+    /// The session's current episode, used to segment intent-bearing tool calls. Shared via `Arc`
+    /// (one server instance per stdio session; rmcp dispatches calls on concurrent tasks) and
+    /// guarded by a `std::sync::Mutex` so the decide+mint critical section holds no `.await`.
+    current_episode: Arc<Mutex<Option<CurrentEpisode>>>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -185,6 +184,7 @@ impl CoralMcpServer {
             episode: app.episode_client(),
             startup_context,
             options,
+            current_episode: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -328,20 +328,33 @@ impl CoralMcpServer {
         })
     }
 
+    /// Issue a single `OpenEpisode` RPC. Shared by the explicit `open_episode` tool and by
+    /// intent-driven segmentation in [`Self::resolve_episode_metadata`].
+    async fn open_episode_request(
+        &self,
+        episode_id: &str,
+        intent: &str,
+        parent_episode_id: Option<&str>,
+    ) -> Result<(), tonic::Status> {
+        let mut episode_client = self.episode.clone();
+        episode_client
+            .open_episode(Request::new(OpenEpisodeRequest {
+                workspace: Some(default_workspace()),
+                episode_id: episode_id.to_string(),
+                intent: intent.to_string(),
+                parent_episode_id: parent_episode_id.unwrap_or_default().to_string(),
+            }))
+            .await?;
+        Ok(())
+    }
+
     async fn open_episode(
         &self,
         intent: &str,
         parent_episode_id: Option<&str>,
     ) -> Result<EpisodeOpenedValue, tonic::Status> {
         let episode_id = format!("ep_{}", uuid::Uuid::new_v4().simple());
-        let mut episode_client = self.episode.clone();
-        episode_client
-            .open_episode(Request::new(OpenEpisodeRequest {
-                workspace: Some(default_workspace()),
-                episode_id: episode_id.clone(),
-                intent: intent.to_string(),
-                parent_episode_id: parent_episode_id.unwrap_or_default().to_string(),
-            }))
+        self.open_episode_request(&episode_id, intent, parent_episode_id)
             .await?;
         Ok(EpisodeOpenedValue {
             episode_id,
@@ -349,6 +362,101 @@ impl CoralMcpServer {
             message: "Episode opened.",
             instructions: "Pass this episode_id as episode_id on subsequent Coral MCP tool calls for this work.",
         })
+    }
+
+    /// Resolve the `coral-episode-id` metadata to attribute a tool call to, segmenting episodes from
+    /// the optional per-call `intent`. Returns `Ok(None)` when nothing should be tagged.
+    ///
+    /// Precedence (episodes on, data tools only):
+    /// 1. explicit `episode_id` arg wins (no segmentation);
+    /// 2. else `intent` matching the current episode reuses it; a changed/new intent mints a fresh
+    ///    `ep_<uuid>`, makes it current, and opens it via `OpenEpisode`;
+    /// 3. else (no intent) reuse the current episode if one exists, otherwise no tag.
+    ///
+    /// Intent is used only to drive segmentation and reaches the store via `OpenEpisode` — it is
+    /// never recorded on the span (store-only; spans carry just the opaque `episode.id`).
+    async fn resolve_episode_metadata(
+        &self,
+        name: &str,
+        arguments: Option<&Map<String, Value>>,
+        span: &tracing::Span,
+    ) -> Result<Option<MetadataValue<Ascii>>, ErrorData> {
+        if !self.options.episodes_enabled {
+            return Ok(None);
+        }
+        // Validate a stray `episode_id` even for `open_episode` (preserves the "reject bad
+        // episode_id" behavior), but never tag the open call itself.
+        let explicit_episode_id = optional_episode_id_argument(arguments, "episode_id")?;
+        if name == "open_episode" {
+            return Ok(None);
+        }
+        let intent = if self.tool_accepts_optional_intent(name) {
+            optional_intent_argument(arguments, "intent")?
+        } else {
+            None
+        };
+
+        // Option B: an explicit episode id wins; do not segment.
+        if let Some(explicit) = explicit_episode_id {
+            let metadata = episode_id_to_metadata(&explicit)?;
+            telemetry::record_episode_id(span, &explicit);
+            return Ok(Some(metadata));
+        }
+
+        // Synchronous decide+mint critical section: holds no `.await` (the rmcp-spawned future must
+        // be `Send`, so a held `std::sync::MutexGuard` across an await would not compile).
+        let resolution = {
+            let mut current = self
+                .current_episode
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            match intent {
+                Some(intent) => {
+                    let normalized = normalize_intent(&intent);
+                    match current.as_ref() {
+                        Some(existing) if existing.normalized_intent == normalized => {
+                            EpisodeResolution::Reuse(existing.episode_id.clone())
+                        }
+                        _ => {
+                            let episode_id = format!("ep_{}", uuid::Uuid::new_v4().simple());
+                            *current = Some(CurrentEpisode {
+                                normalized_intent: normalized,
+                                episode_id: episode_id.clone(),
+                            });
+                            EpisodeResolution::Open { episode_id, intent }
+                        }
+                    }
+                }
+                None => match current.as_ref() {
+                    Some(existing) => EpisodeResolution::Reuse(existing.episode_id.clone()),
+                    None => EpisodeResolution::Untagged,
+                },
+            }
+        };
+
+        let episode_id = match resolution {
+            EpisodeResolution::Untagged => return Ok(None),
+            EpisodeResolution::Reuse(episode_id) => episode_id,
+            EpisodeResolution::Open { episode_id, intent } => {
+                // Segmented episodes are roots (lineage comes from explicit open_episode). Best
+                // effort: a failed open must not fail the user's data call — log and still tag, so
+                // attribution telemetry stays meaningful and we honor "open once per intent".
+                if let Err(status) = self
+                    .open_episode_request(&episode_id, &intent, None)
+                    .await
+                {
+                    tracing::warn!(
+                        error = %status,
+                        episode_id = %episode_id,
+                        "failed to open episode for intent segmentation"
+                    );
+                }
+                episode_id
+            }
+        };
+        let metadata = episode_id_to_metadata(&episode_id)?;
+        telemetry::record_episode_id(span, &episode_id);
+        Ok(Some(metadata))
     }
 
     async fn submit_feedback_value(
@@ -489,7 +597,6 @@ impl CoralMcpServer {
             }
             "open_episode" if self.options.episodes_enabled => {
                 let arguments = open_episode_arguments(request.arguments.as_ref())?;
-                telemetry::record_tool_intent(span, &arguments.intent);
                 match self
                     .open_episode(&arguments.intent, arguments.parent_episode_id.as_deref())
                     .await
@@ -622,21 +729,22 @@ impl ServerHandler for CoralMcpServer {
                 search_catalog_tool(&tool_context),
                 describe_table_tool(),
                 list_columns_tool(),
-            ]
-            .into_iter()
-            .map(with_intent_argument)
-            .collect::<Vec<_>>();
+            ];
             if self.options.episodes_enabled {
-                tools = tools.into_iter().map(with_episode_id_argument).collect();
+                // `intent` (segmentation input) and `episode_id` (explicit attribution) are only
+                // advertised when episodes are on. `open_episode` already declares its own `intent`.
+                tools = tools
+                    .into_iter()
+                    .map(with_intent_argument)
+                    .map(with_episode_id_argument)
+                    .collect();
                 tools.push(open_episode_tool());
             }
             if self.options.feedback_enabled {
-                let feedback = with_intent_argument(feedback_tool());
-                let feedback = if self.options.episodes_enabled {
-                    with_episode_id_argument(feedback)
-                } else {
-                    feedback
-                };
+                let mut feedback = feedback_tool();
+                if self.options.episodes_enabled {
+                    feedback = with_episode_id_argument(with_intent_argument(feedback));
+                }
                 tools.push(feedback);
             }
             Ok(ListToolsResult::with_all_items(tools))
@@ -651,29 +759,18 @@ impl ServerHandler for CoralMcpServer {
     ) -> Result<CallToolResult, ErrorData> {
         let span =
             telemetry::call_tool_span(request.name.as_ref(), self.options.trace_parent.as_deref());
-        let inject_episode_metadata = request.name.as_ref() != "open_episode";
-        let tool_intent = if self.tool_accepts_optional_intent(request.name.as_ref()) {
-            optional_intent_argument(request.arguments.as_ref(), "intent")
-        } else {
-            Ok(None)
-        };
-        let episode_tag = EpisodeTag::from_tool_request(&self.options, request.arguments.as_ref());
-        let outcome = match (tool_intent, episode_tag) {
-            (Ok(tool_intent), Ok(episode_tag)) => {
-                if let Some(intent) = tool_intent.as_deref() {
-                    telemetry::record_tool_intent(&span, intent);
-                }
-                episode_tag.record_telemetry(&span);
-                let episode_id_metadata = inject_episode_metadata
-                    .then(|| episode_tag.into_metadata())
-                    .flatten();
+        let outcome = match self
+            .resolve_episode_metadata(request.name.as_ref(), request.arguments.as_ref(), &span)
+            .await
+        {
+            Ok(episode_id_metadata) => {
                 telemetry::instrument(
                     span.clone(),
                     with_episode_metadata(episode_id_metadata, self.dispatch_tool(request, &span)),
                 )
                 .await
             }
-            (Err(error), _) | (_, Err(error)) => Err(error),
+            Err(error) => Err(error),
         };
         finish_tool_call(&span, outcome)
     }

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -22,6 +22,7 @@ pub(crate) use tools::{
     CatalogToolKind, ToolDescriptionContext, build_tool_result, describe_table_arguments,
     describe_table_tool, feedback_tool, list_catalog_arguments, list_catalog_tool,
     list_columns_arguments, list_columns_tool, open_episode_arguments, open_episode_tool,
-    optional_episode_id_argument, required_string_argument, search_catalog_arguments,
-    search_catalog_tool, sql_tool, with_episode_id_argument,
+    optional_episode_id_argument, optional_intent_argument, required_string_argument,
+    search_catalog_arguments, search_catalog_tool, sql_tool, with_episode_id_argument,
+    with_intent_argument,
 };

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -13,6 +13,7 @@ use super::{
 };
 
 const EPISODE_ID_ARGUMENT_DESCRIPTION: &str = "Optional episode id returned by open_episode. Pass it on subsequent Coral tool calls for the same task so Coral can attribute the call to that episode.";
+const TOOL_INTENT_ARGUMENT_DESCRIPTION: &str = "Optional natural-language description of what this tool call is trying to accomplish. Supplying intent helps Coral attribute and learn from tool-use traces without changing query behavior.";
 const EPISODE_ID_JSON_SCHEMA_PATTERN: &str = "^[!-~]+$";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -385,8 +386,17 @@ pub(crate) fn required_string_argument(
 pub(crate) fn open_episode_arguments(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<OpenEpisodeArguments, ErrorData> {
+    let intent = required_string_argument(arguments, "intent")?;
+    if intent.chars().count() > CORAL_EPISODE_INTENT_MAX_CHARS {
+        return Err(ErrorData::invalid_params(
+            format!(
+                "argument 'intent' must be at most {CORAL_EPISODE_INTENT_MAX_CHARS} characters"
+            ),
+            None,
+        ));
+    }
     Ok(OpenEpisodeArguments {
-        intent: required_string_argument(arguments, "intent")?,
+        intent,
         parent_episode_id: optional_episode_id_argument(arguments, "parent_episode_id")?,
     })
 }
@@ -485,6 +495,35 @@ pub(crate) fn optional_episode_id_argument(
     Ok(Some(value.to_string()))
 }
 
+pub(crate) fn optional_intent_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+) -> Result<Option<String>, ErrorData> {
+    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let value = value.as_str().ok_or_else(|| {
+        ErrorData::invalid_params(format!("argument '{key}' must be a string"), None)
+    })?;
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(ErrorData::invalid_params(
+            format!("argument '{key}' must not be blank"),
+            None,
+        ));
+    }
+    if value.chars().count() > CORAL_EPISODE_INTENT_MAX_CHARS {
+        return Err(ErrorData::invalid_params(
+            format!("argument '{key}' must be at most {CORAL_EPISODE_INTENT_MAX_CHARS} characters"),
+            None,
+        ));
+    }
+    Ok(Some(value.to_string()))
+}
+
 pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
     let compact = serde_json::to_string(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
@@ -520,6 +559,28 @@ fn search_catalog_description(context: &ToolDescriptionContext) -> String {
 pub(crate) fn with_episode_id_argument(mut tool: Tool) -> Tool {
     add_episode_id_property(Arc::make_mut(&mut tool.input_schema));
     tool
+}
+
+pub(crate) fn with_intent_argument(mut tool: Tool) -> Tool {
+    add_intent_property(Arc::make_mut(&mut tool.input_schema));
+    tool
+}
+
+fn add_intent_property(schema: &mut Map<String, Value>) {
+    schema
+        .entry("properties")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .expect("tool input properties are an object")
+        .entry("intent".to_string())
+        .or_insert_with(|| {
+            json!({
+                "type": "string",
+                "description": TOOL_INTENT_ARGUMENT_DESCRIPTION,
+                "minLength": 1,
+                "maxLength": CORAL_EPISODE_INTENT_MAX_CHARS
+            })
+        });
 }
 
 fn add_episode_id_property(schema: &mut Map<String, Value>) {
@@ -984,7 +1045,7 @@ mod tests {
     use super::{
         EPISODE_ID_ARGUMENT_DESCRIPTION, ToolDescriptionContext, build_tool_result,
         connected_source_names_text, list_catalog_arguments, search_catalog_arguments,
-        search_catalog_tool, sql_tool, with_episode_id_argument,
+        search_catalog_tool, sql_tool, with_episode_id_argument, with_intent_argument,
     };
 
     #[test]
@@ -1081,6 +1142,32 @@ mod tests {
         assert_eq!(
             episode_id_schema.get("description").and_then(Value::as_str),
             Some(EPISODE_ID_ARGUMENT_DESCRIPTION)
+        );
+    }
+
+    #[test]
+    fn with_intent_argument_decorates_tool_schema() {
+        let context = ToolDescriptionContext::new(1, 0, Vec::new());
+        let tool = sql_tool(&context);
+        let properties = tool
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("input properties");
+        assert!(!properties.contains_key("intent"));
+
+        let tool = with_intent_argument(tool);
+        let intent_schema = tool
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .and_then(|properties| properties.get("intent"))
+            .expect("intent schema");
+
+        assert_eq!(intent_schema.get("type"), Some(&json!("string")));
+        assert_eq!(
+            intent_schema.get("maxLength"),
+            Some(&json!(coral_api::CORAL_EPISODE_INTENT_MAX_CHARS))
         );
     }
 

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -50,6 +50,7 @@ pub(crate) fn call_tool_span(tool_name: &str, trace_parent: Option<&str>) -> tra
         error.type = field::Empty,
         exception.message = field::Empty,
         mcp.method = "tools/call",
+        mcp.tool.intent = field::Empty,
         mcp.tool.name = tool_name,
         otel.kind = "server",
         otel.name = "coral.mcp.call_tool",
@@ -124,6 +125,10 @@ pub(crate) fn record_success(span: &tracing::Span) {
 
 pub(crate) fn record_episode_id(span: &tracing::Span, episode_id: &str) {
     span.record("episode.id", episode_id);
+}
+
+pub(crate) fn record_tool_intent(span: &tracing::Span, intent: &str) {
+    span.record("mcp.tool.intent", intent);
 }
 
 fn record_error(span: &tracing::Span, error_type: &str, message: impl std::fmt::Display) {

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -54,7 +54,6 @@ pub(crate) fn call_tool_span(tool_name: &str, trace_parent: Option<&str>) -> tra
         otel.kind = "server",
         otel.name = "coral.mcp.call_tool",
         episode.id = field::Empty,
-        tool.intent = field::Empty,
         status = field::Empty,
     );
     apply_trace_parent(&span, trace_parent);
@@ -125,10 +124,6 @@ pub(crate) fn record_success(span: &tracing::Span) {
 
 pub(crate) fn record_episode_id(span: &tracing::Span, episode_id: &str) {
     span.record("episode.id", episode_id);
-}
-
-pub(crate) fn record_tool_intent(span: &tracing::Span, intent: &str) {
-    span.record("tool.intent", intent);
 }
 
 fn record_error(span: &tracing::Span, error_type: &str, message: impl std::fmt::Display) {

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -54,6 +54,7 @@ pub(crate) fn call_tool_span(tool_name: &str, trace_parent: Option<&str>) -> tra
         otel.kind = "server",
         otel.name = "coral.mcp.call_tool",
         episode.id = field::Empty,
+        tool.intent = field::Empty,
         status = field::Empty,
     );
     apply_trace_parent(&span, trace_parent);
@@ -124,6 +125,10 @@ pub(crate) fn record_success(span: &tracing::Span) {
 
 pub(crate) fn record_episode_id(span: &tracing::Span, episode_id: &str) {
     span.record("episode.id", episode_id);
+}
+
+pub(crate) fn record_tool_intent(span: &tracing::Span, intent: &str) {
+    span.record("tool.intent", intent);
 }
 
 fn record_error(span: &tracing::Span, error_type: &str, message: impl std::fmt::Display) {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -287,14 +287,6 @@ fn assert_tool_advertises_intent(tool: &Tool) {
     );
 }
 
-fn assert_tool_omits_intent(tool: &Tool) {
-    assert!(
-        !tool_input_properties(tool).contains_key("intent"),
-        "tool '{}' should not advertise intent by default",
-        tool.name
-    );
-}
-
 /// Read the per-workspace episode records (one JSON object per JSONL line) for the default workspace.
 fn read_episode_records(temp: &TempDir) -> Vec<Value> {
     let episodes_path = temp
@@ -577,7 +569,7 @@ async fn mcp_episode_tool_is_disabled_by_default() {
         "open_episode should not be listed by default"
     );
     for tool in &tools {
-        assert_tool_omits_intent(tool);
+        assert_tool_advertises_intent(tool);
         assert_tool_omits_episode_id(tool);
     }
 
@@ -595,7 +587,7 @@ async fn mcp_episode_tool_is_disabled_by_default() {
             .contains("tool 'open_episode' not found")
     );
 
-    // A stray `intent` on a data call is ignored when episodes are off — no segmentation, no store.
+    // A data-tool `intent` is accepted even when episodes are off — no segmentation, no store.
     let sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
@@ -606,6 +598,21 @@ async fn mcp_episode_tool_is_disabled_by_default() {
         .await
         .expect("sql should run with episodes disabled");
     assert_eq!(sql.is_error, Some(false));
+
+    let invalid_intent = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "sql": "SELECT 1",
+                "intent": " "
+            }))),
+        )
+        .await
+        .expect_err("blank tool intent should fail before query dispatch");
+    assert!(
+        invalid_intent
+            .to_string()
+            .contains("argument 'intent' must not be blank")
+    );
     assert!(
         !temp
             .path()

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -287,6 +287,26 @@ fn assert_tool_advertises_intent(tool: &Tool) {
     );
 }
 
+fn assert_tool_omits_intent(tool: &Tool) {
+    assert!(
+        !tool_input_properties(tool).contains_key("intent"),
+        "tool '{}' should not advertise intent by default",
+        tool.name
+    );
+}
+
+/// Read the per-workspace episode records (one JSON object per JSONL line) for the default workspace.
+fn read_episode_records(temp: &TempDir) -> Vec<Value> {
+    let episodes_path = temp
+        .path()
+        .join("coral-config/workspaces/default/episodes/episodes.jsonl");
+    fs::read_to_string(&episodes_path)
+        .expect("episode file should exist")
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("episode JSONL should parse"))
+        .collect()
+}
+
 fn assert_nullable_episode_id_schema(schema: &Value, label: &str) {
     let any_of = schema
         .get("anyOf")
@@ -557,7 +577,7 @@ async fn mcp_episode_tool_is_disabled_by_default() {
         "open_episode should not be listed by default"
     );
     for tool in &tools {
-        assert_tool_advertises_intent(tool);
+        assert_tool_omits_intent(tool);
         assert_tool_omits_episode_id(tool);
     }
 
@@ -574,12 +594,185 @@ async fn mcp_episode_tool_is_disabled_by_default() {
             .to_string()
             .contains("tool 'open_episode' not found")
     );
+
+    // A stray `intent` on a data call is ignored when episodes are off — no segmentation, no store.
+    let sql = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "sql": "SELECT 1 AS ok",
+                "intent": "Investigate customer renewal risk"
+            }))),
+        )
+        .await
+        .expect("sql should run with episodes disabled");
+    assert_eq!(sql.is_error, Some(false));
     assert!(
         !temp
             .path()
             .join("coral-config/workspaces/default/episodes/episodes.jsonl")
             .exists()
     );
+
+    session.shutdown().await;
+}
+
+/// Open an episodes-enabled MCP session for the segmentation tests below.
+async fn start_episodes_session(temp: &TempDir) -> TestSession {
+    start_session_with_options(
+        temp,
+        McpOptions {
+            episodes_enabled: true,
+            ..McpOptions::default()
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn mcp_intent_opens_one_episode_then_reuses_while_stable() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_episodes_session(&temp).await;
+    let client = &session.client;
+
+    for _ in 0..2 {
+        let result = client
+            .call_tool(
+                CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                    "sql": "SELECT 1 AS ok",
+                    "intent": "Investigate customer renewal risk"
+                }))),
+            )
+            .await
+            .expect("sql with intent");
+        assert_eq!(result.is_error, Some(false));
+    }
+
+    // Same intent across both calls → a single root episode, opened once.
+    let records = read_episode_records(&temp);
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["intent"], "Investigate customer renewal risk");
+    assert_eq!(records[0]["parent_episode_id"], Value::Null);
+    assert!(records[0]["id"].as_str().expect("id").starts_with("ep_"));
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_changed_intent_opens_a_new_episode() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_episodes_session(&temp).await;
+    let client = &session.client;
+
+    for intent in ["Investigate renewal risk", "Draft the renewal email"] {
+        client
+            .call_tool(
+                CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                    "sql": "SELECT 1 AS ok",
+                    "intent": intent
+                }))),
+            )
+            .await
+            .expect("sql with intent");
+    }
+
+    let records = read_episode_records(&temp);
+    assert_eq!(records.len(), 2);
+    let intents = records
+        .iter()
+        .map(|record| record["intent"].as_str().expect("intent").to_string())
+        .collect::<Vec<_>>();
+    assert!(intents.contains(&"Investigate renewal risk".to_string()));
+    assert!(intents.contains(&"Draft the renewal email".to_string()));
+    // Intent-segmented episodes are roots; lineage is not inferred from the intent stream.
+    for record in &records {
+        assert_eq!(record["parent_episode_id"], Value::Null);
+    }
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_intent_normalization_collapses_whitespace_into_one_episode() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_episodes_session(&temp).await;
+    let client = &session.client;
+
+    for intent in ["renewal   risk", "renewal risk"] {
+        client
+            .call_tool(
+                CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                    "sql": "SELECT 1 AS ok",
+                    "intent": intent
+                }))),
+            )
+            .await
+            .expect("sql with intent");
+    }
+
+    // Internal-whitespace-only difference normalizes equal → reuse, so just one episode.
+    let records = read_episode_records(&temp);
+    assert_eq!(records.len(), 1);
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_explicit_episode_id_wins_over_intent() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_episodes_session(&temp).await;
+    let client = &session.client;
+
+    let root = client
+        .call_tool(
+            CallToolRequestParams::new("open_episode").with_arguments(json_object(&json!({
+                "intent": "Investigate renewal risk"
+            }))),
+        )
+        .await
+        .expect("open episode");
+    let episode_id = root.structured_content.expect("structured")["episode_id"]
+        .as_str()
+        .expect("episode id")
+        .to_string();
+    assert_eq!(read_episode_records(&temp).len(), 1);
+
+    // A different intent alongside an explicit episode_id must not open a new episode.
+    let sql = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "sql": "SELECT 1 AS ok",
+                "episode_id": episode_id,
+                "intent": "A completely different task"
+            }))),
+        )
+        .await
+        .expect("tagged sql");
+    assert_eq!(sql.is_error, Some(false));
+    assert_eq!(read_episode_records(&temp).len(), 1);
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_concurrent_same_intent_opens_single_episode() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_episodes_session(&temp).await;
+    let client = &session.client;
+
+    let call = || {
+        client.call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "sql": "SELECT 1 AS ok",
+                "intent": "Investigate renewal risk"
+            }))),
+        )
+    };
+    // Two concurrent calls with the same new intent must mint exactly one episode (mint-under-lock).
+    let (a, b) = tokio::join!(call(), call());
+    a.expect("first concurrent sql");
+    b.expect("second concurrent sql");
+
+    assert_eq!(read_episode_records(&temp).len(), 1);
 
     session.shutdown().await;
 }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use coral_api::{
-    CORAL_EPISODE_ID_MAX_LEN,
+    CORAL_EPISODE_ID_MAX_LEN, CORAL_EPISODE_INTENT_MAX_CHARS,
     v1::{ImportSourceRequest, import_source_response},
 };
 use coral_client::{
@@ -275,6 +275,18 @@ fn assert_tool_advertises_episode_id(tool: &Tool) {
     assert_nullable_episode_id_schema(episode_id_schema, tool.name.as_ref());
 }
 
+fn assert_tool_advertises_intent(tool: &Tool) {
+    let intent_schema = tool_input_properties(tool)
+        .get("intent")
+        .unwrap_or_else(|| panic!("tool '{}' should advertise optional intent", tool.name));
+    assert_eq!(intent_schema["type"], json!("string"));
+    assert_eq!(intent_schema["minLength"], json!(1));
+    assert_eq!(
+        intent_schema["maxLength"],
+        json!(CORAL_EPISODE_INTENT_MAX_CHARS)
+    );
+}
+
 fn assert_nullable_episode_id_schema(schema: &Value, label: &str) {
     let any_of = schema
         .get("anyOf")
@@ -363,9 +375,12 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
         "describe_table",
         "list_columns",
     ] {
-        assert_tool_advertises_episode_id(tool_by_name(&tools, name));
+        let tool = tool_by_name(&tools, name);
+        assert_tool_advertises_intent(tool);
+        assert_tool_advertises_episode_id(tool);
     }
     let open_episode_tool = tool_by_name(&tools, "open_episode");
+    assert_tool_advertises_intent(open_episode_tool);
     assert!(!tool_input_properties(open_episode_tool).contains_key("episode_id"));
     let parent_episode_id_schema = tool_input_properties(open_episode_tool)
         .get("parent_episode_id")
@@ -428,7 +443,8 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
                 "sql": "SELECT 1 AS ok",
-                "episode_id": child_episode_id
+                "episode_id": child_episode_id,
+                "intent": "Verify the child episode can run a SQL probe"
             }))),
         )
         .await
@@ -452,6 +468,21 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
         invalid_episode_id
             .to_string()
             .contains("argument 'episode_id' must be graphic ASCII")
+    );
+
+    let invalid_intent = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "sql": "SELECT 1",
+                "intent": " "
+            }))),
+        )
+        .await
+        .expect_err("blank tool intent should fail before query dispatch");
+    assert!(
+        invalid_intent
+            .to_string()
+            .contains("argument 'intent' must not be blank")
     );
 
     let invalid_open_episode_id = client
@@ -526,6 +557,7 @@ async fn mcp_episode_tool_is_disabled_by_default() {
         "open_episode should not be listed by default"
     );
     for tool in &tools {
+        assert_tool_advertises_intent(tool);
         assert_tool_omits_episode_id(tool);
     }
 


### PR DESCRIPTION
## What & why

BENCH-496 MCP path (Option A): let coding agents annotate Coral tool calls with a free-text `intent`, and turn that stream into **episodes** captured in the per-tenant episode store — the substrate for trajectory/golden-path mining.

Builds on the draft `feat(mcp): add optional tool intent` and reworks it per design discussion into **store-only segmentation**:

- **Gate `intent` behind the `episodes` flag** (was unconditional). Off by default it is neither advertised, parsed, nor recorded.
- **Per-session segmentation.** `CoralMcpServer` holds a current episode. On a data-tool call: explicit `episode_id` wins; otherwise an `intent` matching the current episode **reuses** it, a **changed/new** intent mints `ep_<uuid>` + fires `OpenEpisode` and becomes current, and **no intent** reuses the current episode if one exists. `OpenEpisode` fires only on intent **change**, not per call.
- **Store-only.** Removed the `tool.intent` span field — intent reaches **only** the episode store; spans carry just the opaque `episode.id`. Keeps BENCH-496's "intent never on spans/logs" invariant (single governed PII home; intelligence layer joins `query span → episode.id → store`).
- **Flat roots.** Intent-segmented episodes have no parent; real lineage stays with explicit `open_episode(parent_episode_id)`. The store keeps the parent column for future compositional reuse.

## Why store, not spans
The trajectory corpus is a durable, complete system-of-record (spans are sampled + TTL'd), and intent is high-PII free text that should come to rest in exactly one governed location. Stamping only `episode.id` on spans keeps full trace correlation without spraying intent across observability sinks.

## Concurrency
The decide+mint critical section holds no `.await` — rmcp `tokio::spawn`s each `call_tool` future, so the `Send` requirement makes a held `std::sync::MutexGuard` across `.await` a compile error, statically enforcing the invariant. Two concurrent calls with the same new intent mint exactly one episode (mint-under-lock). `OpenEpisode` is awaited best-effort outside the lock; a failed open never fails the user's tool call.

## Tests
- `coral-mcp`: gated advertisement (off → no `intent`); new segmentation tests — open-once/reuse, changed-intent → new episode, whitespace-normalization, explicit `episode_id` wins, concurrent same-intent → single episode, off-by-default ignores stray intent.
- `coral-cli` (`--features cli-test-server`): list-tools advertisement gating.
- `cargo test -p coral-mcp` (42 pass) and `cargo test -p coral-cli --test mcp --features cli-test-server` (14 pass); clippy clean.

## Out of scope (filed)
- **BENCH-680** — document the episodes model in the MCP `initialize` instructions (intent → suggestions once retrieval lands; `start_task` for multi-call tasks).
- **BENCH-681** — rename `open_episode` → a task-native name (e.g. `start_task`).

Refs BENCH-496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
