### PR TITLE
feat(app): persist workspace state

### DIFF
--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -96,6 +96,9 @@ pub const CORAL_EPISODE_INTENT_MAX_CHARS: usize = 4096;
 /// Machine-readable reason for a configured source lookup miss.
 pub const CORAL_ERROR_REASON_SOURCE_NOT_FOUND: &str = "SOURCE_NOT_FOUND";
 
+/// Machine-readable reason for a configured workspace lookup miss.
+pub const CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND: &str = "WORKSPACE_NOT_FOUND";
+
 /// Reserved `ErrorInfo.metadata` key for a one-line error summary.
 pub const CORAL_ERROR_METADATA_SUMMARY: &str = "summary";
 

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -3,6 +3,7 @@
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_DETAIL, CORAL_ERROR_METADATA_HINT,
     CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+    CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND,
 };
 use coral_engine::{CoreError, StatusCode};
 use tonic::{Code, Status};
@@ -16,6 +17,12 @@ pub enum AppError {
     /// A requested source was not found in config.
     #[error("source '{0}' not found")]
     SourceNotFound(String),
+    /// A requested workspace was not found in config.
+    #[error("workspace '{0}' not found")]
+    WorkspaceNotFound(String),
+    /// A requested workspace already exists in config.
+    #[error("workspace '{0}' already exists")]
+    WorkspaceAlreadyExists(String),
     /// Caller-supplied input was invalid.
     #[error("invalid input: {0}")]
     InvalidInput(String),
@@ -107,16 +114,16 @@ fn truncate_status_detail(detail: String) -> String {
     reason = "used directly as a map_err adapter across tonic service handlers"
 )]
 pub(crate) fn app_status(error: AppError) -> Status {
-    if matches!(error, AppError::SourceNotFound(_)) {
-        // The `reason` alone discriminates `SOURCE_NOT_FOUND` from other
-        // `Code::NotFound` causes (e.g. `io::ErrorKind::NotFound` raised
-        // when a manifest file is missing). The qualified name already
-        // appears in the truncated status message; we deliberately do
-        // not duplicate it into structured metadata so unbounded
-        // identifiers cannot push the `grpc-status-details-bin` trailer
-        // past the h2 `MAX_HEADER_LIST_SIZE` budget.
+    let not_found_reason = match &error {
+        AppError::SourceNotFound(_) => Some(CORAL_ERROR_REASON_SOURCE_NOT_FOUND),
+        AppError::WorkspaceNotFound(_) => Some(CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND),
+        _ => None,
+    };
+    if let Some(reason) = not_found_reason {
+        // The `reason` alone discriminates typed Coral misses from other
+        // `Code::NotFound` causes without echoing unbounded identifiers.
         let details = vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
-            CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+            reason,
             CORAL_ERROR_DOMAIN,
             std::collections::HashMap::new(),
         ))];
@@ -194,7 +201,8 @@ fn grpc_code(status: StatusCode) -> Code {
 
 fn app_code(error: &AppError) -> Code {
     match error {
-        AppError::SourceNotFound(_) => Code::NotFound,
+        AppError::SourceNotFound(_) | AppError::WorkspaceNotFound(_) => Code::NotFound,
+        AppError::WorkspaceAlreadyExists(_) => Code::AlreadyExists,
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
         | AppError::MissingOrIncompatibleV4Materialization { .. }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -549,6 +549,8 @@ fn query_error_message(error: &QueryManagerError) -> String {
 fn app_error_type(error: &AppError) -> &'static str {
     match error {
         AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
+        AppError::WorkspaceNotFound(_) => "WORKSPACE_NOT_FOUND",
+        AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",
         AppError::InvalidInput(_) => "INVALID_INPUT",
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
         AppError::MissingOrIncompatibleV4Materialization { .. } => {

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -248,6 +248,9 @@ impl QueryManager {
             .config_store
             .load_config()
             .map_err(QueryManagerError::App)?;
+        config
+            .require_workspace(workspace_name)
+            .map_err(QueryManagerError::App)?;
         let source = config
             .get_source(workspace_name, source_name)
             .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
@@ -279,6 +282,7 @@ impl QueryManager {
             source.count = tracing::field::Empty,
         );
         let _guard = span.enter();
+        config.require_workspace(workspace_name)?;
         let mut query_sources = Vec::new();
         for source in config.workspace_sources(workspace_name) {
             match self.load_query_source(workspace_name, &source) {
@@ -658,6 +662,55 @@ mod tests {
         QueryManagerFixture {
             _temp: temp,
             manager,
+        }
+    }
+
+    fn assert_workspace_not_found(error: AppError, workspace_name: &WorkspaceName) {
+        match error {
+            AppError::WorkspaceNotFound(actual) => assert_eq!(actual, workspace_name.as_str()),
+            error => panic!("expected WorkspaceNotFound for '{workspace_name}', got {error}"),
+        }
+    }
+
+    #[test]
+    fn load_query_sources_fails_closed_for_missing_workspace() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        let missing_workspace = WorkspaceName::parse("missing").expect("workspace");
+        let config = fixture
+            .manager
+            .config_store
+            .load_config()
+            .expect("load config");
+
+        let error = fixture
+            .manager
+            .load_query_sources(&missing_workspace, &config)
+            .expect_err("missing workspace should fail closed");
+
+        assert_workspace_not_found(error, &missing_workspace);
+    }
+
+    #[tokio::test]
+    async fn validate_source_fails_with_workspace_not_found_for_missing_workspace() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        let missing_workspace = WorkspaceName::parse("missing").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source");
+
+        let result = fixture
+            .manager
+            .validate_source(&missing_workspace, &source_name)
+            .await;
+        let Err(error) = result else {
+            panic!("missing workspace should fail before source lookup");
+        };
+
+        match error {
+            QueryManagerError::App(error) => {
+                assert_workspace_not_found(error, &missing_workspace);
+            }
+            QueryManagerError::Core(error) => {
+                panic!("expected app error for missing workspace, got {error}");
+            }
         }
     }
 

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -32,7 +32,6 @@ use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthC
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
-use uuid::Uuid;
 
 #[derive(Clone)]
 pub(crate) struct SourceManager {
@@ -506,14 +505,10 @@ impl SourceManager {
             );
             return Err(error);
         }
-        let source_dir_backup =
-            source_dir.with_file_name(format!("{source_name}.delete.rollback.{}", Uuid::new_v4()));
-        let had_source_dir = source_dir.exists();
-        if had_source_dir {
-            if source_dir_backup.exists() {
-                std::fs::remove_dir_all(&source_dir_backup)?;
-            }
-            if let Err(error) = std::fs::rename(&source_dir, &source_dir_backup) {
+        let source_dir_backup = match fs::DirectoryBackup::move_for_delete(&source_dir, source_name)
+        {
+            Ok(backup) => backup,
+            Err(error) => {
                 self.restore_source_rollback_state(
                     workspace_name,
                     source_name,
@@ -523,17 +518,9 @@ impl SourceManager {
                 );
                 return Err(error.into());
             }
-        }
+        };
         if let Err(error) = self.config_store.remove_source(workspace_name, source_name) {
-            if had_source_dir
-                && source_dir_backup.exists()
-                && let Err(restore_error) = std::fs::rename(&source_dir_backup, &source_dir)
-            {
-                return Err(AppError::FailedPrecondition(format!(
-                    "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
-                    source_dir_backup.display()
-                )));
-            }
+            let restore_dir_result = source_dir_backup.restore();
             self.restore_source_rollback_state(
                 workspace_name,
                 source_name,
@@ -541,11 +528,15 @@ impl SourceManager {
                 None,
                 &credential_guard,
             );
+            if let Err(restore_error) = restore_dir_result {
+                return Err(AppError::FailedPrecondition(format!(
+                    "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
+                    source_dir_backup.backup_path().display()
+                )));
+            }
             return Err(error);
         }
-        if source_dir_backup.exists() {
-            std::fs::remove_dir_all(&source_dir_backup)?;
-        }
+        source_dir_backup.commit()?;
         cleanup_empty_parent(&self.layout.workspaces_root(), source_dir.parent());
         cleanup_empty_parent(
             &self.layout.workspaces_root(),

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -1,6 +1,8 @@
 //! Persists the installed source catalog in top-level `config.toml`.
 
-use std::collections::BTreeMap;
+#![expect(dead_code, reason = "used in next stack PR")]
+
+use std::collections::{BTreeMap, BTreeSet};
 
 use coral_engine::{DependentJoinConfig, DependentJoinSourceConfig, MemorySize, QueryMemoryConfig};
 use serde::{Deserialize, Serialize};
@@ -14,11 +16,13 @@ use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
 use crate::storage::fs::{self as storage_fs, FileLock};
 use crate::workspaces::WorkspaceName;
+use crate::workspaces::{WorkspaceRecord, WorkspaceStore};
 
 #[derive(Debug, Clone)]
 pub(crate) struct AppConfig {
     version: u32,
     engine: PersistedEngineConfig,
+    workspaces: WorkspaceCatalog,
     catalog: SourceCatalog,
 }
 
@@ -27,12 +31,21 @@ impl Default for AppConfig {
         Self {
             version: default_config_version(),
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
         }
     }
 }
 
 impl AppConfig {
+    pub(crate) fn workspaces(&self) -> Vec<WorkspaceRecord> {
+        self.workspaces.list()
+    }
+
+    pub(crate) fn has_workspace(&self, workspace_name: &WorkspaceName) -> bool {
+        self.workspaces.contains(workspace_name)
+    }
+
     pub(crate) fn workspace_sources(&self, workspace_name: &WorkspaceName) -> Vec<InstalledSource> {
         self.catalog.workspace_sources(workspace_name)
     }
@@ -215,6 +228,37 @@ impl From<&InstalledSource> for PersistedInstalledSource {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceCatalog(BTreeSet<WorkspaceName>);
+
+impl Default for WorkspaceCatalog {
+    fn default() -> Self {
+        Self(BTreeSet::from([WorkspaceName::default()]))
+    }
+}
+
+impl WorkspaceCatalog {
+    pub(crate) fn list(&self) -> Vec<WorkspaceRecord> {
+        self.0
+            .iter()
+            .cloned()
+            .map(|name| WorkspaceRecord { name })
+            .collect()
+    }
+
+    pub(crate) fn contains(&self, workspace_name: &WorkspaceName) -> bool {
+        self.0.contains(workspace_name)
+    }
+
+    pub(crate) fn insert(&mut self, workspace_name: WorkspaceName) -> bool {
+        self.0.insert(workspace_name)
+    }
+
+    pub(crate) fn remove(&mut self, workspace_name: &WorkspaceName) -> bool {
+        self.0.remove(workspace_name)
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SourceCatalog(BTreeMap<WorkspaceName, BTreeMap<SourceName, InstalledSource>>);
 
@@ -289,6 +333,13 @@ impl SourceCatalog {
         }
 
         removed
+    }
+
+    pub(crate) fn remove_workspace(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Option<BTreeMap<SourceName, InstalledSource>> {
+        self.0.remove(workspace_name)
     }
 }
 
@@ -427,31 +478,76 @@ impl ConfigStore {
         self.load_config().map(|config| config.catalog)
     }
 
-    fn update_catalog<T>(
+    fn update_config<T>(
         &self,
-        update: impl FnOnce(&mut SourceCatalog) -> T,
+        update: impl FnOnce(&mut AppConfig) -> Result<T, AppError>,
     ) -> Result<T, AppError> {
         let _lock = self.lock_exclusive()?;
         let mut config = self.load_unlocked()?;
-        let result = update(&mut config.catalog);
+        let result = update(&mut config)?;
         self.save_unlocked(&config)?;
         Ok(result)
+    }
+
+    pub(crate) fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, AppError> {
+        self.load_config().map(|config| config.workspaces())
+    }
+
+    pub(crate) fn create_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<WorkspaceRecord, AppError> {
+        self.update_config(|config| {
+            if config.workspaces.insert(workspace_name.clone()) {
+                Ok(WorkspaceRecord {
+                    name: workspace_name.clone(),
+                })
+            } else {
+                Err(AppError::WorkspaceAlreadyExists(workspace_name.to_string()))
+            }
+        })
+    }
+
+    pub(crate) fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<WorkspaceRecord>, AppError> {
+        self.update_config(|config| {
+            if workspace_name == &WorkspaceName::default() {
+                return Err(AppError::FailedPrecondition(
+                    "default workspace cannot be removed".to_string(),
+                ));
+            }
+            let removed = config.workspaces.remove(workspace_name);
+            if removed {
+                config.catalog.remove_workspace(workspace_name);
+            }
+            Ok(removed.then(|| WorkspaceRecord {
+                name: workspace_name.clone(),
+            }))
+        })
     }
 
     pub(crate) fn list_workspace_sources(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<InstalledSource>, AppError> {
-        self.load_catalog()
-            .map(|catalog| catalog.workspace_sources(workspace_name))
+        let config = self.load_config()?;
+        if !config.has_workspace(workspace_name) {
+            return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
+        }
+        Ok(config.workspace_sources(workspace_name))
     }
 
     pub(crate) fn list_workspace_source_names(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<String>, AppError> {
-        self.load_catalog()
-            .map(|catalog| catalog.workspace_source_names(workspace_name))
+        let config = self.load_config()?;
+        if !config.has_workspace(workspace_name) {
+            return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
+        }
+        Ok(config.catalog.workspace_source_names(workspace_name))
     }
 
     pub(crate) fn get_source(
@@ -459,7 +555,12 @@ impl ConfigStore {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
-        self.load_catalog()?
+        let config = self.load_config()?;
+        if !config.has_workspace(workspace_name) {
+            return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
+        }
+        config
+            .catalog
             .get_source(workspace_name, source_name)
             .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }
@@ -469,7 +570,13 @@ impl ConfigStore {
         workspace_name: &WorkspaceName,
         source: InstalledSource,
     ) -> Result<(), AppError> {
-        self.update_catalog(|catalog| catalog.upsert_source(workspace_name, source))
+        self.update_config(|config| {
+            if !config.has_workspace(workspace_name) {
+                return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
+            }
+            config.catalog.upsert_source(workspace_name, source);
+            Ok(())
+        })
     }
 
     pub(crate) fn remove_source(
@@ -477,9 +584,51 @@ impl ConfigStore {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<(), AppError> {
-        self.update_catalog(|catalog| {
-            catalog.remove_source(workspace_name, source_name);
+        self.update_config(|config| {
+            if !config.has_workspace(workspace_name) {
+                return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
+            }
+            config.catalog.remove_source(workspace_name, source_name);
+            Ok(())
         })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ConfigWorkspaceStore {
+    config_store: ConfigStore,
+}
+
+impl ConfigWorkspaceStore {
+    pub(crate) fn new(config_store: ConfigStore) -> Self {
+        Self { config_store }
+    }
+}
+
+impl WorkspaceStore for ConfigWorkspaceStore {
+    fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, AppError> {
+        self.config_store.list_workspaces()
+    }
+
+    fn create_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<WorkspaceRecord, AppError> {
+        self.config_store.create_workspace(workspace_name)
+    }
+
+    fn list_workspace_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        self.config_store.list_workspace_sources(workspace_name)
+    }
+
+    fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<WorkspaceRecord>, AppError> {
+        self.config_store.delete_workspace(workspace_name)
     }
 }
 
@@ -495,13 +644,19 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
     doc["version"] = value(i64::from(config.version));
     render_engine_config(&mut doc, &config.engine);
 
-    // Remove and fully rebuild the workspaces section so removed sources don't linger.
+    // Remove and fully rebuild the workspaces section so removed sources and
+    // removed empty workspaces don't linger.
     doc.remove("workspaces");
+
+    for workspace_name in config.workspaces.keys() {
+        ensure_implicit_table(&mut doc["workspaces"]);
+        ensure_explicit_table(&mut doc["workspaces"][workspace_name]);
+    }
 
     for (workspace_name, workspace) in &config.workspaces {
         for (source_name, source) in &workspace.sources {
             ensure_implicit_table(&mut doc["workspaces"]);
-            ensure_implicit_table(&mut doc["workspaces"][workspace_name]);
+            ensure_explicit_table(&mut doc["workspaces"][workspace_name]);
             ensure_implicit_table(&mut doc["workspaces"][workspace_name]["sources"]);
 
             let source_item = &mut doc["workspaces"][workspace_name]["sources"][source_name];
@@ -598,13 +753,24 @@ fn ensure_implicit_table(item: &mut Item) {
         .set_implicit(true);
 }
 
+fn ensure_explicit_table(item: &mut Item) {
+    if !item.is_table() {
+        *item = toml_edit::table();
+    }
+    item.as_table_mut()
+        .expect("table item must be available")
+        .set_implicit(false);
+}
+
 impl TryFrom<PersistedAppConfig> for AppConfig {
     type Error = AppError;
 
     fn try_from(value: PersistedAppConfig) -> Result<Self, Self::Error> {
+        let mut workspaces = WorkspaceCatalog::default();
         let mut catalog = SourceCatalog::default();
         for (workspace_name, workspace_config) in value.workspaces {
             let workspace_name = WorkspaceName::parse(&workspace_name)?;
+            workspaces.insert(workspace_name.clone());
             for (source_name, source) in workspace_config.sources {
                 let source_name = SourceName::parse(&source_name)?;
                 catalog.upsert_source(&workspace_name, source.into_installed_source(source_name));
@@ -613,6 +779,7 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
         Ok(Self {
             version: value.version,
             engine: value.engine,
+            workspaces,
             catalog,
         })
     }
@@ -621,6 +788,11 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
 impl From<&AppConfig> for PersistedAppConfig {
     fn from(value: &AppConfig) -> Self {
         let mut workspaces = BTreeMap::new();
+        for workspace in value.workspaces.list() {
+            workspaces
+                .entry(workspace.name.as_str().to_string())
+                .or_insert_with(PersistedWorkspaceConfig::default);
+        }
         for (workspace_name, sources) in &value.catalog.0 {
             let workspace_config = workspaces
                 .entry(workspace_name.as_str().to_string())
@@ -808,8 +980,8 @@ mod tests {
 
     use super::{
         AppConfig, PersistedAppConfig, PersistedEngineConfig, PersistedMemoryConfig,
-        RawFeatureContainerState, RawFeatureValue, SourceCatalog, load_raw_feature_overrides,
-        render_config, set_raw_feature_override,
+        RawFeatureContainerState, RawFeatureValue, SourceCatalog, WorkspaceCatalog,
+        load_raw_feature_overrides, render_config, set_raw_feature_override,
     };
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
@@ -881,6 +1053,7 @@ mod tests {
         let config = AppConfig {
             version: 1,
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog,
         };
 
@@ -895,6 +1068,46 @@ mod tests {
     }
 
     #[test]
+    fn renders_empty_workspaces_as_explicit_tables() {
+        let mut workspaces = WorkspaceCatalog::default();
+        workspaces.insert(WorkspaceName::parse("work").expect("workspace"));
+        let config = AppConfig {
+            version: 1,
+            engine: PersistedEngineConfig::default(),
+            workspaces,
+            catalog: SourceCatalog::default(),
+        };
+
+        let raw = render_config(&PersistedAppConfig::from(&config), None);
+
+        assert!(raw.contains("[workspaces.default]"));
+        assert!(raw.contains("[workspaces.work]"));
+    }
+
+    #[test]
+    fn loads_empty_workspace_tables() {
+        let raw = r"
+version = 1
+
+[workspaces.default]
+
+[workspaces.work]
+";
+
+        let config = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(raw).expect("workspace config should parse"),
+        )
+        .expect("config");
+        let names = config
+            .workspaces()
+            .into_iter()
+            .map(|workspace| workspace.name.as_str().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["default", "work"]);
+    }
+
+    #[test]
     fn omits_empty_versions_from_rendered_source_entries() {
         let workspace_name = default_workspace();
         let mut source = installed_source("github");
@@ -905,6 +1118,7 @@ mod tests {
         let config = AppConfig {
             version: 1,
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog,
         };
 
@@ -1090,6 +1304,7 @@ limit = 2147483648
                 },
                 ..PersistedEngineConfig::default()
             },
+            workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
         };
 
@@ -1115,6 +1330,7 @@ flag = true
                 },
                 ..PersistedEngineConfig::default()
             },
+            workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
         };
 
@@ -1140,6 +1356,7 @@ flag = true
         let config = AppConfig {
             version: 1,
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
         };
 
@@ -1274,6 +1491,7 @@ max_concurrency = 0
         let config = AppConfig {
             version: 1,
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog,
         };
 
@@ -1379,6 +1597,7 @@ origin = "bundled"
         let config = AppConfig {
             version: 1,
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog,
         };
 

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -1,7 +1,5 @@
 //! Persists the installed source catalog in top-level `config.toml`.
 
-#![expect(dead_code, reason = "used in next stack PR")]
-
 use std::collections::{BTreeMap, BTreeSet};
 
 use coral_engine::{DependentJoinConfig, DependentJoinSourceConfig, MemorySize, QueryMemoryConfig};
@@ -15,8 +13,7 @@ use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
 use crate::storage::fs::{self as storage_fs, FileLock};
-use crate::workspaces::WorkspaceName;
-use crate::workspaces::{WorkspaceRecord, WorkspaceStore};
+use crate::workspaces::{WorkspaceName, WorkspaceRecord, WorkspaceStore};
 
 #[derive(Debug, Clone)]
 pub(crate) struct AppConfig {
@@ -44,6 +41,14 @@ impl AppConfig {
 
     pub(crate) fn has_workspace(&self, workspace_name: &WorkspaceName) -> bool {
         self.workspaces.contains(workspace_name)
+    }
+
+    pub(crate) fn require_workspace(&self, workspace_name: &WorkspaceName) -> Result<(), AppError> {
+        if self.has_workspace(workspace_name) {
+            Ok(())
+        } else {
+            Err(AppError::WorkspaceNotFound(workspace_name.to_string()))
+        }
     }
 
     pub(crate) fn workspace_sources(&self, workspace_name: &WorkspaceName) -> Vec<InstalledSource> {
@@ -533,9 +538,7 @@ impl ConfigStore {
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<InstalledSource>, AppError> {
         let config = self.load_config()?;
-        if !config.has_workspace(workspace_name) {
-            return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
-        }
+        config.require_workspace(workspace_name)?;
         Ok(config.workspace_sources(workspace_name))
     }
 
@@ -544,9 +547,7 @@ impl ConfigStore {
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<String>, AppError> {
         let config = self.load_config()?;
-        if !config.has_workspace(workspace_name) {
-            return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
-        }
+        config.require_workspace(workspace_name)?;
         Ok(config.catalog.workspace_source_names(workspace_name))
     }
 
@@ -556,9 +557,7 @@ impl ConfigStore {
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
         let config = self.load_config()?;
-        if !config.has_workspace(workspace_name) {
-            return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
-        }
+        config.require_workspace(workspace_name)?;
         config
             .catalog
             .get_source(workspace_name, source_name)
@@ -571,9 +570,7 @@ impl ConfigStore {
         source: InstalledSource,
     ) -> Result<(), AppError> {
         self.update_config(|config| {
-            if !config.has_workspace(workspace_name) {
-                return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
-            }
+            config.require_workspace(workspace_name)?;
             config.catalog.upsert_source(workspace_name, source);
             Ok(())
         })
@@ -585,50 +582,37 @@ impl ConfigStore {
         source_name: &SourceName,
     ) -> Result<(), AppError> {
         self.update_config(|config| {
-            if !config.has_workspace(workspace_name) {
-                return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
-            }
+            config.require_workspace(workspace_name)?;
             config.catalog.remove_source(workspace_name, source_name);
             Ok(())
         })
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct ConfigWorkspaceStore {
-    config_store: ConfigStore,
-}
-
-impl ConfigWorkspaceStore {
-    pub(crate) fn new(config_store: ConfigStore) -> Self {
-        Self { config_store }
-    }
-}
-
-impl WorkspaceStore for ConfigWorkspaceStore {
+impl WorkspaceStore for ConfigStore {
     fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, AppError> {
-        self.config_store.list_workspaces()
+        ConfigStore::list_workspaces(self)
     }
 
     fn create_workspace(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<WorkspaceRecord, AppError> {
-        self.config_store.create_workspace(workspace_name)
+        ConfigStore::create_workspace(self, workspace_name)
     }
 
     fn list_workspace_sources(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<InstalledSource>, AppError> {
-        self.config_store.list_workspace_sources(workspace_name)
+        ConfigStore::list_workspace_sources(self, workspace_name)
     }
 
     fn delete_workspace(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Option<WorkspaceRecord>, AppError> {
-        self.config_store.delete_workspace(workspace_name)
+        ConfigStore::delete_workspace(self, workspace_name)
     }
 }
 
@@ -979,9 +963,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        AppConfig, PersistedAppConfig, PersistedEngineConfig, PersistedMemoryConfig,
-        RawFeatureContainerState, RawFeatureValue, SourceCatalog, WorkspaceCatalog,
-        load_raw_feature_overrides, render_config, set_raw_feature_override,
+        AppConfig, AppError, ConfigStore, PersistedAppConfig, PersistedEngineConfig,
+        PersistedMemoryConfig, RawFeatureContainerState, RawFeatureValue, SourceCatalog,
+        WorkspaceCatalog, load_raw_feature_overrides, render_config, set_raw_feature_override,
     };
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
@@ -1040,9 +1024,33 @@ mod tests {
         names.iter().map(|name| (*name).to_string()).collect()
     }
 
+    fn assert_workspace_not_found<T>(result: Result<T, AppError>, workspace_name: &WorkspaceName) {
+        match result {
+            Err(AppError::WorkspaceNotFound(actual)) => {
+                assert_eq!(actual, workspace_name.as_str());
+            }
+            Ok(_) => panic!("expected WorkspaceNotFound for '{workspace_name}'"),
+            Err(error) => panic!("expected WorkspaceNotFound for '{workspace_name}', got {error}"),
+        }
+    }
+
     #[test]
     fn default_config_uses_canonical_version() {
         assert_eq!(AppConfig::default().version, 1);
+    }
+
+    #[test]
+    fn require_workspace_rejects_missing_workspace() {
+        let config = AppConfig::default();
+        let missing_workspace = WorkspaceName::parse("missing").expect("workspace");
+
+        config
+            .require_workspace(&default_workspace())
+            .expect("default workspace should exist");
+        assert_workspace_not_found(
+            config.require_workspace(&missing_workspace),
+            &missing_workspace,
+        );
     }
 
     #[test]
@@ -1174,6 +1182,35 @@ origin = "bundled"
                 "linear".to_string(),
                 "slack".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn scoped_config_store_methods_reject_missing_workspace() {
+        let temp = TempDir::new().expect("temp dir");
+        let store = ConfigStore::new(test_layout(&temp));
+        let missing_workspace = WorkspaceName::parse("missing").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source");
+
+        assert_workspace_not_found(
+            store.list_workspace_sources(&missing_workspace),
+            &missing_workspace,
+        );
+        assert_workspace_not_found(
+            store.list_workspace_source_names(&missing_workspace),
+            &missing_workspace,
+        );
+        assert_workspace_not_found(
+            store.get_source(&missing_workspace, &source_name),
+            &missing_workspace,
+        );
+        assert_workspace_not_found(
+            store.upsert_source(&missing_workspace, installed_source("github")),
+            &missing_workspace,
+        );
+        assert_workspace_not_found(
+            store.remove_source(&missing_workspace, &source_name),
+            &missing_workspace,
         );
     }
 

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -13,7 +13,7 @@ use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
 use crate::storage::fs::{self as storage_fs, FileLock};
-use crate::workspaces::{WorkspaceName, WorkspaceRecord, WorkspaceStore};
+use crate::workspaces::{DeletedWorkspace, WorkspaceName, WorkspaceRecord, WorkspaceStore};
 
 #[derive(Debug, Clone)]
 pub(crate) struct AppConfig {
@@ -516,20 +516,29 @@ impl ConfigStore {
     pub(crate) fn delete_workspace(
         &self,
         workspace_name: &WorkspaceName,
-    ) -> Result<Option<WorkspaceRecord>, AppError> {
+    ) -> Result<Option<DeletedWorkspace>, AppError> {
         self.update_config(|config| {
-            if workspace_name == &WorkspaceName::default() {
+            if workspace_name.is_default() {
                 return Err(AppError::FailedPrecondition(
                     "default workspace cannot be removed".to_string(),
                 ));
             }
             let removed = config.workspaces.remove(workspace_name);
             if removed {
-                config.catalog.remove_workspace(workspace_name);
+                let sources = config
+                    .catalog
+                    .remove_workspace(workspace_name)
+                    .map(BTreeMap::into_values)
+                    .map(Iterator::collect)
+                    .unwrap_or_default();
+                return Ok(Some(DeletedWorkspace {
+                    workspace: WorkspaceRecord {
+                        name: workspace_name.clone(),
+                    },
+                    sources,
+                }));
             }
-            Ok(removed.then(|| WorkspaceRecord {
-                name: workspace_name.clone(),
-            }))
+            Ok(None)
         })
     }
 
@@ -601,17 +610,10 @@ impl WorkspaceStore for ConfigStore {
         ConfigStore::create_workspace(self, workspace_name)
     }
 
-    fn list_workspace_sources(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<Vec<InstalledSource>, AppError> {
-        ConfigStore::list_workspace_sources(self, workspace_name)
-    }
-
     fn delete_workspace(
         &self,
         workspace_name: &WorkspaceName,
-    ) -> Result<Option<WorkspaceRecord>, AppError> {
+    ) -> Result<Option<DeletedWorkspace>, AppError> {
         ConfigStore::delete_workspace(self, workspace_name)
     }
 }
@@ -1211,6 +1213,33 @@ origin = "bundled"
         assert_workspace_not_found(
             store.remove_source(&missing_workspace, &source_name),
             &missing_workspace,
+        );
+    }
+
+    #[test]
+    fn delete_workspace_returns_removed_sources() {
+        let temp = TempDir::new().expect("temp dir");
+        let store = ConfigStore::new(test_layout(&temp));
+        let workspace_name = WorkspaceName::parse("work").expect("workspace");
+
+        store
+            .create_workspace(&workspace_name)
+            .expect("create workspace");
+        store
+            .upsert_source(&workspace_name, installed_source("github"))
+            .expect("upsert source");
+
+        let deleted = store
+            .delete_workspace(&workspace_name)
+            .expect("delete workspace")
+            .expect("workspace should be deleted");
+
+        assert_eq!(deleted.workspace.name, workspace_name);
+        assert_eq!(deleted.sources.len(), 1);
+        assert_eq!(deleted.sources[0].name.as_str(), "github");
+        assert_workspace_not_found(
+            store.list_workspace_sources(&deleted.workspace.name),
+            &deleted.workspace.name,
         );
     }
 

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -3,8 +3,7 @@
 mod config;
 mod layout;
 
-#[expect(unused_imports, reason = "used in next stack PR")]
-pub(crate) use config::{AppConfig, ConfigStore, ConfigWorkspaceStore};
+pub(crate) use config::{AppConfig, ConfigStore};
 pub(crate) use config::{
     RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue, load_raw_feature_overrides,
     set_raw_feature_override,

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -3,7 +3,8 @@
 mod config;
 mod layout;
 
-pub(crate) use config::{AppConfig, ConfigStore};
+#[expect(unused_imports, reason = "used in next stack PR")]
+pub(crate) use config::{AppConfig, ConfigStore, ConfigWorkspaceStore};
 pub(crate) use config::{
     RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue, load_raw_feature_overrides,
     set_raw_feature_override,

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -87,14 +87,14 @@ pub(crate) struct DirectoryBackup {
 impl DirectoryBackup {
     pub(crate) fn move_for_delete(path: &Path, name: impl fmt::Display) -> io::Result<Self> {
         let backup = path.with_file_name(format!("{name}.delete.rollback.{}", Uuid::new_v4()));
-        if !path.exists() {
+        if !path.try_exists()? {
             return Ok(Self {
                 original: path.to_path_buf(),
                 backup,
                 moved: false,
             });
         }
-        if backup.exists() {
+        if backup.try_exists()? {
             fs::remove_dir_all(&backup)?;
         }
         fs::rename(path, &backup)?;
@@ -110,8 +110,8 @@ impl DirectoryBackup {
     }
 
     pub(crate) fn restore(&self) -> io::Result<()> {
-        if self.moved && self.backup.exists() {
-            if self.original.exists() {
+        if self.moved && self.backup.try_exists()? {
+            if self.original.try_exists()? {
                 fs::remove_dir_all(&self.original)?;
             }
             fs::rename(&self.backup, &self.original)?;
@@ -120,7 +120,7 @@ impl DirectoryBackup {
     }
 
     pub(crate) fn commit(&self) -> io::Result<()> {
-        if self.moved && self.backup.exists() {
+        if self.moved && self.backup.try_exists()? {
             fs::remove_dir_all(&self.backup)?;
         }
         Ok(())

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -1,10 +1,12 @@
 //! Filesystem helpers for private directories, atomic writes, and file locks.
 
+use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 
 use fs2::FileExt;
+use uuid::Uuid;
 
 pub(crate) fn ensure_dir(path: &Path) -> io::Result<()> {
     if path.as_os_str().is_empty() || path == Path::new(".") {
@@ -73,6 +75,56 @@ pub(crate) fn replace_atomic(from: &Path, to: &Path) -> io::Result<()> {
     }
 
     Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) struct DirectoryBackup {
+    original: PathBuf,
+    backup: PathBuf,
+    moved: bool,
+}
+
+impl DirectoryBackup {
+    pub(crate) fn move_for_delete(path: &Path, name: impl fmt::Display) -> io::Result<Self> {
+        let backup = path.with_file_name(format!("{name}.delete.rollback.{}", Uuid::new_v4()));
+        if !path.exists() {
+            return Ok(Self {
+                original: path.to_path_buf(),
+                backup,
+                moved: false,
+            });
+        }
+        if backup.exists() {
+            fs::remove_dir_all(&backup)?;
+        }
+        fs::rename(path, &backup)?;
+        Ok(Self {
+            original: path.to_path_buf(),
+            backup,
+            moved: true,
+        })
+    }
+
+    pub(crate) fn backup_path(&self) -> &Path {
+        &self.backup
+    }
+
+    pub(crate) fn restore(&self) -> io::Result<()> {
+        if self.moved && self.backup.exists() {
+            if self.original.exists() {
+                fs::remove_dir_all(&self.original)?;
+            }
+            fs::rename(&self.backup, &self.original)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn commit(&self) -> io::Result<()> {
+        if self.moved && self.backup.exists() {
+            fs::remove_dir_all(&self.backup)?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -209,4 +261,63 @@ fn set_file_permissions_private(path: &Path) -> io::Result<()> {
 #[cfg(not(unix))]
 fn set_file_permissions_private(_path: &Path) -> io::Result<()> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DirectoryBackup;
+
+    #[test]
+    fn directory_backup_moves_and_restores_delete_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source_dir = temp.path().join("github");
+        std::fs::create_dir(&source_dir).expect("create source dir");
+        std::fs::write(source_dir.join("manifest.yaml"), "name: github\n").expect("write file");
+
+        let backup = DirectoryBackup::move_for_delete(&source_dir, "github").expect("move backup");
+
+        assert!(!source_dir.exists());
+        assert!(backup.backup_path().exists());
+        assert!(
+            backup
+                .backup_path()
+                .file_name()
+                .expect("backup filename")
+                .to_string_lossy()
+                .starts_with("github.delete.rollback.")
+        );
+
+        backup.restore().expect("restore backup");
+
+        assert!(source_dir.join("manifest.yaml").exists());
+        assert!(!backup.backup_path().exists());
+    }
+
+    #[test]
+    fn directory_backup_commits_delete_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir(&workspace_dir).expect("create workspace dir");
+
+        let backup =
+            DirectoryBackup::move_for_delete(&workspace_dir, "workspace").expect("move backup");
+        backup.commit().expect("commit backup");
+
+        assert!(!workspace_dir.exists());
+        assert!(!backup.backup_path().exists());
+    }
+
+    #[test]
+    fn directory_backup_noops_for_missing_delete_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let missing_dir = temp.path().join("missing");
+
+        let backup =
+            DirectoryBackup::move_for_delete(&missing_dir, "missing").expect("prepare backup");
+        backup.restore().expect("restore missing");
+        backup.commit().expect("commit missing");
+
+        assert!(!missing_dir.exists());
+        assert!(!backup.backup_path().exists());
+    }
 }

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 use tracing::warn;
 
 use crate::bootstrap::AppError;
-use crate::credentials::{CredentialManager, CredentialMaterialSnapshot, CredentialSetId};
+use crate::credentials::{CredentialManager, CredentialSetId};
 use crate::state::AppStateLayout;
 use crate::storage::fs::DirectoryBackup;
-use crate::workspaces::{DEFAULT_WORKSPACE_ID, WorkspaceName, WorkspaceRecord, WorkspaceStore};
+use crate::workspaces::{DeletedWorkspace, WorkspaceName, WorkspaceRecord, WorkspaceStore};
 
 /// App-owned workspace lifecycle behavior.
 #[derive(Clone)]
@@ -46,46 +46,28 @@ impl WorkspaceManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<WorkspaceRecord, AppError> {
-        if workspace_name.as_str() == DEFAULT_WORKSPACE_ID {
+        if workspace_name.is_default() {
             return Err(AppError::FailedPrecondition(
                 "default workspace cannot be removed".to_string(),
             ));
         }
 
-        let credential_snapshots = self.remove_workspace_credentials(workspace_name)?;
-        let workspace_dir = self.layout.workspace_dir(workspace_name);
-        let backup = match DirectoryBackup::move_for_delete(&workspace_dir, workspace_name) {
-            Ok(backup) => backup,
-            Err(error) => {
-                self.restore_workspace_credentials(workspace_name, &credential_snapshots);
-                return Err(error.into());
-            }
-        };
-
-        match self.store.delete_workspace(workspace_name) {
-            Ok(Some(record)) => {
-                backup.commit()?;
-                Ok(record)
-            }
-            Ok(None) => {
-                backup.commit()?;
-                Err(AppError::WorkspaceNotFound(workspace_name.to_string()))
-            }
-            Err(error) => {
-                let restore_dir_result = backup.restore();
-                self.restore_workspace_credentials(workspace_name, &credential_snapshots);
-                restore_dir_result?;
-                Err(error)
-            }
-        }
+        let deleted = self
+            .store
+            .delete_workspace(workspace_name)?
+            .ok_or_else(|| AppError::WorkspaceNotFound(workspace_name.to_string()))?;
+        self.cleanup_deleted_workspace_artifacts(&deleted);
+        Ok(deleted.workspace)
     }
 
-    fn remove_workspace_credentials(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<Vec<WorkspaceCredentialSnapshot>, AppError> {
-        let mut snapshots = Vec::new();
-        for source in self.store.list_workspace_sources(workspace_name)? {
+    fn cleanup_deleted_workspace_artifacts(&self, deleted: &DeletedWorkspace) {
+        self.remove_deleted_workspace_credentials(deleted);
+        self.remove_deleted_workspace_dir(&deleted.workspace.name);
+    }
+
+    fn remove_deleted_workspace_credentials(&self, deleted: &DeletedWorkspace) {
+        let workspace_name = &deleted.workspace.name;
+        for source in &deleted.sources {
             let Some(storage) = source.credential_storage_for_material() else {
                 continue;
             };
@@ -96,93 +78,135 @@ impl WorkspaceManager {
             {
                 Ok(guard) => guard,
                 Err(error) => {
-                    return self.rollback_removed_workspace_credentials(
-                        workspace_name,
-                        &snapshots,
-                        error,
-                    );
-                }
-            };
-            let snapshot = match guard.snapshot_material(storage) {
-                Ok(snapshot) => snapshot,
-                Err(error) => {
-                    return self.rollback_removed_workspace_credentials(
-                        workspace_name,
-                        &snapshots,
-                        error,
-                    );
-                }
-            };
-            if let Err(error) = guard.remove_material(storage) {
-                return self.rollback_removed_workspace_credentials_with_snapshot(
-                    workspace_name,
-                    &mut snapshots,
-                    WorkspaceCredentialSnapshot {
-                        credential_set_id,
-                        snapshot,
-                    },
-                    error,
-                );
-            }
-            snapshots.push(WorkspaceCredentialSnapshot {
-                credential_set_id,
-                snapshot,
-            });
-        }
-        Ok(snapshots)
-    }
-
-    fn rollback_removed_workspace_credentials<T>(
-        &self,
-        workspace_name: &WorkspaceName,
-        snapshots: &[WorkspaceCredentialSnapshot],
-        error: AppError,
-    ) -> Result<T, AppError> {
-        self.restore_workspace_credentials(workspace_name, snapshots);
-        Err(error)
-    }
-
-    fn rollback_removed_workspace_credentials_with_snapshot<T>(
-        &self,
-        workspace_name: &WorkspaceName,
-        snapshots: &mut Vec<WorkspaceCredentialSnapshot>,
-        snapshot: WorkspaceCredentialSnapshot,
-        error: AppError,
-    ) -> Result<T, AppError> {
-        snapshots.push(snapshot);
-        self.rollback_removed_workspace_credentials(workspace_name, snapshots, error)
-    }
-
-    fn restore_workspace_credentials(
-        &self,
-        workspace_name: &WorkspaceName,
-        snapshots: &[WorkspaceCredentialSnapshot],
-    ) {
-        for snapshot in snapshots.iter().rev() {
-            let guard = match self
-                .credential_manager
-                .material_guard(workspace_name, &snapshot.credential_set_id)
-            {
-                Ok(guard) => guard,
-                Err(error) => {
                     warn!(
-                        credential_set_id = %snapshot.credential_set_id,
-                        "rollback: failed to access workspace credential material: {error}"
+                        workspace = %workspace_name,
+                        source = %source.name,
+                        credential_set_id = %credential_set_id,
+                        "workspace deleted, but failed to access credential material for cleanup: {error}"
                     );
                     continue;
                 }
             };
-            if let Err(error) = guard.restore_material(&snapshot.snapshot) {
+            if let Err(error) = guard.remove_material(storage) {
                 warn!(
-                    credential_set_id = %snapshot.credential_set_id,
-                    "rollback: failed to restore workspace credential material: {error}"
+                    workspace = %workspace_name,
+                    source = %source.name,
+                    credential_set_id = %credential_set_id,
+                    %storage,
+                    "workspace deleted, but failed to remove credential material: {error}"
                 );
             }
         }
     }
+
+    fn remove_deleted_workspace_dir(&self, workspace_name: &WorkspaceName) {
+        let workspace_dir = self.layout.workspace_dir(workspace_name);
+        let backup = match DirectoryBackup::move_for_delete(&workspace_dir, workspace_name) {
+            Ok(backup) => backup,
+            Err(error) => {
+                warn!(
+                    workspace = %workspace_name,
+                    workspace_dir = %workspace_dir.display(),
+                    "workspace deleted, but failed to stage workspace directory cleanup: {error}"
+                );
+                return;
+            }
+        };
+        if let Err(error) = backup.commit() {
+            warn!(
+                workspace = %workspace_name,
+                backup_path = %backup.backup_path().display(),
+                "workspace deleted, but failed to remove workspace artifact backup: {error}"
+            );
+        }
+    }
 }
 
-struct WorkspaceCredentialSnapshot {
-    credential_set_id: CredentialSetId,
-    snapshot: CredentialMaterialSnapshot,
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use tempfile::TempDir;
+
+    use super::WorkspaceManager;
+    use crate::credentials::{CredentialManager, CredentialSetId, CredentialStore};
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::{AppStateLayout, ConfigStore};
+    use crate::workspaces::WorkspaceName;
+
+    fn test_layout(temp: &TempDir) -> AppStateLayout {
+        AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout")
+    }
+
+    fn installed_source(name: &str) -> InstalledSource {
+        InstalledSource {
+            name: SourceName::parse(name).expect("source"),
+            version: Some("1.0.0".to_string()),
+            variables: BTreeMap::new(),
+            secrets: vec!["TOKEN".to_string()],
+            credential_storage: None,
+            origin: SourceOrigin::Imported,
+        }
+    }
+
+    #[test]
+    fn delete_workspace_commits_config_then_cleans_artifacts() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager =
+            WorkspaceManager::new(store.clone(), credential_manager.clone(), layout.clone());
+        let workspace_name = WorkspaceName::parse("work").expect("workspace");
+        let source = installed_source("github");
+        let credential_set_id = CredentialSetId::for_source(&source.name);
+
+        store
+            .create_workspace(&workspace_name)
+            .expect("create workspace");
+        store
+            .upsert_source(&workspace_name, source)
+            .expect("upsert source");
+        credential_manager
+            .replace_material(
+                &workspace_name,
+                &credential_set_id,
+                crate::credentials::CredentialStorageKind::File,
+                &BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+            )
+            .expect("write credential material");
+        std::fs::create_dir_all(layout.feedback_dir(&workspace_name)).expect("create feedback dir");
+        std::fs::write(
+            layout.feedback_reports_file(&workspace_name),
+            b"{\"message\":\"report\"}\n",
+        )
+        .expect("write workspace artifact");
+
+        let deleted = manager
+            .delete_workspace(&workspace_name)
+            .expect("delete workspace");
+
+        assert_eq!(deleted.name, workspace_name);
+        assert!(matches!(
+            store.list_workspace_sources(&workspace_name),
+            Err(crate::bootstrap::AppError::WorkspaceNotFound(_))
+        ));
+        assert!(
+            !layout.workspace_dir(&workspace_name).exists(),
+            "workspace artifact directory should be removed after config commit"
+        );
+        let material = credential_manager
+            .read_material(
+                &workspace_name,
+                &credential_set_id,
+                crate::credentials::CredentialStorageKind::File,
+            )
+            .expect("read credential material");
+        assert!(
+            material.is_empty(),
+            "credential material should be removed during best-effort cleanup"
+        );
+    }
 }

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -1,14 +1,13 @@
 #![expect(dead_code, reason = "used in next stack PR")]
 
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tracing::warn;
-use uuid::Uuid;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialMaterialSnapshot, CredentialSetId};
 use crate::state::AppStateLayout;
+use crate::storage::fs::DirectoryBackup;
 use crate::workspaces::{DEFAULT_WORKSPACE_ID, WorkspaceName, WorkspaceRecord, WorkspaceStore};
 
 /// App-owned workspace lifecycle behavior.
@@ -55,37 +54,25 @@ impl WorkspaceManager {
 
         let credential_snapshots = self.remove_workspace_credentials(workspace_name)?;
         let workspace_dir = self.layout.workspace_dir(workspace_name);
-        let backup = workspace_delete_backup_path(&workspace_dir, workspace_name);
-        let had_workspace_dir = workspace_dir.exists();
-        if had_workspace_dir {
-            if backup.exists()
-                && let Err(error) = std::fs::remove_dir_all(&backup)
-            {
+        let backup = match DirectoryBackup::move_for_delete(&workspace_dir, workspace_name) {
+            Ok(backup) => backup,
+            Err(error) => {
                 self.restore_workspace_credentials(workspace_name, &credential_snapshots);
                 return Err(error.into());
             }
-            if let Err(error) = std::fs::rename(&workspace_dir, &backup) {
-                self.restore_workspace_credentials(workspace_name, &credential_snapshots);
-                return Err(error.into());
-            }
-        }
+        };
 
         match self.store.delete_workspace(workspace_name) {
             Ok(Some(record)) => {
-                if backup.exists() {
-                    std::fs::remove_dir_all(&backup)?;
-                }
+                backup.commit()?;
                 Ok(record)
             }
             Ok(None) => {
-                if backup.exists() {
-                    std::fs::remove_dir_all(&backup)?;
-                }
+                backup.commit()?;
                 Err(AppError::WorkspaceNotFound(workspace_name.to_string()))
             }
             Err(error) => {
-                let restore_dir_result =
-                    restore_workspace_dir(&workspace_dir, &backup, had_workspace_dir);
+                let restore_dir_result = backup.restore();
                 self.restore_workspace_credentials(workspace_name, &credential_snapshots);
                 restore_dir_result?;
                 Err(error)
@@ -109,24 +96,33 @@ impl WorkspaceManager {
             {
                 Ok(guard) => guard,
                 Err(error) => {
-                    self.restore_workspace_credentials(workspace_name, &snapshots);
-                    return Err(error);
+                    return self.rollback_removed_workspace_credentials(
+                        workspace_name,
+                        &snapshots,
+                        error,
+                    );
                 }
             };
             let snapshot = match guard.snapshot_material(storage) {
                 Ok(snapshot) => snapshot,
                 Err(error) => {
-                    self.restore_workspace_credentials(workspace_name, &snapshots);
-                    return Err(error);
+                    return self.rollback_removed_workspace_credentials(
+                        workspace_name,
+                        &snapshots,
+                        error,
+                    );
                 }
             };
             if let Err(error) = guard.remove_material(storage) {
-                snapshots.push(WorkspaceCredentialSnapshot {
-                    credential_set_id,
-                    snapshot,
-                });
-                self.restore_workspace_credentials(workspace_name, &snapshots);
-                return Err(error);
+                return self.rollback_removed_workspace_credentials_with_snapshot(
+                    workspace_name,
+                    &mut snapshots,
+                    WorkspaceCredentialSnapshot {
+                        credential_set_id,
+                        snapshot,
+                    },
+                    error,
+                );
             }
             snapshots.push(WorkspaceCredentialSnapshot {
                 credential_set_id,
@@ -134,6 +130,27 @@ impl WorkspaceManager {
             });
         }
         Ok(snapshots)
+    }
+
+    fn rollback_removed_workspace_credentials<T>(
+        &self,
+        workspace_name: &WorkspaceName,
+        snapshots: &[WorkspaceCredentialSnapshot],
+        error: AppError,
+    ) -> Result<T, AppError> {
+        self.restore_workspace_credentials(workspace_name, snapshots);
+        Err(error)
+    }
+
+    fn rollback_removed_workspace_credentials_with_snapshot<T>(
+        &self,
+        workspace_name: &WorkspaceName,
+        snapshots: &mut Vec<WorkspaceCredentialSnapshot>,
+        snapshot: WorkspaceCredentialSnapshot,
+        error: AppError,
+    ) -> Result<T, AppError> {
+        snapshots.push(snapshot);
+        self.rollback_removed_workspace_credentials(workspace_name, snapshots, error)
     }
 
     fn restore_workspace_credentials(
@@ -168,26 +185,4 @@ impl WorkspaceManager {
 struct WorkspaceCredentialSnapshot {
     credential_set_id: CredentialSetId,
     snapshot: CredentialMaterialSnapshot,
-}
-
-fn workspace_delete_backup_path(workspace_dir: &Path, workspace_name: &WorkspaceName) -> PathBuf {
-    workspace_dir.with_file_name(format!(
-        "{}.delete.rollback.{}",
-        workspace_name,
-        Uuid::new_v4()
-    ))
-}
-
-fn restore_workspace_dir(
-    workspace_dir: &Path,
-    backup: &Path,
-    had_workspace_dir: bool,
-) -> Result<(), AppError> {
-    if had_workspace_dir && backup.exists() {
-        if workspace_dir.exists() {
-            std::fs::remove_dir_all(workspace_dir)?;
-        }
-        std::fs::rename(backup, workspace_dir)?;
-    }
-    Ok(())
 }

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -1,0 +1,193 @@
+#![expect(dead_code, reason = "used in next stack PR")]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::bootstrap::AppError;
+use crate::credentials::{CredentialManager, CredentialMaterialSnapshot, CredentialSetId};
+use crate::state::AppStateLayout;
+use crate::workspaces::{DEFAULT_WORKSPACE_ID, WorkspaceName, WorkspaceRecord, WorkspaceStore};
+
+/// App-owned workspace lifecycle behavior.
+#[derive(Clone)]
+pub(crate) struct WorkspaceManager {
+    store: Arc<dyn WorkspaceStore>,
+    credential_manager: CredentialManager,
+    layout: AppStateLayout,
+}
+
+impl WorkspaceManager {
+    pub(crate) fn new(
+        store: impl WorkspaceStore,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+    ) -> Self {
+        Self {
+            store: Arc::new(store),
+            credential_manager,
+            layout,
+        }
+    }
+
+    pub(crate) fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, AppError> {
+        self.store.list_workspaces()
+    }
+
+    pub(crate) fn create_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<WorkspaceRecord, AppError> {
+        self.store.create_workspace(workspace_name)
+    }
+
+    pub(crate) fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<WorkspaceRecord, AppError> {
+        if workspace_name.as_str() == DEFAULT_WORKSPACE_ID {
+            return Err(AppError::FailedPrecondition(
+                "default workspace cannot be removed".to_string(),
+            ));
+        }
+
+        let credential_snapshots = self.remove_workspace_credentials(workspace_name)?;
+        let workspace_dir = self.layout.workspace_dir(workspace_name);
+        let backup = workspace_delete_backup_path(&workspace_dir, workspace_name);
+        let had_workspace_dir = workspace_dir.exists();
+        if had_workspace_dir {
+            if backup.exists()
+                && let Err(error) = std::fs::remove_dir_all(&backup)
+            {
+                self.restore_workspace_credentials(workspace_name, &credential_snapshots);
+                return Err(error.into());
+            }
+            if let Err(error) = std::fs::rename(&workspace_dir, &backup) {
+                self.restore_workspace_credentials(workspace_name, &credential_snapshots);
+                return Err(error.into());
+            }
+        }
+
+        match self.store.delete_workspace(workspace_name) {
+            Ok(Some(record)) => {
+                if backup.exists() {
+                    std::fs::remove_dir_all(&backup)?;
+                }
+                Ok(record)
+            }
+            Ok(None) => {
+                if backup.exists() {
+                    std::fs::remove_dir_all(&backup)?;
+                }
+                Err(AppError::WorkspaceNotFound(workspace_name.to_string()))
+            }
+            Err(error) => {
+                let restore_dir_result =
+                    restore_workspace_dir(&workspace_dir, &backup, had_workspace_dir);
+                self.restore_workspace_credentials(workspace_name, &credential_snapshots);
+                restore_dir_result?;
+                Err(error)
+            }
+        }
+    }
+
+    fn remove_workspace_credentials(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<WorkspaceCredentialSnapshot>, AppError> {
+        let mut snapshots = Vec::new();
+        for source in self.store.list_workspace_sources(workspace_name)? {
+            let Some(storage) = source.credential_storage_for_material() else {
+                continue;
+            };
+            let credential_set_id = CredentialSetId::for_source(&source.name);
+            let guard = match self
+                .credential_manager
+                .material_guard(workspace_name, &credential_set_id)
+            {
+                Ok(guard) => guard,
+                Err(error) => {
+                    self.restore_workspace_credentials(workspace_name, &snapshots);
+                    return Err(error);
+                }
+            };
+            let snapshot = match guard.snapshot_material(storage) {
+                Ok(snapshot) => snapshot,
+                Err(error) => {
+                    self.restore_workspace_credentials(workspace_name, &snapshots);
+                    return Err(error);
+                }
+            };
+            if let Err(error) = guard.remove_material(storage) {
+                snapshots.push(WorkspaceCredentialSnapshot {
+                    credential_set_id,
+                    snapshot,
+                });
+                self.restore_workspace_credentials(workspace_name, &snapshots);
+                return Err(error);
+            }
+            snapshots.push(WorkspaceCredentialSnapshot {
+                credential_set_id,
+                snapshot,
+            });
+        }
+        Ok(snapshots)
+    }
+
+    fn restore_workspace_credentials(
+        &self,
+        workspace_name: &WorkspaceName,
+        snapshots: &[WorkspaceCredentialSnapshot],
+    ) {
+        for snapshot in snapshots.iter().rev() {
+            let guard = match self
+                .credential_manager
+                .material_guard(workspace_name, &snapshot.credential_set_id)
+            {
+                Ok(guard) => guard,
+                Err(error) => {
+                    warn!(
+                        credential_set_id = %snapshot.credential_set_id,
+                        "rollback: failed to access workspace credential material: {error}"
+                    );
+                    continue;
+                }
+            };
+            if let Err(error) = guard.restore_material(&snapshot.snapshot) {
+                warn!(
+                    credential_set_id = %snapshot.credential_set_id,
+                    "rollback: failed to restore workspace credential material: {error}"
+                );
+            }
+        }
+    }
+}
+
+struct WorkspaceCredentialSnapshot {
+    credential_set_id: CredentialSetId,
+    snapshot: CredentialMaterialSnapshot,
+}
+
+fn workspace_delete_backup_path(workspace_dir: &Path, workspace_name: &WorkspaceName) -> PathBuf {
+    workspace_dir.with_file_name(format!(
+        "{}.delete.rollback.{}",
+        workspace_name,
+        Uuid::new_v4()
+    ))
+}
+
+fn restore_workspace_dir(
+    workspace_dir: &Path,
+    backup: &Path,
+    had_workspace_dir: bool,
+) -> Result<(), AppError> {
+    if had_workspace_dir && backup.exists() {
+        if workspace_dir.exists() {
+            std::fs::remove_dir_all(workspace_dir)?;
+        }
+        std::fs::rename(backup, workspace_dir)?;
+    }
+    Ok(())
+}

--- a/crates/coral-app/src/workspaces/mod.rs
+++ b/crates/coral-app/src/workspaces/mod.rs
@@ -1,4 +1,11 @@
+pub(crate) mod manager;
+pub(crate) mod model;
 pub(crate) mod name;
+pub(crate) mod store;
 
+#[expect(unused_imports, reason = "used in next stack PR")]
+pub(crate) use manager::WorkspaceManager;
+pub(crate) use model::WorkspaceRecord;
 pub use name::DEFAULT_WORKSPACE_ID;
 pub(crate) use name::WorkspaceName;
+pub(crate) use store::WorkspaceStore;

--- a/crates/coral-app/src/workspaces/mod.rs
+++ b/crates/coral-app/src/workspaces/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod store;
 
 #[expect(unused_imports, reason = "used in next stack PR")]
 pub(crate) use manager::WorkspaceManager;
-pub(crate) use model::WorkspaceRecord;
+pub(crate) use model::{DeletedWorkspace, WorkspaceRecord};
 pub use name::DEFAULT_WORKSPACE_ID;
 pub(crate) use name::WorkspaceName;
 pub(crate) use store::WorkspaceStore;

--- a/crates/coral-app/src/workspaces/model.rs
+++ b/crates/coral-app/src/workspaces/model.rs
@@ -1,0 +1,7 @@
+use crate::workspaces::WorkspaceName;
+
+/// App-owned workspace metadata record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceRecord {
+    pub(crate) name: WorkspaceName,
+}

--- a/crates/coral-app/src/workspaces/model.rs
+++ b/crates/coral-app/src/workspaces/model.rs
@@ -5,3 +5,11 @@ use crate::workspaces::WorkspaceName;
 pub(crate) struct WorkspaceRecord {
     pub(crate) name: WorkspaceName,
 }
+
+/// Workspace metadata and scoped source state captured at the config deletion
+/// commit point for post-commit artifact cleanup.
+#[derive(Debug, Clone)]
+pub(crate) struct DeletedWorkspace {
+    pub(crate) workspace: WorkspaceRecord,
+    pub(crate) sources: Vec<crate::sources::model::InstalledSource>,
+}

--- a/crates/coral-app/src/workspaces/name.rs
+++ b/crates/coral-app/src/workspaces/name.rs
@@ -26,6 +26,11 @@ impl WorkspaceName {
     pub(crate) fn as_str(&self) -> &str {
         &self.0
     }
+
+    #[must_use]
+    pub(crate) fn is_default(&self) -> bool {
+        self.0 == DEFAULT_WORKSPACE_ID
+    }
 }
 
 impl fmt::Display for WorkspaceName {

--- a/crates/coral-app/src/workspaces/store.rs
+++ b/crates/coral-app/src/workspaces/store.rs
@@ -1,6 +1,5 @@
 use crate::bootstrap::AppError;
-use crate::sources::model::InstalledSource;
-use crate::workspaces::{WorkspaceName, WorkspaceRecord};
+use crate::workspaces::{DeletedWorkspace, WorkspaceName, WorkspaceRecord};
 
 /// Repository boundary for workspace metadata and workspace-owned source state.
 pub(crate) trait WorkspaceStore: Send + Sync + 'static {
@@ -9,13 +8,8 @@ pub(crate) trait WorkspaceStore: Send + Sync + 'static {
     fn create_workspace(&self, workspace_name: &WorkspaceName)
     -> Result<WorkspaceRecord, AppError>;
 
-    fn list_workspace_sources(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<Vec<InstalledSource>, AppError>;
-
     fn delete_workspace(
         &self,
         workspace_name: &WorkspaceName,
-    ) -> Result<Option<WorkspaceRecord>, AppError>;
+    ) -> Result<Option<DeletedWorkspace>, AppError>;
 }

--- a/crates/coral-app/src/workspaces/store.rs
+++ b/crates/coral-app/src/workspaces/store.rs
@@ -1,0 +1,21 @@
+use crate::bootstrap::AppError;
+use crate::sources::model::InstalledSource;
+use crate::workspaces::{WorkspaceName, WorkspaceRecord};
+
+/// Repository boundary for workspace metadata and workspace-owned source state.
+pub(crate) trait WorkspaceStore: Send + Sync + 'static {
+    fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, AppError>;
+
+    fn create_workspace(&self, workspace_name: &WorkspaceName)
+    -> Result<WorkspaceRecord, AppError>;
+
+    fn list_workspace_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError>;
+
+    fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<WorkspaceRecord>, AppError>;
+}


### PR DESCRIPTION
## Intent

Introduce the app-owned workspace persistence foundation without changing the CLI or MCP surface yet.

## What it enables

Adds explicit workspace records, workspace-scoped installed source catalog state, and a workspace manager that can create and remove workspace-owned config, artifacts, and credentials.

## Usage examples

Downstack PRs expose this through commands such as `coral workspace create work`, while app code can use `WorkspaceManager::create_workspace` and `WorkspaceManager::delete_workspace`.
