### PR TITLE
feat(api): expose workspace lifecycle service

### DIFF
--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -16,6 +16,7 @@ fn main() {
             &[
                 "proto/coral/v1/catalog.proto",
                 "proto/coral/v1/resources.proto",
+                "proto/coral/v1/workspaces.proto",
                 "proto/coral/v1/feedback.proto",
                 "proto/coral/v1/sources.proto",
                 "proto/coral/v1/query.proto",

--- a/crates/coral-api/proto/coral/v1/workspaces.proto
+++ b/crates/coral-api/proto/coral/v1/workspaces.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/resources.proto";
+
+// Lists configured workspaces.
+message ListWorkspacesRequest {}
+
+// Returns configured workspaces.
+message ListWorkspacesResponse {
+  // Configured workspace resources.
+  repeated Workspace workspaces = 1;
+}
+
+// Creates one workspace.
+message CreateWorkspaceRequest {
+  // Workspace resource to create.
+  Workspace workspace = 1;
+}
+
+// Returns the created workspace.
+message CreateWorkspaceResponse {
+  // Created workspace resource.
+  Workspace workspace = 1;
+}
+
+// Deletes one workspace and its managed artifacts.
+message DeleteWorkspaceRequest {
+  // Workspace resource to delete.
+  Workspace workspace = 1;
+}
+
+// Returns the deleted workspace.
+message DeleteWorkspaceResponse {
+  // Deleted workspace resource.
+  Workspace workspace = 1;
+}
+
+// Workspace management APIs.
+service WorkspaceService {
+  // Lists configured workspaces.
+  rpc ListWorkspaces(ListWorkspacesRequest) returns (ListWorkspacesResponse);
+  // Creates one workspace.
+  rpc CreateWorkspace(CreateWorkspaceRequest) returns (CreateWorkspaceResponse);
+  // Deletes one workspace and its managed artifacts.
+  rpc DeleteWorkspace(DeleteWorkspaceRequest) returns (DeleteWorkspaceResponse);
+}

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -20,6 +20,7 @@ use coral_api::v1::feedback_service_server::FeedbackServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
 use coral_api::v1::trace_service_server::TraceServiceServer;
+use coral_api::v1::workspace_service_server::WorkspaceServiceServer;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
     TRACE_RESPONSE_MAX_MESSAGE_SIZE,
@@ -56,6 +57,7 @@ use crate::state::ConfigStore;
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
+use crate::workspaces::{WorkspaceManager, WorkspaceService};
 
 /// A static asset (e.g., a built SPA file) served on the same port as
 /// gRPC-Web.
@@ -270,6 +272,11 @@ impl ServerBuilder {
             credential_manager.clone(),
             layout.clone(),
         );
+        let workspace_manager = WorkspaceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+        );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
         let episode_store = EpisodeStore::new(layout.clone());
@@ -294,6 +301,7 @@ impl ServerBuilder {
         };
         start_server(
             source_manager,
+            workspace_manager,
             query_manager,
             feedback_manager,
             episode_store,
@@ -376,6 +384,7 @@ impl Drop for RunningServer {
 
 async fn start_server(
     source_manager: SourceManager,
+    workspace_manager: WorkspaceManager,
     query_manager: QueryManager,
     feedback_manager: FeedbackManager,
     episode_store: EpisodeStore,
@@ -383,6 +392,7 @@ async fn start_server(
     mode: ServerMode,
 ) -> Result<RunningServer, AppError> {
     let source_service = SourceService::new(source_manager, query_manager.clone());
+    let workspace_service = WorkspaceService::new(workspace_manager);
     let catalog_service = CatalogService::new(query_manager.clone());
     let query_service = QueryService::new(query_manager);
     let feedback_service = FeedbackService::new(feedback_manager);
@@ -391,6 +401,9 @@ async fn start_server(
         .add_service(GrpcMethodAnnotatedService::new(SourceServiceServer::new(
             source_service,
         )))
+        .add_service(GrpcMethodAnnotatedService::new(
+            WorkspaceServiceServer::new(workspace_service),
+        ))
         .add_service(GrpcMethodAnnotatedService::new(
             CatalogServiceServer::new(catalog_service)
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
@@ -662,7 +675,7 @@ mod tests {
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::telemetry::service::TraceService;
     use crate::transport::workspace_to_proto;
-    use crate::workspaces::WorkspaceName;
+    use crate::workspaces::{WorkspaceManager, WorkspaceName};
     use crate::{AwsEngineExtensionsProvider, NoopEngineExtensionsProvider};
 
     fn default_workspace() -> Workspace {
@@ -774,6 +787,11 @@ enabled = false
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
+        let workspace_manager = WorkspaceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+        );
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -785,6 +803,7 @@ enabled = false
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
         let server = start_server(
             source_manager,
+            workspace_manager,
             query_manager,
             feedback_manager,
             episode_store,
@@ -1154,6 +1173,11 @@ tables:
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
+        let workspace_manager = WorkspaceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+        );
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -1166,6 +1190,7 @@ tables:
         );
         let running = start_server(
             source_manager,
+            workspace_manager,
             query_manager,
             feedback_manager,
             episode_store,
@@ -1258,6 +1283,11 @@ tables:
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
+        let workspace_manager = WorkspaceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+        );
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -1267,6 +1297,7 @@ tables:
         );
         let running = start_server(
             source_manager,
+            workspace_manager,
             query_manager,
             feedback_manager,
             episode_store,
@@ -1359,6 +1390,11 @@ tables:
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
+        let workspace_manager = WorkspaceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+        );
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -1368,6 +1404,7 @@ tables:
         );
         let running = start_server(
             source_manager,
+            workspace_manager,
             query_manager,
             feedback_manager,
             episode_store,

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -1,5 +1,3 @@
-#![expect(dead_code, reason = "used in next stack PR")]
-
 use std::sync::Arc;
 
 use tracing::warn;

--- a/crates/coral-app/src/workspaces/mod.rs
+++ b/crates/coral-app/src/workspaces/mod.rs
@@ -1,11 +1,12 @@
 pub(crate) mod manager;
 pub(crate) mod model;
 pub(crate) mod name;
+pub(crate) mod service;
 pub(crate) mod store;
 
-#[expect(unused_imports, reason = "used in next stack PR")]
 pub(crate) use manager::WorkspaceManager;
 pub(crate) use model::{DeletedWorkspace, WorkspaceRecord};
 pub use name::DEFAULT_WORKSPACE_ID;
 pub(crate) use name::WorkspaceName;
+pub(crate) use service::WorkspaceService;
 pub(crate) use store::WorkspaceStore;

--- a/crates/coral-app/src/workspaces/service.rs
+++ b/crates/coral-app/src/workspaces/service.rs
@@ -1,0 +1,88 @@
+//! Implements the gRPC `WorkspaceService` for workspace lifecycle APIs.
+
+use coral_api::v1::workspace_service_server::WorkspaceService as WorkspaceServiceApi;
+use coral_api::v1::{
+    CreateWorkspaceRequest, CreateWorkspaceResponse, DeleteWorkspaceRequest,
+    DeleteWorkspaceResponse, ListWorkspacesRequest, ListWorkspacesResponse, Workspace,
+};
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::app_status;
+use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto, workspace_to_proto};
+use crate::workspaces::{WorkspaceManager, WorkspaceRecord};
+
+#[derive(Clone)]
+pub(crate) struct WorkspaceService {
+    workspaces: WorkspaceManager,
+}
+
+impl WorkspaceService {
+    pub(crate) fn new(workspace_manager: WorkspaceManager) -> Self {
+        Self {
+            workspaces: workspace_manager,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl WorkspaceServiceApi for WorkspaceService {
+    async fn list_workspaces(
+        &self,
+        request: Request<ListWorkspacesRequest>,
+    ) -> Result<Response<ListWorkspacesResponse>, Status> {
+        let span = grpc_span(&request);
+        let workspaces = self.workspaces.clone();
+        instrument_grpc(span, async move {
+            let workspaces = workspaces
+                .list_workspaces()
+                .map_err(app_status)?
+                .iter()
+                .map(workspace_record_to_proto)
+                .collect();
+            Ok(Response::new(ListWorkspacesResponse { workspaces }))
+        })
+        .await
+    }
+
+    async fn create_workspace(
+        &self,
+        request: Request<CreateWorkspaceRequest>,
+    ) -> Result<Response<CreateWorkspaceResponse>, Status> {
+        let span = grpc_span(&request);
+        let workspaces = self.workspaces.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let workspace = workspaces
+                .create_workspace(&workspace_name)
+                .map_err(app_status)?;
+            Ok(Response::new(CreateWorkspaceResponse {
+                workspace: Some(workspace_record_to_proto(&workspace)),
+            }))
+        })
+        .await
+    }
+
+    async fn delete_workspace(
+        &self,
+        request: Request<DeleteWorkspaceRequest>,
+    ) -> Result<Response<DeleteWorkspaceResponse>, Status> {
+        let span = grpc_span(&request);
+        let workspaces = self.workspaces.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let workspace = workspaces
+                .delete_workspace(&workspace_name)
+                .map_err(app_status)?;
+            Ok(Response::new(DeleteWorkspaceResponse {
+                workspace: Some(workspace_record_to_proto(&workspace)),
+            }))
+        })
+        .await
+    }
+}
+
+fn workspace_record_to_proto(record: &WorkspaceRecord) -> Workspace {
+    workspace_to_proto(&record.name)
+}

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -6,6 +6,7 @@ use coral_api::v1::episode_service_client::EpisodeServiceClient;
 use coral_api::v1::feedback_service_client::FeedbackServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
+use coral_api::v1::workspace_service_client::WorkspaceServiceClient;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
 };
@@ -27,11 +28,20 @@ pub fn default_workspace() -> Workspace {
     }
 }
 
+#[must_use]
+/// Returns a workspace resource with the provided name.
+pub fn workspace(name: impl Into<String>) -> Workspace {
+    Workspace { name: name.into() }
+}
+
 type RawGrpcService = InterceptedService<Channel, RequestContextInterceptor>;
 type GrpcService = InstrumentedGrpcService<RawGrpcService>;
 
 /// Public source-management gRPC client.
 pub type SourceClient = SourceServiceClient<GrpcService>;
+
+/// Public workspace-management gRPC client.
+pub type WorkspaceClient = WorkspaceServiceClient<GrpcService>;
 
 /// Public catalog-discovery gRPC client.
 pub type CatalogClient = CatalogServiceClient<GrpcService>;
@@ -51,6 +61,7 @@ pub type EpisodeClient = EpisodeServiceClient<GrpcService>;
 #[derive(Clone)]
 pub struct AppClient {
     source: SourceClient,
+    workspace: WorkspaceClient,
     catalog: CatalogClient,
     query: QueryClient,
     feedback: FeedbackClient,
@@ -72,6 +83,7 @@ impl AppClient {
         let grpc_endpoint = GrpcClientEndpoint::from_endpoint_uri(endpoint_uri);
         let channel = endpoint.connect().await?;
         let source_client = SourceClient::new(grpc_service(channel.clone(), &grpc_endpoint));
+        let workspace_client = WorkspaceClient::new(grpc_service(channel.clone(), &grpc_endpoint));
         let catalog_client = CatalogClient::new(grpc_service(channel.clone(), &grpc_endpoint))
             .max_decoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE);
         let query_client = QueryClient::new(grpc_service(channel.clone(), &grpc_endpoint))
@@ -80,6 +92,7 @@ impl AppClient {
         let episode_client = EpisodeClient::new(grpc_service(channel, &grpc_endpoint));
         Ok(Self {
             source: source_client,
+            workspace: workspace_client,
             catalog: catalog_client,
             query: query_client,
             feedback: feedback_client,
@@ -91,6 +104,12 @@ impl AppClient {
     /// Returns a cloned source-management client.
     pub fn source_client(&self) -> SourceClient {
         self.source.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned workspace-management client.
+    pub fn workspace_client(&self) -> WorkspaceClient {
+        self.workspace.clone()
     }
 
     #[must_use]

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -41,7 +41,7 @@ use serde_json::Value;
 
 pub use client::{
     AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, EpisodeClient, FeedbackClient, QueryClient,
-    SourceClient, default_workspace,
+    SourceClient, WorkspaceClient, default_workspace, workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use propagation::with_episode_metadata;

--- a/docs/project/architecture.mdx
+++ b/docs/project/architecture.mdx
@@ -64,7 +64,7 @@ The local server and core orchestrator.
 | --- | --- |
 | Server bootstrap | In-process gRPC server lifecycle (`bootstrap/`) |
 | Source management | Install, add from file, list, validate, remove (`sources/`) |
-| Workspace state | Config, secrets, and workspace layout (`state/`, `storage/`) |
+| Workspace state and lifecycle | Workspace service plus config, secrets, and layout (`workspaces/`, `state/`, `storage/`) |
 | Feedback persistence | Workspace-scoped blocked-agent feedback reports (`feedback/`) |
 | Query orchestration | Loads sources, builds the engine, executes SQL (`query/`) |
 | Catalog discovery | Lists/searches/describes query-visible tables and columns (`catalog/`) |
@@ -114,7 +114,7 @@ The shared gRPC contract.
 
 | Owns                 | Details                                                                                |
 | -------------------- | -------------------------------------------------------------------------------------- |
-| Protobuf definitions | `proto/coral/v1/` — `query.proto`, `sources.proto`, `catalog.proto`, `resources.proto` |
+| Protobuf definitions | `proto/coral/v1/` transport contracts for Coral services and messages |
 | Generated bindings   | Tonic-generated Rust types and service traits                                          |
 
 All inter-crate communication between `coral-client` and `coral-app` goes through these generated types.


### PR DESCRIPTION
## Intent

Expose workspace lifecycle management over Coral's protobuf and gRPC boundary.

## What it enables

Adds the workspace service contract, app server registration, and thin client accessors so adapters can list, create, and delete workspaces without reaching into app internals.

## Usage examples

Clients can call `AppClient::workspace_client().list_workspaces(...)`, `create_workspace(...)`, and `delete_workspace(...)`.
