### PR TITLE
feat(cli): add workspace selection commands

### DIFF
--- a/crates/coral-cli/src/env.rs
+++ b/crates/coral-cli/src/env.rs
@@ -20,6 +20,7 @@ pub fn bootstrap_endpoint() -> Option<String> {
 }
 
 const CORAL_TRACE_PARENT_ENV: &str = "CORAL_TRACE_PARENT";
+const CORAL_WORKSPACE_ENV: &str = "CORAL_WORKSPACE";
 
 /// Reads the optional W3C `traceparent` used to link CLI spans to a parent trace.
 #[expect(
@@ -29,4 +30,14 @@ const CORAL_TRACE_PARENT_ENV: &str = "CORAL_TRACE_PARENT";
 #[must_use]
 pub fn trace_parent() -> Option<String> {
     std::env::var(CORAL_TRACE_PARENT_ENV).ok()
+}
+
+/// Reads the optional default workspace for CLI commands.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "CORAL_WORKSPACE is a CLI-owned per-invocation workspace selector."
+)]
+#[must_use]
+pub fn workspace() -> Option<String> {
+    std::env::var(CORAL_WORKSPACE_ENV).ok()
 }

--- a/crates/coral-cli/src/env.rs
+++ b/crates/coral-cli/src/env.rs
@@ -39,5 +39,7 @@ pub fn trace_parent() -> Option<String> {
 )]
 #[must_use]
 pub fn workspace() -> Option<String> {
-    std::env::var(CORAL_WORKSPACE_ENV).ok()
+    std::env::var(CORAL_WORKSPACE_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -27,12 +27,15 @@ use clap::{
     Parser, Subcommand, ValueEnum,
 };
 use clap_complete::{Shell, generate};
-use coral_api::v1::ExecuteSqlRequest;
+use coral_api::v1::{
+    CreateWorkspaceRequest, DeleteWorkspaceRequest, ExecuteSqlRequest, ListWorkspacesRequest,
+    Workspace,
+};
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
 use coral_client::{
-    AppClient, decode_execute_sql_response, default_workspace, format_batches_json,
-    format_batches_table, manifest_input_from_proto,
+    AppClient, DEFAULT_WORKSPACE_ID, decode_execute_sql_response, format_batches_json,
+    format_batches_table, manifest_input_from_proto, workspace as workspace_resource,
 };
 use dialoguer::console::measure_text_width;
 use tonic::Request;
@@ -56,6 +59,8 @@ const MCP_INITIAL_QUERY_EXAMPLE_LIMIT: usize = 5;
 struct Cli {
     #[command(flatten)]
     feature_overrides: FeatureOverrideArgs,
+    #[command(flatten)]
+    workspace_selection: WorkspaceSelectionArgs,
     #[command(subcommand)]
     command: Command,
 }
@@ -66,6 +71,8 @@ enum Command {
     Sql(SqlArgs),
     /// Manage data sources
     Source(SourceArgs),
+    /// Manage workspaces
+    Workspace(WorkspaceArgs),
     /// Interactive wizard to set up Coral and explore use cases
     Onboard,
     /// Start the MCP server over stdio
@@ -113,6 +120,13 @@ struct SqlArgs {
     format: OutputFormat,
     /// SQL query to execute
     sql: String,
+}
+
+#[derive(Debug, Args)]
+struct WorkspaceSelectionArgs {
+    /// Workspace to target. Overrides `CORAL_WORKSPACE`.
+    #[arg(long = "workspace", value_name = "NAME", global = true)]
+    workspace: Option<String>,
 }
 
 #[derive(Debug, Default)]
@@ -210,6 +224,29 @@ fn add_feature_override_args(mut cmd: clap::Command) -> clap::Command {
 #[derive(Debug, Args)]
 /// Start the MCP server over stdio
 struct McpStdioArgs {}
+
+#[derive(Debug, Args)]
+/// Manage workspaces
+struct WorkspaceArgs {
+    #[command(subcommand)]
+    command: WorkspaceCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum WorkspaceCommand {
+    /// List configured workspaces
+    List,
+    /// Create a workspace
+    Create {
+        /// Name of the workspace to create
+        name: String,
+    },
+    /// Remove a workspace and its sources/artifacts
+    Remove {
+        /// Name of the workspace to remove
+        name: String,
+    },
+}
 
 #[derive(Debug, Args)]
 /// Inspect and manage experimental runtime features
@@ -359,9 +396,11 @@ impl CliError {
 impl Command {
     fn required_runtime(&self) -> RequiredRuntime {
         match self {
-            Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
-                RequiredRuntime::AppClient
-            }
+            Command::Sql(_)
+            | Command::Source(_)
+            | Command::Workspace(_)
+            | Command::Onboard
+            | Command::McpStdio(_) => RequiredRuntime::AppClient,
             Command::Features(_) | Command::Completion(_) => RequiredRuntime::None,
             #[cfg(feature = "embedded-ui")]
             Command::Ui(_) => RequiredRuntime::None,
@@ -370,6 +409,13 @@ impl Command {
 
     fn enables_stderr_logs(&self) -> bool {
         matches!(self, Command::McpStdio(_))
+    }
+
+    fn uses_selected_workspace(&self) -> bool {
+        matches!(
+            self,
+            Command::Sql(_) | Command::Source(_) | Command::Onboard
+        )
     }
 }
 
@@ -426,6 +472,7 @@ where
 pub async fn run_from_env() -> Result<(), CliError> {
     let Cli {
         feature_overrides,
+        workspace_selection,
         command,
     } = Cli::parse();
     let feature_overrides = feature_overrides.into_overrides();
@@ -435,6 +482,11 @@ pub async fn run_from_env() -> Result<(), CliError> {
 
     match command.required_runtime() {
         RequiredRuntime::AppClient => {
+            let workspace = if command.uses_selected_workspace() {
+                selected_workspace(workspace_selection.workspace)
+            } else {
+                workspace_resource(DEFAULT_WORKSPACE_ID)
+            };
             let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
             let bootstrap = bootstrap::bootstrap(bootstrap::BootstrapOptions {
                 enable_stderr_logs: command.enables_stderr_logs(),
@@ -443,11 +495,17 @@ pub async fn run_from_env() -> Result<(), CliError> {
             .map_err(anyhow::Error::from)?;
             let app = bootstrap.app.clone();
             let result = if is_mcp_stdio {
-                run_app_command(app, command, Some(&ctx), &feature_overrides).await
+                run_app_command(app, command, Some(&ctx), &feature_overrides, &workspace).await
             } else {
                 coral_app::run_with_context(
                     &ctx,
-                    Box::pin(run_app_command(app, command, None, &feature_overrides)),
+                    Box::pin(run_app_command(
+                        app,
+                        command,
+                        None,
+                        &feature_overrides,
+                        &workspace,
+                    )),
                 )
                 .await
             };
@@ -462,6 +520,13 @@ pub async fn run_from_env() -> Result<(), CliError> {
             .await
         }
     }
+}
+
+fn selected_workspace(cli_workspace: Option<String>) -> Workspace {
+    let raw = cli_workspace
+        .or_else(env::workspace)
+        .unwrap_or_else(|| DEFAULT_WORKSPACE_ID.to_string());
+    workspace_resource(raw)
 }
 
 /// Returns the embedded Coral UI assets for the local server to serve.
@@ -521,7 +586,11 @@ async fn run_no_runtime_command(
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args).await.map_err(Into::into),
-        Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
+        Command::Sql(_)
+        | Command::Source(_)
+        | Command::Workspace(_)
+        | Command::Onboard
+        | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
         }
     }
@@ -532,13 +601,14 @@ async fn run_app_command(
     command: Command,
     ctx: Option<&coral_app::RunContext>,
     feature_overrides: &coral_app::features::FeatureOverrides,
+    workspace: &Workspace,
 ) -> Result<(), CliError> {
     match command {
         Command::Sql(args) => {
             let response = match app
                 .query_client()
                 .execute_sql(Request::new(ExecuteSqlRequest {
-                    workspace: Some(default_workspace()),
+                    workspace: Some(workspace.clone()),
                     sql: args.sql,
                 }))
                 .await
@@ -555,9 +625,10 @@ async fn run_app_command(
             let result = decode_execute_sql_response(&response).map_err(anyhow::Error::from)?;
             print_batches(result.batches(), args.format)?;
         }
-        Command::Source(args) => run_source(&app, args).await?,
+        Command::Source(args) => run_source(&app, workspace, args).await?,
+        Command::Workspace(args) => run_workspace(&app, args).await?,
         Command::Onboard => {
-            onboard::run(&app).await?;
+            onboard::run(&app, workspace).await?;
         }
         Command::McpStdio(_) => {
             let features = coral_app::features::FeatureStore::discover(None)
@@ -656,10 +727,63 @@ fn run_features(
     Ok(())
 }
 
-async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
+async fn run_workspace(app: &AppClient, args: WorkspaceArgs) -> Result<(), CliError> {
+    match args.command {
+        WorkspaceCommand::List => {
+            let workspaces = app
+                .workspace_client()
+                .list_workspaces(Request::new(ListWorkspacesRequest {}))
+                .await
+                .map_err(anyhow::Error::from)?
+                .into_inner()
+                .workspaces;
+            if workspaces.is_empty() {
+                println!("No workspaces configured.");
+            } else {
+                let rows = workspaces.into_iter().map(|workspace| [workspace.name]);
+                print_text_table(["Workspace"], rows);
+            }
+        }
+        WorkspaceCommand::Create { name } => {
+            let workspace = workspace_resource(name);
+            let workspace = app
+                .workspace_client()
+                .create_workspace(Request::new(CreateWorkspaceRequest {
+                    workspace: Some(workspace),
+                }))
+                .await
+                .map_err(anyhow::Error::from)?
+                .into_inner()
+                .workspace
+                .ok_or_else(|| anyhow::anyhow!("create workspace response missing workspace"))?;
+            println!("Created workspace {}", workspace.name);
+        }
+        WorkspaceCommand::Remove { name } => {
+            let workspace = workspace_resource(name);
+            let workspace = app
+                .workspace_client()
+                .delete_workspace(Request::new(DeleteWorkspaceRequest {
+                    workspace: Some(workspace),
+                }))
+                .await
+                .map_err(anyhow::Error::from)?
+                .into_inner()
+                .workspace
+                .ok_or_else(|| anyhow::anyhow!("delete workspace response missing workspace"))?;
+            println!("Removed workspace {}", workspace.name);
+        }
+    }
+    Ok(())
+}
+
+async fn run_source(
+    app: &AppClient,
+    workspace: &Workspace,
+    args: SourceArgs,
+) -> Result<(), CliError> {
     match args.command {
         SourceCommand::Discover => {
-            let sources = source_ops::discover_sources(app).await?;
+            let sources = source_ops::discover_sources(app, workspace).await?;
             if sources.is_empty() {
                 println!("No bundled sources available.");
             } else {
@@ -679,7 +803,7 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
             }
         }
         SourceCommand::List => {
-            let sources = source_ops::list_sources(app).await?;
+            let sources = source_ops::list_sources(app, workspace).await?;
             if sources.is_empty() {
                 println!("No sources configured.");
             } else {
@@ -696,9 +820,9 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
             }
         }
         SourceCommand::Info { name, verbose } => {
-            source_ops::print_source_info(app, &name, verbose).await?;
+            source_ops::print_source_info(app, workspace, &name, verbose).await?;
         }
-        SourceCommand::Add(args) => run_source_add(app, args).await?,
+        SourceCommand::Add(args) => run_source_add(app, workspace, args).await?,
         SourceCommand::Lint { file } => {
             source_ops::load_validated_manifest_file(&file)?;
             println!("Manifest is valid");
@@ -706,6 +830,7 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
         SourceCommand::Test { name } => {
             source_ops::test_and_print(
                 app,
+                workspace,
                 &name,
                 source_ops::TableDisplayLimit::All,
                 source_ops::ValidationSeverityMode::Strict,
@@ -713,7 +838,7 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
             .await?;
         }
         SourceCommand::Remove { name } => {
-            source_ops::remove_and_print(app, &name).await?;
+            source_ops::remove_and_print(app, workspace, &name).await?;
         }
     }
     Ok(())
@@ -806,7 +931,11 @@ fn pad_cell(value: &str, width: usize, pad: bool) -> String {
     format!("{value}{}", " ".repeat(padding))
 }
 
-async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliError> {
+async fn run_source_add(
+    app: &AppClient,
+    workspace: &Workspace,
+    args: SourceAddArgs,
+) -> Result<(), CliError> {
     let SourceAddArgs {
         name,
         file,
@@ -818,7 +947,7 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
     let response = match (name, file) {
         (Some(name), None) => {
             let bundled_name = source_ops::source_name_arg(Some(&name))?;
-            let discover = source_ops::discover_sources(app).await?;
+            let discover = source_ops::discover_sources(app, workspace).await?;
             let available = discover
                 .into_iter()
                 .find(|source| source.name == bundled_name)
@@ -831,14 +960,20 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
                 .map_err(anyhow::Error::from)?;
             if interactive {
                 let inputs = source_ops::prompt_for_inputs_with_credential_methods(&inputs)?;
-                source_ops::add_bundled_source_with_credentials(app, &available.name, inputs)
-                    .await?
+                source_ops::add_bundled_source_with_credentials(
+                    app,
+                    workspace,
+                    &available.name,
+                    inputs,
+                )
+                .await?
             } else {
                 let (variables, secrets) = source_ops::collect_inputs_from_env(
                     &inputs,
                     format!("coral source add --interactive {}", available.name),
                 )?;
-                source_ops::add_bundled_source(app, &available.name, variables, secrets).await?
+                source_ops::add_bundled_source(app, workspace, &available.name, variables, secrets)
+                    .await?
             }
         }
         (None, Some(file)) => {
@@ -847,7 +982,8 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
                 let inputs = source_ops::prompt_for_inputs_with_credential_methods(
                     manifest.declared_inputs(),
                 )?;
-                source_ops::import_source_with_credentials(app, manifest_yaml, inputs).await?
+                source_ops::import_source_with_credentials(app, workspace, manifest_yaml, inputs)
+                    .await?
             } else {
                 let (variables, secrets) = source_ops::collect_inputs_from_env(
                     manifest.declared_inputs(),
@@ -856,7 +992,7 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
                         source_ops::shell_quote_arg(&file.display().to_string())
                     ),
                 )?;
-                source_ops::import_source(app, manifest_yaml, variables, secrets).await?
+                source_ops::import_source(app, workspace, manifest_yaml, variables, secrets).await?
             }
         }
         _ => unreachable!("clap enforces exactly one of name or file"),
@@ -866,9 +1002,14 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
         response.name,
         source_ops::source_credential_storage_label(response.credential_storage)
     );
-    source_ops::validate_and_warn(app, &response.name, source_ops::TableDisplayLimit::DEFAULT)
-        .await
-        .map_err(Into::into)
+    source_ops::validate_and_warn(
+        app,
+        workspace,
+        &response.name,
+        source_ops::TableDisplayLimit::DEFAULT,
+    )
+    .await
+    .map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -923,6 +1064,29 @@ mod tests {
         let cli = Cli::try_parse_from(["coral", "source", "list"]).expect("source list parses");
 
         assert_eq!(cli.command.required_runtime(), RequiredRuntime::AppClient);
+    }
+
+    #[test]
+    fn selected_workspace_preserves_raw_name_for_app_validation() {
+        let workspace = super::selected_workspace(Some(" ../bad ".to_string()));
+
+        assert_eq!(workspace.name, " ../bad ");
+    }
+
+    #[test]
+    fn only_workspace_scoped_commands_use_selected_workspace() {
+        let sql = Cli::try_parse_from(["coral", "sql", "SELECT 1"]).expect("sql parses");
+        let source = Cli::try_parse_from(["coral", "source", "list"]).expect("source parses");
+        let onboard = Cli::try_parse_from(["coral", "onboard"]).expect("onboard parses");
+        let workspace =
+            Cli::try_parse_from(["coral", "workspace", "list"]).expect("workspace parses");
+        let mcp = Cli::try_parse_from(["coral", "mcp-stdio"]).expect("mcp parses");
+
+        assert!(sql.command.uses_selected_workspace());
+        assert!(source.command.uses_selected_workspace());
+        assert!(onboard.command.uses_selected_workspace());
+        assert!(!workspace.command.uses_selected_workspace());
+        assert!(!mcp.command.uses_selected_workspace());
     }
 
     #[test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -523,10 +523,14 @@ pub async fn run_from_env() -> Result<(), CliError> {
 }
 
 fn selected_workspace(cli_workspace: Option<String>) -> Workspace {
-    let raw = cli_workspace
-        .or_else(env::workspace)
-        .unwrap_or_else(|| DEFAULT_WORKSPACE_ID.to_string());
-    workspace_resource(raw)
+    workspace_resource(selected_workspace_name(cli_workspace, env::workspace()))
+}
+
+fn selected_workspace_name(cli_workspace: Option<String>, env_workspace: Option<String>) -> String {
+    cli_workspace
+        .filter(|value| !value.is_empty())
+        .or_else(|| env_workspace.filter(|value| !value.is_empty()))
+        .unwrap_or_else(|| DEFAULT_WORKSPACE_ID.to_string())
 }
 
 /// Returns the embedded Coral UI assets for the local server to serve.
@@ -1071,6 +1075,20 @@ mod tests {
         let workspace = super::selected_workspace(Some(" ../bad ".to_string()));
 
         assert_eq!(workspace.name, " ../bad ");
+    }
+
+    #[test]
+    fn selected_workspace_treats_empty_cli_value_as_unset() {
+        let workspace = super::selected_workspace_name(Some(String::new()), None);
+
+        assert_eq!(workspace, super::DEFAULT_WORKSPACE_ID);
+    }
+
+    #[test]
+    fn selected_workspace_treats_empty_env_value_as_unset() {
+        let workspace = super::selected_workspace_name(None, Some(String::new()));
+
+        assert_eq!(workspace, super::DEFAULT_WORKSPACE_ID);
     }
 
     #[test]

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -1,7 +1,6 @@
-use coral_api::v1::{ExecuteSqlRequest, Source, SourceInfo};
+use coral_api::v1::{ExecuteSqlRequest, Source, SourceInfo, Workspace};
 use coral_client::{
-    AppClient, decode_execute_sql_response, default_workspace, format_batches_table,
-    manifest_input_from_proto,
+    AppClient, decode_execute_sql_response, format_batches_table, manifest_input_from_proto,
 };
 use dialoguer::console::{measure_text_width, style};
 use dialoguer::{Select, theme::ColorfulTheme};
@@ -37,14 +36,14 @@ enum InstalledSourceAction {
     Back,
 }
 
-pub(crate) async fn run(app: &AppClient) -> Result<(), anyhow::Error> {
+pub(crate) async fn run(app: &AppClient, workspace: &Workspace) -> Result<(), anyhow::Error> {
     source_ops::require_interactive()?;
     let theme = ColorfulTheme::default();
 
     crate::branding::print_welcome_header();
 
     loop {
-        let bundled_sources = source_ops::discover_sources(app).await?;
+        let bundled_sources = source_ops::discover_sources(app, workspace).await?;
 
         if bundled_sources.is_empty() {
             println!();
@@ -65,16 +64,16 @@ pub(crate) async fn run(app: &AppClient) -> Result<(), anyhow::Error> {
                     .get(idx)
                     .expect("selected source index comes from menu items");
                 if source.installed {
-                    run_installed_source_menu(app, &theme, source).await?;
+                    run_installed_source_menu(app, workspace, &theme, source).await?;
                 } else {
-                    run_add_bundled_source(app, source).await?;
-                    match run_next_steps(app, &theme).await? {
+                    run_add_bundled_source(app, workspace, source).await?;
+                    match run_next_steps(app, workspace, &theme).await? {
                         NextStepChoice::AddMoreSources => {}
                         NextStepChoice::Exit => return Ok(()),
                     }
                 }
             }
-            TopLevelChoice::Finish => match run_next_steps(app, &theme).await? {
+            TopLevelChoice::Finish => match run_next_steps(app, workspace, &theme).await? {
                 NextStepChoice::AddMoreSources => {}
                 NextStepChoice::Exit => return Ok(()),
             },
@@ -139,6 +138,7 @@ fn format_source_list_item(source: &SourceInfo, name_width: usize) -> String {
 
 async fn run_installed_source_menu(
     app: &AppClient,
+    workspace: &Workspace,
     theme: &ColorfulTheme,
     source: &SourceInfo,
 ) -> Result<(), anyhow::Error> {
@@ -163,6 +163,7 @@ async fn run_installed_source_menu(
         Some(InstalledSourceAction::Validate) => {
             source_ops::validate_and_warn(
                 app,
+                workspace,
                 &source.name,
                 source_ops::TableDisplayLimit::DEFAULT,
             )
@@ -178,11 +179,17 @@ async fn run_installed_source_menu(
                 &inputs,
                 source_ops::CredentialPromptMode::CredentialMethodFirst,
             )?;
-            let result =
-                source_ops::add_bundled_source_with_credentials(app, &source.name, inputs).await?;
+            let result = source_ops::add_bundled_source_with_credentials(
+                app,
+                workspace,
+                &source.name,
+                inputs,
+            )
+            .await?;
             println!("Reconfigured source {}", result.name);
             source_ops::validate_and_warn(
                 app,
+                workspace,
                 &result.name,
                 source_ops::TableDisplayLimit::DEFAULT,
             )
@@ -194,7 +201,11 @@ async fn run_installed_source_menu(
     Ok(())
 }
 
-async fn run_add_bundled_source(app: &AppClient, source: &SourceInfo) -> Result<(), anyhow::Error> {
+async fn run_add_bundled_source(
+    app: &AppClient,
+    workspace: &Workspace,
+    source: &SourceInfo,
+) -> Result<(), anyhow::Error> {
     let inputs = source
         .inputs
         .iter()
@@ -204,21 +215,31 @@ async fn run_add_bundled_source(app: &AppClient, source: &SourceInfo) -> Result<
         &inputs,
         source_ops::CredentialPromptMode::CredentialMethodFirst,
     )?;
-    let result = source_ops::add_bundled_source_with_credentials(app, &source.name, inputs).await?;
+    let result =
+        source_ops::add_bundled_source_with_credentials(app, workspace, &source.name, inputs)
+            .await?;
     println!("Added source {}", result.name);
-    source_ops::validate_and_warn(app, &result.name, source_ops::TableDisplayLimit::DEFAULT).await
+    source_ops::validate_and_warn(
+        app,
+        workspace,
+        &result.name,
+        source_ops::TableDisplayLimit::DEFAULT,
+    )
+    .await
 }
 
 async fn run_next_steps(
     app: &AppClient,
+    workspace: &Workspace,
     theme: &ColorfulTheme,
 ) -> Result<NextStepChoice, anyhow::Error> {
-    let installed_sources = source_ops::list_sources(app).await?;
-    show_next_steps_screen(app, theme, &installed_sources).await
+    let installed_sources = source_ops::list_sources(app, workspace).await?;
+    show_next_steps_screen(app, workspace, theme, &installed_sources).await
 }
 
 async fn show_next_steps_screen(
     app: &AppClient,
+    workspace: &Workspace,
     theme: &ColorfulTheme,
     installed_sources: &[Source],
 ) -> Result<NextStepChoice, anyhow::Error> {
@@ -301,7 +322,7 @@ async fn show_next_steps_screen(
         match action {
             Some(NextStepAction::RunExampleQuery) => {
                 let sql = "SELECT schema_name, COUNT(*) AS table_count FROM coral.tables GROUP BY schema_name ORDER BY 1";
-                match run_first_query(app, sql).await {
+                match run_first_query(app, workspace, sql).await {
                     Ok(output) => {
                         println!();
                         println!("{}", style(sql).dim());
@@ -327,11 +348,15 @@ async fn show_next_steps_screen(
     }
 }
 
-async fn run_first_query(app: &AppClient, sql: &str) -> Result<String, anyhow::Error> {
+async fn run_first_query(
+    app: &AppClient,
+    workspace: &Workspace,
+    sql: &str,
+) -> Result<String, anyhow::Error> {
     let response = app
         .query_client()
         .execute_sql(Request::new(ExecuteSqlRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace.clone()),
             sql: sql.to_string(),
         }))
         .await?

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -16,10 +16,11 @@ use coral_api::v1::{
     GetSourceInfoRequest, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
     OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source,
     SourceCredentialStorage, SourceInfo, SourceOrigin, SourceSecret, SourceVariable,
-    ValidateSourceRequest, ValidateSourceResponse, create_bundled_source_with_o_auth_response,
-    import_source_response, query_test_result, source_input_spec::Input as ProtoSourceInput,
+    ValidateSourceRequest, ValidateSourceResponse, Workspace,
+    create_bundled_source_with_o_auth_response, import_source_response, query_test_result,
+    source_input_spec::Input as ProtoSourceInput,
 };
-use coral_client::{AppClient, DecodedStatusError, decode_status_error, default_workspace};
+use coral_client::{AppClient, DecodedStatusError, decode_status_error};
 use coral_spec::v4::SurfaceDescriptor;
 use coral_spec::{
     ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
@@ -70,22 +71,28 @@ impl TableDisplayLimit {
     pub(crate) const DEFAULT: Self = Self::Max(MAX_TABLES_PER_SCHEMA);
 }
 
-pub(crate) async fn discover_sources(app: &AppClient) -> Result<Vec<SourceInfo>, anyhow::Error> {
+pub(crate) async fn discover_sources(
+    app: &AppClient,
+    workspace: &Workspace,
+) -> Result<Vec<SourceInfo>, anyhow::Error> {
     Ok(app
         .source_client()
         .discover_sources(Request::new(DiscoverSourcesRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace.clone()),
         }))
         .await?
         .into_inner()
         .sources)
 }
 
-pub(crate) async fn list_sources(app: &AppClient) -> Result<Vec<Source>, anyhow::Error> {
+pub(crate) async fn list_sources(
+    app: &AppClient,
+    workspace: &Workspace,
+) -> Result<Vec<Source>, anyhow::Error> {
     Ok(app
         .source_client()
         .list_sources(Request::new(ListSourcesRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace.clone()),
         }))
         .await?
         .into_inner()
@@ -94,6 +101,7 @@ pub(crate) async fn list_sources(app: &AppClient) -> Result<Vec<Source>, anyhow:
 
 pub(crate) async fn add_bundled_source(
     app: &AppClient,
+    workspace: &Workspace,
     name: &str,
     variables: Vec<SourceVariable>,
     secrets: Vec<SourceSecret>,
@@ -101,7 +109,7 @@ pub(crate) async fn add_bundled_source(
     let response = app
         .source_client()
         .create_bundled_source(Request::new(CreateBundledSourceRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace.clone()),
             name: name.to_string(),
             variables,
             secrets,
@@ -115,6 +123,7 @@ pub(crate) async fn add_bundled_source(
 
 pub(crate) async fn import_source(
     app: &AppClient,
+    workspace: &Workspace,
     manifest_yaml: String,
     variables: Vec<SourceVariable>,
     secrets: Vec<SourceSecret>,
@@ -122,7 +131,7 @@ pub(crate) async fn import_source(
     let mut responses = app
         .source_client()
         .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace.clone()),
             manifest_yaml,
             variables,
             secrets,
@@ -175,16 +184,17 @@ impl CredentialPromptMode {
 
 pub(crate) async fn add_bundled_source_with_credentials(
     app: &AppClient,
+    workspace: &Workspace,
     name: &str,
     inputs: CollectedSourceInputs,
 ) -> Result<Source, anyhow::Error> {
     if inputs.oauth_credential_retrievals.is_empty() {
-        return add_bundled_source(app, name, inputs.variables, inputs.secrets).await;
+        return add_bundled_source(app, workspace, name, inputs.variables, inputs.secrets).await;
     }
     let response = app
         .source_client()
         .create_bundled_source_with_o_auth(Request::new(CreateBundledSourceWithOAuthRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace.clone()),
             name: name.to_string(),
             variables: inputs.variables,
             secrets: inputs.secrets,
@@ -196,16 +206,24 @@ pub(crate) async fn add_bundled_source_with_credentials(
 
 pub(crate) async fn import_source_with_credentials(
     app: &AppClient,
+    workspace: &Workspace,
     manifest_yaml: String,
     inputs: CollectedSourceInputs,
 ) -> Result<Source, anyhow::Error> {
     if inputs.oauth_credential_retrievals.is_empty() {
-        return import_source(app, manifest_yaml, inputs.variables, inputs.secrets).await;
+        return import_source(
+            app,
+            workspace,
+            manifest_yaml,
+            inputs.variables,
+            inputs.secrets,
+        )
+        .await;
     }
     let response = app
         .source_client()
         .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace.clone()),
             manifest_yaml,
             variables: inputs.variables,
             secrets: inputs.secrets,
@@ -361,19 +379,21 @@ fn handle_credential_stream_event(
 
 pub(crate) async fn validate_source(
     app: &AppClient,
+    workspace: &Workspace,
     name: &str,
 ) -> Result<ValidateSourceResponse, anyhow::Error> {
-    Ok(validate_source_request(app, source_name_arg(Some(name))?).await?)
+    Ok(validate_source_request(app, workspace, source_name_arg(Some(name))?).await?)
 }
 
 async fn validate_source_request(
     app: &AppClient,
+    workspace: &Workspace,
     name: String,
 ) -> Result<ValidateSourceResponse, tonic::Status> {
     Ok(app
         .source_client()
         .validate_source(Request::new(ValidateSourceRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace.clone()),
             name,
         }))
         .await?
@@ -503,13 +523,14 @@ fn canonicalize_manifest_descriptor(
 
 pub(crate) async fn print_source_info(
     app: &AppClient,
+    workspace: &Workspace,
     name: &str,
     verbose: bool,
 ) -> Result<(), anyhow::Error> {
     let response = app
         .source_client()
         .get_source_info(Request::new(GetSourceInfoRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace.clone()),
             name: source_name_arg(Some(name))?,
         }))
         .await?
@@ -585,10 +606,14 @@ pub(crate) fn display_version(version: &str) -> String {
     }
 }
 
-pub(crate) async fn delete_source(app: &AppClient, name: &str) -> Result<(), anyhow::Error> {
+pub(crate) async fn delete_source(
+    app: &AppClient,
+    workspace: &Workspace,
+    name: &str,
+) -> Result<(), anyhow::Error> {
     app.source_client()
         .delete_source(Request::new(DeleteSourceRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace.clone()),
             name: source_name_arg(Some(name))?,
         }))
         .await?;
@@ -783,10 +808,11 @@ pub(crate) fn source_credential_storage_label(storage: i32) -> &'static str {
 
 pub(crate) async fn validate_and_print(
     app: &AppClient,
+    workspace: &Workspace,
     source_name: &str,
     limit: TableDisplayLimit,
 ) -> Result<(), anyhow::Error> {
-    let response = validate_source(app, source_name).await?;
+    let response = validate_source(app, workspace, source_name).await?;
     print_validation_pretty(&response, limit)?;
     match validation_follow_up(&response, ValidationSeverityMode::WarnOnly) {
         ValidationFollowUp::None => Ok(()),
@@ -800,10 +826,11 @@ pub(crate) async fn validate_and_print(
 
 pub(crate) async fn validate_and_warn(
     app: &AppClient,
+    workspace: &Workspace,
     source_name: &str,
     limit: TableDisplayLimit,
 ) -> Result<(), anyhow::Error> {
-    if let Err(err) = validate_and_print(app, source_name, limit).await {
+    if let Err(err) = validate_and_print(app, workspace, source_name, limit).await {
         eprintln!("Warning: validation failed: {err}");
     }
     Ok(())
@@ -811,15 +838,16 @@ pub(crate) async fn validate_and_warn(
 
 pub(crate) async fn test_and_print(
     app: &AppClient,
+    workspace: &Workspace,
     source_name: &str,
     limit: TableDisplayLimit,
     severity_mode: ValidationSeverityMode,
 ) -> Result<(), crate::CliError> {
     let normalized = source_name_arg(Some(source_name))?;
-    let response = match validate_source_request(app, normalized.clone()).await {
+    let response = match validate_source_request(app, workspace, normalized.clone()).await {
         Ok(response) => response,
         Err(status) if is_source_missing_status(&status) => {
-            return source_test_not_found_error(app, &normalized, status).await;
+            return source_test_not_found_error(app, workspace, &normalized, status).await;
         }
         Err(status) => return Err(anyhow::Error::from(status).into()),
     };
@@ -837,11 +865,12 @@ pub(crate) async fn test_and_print(
 
 async fn source_test_not_found_error(
     app: &AppClient,
+    workspace: &Workspace,
     source_name: &str,
     original_status: tonic::Status,
 ) -> Result<(), crate::CliError> {
     // Discovery failure must not mask the original validation error.
-    let Ok(available) = discover_sources(app).await else {
+    let Ok(available) = discover_sources(app, workspace).await else {
         return Err(anyhow::Error::from(original_status).into());
     };
     if available
@@ -860,10 +889,11 @@ async fn source_test_not_found_error(
 
 pub(crate) async fn remove_and_print(
     app: &AppClient,
+    workspace: &Workspace,
     source_name: &str,
 ) -> Result<(), crate::CliError> {
     let normalized = source_name_arg(Some(source_name))?;
-    match delete_source(app, &normalized).await {
+    match delete_source(app, workspace, &normalized).await {
         Ok(()) => {
             println!("Removed source {normalized}");
             Ok(())

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -18,6 +18,21 @@ coral --disable-feedback mcp-stdio
 These flags do not edit `config.toml`. Use `coral features enable <FEATURE>` or
 `coral features disable <FEATURE>` to persist a preference.
 
+## Global workspace selection
+
+Commands that operate on local source state target the `default` workspace
+unless you select another workspace.
+
+```shellscript
+coral --workspace work source list
+coral source add github --workspace work
+CORAL_WORKSPACE=work coral sql "select * from coral.tables"
+```
+
+The `--workspace <NAME>` flag overrides `CORAL_WORKSPACE` for that process.
+Coral does not persist a separate active-workspace setting; set
+`CORAL_WORKSPACE` in your shell when you want a default for repeated commands.
+
 ## `coral sql`
 
 Run one SQL query and exit.
@@ -159,6 +174,43 @@ Remove an installed source.
 ```shellscript
 coral source remove github
 ```
+
+## `coral workspace`
+
+Manage local workspaces. Workspaces isolate installed source metadata and
+workspace-scoped artifacts such as source manifests, local credential material,
+feedback reports, and episode logs.
+
+Imported source specs and source credential material are attached to the source
+installation in that workspace. Reusable global source specs and reusable
+credential references are separate concepts and are not represented by
+`coral workspace` today.
+
+### `coral workspace list`
+
+List configured workspaces.
+
+```shellscript
+coral workspace list
+```
+
+### `coral workspace create <NAME>`
+
+Create an empty workspace.
+
+```shellscript
+coral workspace create work
+```
+
+### `coral workspace remove <NAME>`
+
+Remove a workspace and its workspace-scoped source/artifact directory.
+
+```shellscript
+coral workspace remove work
+```
+
+The `default` workspace cannot be removed.
 
 ## `coral onboard`
 

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -15,6 +15,34 @@ This state includes installed-source metadata and non-secret source variables. S
   Prefer the `coral source` commands for source state instead of editing workspace entries manually.
 </Note>
 
+## Workspaces
+
+Workspace metadata is stored under `[workspaces]`. The `default` workspace
+exists automatically, and additional workspaces can be managed with
+`coral workspace`.
+
+```toml
+[workspaces.default]
+
+[workspaces.work]
+
+[workspaces.work.sources.github]
+version = "1.0.0"
+variables = {}
+secrets = ["GITHUB_TOKEN"]
+origin = "bundled"
+```
+
+An empty workspace is represented by an explicit `[workspaces.<name>]` table.
+Installed sources for that workspace live under
+`[workspaces.<name>.sources.<source>]`.
+
+There is no separate active-workspace key in `config.toml`; use
+`CORAL_WORKSPACE` for a shell default or `--workspace <NAME>` for one command.
+Source specs imported from files and source credential material remain scoped
+to the source installation in a workspace. Reusable global source specs and
+reusable credential references are not config objects today.
+
 ## Runtime features
 
 Experimental runtime features are configured under `[features]`.


### PR DESCRIPTION
## Intent

Add the user-facing CLI surface for workspace selection and workspace lifecycle commands.

## What it enables

Users can target commands with `--workspace` or `CORAL_WORKSPACE`, manage workspaces with `coral workspace`, and have source/onboarding flows respect the selected workspace.

## Usage examples

`coral workspace create work`

`coral --workspace work source list`

`CORAL_WORKSPACE=work coral sql "select * from coral.tables"`
