### PR TITLE
fix(app): harden workspace deletion rollback

### DIFF
--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -2,12 +2,12 @@ use std::fs;
 
 use coral_api::v1::{
     CreateWorkspaceRequest, DeleteWorkspaceRequest, ImportSourceRequest, ListSourcesRequest,
-    ListWorkspacesRequest, Workspace, import_source_response,
+    ListWorkspacesRequest, Source, SourceSecret, SourceVariable, Workspace, import_source_response,
 };
 use coral_client::default_workspace;
 use tonic::Request;
 
-use crate::harness::{GrpcHarness, fixture_manifest_yaml};
+use crate::harness::{GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml};
 
 fn workspace(name: &str) -> Workspace {
     Workspace {
@@ -26,6 +26,54 @@ async fn workspace_names(harness: &GrpcHarness) -> Vec<String> {
         .into_iter()
         .map(|workspace| workspace.name)
         .collect()
+}
+
+async fn import_source_in_workspace(
+    harness: &GrpcHarness,
+    workspace_name: &str,
+    manifest_yaml: String,
+    variables: Vec<SourceVariable>,
+    secrets: Vec<SourceSecret>,
+) -> Source {
+    let mut stream = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(workspace(workspace_name)),
+            manifest_yaml,
+            variables,
+            secrets,
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect("import source")
+        .into_inner();
+    stream
+        .message()
+        .await
+        .expect("import source stream")
+        .and_then(|response| match response.event {
+            Some(import_source_response::Event::Source(source)) => Some(source),
+            _ => None,
+        })
+        .expect("import source response")
+}
+
+#[cfg(unix)]
+fn find_workspace_delete_backup(
+    config_dir: &std::path::Path,
+    workspace_name: &str,
+) -> std::path::PathBuf {
+    let prefix = format!("{workspace_name}.delete.rollback.");
+    fs::read_dir(config_dir.join("workspaces"))
+        .expect("read workspaces dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(&prefix))
+        })
+        .expect("workspace delete backup dir")
 }
 
 #[tokio::test]
@@ -124,27 +172,14 @@ async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
         .await
         .expect("create workspace");
 
-    let mut import_stream = harness
-        .source_client()
-        .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(workspace("work")),
-            manifest_yaml: fixture_manifest_yaml(harness.temp_path()),
-            variables: Vec::new(),
-            secrets: Vec::new(),
-            oauth_credential_retrievals: Vec::new(),
-        }))
-        .await
-        .expect("import source")
-        .into_inner();
-    let imported = import_stream
-        .message()
-        .await
-        .expect("import source stream")
-        .and_then(|response| match response.event {
-            Some(import_source_response::Event::Source(source)) => Some(source),
-            _ => None,
-        })
-        .expect("import source response");
+    let imported = import_source_in_workspace(
+        &harness,
+        "work",
+        fixture_manifest_yaml(harness.temp_path()),
+        Vec::new(),
+        Vec::new(),
+    )
+    .await;
     assert_eq!(imported.name, "local_messages");
 
     let source_dir = harness
@@ -171,6 +206,78 @@ async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
     assert!(
         !source_dir.exists(),
         "delete should remove workspace artifacts"
+    );
+
+    let raw = fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    assert!(
+        !raw.contains("[workspaces.work"),
+        "deleted workspace should be removed from config: {raw}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn delete_workspace_succeeds_when_backup_cleanup_fails_after_config_delete() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let harness = GrpcHarness::new().await;
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("create workspace");
+
+    let imported = import_source_in_workspace(
+        &harness,
+        "work",
+        fixture_manifest_with_inputs_yaml(),
+        vec![SourceVariable {
+            key: "API_BASE".to_string(),
+            value: "https://example.com".to_string(),
+        }],
+        vec![SourceSecret {
+            key: "API_TOKEN".to_string(),
+            value: "secret-token".to_string(),
+        }],
+    )
+    .await;
+    assert_eq!(imported.name, "secured_messages");
+
+    let workspace_dir = harness.config_dir().join("workspaces").join("work");
+    let sources_root = workspace_dir.join("sources");
+    assert!(
+        sources_root
+            .join("secured_messages")
+            .join("secrets.env")
+            .exists(),
+        "import should persist file-backed credential material"
+    );
+    fs::set_permissions(&sources_root, fs::Permissions::from_mode(0o500))
+        .expect("make nested sources dir read-only");
+
+    let deleted = harness
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("delete workspace should succeed after committed config removal")
+        .into_inner()
+        .workspace
+        .expect("delete workspace response");
+    assert_eq!(deleted.name, "work");
+
+    let backup = find_workspace_delete_backup(harness.config_dir(), "work");
+    fs::set_permissions(backup.join("sources"), fs::Permissions::from_mode(0o700))
+        .expect("restore backup sources permissions");
+    fs::remove_dir_all(&backup).expect("remove backup after assertion");
+
+    assert_eq!(workspace_names(&harness).await, vec!["default"]);
+    assert!(
+        !workspace_dir.exists(),
+        "deleted workspace should no longer exist at its normal artifact path"
     );
 
     let raw = fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");


### PR DESCRIPTION
## Intent

Harden workspace deletion rollback before layering trace-history cleanup on top.

## What it enables

Workspace deletion now has stronger tests around rollback behavior, missing workspace handling, default workspace protection, and preservation of unrelated workspace state.

## Usage examples

If `coral workspace remove work` cannot finish deleting workspace-owned artifacts, the workspace config and credential material are restored instead of leaving a partial delete.
