### PR TITLE
refactor(app): narrow workspace manager artifact dependency

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -275,7 +275,7 @@ impl ServerBuilder {
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            layout.clone(),
+            layout.workspaces_root(),
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
@@ -790,7 +790,7 @@ enabled = false
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            layout.clone(),
+            layout.workspaces_root(),
         );
         let query_manager = QueryManager::new(
             config_store,
@@ -1176,7 +1176,7 @@ tables:
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            layout.clone(),
+            layout.workspaces_root(),
         );
         let query_manager = QueryManager::new(
             config_store,
@@ -1286,7 +1286,7 @@ tables:
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            layout.clone(),
+            layout.workspaces_root(),
         );
         let query_manager = QueryManager::new(
             config_store,
@@ -1393,7 +1393,7 @@ tables:
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            layout.clone(),
+            layout.workspaces_root(),
         );
         let query_manager = QueryManager::new(
             config_store,

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -275,7 +275,7 @@ impl ServerBuilder {
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            layout.workspaces_root(),
+            layout.clone(),
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
@@ -790,7 +790,7 @@ enabled = false
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            layout.workspaces_root(),
+            layout.clone(),
         );
         let query_manager = QueryManager::new(
             config_store,
@@ -1176,7 +1176,7 @@ tables:
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            layout.workspaces_root(),
+            layout.clone(),
         );
         let query_manager = QueryManager::new(
             config_store,
@@ -1286,7 +1286,7 @@ tables:
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            layout.workspaces_root(),
+            layout.clone(),
         );
         let query_manager = QueryManager::new(
             config_store,
@@ -1393,7 +1393,7 @@ tables:
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            layout.workspaces_root(),
+            layout.clone(),
         );
         let query_manager = QueryManager::new(
             config_store,

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -7,7 +7,7 @@ use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_native_strateg
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
 use crate::storage::fs::ensure_dir;
-use crate::workspaces::WorkspaceName;
+use crate::workspaces::{WorkspaceName, WorkspacePaths};
 
 pub(crate) const INSTALLED_MANIFEST_FILE_NAME: &str = "manifest.yaml";
 pub(crate) const INSTALLED_SECRETS_FILE_NAME: &str = "secrets.env";
@@ -190,6 +190,12 @@ impl AppStateLayout {
         self.v4_materialized_dir(workspace_name, source_name)
             .join("surfaces")
             .join(surface_id)
+    }
+}
+
+impl WorkspacePaths for AppStateLayout {
+    fn workspace_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        AppStateLayout::workspace_dir(self, workspace_name)
     }
 }
 

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use tracing::warn;
@@ -6,26 +5,28 @@ use tracing::warn;
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId};
 use crate::storage::fs::DirectoryBackup;
-use crate::workspaces::{DeletedWorkspace, WorkspaceName, WorkspaceRecord, WorkspaceStore};
+use crate::workspaces::{
+    DeletedWorkspace, WorkspaceName, WorkspacePaths, WorkspaceRecord, WorkspaceStore,
+};
 
 /// App-owned workspace lifecycle behavior.
 #[derive(Clone)]
 pub(crate) struct WorkspaceManager {
     store: Arc<dyn WorkspaceStore>,
     credential_manager: CredentialManager,
-    workspaces_root: PathBuf,
+    paths: Arc<dyn WorkspacePaths>,
 }
 
 impl WorkspaceManager {
     pub(crate) fn new(
         store: impl WorkspaceStore,
         credential_manager: CredentialManager,
-        workspaces_root: impl Into<PathBuf>,
+        paths: impl WorkspacePaths,
     ) -> Self {
         Self {
             store: Arc::new(store),
             credential_manager,
-            workspaces_root: workspaces_root.into(),
+            paths: Arc::new(paths),
         }
     }
 
@@ -119,8 +120,8 @@ impl WorkspaceManager {
         }
     }
 
-    fn workspace_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
-        self.workspaces_root.join(workspace_name.as_str())
+    fn workspace_dir(&self, workspace_name: &WorkspaceName) -> std::path::PathBuf {
+        self.paths.workspace_dir(workspace_name)
     }
 }
 
@@ -159,11 +160,8 @@ mod tests {
         let store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = WorkspaceManager::new(
-            store.clone(),
-            credential_manager.clone(),
-            layout.workspaces_root(),
-        );
+        let manager =
+            WorkspaceManager::new(store.clone(), credential_manager.clone(), layout.clone());
         let workspace_name = WorkspaceName::parse("work").expect("workspace");
         let source = installed_source("github");
         let credential_set_id = CredentialSetId::for_source(&source.name);

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -1,10 +1,10 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tracing::warn;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId};
-use crate::state::AppStateLayout;
 use crate::storage::fs::DirectoryBackup;
 use crate::workspaces::{DeletedWorkspace, WorkspaceName, WorkspaceRecord, WorkspaceStore};
 
@@ -13,19 +13,19 @@ use crate::workspaces::{DeletedWorkspace, WorkspaceName, WorkspaceRecord, Worksp
 pub(crate) struct WorkspaceManager {
     store: Arc<dyn WorkspaceStore>,
     credential_manager: CredentialManager,
-    layout: AppStateLayout,
+    workspaces_root: PathBuf,
 }
 
 impl WorkspaceManager {
     pub(crate) fn new(
         store: impl WorkspaceStore,
         credential_manager: CredentialManager,
-        layout: AppStateLayout,
+        workspaces_root: impl Into<PathBuf>,
     ) -> Self {
         Self {
             store: Arc::new(store),
             credential_manager,
-            layout,
+            workspaces_root: workspaces_root.into(),
         }
     }
 
@@ -98,7 +98,7 @@ impl WorkspaceManager {
     }
 
     fn remove_deleted_workspace_dir(&self, workspace_name: &WorkspaceName) {
-        let workspace_dir = self.layout.workspace_dir(workspace_name);
+        let workspace_dir = self.workspace_dir(workspace_name);
         let backup = match DirectoryBackup::move_for_delete(&workspace_dir, workspace_name) {
             Ok(backup) => backup,
             Err(error) => {
@@ -117,6 +117,10 @@ impl WorkspaceManager {
                 "workspace deleted, but failed to remove workspace artifact backup: {error}"
             );
         }
+    }
+
+    fn workspace_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.workspaces_root.join(workspace_name.as_str())
     }
 }
 
@@ -155,8 +159,11 @@ mod tests {
         let store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            WorkspaceManager::new(store.clone(), credential_manager.clone(), layout.clone());
+        let manager = WorkspaceManager::new(
+            store.clone(),
+            credential_manager.clone(),
+            layout.workspaces_root(),
+        );
         let workspace_name = WorkspaceName::parse("work").expect("workspace");
         let source = installed_source("github");
         let credential_set_id = CredentialSetId::for_source(&source.name);

--- a/crates/coral-app/src/workspaces/mod.rs
+++ b/crates/coral-app/src/workspaces/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod manager;
 pub(crate) mod model;
 pub(crate) mod name;
+pub(crate) mod paths;
 pub(crate) mod service;
 pub(crate) mod store;
 
@@ -8,5 +9,6 @@ pub(crate) use manager::WorkspaceManager;
 pub(crate) use model::{DeletedWorkspace, WorkspaceRecord};
 pub use name::DEFAULT_WORKSPACE_ID;
 pub(crate) use name::WorkspaceName;
+pub(crate) use paths::WorkspacePaths;
 pub(crate) use service::WorkspaceService;
 pub(crate) use store::WorkspaceStore;

--- a/crates/coral-app/src/workspaces/paths.rs
+++ b/crates/coral-app/src/workspaces/paths.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+
+use crate::workspaces::WorkspaceName;
+
+/// Path capability for workspace-owned filesystem artifacts.
+pub(crate) trait WorkspacePaths: Send + Sync + 'static {
+    fn workspace_dir(&self, workspace_name: &WorkspaceName) -> PathBuf;
+}


### PR DESCRIPTION
## Intent

Narrow the workspace manager's dependency on app state layout before adding trace cleanup wiring.

## What it enables

The workspace manager now receives the specific workspace artifact root it needs, reducing constructor coupling and making later trace-store wiring more explicit.

## Usage examples

Server bootstrap passes `layout.workspaces_root()` to `WorkspaceManager` instead of handing over the broader layout object.
