### PR TITLE
fix(app): add workspace trace pruning store

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -32,6 +32,7 @@ use crate::sources::materialization::{
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::runtime_components_for_v4_source;
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
+use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug)]
@@ -301,9 +302,10 @@ impl QueryManager {
     ) -> Result<Vec<LoadedQuerySource>, AppError> {
         let span = tracing::info_span!(
             "coral.app.query_sources.load",
-            workspace = %workspace_name,
+            workspace = tracing::field::Empty,
             source.count = tracing::field::Empty,
         );
+        span.record(WORKSPACE_SPAN_ATTRIBUTE, workspace_name.as_str());
         let _guard = span.enter();
         config.require_workspace(workspace_name)?;
         let mut loaded_sources = Vec::new();
@@ -564,7 +566,7 @@ fn create_query_span(
         "coral.query",
         otel.name = "coral.query",
         operation = operation,
-        workspace = %workspace_name.as_str(),
+        workspace = tracing::field::Empty,
         sql = %sql,
         // Trajectory-memory attribution: present only when the caller tagged the
         // call with a valid `coral-episode-id`. Joins to the intent registered by
@@ -582,6 +584,7 @@ fn create_query_span(
     if let Some(episode_id) = episode_id {
         span.record("episode.id", episode_id.as_str());
     }
+    span.record(WORKSPACE_SPAN_ATTRIBUTE, workspace_name.as_str());
     span
 }
 

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -20,6 +20,7 @@ use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue, json}
 use tokio::task;
 
 use crate::storage::fs as storage_fs;
+use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 
 const JSONL_MAX_FILE_BYTES: u64 = 16 * 1024 * 1024;
 const JSONL_MAX_FILE_ROWS: usize = 50_000;
@@ -556,7 +557,6 @@ struct TraceListAggregate {
 #[derive(Debug, Deserialize)]
 struct TraceSpanIdentityRecord {
     trace_id: String,
-    span_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -571,15 +571,10 @@ struct TraceQueryHistorySpanRecord {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-struct TraceWorkspaceSpanRecord {
+struct TraceWorkspaceRecord {
     trace_id: String,
-    span_id: String,
-    #[serde(default)]
-    parent_span_id: Option<String>,
     attributes_json: String,
 }
-
-type TraceSpanKey = (String, String);
 
 impl TraceStore {
     pub(crate) fn new(dir: PathBuf) -> Self {
@@ -763,17 +758,13 @@ impl TraceStore {
 
         self.prune_expired()?;
         let files = self.jsonl_files_by_modified()?;
-        let span_keys = read_workspace_trace_span_keys(&files, workspace_name)?;
-        if span_keys.is_empty() {
+        let trace_ids = read_workspace_trace_ids(&files, workspace_name)?;
+        if trace_ids.is_empty() {
             return Ok(0);
         }
-        let affected_trace_ids = span_keys
-            .iter()
-            .map(|(trace_id, _span_id)| trace_id.clone())
-            .collect::<HashSet<_>>();
 
-        rewrite_trace_files_excluding_span_keys(&files, &span_keys)?;
-        Ok(affected_trace_ids.len())
+        rewrite_trace_files_excluding_trace_ids(&files, &trace_ids)?;
+        Ok(trace_ids.len())
     }
 
     fn prune_expired(&self) -> Result<(), TraceStoreError> {
@@ -1270,20 +1261,20 @@ fn read_query_history_spans_file(
     Ok(spans_by_id.into_values().collect())
 }
 
-fn read_workspace_trace_span_keys(
+fn read_workspace_trace_ids(
     files: &[TraceStoreFile],
     workspace_name: &str,
-) -> Result<HashSet<TraceSpanKey>, TraceStoreError> {
+) -> Result<HashSet<String>, TraceStoreError> {
     let mut spans = Vec::new();
     for file in files {
-        spans.extend(read_workspace_trace_spans_file(&file.path)?);
+        spans.extend(read_workspace_trace_records_file(&file.path)?);
     }
-    Ok(workspace_trace_span_keys(spans, workspace_name))
+    Ok(workspace_trace_ids(spans, workspace_name))
 }
 
-fn read_workspace_trace_spans_file(
+fn read_workspace_trace_records_file(
     path: &Path,
-) -> Result<Vec<TraceWorkspaceSpanRecord>, TraceStoreError> {
+) -> Result<Vec<TraceWorkspaceRecord>, TraceStoreError> {
     let file = File::open(path).map_err(|source| TraceStoreError::OpenFile {
         path: path.to_path_buf(),
         source,
@@ -1311,9 +1302,12 @@ fn read_workspace_trace_spans_file(
             continue;
         }
 
-        match serde_json::from_str::<TraceWorkspaceSpanRecord>(trimmed) {
+        match serde_json::from_str::<TraceWorkspaceRecord>(trimmed) {
             Ok(record) => spans.push(record),
             Err(_source) if !complete_line => break,
+            // Workspace trace cleanup is best-effort. A complete malformed line
+            // cannot be attributed to a workspace, so preserve it during rewrite
+            // instead of blocking deletion of config-owned workspace state.
             Err(_source) => {}
         }
     }
@@ -1321,88 +1315,21 @@ fn read_workspace_trace_spans_file(
     Ok(spans)
 }
 
-fn workspace_trace_span_keys(
-    spans: Vec<TraceWorkspaceSpanRecord>,
-    workspace_name: &str,
-) -> HashSet<TraceSpanKey> {
-    let mut spans_by_trace: HashMap<String, HashMap<String, TraceWorkspaceSpanRecord>> =
-        HashMap::new();
-    let mut children_by_trace: HashMap<String, HashMap<String, Vec<String>>> = HashMap::new();
-
-    for span in spans {
-        if let Some(parent_span_id) = span.parent_span_id.as_ref() {
-            children_by_trace
-                .entry(span.trace_id.clone())
-                .or_default()
-                .entry(parent_span_id.clone())
-                .or_default()
-                .push(span.span_id.clone());
-        }
-        spans_by_trace
-            .entry(span.trace_id.clone())
-            .or_default()
-            .insert(span.span_id.clone(), span);
-    }
-
-    let mut span_keys = HashSet::new();
-    for (trace_id, trace_spans) in &spans_by_trace {
-        for span in trace_spans.values() {
-            if attributes_match_workspace(&span.attributes_json, workspace_name) {
-                collect_workspace_span_tree(
-                    trace_id,
-                    &span.span_id,
-                    workspace_name,
-                    &spans_by_trace,
-                    &children_by_trace,
-                    &mut span_keys,
-                );
-            }
-        }
-    }
-    span_keys
+fn workspace_trace_ids(spans: Vec<TraceWorkspaceRecord>, workspace_name: &str) -> HashSet<String> {
+    spans
+        .into_iter()
+        .filter(|span| attributes_match_workspace(&span.attributes_json, workspace_name))
+        .map(|span| span.trace_id)
+        .collect()
 }
 
-fn collect_workspace_span_tree(
-    trace_id: &str,
-    root_span_id: &str,
-    workspace_name: &str,
-    spans_by_trace: &HashMap<String, HashMap<String, TraceWorkspaceSpanRecord>>,
-    children_by_trace: &HashMap<String, HashMap<String, Vec<String>>>,
-    span_keys: &mut HashSet<TraceSpanKey>,
-) {
-    let mut pending = vec![(root_span_id.to_string(), true)];
-    while let Some((span_id, is_root)) = pending.pop() {
-        let Some(span) = spans_by_trace
-            .get(trace_id)
-            .and_then(|trace_spans| trace_spans.get(&span_id))
-        else {
-            continue;
-        };
-        if !is_root
-            && workspace_attribute(&span.attributes_json)
-                .is_some_and(|workspace| workspace != workspace_name)
-        {
-            continue;
-        }
-        if !span_keys.insert((trace_id.to_string(), span_id.clone())) {
-            continue;
-        }
-        if let Some(children) = children_by_trace
-            .get(trace_id)
-            .and_then(|trace_children| trace_children.get(&span_id))
-        {
-            pending.extend(children.iter().cloned().map(|child| (child, false)));
-        }
-    }
-}
-
-fn rewrite_trace_files_excluding_span_keys(
+fn rewrite_trace_files_excluding_trace_ids(
     files: &[TraceStoreFile],
-    span_keys: &HashSet<TraceSpanKey>,
+    trace_ids: &HashSet<String>,
 ) -> Result<(), TraceStoreError> {
     let mut rewrites = Vec::new();
     for file in files {
-        if let Some(rewrite) = plan_trace_file_rewrite(&file.path, span_keys)? {
+        if let Some(rewrite) = plan_trace_file_rewrite(&file.path, trace_ids)? {
             rewrites.push(rewrite);
         }
     }
@@ -1446,7 +1373,7 @@ struct TraceFileRewrite {
 
 fn plan_trace_file_rewrite(
     path: &Path,
-    span_keys: &HashSet<TraceSpanKey>,
+    trace_ids: &HashSet<String>,
 ) -> Result<Option<TraceFileRewrite>, TraceStoreError> {
     let original = fs::read(path).map_err(|source| TraceStoreError::ReadFile {
         path: path.to_path_buf(),
@@ -1478,13 +1405,14 @@ fn plan_trace_file_rewrite(
         }
 
         match serde_json::from_str::<TraceSpanIdentityRecord>(trimmed) {
-            Ok(identity)
-                if span_keys.contains(&(identity.trace_id.clone(), identity.span_id.clone())) =>
-            {
+            Ok(identity) if trace_ids.contains(&identity.trace_id) => {
                 removed = true;
             }
             Ok(_identity) => kept.extend_from_slice(line.as_bytes()),
             Err(_source) if !complete_line => kept.extend_from_slice(line.as_bytes()),
+            // Preserve malformed complete lines. The discovery pass applies the
+            // same best-effort policy, so these lines are never attributed to a
+            // workspace trace ID.
             Err(_source) => kept.extend_from_slice(line.as_bytes()),
         }
     }
@@ -1712,7 +1640,7 @@ fn attributes_match_workspace(attributes_json: &str, workspace_name: &str) -> bo
 fn workspace_attribute(attributes_json: &str) -> Option<String> {
     parse_attributes(attributes_json)
         .as_ref()
-        .and_then(|attributes| attr_string(attributes, "workspace"))
+        .and_then(|attributes| attr_string(attributes, WORKSPACE_SPAN_ATTRIBUTE))
 }
 
 fn status_from_attributes(attributes: Option<&JsonValue>) -> Option<StoredTraceStatus> {

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -411,12 +411,6 @@ pub(crate) enum TraceStoreError {
     WriterPoisoned,
     #[error("failed to close active local trace store writer before cleanup: {source}")]
     CloseActiveWriter { source: LocalTraceStoreError },
-    #[error("failed to decode local trace store file {path} line {line}: {source}")]
-    DecodeLine {
-        path: PathBuf,
-        line: usize,
-        source: serde_json::Error,
-    },
     #[error("failed to prune expired local trace store files: {source}")]
     PruneExpired { source: LocalTraceStoreError },
     #[error("local trace store worker failed before returning a response: {source}")]
@@ -1105,7 +1099,6 @@ fn read_list_spans_file_filtered(
     let mut reader = BufReader::new(file);
     let mut spans_by_id = HashMap::new();
     let mut line = String::new();
-    let mut line_number = 0;
 
     loop {
         line.clear();
@@ -1120,7 +1113,6 @@ fn read_list_spans_file_filtered(
             break;
         }
 
-        line_number += 1;
         let complete_line = line.ends_with('\n');
         let trimmed = line.trim_end_matches(['\r', '\n']);
         if trimmed.trim().is_empty() {
@@ -1138,13 +1130,7 @@ fn read_list_spans_file_filtered(
             }
             Ok(_span) => {}
             Err(_) if !complete_line => break,
-            Err(source) => {
-                return Err(TraceStoreError::DecodeLine {
-                    path: path.to_path_buf(),
-                    line: line_number,
-                    source,
-                });
-            }
+            Err(_source) => {}
         }
     }
 
@@ -1162,7 +1148,6 @@ fn read_trace_spans_file(
     let mut reader = BufReader::new(file);
     let mut spans_by_id = HashMap::new();
     let mut line = String::new();
-    let mut line_number = 0;
 
     loop {
         line.clear();
@@ -1177,7 +1162,6 @@ fn read_trace_spans_file(
             break;
         }
 
-        line_number += 1;
         let complete_line = line.ends_with('\n');
         let trimmed = line.trim_end_matches(['\r', '\n']);
         if trimmed.trim().is_empty() {
@@ -1194,24 +1178,12 @@ fn read_trace_spans_file(
                         spans_by_id.insert((span.trace_id.clone(), span.span_id.clone()), span);
                     }
                     Err(_) if !complete_line => break,
-                    Err(source) => {
-                        return Err(TraceStoreError::DecodeLine {
-                            path: path.to_path_buf(),
-                            line: line_number,
-                            source,
-                        });
-                    }
+                    Err(_source) => {}
                 }
             }
             Ok(_identity) => {}
             Err(_) if !complete_line => break,
-            Err(source) => {
-                return Err(TraceStoreError::DecodeLine {
-                    path: path.to_path_buf(),
-                    line: line_number,
-                    source,
-                });
-            }
+            Err(_source) => {}
         }
     }
 

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -6,7 +6,7 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use opentelemetry::trace::{SpanId, SpanKind, Status};
@@ -26,6 +26,10 @@ const JSONL_MAX_FILE_ROWS: usize = 50_000;
 const JSONL_MAX_FILE_AGE: Duration = Duration::from_hours(24);
 const JSONL_PRUNE_INTERVAL: Duration = Duration::from_hours(1);
 const JSONL_FILE_MTIME_SPAN_END_TOLERANCE: Duration = Duration::from_secs(2);
+type ActiveTraceWriter = Arc<Mutex<RollingJsonlWriter>>;
+type WeakActiveTraceWriter = Weak<Mutex<RollingJsonlWriter>>;
+type ActiveTraceWriterRegistry = Mutex<HashMap<PathBuf, Vec<WeakActiveTraceWriter>>>;
+static ACTIVE_TRACE_WRITERS: OnceLock<ActiveTraceWriterRegistry> = OnceLock::new();
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum LocalTraceStoreError {
@@ -78,9 +82,15 @@ pub(crate) struct JsonlSpanExporter {
 }
 
 impl JsonlSpanExporter {
-    pub(crate) fn new(dir: PathBuf, retention: Duration) -> Result<Self, LocalTraceStoreError> {
+    pub(crate) fn new(
+        dir: impl Into<PathBuf>,
+        retention: Duration,
+    ) -> Result<Self, LocalTraceStoreError> {
+        let dir = dir.into();
+        let writer = Arc::new(Mutex::new(RollingJsonlWriter::new(dir.clone(), retention)?));
+        register_active_trace_writer(&dir, &writer);
         Ok(Self {
-            writer: Arc::new(Mutex::new(RollingJsonlWriter::new(dir, retention)?)),
+            writer,
             resource_json: Arc::new(Mutex::new("{}".to_string())),
             shutdown_called: Arc::new(AtomicBool::new(false)),
         })
@@ -379,6 +389,27 @@ pub(crate) enum TraceStoreError {
         path: PathBuf,
         source: std::io::Error,
     },
+    #[error("failed to rewrite local trace store file {path}: {source}")]
+    WriteFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to remove local trace store file {path}: {source}")]
+    RemoveFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to restore local trace store file {path} after cleanup failure: {source}")]
+    RestoreFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("local trace store writer registry mutex poisoned")]
+    WriterRegistryPoisoned,
+    #[error("local trace store writer mutex poisoned")]
+    WriterPoisoned,
+    #[error("failed to close active local trace store writer before cleanup: {source}")]
+    CloseActiveWriter { source: LocalTraceStoreError },
     #[error("failed to decode local trace store file {path} line {line}: {source}")]
     DecodeLine {
         path: PathBuf,
@@ -525,6 +556,7 @@ struct TraceListAggregate {
 #[derive(Debug, Deserialize)]
 struct TraceSpanIdentityRecord {
     trace_id: String,
+    span_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -538,8 +570,18 @@ struct TraceQueryHistorySpanRecord {
     attributes_json: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct TraceWorkspaceSpanRecord {
+    trace_id: String,
+    span_id: String,
+    #[serde(default)]
+    parent_span_id: Option<String>,
+    attributes_json: String,
+}
+
+type TraceSpanKey = (String, String);
+
 impl TraceStore {
-    #[cfg(test)]
     pub(crate) fn new(dir: PathBuf) -> Self {
         Self {
             dir,
@@ -571,6 +613,16 @@ impl TraceStore {
     ) -> Result<TraceDetailRecord, TraceStoreError> {
         let traces = self.clone();
         task::spawn_blocking(move || traces.get_trace_sync(&trace_id))
+            .await
+            .map_err(|source| TraceStoreError::Worker { source })?
+    }
+
+    pub(crate) async fn delete_traces_for_workspace(
+        &self,
+        workspace_name: String,
+    ) -> Result<usize, TraceStoreError> {
+        let traces = self.clone();
+        task::spawn_blocking(move || traces.delete_traces_for_workspace_sync(&workspace_name))
             .await
             .map_err(|source| TraceStoreError::Worker { source })?
     }
@@ -699,6 +751,31 @@ impl TraceStore {
         Ok(entries)
     }
 
+    fn delete_traces_for_workspace_sync(
+        &self,
+        workspace_name: &str,
+    ) -> Result<usize, TraceStoreError> {
+        if !self.dir.exists() {
+            return Ok(0);
+        }
+
+        close_active_trace_writers_for_dir(&self.dir)?;
+
+        self.prune_expired()?;
+        let files = self.jsonl_files_by_modified()?;
+        let span_keys = read_workspace_trace_span_keys(&files, workspace_name)?;
+        if span_keys.is_empty() {
+            return Ok(0);
+        }
+        let affected_trace_ids = span_keys
+            .iter()
+            .map(|(trace_id, _span_id)| trace_id.clone())
+            .collect::<HashSet<_>>();
+
+        rewrite_trace_files_excluding_span_keys(&files, &span_keys)?;
+        Ok(affected_trace_ids.len())
+    }
+
     fn prune_expired(&self) -> Result<(), TraceStoreError> {
         if let Some(retention) = self.retention
             && self.dir.exists()
@@ -763,6 +840,46 @@ fn span_jsonl_file(path: &Path) -> bool {
                 name.strip_prefix("spans")
                     .is_some_and(|suffix| suffix.starts_with('-'))
             })
+}
+
+fn active_trace_writers() -> &'static ActiveTraceWriterRegistry {
+    ACTIVE_TRACE_WRITERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn register_active_trace_writer(dir: &Path, writer: &ActiveTraceWriter) {
+    if let Ok(mut writers) = active_trace_writers().lock() {
+        writers
+            .entry(dir.to_path_buf())
+            .or_default()
+            .push(Arc::downgrade(writer));
+    }
+}
+
+fn active_trace_writers_for_dir(dir: &Path) -> Result<Vec<ActiveTraceWriter>, TraceStoreError> {
+    let mut writers = active_trace_writers()
+        .lock()
+        .map_err(|_poisoned| TraceStoreError::WriterRegistryPoisoned)?;
+    let registered = writers.entry(dir.to_path_buf()).or_default();
+    let mut active = Vec::new();
+    registered.retain(|writer| match writer.upgrade() {
+        Some(writer) => {
+            active.push(writer);
+            true
+        }
+        None => false,
+    });
+    Ok(active)
+}
+
+fn close_active_trace_writers_for_dir(dir: &Path) -> Result<(), TraceStoreError> {
+    for writer in active_trace_writers_for_dir(dir)? {
+        writer
+            .lock()
+            .map_err(|_poisoned| TraceStoreError::WriterPoisoned)?
+            .close_current()
+            .map_err(|source| TraceStoreError::CloseActiveWriter { source })?;
+    }
+    Ok(())
 }
 
 impl TracePrimaryCandidate {
@@ -1153,6 +1270,247 @@ fn read_query_history_spans_file(
     Ok(spans_by_id.into_values().collect())
 }
 
+fn read_workspace_trace_span_keys(
+    files: &[TraceStoreFile],
+    workspace_name: &str,
+) -> Result<HashSet<TraceSpanKey>, TraceStoreError> {
+    let mut spans = Vec::new();
+    for file in files {
+        spans.extend(read_workspace_trace_spans_file(&file.path)?);
+    }
+    Ok(workspace_trace_span_keys(spans, workspace_name))
+}
+
+fn read_workspace_trace_spans_file(
+    path: &Path,
+) -> Result<Vec<TraceWorkspaceSpanRecord>, TraceStoreError> {
+    let file = File::open(path).map_err(|source| TraceStoreError::OpenFile {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut reader = BufReader::new(file);
+    let mut spans = Vec::new();
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let bytes_read =
+            reader
+                .read_line(&mut line)
+                .map_err(|source| TraceStoreError::ReadFile {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        let complete_line = line.ends_with('\n');
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.trim().is_empty() {
+            continue;
+        }
+
+        match serde_json::from_str::<TraceWorkspaceSpanRecord>(trimmed) {
+            Ok(record) => spans.push(record),
+            Err(_source) if !complete_line => break,
+            Err(_source) => {}
+        }
+    }
+
+    Ok(spans)
+}
+
+fn workspace_trace_span_keys(
+    spans: Vec<TraceWorkspaceSpanRecord>,
+    workspace_name: &str,
+) -> HashSet<TraceSpanKey> {
+    let mut spans_by_trace: HashMap<String, HashMap<String, TraceWorkspaceSpanRecord>> =
+        HashMap::new();
+    let mut children_by_trace: HashMap<String, HashMap<String, Vec<String>>> = HashMap::new();
+
+    for span in spans {
+        if let Some(parent_span_id) = span.parent_span_id.as_ref() {
+            children_by_trace
+                .entry(span.trace_id.clone())
+                .or_default()
+                .entry(parent_span_id.clone())
+                .or_default()
+                .push(span.span_id.clone());
+        }
+        spans_by_trace
+            .entry(span.trace_id.clone())
+            .or_default()
+            .insert(span.span_id.clone(), span);
+    }
+
+    let mut span_keys = HashSet::new();
+    for (trace_id, trace_spans) in &spans_by_trace {
+        for span in trace_spans.values() {
+            if attributes_match_workspace(&span.attributes_json, workspace_name) {
+                collect_workspace_span_tree(
+                    trace_id,
+                    &span.span_id,
+                    workspace_name,
+                    &spans_by_trace,
+                    &children_by_trace,
+                    &mut span_keys,
+                );
+            }
+        }
+    }
+    span_keys
+}
+
+fn collect_workspace_span_tree(
+    trace_id: &str,
+    root_span_id: &str,
+    workspace_name: &str,
+    spans_by_trace: &HashMap<String, HashMap<String, TraceWorkspaceSpanRecord>>,
+    children_by_trace: &HashMap<String, HashMap<String, Vec<String>>>,
+    span_keys: &mut HashSet<TraceSpanKey>,
+) {
+    let mut pending = vec![(root_span_id.to_string(), true)];
+    while let Some((span_id, is_root)) = pending.pop() {
+        let Some(span) = spans_by_trace
+            .get(trace_id)
+            .and_then(|trace_spans| trace_spans.get(&span_id))
+        else {
+            continue;
+        };
+        if !is_root
+            && workspace_attribute(&span.attributes_json)
+                .is_some_and(|workspace| workspace != workspace_name)
+        {
+            continue;
+        }
+        if !span_keys.insert((trace_id.to_string(), span_id.clone())) {
+            continue;
+        }
+        if let Some(children) = children_by_trace
+            .get(trace_id)
+            .and_then(|trace_children| trace_children.get(&span_id))
+        {
+            pending.extend(children.iter().cloned().map(|child| (child, false)));
+        }
+    }
+}
+
+fn rewrite_trace_files_excluding_span_keys(
+    files: &[TraceStoreFile],
+    span_keys: &HashSet<TraceSpanKey>,
+) -> Result<(), TraceStoreError> {
+    let mut rewrites = Vec::new();
+    for file in files {
+        if let Some(rewrite) = plan_trace_file_rewrite(&file.path, span_keys)? {
+            rewrites.push(rewrite);
+        }
+    }
+
+    let mut snapshots = Vec::new();
+    for rewrite in rewrites {
+        let path = rewrite.snapshot.path.clone();
+        let result = if rewrite.kept.is_empty() {
+            fs::remove_file(&path).map_err(|source| TraceStoreError::RemoveFile {
+                path: path.clone(),
+                source,
+            })
+        } else {
+            storage_fs::write_atomic(&path, &rewrite.kept).map_err(|source| {
+                TraceStoreError::WriteFile {
+                    path: path.clone(),
+                    source,
+                }
+            })
+        };
+        if let Err(error) = result {
+            restore_trace_file_snapshots(snapshots)?;
+            return Err(error);
+        }
+        snapshots.push(rewrite.snapshot);
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct TraceFileSnapshot {
+    path: PathBuf,
+    original: Vec<u8>,
+}
+
+#[derive(Debug)]
+struct TraceFileRewrite {
+    snapshot: TraceFileSnapshot,
+    kept: Vec<u8>,
+}
+
+fn plan_trace_file_rewrite(
+    path: &Path,
+    span_keys: &HashSet<TraceSpanKey>,
+) -> Result<Option<TraceFileRewrite>, TraceStoreError> {
+    let original = fs::read(path).map_err(|source| TraceStoreError::ReadFile {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut reader = BufReader::new(original.as_slice());
+    let mut kept = Vec::new();
+    let mut removed = false;
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let bytes_read =
+            reader
+                .read_line(&mut line)
+                .map_err(|source| TraceStoreError::ReadFile {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        let complete_line = line.ends_with('\n');
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.trim().is_empty() {
+            kept.extend_from_slice(line.as_bytes());
+            continue;
+        }
+
+        match serde_json::from_str::<TraceSpanIdentityRecord>(trimmed) {
+            Ok(identity)
+                if span_keys.contains(&(identity.trace_id.clone(), identity.span_id.clone())) =>
+            {
+                removed = true;
+            }
+            Ok(_identity) => kept.extend_from_slice(line.as_bytes()),
+            Err(_source) if !complete_line => kept.extend_from_slice(line.as_bytes()),
+            Err(_source) => kept.extend_from_slice(line.as_bytes()),
+        }
+    }
+
+    if !removed {
+        return Ok(None);
+    }
+    let snapshot = TraceFileSnapshot {
+        path: path.to_path_buf(),
+        original,
+    };
+    Ok(Some(TraceFileRewrite { snapshot, kept }))
+}
+
+fn restore_trace_file_snapshots(snapshots: Vec<TraceFileSnapshot>) -> Result<(), TraceStoreError> {
+    for snapshot in snapshots.into_iter().rev() {
+        storage_fs::write_atomic(&snapshot.path, &snapshot.original).map_err(|source| {
+            TraceStoreError::RestoreFile {
+                path: snapshot.path,
+                source,
+            }
+        })?;
+    }
+    Ok(())
+}
+
 fn summary_from_spans(trace_id: &str, spans: &[TraceSpanRecord]) -> TraceSummaryRecord {
     let start_time_unix_nanos = spans
         .iter()
@@ -1345,6 +1703,16 @@ fn span_record(resource_json: &str, span: &SpanData) -> TraceSpanRecord {
 
 fn parse_attributes(attributes_json: &str) -> Option<JsonValue> {
     serde_json::from_str(attributes_json).ok()
+}
+
+fn attributes_match_workspace(attributes_json: &str, workspace_name: &str) -> bool {
+    workspace_attribute(attributes_json).is_some_and(|workspace| workspace == workspace_name)
+}
+
+fn workspace_attribute(attributes_json: &str) -> Option<String> {
+    parse_attributes(attributes_json)
+        .as_ref()
+        .and_then(|attributes| attr_string(attributes, "workspace"))
 }
 
 fn status_from_attributes(attributes: Option<&JsonValue>) -> Option<StoredTraceStatus> {

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -32,6 +32,7 @@ pub mod metrics;
 pub(crate) mod service;
 
 use crate::bootstrap::AppError;
+use crate::workspaces::WorkspaceName;
 pub use config::TelemetryConfig;
 use config::{DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER};
 pub(crate) use local_store::{
@@ -269,6 +270,17 @@ fn configured_local_trace_store(
         .map(|dir| InstalledLocalTraceStore::new(dir, config.trace_history.retention()))
 }
 
+#[expect(dead_code, reason = "used in next stack PR")]
+pub(crate) async fn delete_workspace_traces(
+    trace_store_dir: PathBuf,
+    workspace_name: &WorkspaceName,
+) -> Result<usize, String> {
+    local_store::TraceStore::new(trace_store_dir)
+        .delete_traces_for_workspace(workspace_name.as_str().to_string())
+        .await
+        .map_err(|error| error.to_string())
+}
+
 fn telemetry_resource(service_name: &str) -> Resource {
     Resource::builder()
         .with_attribute(opentelemetry::KeyValue::new(
@@ -313,7 +325,7 @@ fn add_local_trace_exporter(
         build_trace_targets(DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOCAL_TRACE_FILTER);
     let exporter = TargetFilteringSpanExporter::new(exporter, internal_trace_targets)
         .excluding_rpc_services(LOCAL_TRACE_EXCLUDED_RPC_SERVICES);
-    Ok(builder.with_span_processor(BatchSpanProcessor::builder(exporter).build()))
+    Ok(builder.with_simple_exporter(exporter))
 }
 
 pub(crate) fn list_local_query_history(

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -50,6 +50,7 @@ const LOCAL_TRACE_EXCLUDED_RPC_SERVICES: &[&str] = &["coral.v1.TraceService"];
 pub(crate) const QUERY_TRACE_SOURCES_ATTR: &str = "coral.query.sources";
 pub(crate) const QUERY_TRACE_TABLES_ATTR: &str = "coral.query.tables";
 pub(crate) const QUERY_TRACE_TABLE_FUNCTIONS_ATTR: &str = "coral.query.table_functions";
+pub(crate) const WORKSPACE_SPAN_ATTRIBUTE: &str = "workspace";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct InstalledLocalTraceStore {

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -123,7 +123,6 @@ fn trace_store_status(error: TraceStoreError) -> Status {
         | TraceStoreError::WriterPoisoned
         | TraceStoreError::CloseActiveWriter { .. }
         | TraceStoreError::ReadFile { .. }
-        | TraceStoreError::DecodeLine { .. }
         | TraceStoreError::PruneExpired { .. }
         | TraceStoreError::Worker { .. } => Status::new(Code::Internal, error.to_string()),
     }

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -116,6 +116,12 @@ fn trace_store_status(error: TraceStoreError) -> Status {
         TraceStoreError::ReadDir { .. }
         | TraceStoreError::OpenFile { .. }
         | TraceStoreError::FileMetadata { .. }
+        | TraceStoreError::WriteFile { .. }
+        | TraceStoreError::RemoveFile { .. }
+        | TraceStoreError::RestoreFile { .. }
+        | TraceStoreError::WriterRegistryPoisoned
+        | TraceStoreError::WriterPoisoned
+        | TraceStoreError::CloseActiveWriter { .. }
         | TraceStoreError::ReadFile { .. }
         | TraceStoreError::DecodeLine { .. }
         | TraceStoreError::PruneExpired { .. }


### PR DESCRIPTION
## Intent

Add the local trace-store primitive needed to delete workspace-attributed trace history.

## What it enables

The local JSONL trace store can coordinate active writers, identify workspace spans and descendants, preserve other workspace spans in shared traces, ignore malformed records, and roll back file rewrites on in-process failures.

## Usage examples

App code can call `delete_workspace_traces(trace_store_dir, &workspace_name)` to remove local trace records attributed to a workspace.
