### PR TITLE
fix(app): prune traces during workspace remove

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -57,7 +57,7 @@ use crate::state::ConfigStore;
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
-use crate::workspaces::{WorkspaceManager, WorkspaceService};
+use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceManager, WorkspaceService};
 
 /// A static asset (e.g., a built SPA file) served on the same port as
 /// gRPC-Web.
@@ -262,20 +262,27 @@ impl ServerBuilder {
             self.config.enable_stderr_logs,
             internal_trace_store_dir.clone(),
         )?;
+        let installed_trace_store_dir = installed_trace_store
+            .as_ref()
+            .map(|store| store.dir.clone());
         let config_store = ConfigStore::new(layout.clone());
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store);
+        let workspace_lifecycle_lock = WorkspaceLifecycleLock::default();
         let source_manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            workspace_lifecycle_lock.clone(),
         );
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            installed_trace_store_dir,
+            workspace_lifecycle_lock,
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
@@ -780,17 +787,18 @@ enabled = false
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
+        let source_manager = SourceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
-        let workspace_manager = WorkspaceManager::new(
+        let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            None,
         );
         let query_manager = QueryManager::new(
             config_store,
@@ -1166,17 +1174,18 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
+        let source_manager = SourceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
-        let workspace_manager = WorkspaceManager::new(
+        let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            None,
         );
         let query_manager = QueryManager::new(
             config_store,
@@ -1276,17 +1285,18 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
+        let source_manager = SourceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
-        let workspace_manager = WorkspaceManager::new(
+        let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            None,
         );
         let query_manager = QueryManager::new(
             config_store,
@@ -1383,17 +1393,18 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
+        let source_manager = SourceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
-        let workspace_manager = WorkspaceManager::new(
+        let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            None,
         );
         let query_manager = QueryManager::new(
             config_store,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1210,7 +1210,7 @@ tables:
 
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
         fixture.manager.layout.ensure().expect("ensure layout");
-        let source_manager = SourceManager::new(
+        let source_manager = SourceManager::new_for_tests(
             fixture.manager.config_store.clone(),
             fixture.manager.credential_manager.clone(),
             fixture.manager.layout.clone(),

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -27,7 +27,7 @@ use crate::sources::materialization::{
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
-use crate::workspaces::WorkspaceName;
+use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
@@ -39,6 +39,7 @@ pub(crate) struct SourceManager {
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
     layout: AppStateLayout,
+    lifecycle_lock: WorkspaceLifecycleLock,
 }
 
 pub(crate) struct CreateBundledSourceCommand {
@@ -167,16 +168,32 @@ fn materialization_inputs_from_bindings(
 }
 
 impl SourceManager {
+    #[cfg(test)]
+    pub(crate) fn new_for_tests(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+    ) -> Self {
+        Self::new(
+            config_store,
+            credential_manager,
+            layout,
+            crate::workspaces::WorkspaceLifecycleLock::default(),
+        )
+    }
+
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
         layout: AppStateLayout,
+        lifecycle_lock: WorkspaceLifecycleLock,
     ) -> Self {
         Self {
             config_store,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
             layout,
+            lifecycle_lock,
         }
     }
 
@@ -349,6 +366,7 @@ impl SourceManager {
         materialization_manifest_yaml: &str,
         origin: SourceOrigin,
     ) -> Result<InstalledSource, AppError> {
+        let _lifecycle_guard = self.lifecycle_lock.lock();
         self.validate_runtime_schema_names_available(
             workspace_name,
             &candidate.name,
@@ -418,18 +436,40 @@ impl SourceManager {
             bindings,
             &oauth_input_keys,
         )?;
-        let stored_material_for_materialization = stored_material.clone();
-        let bindings = self
-            .bindings_with_oauth_material(
+        let preflight_bindings = Self::validate_oauth_import_preflight(
+            candidate,
+            bindings,
+            &stored_material,
+            &oauth_credential_retrievals,
+        )?;
+        let oauth_material = self
+            .retrieve_oauth_material(
                 candidate,
-                bindings,
-                stored_material,
+                &preflight_bindings.variables,
                 oauth_credential_retrievals,
                 events,
             )
             .await?;
+        let _lifecycle_guard = self.lifecycle_lock.lock();
+        self.validate_runtime_schema_names_available(
+            workspace_name,
+            &candidate.name,
+            materialization_manifest_yaml,
+        )?;
+        let stored_material = self.source_stored_material_for_validation(
+            workspace_name,
+            candidate,
+            bindings,
+            &oauth_input_keys,
+        )?;
+        let mut validation_material = stored_material.clone();
+        for material in &oauth_material {
+            validation_material.insert(material.input_key.clone(), material.access_token.clone());
+        }
+        let mut bindings = validate_bindings(candidate, bindings, &validation_material)?;
+        merge_oauth_material_into_bindings(&mut bindings, oauth_material)?;
         let materialization_inputs =
-            materialization_inputs_from_bindings(&bindings, &stored_material_for_materialization);
+            materialization_inputs_from_bindings(&bindings, &stored_material);
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
@@ -456,6 +496,7 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
+        let _lifecycle_guard = self.lifecycle_lock.lock();
         let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
         let credential_guard = self
@@ -995,37 +1036,6 @@ impl SourceManager {
             materials.push(material);
         }
         Ok(materials)
-    }
-
-    async fn bindings_with_oauth_material(
-        &self,
-        candidate: &CandidateSource,
-        bindings: &SourceBindings,
-        stored_material: BTreeMap<String, String>,
-        oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
-        events: ImportSourceEventSender,
-    ) -> Result<ValidatedBindings, AppError> {
-        let preflight_bindings = Self::validate_oauth_import_preflight(
-            candidate,
-            bindings,
-            &stored_material,
-            &oauth_credential_retrievals,
-        )?;
-        let oauth_material = self
-            .retrieve_oauth_material(
-                candidate,
-                &preflight_bindings.variables,
-                oauth_credential_retrievals,
-                events,
-            )
-            .await?;
-        let mut validation_material = stored_material;
-        for material in &oauth_material {
-            validation_material.insert(material.input_key.clone(), material.access_token.clone());
-        }
-        let mut bindings = validate_bindings(candidate, bindings, &validation_material)?;
-        merge_oauth_material_into_bindings(&mut bindings, oauth_material)?;
-        Ok(bindings)
     }
 
     fn load_source_rollback_state(
@@ -1769,7 +1779,12 @@ tables:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new(config_store.clone(), credential_manager, layout.clone());
+        let manager = SourceManager::new(
+            config_store.clone(),
+            credential_manager,
+            layout.clone(),
+            crate::workspaces::WorkspaceLifecycleLock::default(),
+        );
 
         let workspace_name = default_workspace();
         let original_manifest = manifest_without_secrets();
@@ -1854,7 +1869,12 @@ tables:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout);
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager.clone(),
+            layout,
+            crate::workspaces::WorkspaceLifecycleLock::default(),
+        );
 
         let workspace_name = default_workspace();
         manager
@@ -1918,7 +1938,12 @@ tables:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new(config_store.clone(), credential_manager.clone(), layout);
+        let manager = SourceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout,
+            crate::workspaces::WorkspaceLifecycleLock::default(),
+        );
 
         let workspace_name = default_workspace();
         manager
@@ -2215,7 +2240,8 @@ tables:
             CredentialStoragePreference::Keychain,
         );
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store.clone(), credential_manager, layout);
+        let manager =
+            SourceManager::new_for_tests(config_store.clone(), credential_manager, layout);
         let candidate = candidate_with_secret("OPTIONAL_TOKEN", false);
 
         config_store
@@ -2268,7 +2294,8 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
 
         let disabled = manager
             .discover_sources(&default_workspace())
@@ -2292,7 +2319,8 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
 
         let installed = manager
             .import_source(
@@ -2332,7 +2360,7 @@ tables:
         layout.ensure().expect("ensure layout");
         let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
         std::fs::write(&openapi_file, v4_openapi_fixture()).expect("write fixture");
-        let manager = SourceManager::new(
+        let manager = SourceManager::new_for_tests(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout.clone(),
@@ -2394,7 +2422,7 @@ tables:
             v4_openapi_fixture_with_defaulted_input_server_url(),
         )
         .expect("write fixture");
-        let manager = SourceManager::new(
+        let manager = SourceManager::new_for_tests(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout.clone(),
@@ -2432,7 +2460,7 @@ tables:
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         layout.ensure().expect("ensure layout");
-        let manager = SourceManager::new(
+        let manager = SourceManager::new_for_tests(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout,
@@ -2465,7 +2493,7 @@ tables:
         layout.ensure().expect("ensure layout");
         let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
         std::fs::write(&openapi_file, v4_openapi_fixture_with_metadata()).expect("write fixture");
-        let manager = SourceManager::new(
+        let manager = SourceManager::new_for_tests(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout.clone(),
@@ -2504,7 +2532,8 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
 
         let source_name = SourceName::parse("secured_messages").expect("source");
         let source_dir = layout.source_dir(&default_workspace(), &source_name);
@@ -2606,7 +2635,7 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout);
+        let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
 
         let source = manager
             .import_source(
@@ -2642,7 +2671,8 @@ tables:
             CredentialStoragePreference::Auto,
         );
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout.clone());
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout.clone());
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
 
@@ -2712,7 +2742,8 @@ tables:
             CredentialStoragePreference::Keychain,
         );
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
         let source_name = SourceName::parse("public_messages").expect("source");
 
         let source = manager
@@ -2753,7 +2784,7 @@ tables:
             CredentialStoragePreference::Keychain,
         );
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout);
+        let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
 
         let error = manager
             .import_source(
@@ -2782,7 +2813,8 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
 
         let source_name = SourceName::parse("secured_messages").expect("source");
         manager
@@ -2835,7 +2867,8 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
 
         let source_name = SourceName::parse("secured_messages").expect("source");
         manager
@@ -2883,7 +2916,8 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout);
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         credential_manager
@@ -2940,7 +2974,8 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
         let source_name = SourceName::parse("secured_messages").expect("source");
         let secret_path = layout.secret_file(&default_workspace(), &source_name);
         std::fs::create_dir_all(&secret_path).expect("create blocking secret directory");
@@ -2975,7 +3010,8 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout);
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         credential_manager
@@ -3041,7 +3077,8 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store.clone());
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout.clone());
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout.clone());
         let workspace_name = default_workspace();
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
@@ -3137,7 +3174,8 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout);
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         let fixture = OAuthFixture::new();
@@ -3237,7 +3275,8 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager.clone(), layout);
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         manager
@@ -3313,7 +3352,7 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new(config_store, credential_manager, layout);
+        let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
         let redirect_port = free_loopback_port();
         let (event_tx, mut event_rx) = import_event_channel();
 

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -2031,7 +2031,12 @@ tables:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new(config_store.clone(), credential_manager.clone(), layout);
+        let manager = SourceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout,
+            crate::workspaces::WorkspaceLifecycleLock::default(),
+        );
 
         let workspace_name = default_workspace();
         manager

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -271,7 +271,6 @@ fn configured_local_trace_store(
         .map(|dir| InstalledLocalTraceStore::new(dir, config.trace_history.retention()))
 }
 
-#[expect(dead_code, reason = "used in next stack PR")]
 pub(crate) async fn delete_workspace_traces(
     trace_store_dir: PathBuf,
     workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -88,7 +88,7 @@ impl WorkspaceManager {
         };
 
         let deleted_workspace_name = deleted.workspace.name.clone();
-        self.commit_deleted_workspace_dir(&deleted_workspace_name, workspace_dir_backup);
+        Self::commit_deleted_workspace_dir(&deleted_workspace_name, workspace_dir_backup);
         self.prune_deleted_workspace_traces(&deleted_workspace_name)
             .await;
         Ok(deleted.workspace)
@@ -147,7 +147,6 @@ impl WorkspaceManager {
     }
 
     fn commit_deleted_workspace_dir(
-        &self,
         workspace_name: &WorkspaceName,
         backup: Option<DirectoryBackup>,
     ) {

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tracing::warn;
@@ -6,7 +7,8 @@ use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId};
 use crate::storage::fs::DirectoryBackup;
 use crate::workspaces::{
-    DeletedWorkspace, WorkspaceName, WorkspacePaths, WorkspaceRecord, WorkspaceStore,
+    DeletedWorkspace, WorkspaceLifecycleLock, WorkspaceName, WorkspacePaths, WorkspaceRecord,
+    WorkspaceStore,
 };
 
 /// App-owned workspace lifecycle behavior.
@@ -15,18 +17,40 @@ pub(crate) struct WorkspaceManager {
     store: Arc<dyn WorkspaceStore>,
     credential_manager: CredentialManager,
     paths: Arc<dyn WorkspacePaths>,
+    trace_store_dir: Option<PathBuf>,
+    lifecycle_lock: WorkspaceLifecycleLock,
 }
 
 impl WorkspaceManager {
+    #[cfg(test)]
+    pub(crate) fn new_for_tests(
+        store: impl WorkspaceStore,
+        credential_manager: CredentialManager,
+        paths: impl WorkspacePaths,
+        trace_store_dir: Option<PathBuf>,
+    ) -> Self {
+        Self::new(
+            store,
+            credential_manager,
+            paths,
+            trace_store_dir,
+            WorkspaceLifecycleLock::default(),
+        )
+    }
+
     pub(crate) fn new(
         store: impl WorkspaceStore,
         credential_manager: CredentialManager,
         paths: impl WorkspacePaths,
+        trace_store_dir: Option<PathBuf>,
+        lifecycle_lock: WorkspaceLifecycleLock,
     ) -> Self {
         Self {
             store: Arc::new(store),
             credential_manager,
             paths: Arc::new(paths),
+            trace_store_dir,
+            lifecycle_lock,
         }
     }
 
@@ -38,10 +62,11 @@ impl WorkspaceManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<WorkspaceRecord, AppError> {
+        let _lifecycle_guard = self.lifecycle_lock.lock();
         self.store.create_workspace(workspace_name)
     }
 
-    pub(crate) fn delete_workspace(
+    pub(crate) async fn delete_workspace(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<WorkspaceRecord, AppError> {
@@ -51,17 +76,22 @@ impl WorkspaceManager {
             ));
         }
 
-        let deleted = self
-            .store
-            .delete_workspace(workspace_name)?
-            .ok_or_else(|| AppError::WorkspaceNotFound(workspace_name.to_string()))?;
-        self.cleanup_deleted_workspace_artifacts(&deleted);
-        Ok(deleted.workspace)
-    }
+        let (deleted, workspace_dir_backup) = {
+            let _lifecycle_guard = self.lifecycle_lock.lock();
+            let deleted = self
+                .store
+                .delete_workspace(workspace_name)?
+                .ok_or_else(|| AppError::WorkspaceNotFound(workspace_name.to_string()))?;
+            self.remove_deleted_workspace_credentials(&deleted);
+            let workspace_dir_backup = self.stage_deleted_workspace_dir(&deleted.workspace.name);
+            (deleted, workspace_dir_backup)
+        };
 
-    fn cleanup_deleted_workspace_artifacts(&self, deleted: &DeletedWorkspace) {
-        self.remove_deleted_workspace_credentials(deleted);
-        self.remove_deleted_workspace_dir(&deleted.workspace.name);
+        let deleted_workspace_name = deleted.workspace.name.clone();
+        self.commit_deleted_workspace_dir(&deleted_workspace_name, workspace_dir_backup);
+        self.prune_deleted_workspace_traces(&deleted_workspace_name)
+            .await;
+        Ok(deleted.workspace)
     }
 
     fn remove_deleted_workspace_credentials(&self, deleted: &DeletedWorkspace) {
@@ -98,18 +128,31 @@ impl WorkspaceManager {
         }
     }
 
-    fn remove_deleted_workspace_dir(&self, workspace_name: &WorkspaceName) {
+    fn stage_deleted_workspace_dir(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Option<DirectoryBackup> {
         let workspace_dir = self.workspace_dir(workspace_name);
-        let backup = match DirectoryBackup::move_for_delete(&workspace_dir, workspace_name) {
-            Ok(backup) => backup,
+        match DirectoryBackup::move_for_delete(&workspace_dir, workspace_name) {
+            Ok(backup) => Some(backup),
             Err(error) => {
                 warn!(
                     workspace = %workspace_name,
                     workspace_dir = %workspace_dir.display(),
                     "workspace deleted, but failed to stage workspace directory cleanup: {error}"
                 );
-                return;
+                None
             }
+        }
+    }
+
+    fn commit_deleted_workspace_dir(
+        &self,
+        workspace_name: &WorkspaceName,
+        backup: Option<DirectoryBackup>,
+    ) {
+        let Some(backup) = backup else {
+            return;
         };
         if let Err(error) = backup.commit() {
             warn!(
@@ -122,6 +165,20 @@ impl WorkspaceManager {
 
     fn workspace_dir(&self, workspace_name: &WorkspaceName) -> std::path::PathBuf {
         self.paths.workspace_dir(workspace_name)
+    }
+
+    async fn prune_deleted_workspace_traces(&self, workspace_name: &WorkspaceName) {
+        let Some(trace_store_dir) = &self.trace_store_dir else {
+            return;
+        };
+        if let Err(error) =
+            crate::telemetry::delete_workspace_traces(trace_store_dir.clone(), workspace_name).await
+        {
+            warn!(
+                workspace = %workspace_name,
+                "workspace deleted, but failed to prune local trace history: {error}"
+            );
+        }
     }
 }
 
@@ -153,15 +210,19 @@ mod tests {
         }
     }
 
-    #[test]
-    fn delete_workspace_commits_config_then_cleans_artifacts() {
+    #[tokio::test]
+    async fn delete_workspace_commits_config_then_cleans_artifacts() {
         let temp = TempDir::new().expect("temp dir");
         let layout = test_layout(&temp);
         let store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            WorkspaceManager::new(store.clone(), credential_manager.clone(), layout.clone());
+        let manager = WorkspaceManager::new_for_tests(
+            store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+            None,
+        );
         let workspace_name = WorkspaceName::parse("work").expect("workspace");
         let source = installed_source("github");
         let credential_set_id = CredentialSetId::for_source(&source.name);
@@ -189,6 +250,7 @@ mod tests {
 
         let deleted = manager
             .delete_workspace(&workspace_name)
+            .await
             .expect("delete workspace");
 
         assert_eq!(deleted.name, workspace_name);

--- a/crates/coral-app/src/workspaces/mod.rs
+++ b/crates/coral-app/src/workspaces/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod service;
 pub(crate) mod store;
 
 pub(crate) use manager::WorkspaceManager;
-pub(crate) use model::{DeletedWorkspace, WorkspaceRecord};
+pub(crate) use model::{DeletedWorkspace, WorkspaceLifecycleLock, WorkspaceRecord};
 pub use name::DEFAULT_WORKSPACE_ID;
 pub(crate) use name::WorkspaceName;
 pub(crate) use paths::WorkspacePaths;

--- a/crates/coral-app/src/workspaces/model.rs
+++ b/crates/coral-app/src/workspaces/model.rs
@@ -1,3 +1,6 @@
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use crate::sources::model::InstalledSource;
 use crate::workspaces::WorkspaceName;
 
 /// App-owned workspace metadata record.
@@ -11,5 +14,27 @@ pub(crate) struct WorkspaceRecord {
 #[derive(Debug, Clone)]
 pub(crate) struct DeletedWorkspace {
     pub(crate) workspace: WorkspaceRecord,
-    pub(crate) sources: Vec<crate::sources::model::InstalledSource>,
+    pub(crate) sources: Vec<InstalledSource>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct WorkspaceLifecycleLock {
+    inner: Arc<Mutex<()>>,
+}
+
+impl WorkspaceLifecycleLock {
+    #[must_use = "bind the returned guard for the full critical section"]
+    pub(crate) fn lock(&self) -> WorkspaceLifecycleGuard<'_> {
+        WorkspaceLifecycleGuard {
+            _guard: self
+                .inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        }
+    }
+}
+
+#[must_use]
+pub(crate) struct WorkspaceLifecycleGuard<'a> {
+    _guard: MutexGuard<'a, ()>,
 }

--- a/crates/coral-app/src/workspaces/service.rs
+++ b/crates/coral-app/src/workspaces/service.rs
@@ -74,6 +74,7 @@ impl WorkspaceServiceApi for WorkspaceService {
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let workspace = workspaces
                 .delete_workspace(&workspace_name)
+                .await
                 .map_err(app_status)?;
             Ok(Response::new(DeleteWorkspaceResponse {
                 workspace: Some(workspace_record_to_proto(&workspace)),


### PR DESCRIPTION
## Intent

Wire local trace-history cleanup into workspace removal.

## What it enables

`workspace remove` now removes workspace-attributed local trace history when trace history is enabled, and it restores workspace config, artifact directories, and credentials if trace cleanup fails.

## Usage examples

`coral workspace remove work` deletes workspace `work` and prunes local trace records attributed to `work`; if trace files cannot be rewritten, the command fails and leaves `work` configured.
