### PR TITLE
test(app): cover workspace trace cleanup

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -262,9 +262,12 @@ impl ServerBuilder {
             self.config.enable_stderr_logs,
             internal_trace_store_dir.clone(),
         )?;
-        let installed_trace_store_dir = installed_trace_store
-            .as_ref()
-            .map(|store| store.dir.clone());
+        let active_trace_store = telemetry_config
+            .trace_history
+            .enabled
+            .then_some(installed_trace_store)
+            .flatten();
+        let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
         let config_store = ConfigStore::new(layout.clone());
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
@@ -281,7 +284,7 @@ impl ServerBuilder {
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
-            installed_trace_store_dir,
+            active_trace_store_dir.clone(),
             workspace_lifecycle_lock,
         );
         let feedback_manager =
@@ -301,18 +304,20 @@ impl ServerBuilder {
             layout,
             self.config.engine_extensions_providers,
         );
-        let trace_service = if telemetry_config.trace_history.enabled {
-            installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))
-        } else {
-            None
-        };
+        let trace_components =
+            active_trace_store.map_or_else(TraceServerComponents::default, |store| {
+                TraceServerComponents {
+                    local_trace_store_dir: Some(store.dir.clone()),
+                    service: Some(TraceService::new(store.dir, store.retention)),
+                }
+            });
         start_server(
             source_manager,
             workspace_manager,
             query_manager,
             feedback_manager,
             episode_store,
-            trace_service,
+            trace_components,
             self.config.mode,
         )
         .await
@@ -326,6 +331,7 @@ impl ServerBuilder {
 /// does not wait for the task to finish.
 pub struct RunningServer {
     endpoint_uri: String,
+    local_trace_store_dir: Option<PathBuf>,
     shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
     task: Mutex<Option<JoinHandle<Result<(), tonic::transport::Error>>>>,
 }
@@ -339,6 +345,13 @@ impl RunningServer {
     /// over server configuration.
     pub fn endpoint_uri(&self) -> &str {
         &self.endpoint_uri
+    }
+
+    #[must_use]
+    /// Returns the process-installed local trace store directory, when local
+    /// trace history is enabled for this process.
+    pub fn local_trace_store_dir(&self) -> Option<&std::path::Path> {
+        self.local_trace_store_dir.as_deref()
     }
 
     /// Shuts the server down and waits for the background task to finish.
@@ -389,15 +402,25 @@ impl Drop for RunningServer {
     }
 }
 
+#[derive(Default)]
+struct TraceServerComponents {
+    service: Option<TraceService>,
+    local_trace_store_dir: Option<PathBuf>,
+}
+
 async fn start_server(
     source_manager: SourceManager,
     workspace_manager: WorkspaceManager,
     query_manager: QueryManager,
     feedback_manager: FeedbackManager,
     episode_store: EpisodeStore,
-    trace_service: Option<TraceService>,
+    trace_components: TraceServerComponents,
     mode: ServerMode,
 ) -> Result<RunningServer, AppError> {
+    let TraceServerComponents {
+        service: trace_service,
+        local_trace_store_dir,
+    } = trace_components;
     let source_service = SourceService::new(source_manager, query_manager.clone());
     let workspace_service = WorkspaceService::new(workspace_manager);
     let catalog_service = CatalogService::new(query_manager.clone());
@@ -452,6 +475,7 @@ async fn start_server(
 
     Ok(RunningServer {
         endpoint_uri,
+        local_trace_store_dir,
         shutdown_tx: Mutex::new(Some(shutdown_tx)),
         task: Mutex::new(Some(task)),
     })
@@ -671,8 +695,8 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider, is_grpc_web_content_type,
-        is_native_grpc_content_type, start_server,
+        ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider, TraceServerComponents,
+        is_grpc_web_content_type, is_native_grpc_content_type, start_server,
     };
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::episode::store::EpisodeStore;
@@ -815,7 +839,10 @@ enabled = false
             query_manager,
             feedback_manager,
             episode_store,
-            Some(trace_service),
+            TraceServerComponents {
+                service: Some(trace_service),
+                local_trace_store_dir: None,
+            },
             ServerMode::NativeGrpc,
         )
         .await
@@ -1203,7 +1230,7 @@ tables:
             query_manager,
             feedback_manager,
             episode_store,
-            None,
+            TraceServerComponents::default(),
             ServerMode::NativeGrpc,
         )
         .await
@@ -1311,7 +1338,7 @@ tables:
             query_manager,
             feedback_manager,
             episode_store,
-            None,
+            TraceServerComponents::default(),
             ServerMode::NativeGrpc,
         )
         .await
@@ -1419,7 +1446,7 @@ tables:
             query_manager,
             feedback_manager,
             episode_store,
-            None,
+            TraceServerComponents::default(),
             ServerMode::NativeGrpc,
         )
         .await

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -18,6 +18,7 @@ use tonic::Request;
 pub(crate) struct GrpcHarness {
     temp_dir: TempDir,
     config_dir: PathBuf,
+    local_trace_store_dir: Option<PathBuf>,
     app: AppClient,
     _server: RunningServer,
 }
@@ -46,12 +47,14 @@ impl GrpcHarness {
             .start()
             .await
             .expect("start server");
+        let local_trace_store_dir = server.local_trace_store_dir().map(Path::to_path_buf);
         let app = AppClient::connect(server.endpoint_uri())
             .await
             .expect("connect client");
         Self {
             temp_dir,
             config_dir,
+            local_trace_store_dir,
             app,
             _server: server,
         }
@@ -63,6 +66,10 @@ impl GrpcHarness {
 
     pub(crate) fn config_dir(&self) -> &Path {
         &self.config_dir
+    }
+
+    pub(crate) fn local_trace_store_dir(&self) -> Option<&Path> {
+        self.local_trace_store_dir.as_deref()
     }
 
     pub(crate) fn source_client(&self) -> SourceClient {

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -374,7 +374,7 @@ async fn delete_workspace_ignores_malformed_trace_history() {
     reason = "Boundary test keeps the trace cleanup failure fixture and assertions together for readability."
 )]
 #[tokio::test]
-async fn delete_workspace_leaves_state_untouched_when_trace_cleanup_fails() {
+async fn delete_workspace_removes_state_when_trace_cleanup_fails() {
     use std::os::unix::fs::PermissionsExt;
 
     let _trace_store_guard = TRACE_STORE_DELETE_TEST_LOCK.lock().await;
@@ -431,59 +431,40 @@ async fn delete_workspace_leaves_state_untouched_when_trace_cleanup_fails() {
     fs::set_permissions(&trace_file, fs::Permissions::from_mode(0o000))
         .expect("make trace file unreadable");
 
-    let result = harness
+    let deleted = harness
         .workspace_client()
         .delete_workspace(Request::new(DeleteWorkspaceRequest {
             workspace: Some(workspace("work")),
         }))
-        .await;
+        .await
+        .expect("workspace delete should succeed when diagnostic trace cleanup fails")
+        .into_inner()
+        .workspace
+        .expect("delete workspace response");
     fs::set_permissions(&trace_file, fs::Permissions::from_mode(0o600))
         .expect("restore trace file permissions");
 
-    let error = result.expect_err("workspace delete should fail when trace cleanup cannot read");
-    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
-    assert!(
-        error
-            .message()
-            .contains("cannot be removed until local trace history can be cleaned up"),
-        "expected trace cleanup failure message, got: {}",
-        error.message()
-    );
-    assert_eq!(workspace_names(&harness).await, vec!["default", "work"]);
+    assert_eq!(deleted.name, "work");
+    assert_eq!(workspace_names(&harness).await, vec!["default"]);
 
     let raw = fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
     assert!(
-        raw.contains("[workspaces.work]"),
-        "workspace config should remain when trace cleanup fails: {raw}"
+        !raw.contains("[workspaces.work"),
+        "workspace config should be removed when trace cleanup fails: {raw}"
     );
     assert!(
-        raw.contains("[workspaces.work.sources.secured_messages]"),
-        "workspace source config should remain when trace cleanup fails: {raw}"
+        !source_dir.exists(),
+        "workspace artifact dir should be removed when trace cleanup fails"
     );
     assert!(
-        source_dir.exists(),
-        "workspace artifact dir should remain when trace cleanup fails"
-    );
-    assert!(
-        secret_path.exists(),
-        "workspace credential material should remain when trace cleanup fails"
+        !secret_path.exists(),
+        "workspace credential material should be removed when trace cleanup fails"
     );
 
-    let sources = harness
-        .source_client()
-        .list_sources(Request::new(ListSourcesRequest {
-            workspace: Some(workspace("work")),
-        }))
-        .await
-        .expect("list sources after failed delete")
-        .into_inner()
-        .sources;
-    assert_eq!(
-        sources
-            .iter()
-            .map(|source| source.name.as_str())
-            .collect::<Vec<_>>(),
-        vec!["secured_messages"]
+    let raw_trace = fs::read_to_string(&trace_file).expect("read trace file");
+    assert!(
+        raw_trace.contains("work-trace"),
+        "failed trace cleanup should leave the diagnostic trace file untouched"
     );
 }
 

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -245,13 +245,13 @@ async fn delete_workspace_removes_workspace_trace_history() {
     fs::write(
         &trace_file,
         [
+            local_trace_line("work-trace", "work-root", None, &json!({})),
             local_trace_line(
                 "work-trace",
-                "work-root",
-                None,
+                "work-child",
+                Some("work-root"),
                 &json!({ "workspace": "work" }),
             ),
-            local_trace_line("work-trace", "work-child", Some("work-root"), &json!({})),
             local_trace_line(
                 "other-trace",
                 "other-root",
@@ -280,7 +280,7 @@ async fn delete_workspace_removes_workspace_trace_history() {
     let raw = fs::read_to_string(&trace_file).expect("read trace file");
     assert!(
         !raw.contains("work-trace"),
-        "workspace trace should be removed from local trace history: {raw}"
+        "workspace trace should remove its unattributed root and attributed child: {raw}"
     );
     assert!(
         raw.contains("other-trace"),

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -369,10 +369,6 @@ async fn delete_workspace_ignores_malformed_trace_history() {
 }
 
 #[cfg(unix)]
-#[expect(
-    clippy::too_many_lines,
-    reason = "Boundary test keeps the trace cleanup failure fixture and assertions together for readability."
-)]
 #[tokio::test]
 async fn delete_workspace_removes_state_when_trace_cleanup_fails() {
     use std::os::unix::fs::PermissionsExt;

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -5,9 +5,13 @@ use coral_api::v1::{
     ListWorkspacesRequest, Source, SourceSecret, SourceVariable, Workspace, import_source_response,
 };
 use coral_client::default_workspace;
+use serde_json::json;
+use tempfile::TempDir;
 use tonic::Request;
 
 use crate::harness::{GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml};
+
+static TRACE_STORE_DELETE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 fn workspace(name: &str) -> Workspace {
     Workspace {
@@ -74,6 +78,13 @@ fn find_workspace_delete_backup(
                 .is_some_and(|name| name.starts_with(&prefix))
         })
         .expect("workspace delete backup dir")
+}
+
+fn local_trace_store_dir(harness: &GrpcHarness) -> std::path::PathBuf {
+    harness
+        .local_trace_store_dir()
+        .expect("trace history should be enabled")
+        .to_path_buf()
 }
 
 #[tokio::test]
@@ -163,6 +174,7 @@ async fn source_requests_reject_unknown_workspace() {
 
 #[tokio::test]
 async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
+    let _trace_store_guard = TRACE_STORE_DELETE_TEST_LOCK.lock().await;
     let harness = GrpcHarness::new().await;
     harness
         .workspace_client()
@@ -215,11 +227,316 @@ async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
     );
 }
 
+#[tokio::test]
+async fn delete_workspace_removes_workspace_trace_history() {
+    let _trace_store_guard = TRACE_STORE_DELETE_TEST_LOCK.lock().await;
+    let harness = GrpcHarness::new().await;
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("create workspace");
+
+    let trace_dir = local_trace_store_dir(&harness);
+    fs::create_dir_all(&trace_dir).expect("create trace dir");
+    let trace_file = trace_dir.join("spans-00000000000000000001-1-0000000000000000.jsonl");
+    fs::write(
+        &trace_file,
+        [
+            local_trace_line(
+                "work-trace",
+                "work-root",
+                None,
+                &json!({ "workspace": "work" }),
+            ),
+            local_trace_line("work-trace", "work-child", Some("work-root"), &json!({})),
+            local_trace_line(
+                "other-trace",
+                "other-root",
+                None,
+                &json!({ "workspace": "other" }),
+            ),
+            local_trace_line("unscoped-trace", "unscoped-root", None, &json!({})),
+        ]
+        .join("\n")
+            + "\n",
+    )
+    .expect("write local trace history");
+
+    let deleted = harness
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("delete workspace")
+        .into_inner()
+        .workspace
+        .expect("delete workspace response");
+    assert_eq!(deleted.name, "work");
+
+    let raw = fs::read_to_string(&trace_file).expect("read trace file");
+    assert!(
+        !raw.contains("work-trace"),
+        "workspace trace should be removed from local trace history: {raw}"
+    );
+    assert!(
+        raw.contains("other-trace"),
+        "other workspace trace should remain in local trace history: {raw}"
+    );
+    assert!(
+        raw.contains("unscoped-trace"),
+        "unscoped trace should remain in local trace history: {raw}"
+    );
+}
+
+#[tokio::test]
+async fn delete_workspace_ignores_malformed_trace_history() {
+    let _trace_store_guard = TRACE_STORE_DELETE_TEST_LOCK.lock().await;
+    let harness = GrpcHarness::new().await;
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("create workspace");
+
+    let imported = import_source_in_workspace(
+        &harness,
+        "work",
+        fixture_manifest_with_inputs_yaml(),
+        vec![SourceVariable {
+            key: "API_BASE".to_string(),
+            value: "https://example.com".to_string(),
+        }],
+        vec![SourceSecret {
+            key: "API_TOKEN".to_string(),
+            value: "secret-token".to_string(),
+        }],
+    )
+    .await;
+    assert_eq!(imported.name, "secured_messages");
+    let source_dir = harness
+        .config_dir()
+        .join("workspaces")
+        .join("work")
+        .join("sources")
+        .join("secured_messages");
+    let secret_path = source_dir.join("secrets.env");
+    assert!(source_dir.exists(), "import should create source artifacts");
+    assert!(
+        secret_path.exists(),
+        "import should create file-backed secret material"
+    );
+
+    let trace_dir = local_trace_store_dir(&harness);
+    fs::create_dir_all(&trace_dir).expect("create trace dir");
+    fs::write(
+        trace_dir.join("spans-00000000000000000001-1-0000000000000000.jsonl"),
+        "not-json\n",
+    )
+    .expect("write malformed local trace history");
+
+    let deleted = harness
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("delete workspace should ignore malformed diagnostic trace history")
+        .into_inner()
+        .workspace
+        .expect("delete workspace response");
+    assert_eq!(deleted.name, "work");
+    assert_eq!(workspace_names(&harness).await, vec!["default"]);
+
+    let raw = fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    assert!(
+        !raw.contains("[workspaces.work"),
+        "workspace config should be removed despite malformed trace history: {raw}"
+    );
+    assert!(
+        !source_dir.exists(),
+        "workspace artifact dir should be removed despite malformed trace history"
+    );
+    assert!(
+        !secret_path.exists(),
+        "workspace credential material should be removed despite malformed trace history"
+    );
+}
+
+#[cfg(unix)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Boundary test keeps the trace cleanup failure fixture and assertions together for readability."
+)]
+#[tokio::test]
+async fn delete_workspace_leaves_state_untouched_when_trace_cleanup_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _trace_store_guard = TRACE_STORE_DELETE_TEST_LOCK.lock().await;
+    let harness = GrpcHarness::new().await;
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("create workspace");
+
+    let imported = import_source_in_workspace(
+        &harness,
+        "work",
+        fixture_manifest_with_inputs_yaml(),
+        vec![SourceVariable {
+            key: "API_BASE".to_string(),
+            value: "https://example.com".to_string(),
+        }],
+        vec![SourceSecret {
+            key: "API_TOKEN".to_string(),
+            value: "secret-token".to_string(),
+        }],
+    )
+    .await;
+    assert_eq!(imported.name, "secured_messages");
+    let source_dir = harness
+        .config_dir()
+        .join("workspaces")
+        .join("work")
+        .join("sources")
+        .join("secured_messages");
+    let secret_path = source_dir.join("secrets.env");
+    assert!(source_dir.exists(), "import should create source artifacts");
+    assert!(
+        secret_path.exists(),
+        "import should create file-backed secret material"
+    );
+
+    let trace_dir = local_trace_store_dir(&harness);
+    fs::create_dir_all(&trace_dir).expect("create trace dir");
+    let trace_file = trace_dir.join("spans-00000000000000000001-1-0000000000000000.jsonl");
+    fs::write(
+        &trace_file,
+        local_trace_line(
+            "work-trace",
+            "work-root",
+            None,
+            &json!({ "workspace": "work" }),
+        ) + "\n",
+    )
+    .expect("write local trace history");
+    fs::set_permissions(&trace_file, fs::Permissions::from_mode(0o000))
+        .expect("make trace file unreadable");
+
+    let result = harness
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await;
+    fs::set_permissions(&trace_file, fs::Permissions::from_mode(0o600))
+        .expect("restore trace file permissions");
+
+    let error = result.expect_err("workspace delete should fail when trace cleanup cannot read");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error
+            .message()
+            .contains("cannot be removed until local trace history can be cleaned up"),
+        "expected trace cleanup failure message, got: {}",
+        error.message()
+    );
+    assert_eq!(workspace_names(&harness).await, vec!["default", "work"]);
+
+    let raw = fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    assert!(
+        raw.contains("[workspaces.work]"),
+        "workspace config should remain when trace cleanup fails: {raw}"
+    );
+    assert!(
+        raw.contains("[workspaces.work.sources.secured_messages]"),
+        "workspace source config should remain when trace cleanup fails: {raw}"
+    );
+    assert!(
+        source_dir.exists(),
+        "workspace artifact dir should remain when trace cleanup fails"
+    );
+    assert!(
+        secret_path.exists(),
+        "workspace credential material should remain when trace cleanup fails"
+    );
+
+    let sources = harness
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("list sources after failed delete")
+        .into_inner()
+        .sources;
+    assert_eq!(
+        sources
+            .iter()
+            .map(|source| source.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["secured_messages"]
+    );
+}
+
+#[tokio::test]
+async fn delete_workspace_ignores_stale_trace_files_when_trace_history_disabled() {
+    let _trace_store_guard = TRACE_STORE_DELETE_TEST_LOCK.lock().await;
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(config_dir.join("telemetry").join("traces")).expect("create trace dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[trace_history]\nenabled = false\n",
+    )
+    .expect("write config");
+    let stale_trace_file = config_dir
+        .join("telemetry")
+        .join("traces")
+        .join("spans-00000000000000000001-1-0000000000000000.jsonl");
+    fs::write(&stale_trace_file, "not-json\n").expect("write stale malformed trace history");
+    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("create workspace");
+
+    let deleted = harness
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("delete workspace")
+        .into_inner()
+        .workspace
+        .expect("delete workspace response");
+
+    assert_eq!(deleted.name, "work");
+    assert_eq!(workspace_names(&harness).await, vec!["default"]);
+    assert!(
+        stale_trace_file.exists(),
+        "disabled trace history should skip trace cleanup"
+    );
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn delete_workspace_succeeds_when_backup_cleanup_fails_after_config_delete() {
     use std::os::unix::fs::PermissionsExt;
 
+    let _trace_store_guard = TRACE_STORE_DELETE_TEST_LOCK.lock().await;
     let harness = GrpcHarness::new().await;
     harness
         .workspace_client()
@@ -307,4 +624,19 @@ async fn delete_default_workspace_returns_failed_precondition() {
         "expected default workspace guard, got: {}",
         error.message()
     );
+}
+
+fn local_trace_line(
+    trace_id: &str,
+    span_id: &str,
+    parent_span_id: Option<&str>,
+    attributes: &serde_json::Value,
+) -> String {
+    json!({
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "attributes_json": attributes.to_string(),
+    })
+    .to_string()
 }

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -180,7 +180,7 @@ coral source remove github
 
 Manage local workspaces. Workspaces isolate installed source metadata and
 workspace-scoped artifacts such as source manifests, local credential material,
-feedback reports, and episode logs.
+feedback reports, episode logs, and workspace-attributed local trace history.
 
 Imported source specs and source credential material are attached to the source
 installation in that workspace. Reusable global source specs and reusable
@@ -205,7 +205,10 @@ coral workspace create work
 
 ### `coral workspace remove <NAME>`
 
-Remove a workspace and its workspace-scoped source/artifact directory.
+Remove a workspace and its workspace-scoped source/artifact directory. When
+trace history is enabled, this also prunes local trace records attributed to
+that workspace. If trace cleanup fails, workspace removal fails and leaves the
+workspace configured.
 
 ```shellscript
 coral workspace remove work


### PR DESCRIPTION
## Intent

Add end-to-end coverage and docs for workspace trace cleanup.

## What it enables

The gRPC lifecycle suite covers trace-history deletion, malformed trace records, disabled trace history, and rollback when trace cleanup fails. CLI docs now describe the cleanup and rollback behavior.

## Usage examples

Users can run `coral workspace remove work`; local trace history for `work` is pruned when enabled, while malformed trace records are preserved and cleanup I/O failures prevent partial deletion.
