### PR TITLE
feat(spec): provide means of overriding projections.yaml

### DIFF
--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -1532,6 +1532,7 @@ mod tests {
     };
     use crate::sources::SourceName;
     use crate::sources::catalog::describe_manifest;
+    use crate::sources::materialization::{FINGERPRINT_FILENAME, PROJECTIONS_FILENAME};
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::WorkspaceName;
@@ -2307,8 +2308,8 @@ tables:
         assert_eq!(installed.name.as_str(), "github_v4_test");
         let source_name = SourceName::parse("github_v4_test").expect("source");
         let materialized = layout.v4_materialized_dir(&default_workspace(), &source_name);
-        assert!(materialized.join("fingerprint.yaml").exists());
-        assert!(materialized.join("projections.yaml").exists());
+        assert!(materialized.join(FINGERPRINT_FILENAME).exists());
+        assert!(materialized.join(PROJECTIONS_FILENAME).exists());
         assert!(
             materialized
                 .join("surfaces")

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -32,6 +32,9 @@ use crate::workspaces::WorkspaceName;
 const DESCRIPTOR_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_DESCRIPTOR_BYTES: u64 = 16 * 1024 * 1024;
 const DESCRIPTOR_USER_AGENT: &str = "coral-dsl-v4-materializer";
+pub(crate) const PROJECTIONS_FILENAME: &str = "projections.yaml";
+pub(crate) const FINGERPRINT_FILENAME: &str = "fingerprint.yaml";
+pub(crate) const DIAGNOSTICS_FILENAME: &str = "diagnostics.yaml";
 
 #[derive(Debug)]
 pub(crate) struct MaterializationBuild {
@@ -650,9 +653,9 @@ fn write_materialization(
     };
     validate_materialized_source(manifest, &materialized)
         .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
-    write_yaml(&temp_dir.join("fingerprint.yaml"), &fingerprint)?;
-    write_yaml(&temp_dir.join("projections.yaml"), &projections)?;
-    write_yaml(&temp_dir.join("diagnostics.yaml"), &diagnostics)?;
+    write_yaml(&temp_dir.join(FINGERPRINT_FILENAME), &fingerprint)?;
+    write_yaml(&temp_dir.join(PROJECTIONS_FILENAME), &projections)?;
+    write_yaml(&temp_dir.join(DIAGNOSTICS_FILENAME), &diagnostics)?;
     Ok(())
 }
 
@@ -1336,7 +1339,7 @@ surfaces:
         );
 
         let projections: ProjectionCatalog =
-            read_yaml(&build.temp_dir.join("projections.yaml")).expect("read projections");
+            read_yaml(&build.temp_dir.join(PROJECTIONS_FILENAME)).expect("read projections");
         let projection = projections.projections.first().expect("projection");
         assert_eq!(projection.namespace, "mcp_materialization_test");
         let column_names = projection
@@ -1394,7 +1397,7 @@ surfaces:
         .expect("partial materialization should succeed");
 
         let fingerprint: Fingerprint =
-            read_yaml(&build.temp_dir.join("fingerprint.yaml")).expect("read fingerprint");
+            read_yaml(&build.temp_dir.join(FINGERPRINT_FILENAME)).expect("read fingerprint");
         let surface_ids = fingerprint
             .surfaces
             .iter()
@@ -1405,7 +1408,7 @@ surfaces:
         assert!(!build.temp_dir.join("surfaces").join("mcp").exists());
 
         let diagnostics: Vec<Diagnostic> =
-            read_yaml(&build.temp_dir.join("diagnostics.yaml")).expect("read diagnostics");
+            read_yaml(&build.temp_dir.join(DIAGNOSTICS_FILENAME)).expect("read diagnostics");
         assert!(
             diagnostics.iter().any(|diagnostic| {
                 diagnostic.code == "SURFACE_MATERIALIZATION_FAILED"

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -6,6 +6,9 @@ use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_native_strateg
 
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
+use crate::sources::materialization::{
+    DIAGNOSTICS_FILENAME, FINGERPRINT_FILENAME, PROJECTIONS_FILENAME,
+};
 use crate::storage::fs::ensure_dir;
 use crate::workspaces::{WorkspaceName, WorkspacePaths};
 
@@ -143,6 +146,15 @@ impl AppStateLayout {
             .join("v4")
     }
 
+    pub(crate) fn v4_override_dir(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> PathBuf {
+        self.source_dir(workspace_name, source_name)
+            .join("overrides")
+    }
+
     pub(crate) fn v4_materialized_tmp_dir(
         &self,
         workspace_name: &WorkspaceName,
@@ -160,7 +172,22 @@ impl AppStateLayout {
         source_name: &SourceName,
     ) -> PathBuf {
         self.v4_materialized_dir(workspace_name, source_name)
-            .join("fingerprint.yaml")
+            .join(FINGERPRINT_FILENAME)
+    }
+
+    fn v4_overridden_or_materialized(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        path: &str,
+    ) -> PathBuf {
+        let override_file = self.v4_override_dir(workspace_name, source_name).join(path);
+        if override_file.exists() {
+            override_file
+        } else {
+            self.v4_materialized_dir(workspace_name, source_name)
+                .join(path)
+        }
     }
 
     pub(crate) fn v4_projections_file(
@@ -168,8 +195,7 @@ impl AppStateLayout {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> PathBuf {
-        self.v4_materialized_dir(workspace_name, source_name)
-            .join("projections.yaml")
+        self.v4_overridden_or_materialized(workspace_name, source_name, PROJECTIONS_FILENAME)
     }
 
     pub(crate) fn v4_diagnostics_file(
@@ -178,7 +204,7 @@ impl AppStateLayout {
         source_name: &SourceName,
     ) -> PathBuf {
         self.v4_materialized_dir(workspace_name, source_name)
-            .join("diagnostics.yaml")
+            .join(DIAGNOSTICS_FILENAME)
     }
 
     pub(crate) fn v4_surface_dir(
@@ -201,8 +227,11 @@ impl WorkspacePaths for AppStateLayout {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::AppStateLayout;
     use crate::sources::SourceName;
+    use crate::sources::materialization::PROJECTIONS_FILENAME;
     use crate::workspaces::WorkspaceName;
     use tempfile::tempdir;
 
@@ -252,6 +281,30 @@ mod tests {
         assert_eq!(
             layout.local_trace_store_dir(),
             config_dir.join("telemetry").join("traces")
+        );
+    }
+
+    #[test]
+    fn v4_projections_file_returns_override_if_present() {
+        let temp = tempdir().expect("tempdir");
+        let config_dir = temp.path().join("coral-config");
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source");
+
+        assert_eq!(
+            layout.v4_projections_file(&workspace_name, &source_name),
+            config_dir.join("workspaces/default/sources/github/materialized/v4/projections.yaml")
+        );
+
+        let override_dir = config_dir.join("workspaces/default/sources/github/overrides");
+        fs::create_dir_all(&override_dir).expect("override dir");
+        let override_file = override_dir.join(PROJECTIONS_FILENAME);
+        fs::write(&override_file, "{}").expect("write to override file");
+
+        assert_eq!(
+            layout.v4_projections_file(&workspace_name, &source_name),
+            override_file
         );
     }
 }


### PR DESCRIPTION
If `workspaces/{workspace name}/sources/{source name}/overrides/projections.yaml` exists, use that instead of the materialised projections.

Strategies for authoring the override file are out of scope for this PR. Right now, copying the materialised file then editing it by hand is the way to go.

## Validation

```shell
$ ./target/debug/coral sql "select count(*) from coral.tables where schema_name = 'github_v4'"
+----------+
| count(*) |
+----------+
| 403      |
+----------+
$ cat my-github-projections.yaml | yq '.projections[].name'
repos
issues
$ cp my-github-projections.yaml ~/Library/Application\ Support/com.withcoral.coral/workspaces/default/sources/github_v4/overrides/projections.yaml
$ ./target/debug/coral sql "select count(*) from coral.tables where schema_name = 'github_v4'"
+----------+
| count(*) |
+----------+
| 2        |
+----------+
```

Closes #1028