### PR TITLE
feat(app): add global source spec registry state

### DIFF
--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -44,20 +44,19 @@ to the source installation in a workspace.
 
 ## Global Source Specs
 
-Reusable global source specs are indexed under `[source_specs]` and store their
-manifest artifacts under `source_specs/<name>` inside Coral's local state
-directory.
+Use global source specs when you want to reuse the same custom source definition
+across multiple workspaces. Importing with `coral source add --file` copies the
+spec into one workspace; registering with `coral source-spec add --file` stores
+one reusable definition that any workspace can install by name.
 
-```toml
-[source_specs.internal_crm]
-version = "1.0.0"
-```
+Registered specs store their manifest artifacts under `source_specs/<name>`
+inside Coral's local state directory.
 
 Sources installed from a global source spec store `origin = "global"` under the
 workspace source entry. Removing a global source spec does not remove those
 workspace sources. Explicit validation for an orphaned source fails until you
-register the spec again or remove and re-add the source; query loading skips the
-orphaned source and continues with the rest of the workspace.
+register the spec again or remove and re-add the source. Queries run without
+that source while the spec is missing.
 
 ## Runtime features
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -55,8 +55,9 @@ version = "1.0.0"
 
 Sources installed from a global source spec store `origin = "global"` under the
 workspace source entry. Removing a global source spec does not remove those
-workspace sources, but validation and queries fail until you register the spec
-again or remove and re-add the source.
+workspace sources. Explicit validation for an orphaned source fails until you
+register the spec again or remove and re-add the source; query loading skips the
+orphaned source and continues with the rest of the workspace.
 
 ## Runtime features
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -40,8 +40,23 @@ Installed sources for that workspace live under
 There is no separate active-workspace key in `config.toml`; use
 `CORAL_WORKSPACE` for a shell default or `--workspace <NAME>` for one command.
 Source specs imported from files and source credential material remain scoped
-to the source installation in a workspace. Reusable global source specs and
-reusable credential references are not config objects today.
+to the source installation in a workspace.
+
+## Global Source Specs
+
+Reusable global source specs are indexed under `[source_specs]` and store their
+manifest artifacts under `source_specs/<name>` inside Coral's local state
+directory.
+
+```toml
+[source_specs.internal_crm]
+version = "1.0.0"
+```
+
+Sources installed from a global source spec store `origin = "global"` under the
+workspace source entry. Removing a global source spec does not remove those
+workspace sources, but validation and queries fail until you register the spec
+again or remove and re-add the source.
 
 ## Runtime features
 

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -13,8 +13,8 @@ enum SourceOrigin {
   SOURCE_ORIGIN_BUNDLED = 1;
   // Source was imported from a user-supplied manifest.
   SOURCE_ORIGIN_IMPORTED = 2;
-  // Source was installed from the global source-spec registry.
-  SOURCE_ORIGIN_GLOBAL = 3;
+  // Source was installed from a global source spec.
+  SOURCE_ORIGIN_GLOBAL_SPEC = 3;
 }
 
 // Where an installed source's credential material is stored.

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -13,6 +13,8 @@ enum SourceOrigin {
   SOURCE_ORIGIN_BUNDLED = 1;
   // Source was imported from a user-supplied manifest.
   SOURCE_ORIGIN_IMPORTED = 2;
+  // Source was installed from the global source-spec registry.
+  SOURCE_ORIGIN_GLOBAL = 3;
 }
 
 // Where an installed source's credential material is stored.

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -29,7 +29,7 @@ pub enum AppError {
     /// The request requires additional setup before it can succeed.
     #[error("failed precondition: {0}")]
     FailedPrecondition(String),
-    /// An installed global-origin source references a missing global source spec.
+    /// An installed source references a missing global source spec.
     #[error(
         "failed precondition: source '{source_name}' references a global source spec that is not registered. Re-register the source spec or remove and re-add the source."
     )]

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -29,6 +29,14 @@ pub enum AppError {
     /// The request requires additional setup before it can succeed.
     #[error("failed precondition: {0}")]
     FailedPrecondition(String),
+    /// An installed global-origin source references a missing global source spec.
+    #[error(
+        "failed precondition: source '{source_name}' references a global source spec that is not registered. Re-register the source spec or remove and re-add the source."
+    )]
+    MissingGlobalSourceSpec {
+        /// Installed source whose registry entry is missing.
+        source_name: String,
+    },
     /// A DSL v4 source has missing or stale generated runtime artifacts.
     #[error(
         "failed precondition: source '{source_name}' has missing or incompatible DSL v4 materialized artifacts: {detail}. Re-add the source to regenerate them."
@@ -205,6 +213,7 @@ fn app_code(error: &AppError) -> Code {
         AppError::WorkspaceAlreadyExists(_) => Code::AlreadyExists,
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
+        | AppError::MissingGlobalSourceSpec { .. }
         | AppError::MissingOrIncompatibleV4Materialization { .. }
         | AppError::CredentialRefresh(_)
         | AppError::MissingConfigDir

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -53,7 +53,7 @@ use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
-use crate::sources::source_specs::GlobalSourceSpecStore;
+use crate::sources::source_specs::FsGlobalSourceSpecStore;
 use crate::state::ConfigStore;
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
@@ -274,12 +274,12 @@ impl ServerBuilder {
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store);
-        let global_source_specs = Arc::new(GlobalSourceSpecStore::new(layout.clone()));
+        let global_source_spec_store = Arc::new(FsGlobalSourceSpecStore::new(layout.clone()));
         let workspace_lifecycle_lock = WorkspaceLifecycleLock::default();
         let source_manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            global_source_specs,
+            global_source_spec_store,
             layout.clone(),
             workspace_lifecycle_lock.clone(),
         );
@@ -707,7 +707,7 @@ mod tests {
     use crate::feedback::manager::FeedbackManager;
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
-    use crate::sources::source_specs::GlobalSourceSpecStore;
+    use crate::sources::source_specs::FsGlobalSourceSpecStore;
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::telemetry::service::TraceService;
     use crate::transport::workspace_to_proto;
@@ -752,7 +752,7 @@ enabled = false
         let source_manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             workspace_lifecycle_lock.clone(),
         );

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -53,6 +53,7 @@ use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
+use crate::sources::source_specs::GlobalSourceSpecStore;
 use crate::state::ConfigStore;
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
@@ -273,10 +274,12 @@ impl ServerBuilder {
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store);
+        let global_source_specs = Arc::new(GlobalSourceSpecStore::new(layout.clone()));
         let workspace_lifecycle_lock = WorkspaceLifecycleLock::default();
         let source_manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
+            global_source_specs,
             layout.clone(),
             workspace_lifecycle_lock.clone(),
         );
@@ -303,6 +306,7 @@ impl ServerBuilder {
             query_runtime_context,
             layout,
             self.config.engine_extensions_providers,
+            source_manager.clone(),
         );
         let trace_components =
             active_trace_store.map_or_else(TraceServerComponents::default, |store| {
@@ -703,10 +707,11 @@ mod tests {
     use crate::feedback::manager::FeedbackManager;
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
+    use crate::sources::source_specs::GlobalSourceSpecStore;
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::telemetry::service::TraceService;
     use crate::transport::workspace_to_proto;
-    use crate::workspaces::{WorkspaceManager, WorkspaceName};
+    use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceManager, WorkspaceName};
     use crate::{AwsEngineExtensionsProvider, NoopEngineExtensionsProvider};
 
     fn default_workspace() -> Workspace {
@@ -811,10 +816,12 @@ enabled = false
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new_for_tests(
+        let source_manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
+            WorkspaceLifecycleLock::default(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
@@ -830,6 +837,7 @@ enabled = false
             QueryRuntimeContext::default(),
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            source_manager.clone(),
         );
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
@@ -1201,10 +1209,12 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new_for_tests(
+        let source_manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
+            WorkspaceLifecycleLock::default(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
@@ -1223,6 +1233,7 @@ tables:
             },
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            source_manager.clone(),
         );
         let running = start_server(
             source_manager,
@@ -1312,10 +1323,12 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new_for_tests(
+        let source_manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
+            WorkspaceLifecycleLock::default(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
@@ -1331,6 +1344,7 @@ tables:
             QueryRuntimeContext::default(),
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            source_manager.clone(),
         );
         let running = start_server(
             source_manager,
@@ -1420,10 +1434,12 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new_for_tests(
+        let source_manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
+            WorkspaceLifecycleLock::default(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let episode_store = EpisodeStore::new(layout.clone());
@@ -1439,6 +1455,7 @@ tables:
             QueryRuntimeContext::default(),
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            source_manager.clone(),
         );
         let running = start_server(
             source_manager,

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -680,7 +680,7 @@ mod tests {
 
     use std::borrow::Cow;
     use std::net::{Ipv4Addr, TcpListener};
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -730,6 +730,54 @@ enabled = false
 ",
         )
         .expect("write telemetry config");
+    }
+
+    struct TestServerComponents {
+        source_manager: SourceManager,
+        workspace_manager: WorkspaceManager,
+        query_manager: QueryManager,
+        feedback_manager: FeedbackManager,
+        episode_store: EpisodeStore,
+    }
+
+    fn test_server_components(
+        config_dir: PathBuf,
+        query_runtime_context: QueryRuntimeContext,
+    ) -> TestServerComponents {
+        let layout = AppStateLayout::discover(Some(config_dir)).expect("layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let workspace_lifecycle_lock = WorkspaceLifecycleLock::default();
+        let source_manager = SourceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            workspace_lifecycle_lock.clone(),
+        );
+        let workspace_manager = WorkspaceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+            None,
+            workspace_lifecycle_lock,
+        );
+        let query_manager = QueryManager::new(
+            config_store,
+            credential_manager,
+            query_runtime_context,
+            layout.clone(),
+            vec![Arc::new(NoopEngineExtensionsProvider)],
+            source_manager.clone(),
+        );
+        TestServerComponents {
+            source_manager,
+            workspace_manager,
+            query_manager,
+            feedback_manager: FeedbackManager::new(layout.clone()),
+            episode_store: EpisodeStore::new(layout),
+        }
     }
 
     #[tokio::test]
@@ -811,42 +859,15 @@ enabled = false
     async fn trace_service_lists_empty_store() {
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
-        let layout = AppStateLayout::discover(Some(config_dir)).expect("layout");
-        layout.ensure().expect("layout dirs");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
-            config_store.clone(),
-            credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
-            layout.clone(),
-            WorkspaceLifecycleLock::default(),
-        );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
-        let workspace_manager = WorkspaceManager::new_for_tests(
-            config_store.clone(),
-            credential_manager.clone(),
-            layout.clone(),
-            None,
-        );
-        let query_manager = QueryManager::new(
-            config_store,
-            credential_manager,
-            QueryRuntimeContext::default(),
-            layout,
-            vec![Arc::new(NoopEngineExtensionsProvider)],
-            source_manager.clone(),
-        );
+        let components = test_server_components(config_dir, QueryRuntimeContext::default());
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
         let server = start_server(
-            source_manager,
-            workspace_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
+            components.source_manager,
+            components.workspace_manager,
+            components.query_manager,
+            components.feedback_manager,
+            components.episode_store,
             TraceServerComponents {
                 service: Some(trace_service),
                 local_trace_store_dir: None,
@@ -1205,42 +1226,19 @@ tables:
         )
         .expect("write fixture");
 
-        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
-            config_store.clone(),
-            credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
-            layout.clone(),
-            WorkspaceLifecycleLock::default(),
-        );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
-        let workspace_manager = WorkspaceManager::new_for_tests(
-            config_store.clone(),
-            credential_manager.clone(),
-            layout.clone(),
-            None,
-        );
-        let query_manager = QueryManager::new(
-            config_store,
-            credential_manager,
+        let components = test_server_components(
+            config_dir.clone(),
             QueryRuntimeContext {
                 home_dir: Some(fake_home.clone()),
                 ..QueryRuntimeContext::default()
             },
-            layout,
-            vec![Arc::new(NoopEngineExtensionsProvider)],
-            source_manager.clone(),
         );
         let running = start_server(
-            source_manager,
-            workspace_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
+            components.source_manager,
+            components.workspace_manager,
+            components.query_manager,
+            components.feedback_manager,
+            components.episode_store,
             TraceServerComponents::default(),
             ServerMode::NativeGrpc,
         )
@@ -1319,39 +1317,13 @@ tables:
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
 
-        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
-            config_store.clone(),
-            credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
-            layout.clone(),
-            WorkspaceLifecycleLock::default(),
-        );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
-        let workspace_manager = WorkspaceManager::new_for_tests(
-            config_store.clone(),
-            credential_manager.clone(),
-            layout.clone(),
-            None,
-        );
-        let query_manager = QueryManager::new(
-            config_store,
-            credential_manager,
-            QueryRuntimeContext::default(),
-            layout,
-            vec![Arc::new(NoopEngineExtensionsProvider)],
-            source_manager.clone(),
-        );
+        let components = test_server_components(config_dir.clone(), QueryRuntimeContext::default());
         let running = start_server(
-            source_manager,
-            workspace_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
+            components.source_manager,
+            components.workspace_manager,
+            components.query_manager,
+            components.feedback_manager,
+            components.episode_store,
             TraceServerComponents::default(),
             ServerMode::NativeGrpc,
         )
@@ -1430,39 +1402,13 @@ tables:
                 .expect("write to String");
         }
 
-        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
-        let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
-            config_store.clone(),
-            credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
-            layout.clone(),
-            WorkspaceLifecycleLock::default(),
-        );
-        let feedback_manager = FeedbackManager::new(layout.clone());
-        let episode_store = EpisodeStore::new(layout.clone());
-        let workspace_manager = WorkspaceManager::new_for_tests(
-            config_store.clone(),
-            credential_manager.clone(),
-            layout.clone(),
-            None,
-        );
-        let query_manager = QueryManager::new(
-            config_store,
-            credential_manager,
-            QueryRuntimeContext::default(),
-            layout,
-            vec![Arc::new(NoopEngineExtensionsProvider)],
-            source_manager.clone(),
-        );
+        let components = test_server_components(config_dir.clone(), QueryRuntimeContext::default());
         let running = start_server(
-            source_manager,
-            workspace_manager,
-            query_manager,
-            feedback_manager,
-            episode_store,
+            components.source_manager,
+            components.workspace_manager,
+            components.query_manager,
+            components.feedback_manager,
+            components.episode_store,
             TraceServerComponents::default(),
             ServerMode::NativeGrpc,
         )

--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -160,7 +160,7 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let attribution = QueryAttribution::from_extensions(request.extensions());
-        instrument_grpc(span, async move {
+        Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
@@ -199,7 +199,7 @@ impl CatalogServiceApi for CatalogService {
                     .collect(),
                 pagination: Some(pagination),
             }))
-        })
+        }))
         .await
     }
 }

--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -44,7 +44,7 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let attribution = QueryAttribution::from_extensions(request.extensions());
-        instrument_grpc(span, async move {
+        Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let pagination = pagination_from_proto(request.pagination.unwrap_or_default());
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -74,7 +74,7 @@ impl CatalogServiceApi for CatalogService {
                     table_function_count: catalog_page.counts.table_function_count,
                 }),
             }))
-        })
+        }))
         .await
     }
 
@@ -85,7 +85,7 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let attribution = QueryAttribution::from_extensions(request.extensions());
-        instrument_grpc(span, async move {
+        Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let schema_name = optional_trimmed(&request.schema_name);
@@ -121,7 +121,7 @@ impl CatalogServiceApi for CatalogService {
                     .collect(),
                 pagination: Some(pagination),
             }))
-        })
+        }))
         .await
     }
 
@@ -132,7 +132,7 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let attribution = QueryAttribution::from_extensions(request.extensions());
-        instrument_grpc(span, async move {
+        Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
@@ -149,7 +149,7 @@ impl CatalogServiceApi for CatalogService {
                 &workspace_name,
                 result,
             )))
-        })
+        }))
         .await
     }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -314,6 +314,7 @@ impl QueryManager {
                 Ok((loaded_source, _version)) => loaded_sources.push(loaded_source),
                 Err(
                     error @ (AppError::Credentials(CredentialsError::Unavailable(_))
+                    | AppError::MissingGlobalSourceSpec { .. }
                     | AppError::MissingOrIncompatibleV4Materialization { .. }),
                 ) => {
                     return Err(error);
@@ -665,6 +666,7 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",
         AppError::InvalidInput(_) => "INVALID_INPUT",
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
+        AppError::MissingGlobalSourceSpec { .. } => "MISSING_GLOBAL_SOURCE_SPEC",
         AppError::MissingOrIncompatibleV4Materialization { .. } => {
             "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION"
         }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -754,7 +754,7 @@ mod tests {
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
     use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
     use crate::sources::model::SourceOrigin;
-    use crate::sources::source_specs::GlobalSourceSpecStore;
+    use crate::sources::source_specs::FsGlobalSourceSpecStore;
     use crate::workspaces::WorkspaceLifecycleLock;
 
     struct QueryManagerFixture {
@@ -774,7 +774,7 @@ mod tests {
         let source_manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -1264,7 +1264,7 @@ tables:
         let source_manager = SourceManager::new(
             fixture.manager.config_store.clone(),
             fixture.manager.credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(fixture.manager.layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(fixture.manager.layout.clone())),
             fixture.manager.layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -1421,7 +1421,7 @@ surfaces:
         let source_manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -317,7 +317,6 @@ impl QueryManager {
                 Ok((loaded_source, _version)) => loaded_sources.push(loaded_source),
                 Err(
                     error @ (AppError::Credentials(CredentialsError::Unavailable(_))
-                    | AppError::MissingGlobalSourceSpec { .. }
                     | AppError::MissingOrIncompatibleV4Materialization { .. }),
                 ) => {
                     return Err(error);
@@ -816,6 +815,39 @@ mod tests {
             .expect_err("missing workspace should fail closed");
 
         assert_workspace_not_found(error, &missing_workspace);
+    }
+
+    #[test]
+    fn load_query_sources_skips_source_with_missing_global_source_spec() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("orphaned_global").expect("source name");
+        fixture
+            .manager
+            .config_store
+            .upsert_source(
+                &workspace_name,
+                InstalledSource {
+                    name: source_name,
+                    version: Some("0.1.0".to_string()),
+                    variables: BTreeMap::new(),
+                    secrets: Vec::new(),
+                    credential_storage: None,
+                    origin: SourceOrigin::GlobalSpec,
+                },
+            )
+            .expect("persist source");
+
+        let (sources, _config) = fixture
+            .manager
+            .load_query_sources(&workspace_name)
+            .expect("orphaned global source should be skipped");
+
+        assert!(
+            sources.is_empty(),
+            "orphaned global source should not be loaded"
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -25,7 +25,7 @@ use crate::query::extensions::{
     engine_extensions_for_providers,
 };
 use crate::sources::SourceName;
-use crate::sources::catalog::resolve_installed_manifest;
+use crate::sources::manager::SourceManager;
 use crate::sources::materialization::{
     incompatible_materialization_error, load_v4_materialization,
 };
@@ -58,6 +58,7 @@ pub(crate) struct QueryManager {
     config_store: ConfigStore,
     credential_manager: CredentialManager,
     runtime_context: QueryRuntimeContext,
+    source_manager: SourceManager,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
 }
@@ -69,11 +70,13 @@ impl QueryManager {
         runtime_context: QueryRuntimeContext,
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        source_manager: SourceManager,
     ) -> Self {
         Self {
             config_store,
             credential_manager,
             runtime_context,
+            source_manager,
             layout,
             engine_extensions_providers,
         }
@@ -337,7 +340,9 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
     ) -> Result<(LoadedQuerySource, Option<String>), AppError> {
-        let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
+        let installed = self
+            .source_manager
+            .resolve_installed_manifest(workspace_name, source)?;
         let source_spec = installed.source_spec;
         let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
             let materialized = load_v4_materialization(
@@ -750,6 +755,8 @@ mod tests {
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
     use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
     use crate::sources::model::SourceOrigin;
+    use crate::sources::source_specs::GlobalSourceSpecStore;
+    use crate::workspaces::WorkspaceLifecycleLock;
 
     struct QueryManagerFixture {
         _temp: TempDir,
@@ -763,12 +770,22 @@ mod tests {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let source_manager = SourceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
         let manager = QueryManager::new(
-            ConfigStore::new(layout.clone()),
-            CredentialManager::new(CredentialStore::new(layout.clone())),
+            config_store,
+            credential_manager,
             runtime_context,
             layout,
             providers,
+            source_manager,
         );
         QueryManagerFixture {
             _temp: temp,
@@ -1212,10 +1229,12 @@ tables:
 
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
         fixture.manager.layout.ensure().expect("ensure layout");
-        let source_manager = SourceManager::new_for_tests(
+        let source_manager = SourceManager::new(
             fixture.manager.config_store.clone(),
             fixture.manager.credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(fixture.manager.layout.clone())),
             fixture.manager.layout.clone(),
+            WorkspaceLifecycleLock::default(),
         );
         let workspace_name = WorkspaceName::default();
         let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
@@ -1366,12 +1385,21 @@ surfaces:
             layout.clone(),
             CredentialStoragePreference::Keychain,
         );
+        let credential_manager = CredentialManager::new(credential_store);
+        let source_manager = SourceManager::new(
+            config_store.clone(),
+            credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
         let manager = QueryManager::new(
             config_store,
-            CredentialManager::new(credential_store),
+            credential_manager,
             QueryRuntimeContext::default(),
             layout,
             Vec::new(),
+            source_manager,
         );
         let error = manager
             .load_query_sources(&workspace_name)

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -1,12 +1,12 @@
 //! Bundled source catalog and installed-manifest resolution helpers.
 
-use std::collections::BTreeSet;
-
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
+use std::collections::BTreeSet;
 
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
+use crate::sources::source_specs::SourceSpecStore;
 use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 
@@ -14,11 +14,6 @@ include!(concat!(env!("OUT_DIR"), "/bundled_sources.rs"));
 
 #[derive(Debug, Clone)]
 pub(crate) struct BundledSourceManifest {
-    pub(crate) manifest_yaml: String,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct GlobalSourceSpecManifest {
     pub(crate) manifest_yaml: String,
 }
 
@@ -63,42 +58,20 @@ pub(crate) fn load_bundled_source(name: &SourceName) -> Result<BundledSourceMani
     })
 }
 
-pub(crate) fn is_bundled_source(name: &SourceName) -> bool {
-    BUNDLED_SOURCES
-        .iter()
-        .any(|(candidate, _)| *candidate == name.as_str())
-}
-
-pub(crate) fn load_global_source_spec(
-    name: &SourceName,
-    layout: &AppStateLayout,
-) -> Result<GlobalSourceSpecManifest, AppError> {
-    let manifest_path = layout.source_spec_manifest_file(name);
-    let manifest_yaml = std::fs::read_to_string(&manifest_path).map_err(|error| {
-        if error.kind() == std::io::ErrorKind::NotFound {
-            AppError::MissingGlobalSourceSpec {
-                source_name: name.to_string(),
-            }
-        } else {
-            AppError::Io(error)
-        }
-    })?;
-    Ok(GlobalSourceSpecManifest { manifest_yaml })
-}
-
 /// Resolve the effective installed manifest and verify it still matches the
 /// installed source identity in app state.
 pub(crate) fn resolve_installed_manifest(
     workspace_name: &WorkspaceName,
     source: &InstalledSource,
     layout: &AppStateLayout,
+    global_source_specs: &dyn SourceSpecStore,
 ) -> Result<InstalledSourceManifest, AppError> {
     let manifest_yaml = match source.origin {
         SourceOrigin::Bundled => load_bundled_source(&source.name)?.manifest_yaml,
         SourceOrigin::Imported => {
             std::fs::read_to_string(layout.manifest_file(workspace_name, &source.name))?
         }
-        SourceOrigin::Global => load_global_source_spec(&source.name, layout)?.manifest_yaml,
+        SourceOrigin::GlobalSpec => global_source_specs.load(&source.name)?.manifest_yaml,
     };
     let source_spec = parse_source_manifest_yaml(&manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
-use crate::sources::source_specs::SourceSpecStore;
+use crate::sources::source_specs::GlobalSourceSpecStore;
 use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 
@@ -64,14 +64,14 @@ pub(crate) fn resolve_installed_manifest(
     workspace_name: &WorkspaceName,
     source: &InstalledSource,
     layout: &AppStateLayout,
-    global_source_specs: &dyn SourceSpecStore,
+    global_source_spec_store: &dyn GlobalSourceSpecStore,
 ) -> Result<InstalledSourceManifest, AppError> {
     let manifest_yaml = match source.origin {
         SourceOrigin::Bundled => load_bundled_source(&source.name)?.manifest_yaml,
         SourceOrigin::Imported => {
             std::fs::read_to_string(layout.manifest_file(workspace_name, &source.name))?
         }
-        SourceOrigin::GlobalSpec => global_source_specs.load(&source.name)?.manifest_yaml,
+        SourceOrigin::GlobalSpec => global_source_spec_store.load(&source.name)?.manifest_yaml,
     };
     let source_spec = parse_source_manifest_yaml(&manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -18,6 +18,11 @@ pub(crate) struct BundledSourceManifest {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct GlobalSourceSpecManifest {
+    pub(crate) manifest_yaml: String,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct InstalledSourceManifest {
     pub(crate) source_spec: ValidatedSourceManifest,
     pub(crate) candidate: CandidateSource,
@@ -58,6 +63,29 @@ pub(crate) fn load_bundled_source(name: &SourceName) -> Result<BundledSourceMani
     })
 }
 
+pub(crate) fn is_bundled_source(name: &SourceName) -> bool {
+    BUNDLED_SOURCES
+        .iter()
+        .any(|(candidate, _)| *candidate == name.as_str())
+}
+
+pub(crate) fn load_global_source_spec(
+    name: &SourceName,
+    layout: &AppStateLayout,
+) -> Result<GlobalSourceSpecManifest, AppError> {
+    let manifest_path = layout.source_spec_manifest_file(name);
+    let manifest_yaml = std::fs::read_to_string(&manifest_path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            AppError::MissingGlobalSourceSpec {
+                source_name: name.to_string(),
+            }
+        } else {
+            AppError::Io(error)
+        }
+    })?;
+    Ok(GlobalSourceSpecManifest { manifest_yaml })
+}
+
 /// Resolve the effective installed manifest and verify it still matches the
 /// installed source identity in app state.
 pub(crate) fn resolve_installed_manifest(
@@ -70,6 +98,7 @@ pub(crate) fn resolve_installed_manifest(
         SourceOrigin::Imported => {
             std::fs::read_to_string(layout.manifest_file(workspace_name, &source.name))?
         }
+        SourceOrigin::Global => load_global_source_spec(&source.name, layout)?.manifest_yaml,
     };
     let source_spec = parse_source_manifest_yaml(&manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -27,7 +27,7 @@ use crate::sources::materialization::{
     new_materialization_suffix, replace_v4_materialization, restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
-use crate::sources::source_specs::SourceSpecStore;
+use crate::sources::source_specs::GlobalSourceSpecStore;
 use crate::state::{AppStateLayout, ConfigStore, RegisteredSourceSpec};
 use crate::storage::fs;
 use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
@@ -41,7 +41,7 @@ pub(crate) struct SourceManager {
     config_store: ConfigStore,
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
-    global_source_specs: Arc<dyn SourceSpecStore>,
+    global_source_spec_store: Arc<dyn GlobalSourceSpecStore>,
     layout: AppStateLayout,
     lifecycle_lock: WorkspaceLifecycleLock,
 }
@@ -180,15 +180,12 @@ fn materialization_inputs_from_bindings(
     }
 }
 
-#[expect(
-    dead_code,
-    reason = "registry methods are wired by the next stack branch"
-)]
+#[expect(dead_code, reason = "store methods are wired by the next stack branch")]
 impl SourceManager {
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
-        global_source_specs: Arc<dyn SourceSpecStore>,
+        global_source_spec_store: Arc<dyn GlobalSourceSpecStore>,
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
     ) -> Self {
@@ -196,7 +193,7 @@ impl SourceManager {
             config_store,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
-            global_source_specs,
+            global_source_spec_store,
             layout,
             lifecycle_lock,
         }
@@ -253,7 +250,7 @@ impl SourceManager {
             workspace_name,
             source,
             &self.layout,
-            self.global_source_specs.as_ref(),
+            self.global_source_spec_store.as_ref(),
         )
     }
 
@@ -289,7 +286,7 @@ impl SourceManager {
             .list_source_specs()?
             .into_iter()
             .map(|source_spec| {
-                let manifest = self.global_source_specs.load(&source_spec.name)?;
+                let manifest = self.global_source_spec_store.load(&source_spec.name)?;
                 describe_manifest(&manifest.manifest_yaml, SourceOrigin::GlobalSpec, false)
             })
             .collect()
@@ -306,7 +303,7 @@ impl SourceManager {
         let candidate = describe_manifest(&manifest_yaml, SourceOrigin::GlobalSpec, false)?;
 
         let previous_manifest = self
-            .global_source_specs
+            .global_source_spec_store
             .load_optional(&candidate.name)?
             .map(|manifest| manifest.manifest_yaml);
         let previous_spec = match self.config_store.get_source_spec(&candidate.name) {
@@ -315,7 +312,7 @@ impl SourceManager {
             Err(error) => return Err(error),
         };
 
-        self.global_source_specs
+        self.global_source_spec_store
             .write_manifest(&candidate.name, &manifest_yaml)?;
 
         let registered = RegisteredSourceSpec {
@@ -340,7 +337,7 @@ impl SourceManager {
         let _lifecycle_guard = self.lifecycle_lock.lock();
         let registered = self.config_store.get_source_spec(source_name)?;
         let manifest = self
-            .global_source_specs
+            .global_source_spec_store
             .load_optional(source_name)?
             .map(|manifest| manifest.manifest_yaml);
         let removed = if let Some(manifest_yaml) = manifest.as_deref() {
@@ -364,7 +361,7 @@ impl SourceManager {
             }
         };
 
-        let removed_manifest_tree = self.global_source_specs.remove(source_name)?;
+        let removed_manifest_tree = self.global_source_spec_store.remove(source_name)?;
 
         if let Err(error) = self.config_store.remove_source_spec(source_name) {
             if let Err(restore_error) = removed_manifest_tree.restore() {
@@ -687,7 +684,7 @@ impl SourceManager {
     ) -> Result<ResolvedNamedSourceSpec, AppError> {
         match self.config_store.get_source_spec(name) {
             Ok(_) => Ok(ResolvedNamedSourceSpec {
-                manifest_yaml: self.global_source_specs.load(name)?.manifest_yaml,
+                manifest_yaml: self.global_source_spec_store.load(name)?.manifest_yaml,
                 source_origin: SourceOrigin::GlobalSpec,
             }),
             Err(AppError::SourceNotFound(_)) => load_bundled_source(name)
@@ -1301,13 +1298,13 @@ impl SourceManager {
     ) {
         if let Some(manifest_yaml) = previous_manifest {
             if let Err(error) = self
-                .global_source_specs
+                .global_source_spec_store
                 .write_manifest(source_name, &manifest_yaml)
             {
                 warn!("rollback: failed to restore source-spec manifest: {error}");
             }
         } else {
-            match self.global_source_specs.remove(source_name) {
+            match self.global_source_spec_store.remove(source_name) {
                 Ok(removed_manifest_tree) => {
                     if let Err(error) = removed_manifest_tree.commit() {
                         warn!("rollback: failed to remove new source-spec directory: {error}");
@@ -1701,7 +1698,7 @@ mod tests {
     use crate::sources::catalog::describe_manifest;
     use crate::sources::materialization::{FINGERPRINT_FILENAME, PROJECTIONS_FILENAME};
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
-    use crate::sources::source_specs::GlobalSourceSpecStore;
+    use crate::sources::source_specs::FsGlobalSourceSpecStore;
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
@@ -1941,7 +1938,7 @@ tables:
         let manager = SourceManager::new(
             config_store.clone(),
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             crate::workspaces::WorkspaceLifecycleLock::default(),
         );
@@ -2032,7 +2029,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             crate::workspaces::WorkspaceLifecycleLock::default(),
         );
@@ -2102,7 +2099,7 @@ tables:
         let manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             crate::workspaces::WorkspaceLifecycleLock::default(),
         );
@@ -2196,7 +2193,7 @@ tables:
         let manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             WorkspaceLifecycleLock::default(),
         );
@@ -2411,7 +2408,7 @@ tables:
         let manager = SourceManager::new(
             config_store.clone(),
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             WorkspaceLifecycleLock::default(),
         );
@@ -2470,7 +2467,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -2493,13 +2490,13 @@ tables:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let source_name = SourceName::parse("github").expect("source");
-        let global_source_specs = Arc::new(GlobalSourceSpecStore::new(layout.clone()));
+        let global_source_spec_store = Arc::new(FsGlobalSourceSpecStore::new(layout.clone()));
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
         let manager = SourceManager::new(
             config_store,
             credential_manager,
-            global_source_specs,
+            global_source_spec_store,
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -2549,7 +2546,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -2595,7 +2592,7 @@ tables:
         let manager = SourceManager::new(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -2659,7 +2656,7 @@ tables:
         let manager = SourceManager::new(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -2699,7 +2696,7 @@ tables:
         let manager = SourceManager::new(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             WorkspaceLifecycleLock::default(),
         );
@@ -2734,7 +2731,7 @@ tables:
         let manager = SourceManager::new(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -2775,7 +2772,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -2883,7 +2880,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             WorkspaceLifecycleLock::default(),
         );
@@ -2925,7 +2922,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -3001,7 +2998,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -3048,7 +3045,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             WorkspaceLifecycleLock::default(),
         );
@@ -3083,7 +3080,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -3142,7 +3139,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -3196,7 +3193,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             WorkspaceLifecycleLock::default(),
         );
@@ -3259,7 +3256,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -3300,7 +3297,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             WorkspaceLifecycleLock::default(),
         );
@@ -3372,7 +3369,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             WorkspaceLifecycleLock::default(),
         );
@@ -3474,7 +3471,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             WorkspaceLifecycleLock::default(),
         );
@@ -3553,7 +3550,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager.clone(),
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             WorkspaceLifecycleLock::default(),
         );
@@ -3635,7 +3632,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager,
-            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            Arc::new(FsGlobalSourceSpecStore::new(layout.clone())),
             layout,
             WorkspaceLifecycleLock::default(),
         );

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use coral_spec::v4::SurfaceDescriptor;
 use serde_yaml::Value as YamlValue;
@@ -17,8 +18,8 @@ use crate::credentials::{
 };
 use crate::sources::SourceName;
 use crate::sources::catalog::{
-    describe_manifest, is_bundled_source, list_bundled_sources, load_bundled_source,
-    load_global_source_spec, resolve_installed_manifest,
+    InstalledSourceManifest, describe_manifest, list_bundled_sources, load_bundled_source,
+    resolve_installed_manifest as resolve_source_manifest,
 };
 use crate::sources::materialization::{
     MaterializationBuild, MaterializationInputs, build_v4_materialization_tmp,
@@ -26,6 +27,7 @@ use crate::sources::materialization::{
     new_materialization_suffix, replace_v4_materialization, restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
+use crate::sources::source_specs::SourceSpecStore;
 use crate::state::{AppStateLayout, ConfigStore, RegisteredSourceSpec};
 use crate::storage::fs;
 use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
@@ -39,27 +41,17 @@ pub(crate) struct SourceManager {
     config_store: ConfigStore,
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
+    global_source_specs: Arc<dyn SourceSpecStore>,
     layout: AppStateLayout,
     lifecycle_lock: WorkspaceLifecycleLock,
 }
 
-pub(crate) struct CreateBundledSourceCommand {
+pub(crate) struct CreateSourceCommand {
     pub(crate) name: SourceName,
     pub(crate) bindings: SourceBindings,
 }
 
-pub(crate) struct CreateBundledSourceWithOAuthCommand {
-    pub(crate) name: SourceName,
-    pub(crate) bindings: SourceBindings,
-    pub(crate) oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
-}
-
-pub(crate) struct CreateGlobalSourceCommand {
-    pub(crate) name: SourceName,
-    pub(crate) bindings: SourceBindings,
-}
-
-pub(crate) struct CreateGlobalSourceWithOAuthCommand {
+pub(crate) struct CreateSourceWithOAuthCommand {
     pub(crate) name: SourceName,
     pub(crate) bindings: SourceBindings,
     pub(crate) oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
@@ -165,6 +157,11 @@ struct PersistSourceRequest<'a> {
     materialization_tmp: Option<PathBuf>,
 }
 
+struct ResolvedNamedSourceSpec {
+    manifest_yaml: String,
+    source_origin: SourceOrigin,
+}
+
 struct SourceRollbackState {
     source: InstalledSource,
     manifest_yaml: Option<String>,
@@ -188,23 +185,10 @@ fn materialization_inputs_from_bindings(
     reason = "registry methods are wired by the next stack branch"
 )]
 impl SourceManager {
-    #[cfg(test)]
-    pub(crate) fn new_for_tests(
-        config_store: ConfigStore,
-        credential_manager: CredentialManager,
-        layout: AppStateLayout,
-    ) -> Self {
-        Self::new(
-            config_store,
-            credential_manager,
-            layout,
-            crate::workspaces::WorkspaceLifecycleLock::default(),
-        )
-    }
-
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
+        global_source_specs: Arc<dyn SourceSpecStore>,
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
     ) -> Self {
@@ -212,6 +196,7 @@ impl SourceManager {
             config_store,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
+            global_source_specs,
             layout,
             lifecycle_lock,
         }
@@ -247,30 +232,29 @@ impl SourceManager {
     ) -> Result<CandidateSource, AppError> {
         match self.config_store.get_source(workspace_name, source_name) {
             Ok(source) => {
-                return Ok(
-                    resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
-                );
+                return Ok(self
+                    .resolve_installed_manifest(workspace_name, &source)?
+                    .candidate);
             }
             Err(AppError::SourceNotFound(_)) => {}
             Err(error) => return Err(error),
         }
 
-        match load_bundled_source(source_name) {
-            Ok(bundled) => self.describe_bundled_source(workspace_name, &bundled.manifest_yaml),
-            Err(AppError::InvalidInput(_)) => {
-                match self.config_store.get_source_spec(source_name) {
-                    Ok(_) => {
-                        let global = load_global_source_spec(source_name, &self.layout)?;
-                        self.describe_global_source(workspace_name, &global.manifest_yaml)
-                    }
-                    Err(AppError::SourceNotFound(_)) => {
-                        Err(AppError::SourceNotFound(source_name.to_string()))
-                    }
-                    Err(error) => Err(error),
-                }
-            }
-            Err(error) => Err(error),
-        }
+        let spec = self.load_named_source_spec(source_name)?;
+        self.describe_named_source(workspace_name, &spec.manifest_yaml, spec.source_origin)
+    }
+
+    pub(crate) fn resolve_installed_manifest(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<InstalledSourceManifest, AppError> {
+        resolve_source_manifest(
+            workspace_name,
+            source,
+            &self.layout,
+            self.global_source_specs.as_ref(),
+        )
     }
 
     pub(crate) fn discover_sources(
@@ -305,8 +289,8 @@ impl SourceManager {
             .list_source_specs()?
             .into_iter()
             .map(|source_spec| {
-                let manifest = load_global_source_spec(&source_spec.name, &self.layout)?;
-                describe_manifest(&manifest.manifest_yaml, SourceOrigin::Global, false)
+                let manifest = self.global_source_specs.load(&source_spec.name)?;
+                describe_manifest(&manifest.manifest_yaml, SourceOrigin::GlobalSpec, false)
             })
             .collect()
     }
@@ -319,30 +303,20 @@ impl SourceManager {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
-        let candidate = describe_manifest(&manifest_yaml, SourceOrigin::Global, false)?;
-        if is_bundled_source(&candidate.name) {
-            return Err(AppError::InvalidInput(format!(
-                "global source spec '{}' conflicts with a bundled source",
-                candidate.name
-            )));
-        }
+        let candidate = describe_manifest(&manifest_yaml, SourceOrigin::GlobalSpec, false)?;
 
-        let manifest_path = self.layout.source_spec_manifest_file(&candidate.name);
-        let previous_manifest = match std::fs::read_to_string(&manifest_path) {
-            Ok(manifest_yaml) => Some(manifest_yaml),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-            Err(error) => return Err(error.into()),
-        };
+        let previous_manifest = self
+            .global_source_specs
+            .load_optional(&candidate.name)?
+            .map(|manifest| manifest.manifest_yaml);
         let previous_spec = match self.config_store.get_source_spec(&candidate.name) {
             Ok(source_spec) => Some(source_spec),
             Err(AppError::SourceNotFound(_)) => None,
             Err(error) => return Err(error),
         };
 
-        if let Some(parent) = manifest_path.parent() {
-            fs::ensure_dir(parent)?;
-        }
-        fs::write_atomic(&manifest_path, manifest_yaml.as_bytes())?;
+        self.global_source_specs
+            .write_manifest(&candidate.name, &manifest_yaml)?;
 
         let registered = RegisteredSourceSpec {
             name: candidate.name.clone(),
@@ -365,13 +339,12 @@ impl SourceManager {
     ) -> Result<CandidateSource, AppError> {
         let _lifecycle_guard = self.lifecycle_lock.lock();
         let registered = self.config_store.get_source_spec(source_name)?;
-        let manifest = match load_global_source_spec(source_name, &self.layout) {
-            Ok(manifest) => Some(manifest.manifest_yaml),
-            Err(AppError::MissingGlobalSourceSpec { .. }) => None,
-            Err(error) => return Err(error),
-        };
+        let manifest = self
+            .global_source_specs
+            .load_optional(source_name)?
+            .map(|manifest| manifest.manifest_yaml);
         let removed = if let Some(manifest_yaml) = manifest.as_deref() {
-            let candidate = describe_manifest(manifest_yaml, SourceOrigin::Global, false)?;
+            let candidate = describe_manifest(manifest_yaml, SourceOrigin::GlobalSpec, false)?;
             if candidate.name != *source_name {
                 return Err(AppError::FailedPrecondition(format!(
                     "registered source spec '{source_name}' does not match manifest name '{}'",
@@ -386,53 +359,53 @@ impl SourceManager {
                 version: registered.version.clone(),
                 inputs: Vec::new(),
                 installed: false,
-                origin: SourceOrigin::Global,
+                origin: SourceOrigin::GlobalSpec,
                 credential_storage: None,
             }
         };
 
-        let source_spec_dir = self.layout.source_spec_dir(source_name);
-        let backup_dir = fs::DirectoryBackup::move_for_delete(&source_spec_dir, source_name)?;
+        let removed_manifest_tree = self.global_source_specs.remove(source_name)?;
 
         if let Err(error) = self.config_store.remove_source_spec(source_name) {
-            if let Err(restore_error) = backup_dir.restore() {
+            if let Err(restore_error) = removed_manifest_tree.restore() {
                 return Err(AppError::FailedPrecondition(format!(
                     "failed to remove source spec '{source_name}': {error}; failed to restore source-spec directory from '{}': {restore_error}",
-                    backup_dir.backup_path().display()
+                    removed_manifest_tree.backup_path().display()
                 )));
             }
             return Err(error);
         }
-        backup_dir.commit()?;
-        cleanup_empty_parent(&self.layout.source_specs_root(), source_spec_dir.parent());
+        removed_manifest_tree.commit()?;
         Ok(removed)
     }
 
-    pub(crate) fn create_bundled_source(
+    pub(crate) fn create_source(
         &self,
         workspace_name: &WorkspaceName,
-        command: &CreateBundledSourceCommand,
+        command: &CreateSourceCommand,
     ) -> Result<InstalledSource, AppError> {
-        let bundled = load_bundled_source(&command.name)?;
-        let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
+        let spec = self.load_named_source_spec(&command.name)?;
+        let candidate =
+            self.describe_named_source(workspace_name, &spec.manifest_yaml, spec.source_origin)?;
         self.install_validated_source(
             workspace_name,
             &candidate,
             &command.bindings,
             None,
-            &bundled.manifest_yaml,
-            SourceOrigin::Bundled,
+            &spec.manifest_yaml,
+            spec.source_origin,
         )
     }
 
-    pub(crate) async fn create_bundled_source_with_oauth(
+    pub(crate) async fn create_source_with_oauth(
         &self,
         workspace_name: &WorkspaceName,
-        command: CreateBundledSourceWithOAuthCommand,
+        command: CreateSourceWithOAuthCommand,
         events: ImportSourceEventSender,
     ) -> Result<InstalledSource, AppError> {
-        let bundled = load_bundled_source(&command.name)?;
-        let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
+        let spec = self.load_named_source_spec(&command.name)?;
+        let candidate =
+            self.describe_named_source(workspace_name, &spec.manifest_yaml, spec.source_origin)?;
         self.install_source_with_oauth(
             workspace_name,
             &candidate,
@@ -440,48 +413,8 @@ impl SourceManager {
             command.oauth_credential_retrievals,
             events,
             None,
-            &bundled.manifest_yaml,
-            SourceOrigin::Bundled,
-        )
-        .await
-    }
-
-    pub(crate) fn create_global_source(
-        &self,
-        workspace_name: &WorkspaceName,
-        command: &CreateGlobalSourceCommand,
-    ) -> Result<InstalledSource, AppError> {
-        self.config_store.get_source_spec(&command.name)?;
-        let global = load_global_source_spec(&command.name, &self.layout)?;
-        let candidate = self.describe_global_source(workspace_name, &global.manifest_yaml)?;
-        self.install_validated_source(
-            workspace_name,
-            &candidate,
-            &command.bindings,
-            None,
-            &global.manifest_yaml,
-            SourceOrigin::Global,
-        )
-    }
-
-    pub(crate) async fn create_global_source_with_oauth(
-        &self,
-        workspace_name: &WorkspaceName,
-        command: CreateGlobalSourceWithOAuthCommand,
-        events: ImportSourceEventSender,
-    ) -> Result<InstalledSource, AppError> {
-        self.config_store.get_source_spec(&command.name)?;
-        let global = load_global_source_spec(&command.name, &self.layout)?;
-        let candidate = self.describe_global_source(workspace_name, &global.manifest_yaml)?;
-        self.install_source_with_oauth(
-            workspace_name,
-            &candidate,
-            &command.bindings,
-            command.oauth_credential_retrievals,
-            events,
-            None,
-            &global.manifest_yaml,
-            SourceOrigin::Global,
+            &spec.manifest_yaml,
+            spec.source_origin,
         )
         .await
     }
@@ -694,7 +627,7 @@ impl SourceManager {
                 SourceOrigin::Imported => Some(std::fs::read_to_string(
                     self.layout.manifest_file(workspace_name, source_name),
                 )?),
-                SourceOrigin::Bundled | SourceOrigin::Global => None,
+                SourceOrigin::Bundled | SourceOrigin::GlobalSpec => None,
             },
             credential_material,
         };
@@ -748,26 +681,41 @@ impl SourceManager {
         Ok(removed)
     }
 
-    fn describe_bundled_source(
+    fn load_named_source_spec(
+        &self,
+        name: &SourceName,
+    ) -> Result<ResolvedNamedSourceSpec, AppError> {
+        match self.config_store.get_source_spec(name) {
+            Ok(_) => Ok(ResolvedNamedSourceSpec {
+                manifest_yaml: self.global_source_specs.load(name)?.manifest_yaml,
+                source_origin: SourceOrigin::GlobalSpec,
+            }),
+            Err(AppError::SourceNotFound(_)) => load_bundled_source(name)
+                .map(|bundled| ResolvedNamedSourceSpec {
+                    manifest_yaml: bundled.manifest_yaml,
+                    source_origin: SourceOrigin::Bundled,
+                })
+                .map_err(|error| {
+                    if matches!(error, AppError::InvalidInput(_)) {
+                        AppError::SourceNotFound(name.to_string())
+                    } else {
+                        error
+                    }
+                }),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn describe_named_source(
         &self,
         workspace_name: &WorkspaceName,
         manifest_yaml: &str,
+        source_origin: SourceOrigin,
     ) -> Result<CandidateSource, AppError> {
-        let mut candidate = describe_manifest(manifest_yaml, SourceOrigin::Bundled, false)?;
+        let mut candidate = describe_manifest(manifest_yaml, source_origin, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         Ok(candidate)
     }
-
-    fn describe_global_source(
-        &self,
-        workspace_name: &WorkspaceName,
-        manifest_yaml: &str,
-    ) -> Result<CandidateSource, AppError> {
-        let mut candidate = describe_manifest(manifest_yaml, SourceOrigin::Global, false)?;
-        candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
-        Ok(candidate)
-    }
-
     #[expect(
         clippy::too_many_lines,
         reason = "Source persistence keeps rollback steps together so failure ordering is visible."
@@ -888,7 +836,7 @@ impl SourceManager {
 
         let persisted_version = match request.origin {
             SourceOrigin::Bundled => None,
-            SourceOrigin::Imported | SourceOrigin::Global => request.candidate.version.clone(),
+            SourceOrigin::Imported | SourceOrigin::GlobalSpec => request.candidate.version.clone(),
         };
         let stored = InstalledSource {
             name: source_name.clone(),
@@ -980,8 +928,7 @@ impl SourceManager {
             if installed.name == *candidate_name {
                 continue;
             }
-            let installed_manifest =
-                resolve_installed_manifest(workspace_name, &installed, &self.layout)?;
+            let installed_manifest = self.resolve_installed_manifest(workspace_name, &installed)?;
             let installed_schema_names = runtime_schema_names(&installed_manifest.source_spec);
             if let Some(schema_name) = candidate_schema_names
                 .intersection(&installed_schema_names)
@@ -1250,7 +1197,7 @@ impl SourceManager {
                 SourceOrigin::Imported => Some(std::fs::read_to_string(
                     self.layout.manifest_file(workspace_name, source_name),
                 )?),
-                SourceOrigin::Bundled | SourceOrigin::Global => None,
+                SourceOrigin::Bundled | SourceOrigin::GlobalSpec => None,
             },
             source,
             credential_material,
@@ -1352,22 +1299,23 @@ impl SourceManager {
         previous_spec: Option<RegisteredSourceSpec>,
         previous_manifest: Option<String>,
     ) {
-        let manifest_path = self.layout.source_spec_manifest_file(source_name);
         if let Some(manifest_yaml) = previous_manifest {
-            if let Some(parent) = manifest_path.parent()
-                && let Err(error) = fs::ensure_dir(parent)
+            if let Err(error) = self
+                .global_source_specs
+                .write_manifest(source_name, &manifest_yaml)
             {
-                warn!("rollback: failed to create source-spec manifest parent dir: {error}");
-            }
-            if let Err(error) = fs::write_atomic(&manifest_path, manifest_yaml.as_bytes()) {
                 warn!("rollback: failed to restore source-spec manifest: {error}");
             }
         } else {
-            let source_spec_dir = self.layout.source_spec_dir(source_name);
-            if source_spec_dir.exists()
-                && let Err(error) = std::fs::remove_dir_all(&source_spec_dir)
-            {
-                warn!("rollback: failed to remove new source-spec directory: {error}");
+            match self.global_source_specs.remove(source_name) {
+                Ok(removed_manifest_tree) => {
+                    if let Err(error) = removed_manifest_tree.commit() {
+                        warn!("rollback: failed to remove new source-spec directory: {error}");
+                    }
+                }
+                Err(error) => {
+                    warn!("rollback: failed to remove new source-spec directory: {error}");
+                }
             }
         }
 
@@ -1390,7 +1338,8 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         mut source: InstalledSource,
     ) -> Result<InstalledSource, AppError> {
-        source.version = resolve_installed_manifest(workspace_name, &source, &self.layout)?
+        source.version = self
+            .resolve_installed_manifest(workspace_name, &source)?
             .candidate
             .version;
         Ok(source)
@@ -1746,7 +1695,7 @@ mod tests {
     use std::io::{Read as _, Write as _};
     use std::net::TcpListener as StdTcpListener;
     use std::path::Path;
-    use std::sync::mpsc as std_mpsc;
+    use std::sync::{Arc, mpsc as std_mpsc};
     use std::thread;
     use std::time::Duration;
 
@@ -1756,11 +1705,12 @@ mod tests {
     use url::Url;
 
     use super::{
-        ImportSourceCommand, ImportSourceEventSender, ImportSourceWithCredentialsCommand,
-        ImportSourceWithCredentialsEvent, PendingImportSourceWithCredentialsEvent,
-        PersistSourceRequest, SourceBinding, SourceBindings, SourceManager,
-        SourceOAuthCredentialRetrieval, ValidatedBindings, materialization_inputs_from_bindings,
-        normalize_binding_key, source_needs_stored_material_for_validation,
+        CreateSourceCommand, ImportSourceCommand, ImportSourceEventSender,
+        ImportSourceWithCredentialsCommand, ImportSourceWithCredentialsEvent,
+        PendingImportSourceWithCredentialsEvent, PersistSourceRequest, RegisterSourceSpecCommand,
+        SourceBinding, SourceBindings, SourceManager, SourceOAuthCredentialRetrieval,
+        ValidatedBindings, materialization_inputs_from_bindings, normalize_binding_key,
+        source_needs_stored_material_for_validation,
     };
     use crate::credentials::{
         CredentialManager, CredentialSetId, CredentialStorageKind, CredentialStoragePreference,
@@ -1770,8 +1720,9 @@ mod tests {
     use crate::sources::catalog::describe_manifest;
     use crate::sources::materialization::{FINGERPRINT_FILENAME, PROJECTIONS_FILENAME};
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
+    use crate::sources::source_specs::GlobalSourceSpecStore;
     use crate::state::{AppStateLayout, ConfigStore};
-    use crate::workspaces::WorkspaceName;
+    use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
     fn default_workspace() -> WorkspaceName {
@@ -2009,6 +1960,7 @@ tables:
         let manager = SourceManager::new(
             config_store.clone(),
             credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
             crate::workspaces::WorkspaceLifecycleLock::default(),
         );
@@ -2099,6 +2051,7 @@ tables:
         let manager = SourceManager::new(
             config_store,
             credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout,
             crate::workspaces::WorkspaceLifecycleLock::default(),
         );
@@ -2168,6 +2121,7 @@ tables:
         let manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout,
             crate::workspaces::WorkspaceLifecycleLock::default(),
         );
@@ -2472,8 +2426,13 @@ tables:
             CredentialStoragePreference::Keychain,
         );
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store.clone(), credential_manager, layout);
+        let manager = SourceManager::new(
+            config_store.clone(),
+            credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout,
+            WorkspaceLifecycleLock::default(),
+        );
         let candidate = candidate_with_secret("OPTIONAL_TOKEN", false);
 
         config_store
@@ -2526,8 +2485,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
 
         let disabled = manager
             .discover_sources(&default_workspace())
@@ -2536,6 +2500,55 @@ tables:
             !disabled
                 .iter()
                 .any(|source| source.name.as_str() == "github_v4")
+        );
+    }
+
+    #[test]
+    fn create_source_prefers_registered_global_spec_over_bundled_source() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let source_name = SourceName::parse("github").expect("source");
+        let global_source_specs = Arc::new(GlobalSourceSpecStore::new(layout.clone()));
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            global_source_specs,
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
+        let registered = manager
+            .register_source_spec(&RegisterSourceSpecCommand {
+                manifest_yaml: manifest_without_secrets().replace("public_messages", "github"),
+            })
+            .expect("register global source spec with bundled source name");
+        assert_eq!(registered.origin, SourceOrigin::GlobalSpec);
+
+        let info = manager
+            .get_source_info(&default_workspace(), &source_name)
+            .expect("registered global spec should shadow bundled source info");
+        assert_eq!(info.origin, SourceOrigin::GlobalSpec);
+
+        let installed = manager
+            .create_source(
+                &default_workspace(),
+                &CreateSourceCommand {
+                    name: source_name,
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("install source from registered global spec before bundled source");
+
+        assert_eq!(installed.name.as_str(), "github");
+        assert_eq!(installed.origin, SourceOrigin::GlobalSpec);
+        assert!(
+            !layout
+                .manifest_file(&default_workspace(), &installed.name)
+                .exists()
         );
     }
 
@@ -2551,8 +2564,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
 
         let installed = manager
             .import_source(
@@ -2592,10 +2610,12 @@ tables:
         layout.ensure().expect("ensure layout");
         let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
         std::fs::write(&openapi_file, v4_openapi_fixture()).expect("write fixture");
-        let manager = SourceManager::new_for_tests(
+        let manager = SourceManager::new(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
+            WorkspaceLifecycleLock::default(),
         );
 
         manager
@@ -2654,10 +2674,12 @@ tables:
             v4_openapi_fixture_with_defaulted_input_server_url(),
         )
         .expect("write fixture");
-        let manager = SourceManager::new_for_tests(
+        let manager = SourceManager::new(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
+            WorkspaceLifecycleLock::default(),
         );
 
         let error = manager
@@ -2692,10 +2714,12 @@ tables:
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         layout.ensure().expect("ensure layout");
-        let manager = SourceManager::new_for_tests(
+        let manager = SourceManager::new(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout,
+            WorkspaceLifecycleLock::default(),
         );
 
         let error = manager
@@ -2725,10 +2749,12 @@ tables:
         layout.ensure().expect("ensure layout");
         let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
         std::fs::write(&openapi_file, v4_openapi_fixture_with_metadata()).expect("write fixture");
-        let manager = SourceManager::new_for_tests(
+        let manager = SourceManager::new(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout.clone(),
+            WorkspaceLifecycleLock::default(),
         );
 
         manager
@@ -2764,8 +2790,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
 
         let source_name = SourceName::parse("secured_messages").expect("source");
         let source_dir = layout.source_dir(&default_workspace(), &source_name);
@@ -2867,7 +2898,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout,
+            WorkspaceLifecycleLock::default(),
+        );
 
         let source = manager
             .import_source(
@@ -2903,8 +2940,13 @@ tables:
             CredentialStoragePreference::Auto,
         );
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout.clone());
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
 
@@ -2974,8 +3016,13 @@ tables:
             CredentialStoragePreference::Keychain,
         );
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
         let source_name = SourceName::parse("public_messages").expect("source");
 
         let source = manager
@@ -3016,7 +3063,13 @@ tables:
             CredentialStoragePreference::Keychain,
         );
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout,
+            WorkspaceLifecycleLock::default(),
+        );
 
         let error = manager
             .import_source(
@@ -3045,8 +3098,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
 
         let source_name = SourceName::parse("secured_messages").expect("source");
         manager
@@ -3099,8 +3157,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
 
         let source_name = SourceName::parse("secured_messages").expect("source");
         manager
@@ -3148,8 +3211,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout,
+            WorkspaceLifecycleLock::default(),
+        );
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         credential_manager
@@ -3206,8 +3274,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
         let source_name = SourceName::parse("secured_messages").expect("source");
         let secret_path = layout.secret_file(&default_workspace(), &source_name);
         std::fs::create_dir_all(&secret_path).expect("create blocking secret directory");
@@ -3242,8 +3315,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout,
+            WorkspaceLifecycleLock::default(),
+        );
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         credential_manager
@@ -3309,8 +3387,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store.clone());
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout.clone());
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout.clone(),
+            WorkspaceLifecycleLock::default(),
+        );
         let workspace_name = default_workspace();
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
@@ -3406,8 +3489,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout,
+            WorkspaceLifecycleLock::default(),
+        );
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         let fixture = OAuthFixture::new();
@@ -3436,34 +3524,7 @@ tables:
             },
             event_tx,
         );
-        let callback = async {
-            let event = event_rx
-                .recv()
-                .await
-                .expect("authorization event")
-                .into_event();
-            let ImportSourceWithCredentialsEvent::OAuthAuthorization {
-                input_key,
-                authorization_url,
-                ..
-            } = event
-            else {
-                panic!("unexpected import event");
-            };
-            assert_eq!(input_key, "API_TOKEN");
-            let parsed = Url::parse(&authorization_url).expect("authorization url");
-            assert_eq!(parsed.path(), "/organizations/oauth/authorize");
-            callback(&authorization_url, redirect_port).await;
-            let event = event_rx
-                .recv()
-                .await
-                .expect("completion event")
-                .into_event();
-            let ImportSourceWithCredentialsEvent::OAuthCompleted { input_key, .. } = event else {
-                panic!("unexpected import event");
-            };
-            assert_eq!(input_key, "API_TOKEN");
-        };
+        let callback = complete_oauth_authorization(&mut event_rx, redirect_port);
 
         let (source, ()) = tokio::join!(import, callback);
         let source = source.expect("import source with OAuth");
@@ -3507,8 +3568,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout,
+            WorkspaceLifecycleLock::default(),
+        );
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         manager
@@ -3584,7 +3650,13 @@ tables:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
+            layout,
+            WorkspaceLifecycleLock::default(),
+        );
         let redirect_port = free_loopback_port();
         let (event_tx, mut event_rx) = import_event_channel();
 
@@ -3640,6 +3712,39 @@ tables:
             .expect("callback response")
             .error_for_status()
             .expect("callback success");
+    }
+
+    async fn complete_oauth_authorization(
+        event_rx: &mut mpsc::Receiver<PendingImportSourceWithCredentialsEvent>,
+        redirect_port: u16,
+    ) {
+        let event = event_rx
+            .recv()
+            .await
+            .expect("authorization event")
+            .into_event();
+        let ImportSourceWithCredentialsEvent::OAuthAuthorization {
+            input_key,
+            authorization_url,
+            ..
+        } = event
+        else {
+            panic!("unexpected import event");
+        };
+        assert_eq!(input_key, "API_TOKEN");
+        let parsed = Url::parse(&authorization_url).expect("authorization url");
+        assert_eq!(parsed.path(), "/organizations/oauth/authorize");
+        callback(&authorization_url, redirect_port).await;
+
+        let event = event_rx
+            .recv()
+            .await
+            .expect("completion event")
+            .into_event();
+        let ImportSourceWithCredentialsEvent::OAuthCompleted { input_key, .. } = event else {
+            panic!("unexpected import event");
+        };
+        assert_eq!(input_key, "API_TOKEN");
     }
 
     fn import_event_channel() -> (

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -17,7 +17,8 @@ use crate::credentials::{
 };
 use crate::sources::SourceName;
 use crate::sources::catalog::{
-    describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
+    describe_manifest, is_bundled_source, list_bundled_sources, load_bundled_source,
+    load_global_source_spec, resolve_installed_manifest,
 };
 use crate::sources::materialization::{
     MaterializationBuild, MaterializationInputs, build_v4_materialization_tmp,
@@ -25,7 +26,7 @@ use crate::sources::materialization::{
     new_materialization_suffix, replace_v4_materialization, restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
-use crate::state::{AppStateLayout, ConfigStore};
+use crate::state::{AppStateLayout, ConfigStore, RegisteredSourceSpec};
 use crate::storage::fs;
 use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
@@ -51,6 +52,21 @@ pub(crate) struct CreateBundledSourceWithOAuthCommand {
     pub(crate) name: SourceName,
     pub(crate) bindings: SourceBindings,
     pub(crate) oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
+}
+
+pub(crate) struct CreateGlobalSourceCommand {
+    pub(crate) name: SourceName,
+    pub(crate) bindings: SourceBindings,
+}
+
+pub(crate) struct CreateGlobalSourceWithOAuthCommand {
+    pub(crate) name: SourceName,
+    pub(crate) bindings: SourceBindings,
+    pub(crate) oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
+}
+
+pub(crate) struct RegisterSourceSpecCommand {
+    pub(crate) manifest_yaml: String,
 }
 
 pub(crate) struct ImportSourceCommand {
@@ -167,6 +183,10 @@ fn materialization_inputs_from_bindings(
     }
 }
 
+#[expect(
+    dead_code,
+    reason = "registry methods are wired by the next stack branch"
+)]
 impl SourceManager {
     #[cfg(test)]
     pub(crate) fn new_for_tests(
@@ -238,7 +258,16 @@ impl SourceManager {
         match load_bundled_source(source_name) {
             Ok(bundled) => self.describe_bundled_source(workspace_name, &bundled.manifest_yaml),
             Err(AppError::InvalidInput(_)) => {
-                Err(AppError::SourceNotFound(source_name.to_string()))
+                match self.config_store.get_source_spec(source_name) {
+                    Ok(_) => {
+                        let global = load_global_source_spec(source_name, &self.layout)?;
+                        self.describe_global_source(workspace_name, &global.manifest_yaml)
+                    }
+                    Err(AppError::SourceNotFound(_)) => {
+                        Err(AppError::SourceNotFound(source_name.to_string()))
+                    }
+                    Err(error) => Err(error),
+                }
             }
             Err(error) => Err(error),
         }
@@ -269,6 +298,114 @@ impl SourceManager {
         }
 
         Ok(candidates)
+    }
+
+    pub(crate) fn list_source_specs(&self) -> Result<Vec<CandidateSource>, AppError> {
+        self.config_store
+            .list_source_specs()?
+            .into_iter()
+            .map(|source_spec| {
+                let manifest = load_global_source_spec(&source_spec.name, &self.layout)?;
+                describe_manifest(&manifest.manifest_yaml, SourceOrigin::Global, false)
+            })
+            .collect()
+    }
+
+    pub(crate) fn register_source_spec(
+        &self,
+        command: &RegisterSourceSpecCommand,
+    ) -> Result<CandidateSource, AppError> {
+        let _lifecycle_guard = self.lifecycle_lock.lock();
+        let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
+        let candidate = describe_manifest(&manifest_yaml, SourceOrigin::Global, false)?;
+        if is_bundled_source(&candidate.name) {
+            return Err(AppError::InvalidInput(format!(
+                "global source spec '{}' conflicts with a bundled source",
+                candidate.name
+            )));
+        }
+
+        let manifest_path = self.layout.source_spec_manifest_file(&candidate.name);
+        let previous_manifest = match std::fs::read_to_string(&manifest_path) {
+            Ok(manifest_yaml) => Some(manifest_yaml),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+        let previous_spec = match self.config_store.get_source_spec(&candidate.name) {
+            Ok(source_spec) => Some(source_spec),
+            Err(AppError::SourceNotFound(_)) => None,
+            Err(error) => return Err(error),
+        };
+
+        if let Some(parent) = manifest_path.parent() {
+            fs::ensure_dir(parent)?;
+        }
+        fs::write_atomic(&manifest_path, manifest_yaml.as_bytes())?;
+
+        let registered = RegisteredSourceSpec {
+            name: candidate.name.clone(),
+            version: candidate.version.clone(),
+        };
+        if let Err(error) = self.config_store.upsert_source_spec(registered) {
+            self.restore_source_spec_registration(
+                &candidate.name,
+                previous_spec,
+                previous_manifest,
+            );
+            return Err(error);
+        }
+        Ok(candidate)
+    }
+
+    pub(crate) fn delete_source_spec(
+        &self,
+        source_name: &SourceName,
+    ) -> Result<CandidateSource, AppError> {
+        let _lifecycle_guard = self.lifecycle_lock.lock();
+        let registered = self.config_store.get_source_spec(source_name)?;
+        let manifest = match load_global_source_spec(source_name, &self.layout) {
+            Ok(manifest) => Some(manifest.manifest_yaml),
+            Err(AppError::MissingGlobalSourceSpec { .. }) => None,
+            Err(error) => return Err(error),
+        };
+        let removed = if let Some(manifest_yaml) = manifest.as_deref() {
+            let candidate = describe_manifest(manifest_yaml, SourceOrigin::Global, false)?;
+            if candidate.name != *source_name {
+                return Err(AppError::FailedPrecondition(format!(
+                    "registered source spec '{source_name}' does not match manifest name '{}'",
+                    candidate.name
+                )));
+            }
+            candidate
+        } else {
+            CandidateSource {
+                name: registered.name.clone(),
+                description: String::new(),
+                version: registered.version.clone(),
+                inputs: Vec::new(),
+                installed: false,
+                origin: SourceOrigin::Global,
+                credential_storage: None,
+            }
+        };
+
+        let source_spec_dir = self.layout.source_spec_dir(source_name);
+        let backup_dir = fs::DirectoryBackup::move_for_delete(&source_spec_dir, source_name)?;
+
+        if let Err(error) = self.config_store.remove_source_spec(source_name) {
+            if let Err(restore_error) = backup_dir.restore() {
+                return Err(AppError::FailedPrecondition(format!(
+                    "failed to remove source spec '{source_name}': {error}; failed to restore source-spec directory from '{}': {restore_error}",
+                    backup_dir.backup_path().display()
+                )));
+            }
+            return Err(error);
+        }
+        backup_dir.commit()?;
+        cleanup_empty_parent(&self.layout.source_specs_root(), source_spec_dir.parent());
+        Ok(removed)
     }
 
     pub(crate) fn create_bundled_source(
@@ -305,6 +442,46 @@ impl SourceManager {
             None,
             &bundled.manifest_yaml,
             SourceOrigin::Bundled,
+        )
+        .await
+    }
+
+    pub(crate) fn create_global_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: &CreateGlobalSourceCommand,
+    ) -> Result<InstalledSource, AppError> {
+        self.config_store.get_source_spec(&command.name)?;
+        let global = load_global_source_spec(&command.name, &self.layout)?;
+        let candidate = self.describe_global_source(workspace_name, &global.manifest_yaml)?;
+        self.install_validated_source(
+            workspace_name,
+            &candidate,
+            &command.bindings,
+            None,
+            &global.manifest_yaml,
+            SourceOrigin::Global,
+        )
+    }
+
+    pub(crate) async fn create_global_source_with_oauth(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: CreateGlobalSourceWithOAuthCommand,
+        events: ImportSourceEventSender,
+    ) -> Result<InstalledSource, AppError> {
+        self.config_store.get_source_spec(&command.name)?;
+        let global = load_global_source_spec(&command.name, &self.layout)?;
+        let candidate = self.describe_global_source(workspace_name, &global.manifest_yaml)?;
+        self.install_source_with_oauth(
+            workspace_name,
+            &candidate,
+            &command.bindings,
+            command.oauth_credential_retrievals,
+            events,
+            None,
+            &global.manifest_yaml,
+            SourceOrigin::Global,
         )
         .await
     }
@@ -514,10 +691,10 @@ impl SourceManager {
         let previous = SourceRollbackState {
             source: stored,
             manifest_yaml: match removed.origin {
-                SourceOrigin::Bundled => None,
                 SourceOrigin::Imported => Some(std::fs::read_to_string(
                     self.layout.manifest_file(workspace_name, source_name),
                 )?),
+                SourceOrigin::Bundled | SourceOrigin::Global => None,
             },
             credential_material,
         };
@@ -577,6 +754,16 @@ impl SourceManager {
         manifest_yaml: &str,
     ) -> Result<CandidateSource, AppError> {
         let mut candidate = describe_manifest(manifest_yaml, SourceOrigin::Bundled, false)?;
+        candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        Ok(candidate)
+    }
+
+    fn describe_global_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        manifest_yaml: &str,
+    ) -> Result<CandidateSource, AppError> {
+        let mut candidate = describe_manifest(manifest_yaml, SourceOrigin::Global, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         Ok(candidate)
     }
@@ -701,7 +888,7 @@ impl SourceManager {
 
         let persisted_version = match request.origin {
             SourceOrigin::Bundled => None,
-            SourceOrigin::Imported => request.candidate.version.clone(),
+            SourceOrigin::Imported | SourceOrigin::Global => request.candidate.version.clone(),
         };
         let stored = InstalledSource {
             name: source_name.clone(),
@@ -1060,10 +1247,10 @@ impl SourceManager {
             .transpose()?;
         Ok(Some(SourceRollbackState {
             manifest_yaml: match source.origin {
-                SourceOrigin::Bundled => None,
                 SourceOrigin::Imported => Some(std::fs::read_to_string(
                     self.layout.manifest_file(workspace_name, source_name),
                 )?),
+                SourceOrigin::Bundled | SourceOrigin::Global => None,
             },
             source,
             credential_material,
@@ -1157,6 +1344,45 @@ impl SourceManager {
         }
         cleanup_empty_parent(&self.layout.workspaces_root(), manifest_path.parent());
         Ok(())
+    }
+
+    fn restore_source_spec_registration(
+        &self,
+        source_name: &SourceName,
+        previous_spec: Option<RegisteredSourceSpec>,
+        previous_manifest: Option<String>,
+    ) {
+        let manifest_path = self.layout.source_spec_manifest_file(source_name);
+        if let Some(manifest_yaml) = previous_manifest {
+            if let Some(parent) = manifest_path.parent()
+                && let Err(error) = fs::ensure_dir(parent)
+            {
+                warn!("rollback: failed to create source-spec manifest parent dir: {error}");
+            }
+            if let Err(error) = fs::write_atomic(&manifest_path, manifest_yaml.as_bytes()) {
+                warn!("rollback: failed to restore source-spec manifest: {error}");
+            }
+        } else {
+            let source_spec_dir = self.layout.source_spec_dir(source_name);
+            if source_spec_dir.exists()
+                && let Err(error) = std::fs::remove_dir_all(&source_spec_dir)
+            {
+                warn!("rollback: failed to remove new source-spec directory: {error}");
+            }
+        }
+
+        match previous_spec {
+            Some(source_spec) => {
+                if let Err(error) = self.config_store.upsert_source_spec(source_spec) {
+                    warn!("rollback: failed to restore source-spec config: {error}");
+                }
+            }
+            None => {
+                if let Err(error) = self.config_store.remove_source_spec(source_name) {
+                    warn!("rollback: failed to remove new source-spec config: {error}");
+                }
+            }
+        }
     }
 
     fn populate_source_version(

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -673,8 +673,8 @@ impl SourceManager {
             return Err(error);
         }
         source_dir_backup.commit()?;
-        cleanup_empty_parent(&self.layout.workspaces_root(), source_dir.parent());
-        cleanup_empty_parent(
+        fs::cleanup_empty_parent_dirs(&self.layout.workspaces_root(), source_dir.parent());
+        fs::cleanup_empty_parent_dirs(
             &self.layout.workspaces_root(),
             self.layout.workspace_dir(workspace_name).parent(),
         );
@@ -1289,7 +1289,7 @@ impl SourceManager {
             }
             None => {}
         }
-        cleanup_empty_parent(&self.layout.workspaces_root(), manifest_path.parent());
+        fs::cleanup_empty_parent_dirs(&self.layout.workspaces_root(), manifest_path.parent());
         Ok(())
     }
 
@@ -1668,25 +1668,6 @@ fn durable_import_manifest_yaml(
         );
     }
     serde_yaml::to_string(&value).map_err(AppError::from)
-}
-
-fn cleanup_empty_parent(root: &std::path::Path, path: Option<&std::path::Path>) {
-    let Some(mut current) = path.map(std::path::Path::to_path_buf) else {
-        return;
-    };
-    while current.starts_with(root) && current != root {
-        let Ok(mut entries) = std::fs::read_dir(&current) else {
-            break;
-        };
-        if entries.next().is_some() {
-            break;
-        }
-        let next = current.parent().unwrap_or(root).to_path_buf();
-        if std::fs::remove_dir(&current).is_err() {
-            break;
-        }
-        current = next;
-    }
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -2215,8 +2215,9 @@ tables:
         let manager = SourceManager::new(
             config_store.clone(),
             credential_manager.clone(),
+            Arc::new(GlobalSourceSpecStore::new(layout.clone())),
             layout,
-            crate::workspaces::WorkspaceLifecycleLock::default(),
+            WorkspaceLifecycleLock::default(),
         );
 
         let workspace_name = default_workspace();

--- a/crates/coral-app/src/sources/mod.rs
+++ b/crates/coral-app/src/sources/mod.rs
@@ -7,5 +7,6 @@ pub(crate) mod model;
 pub(crate) mod name;
 pub(crate) mod runtime_package;
 pub(crate) mod service;
+pub(crate) mod source_specs;
 
 pub(crate) use name::SourceName;

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -67,6 +67,7 @@ impl InstalledSource {
 pub(crate) enum SourceOrigin {
     Bundled,
     Imported,
+    Global,
 }
 
 impl SourceOrigin {
@@ -74,6 +75,7 @@ impl SourceOrigin {
         match self {
             Self::Bundled => "bundled",
             Self::Imported => "imported",
+            Self::Global => "global",
         }
     }
 }

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -67,7 +67,7 @@ impl InstalledSource {
 pub(crate) enum SourceOrigin {
     Bundled,
     Imported,
-    Global,
+    GlobalSpec,
 }
 
 impl SourceOrigin {
@@ -75,7 +75,7 @@ impl SourceOrigin {
         match self {
             Self::Bundled => "bundled",
             Self::Imported => "imported",
-            Self::Global => "global",
+            Self::GlobalSpec => "global_spec",
         }
     }
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -38,7 +38,7 @@ use crate::credentials::CredentialStorageKind;
 use crate::query::manager::QueryManager;
 use crate::sources::SourceName;
 use crate::sources::manager::{
-    CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
+    CreateSourceCommand, CreateSourceWithOAuthCommand, ImportSourceCommand,
     ImportSourceEventSender, ImportSourceWithCredentialsCommand, ImportSourceWithCredentialsEvent,
     PendingImportSourceWithCredentialsEvent, SourceBinding, SourceBindings, SourceManager,
     SourceOAuthCredentialRetrieval,
@@ -164,13 +164,13 @@ impl SourceServiceApi for SourceService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
-            let command = CreateBundledSourceCommand {
+            let command = CreateSourceCommand {
                 name: bundled_name,
                 bindings: source_bindings_from_proto(request.variables, request.secrets),
             };
             let response_workspace_name = workspace_name.clone();
             let installed = run_blocking_source_operation(move || {
-                sources.create_bundled_source(&workspace_name, &command)
+                sources.create_source(&workspace_name, &command)
             })
             .await?;
             Ok(Response::new(CreateBundledSourceResponse {
@@ -193,7 +193,7 @@ impl SourceServiceApi for SourceService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let response_workspace_name = workspace_name.clone();
-            let command = CreateBundledSourceWithOAuthCommand {
+            let command = CreateSourceWithOAuthCommand {
                 name: SourceName::parse(&request.name).map_err(app_status)?,
                 bindings: source_bindings_from_proto(request.variables, request.secrets),
                 oauth_credential_retrievals: request
@@ -207,11 +207,7 @@ impl SourceServiceApi for SourceService {
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
                         sources
-                            .create_bundled_source_with_oauth(
-                                &workspace_name,
-                                command,
-                                event_sender,
-                            )
+                            .create_source_with_oauth(&workspace_name, command, event_sender)
                             .await
                             .map_err(app_status)
                     })
@@ -548,7 +544,7 @@ fn proto_source_origin(origin: SourceOrigin) -> ProtoSourceOrigin {
     match origin {
         SourceOrigin::Bundled => ProtoSourceOrigin::Bundled,
         SourceOrigin::Imported => ProtoSourceOrigin::Imported,
-        SourceOrigin::Global => ProtoSourceOrigin::Global,
+        SourceOrigin::GlobalSpec => ProtoSourceOrigin::GlobalSpec,
     }
 }
 

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -548,6 +548,7 @@ fn proto_source_origin(origin: SourceOrigin) -> ProtoSourceOrigin {
     match origin {
         SourceOrigin::Bundled => ProtoSourceOrigin::Bundled,
         SourceOrigin::Imported => ProtoSourceOrigin::Imported,
+        SourceOrigin::Global => ProtoSourceOrigin::Global,
     }
 }
 

--- a/crates/coral-app/src/sources/source_specs.rs
+++ b/crates/coral-app/src/sources/source_specs.rs
@@ -99,27 +99,8 @@ impl RemovedGlobalSourceSpec for FsRemovedGlobalSourceSpec {
 
     fn commit(self: Box<Self>) -> Result<(), AppError> {
         self.backup.commit()?;
-        cleanup_empty_parent(&self.root, self.parent.as_deref());
+        fs::cleanup_empty_parent_dirs(&self.root, self.parent.as_deref());
         Ok(())
-    }
-}
-
-fn cleanup_empty_parent(root: &Path, path: Option<&Path>) {
-    let Some(mut current) = path.map(Path::to_path_buf) else {
-        return;
-    };
-    while current.starts_with(root) && current != root {
-        let Ok(mut entries) = std::fs::read_dir(&current) else {
-            break;
-        };
-        if entries.next().is_some() {
-            break;
-        }
-        let next = current.parent().unwrap_or(root).to_path_buf();
-        if std::fs::remove_dir(&current).is_err() {
-            break;
-        }
-        current = next;
     }
 }
 

--- a/crates/coral-app/src/sources/source_specs.rs
+++ b/crates/coral-app/src/sources/source_specs.rs
@@ -1,4 +1,4 @@
-//! Storage seam for globally registered source-spec manifests.
+//! Filesystem-backed store for source-spec registrations.
 
 use std::path::{Path, PathBuf};
 
@@ -12,7 +12,7 @@ pub(crate) struct GlobalSourceSpecManifest {
     pub(crate) manifest_yaml: String,
 }
 
-pub(crate) trait SourceSpecStore: Send + Sync + 'static {
+pub(crate) trait GlobalSourceSpecStore: Send + Sync + 'static {
     fn load(&self, name: &SourceName) -> Result<GlobalSourceSpecManifest, AppError> {
         self.load_optional(name)?
             .ok_or_else(|| AppError::MissingGlobalSourceSpec {
@@ -39,17 +39,17 @@ pub(crate) trait RemovedGlobalSourceSpec {
 }
 
 #[derive(Clone)]
-pub(crate) struct GlobalSourceSpecStore {
+pub(crate) struct FsGlobalSourceSpecStore {
     layout: AppStateLayout,
 }
 
-impl GlobalSourceSpecStore {
+impl FsGlobalSourceSpecStore {
     pub(crate) fn new(layout: AppStateLayout) -> Self {
         Self { layout }
     }
 }
 
-impl SourceSpecStore for GlobalSourceSpecStore {
+impl GlobalSourceSpecStore for FsGlobalSourceSpecStore {
     fn load_optional(
         &self,
         name: &SourceName,
@@ -108,17 +108,17 @@ impl RemovedGlobalSourceSpec for FsRemovedGlobalSourceSpec {
 mod tests {
     use tempfile::TempDir;
 
-    use super::{GlobalSourceSpecStore, SourceSpecStore};
+    use super::{FsGlobalSourceSpecStore, GlobalSourceSpecStore};
     use crate::bootstrap::AppError;
     use crate::sources::SourceName;
     use crate::state::AppStateLayout;
 
-    fn test_store() -> (TempDir, AppStateLayout, GlobalSourceSpecStore) {
+    fn test_store() -> (TempDir, AppStateLayout, FsGlobalSourceSpecStore) {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         layout.ensure().expect("ensure layout");
-        let store = GlobalSourceSpecStore::new(layout.clone());
+        let store = FsGlobalSourceSpecStore::new(layout.clone());
         (temp, layout, store)
     }
 

--- a/crates/coral-app/src/sources/source_specs.rs
+++ b/crates/coral-app/src/sources/source_specs.rs
@@ -1,0 +1,191 @@
+//! Storage seam for globally registered source-spec manifests.
+
+use std::path::{Path, PathBuf};
+
+use crate::bootstrap::AppError;
+use crate::sources::SourceName;
+use crate::state::AppStateLayout;
+use crate::storage::fs;
+
+#[derive(Debug, Clone)]
+pub(crate) struct GlobalSourceSpecManifest {
+    pub(crate) manifest_yaml: String,
+}
+
+pub(crate) trait SourceSpecStore: Send + Sync + 'static {
+    fn load(&self, name: &SourceName) -> Result<GlobalSourceSpecManifest, AppError> {
+        self.load_optional(name)?
+            .ok_or_else(|| AppError::MissingGlobalSourceSpec {
+                source_name: name.to_string(),
+            })
+    }
+
+    fn load_optional(
+        &self,
+        name: &SourceName,
+    ) -> Result<Option<GlobalSourceSpecManifest>, AppError>;
+
+    fn write_manifest(&self, name: &SourceName, manifest_yaml: &str) -> Result<(), AppError>;
+
+    fn remove(&self, name: &SourceName) -> Result<Box<dyn RemovedGlobalSourceSpec>, AppError>;
+}
+
+pub(crate) trait RemovedGlobalSourceSpec {
+    fn backup_path(&self) -> &Path;
+
+    fn restore(&self) -> Result<(), AppError>;
+
+    fn commit(self: Box<Self>) -> Result<(), AppError>;
+}
+
+#[derive(Clone)]
+pub(crate) struct GlobalSourceSpecStore {
+    layout: AppStateLayout,
+}
+
+impl GlobalSourceSpecStore {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+}
+
+impl SourceSpecStore for GlobalSourceSpecStore {
+    fn load_optional(
+        &self,
+        name: &SourceName,
+    ) -> Result<Option<GlobalSourceSpecManifest>, AppError> {
+        let manifest_path = self.layout.source_spec_manifest_file(name);
+        let manifest_yaml = match std::fs::read_to_string(&manifest_path) {
+            Ok(manifest_yaml) => manifest_yaml,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(AppError::Io(error)),
+        };
+        Ok(Some(GlobalSourceSpecManifest { manifest_yaml }))
+    }
+
+    fn write_manifest(&self, name: &SourceName, manifest_yaml: &str) -> Result<(), AppError> {
+        let manifest_path = self.layout.source_spec_manifest_file(name);
+        if let Some(parent) = manifest_path.parent() {
+            fs::ensure_dir(parent)?;
+        }
+        fs::write_atomic(&manifest_path, manifest_yaml.as_bytes())?;
+        Ok(())
+    }
+
+    fn remove(&self, name: &SourceName) -> Result<Box<dyn RemovedGlobalSourceSpec>, AppError> {
+        let source_spec_dir = self.layout.source_spec_dir(name);
+        Ok(Box::new(FsRemovedGlobalSourceSpec {
+            parent: source_spec_dir.parent().map(Path::to_path_buf),
+            root: self.layout.source_specs_root(),
+            backup: fs::DirectoryBackup::move_for_delete(&source_spec_dir, name)?,
+        }))
+    }
+}
+
+struct FsRemovedGlobalSourceSpec {
+    backup: fs::DirectoryBackup,
+    parent: Option<PathBuf>,
+    root: PathBuf,
+}
+
+impl RemovedGlobalSourceSpec for FsRemovedGlobalSourceSpec {
+    fn backup_path(&self) -> &Path {
+        self.backup.backup_path()
+    }
+
+    fn restore(&self) -> Result<(), AppError> {
+        self.backup.restore().map_err(AppError::from)
+    }
+
+    fn commit(self: Box<Self>) -> Result<(), AppError> {
+        self.backup.commit()?;
+        cleanup_empty_parent(&self.root, self.parent.as_deref());
+        Ok(())
+    }
+}
+
+fn cleanup_empty_parent(root: &Path, path: Option<&Path>) {
+    let Some(mut current) = path.map(Path::to_path_buf) else {
+        return;
+    };
+    while current.starts_with(root) && current != root {
+        let Ok(mut entries) = std::fs::read_dir(&current) else {
+            break;
+        };
+        if entries.next().is_some() {
+            break;
+        }
+        let next = current.parent().unwrap_or(root).to_path_buf();
+        if std::fs::remove_dir(&current).is_err() {
+            break;
+        }
+        current = next;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::{GlobalSourceSpecStore, SourceSpecStore};
+    use crate::bootstrap::AppError;
+    use crate::sources::SourceName;
+    use crate::state::AppStateLayout;
+
+    fn test_store() -> (TempDir, AppStateLayout, GlobalSourceSpecStore) {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let store = GlobalSourceSpecStore::new(layout.clone());
+        (temp, layout, store)
+    }
+
+    #[test]
+    fn load_missing_returns_global_source_spec_error() {
+        let (_temp, _layout, store) = test_store();
+        let source_name = SourceName::parse("linear").expect("source name");
+
+        let error = store
+            .load(&source_name)
+            .expect_err("missing manifest should be explicit");
+
+        assert!(matches!(error, AppError::MissingGlobalSourceSpec { .. }));
+    }
+
+    #[test]
+    fn writes_loads_removes_and_restores_manifest_tree() {
+        let (_temp, layout, store) = test_store();
+        let source_name = SourceName::parse("linear").expect("source name");
+        let manifest_yaml = "name: linear\nversion: 1.0.0\n";
+
+        store
+            .write_manifest(&source_name, manifest_yaml)
+            .expect("write manifest");
+        assert_eq!(
+            store
+                .load(&source_name)
+                .expect("load manifest")
+                .manifest_yaml,
+            manifest_yaml
+        );
+
+        let removed = store.remove(&source_name).expect("remove manifest tree");
+        assert!(matches!(
+            store.load(&source_name),
+            Err(AppError::MissingGlobalSourceSpec { .. })
+        ));
+        removed.restore().expect("restore manifest tree");
+        assert_eq!(
+            store
+                .load(&source_name)
+                .expect("load restored manifest")
+                .manifest_yaml,
+            manifest_yaml
+        );
+
+        let removed = store.remove(&source_name).expect("remove manifest tree");
+        removed.commit().expect("commit deletion");
+        assert!(!layout.source_spec_dir(&source_name).exists());
+    }
+}

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -1151,9 +1151,9 @@ mod tests {
 
     use super::{
         AppConfig, AppError, ConfigStore, PersistedAppConfig, PersistedEngineConfig,
-        RawFeatureContainerState, RawFeatureValue, RegisteredSourceSpec, SourceCatalog,
-        SourceSpecCatalog, WorkspaceCatalog, load_raw_feature_overrides, render_config,
-        set_raw_feature_override,
+        PersistedMemoryConfig, RawFeatureContainerState, RawFeatureValue, RegisteredSourceSpec,
+        SourceCatalog, SourceSpecCatalog, WorkspaceCatalog, load_raw_feature_overrides,
+        render_config, set_raw_feature_override,
     };
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -21,6 +21,7 @@ pub(crate) struct AppConfig {
     engine: PersistedEngineConfig,
     workspaces: WorkspaceCatalog,
     catalog: SourceCatalog,
+    source_specs: SourceSpecCatalog,
 }
 
 impl Default for AppConfig {
@@ -30,6 +31,7 @@ impl Default for AppConfig {
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
+            source_specs: SourceSpecCatalog::default(),
         }
     }
 }
@@ -63,6 +65,14 @@ impl AppConfig {
         self.catalog.get_source(workspace_name, source_name)
     }
 
+    pub(crate) fn source_specs(&self) -> Vec<RegisteredSourceSpec> {
+        self.source_specs.list()
+    }
+
+    pub(crate) fn get_source_spec(&self, source_name: &SourceName) -> Option<RegisteredSourceSpec> {
+        self.source_specs.get(source_name)
+    }
+
     pub(crate) fn dependent_join_config(
         &self,
         selected_source_names: &[String],
@@ -88,6 +98,8 @@ struct PersistedAppConfig {
     version: u32,
     #[serde(default)]
     engine: PersistedEngineConfig,
+    #[serde(default)]
+    source_specs: BTreeMap<String, PersistedSourceSpec>,
     #[serde(default)]
     workspaces: BTreeMap<String, PersistedWorkspaceConfig>,
 }
@@ -206,6 +218,26 @@ struct PersistedInstalledSource {
     #[serde(default)]
     credential_storage: Option<CredentialStorageKind>,
     origin: SourceOrigin,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct PersistedSourceSpec {
+    #[serde(default)]
+    version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RegisteredSourceSpec {
+    pub(crate) name: SourceName,
+    pub(crate) version: Option<String>,
+}
+
+impl RegisteredSourceSpec {
+    fn into_persisted(self) -> PersistedSourceSpec {
+        PersistedSourceSpec {
+            version: self.version,
+        }
+    }
 }
 
 impl PersistedInstalledSource {
@@ -333,6 +365,27 @@ impl SourceCatalog {
         workspace_name: &WorkspaceName,
     ) -> Option<BTreeMap<SourceName, InstalledSource>> {
         self.0.remove(workspace_name)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SourceSpecCatalog(BTreeMap<SourceName, RegisteredSourceSpec>);
+
+impl SourceSpecCatalog {
+    pub(crate) fn list(&self) -> Vec<RegisteredSourceSpec> {
+        self.0.values().cloned().collect()
+    }
+
+    pub(crate) fn get(&self, source_name: &SourceName) -> Option<RegisteredSourceSpec> {
+        self.0.get(source_name).cloned()
+    }
+
+    pub(crate) fn upsert(&mut self, source_spec: RegisteredSourceSpec) {
+        self.0.insert(source_spec.name.clone(), source_spec);
+    }
+
+    pub(crate) fn remove(&mut self, source_name: &SourceName) -> Option<RegisteredSourceSpec> {
+        self.0.remove(source_name)
     }
 }
 
@@ -660,6 +713,38 @@ impl ConfigStore {
             Ok(())
         })
     }
+
+    pub(crate) fn list_source_specs(&self) -> Result<Vec<RegisteredSourceSpec>, AppError> {
+        self.load_config().map(|config| config.source_specs())
+    }
+
+    pub(crate) fn get_source_spec(
+        &self,
+        source_name: &SourceName,
+    ) -> Result<RegisteredSourceSpec, AppError> {
+        self.load_config()?
+            .get_source_spec(source_name)
+            .ok_or_else(|| {
+                AppError::SourceNotFound(format!("source spec {}", source_name.as_str()))
+            })
+    }
+
+    pub(crate) fn upsert_source_spec(
+        &self,
+        source_spec: RegisteredSourceSpec,
+    ) -> Result<(), AppError> {
+        self.update_config(|config| {
+            config.source_specs.upsert(source_spec);
+            Ok(())
+        })
+    }
+
+    pub(crate) fn remove_source_spec(
+        &self,
+        source_name: &SourceName,
+    ) -> Result<Option<RegisteredSourceSpec>, AppError> {
+        self.update_config(|config| Ok(config.source_specs.remove(source_name)))
+    }
 }
 
 impl WorkspaceStore for ConfigStore {
@@ -693,6 +778,20 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
 
     doc["version"] = value(i64::from(config.version));
     render_engine_config(&mut doc, &config.engine);
+
+    // Remove and rebuild the global source-spec registry index so deleted
+    // entries don't linger while preserving unrelated top-level config.
+    doc.remove("source_specs");
+    for (source_name, source_spec) in &config.source_specs {
+        ensure_implicit_table(&mut doc["source_specs"]);
+        let source_spec_item = &mut doc["source_specs"][source_name];
+        if !source_spec_item.is_table() {
+            *source_spec_item = toml_edit::table();
+        }
+        if let Some(version) = &source_spec.version {
+            source_spec_item["version"] = value(version.clone());
+        }
+    }
 
     // Remove and fully rebuild the workspaces section so removed sources and
     // removed empty workspaces don't linger.
@@ -818,6 +917,14 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
     fn try_from(value: PersistedAppConfig) -> Result<Self, Self::Error> {
         let mut workspaces = WorkspaceCatalog::default();
         let mut catalog = SourceCatalog::default();
+        let mut source_specs = SourceSpecCatalog::default();
+        for (source_name, source_spec) in value.source_specs {
+            let source_name = SourceName::parse(&source_name)?;
+            source_specs.upsert(RegisteredSourceSpec {
+                name: source_name,
+                version: source_spec.version,
+            });
+        }
         for (workspace_name, workspace_config) in value.workspaces {
             let workspace_name = WorkspaceName::parse(&workspace_name)?;
             workspaces.insert(workspace_name.clone());
@@ -831,6 +938,7 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
             engine: value.engine,
             workspaces,
             catalog,
+            source_specs,
         })
     }
 }
@@ -854,9 +962,22 @@ impl From<&AppConfig> for PersistedAppConfig {
                 );
             }
         }
+        let source_specs = value
+            .source_specs
+            .0
+            .values()
+            .cloned()
+            .map(|source_spec| {
+                (
+                    source_spec.name.as_str().to_string(),
+                    source_spec.into_persisted(),
+                )
+            })
+            .collect();
         Self {
             version: value.version,
             engine: value.engine.clone(),
+            source_specs,
             workspaces,
         }
     }
@@ -1030,8 +1151,9 @@ mod tests {
 
     use super::{
         AppConfig, AppError, ConfigStore, PersistedAppConfig, PersistedEngineConfig,
-        PersistedMemoryConfig, RawFeatureContainerState, RawFeatureValue, SourceCatalog,
-        WorkspaceCatalog, load_raw_feature_overrides, render_config, set_raw_feature_override,
+        RawFeatureContainerState, RawFeatureValue, RegisteredSourceSpec, SourceCatalog,
+        SourceSpecCatalog, WorkspaceCatalog, load_raw_feature_overrides, render_config,
+        set_raw_feature_override,
     };
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
@@ -1129,6 +1251,7 @@ mod tests {
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog,
+            source_specs: SourceSpecCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -1150,12 +1273,43 @@ mod tests {
             engine: PersistedEngineConfig::default(),
             workspaces,
             catalog: SourceCatalog::default(),
+            source_specs: SourceSpecCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
 
         assert!(raw.contains("[workspaces.default]"));
         assert!(raw.contains("[workspaces.work]"));
+    }
+
+    #[test]
+    fn renders_and_loads_global_source_specs() {
+        let source_name = SourceName::parse("linear").expect("source");
+        let mut source_specs = SourceSpecCatalog::default();
+        source_specs.upsert(RegisteredSourceSpec {
+            name: source_name.clone(),
+            version: Some("3.0.0".to_string()),
+        });
+        let config = AppConfig {
+            version: 1,
+            engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
+            catalog: SourceCatalog::default(),
+            source_specs,
+        };
+
+        let raw = render_config(&PersistedAppConfig::from(&config), None);
+
+        assert!(raw.contains("[source_specs.linear]"));
+        assert!(raw.contains("version = \"3.0.0\""));
+        let loaded = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(&raw).expect("config should parse"),
+        )
+        .expect("config");
+        let source_spec = loaded
+            .get_source_spec(&source_name)
+            .expect("source spec should load");
+        assert_eq!(source_spec.version.as_deref(), Some("3.0.0"));
     }
 
     #[test]
@@ -1194,6 +1348,7 @@ version = 1
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog,
+            source_specs: SourceSpecCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -1414,6 +1569,7 @@ limit = 2147483648
             },
             workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
+            source_specs: SourceSpecCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -1440,6 +1596,7 @@ flag = true
             },
             workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
+            source_specs: SourceSpecCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), Some(existing_raw));
@@ -1466,6 +1623,7 @@ flag = true
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
+            source_specs: SourceSpecCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), Some(existing_raw));
@@ -1601,6 +1759,7 @@ max_concurrency = 0
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog,
+            source_specs: SourceSpecCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -1707,6 +1866,7 @@ origin = "bundled"
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog,
+            source_specs: SourceSpecCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), Some(existing));

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -73,6 +73,19 @@ impl AppStateLayout {
         self.config_dir.join("workspaces")
     }
 
+    pub(crate) fn source_specs_root(&self) -> PathBuf {
+        self.config_dir.join("source_specs")
+    }
+
+    pub(crate) fn source_spec_dir(&self, source_name: &SourceName) -> PathBuf {
+        self.source_specs_root().join(source_name.as_str())
+    }
+
+    pub(crate) fn source_spec_manifest_file(&self, source_name: &SourceName) -> PathBuf {
+        self.source_spec_dir(source_name)
+            .join(INSTALLED_MANIFEST_FILE_NAME)
+    }
+
     pub(crate) fn workspace_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.workspaces_root().join(workspace_name.as_str())
     }

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -3,7 +3,7 @@
 mod config;
 mod layout;
 
-pub(crate) use config::{AppConfig, ConfigStore};
+pub(crate) use config::{AppConfig, ConfigStore, RegisteredSourceSpec};
 pub(crate) use config::{
     RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue, load_raw_feature_overrides,
     set_raw_feature_override,

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -127,6 +127,25 @@ impl DirectoryBackup {
     }
 }
 
+pub(crate) fn cleanup_empty_parent_dirs(root: &Path, path: Option<&Path>) {
+    let Some(mut current) = path.map(Path::to_path_buf) else {
+        return;
+    };
+    while current.starts_with(root) && current != root {
+        let Ok(mut entries) = fs::read_dir(&current) else {
+            break;
+        };
+        if entries.next().is_some() {
+            break;
+        }
+        let next = current.parent().unwrap_or(root).to_path_buf();
+        if fs::remove_dir(&current).is_err() {
+            break;
+        }
+        current = next;
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct FileLock {
     _file: File,

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -793,6 +793,7 @@ pub(crate) fn source_origin_label(origin: i32) -> &'static str {
     match SourceOrigin::try_from(origin) {
         Ok(SourceOrigin::Bundled) => "bundled",
         Ok(SourceOrigin::Imported) => "imported",
+        Ok(SourceOrigin::Global) => "global",
         Ok(SourceOrigin::Unspecified) | Err(_) => "unknown",
     }
 }

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -793,7 +793,7 @@ pub(crate) fn source_origin_label(origin: i32) -> &'static str {
     match SourceOrigin::try_from(origin) {
         Ok(SourceOrigin::Bundled) => "bundled",
         Ok(SourceOrigin::Imported) => "imported",
-        Ok(SourceOrigin::Global) => "global",
+        Ok(SourceOrigin::GlobalSpec) => "global-spec",
         Ok(SourceOrigin::Unspecified) | Err(_) => "unknown",
     }
 }


### PR DESCRIPTION
## Intent

Introduce app-owned global source-spec registry state without changing the workspace-source lifecycle underneath it. This gives Coral a durable place to remember reusable source specs independently from any one workspace installation.

## What it enables

- Persists registered source specs in config under `[source_specs]`.
- Stores registry manifest artifacts under `source_specs/<name>/manifest.yaml`.
- Lets workspace sources with `origin = "global"` resolve their manifest through the registry.
- Skips orphaned global-spec workspace sources during query loading when their registry entry has been deleted, so the rest of the workspace remains usable.
- Keeps explicit validation for an orphaned source fail-fast, with guidance to re-register the spec or reinstall the source.
- Documents the `[source_specs]` config shape and keeps source/workspace lifecycle test wiring aligned with production locking.

## Usage examples

This branch is the state/model foundation; the RPC and CLI surfaces land later in the stack. The persisted config shape is:

```toml
[source_specs.internal_crm]
version = "1.0.0"
```

Workspace-installed global sources then point at the registry by name and resolve their manifest from the global source-spec directory. If that registry entry is later removed, query context loading omits the orphaned source and continues loading the rest of the workspace.

## Validation

- `make rust-checks`
- `npm run check --prefix ui`
- `make lint-proto`
- `make docs-check`
- `make perf-check` (`coral.tables` mean 249.8 ms, threshold 750 ms)
- Latest focused checks: `cargo fmt --all --check`
- Latest focused checks: `cargo test -p coral-app --lib query::manager::tests::load_query_sources_skips_source_with_missing_global_source_spec`
- Latest focused checks: `make docs-check`
