### PR TITLE
feat(api): expose global source spec registry RPCs

### DIFF
--- a/apps/ui/src/lib/sources.ts
+++ b/apps/ui/src/lib/sources.ts
@@ -82,8 +82,10 @@ export async function deleteSource(name: string): Promise<void> {
 }
 
 function splitBindings(inputs: InstallInput[]) {
-  const variables = inputs.filter((i) => !i.secret).map((i) => ({ key: i.key, value: i.value }))
-  const secrets = inputs.filter((i) => i.secret).map((i) => ({ key: i.key, value: i.value }))
+  const variables = inputs
+    .filter((i) => !i.secret)
+    .map((i) => ({ key: i.key, value: i.value.trim() }))
+  const secrets = inputs.filter((i) => i.secret).map((i) => ({ key: i.key, value: i.value.trim() }))
   return { variables, secrets }
 }
 

--- a/apps/ui/src/lib/sources.ts
+++ b/apps/ui/src/lib/sources.ts
@@ -1,8 +1,8 @@
 import { create } from '@bufbuild/protobuf'
 
 import {
-  CreateBundledSourceRequestSchema,
-  CreateBundledSourceWithOAuthRequestSchema,
+  CreateSourceRequestSchema,
+  CreateSourceWithOAuthRequestSchema,
   DeleteSourceRequestSchema,
   DiscoverSourcesRequestSchema,
   GetSourceInfoRequestSchema,
@@ -15,7 +15,7 @@ import {
 
 import { sourceClient, WORKSPACE } from './coral-clients'
 
-export type SourceOriginLabel = 'bundled' | 'imported' | 'unknown'
+export type SourceOriginLabel = 'bundled' | 'imported' | 'global-spec' | 'unknown'
 
 export interface CatalogEntry {
   name: string
@@ -38,6 +38,7 @@ export interface InstallInput {
 export function originLabel(origin: SourceOrigin): SourceOriginLabel {
   if (origin === SourceOrigin.BUNDLED) return 'bundled'
   if (origin === SourceOrigin.IMPORTED) return 'imported'
+  if (origin === SourceOrigin.GLOBAL_SPEC) return 'global-spec'
   return 'unknown'
 }
 
@@ -86,17 +87,17 @@ function splitBindings(inputs: InstallInput[]) {
   return { variables, secrets }
 }
 
-export async function createBundledSource(name: string, inputs: InstallInput[]): Promise<Source> {
+export async function createSource(name: string, inputs: InstallInput[]): Promise<Source> {
   const { variables, secrets } = splitBindings(inputs)
-  const resp = await sourceClient.createBundledSource(
-    create(CreateBundledSourceRequestSchema, {
+  const resp = await sourceClient.createSource(
+    create(CreateSourceRequestSchema, {
       workspace: WORKSPACE,
       name,
       variables,
       secrets,
     }),
   )
-  if (!resp.source) throw new Error(`createBundledSource returned no source`)
+  if (!resp.source) throw new Error(`createSource returned no source`)
   return resp.source
 }
 
@@ -112,16 +113,16 @@ export interface OAuthFlowCallbacks {
   onCompleted?: (event: { inputKey: string; metadata: Map<string, string> }) => void
 }
 
-/** Run the bundled-source OAuth install stream and deliver progress events. */
-export async function createBundledSourceWithOAuth(
+/** Run the source OAuth install stream and deliver progress events. */
+export async function createSourceWithOAuth(
   name: string,
   inputs: InstallInput[],
   oauthRetrievals: OAuthCredentialRetrieval[],
   callbacks: OAuthFlowCallbacks = {},
 ): Promise<Source> {
   const { variables, secrets } = splitBindings(inputs)
-  const stream = sourceClient.createBundledSourceWithOAuth(
-    create(CreateBundledSourceWithOAuthRequestSchema, {
+  const stream = sourceClient.createSourceWithOAuth(
+    create(CreateSourceWithOAuthRequestSchema, {
       workspace: WORKSPACE,
       name,
       variables,

--- a/apps/ui/src/views/sources/source-detail.tsx
+++ b/apps/ui/src/views/sources/source-detail.tsx
@@ -13,7 +13,7 @@ import { Typography } from '@/wax/components/typography'
 
 import { providerIcon } from '@/lib/provider-icons'
 import {
-  createBundledSource,
+  createSource,
   deleteSource,
   getInstalledSource,
   getSourceInfo,
@@ -187,7 +187,7 @@ function SourceDetailDialogContent({
           }
         }
       }
-      await createBundledSource(name, bindings)
+      await createSource(name, bindings)
       onClose()
       addToast('success', { title: `Updated ${name}` })
     } catch (e) {

--- a/apps/ui/src/views/sources/source-install.tsx
+++ b/apps/ui/src/views/sources/source-install.tsx
@@ -21,8 +21,8 @@ import { Typography } from '@/wax/components/typography'
 import { Markdown } from '@/components/markdown'
 import { providerIcon } from '@/lib/provider-icons'
 import {
-  createBundledSource,
-  createBundledSourceWithOAuth,
+  createSource,
+  createSourceWithOAuth,
   getSourceInfo,
   type InstallInput,
   type ResolvedSourceInfo,
@@ -189,9 +189,9 @@ function SourceInstallDialogContent({
       }
 
       if (retrievalProtos.length === 0) {
-        await createBundledSource(name, bindings)
+        await createSource(name, bindings)
       } else {
-        await createBundledSourceWithOAuth(name, bindings, retrievalProtos, callbacks)
+        await createSourceWithOAuth(name, bindings, retrievalProtos, callbacks)
       }
 
       addToast('neutral', {

--- a/apps/ui/tests/ui/support/source-fixtures.ts
+++ b/apps/ui/tests/ui/support/source-fixtures.ts
@@ -1,8 +1,8 @@
 import { create } from '@bufbuild/protobuf'
 
 import {
-  CreateBundledSourceResponseSchema,
-  CreateBundledSourceWithOAuthResponseSchema,
+  CreateSourceResponseSchema,
+  CreateSourceWithOAuthResponseSchema,
   DeleteSourceResponseSchema,
   DiscoverSourcesResponseSchema,
   GetSourceInfoResponseSchema,
@@ -296,12 +296,12 @@ export const getInstalledLinearResponse = create(GetSourceResponseSchema, {
   source: installedLinear,
 })
 
-export const createLinearResponse = create(CreateBundledSourceResponseSchema, {
+export const createLinearResponse = create(CreateSourceResponseSchema, {
   source: installedLinear,
 })
 
 export const createGithubOauthResponses = [
-  create(CreateBundledSourceWithOAuthResponseSchema, {
+  create(CreateSourceWithOAuthResponseSchema, {
     event: {
       case: 'oauthAuthorization',
       value: create(OAuthCredentialAuthorizationSchema, {
@@ -314,7 +314,7 @@ export const createGithubOauthResponses = [
       }),
     },
   }),
-  create(CreateBundledSourceWithOAuthResponseSchema, {
+  create(CreateSourceWithOAuthResponseSchema, {
     event: {
       case: 'oauthCompleted',
       value: create(OAuthCredentialCompletedSchema, {
@@ -323,7 +323,7 @@ export const createGithubOauthResponses = [
       }),
     },
   }),
-  create(CreateBundledSourceWithOAuthResponseSchema, {
+  create(CreateSourceWithOAuthResponseSchema, {
     event: {
       case: 'source',
       value: installedBundledGithub,

--- a/apps/ui/tests/ui/support/source-handlers.ts
+++ b/apps/ui/tests/ui/support/source-handlers.ts
@@ -1,10 +1,10 @@
 import { http } from 'msw'
 
 import {
-  CreateBundledSourceRequestSchema,
-  CreateBundledSourceResponseSchema,
-  CreateBundledSourceWithOAuthRequestSchema,
-  CreateBundledSourceWithOAuthResponseSchema,
+  CreateSourceRequestSchema,
+  CreateSourceResponseSchema,
+  CreateSourceWithOAuthRequestSchema,
+  CreateSourceWithOAuthResponseSchema,
   DeleteSourceRequestSchema,
   DeleteSourceResponseSchema,
   DiscoverSourcesResponseSchema,
@@ -41,8 +41,8 @@ const discoverUrl = '*/coral.v1.SourceService/DiscoverSources'
 const listUrl = '*/coral.v1.SourceService/ListSources'
 const getUrl = '*/coral.v1.SourceService/GetSource'
 const getInfoUrl = '*/coral.v1.SourceService/GetSourceInfo'
-const createBundledUrl = '*/coral.v1.SourceService/CreateBundledSource'
-const createBundledWithOAuthUrl = '*/coral.v1.SourceService/CreateBundledSourceWithOAuth'
+const createUrl = '*/coral.v1.SourceService/CreateSource'
+const createWithOAuthUrl = '*/coral.v1.SourceService/CreateSourceWithOAuth'
 const deleteUrl = '*/coral.v1.SourceService/DeleteSource'
 
 function sourceInfoResponse(name: string) {
@@ -89,10 +89,10 @@ export function sourceLifecycleHandlers() {
       if (!response) return grpcWebError(5, `source ${message.name} not found`)
       return grpcWebResponse(GetSourceResponseSchema, response)
     }),
-    http.post(createBundledUrl, async ({ request }) => {
-      const message = await grpcWebRequest(CreateBundledSourceRequestSchema, request)
+    http.post(createUrl, async ({ request }) => {
+      const message = await grpcWebRequest(CreateSourceRequestSchema, request)
       if (message.name !== 'linear') {
-        throw new Error(`expected CreateBundledSource for linear, got ${message.name}`)
+        throw new Error(`expected CreateSource for linear, got ${message.name}`)
       }
 
       createCalls += 1
@@ -102,12 +102,12 @@ export function sourceLifecycleHandlers() {
       } else if (createCalls === 2) {
         expectLinearSecret(token ?? '', 'lin_test_token_v2', 'edit')
       } else {
-        throw new Error(`unexpected CreateBundledSource call ${createCalls}`)
+        throw new Error(`unexpected CreateSource call ${createCalls}`)
       }
 
       listResponse = listAfterLinearInstallResponse
       discoverResponse = discoverAfterLinearInstallResponse
-      return grpcWebResponse(CreateBundledSourceResponseSchema, createLinearResponse)
+      return grpcWebResponse(CreateSourceResponseSchema, createLinearResponse)
     }),
     http.post(deleteUrl, async ({ request }) => {
       const message = await grpcWebRequest(DeleteSourceRequestSchema, request)
@@ -138,10 +138,10 @@ export function sourceOAuthInstallHandlers() {
       if (message.name !== 'github') return grpcWebError(5, `source ${message.name} not found`)
       return grpcWebResponse(GetSourceResponseSchema, getInstalledBundledGithubResponse)
     }),
-    http.post(createBundledWithOAuthUrl, async ({ request }) => {
-      const message = await grpcWebRequest(CreateBundledSourceWithOAuthRequestSchema, request)
+    http.post(createWithOAuthUrl, async ({ request }) => {
+      const message = await grpcWebRequest(CreateSourceWithOAuthRequestSchema, request)
       if (message.name !== 'github') {
-        throw new Error(`expected CreateBundledSourceWithOAuth for github, got ${message.name}`)
+        throw new Error(`expected CreateSourceWithOAuth for github, got ${message.name}`)
       }
       const retrieval = message.oauthCredentialRetrievals[0]
       if (
@@ -155,7 +155,7 @@ export function sourceOAuthInstallHandlers() {
       listResponse = listAfterGithubOauthResponse
       discoverResponse = discoverInitialResponse
       return grpcWebStreamResponse(
-        CreateBundledSourceWithOAuthResponseSchema,
+        CreateSourceWithOAuthResponseSchema,
         createGithubOauthResponses,
         { delayMs: 1500 },
       )

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -294,6 +294,20 @@ message SourceInfo {
   SourceCredentialStorage credential_storage = 7;
 }
 
+// One globally registered source-spec metadata record.
+message SourceSpecInfo {
+  // Canonical source name.
+  string name = 1;
+  // Human-readable description.
+  string description = 2;
+  // Manifest version string.
+  string version = 3;
+  // Prompted source inputs in stable manifest order.
+  repeated SourceInputSpec inputs = 4;
+  // Where this source spec came from.
+  SourceOrigin origin = 5;
+}
+
 // Lists all bundled sources available for one workspace.
 message DiscoverSourcesRequest {
   // Workspace used to mark which bundled sources are already installed.
@@ -477,7 +491,7 @@ message ListSourceSpecsRequest {}
 // Returns globally registered source-spec summaries.
 message ListSourceSpecsResponse {
   // Globally registered source specs.
-  repeated SourceInfo source_specs = 1;
+  repeated SourceSpecInfo source_specs = 1;
 }
 
 // Registers one user-supplied source manifest in the global source-spec registry.

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -306,11 +306,11 @@ message DiscoverSourcesResponse {
   repeated SourceInfo sources = 1;
 }
 
-// Installs one bundled source by name.
-message CreateBundledSourceRequest {
+// Installs one named source by resolving registered global specs before bundled sources.
+message CreateSourceRequest {
   // Owning workspace resource.
   Workspace workspace = 1;
-  // Canonical bundled source name.
+  // Canonical source name.
   string name = 2;
   // Visible configured non-secret variables.
   repeated SourceVariable variables = 3;
@@ -318,17 +318,17 @@ message CreateBundledSourceRequest {
   repeated SourceSecret secrets = 4;
 }
 
-// Returns the installed bundled source.
-message CreateBundledSourceResponse {
+// Returns the installed source.
+message CreateSourceResponse {
   // The installed source resource.
   Source source = 1;
 }
 
-// Installs one bundled source with app-owned OAuth credential retrieval.
-message CreateBundledSourceWithOAuthRequest {
+// Installs one named source with app-owned OAuth credential retrieval.
+message CreateSourceWithOAuthRequest {
   // Owning workspace resource.
   Workspace workspace = 1;
-  // Canonical bundled source name.
+  // Canonical source name.
   string name = 2;
   // Visible configured non-secret variables.
   repeated SourceVariable variables = 3;
@@ -338,56 +338,11 @@ message CreateBundledSourceWithOAuthRequest {
   repeated OAuthCredentialRetrieval oauth_credential_retrievals = 5;
 }
 
-// Streaming event emitted while installing a bundled source with OAuth.
-message CreateBundledSourceWithOAuthResponse {
+// Streaming event emitted while installing a named source with OAuth.
+message CreateSourceWithOAuthResponse {
   // Installation progress or completion event.
   oneof event {
-    // Bundled source installation completed.
-    Source source = 1;
-    // OAuth authorization URL is ready.
-    OAuthCredentialAuthorization oauth_authorization = 2;
-    // OAuth credential retrieval completed.
-    OAuthCredentialCompleted oauth_completed = 3;
-  }
-}
-
-// Installs one globally registered source spec by name.
-message CreateGlobalSourceRequest {
-  // Owning workspace resource.
-  Workspace workspace = 1;
-  // Canonical globally registered source name.
-  string name = 2;
-  // Visible configured non-secret variables.
-  repeated SourceVariable variables = 3;
-  // Source-owned secret values.
-  repeated SourceSecret secrets = 4;
-}
-
-// Returns the installed globally registered source.
-message CreateGlobalSourceResponse {
-  // The installed source resource.
-  Source source = 1;
-}
-
-// Installs one globally registered source spec with app-owned OAuth credential retrieval.
-message CreateGlobalSourceWithOAuthRequest {
-  // Owning workspace resource.
-  Workspace workspace = 1;
-  // Canonical globally registered source name.
-  string name = 2;
-  // Visible configured non-secret variables.
-  repeated SourceVariable variables = 3;
-  // Source-config secret bindings.
-  repeated SourceSecret secrets = 4;
-  // OAuth credential retrievals the app should run before validation and install.
-  repeated OAuthCredentialRetrieval oauth_credential_retrievals = 5;
-}
-
-// Streaming event emitted while installing a globally registered source with OAuth.
-message CreateGlobalSourceWithOAuthResponse {
-  // Installation progress or completion event.
-  oneof event {
-    // Global source installation completed.
+    // Source installation completed.
     Source source = 1;
     // OAuth authorization URL is ready.
     OAuthCredentialAuthorization oauth_authorization = 2;
@@ -512,7 +467,7 @@ message GetSourceInfoRequest {
 
 // Returns source metadata.
 message GetSourceInfoResponse {
-  // Metadata for the installed or bundled source.
+  // Metadata for the installed, registered global, or bundled source.
   SourceInfo source_info = 1;
 }
 
@@ -616,18 +571,13 @@ service SourceService {
   rpc ListSources(ListSourcesRequest) returns (ListSourcesResponse);
   // Fetches one registered source.
   rpc GetSource(GetSourceRequest) returns (GetSourceResponse);
-  // Fetches metadata for one installed or bundled source.
+  // Fetches metadata for one installed, registered global, or bundled source.
   rpc GetSourceInfo(GetSourceInfoRequest) returns (GetSourceInfoResponse);
-  // Installs one bundled source.
-  rpc CreateBundledSource(CreateBundledSourceRequest) returns (CreateBundledSourceResponse);
-  // Installs one bundled source with app-owned OAuth credential retrieval.
-  rpc CreateBundledSourceWithOAuth(CreateBundledSourceWithOAuthRequest)
-      returns (stream CreateBundledSourceWithOAuthResponse);
-  // Installs one globally registered source spec.
-  rpc CreateGlobalSource(CreateGlobalSourceRequest) returns (CreateGlobalSourceResponse);
-  // Installs one globally registered source spec with app-owned OAuth credential retrieval.
-  rpc CreateGlobalSourceWithOAuth(CreateGlobalSourceWithOAuthRequest)
-      returns (stream CreateGlobalSourceWithOAuthResponse);
+  // Installs one named source by resolving registered global specs before bundled sources.
+  rpc CreateSource(CreateSourceRequest) returns (CreateSourceResponse);
+  // Installs one named source with app-owned OAuth credential retrieval.
+  rpc CreateSourceWithOAuth(CreateSourceWithOAuthRequest)
+      returns (stream CreateSourceWithOAuthResponse);
   // Imports one user-provided source manifest, streaming credential retrieval
   // progress before the final source event when credentials are app-owned.
   rpc ImportSource(ImportSourceRequest) returns (stream ImportSourceResponse);

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -351,6 +351,51 @@ message CreateBundledSourceWithOAuthResponse {
   }
 }
 
+// Installs one globally registered source spec by name.
+message CreateGlobalSourceRequest {
+  // Owning workspace resource.
+  Workspace workspace = 1;
+  // Canonical globally registered source name.
+  string name = 2;
+  // Visible configured non-secret variables.
+  repeated SourceVariable variables = 3;
+  // Source-owned secret values.
+  repeated SourceSecret secrets = 4;
+}
+
+// Returns the installed globally registered source.
+message CreateGlobalSourceResponse {
+  // The installed source resource.
+  Source source = 1;
+}
+
+// Installs one globally registered source spec with app-owned OAuth credential retrieval.
+message CreateGlobalSourceWithOAuthRequest {
+  // Owning workspace resource.
+  Workspace workspace = 1;
+  // Canonical globally registered source name.
+  string name = 2;
+  // Visible configured non-secret variables.
+  repeated SourceVariable variables = 3;
+  // Source-config secret bindings.
+  repeated SourceSecret secrets = 4;
+  // OAuth credential retrievals the app should run before validation and install.
+  repeated OAuthCredentialRetrieval oauth_credential_retrievals = 5;
+}
+
+// Streaming event emitted while installing a globally registered source with OAuth.
+message CreateGlobalSourceWithOAuthResponse {
+  // Installation progress or completion event.
+  oneof event {
+    // Global source installation completed.
+    Source source = 1;
+    // OAuth authorization URL is ready.
+    OAuthCredentialAuthorization oauth_authorization = 2;
+    // OAuth credential retrieval completed.
+    OAuthCredentialCompleted oauth_completed = 3;
+  }
+}
+
 // Imports one user-supplied source manifest into Coral ownership.
 message ImportSourceRequest {
   // Owning workspace resource.
@@ -471,6 +516,42 @@ message GetSourceInfoResponse {
   SourceInfo source_info = 1;
 }
 
+// Lists globally registered source specs.
+message ListSourceSpecsRequest {}
+
+// Returns globally registered source-spec summaries.
+message ListSourceSpecsResponse {
+  // Globally registered source specs.
+  repeated SourceInfo source_specs = 1;
+}
+
+// Registers one user-supplied source manifest in the global source-spec registry.
+message RegisterSourceSpecRequest {
+  // Raw source manifest YAML to validate and register.
+  string manifest_yaml = 1;
+}
+
+// Returns the registered source-spec metadata.
+message RegisterSourceSpecResponse {
+  // Registered source spec metadata.
+  SourceInfo source_spec = 1;
+}
+
+// Deletes one globally registered source spec.
+//
+// Installed global-origin sources are intentionally not removed; they become
+// orphaned until the spec is registered again or the source is removed.
+message DeleteSourceSpecRequest {
+  // Bare source-spec name to remove.
+  string name = 1;
+}
+
+// Returns the source-spec metadata that was removed.
+message DeleteSourceSpecResponse {
+  // Removed source spec metadata.
+  SourceInfo source_spec = 1;
+}
+
 // Deletes one registered source and its managed artifacts.
 message DeleteSourceRequest {
   // Owning workspace resource.
@@ -542,9 +623,20 @@ service SourceService {
   // Installs one bundled source with app-owned OAuth credential retrieval.
   rpc CreateBundledSourceWithOAuth(CreateBundledSourceWithOAuthRequest)
       returns (stream CreateBundledSourceWithOAuthResponse);
+  // Installs one globally registered source spec.
+  rpc CreateGlobalSource(CreateGlobalSourceRequest) returns (CreateGlobalSourceResponse);
+  // Installs one globally registered source spec with app-owned OAuth credential retrieval.
+  rpc CreateGlobalSourceWithOAuth(CreateGlobalSourceWithOAuthRequest)
+      returns (stream CreateGlobalSourceWithOAuthResponse);
   // Imports one user-provided source manifest, streaming credential retrieval
   // progress before the final source event when credentials are app-owned.
   rpc ImportSource(ImportSourceRequest) returns (stream ImportSourceResponse);
+  // Lists globally registered source specs.
+  rpc ListSourceSpecs(ListSourceSpecsRequest) returns (ListSourceSpecsResponse);
+  // Registers one source manifest in the global source-spec registry.
+  rpc RegisterSourceSpec(RegisterSourceSpecRequest) returns (RegisterSourceSpecResponse);
+  // Deletes one globally registered source spec.
+  rpc DeleteSourceSpec(DeleteSourceSpecRequest) returns (DeleteSourceSpecResponse);
   // Deletes a registered source.
   rpc DeleteSource(DeleteSourceRequest) returns (DeleteSourceResponse);
   // Validates that a registered source is queryable.

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -180,7 +180,6 @@ fn materialization_inputs_from_bindings(
     }
 }
 
-#[expect(dead_code, reason = "store methods are wired by the next stack branch")]
 impl SourceManager {
     pub(crate) fn new(
         config_store: ConfigStore,

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -284,7 +284,7 @@ impl SourceServiceApi for SourceService {
                 .list_source_specs()
                 .map_err(app_status)?
                 .into_iter()
-                .map(candidate_source_to_proto)
+                .map(source_spec_to_proto)
                 .collect();
             Ok(Response::new(ListSourceSpecsResponse { source_specs }))
         })
@@ -630,6 +630,20 @@ fn candidate_source_to_proto(source: CandidateSource) -> SourceInfo {
         installed: source.installed,
         origin: proto_source_origin(source.origin) as i32,
         credential_storage: proto_source_credential_storage(source.credential_storage) as i32,
+    }
+}
+
+fn source_spec_to_proto(source: CandidateSource) -> SourceSpecInfo {
+    SourceSpecInfo {
+        name: source.name.as_str().to_string(),
+        description: source.description,
+        version: source.version.unwrap_or_default(),
+        inputs: source
+            .inputs
+            .into_iter()
+            .map(candidate_source_input_to_proto)
+            .collect(),
+        origin: proto_source_origin(source.origin) as i32,
     }
 }
 

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -6,26 +6,24 @@ use std::task::{Context, Poll};
 
 use coral_api::v1::source_service_server::SourceService as SourceServiceApi;
 use coral_api::v1::{
-    CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
-    CreateBundledSourceWithOAuthResponse, CreateGlobalSourceRequest, CreateGlobalSourceResponse,
-    CreateGlobalSourceWithOAuthRequest, CreateGlobalSourceWithOAuthResponse, CredentialMetadata,
-    DeleteSourceRequest, DeleteSourceResponse, DeleteSourceSpecRequest, DeleteSourceSpecResponse,
-    DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest, GetSourceInfoResponse,
-    GetSourceRequest, GetSourceResponse, ImportSourceRequest, ImportSourceResponse,
-    ListSourceSpecsRequest, ListSourceSpecsResponse, ListSourcesRequest, ListSourcesResponse,
-    OAuthCredentialAuthorization, OAuthCredentialClient, OAuthCredentialClientId,
-    OAuthCredentialClientSecret, OAuthCredentialCompleted, OAuthCredentialEndpoints,
-    OAuthCredentialInput, OAuthCredentialMethod, OAuthCredentialRetrieval, OAuthCredentialScope,
-    OAuthCredentialScopes, OAuthDynamicClientRegistration, OauthCredentialClientSecretTransport,
-    OauthCredentialFlowType, OauthCredentialPkceMode, OauthCredentialRedirectUriPortMode,
-    OauthCredentialScopeDelimiter, OauthDynamicClientRegistrationAuthMethod,
-    RegisterSourceSpecRequest, RegisterSourceSpecResponse, Source, SourceConfigCredentialMethod,
-    SourceCredential, SourceCredentialMethod,
-    SourceCredentialStorage as ProtoSourceCredentialStorage, SourceInfo, SourceInputSpec,
-    SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceSecretInput, SourceVariable,
-    SourceVariableInput, ValidateSourceRequest, ValidateSourceResponse,
-    create_bundled_source_with_o_auth_response, create_global_source_with_o_auth_response,
-    import_source_response, source_credential_method::Method as ProtoCredentialMethod,
+    CreateSourceRequest, CreateSourceResponse, CreateSourceWithOAuthRequest,
+    CreateSourceWithOAuthResponse, CredentialMetadata, DeleteSourceRequest, DeleteSourceResponse,
+    DeleteSourceSpecRequest, DeleteSourceSpecResponse, DiscoverSourcesRequest,
+    DiscoverSourcesResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
+    GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListSourceSpecsRequest,
+    ListSourceSpecsResponse, ListSourcesRequest, ListSourcesResponse, OAuthCredentialAuthorization,
+    OAuthCredentialClient, OAuthCredentialClientId, OAuthCredentialClientSecret,
+    OAuthCredentialCompleted, OAuthCredentialEndpoints, OAuthCredentialInput,
+    OAuthCredentialMethod, OAuthCredentialRetrieval, OAuthCredentialScope, OAuthCredentialScopes,
+    OAuthDynamicClientRegistration, OauthCredentialClientSecretTransport, OauthCredentialFlowType,
+    OauthCredentialPkceMode, OauthCredentialRedirectUriPortMode, OauthCredentialScopeDelimiter,
+    OauthDynamicClientRegistrationAuthMethod, RegisterSourceSpecRequest,
+    RegisterSourceSpecResponse, Source, SourceConfigCredentialMethod, SourceCredential,
+    SourceCredentialMethod, SourceCredentialStorage as ProtoSourceCredentialStorage, SourceInfo,
+    SourceInputSpec, SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceSecretInput,
+    SourceSpecInfo, SourceVariable, SourceVariableInput, ValidateSourceRequest,
+    ValidateSourceResponse, create_source_with_o_auth_response, import_source_response,
+    source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_spec::{
@@ -74,8 +72,7 @@ impl SourceService {
 
 #[tonic::async_trait]
 impl SourceServiceApi for SourceService {
-    type CreateBundledSourceWithOAuthStream = CreateBundledSourceWithOAuthResponseStreamBox;
-    type CreateGlobalSourceWithOAuthStream = CreateGlobalSourceWithOAuthResponseStreamBox;
+    type CreateSourceWithOAuthStream = CreateSourceWithOAuthResponseStreamBox;
     type ImportSourceStream = ImportSourceResponseStreamBox;
 
     async fn discover_sources(
@@ -158,76 +155,10 @@ impl SourceServiceApi for SourceService {
         .await
     }
 
-    async fn create_bundled_source(
+    async fn create_source(
         &self,
-        request: Request<CreateBundledSourceRequest>,
-    ) -> Result<Response<CreateBundledSourceResponse>, Status> {
-        let span = grpc_span(&request);
-        let sources = self.sources.clone();
-        instrument_grpc(span, async move {
-            let request = request.into_inner();
-            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
-            let command = CreateSourceCommand {
-                name: bundled_name,
-                bindings: source_bindings_from_proto(request.variables, request.secrets),
-            };
-            let response_workspace_name = workspace_name.clone();
-            let installed = run_blocking_source_operation(move || {
-                sources.create_source(&workspace_name, &command)
-            })
-            .await?;
-            Ok(Response::new(CreateBundledSourceResponse {
-                source: Some(installed_source_to_proto(
-                    &response_workspace_name,
-                    installed,
-                )),
-            }))
-        })
-        .await
-    }
-
-    async fn create_bundled_source_with_o_auth(
-        &self,
-        request: Request<CreateBundledSourceWithOAuthRequest>,
-    ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
-        let span = grpc_span(&request);
-        let sources = self.sources.clone();
-        instrument_grpc(span.clone(), async move {
-            let request = request.into_inner();
-            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let response_workspace_name = workspace_name.clone();
-            let command = CreateSourceWithOAuthCommand {
-                name: SourceName::parse(&request.name).map_err(app_status)?,
-                bindings: source_bindings_from_proto(request.variables, request.secrets),
-                oauth_credential_retrievals: request
-                    .oauth_credential_retrievals
-                    .into_iter()
-                    .map(oauth_credential_retrieval_from_proto)
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(app_status)?,
-            };
-            let stream =
-                import_source_response_stream(response_workspace_name, move |event_sender| {
-                    instrument_grpc(span, async move {
-                        sources
-                            .create_source_with_oauth(&workspace_name, command, event_sender)
-                            .await
-                            .map_err(app_status)
-                    })
-                });
-            Ok(Response::new(Box::pin(stream.map(|response| {
-                response.map(create_bundled_source_with_o_auth_response_from_import_response)
-            }))
-                as Self::CreateBundledSourceWithOAuthStream))
-        })
-        .await
-    }
-
-    async fn create_global_source(
-        &self,
-        request: Request<CreateGlobalSourceRequest>,
-    ) -> Result<Response<CreateGlobalSourceResponse>, Status> {
+        request: Request<CreateSourceRequest>,
+    ) -> Result<Response<CreateSourceResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
@@ -243,7 +174,7 @@ impl SourceServiceApi for SourceService {
                 sources.create_source(&workspace_name, &command)
             })
             .await?;
-            Ok(Response::new(CreateGlobalSourceResponse {
+            Ok(Response::new(CreateSourceResponse {
                 source: Some(installed_source_to_proto(
                     &response_workspace_name,
                     installed,
@@ -253,10 +184,10 @@ impl SourceServiceApi for SourceService {
         .await
     }
 
-    async fn create_global_source_with_o_auth(
+    async fn create_source_with_o_auth(
         &self,
-        request: Request<CreateGlobalSourceWithOAuthRequest>,
-    ) -> Result<Response<Self::CreateGlobalSourceWithOAuthStream>, Status> {
+        request: Request<CreateSourceWithOAuthRequest>,
+    ) -> Result<Response<Self::CreateSourceWithOAuthStream>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span.clone(), async move {
@@ -283,9 +214,9 @@ impl SourceServiceApi for SourceService {
                     })
                 });
             Ok(Response::new(Box::pin(stream.map(|response| {
-                response.map(create_global_source_with_o_auth_response_from_import_response)
+                response.map(create_source_with_o_auth_response_from_import_response)
             }))
-                as Self::CreateGlobalSourceWithOAuthStream))
+                as Self::CreateSourceWithOAuthStream))
         })
         .await
     }
@@ -445,10 +376,8 @@ impl SourceServiceApi for SourceService {
     }
 }
 
-type CreateBundledSourceWithOAuthResponseStreamBox =
-    Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithOAuthResponse, Status>> + Send>>;
-type CreateGlobalSourceWithOAuthResponseStreamBox =
-    Pin<Box<dyn Stream<Item = Result<CreateGlobalSourceWithOAuthResponse, Status>> + Send>>;
+type CreateSourceWithOAuthResponseStreamBox =
+    Pin<Box<dyn Stream<Item = Result<CreateSourceWithOAuthResponse, Status>> + Send>>;
 type ImportSourceResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 type ImportSourceFuture = Pin<Box<dyn Future<Output = Result<InstalledSource, Status>> + Send>>;
@@ -629,38 +558,21 @@ fn import_source_event_to_proto(event: ImportSourceWithCredentialsEvent) -> Impo
     ImportSourceResponse { event: Some(event) }
 }
 
-fn create_bundled_source_with_o_auth_response_from_import_response(
+fn create_source_with_o_auth_response_from_import_response(
     response: ImportSourceResponse,
-) -> CreateBundledSourceWithOAuthResponse {
+) -> CreateSourceWithOAuthResponse {
     let event = response.event.map(|event| match event {
         import_source_response::Event::Source(source) => {
-            create_bundled_source_with_o_auth_response::Event::Source(source)
+            create_source_with_o_auth_response::Event::Source(source)
         }
         import_source_response::Event::OauthAuthorization(authorization) => {
-            create_bundled_source_with_o_auth_response::Event::OauthAuthorization(authorization)
+            create_source_with_o_auth_response::Event::OauthAuthorization(authorization)
         }
         import_source_response::Event::OauthCompleted(completed) => {
-            create_bundled_source_with_o_auth_response::Event::OauthCompleted(completed)
+            create_source_with_o_auth_response::Event::OauthCompleted(completed)
         }
     });
-    CreateBundledSourceWithOAuthResponse { event }
-}
-
-fn create_global_source_with_o_auth_response_from_import_response(
-    response: ImportSourceResponse,
-) -> CreateGlobalSourceWithOAuthResponse {
-    let event = response.event.map(|event| match event {
-        import_source_response::Event::Source(source) => {
-            create_global_source_with_o_auth_response::Event::Source(source)
-        }
-        import_source_response::Event::OauthAuthorization(authorization) => {
-            create_global_source_with_o_auth_response::Event::OauthAuthorization(authorization)
-        }
-        import_source_response::Event::OauthCompleted(completed) => {
-            create_global_source_with_o_auth_response::Event::OauthCompleted(completed)
-        }
-    });
-    CreateGlobalSourceWithOAuthResponse { event }
+    CreateSourceWithOAuthResponse { event }
 }
 
 fn installed_source_to_proto(workspace_name: &WorkspaceName, source: InstalledSource) -> Source {

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -7,22 +7,25 @@ use std::task::{Context, Poll};
 use coral_api::v1::source_service_server::SourceService as SourceServiceApi;
 use coral_api::v1::{
     CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
-    CreateBundledSourceWithOAuthResponse, CredentialMetadata, DeleteSourceRequest,
-    DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
-    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
-    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, OAuthCredentialAuthorization,
-    OAuthCredentialClient, OAuthCredentialClientId, OAuthCredentialClientSecret,
-    OAuthCredentialCompleted, OAuthCredentialEndpoints, OAuthCredentialInput,
-    OAuthCredentialMethod, OAuthCredentialRetrieval, OAuthCredentialScope, OAuthCredentialScopes,
-    OAuthDynamicClientRegistration, OauthCredentialClientSecretTransport, OauthCredentialFlowType,
-    OauthCredentialPkceMode, OauthCredentialRedirectUriPortMode, OauthCredentialScopeDelimiter,
-    OauthDynamicClientRegistrationAuthMethod, Source, SourceConfigCredentialMethod,
+    CreateBundledSourceWithOAuthResponse, CreateGlobalSourceRequest, CreateGlobalSourceResponse,
+    CreateGlobalSourceWithOAuthRequest, CreateGlobalSourceWithOAuthResponse, CredentialMetadata,
+    DeleteSourceRequest, DeleteSourceResponse, DeleteSourceSpecRequest, DeleteSourceSpecResponse,
+    DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest, GetSourceInfoResponse,
+    GetSourceRequest, GetSourceResponse, ImportSourceRequest, ImportSourceResponse,
+    ListSourceSpecsRequest, ListSourceSpecsResponse, ListSourcesRequest, ListSourcesResponse,
+    OAuthCredentialAuthorization, OAuthCredentialClient, OAuthCredentialClientId,
+    OAuthCredentialClientSecret, OAuthCredentialCompleted, OAuthCredentialEndpoints,
+    OAuthCredentialInput, OAuthCredentialMethod, OAuthCredentialRetrieval, OAuthCredentialScope,
+    OAuthCredentialScopes, OAuthDynamicClientRegistration, OauthCredentialClientSecretTransport,
+    OauthCredentialFlowType, OauthCredentialPkceMode, OauthCredentialRedirectUriPortMode,
+    OauthCredentialScopeDelimiter, OauthDynamicClientRegistrationAuthMethod,
+    RegisterSourceSpecRequest, RegisterSourceSpecResponse, Source, SourceConfigCredentialMethod,
     SourceCredential, SourceCredentialMethod,
     SourceCredentialStorage as ProtoSourceCredentialStorage, SourceInfo, SourceInputSpec,
     SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceSecretInput, SourceVariable,
     SourceVariableInput, ValidateSourceRequest, ValidateSourceResponse,
-    create_bundled_source_with_o_auth_response, import_source_response,
-    source_credential_method::Method as ProtoCredentialMethod,
+    create_bundled_source_with_o_auth_response, create_global_source_with_o_auth_response,
+    import_source_response, source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_spec::{
@@ -40,8 +43,8 @@ use crate::sources::SourceName;
 use crate::sources::manager::{
     CreateSourceCommand, CreateSourceWithOAuthCommand, ImportSourceCommand,
     ImportSourceEventSender, ImportSourceWithCredentialsCommand, ImportSourceWithCredentialsEvent,
-    PendingImportSourceWithCredentialsEvent, SourceBinding, SourceBindings, SourceManager,
-    SourceOAuthCredentialRetrieval,
+    PendingImportSourceWithCredentialsEvent, RegisterSourceSpecCommand, SourceBinding,
+    SourceBindings, SourceManager, SourceOAuthCredentialRetrieval,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::transport::{
@@ -72,6 +75,7 @@ impl SourceService {
 #[tonic::async_trait]
 impl SourceServiceApi for SourceService {
     type CreateBundledSourceWithOAuthStream = CreateBundledSourceWithOAuthResponseStreamBox;
+    type CreateGlobalSourceWithOAuthStream = CreateGlobalSourceWithOAuthResponseStreamBox;
     type ImportSourceStream = ImportSourceResponseStreamBox;
 
     async fn discover_sources(
@@ -220,6 +224,72 @@ impl SourceServiceApi for SourceService {
         .await
     }
 
+    async fn create_global_source(
+        &self,
+        request: Request<CreateGlobalSourceRequest>,
+    ) -> Result<Response<CreateGlobalSourceResponse>, Status> {
+        let span = grpc_span(&request);
+        let sources = self.sources.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let source_name = SourceName::parse(&request.name).map_err(app_status)?;
+            let command = CreateSourceCommand {
+                name: source_name,
+                bindings: source_bindings_from_proto(request.variables, request.secrets),
+            };
+            let response_workspace_name = workspace_name.clone();
+            let installed = run_blocking_source_operation(move || {
+                sources.create_source(&workspace_name, &command)
+            })
+            .await?;
+            Ok(Response::new(CreateGlobalSourceResponse {
+                source: Some(installed_source_to_proto(
+                    &response_workspace_name,
+                    installed,
+                )),
+            }))
+        })
+        .await
+    }
+
+    async fn create_global_source_with_o_auth(
+        &self,
+        request: Request<CreateGlobalSourceWithOAuthRequest>,
+    ) -> Result<Response<Self::CreateGlobalSourceWithOAuthStream>, Status> {
+        let span = grpc_span(&request);
+        let sources = self.sources.clone();
+        instrument_grpc(span.clone(), async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let response_workspace_name = workspace_name.clone();
+            let command = CreateSourceWithOAuthCommand {
+                name: SourceName::parse(&request.name).map_err(app_status)?,
+                bindings: source_bindings_from_proto(request.variables, request.secrets),
+                oauth_credential_retrievals: request
+                    .oauth_credential_retrievals
+                    .into_iter()
+                    .map(oauth_credential_retrieval_from_proto)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(app_status)?,
+            };
+            let stream =
+                import_source_response_stream(response_workspace_name, move |event_sender| {
+                    instrument_grpc(span, async move {
+                        sources
+                            .create_source_with_oauth(&workspace_name, command, event_sender)
+                            .await
+                            .map_err(app_status)
+                    })
+                });
+            Ok(Response::new(Box::pin(stream.map(|response| {
+                response.map(create_global_source_with_o_auth_response_from_import_response)
+            }))
+                as Self::CreateGlobalSourceWithOAuthStream))
+        })
+        .await
+    }
+
     async fn import_source(
         &self,
         request: Request<ImportSourceRequest>,
@@ -272,6 +342,64 @@ impl SourceServiceApi for SourceService {
         .await
     }
 
+    async fn list_source_specs(
+        &self,
+        request: Request<ListSourceSpecsRequest>,
+    ) -> Result<Response<ListSourceSpecsResponse>, Status> {
+        let span = grpc_span(&request);
+        let sources = self.sources.clone();
+        instrument_grpc(span, async move {
+            let source_specs = sources
+                .list_source_specs()
+                .map_err(app_status)?
+                .into_iter()
+                .map(candidate_source_to_proto)
+                .collect();
+            Ok(Response::new(ListSourceSpecsResponse { source_specs }))
+        })
+        .await
+    }
+
+    async fn register_source_spec(
+        &self,
+        request: Request<RegisterSourceSpecRequest>,
+    ) -> Result<Response<RegisterSourceSpecResponse>, Status> {
+        let span = grpc_span(&request);
+        let sources = self.sources.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let command = RegisterSourceSpecCommand {
+                manifest_yaml: request.manifest_yaml,
+            };
+            let source_spec =
+                run_blocking_source_operation(move || sources.register_source_spec(&command))
+                    .await?;
+            Ok(Response::new(RegisterSourceSpecResponse {
+                source_spec: Some(candidate_source_to_proto(source_spec)),
+            }))
+        })
+        .await
+    }
+
+    async fn delete_source_spec(
+        &self,
+        request: Request<DeleteSourceSpecRequest>,
+    ) -> Result<Response<DeleteSourceSpecResponse>, Status> {
+        let span = grpc_span(&request);
+        let sources = self.sources.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let source_name = SourceName::parse(&request.name).map_err(app_status)?;
+            let source_spec =
+                run_blocking_source_operation(move || sources.delete_source_spec(&source_name))
+                    .await?;
+            Ok(Response::new(DeleteSourceSpecResponse {
+                source_spec: Some(candidate_source_to_proto(source_spec)),
+            }))
+        })
+        .await
+    }
+
     async fn delete_source(
         &self,
         request: Request<DeleteSourceRequest>,
@@ -319,6 +447,8 @@ impl SourceServiceApi for SourceService {
 
 type CreateBundledSourceWithOAuthResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithOAuthResponse, Status>> + Send>>;
+type CreateGlobalSourceWithOAuthResponseStreamBox =
+    Pin<Box<dyn Stream<Item = Result<CreateGlobalSourceWithOAuthResponse, Status>> + Send>>;
 type ImportSourceResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 type ImportSourceFuture = Pin<Box<dyn Future<Output = Result<InstalledSource, Status>> + Send>>;
@@ -514,6 +644,23 @@ fn create_bundled_source_with_o_auth_response_from_import_response(
         }
     });
     CreateBundledSourceWithOAuthResponse { event }
+}
+
+fn create_global_source_with_o_auth_response_from_import_response(
+    response: ImportSourceResponse,
+) -> CreateGlobalSourceWithOAuthResponse {
+    let event = response.event.map(|event| match event {
+        import_source_response::Event::Source(source) => {
+            create_global_source_with_o_auth_response::Event::Source(source)
+        }
+        import_source_response::Event::OauthAuthorization(authorization) => {
+            create_global_source_with_o_auth_response::Event::OauthAuthorization(authorization)
+        }
+        import_source_response::Event::OauthCompleted(completed) => {
+            create_global_source_with_o_auth_response::Event::OauthCompleted(completed)
+        }
+    });
+    CreateGlobalSourceWithOAuthResponse { event }
 }
 
 fn installed_source_to_proto(workspace_name: &WorkspaceName, source: InstalledSource) -> Source {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use coral_api::v1::{
-    CreateGlobalSourceRequest, DeleteSourceSpecRequest, ExecuteSqlRequest, ImportSourceRequest,
+    CreateSourceRequest, DeleteSourceSpecRequest, ExecuteSqlRequest, ImportSourceRequest,
     ListCatalogRequest, ListSourceSpecsRequest, ListSourcesRequest, PaginationRequest,
     RegisterSourceSpecRequest, Source, SourceInfo, SourceSecret, SourceVariable, TableSummary,
     ValidateSourceRequest, ValidateSourceResponse, catalog_item, import_source_response,
@@ -137,9 +137,9 @@ impl GrpcHarness {
             .source_specs
     }
 
-    pub(crate) async fn create_global_source(&self, name: &str) -> Source {
+    pub(crate) async fn create_source(&self, name: &str) -> Source {
         self.source_client()
-            .create_global_source(Request::new(CreateGlobalSourceRequest {
+            .create_source(Request::new(CreateSourceRequest {
                 workspace: Some(default_workspace()),
                 name: name.to_string(),
                 variables: Vec::new(),

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -2,9 +2,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use coral_api::v1::{
-    ExecuteSqlRequest, ImportSourceRequest, ListCatalogRequest, ListSourcesRequest,
-    PaginationRequest, Source, SourceSecret, SourceVariable, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, catalog_item, import_source_response,
+    CreateGlobalSourceRequest, DeleteSourceSpecRequest, ExecuteSqlRequest, ImportSourceRequest,
+    ListCatalogRequest, ListSourceSpecsRequest, ListSourcesRequest, PaginationRequest,
+    RegisterSourceSpecRequest, Source, SourceInfo, SourceSecret, SourceVariable, TableSummary,
+    ValidateSourceRequest, ValidateSourceResponse, catalog_item, import_source_response,
 };
 use coral_client::{
     AppClient, CatalogClient, QueryClient, SourceClient, WorkspaceClient, batches_to_json_rows,
@@ -115,6 +116,52 @@ impl GrpcHarness {
                 _ => None,
             })
             .expect("import source response")
+    }
+
+    pub(crate) async fn register_source_spec(&self, manifest_yaml: String) -> SourceInfo {
+        self.source_client()
+            .register_source_spec(Request::new(RegisterSourceSpecRequest { manifest_yaml }))
+            .await
+            .expect("register source spec")
+            .into_inner()
+            .source_spec
+            .expect("register source spec response")
+    }
+
+    pub(crate) async fn list_source_specs(&self) -> Vec<SourceInfo> {
+        self.source_client()
+            .list_source_specs(Request::new(ListSourceSpecsRequest {}))
+            .await
+            .expect("list source specs")
+            .into_inner()
+            .source_specs
+    }
+
+    pub(crate) async fn create_global_source(&self, name: &str) -> Source {
+        self.source_client()
+            .create_global_source(Request::new(CreateGlobalSourceRequest {
+                workspace: Some(default_workspace()),
+                name: name.to_string(),
+                variables: Vec::new(),
+                secrets: Vec::new(),
+            }))
+            .await
+            .expect("create global source")
+            .into_inner()
+            .source
+            .expect("create global source response")
+    }
+
+    pub(crate) async fn delete_source_spec(&self, name: &str) -> SourceInfo {
+        self.source_client()
+            .delete_source_spec(Request::new(DeleteSourceSpecRequest {
+                name: name.to_string(),
+            }))
+            .await
+            .expect("delete source spec")
+            .into_inner()
+            .source_spec
+            .expect("delete source spec response")
     }
 
     pub(crate) async fn list_sources(&self) -> Vec<Source> {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -4,8 +4,9 @@ use std::path::{Path, PathBuf};
 use coral_api::v1::{
     CreateSourceRequest, DeleteSourceSpecRequest, ExecuteSqlRequest, ImportSourceRequest,
     ListCatalogRequest, ListSourceSpecsRequest, ListSourcesRequest, PaginationRequest,
-    RegisterSourceSpecRequest, Source, SourceInfo, SourceSecret, SourceVariable, TableSummary,
-    ValidateSourceRequest, ValidateSourceResponse, catalog_item, import_source_response,
+    RegisterSourceSpecRequest, Source, SourceInfo, SourceSecret, SourceSpecInfo, SourceVariable,
+    TableSummary, ValidateSourceRequest, ValidateSourceResponse, catalog_item,
+    import_source_response,
 };
 use coral_client::{
     AppClient, CatalogClient, QueryClient, SourceClient, WorkspaceClient, batches_to_json_rows,
@@ -128,7 +129,7 @@ impl GrpcHarness {
             .expect("register source spec response")
     }
 
-    pub(crate) async fn list_source_specs(&self) -> Vec<SourceInfo> {
+    pub(crate) async fn list_source_specs(&self) -> Vec<SourceSpecInfo> {
         self.source_client()
             .list_source_specs(Request::new(ListSourceSpecsRequest {}))
             .await

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -7,7 +7,7 @@
 use std::fs;
 
 use coral_api::v1::{
-    CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
+    CreateSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
     ExplainSqlRequest, GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest,
     ListCatalogRequest, OauthCredentialFlowType, OauthCredentialScopeDelimiter, PaginationRequest,
     QueryTestFailure, QueryTestSuccess, SourceCredentialStorage, SourceOrigin, SourceSecret,
@@ -101,7 +101,7 @@ async fn global_source_spec_registers_installs_and_orphans_on_delete() {
     );
     assert!(harness.list_sources().await.is_empty());
 
-    let created = harness.create_global_source("local_messages").await;
+    let created = harness.create_source("local_messages").await;
 
     assert_eq!(created.name, "local_messages");
     assert_eq!(created.version, "0.1.0");
@@ -844,7 +844,7 @@ async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() 
 
     harness
         .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+        .create_source(Request::new(CreateSourceRequest {
             workspace: Some(default_workspace()),
             name: "github".to_string(),
             variables: vec![SourceVariable {
@@ -1030,12 +1030,12 @@ async fn get_source_info_uses_effective_installed_imported_manifest() {
 }
 
 #[tokio::test]
-async fn create_bundled_source_registers_tables() {
+async fn create_source_registers_tables() {
     let harness = GrpcHarness::new().await;
 
     harness
         .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+        .create_source(Request::new(CreateSourceRequest {
             workspace: Some(default_workspace()),
             name: "github".to_string(),
             variables: vec![SourceVariable {
@@ -1058,12 +1058,12 @@ async fn create_bundled_source_registers_tables() {
 }
 
 #[tokio::test]
-async fn create_bundled_source_missing_required_secret_returns_invalid_argument() {
+async fn create_source_missing_required_secret_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
 
     let error = harness
         .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+        .create_source(Request::new(CreateSourceRequest {
             workspace: Some(default_workspace()),
             name: "sentry".to_string(),
             variables: vec![SourceVariable {
@@ -1083,12 +1083,12 @@ async fn create_bundled_source_missing_required_secret_returns_invalid_argument(
 }
 
 #[tokio::test]
-async fn create_bundled_source_missing_required_variable_returns_invalid_argument() {
+async fn create_source_missing_required_variable_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
 
     let error = harness
         .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+        .create_source(Request::new(CreateSourceRequest {
             workspace: Some(default_workspace()),
             name: "sentry".to_string(),
             variables: Vec::new(),
@@ -1108,12 +1108,12 @@ async fn create_bundled_source_missing_required_variable_returns_invalid_argumen
 }
 
 #[tokio::test]
-async fn create_bundled_source_unknown_input_returns_invalid_argument() {
+async fn create_source_unknown_input_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
 
     let error = harness
         .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+        .create_source(Request::new(CreateSourceRequest {
             workspace: Some(default_workspace()),
             name: "sentry".to_string(),
             variables: vec![
@@ -1138,12 +1138,12 @@ async fn create_bundled_source_unknown_input_returns_invalid_argument() {
 }
 
 #[tokio::test]
-async fn create_bundled_source_repeated_secret_returns_invalid_argument() {
+async fn create_source_repeated_secret_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
 
     let error = harness
         .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+        .create_source(Request::new(CreateSourceRequest {
             workspace: Some(default_workspace()),
             name: "sentry".to_string(),
             variables: vec![SourceVariable {
@@ -1172,12 +1172,12 @@ async fn create_bundled_source_repeated_secret_returns_invalid_argument() {
 }
 
 #[tokio::test]
-async fn create_bundled_source_does_not_persist_manifest_to_config_dir() {
+async fn create_source_does_not_persist_manifest_to_config_dir() {
     let harness = GrpcHarness::new().await;
 
     let created = harness
         .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+        .create_source(Request::new(CreateSourceRequest {
             workspace: Some(default_workspace()),
             name: "github".to_string(),
             variables: vec![SourceVariable {

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -72,6 +72,71 @@ async fn import_source_persists_and_lists() {
 }
 
 #[tokio::test]
+async fn global_source_spec_registers_installs_and_orphans_on_delete() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
+
+    let registered = harness.register_source_spec(manifest_yaml.clone()).await;
+
+    assert_eq!(registered.name, "local_messages");
+    assert_eq!(registered.version, "0.1.0");
+    assert!(!registered.installed);
+    assert_eq!(registered.origin, SourceOrigin::GlobalSpec as i32);
+    let source_specs = harness.list_source_specs().await;
+    assert_eq!(source_specs.len(), 1);
+    assert_eq!(source_specs[0].name, "local_messages");
+    let config_raw =
+        fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    assert!(config_raw.contains("[source_specs.local_messages]"));
+    assert_eq!(
+        fs::read_to_string(
+            harness
+                .config_dir()
+                .join("source_specs")
+                .join("local_messages")
+                .join("manifest.yaml")
+        )
+        .expect("read global source spec manifest"),
+        manifest_yaml
+    );
+    assert!(harness.list_sources().await.is_empty());
+
+    let created = harness.create_global_source("local_messages").await;
+
+    assert_eq!(created.name, "local_messages");
+    assert_eq!(created.version, "0.1.0");
+    assert_eq!(created.origin, SourceOrigin::GlobalSpec as i32);
+    assert!(
+        !source_dir(harness.config_dir(), "local_messages")
+            .join("manifest.yaml")
+            .exists()
+    );
+    let listed = harness.list_sources().await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].origin, SourceOrigin::GlobalSpec as i32);
+    harness.validate_source("local_messages").await;
+
+    let removed = harness.delete_source_spec("local_messages").await;
+
+    assert_eq!(removed.name, "local_messages");
+    assert!(harness.list_source_specs().await.is_empty());
+    let listed = harness.list_sources().await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "local_messages");
+    assert_eq!(listed[0].origin, SourceOrigin::GlobalSpec as i32);
+    let error = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "local_messages".to_string(),
+        }))
+        .await
+        .expect_err("orphaned global source should fail validation");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(error.message().contains("global source spec"));
+}
+
+#[tokio::test]
 async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     let harness = GrpcHarness::new().await;
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -964,7 +964,7 @@ async fn run_source_add(
                 .map_err(anyhow::Error::from)?;
             if interactive {
                 let inputs = source_ops::prompt_for_inputs_with_credential_methods(&inputs)?;
-                source_ops::add_bundled_source_with_credentials(
+                source_ops::add_named_source_with_credentials(
                     app,
                     workspace,
                     &available.name,
@@ -976,7 +976,7 @@ async fn run_source_add(
                     &inputs,
                     format!("coral source add --interactive {}", available.name),
                 )?;
-                source_ops::add_bundled_source(app, workspace, &available.name, variables, secrets)
+                source_ops::add_named_source(app, workspace, &available.name, variables, secrets)
                     .await?
             }
         }

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -66,7 +66,7 @@ pub(crate) async fn run(app: &AppClient, workspace: &Workspace) -> Result<(), an
                 if source.installed {
                     run_installed_source_menu(app, workspace, &theme, source).await?;
                 } else {
-                    run_add_bundled_source(app, workspace, source).await?;
+                    run_add_named_source(app, workspace, source).await?;
                     match run_next_steps(app, workspace, &theme).await? {
                         NextStepChoice::AddMoreSources => {}
                         NextStepChoice::Exit => return Ok(()),
@@ -179,13 +179,9 @@ async fn run_installed_source_menu(
                 &inputs,
                 source_ops::CredentialPromptMode::CredentialMethodFirst,
             )?;
-            let result = source_ops::add_bundled_source_with_credentials(
-                app,
-                workspace,
-                &source.name,
-                inputs,
-            )
-            .await?;
+            let result =
+                source_ops::add_named_source_with_credentials(app, workspace, &source.name, inputs)
+                    .await?;
             println!("Reconfigured source {}", result.name);
             source_ops::validate_and_warn(
                 app,
@@ -201,7 +197,7 @@ async fn run_installed_source_menu(
     Ok(())
 }
 
-async fn run_add_bundled_source(
+async fn run_add_named_source(
     app: &AppClient,
     workspace: &Workspace,
     source: &SourceInfo,
@@ -216,8 +212,7 @@ async fn run_add_bundled_source(
         source_ops::CredentialPromptMode::CredentialMethodFirst,
     )?;
     let result =
-        source_ops::add_bundled_source_with_credentials(app, workspace, &source.name, inputs)
-            .await?;
+        source_ops::add_named_source_with_credentials(app, workspace, &source.name, inputs).await?;
     println!("Added source {}", result.name);
     source_ops::validate_and_warn(
         app,

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -11,13 +11,12 @@ use std::time::Duration;
 use anyhow::{Context as _, bail};
 use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
-    CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
-    CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DiscoverSourcesRequest,
-    GetSourceInfoRequest, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
-    OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source,
-    SourceCredentialStorage, SourceInfo, SourceOrigin, SourceSecret, SourceVariable,
-    ValidateSourceRequest, ValidateSourceResponse, Workspace,
-    create_bundled_source_with_o_auth_response, import_source_response, query_test_result,
+    CreateSourceRequest, CreateSourceWithOAuthRequest, CreateSourceWithOAuthResponse,
+    DeleteSourceRequest, DiscoverSourcesRequest, GetSourceInfoRequest, ImportSourceRequest,
+    ImportSourceResponse, ListSourcesRequest, OAuthCredentialInput, OAuthCredentialRetrieval,
+    QueryTestFailure, QueryTestSuccess, Source, SourceCredentialStorage, SourceInfo, SourceOrigin,
+    SourceSecret, SourceVariable, ValidateSourceRequest, ValidateSourceResponse, Workspace,
+    create_source_with_o_auth_response, import_source_response, query_test_result,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::{AppClient, DecodedStatusError, decode_status_error};
@@ -99,7 +98,7 @@ pub(crate) async fn list_sources(
         .sources)
 }
 
-pub(crate) async fn add_bundled_source(
+pub(crate) async fn add_named_source(
     app: &AppClient,
     workspace: &Workspace,
     name: &str,
@@ -108,7 +107,7 @@ pub(crate) async fn add_bundled_source(
 ) -> Result<Source, anyhow::Error> {
     let response = app
         .source_client()
-        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+        .create_source(Request::new(CreateSourceRequest {
             workspace: Some(workspace.clone()),
             name: name.to_string(),
             variables,
@@ -118,7 +117,7 @@ pub(crate) async fn add_bundled_source(
         .into_inner();
     response
         .source
-        .ok_or_else(|| anyhow::anyhow!("create bundled source response missing source"))
+        .ok_or_else(|| anyhow::anyhow!("create source response missing source"))
 }
 
 pub(crate) async fn import_source(
@@ -182,18 +181,18 @@ impl CredentialPromptMode {
     }
 }
 
-pub(crate) async fn add_bundled_source_with_credentials(
+pub(crate) async fn add_named_source_with_credentials(
     app: &AppClient,
     workspace: &Workspace,
     name: &str,
     inputs: CollectedSourceInputs,
 ) -> Result<Source, anyhow::Error> {
     if inputs.oauth_credential_retrievals.is_empty() {
-        return add_bundled_source(app, workspace, name, inputs.variables, inputs.secrets).await;
+        return add_named_source(app, workspace, name, inputs.variables, inputs.secrets).await;
     }
     let response = app
         .source_client()
-        .create_bundled_source_with_o_auth(Request::new(CreateBundledSourceWithOAuthRequest {
+        .create_source_with_o_auth(Request::new(CreateSourceWithOAuthRequest {
             workspace: Some(workspace.clone()),
             name: name.to_string(),
             variables: inputs.variables,
@@ -201,7 +200,7 @@ pub(crate) async fn add_bundled_source_with_credentials(
             oauth_credential_retrievals: inputs.oauth_credential_retrievals,
         }))
         .await?;
-    source_from_bundled_credential_stream(response.into_inner(), &inputs.oauth_labels).await
+    source_from_create_credential_stream(response.into_inner(), &inputs.oauth_labels).await
 }
 
 pub(crate) async fn import_source_with_credentials(
@@ -233,8 +232,8 @@ pub(crate) async fn import_source_with_credentials(
     source_from_import_credential_stream(response.into_inner(), &inputs.oauth_labels).await
 }
 
-async fn source_from_bundled_credential_stream(
-    mut stream: tonic::Streaming<CreateBundledSourceWithOAuthResponse>,
+async fn source_from_create_credential_stream(
+    mut stream: tonic::Streaming<CreateSourceWithOAuthResponse>,
     oauth_labels: &BTreeMap<String, String>,
 ) -> Result<Source, anyhow::Error> {
     let mut redirect_prompt = OAuthRedirectPastePrompt::default();
@@ -301,22 +300,18 @@ enum CredentialStreamEvent {
     OAuthCompleted,
 }
 
-impl From<create_bundled_source_with_o_auth_response::Event> for CredentialStreamEvent {
-    fn from(event: create_bundled_source_with_o_auth_response::Event) -> Self {
+impl From<create_source_with_o_auth_response::Event> for CredentialStreamEvent {
+    fn from(event: create_source_with_o_auth_response::Event) -> Self {
         match event {
-            create_bundled_source_with_o_auth_response::Event::Source(source) => {
-                Self::Source(source)
+            create_source_with_o_auth_response::Event::Source(source) => Self::Source(source),
+            create_source_with_o_auth_response::Event::OauthAuthorization(authorization) => {
+                Self::OAuthAuthorization {
+                    input_key: authorization.input_key,
+                    authorization_url: authorization.authorization_url,
+                    user_code: authorization.user_code,
+                }
             }
-            create_bundled_source_with_o_auth_response::Event::OauthAuthorization(
-                authorization,
-            ) => Self::OAuthAuthorization {
-                input_key: authorization.input_key,
-                authorization_url: authorization.authorization_url,
-                user_code: authorization.user_code,
-            },
-            create_bundled_source_with_o_auth_response::Event::OauthCompleted(_) => {
-                Self::OAuthCompleted
-            }
+            create_source_with_o_auth_response::Event::OauthCompleted(_) => Self::OAuthCompleted,
         }
     }
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -20,18 +20,22 @@ use coral_api::v1::workspace_service_server::{WorkspaceService, WorkspaceService
 use coral_api::v1::{
     CatalogCounts, CatalogItem, CatalogSearchResult, Column, ColumnSearchResult,
     CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
-    CreateBundledSourceWithOAuthResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
-    DeleteSourceRequest, DeleteSourceResponse, DeleteWorkspaceRequest, DeleteWorkspaceResponse,
-    DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
-    ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
-    GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest, GetSourceResponse,
-    ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
-    ListColumnsRequest, ListColumnsResponse, ListSourcesRequest, ListSourcesResponse,
-    ListWorkspacesRequest, ListWorkspacesResponse, PaginationRequest, PaginationResponse,
-    QueryPlan, SearchCatalogRequest, SearchCatalogResponse, Source, SourceCredentialStorage,
-    SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableSummary,
-    ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
-    create_bundled_source_with_o_auth_response, import_source_response,
+    CreateBundledSourceWithOAuthResponse, CreateGlobalSourceRequest, CreateGlobalSourceResponse,
+    CreateGlobalSourceWithOAuthRequest, CreateGlobalSourceWithOAuthResponse,
+    CreateWorkspaceRequest, CreateWorkspaceResponse, DeleteSourceRequest, DeleteSourceResponse,
+    DeleteSourceSpecRequest, DeleteSourceSpecResponse, DeleteWorkspaceRequest,
+    DeleteWorkspaceResponse, DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest,
+    DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest,
+    ExplainSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
+    GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListCatalogRequest,
+    ListCatalogResponse, ListColumnsRequest, ListColumnsResponse, ListSourceSpecsRequest,
+    ListSourceSpecsResponse, ListSourcesRequest, ListSourcesResponse, ListWorkspacesRequest,
+    ListWorkspacesResponse, PaginationRequest, PaginationResponse, QueryPlan,
+    RegisterSourceSpecRequest, RegisterSourceSpecResponse, SearchCatalogRequest,
+    SearchCatalogResponse, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec,
+    SourceOrigin, SourceSecretInput, Table, TableSummary, ValidateSourceRequest,
+    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
+    create_global_source_with_o_auth_response, import_source_response,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
@@ -62,6 +66,18 @@ fn mock_source() -> Source {
         variables: Vec::new(),
         origin: SourceOrigin::Bundled as i32,
         credential_storage: SourceCredentialStorage::File as i32,
+    }
+}
+
+fn mock_global_source() -> Source {
+    Source {
+        workspace: Some(workspace()),
+        name: "linear".to_string(),
+        version: "3.0.0".to_string(),
+        secrets: Vec::new(),
+        variables: Vec::new(),
+        origin: SourceOrigin::GlobalSpec as i32,
+        credential_storage: SourceCredentialStorage::Unspecified as i32,
     }
 }
 
@@ -326,6 +342,24 @@ fn mock_discover_response() -> DiscoverSourcesResponse {
     }
 }
 
+fn mock_source_spec() -> SourceInfo {
+    SourceInfo {
+        name: "linear".to_string(),
+        description: "Linear data".to_string(),
+        version: "3.0.0".to_string(),
+        inputs: Vec::new(),
+        installed: false,
+        origin: SourceOrigin::GlobalSpec as i32,
+        credential_storage: SourceCredentialStorage::Unspecified as i32,
+    }
+}
+
+fn mock_list_source_specs_response() -> ListSourceSpecsResponse {
+    ListSourceSpecsResponse {
+        source_specs: vec![mock_source_spec()],
+    }
+}
+
 fn mock_validate_response() -> ValidateSourceResponse {
     ValidateSourceResponse {
         source: Some(mock_source()),
@@ -365,6 +399,7 @@ fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
             origin: SourceOrigin::Bundled as i32,
             credential_storage: SourceCredentialStorage::Unspecified as i32,
         }),
+        "linear" => Ok(mock_source_spec()),
         "jira" => Ok(SourceInfo {
             name: "jira".to_string(),
             description: "Jira data".to_string(),
@@ -463,6 +498,7 @@ impl<T> MockResult<T> {
 pub(crate) struct MockServerConfig {
     execute_sql_override: Option<MockResult<ExecuteSqlResponse>>,
     discover_sources: MockResult<DiscoverSourcesResponse>,
+    list_source_specs: MockResult<ListSourceSpecsResponse>,
     list_sources: MockResult<ListSourcesResponse>,
     list_workspaces: MockResult<ListWorkspacesResponse>,
     validate_source: MockResult<ValidateSourceResponse>,
@@ -474,6 +510,7 @@ impl Default for MockServerConfig {
         Self {
             execute_sql_override: None,
             discover_sources: MockResult::ok(mock_discover_response()),
+            list_source_specs: MockResult::ok(mock_list_source_specs_response()),
             list_sources: MockResult::ok(ListSourcesResponse {
                 sources: vec![
                     Source {
@@ -513,6 +550,11 @@ impl MockServerConfig {
 
     pub(crate) fn with_list_sources(mut self, response: ListSourcesResponse) -> Self {
         self.list_sources = MockResult::ok(response);
+        self
+    }
+
+    pub(crate) fn with_list_source_specs(mut self, response: ListSourceSpecsResponse) -> Self {
+        self.list_source_specs = MockResult::ok(response);
         self
     }
 
@@ -618,7 +660,12 @@ struct Captured {
     get_source_info: Mutex<Vec<GetSourceInfoRequest>>,
     create_bundled_source: Mutex<Vec<CreateBundledSourceRequest>>,
     create_bundled_source_with_oauth: Mutex<Vec<CreateBundledSourceWithOAuthRequest>>,
+    create_global_source: Mutex<Vec<CreateGlobalSourceRequest>>,
+    create_global_source_with_oauth: Mutex<Vec<CreateGlobalSourceWithOAuthRequest>>,
     import_source: Mutex<Vec<ImportSourceRequest>>,
+    list_source_specs: Mutex<Vec<ListSourceSpecsRequest>>,
+    register_source_spec: Mutex<Vec<RegisterSourceSpecRequest>>,
+    delete_source_spec: Mutex<Vec<DeleteSourceSpecRequest>>,
     delete_source: Mutex<Vec<DeleteSourceRequest>>,
     validate_source: Mutex<Vec<ValidateSourceRequest>>,
     list_workspaces: Mutex<Vec<ListWorkspacesRequest>>,
@@ -864,6 +911,8 @@ struct MockSourceService {
 
 type MockBundledSourceStream =
     Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithOAuthResponse, Status>> + Send>>;
+type MockGlobalSourceStream =
+    Pin<Box<dyn Stream<Item = Result<CreateGlobalSourceWithOAuthResponse, Status>> + Send>>;
 type MockImportSourceStream =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 
@@ -879,6 +928,18 @@ fn mock_bundled_source_stream() -> MockBundledSourceStream {
     Box::pin(ReceiverStream::new(rx))
 }
 
+fn mock_global_source_stream() -> MockGlobalSourceStream {
+    let (tx, rx) =
+        tokio::sync::mpsc::channel::<Result<CreateGlobalSourceWithOAuthResponse, Status>>(1);
+    tx.try_send(Ok(CreateGlobalSourceWithOAuthResponse {
+        event: Some(create_global_source_with_o_auth_response::Event::Source(
+            mock_global_source(),
+        )),
+    }))
+    .expect("send mock global source credential event");
+    Box::pin(ReceiverStream::new(rx))
+}
+
 fn mock_import_source_stream() -> MockImportSourceStream {
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<ImportSourceResponse, Status>>(1);
     tx.try_send(Ok(ImportSourceResponse {
@@ -891,6 +952,7 @@ fn mock_import_source_stream() -> MockImportSourceStream {
 #[tonic::async_trait]
 impl SourceService for MockSourceService {
     type CreateBundledSourceWithOAuthStream = MockBundledSourceStream;
+    type CreateGlobalSourceWithOAuthStream = MockGlobalSourceStream;
     type ImportSourceStream = MockImportSourceStream;
 
     async fn discover_sources(
@@ -976,6 +1038,32 @@ impl SourceService for MockSourceService {
         Ok(Response::new(mock_bundled_source_stream()))
     }
 
+    async fn create_global_source(
+        &self,
+        request: Request<CreateGlobalSourceRequest>,
+    ) -> Result<Response<CreateGlobalSourceResponse>, Status> {
+        self.captured
+            .create_global_source
+            .lock()
+            .expect("create_global_source capture")
+            .push(request.into_inner());
+        Ok(Response::new(CreateGlobalSourceResponse {
+            source: Some(mock_global_source()),
+        }))
+    }
+
+    async fn create_global_source_with_o_auth(
+        &self,
+        request: Request<CreateGlobalSourceWithOAuthRequest>,
+    ) -> Result<Response<Self::CreateGlobalSourceWithOAuthStream>, Status> {
+        self.captured
+            .create_global_source_with_oauth
+            .lock()
+            .expect("create_global_source_with_oauth capture")
+            .push(request.into_inner());
+        Ok(Response::new(mock_global_source_stream()))
+    }
+
     async fn import_source(
         &self,
         request: Request<ImportSourceRequest>,
@@ -986,6 +1074,48 @@ impl SourceService for MockSourceService {
             .expect("import_source capture")
             .push(request.into_inner());
         Ok(Response::new(mock_import_source_stream()))
+    }
+
+    async fn list_source_specs(
+        &self,
+        request: Request<ListSourceSpecsRequest>,
+    ) -> Result<Response<ListSourceSpecsResponse>, Status> {
+        self.captured
+            .list_source_specs
+            .lock()
+            .expect("list_source_specs capture")
+            .push(request.into_inner());
+        Ok(Response::new(
+            self.config.list_source_specs.clone().into_tonic_result()?,
+        ))
+    }
+
+    async fn register_source_spec(
+        &self,
+        request: Request<RegisterSourceSpecRequest>,
+    ) -> Result<Response<RegisterSourceSpecResponse>, Status> {
+        self.captured
+            .register_source_spec
+            .lock()
+            .expect("register_source_spec capture")
+            .push(request.into_inner());
+        Ok(Response::new(RegisterSourceSpecResponse {
+            source_spec: Some(mock_source_spec()),
+        }))
+    }
+
+    async fn delete_source_spec(
+        &self,
+        request: Request<DeleteSourceSpecRequest>,
+    ) -> Result<Response<DeleteSourceSpecResponse>, Status> {
+        self.captured
+            .delete_source_spec
+            .lock()
+            .expect("delete_source_spec capture")
+            .push(request.into_inner());
+        Ok(Response::new(DeleteSourceSpecResponse {
+            source_spec: Some(mock_source_spec()),
+        }))
     }
 
     async fn delete_source(
@@ -1217,6 +1347,38 @@ impl MockServer {
             .get_source_info
             .lock()
             .expect("get_source_info capture")
+            .clone()
+    }
+
+    pub(crate) fn create_global_source_requests(&self) -> Vec<CreateGlobalSourceRequest> {
+        self.captured
+            .create_global_source
+            .lock()
+            .expect("create_global_source capture")
+            .clone()
+    }
+
+    pub(crate) fn list_source_specs_requests(&self) -> Vec<ListSourceSpecsRequest> {
+        self.captured
+            .list_source_specs
+            .lock()
+            .expect("list_source_specs capture")
+            .clone()
+    }
+
+    pub(crate) fn register_source_spec_requests(&self) -> Vec<RegisterSourceSpecRequest> {
+        self.captured
+            .register_source_spec
+            .lock()
+            .expect("register_source_spec capture")
+            .clone()
+    }
+
+    pub(crate) fn delete_source_spec_requests(&self) -> Vec<DeleteSourceSpecRequest> {
+        self.captured
+            .delete_source_spec
+            .lock()
+            .expect("delete_source_spec capture")
             .clone()
     }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -31,7 +31,7 @@ use coral_api::v1::{
     ListWorkspacesRequest, ListWorkspacesResponse, PaginationRequest, PaginationResponse,
     QueryPlan, RegisterSourceSpecRequest, RegisterSourceSpecResponse, SearchCatalogRequest,
     SearchCatalogResponse, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec,
-    SourceOrigin, SourceSecretInput, Table, TableSummary, ValidateSourceRequest,
+    SourceOrigin, SourceSecretInput, SourceSpecInfo, Table, TableSummary, ValidateSourceRequest,
     ValidateSourceResponse, Workspace, catalog_item, create_source_with_o_auth_response,
     import_source_response, source_input_spec::Input as ProtoSourceInput,
 };
@@ -351,9 +351,19 @@ fn mock_source_spec() -> SourceInfo {
     }
 }
 
+fn mock_listed_source_spec() -> SourceSpecInfo {
+    SourceSpecInfo {
+        name: "linear".to_string(),
+        description: "Linear data".to_string(),
+        version: "3.0.0".to_string(),
+        inputs: Vec::new(),
+        origin: SourceOrigin::GlobalSpec as i32,
+    }
+}
+
 fn mock_list_source_specs_response() -> ListSourceSpecsResponse {
     ListSourceSpecsResponse {
-        source_specs: vec![mock_source_spec()],
+        source_specs: vec![mock_listed_source_spec()],
     }
 }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -19,24 +19,21 @@ use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::workspace_service_server::{WorkspaceService, WorkspaceServiceServer};
 use coral_api::v1::{
     CatalogCounts, CatalogItem, CatalogSearchResult, Column, ColumnSearchResult,
-    CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
-    CreateBundledSourceWithOAuthResponse, CreateGlobalSourceRequest, CreateGlobalSourceResponse,
-    CreateGlobalSourceWithOAuthRequest, CreateGlobalSourceWithOAuthResponse,
-    CreateWorkspaceRequest, CreateWorkspaceResponse, DeleteSourceRequest, DeleteSourceResponse,
-    DeleteSourceSpecRequest, DeleteSourceSpecResponse, DeleteWorkspaceRequest,
-    DeleteWorkspaceResponse, DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest,
-    DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest,
-    ExplainSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
-    GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListCatalogRequest,
-    ListCatalogResponse, ListColumnsRequest, ListColumnsResponse, ListSourceSpecsRequest,
-    ListSourceSpecsResponse, ListSourcesRequest, ListSourcesResponse, ListWorkspacesRequest,
-    ListWorkspacesResponse, PaginationRequest, PaginationResponse, QueryPlan,
-    RegisterSourceSpecRequest, RegisterSourceSpecResponse, SearchCatalogRequest,
+    CreateSourceRequest, CreateSourceResponse, CreateSourceWithOAuthRequest,
+    CreateSourceWithOAuthResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
+    DeleteSourceRequest, DeleteSourceResponse, DeleteSourceSpecRequest, DeleteSourceSpecResponse,
+    DeleteWorkspaceRequest, DeleteWorkspaceResponse, DescribeTableRequest, DescribeTableResponse,
+    DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse,
+    ExplainSqlRequest, ExplainSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse,
+    GetSourceRequest, GetSourceResponse, ImportSourceRequest, ImportSourceResponse,
+    ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListColumnsResponse,
+    ListSourceSpecsRequest, ListSourceSpecsResponse, ListSourcesRequest, ListSourcesResponse,
+    ListWorkspacesRequest, ListWorkspacesResponse, PaginationRequest, PaginationResponse,
+    QueryPlan, RegisterSourceSpecRequest, RegisterSourceSpecResponse, SearchCatalogRequest,
     SearchCatalogResponse, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec,
     SourceOrigin, SourceSecretInput, Table, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
-    create_global_source_with_o_auth_response, import_source_response,
-    source_input_spec::Input as ProtoSourceInput,
+    ValidateSourceResponse, Workspace, catalog_item, create_source_with_o_auth_response,
+    import_source_response, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
     CORAL_EPISODE_ID_METADATA_KEY, CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
@@ -658,10 +655,8 @@ struct Captured {
     list_sources: Mutex<Vec<ListSourcesRequest>>,
     get_source: Mutex<Vec<GetSourceRequest>>,
     get_source_info: Mutex<Vec<GetSourceInfoRequest>>,
-    create_bundled_source: Mutex<Vec<CreateBundledSourceRequest>>,
-    create_bundled_source_with_oauth: Mutex<Vec<CreateBundledSourceWithOAuthRequest>>,
-    create_global_source: Mutex<Vec<CreateGlobalSourceRequest>>,
-    create_global_source_with_oauth: Mutex<Vec<CreateGlobalSourceWithOAuthRequest>>,
+    create_source: Mutex<Vec<CreateSourceRequest>>,
+    create_source_with_oauth: Mutex<Vec<CreateSourceWithOAuthRequest>>,
     import_source: Mutex<Vec<ImportSourceRequest>>,
     list_source_specs: Mutex<Vec<ListSourceSpecsRequest>>,
     register_source_spec: Mutex<Vec<RegisterSourceSpecRequest>>,
@@ -909,34 +904,17 @@ struct MockSourceService {
     captured: Arc<Captured>,
 }
 
-type MockBundledSourceStream =
-    Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithOAuthResponse, Status>> + Send>>;
-type MockGlobalSourceStream =
-    Pin<Box<dyn Stream<Item = Result<CreateGlobalSourceWithOAuthResponse, Status>> + Send>>;
+type MockSourceStream =
+    Pin<Box<dyn Stream<Item = Result<CreateSourceWithOAuthResponse, Status>> + Send>>;
 type MockImportSourceStream =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 
-fn mock_bundled_source_stream() -> MockBundledSourceStream {
-    let (tx, rx) =
-        tokio::sync::mpsc::channel::<Result<CreateBundledSourceWithOAuthResponse, Status>>(1);
-    tx.try_send(Ok(CreateBundledSourceWithOAuthResponse {
-        event: Some(create_bundled_source_with_o_auth_response::Event::Source(
-            mock_source(),
-        )),
+fn mock_source_stream(source: Source) -> MockSourceStream {
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<CreateSourceWithOAuthResponse, Status>>(1);
+    tx.try_send(Ok(CreateSourceWithOAuthResponse {
+        event: Some(create_source_with_o_auth_response::Event::Source(source)),
     }))
-    .expect("send mock bundled source credential event");
-    Box::pin(ReceiverStream::new(rx))
-}
-
-fn mock_global_source_stream() -> MockGlobalSourceStream {
-    let (tx, rx) =
-        tokio::sync::mpsc::channel::<Result<CreateGlobalSourceWithOAuthResponse, Status>>(1);
-    tx.try_send(Ok(CreateGlobalSourceWithOAuthResponse {
-        event: Some(create_global_source_with_o_auth_response::Event::Source(
-            mock_global_source(),
-        )),
-    }))
-    .expect("send mock global source credential event");
+    .expect("send mock source credential event");
     Box::pin(ReceiverStream::new(rx))
 }
 
@@ -951,8 +929,7 @@ fn mock_import_source_stream() -> MockImportSourceStream {
 
 #[tonic::async_trait]
 impl SourceService for MockSourceService {
-    type CreateBundledSourceWithOAuthStream = MockBundledSourceStream;
-    type CreateGlobalSourceWithOAuthStream = MockGlobalSourceStream;
+    type CreateSourceWithOAuthStream = MockSourceStream;
     type ImportSourceStream = MockImportSourceStream;
 
     async fn discover_sources(
@@ -1012,56 +989,42 @@ impl SourceService for MockSourceService {
         }))
     }
 
-    async fn create_bundled_source(
+    async fn create_source(
         &self,
-        request: Request<CreateBundledSourceRequest>,
-    ) -> Result<Response<CreateBundledSourceResponse>, Status> {
+        request: Request<CreateSourceRequest>,
+    ) -> Result<Response<CreateSourceResponse>, Status> {
+        let request = request.into_inner();
+        let source = if request.name == "linear" {
+            mock_global_source()
+        } else {
+            mock_source()
+        };
         self.captured
-            .create_bundled_source
+            .create_source
             .lock()
-            .expect("create_bundled_source capture")
-            .push(request.into_inner());
-        Ok(Response::new(CreateBundledSourceResponse {
-            source: Some(mock_source()),
+            .expect("create_source capture")
+            .push(request);
+        Ok(Response::new(CreateSourceResponse {
+            source: Some(source),
         }))
     }
 
-    async fn create_bundled_source_with_o_auth(
+    async fn create_source_with_o_auth(
         &self,
-        request: Request<CreateBundledSourceWithOAuthRequest>,
-    ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
+        request: Request<CreateSourceWithOAuthRequest>,
+    ) -> Result<Response<Self::CreateSourceWithOAuthStream>, Status> {
+        let request = request.into_inner();
+        let source = if request.name == "linear" {
+            mock_global_source()
+        } else {
+            mock_source()
+        };
         self.captured
-            .create_bundled_source_with_oauth
+            .create_source_with_oauth
             .lock()
-            .expect("create_bundled_source_with_oauth capture")
-            .push(request.into_inner());
-        Ok(Response::new(mock_bundled_source_stream()))
-    }
-
-    async fn create_global_source(
-        &self,
-        request: Request<CreateGlobalSourceRequest>,
-    ) -> Result<Response<CreateGlobalSourceResponse>, Status> {
-        self.captured
-            .create_global_source
-            .lock()
-            .expect("create_global_source capture")
-            .push(request.into_inner());
-        Ok(Response::new(CreateGlobalSourceResponse {
-            source: Some(mock_global_source()),
-        }))
-    }
-
-    async fn create_global_source_with_o_auth(
-        &self,
-        request: Request<CreateGlobalSourceWithOAuthRequest>,
-    ) -> Result<Response<Self::CreateGlobalSourceWithOAuthStream>, Status> {
-        self.captured
-            .create_global_source_with_oauth
-            .lock()
-            .expect("create_global_source_with_oauth capture")
-            .push(request.into_inner());
-        Ok(Response::new(mock_global_source_stream()))
+            .expect("create_source_with_oauth capture")
+            .push(request);
+        Ok(Response::new(mock_source_stream(source)))
     }
 
     async fn import_source(
@@ -1350,11 +1313,11 @@ impl MockServer {
             .clone()
     }
 
-    pub(crate) fn create_global_source_requests(&self) -> Vec<CreateGlobalSourceRequest> {
+    pub(crate) fn create_source_requests(&self) -> Vec<CreateSourceRequest> {
         self.captured
-            .create_global_source
+            .create_source
             .lock()
-            .expect("create_global_source capture")
+            .expect("create_source capture")
             .clone()
     }
 


### PR DESCRIPTION
## Intent

Expose the global source-spec registry through the app gRPC API so clients can register, list, delete, inspect, and install globally registered source specs without reaching into app state directly.

## What it enables

- Adds RPC coverage for registering, listing, and deleting global source specs.
- Extends named source creation so `CreateSource` resolves registered global specs before bundled sources.
- Keeps existing bundled-source RPC aliases while adding the unified named-source path.
- Uses `SourceSpecInfo` for `ListSourceSpecs` so the global list response does not pretend to know workspace-relative installed state.
- Allows workspace sources to be installed from a global source spec, including OAuth-backed installs through the unified streaming create path.
- Trims UI-provided variable and secret values before sending install bindings to the app service.

## Usage examples

API clients can register a validated manifest, list registry entries, then install by name into a workspace:

```text
RegisterSourceSpec(manifest_yaml)
ListSourceSpecs()
CreateSource(workspace, name)
DeleteSourceSpec(name)
```

OAuth-backed specs use `CreateSourceWithOAuth`, matching the existing OAuth install event stream.

## Validation

- `make rust-checks`
- `npm run check --prefix ui`
- `make lint-proto`
- `make docs-check`
- `make perf-check` (`coral.tables` mean 249.8 ms, threshold 750 ms)
