### PR TITLE
feat(cli): add source spec registry commands

### DIFF
--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -223,6 +223,7 @@ Important files include:
 
 - `config.toml` for installed-source metadata, non-secret variables, and runtime settings. See [Configuration](/reference/configuration).
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
+- globally registered source specs under `source_specs/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 
 <Note>

--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -223,7 +223,7 @@ Important files include:
 
 - `config.toml` for installed-source metadata, non-secret variables, and runtime settings. See [Configuration](/reference/configuration).
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
-- globally registered source specs under `source_specs/<source>/manifest.yaml`
+- [globally registered source specs](/reference/configuration#global-source-specs) under `source_specs/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 
 <Note>

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -63,7 +63,7 @@ coral sql "DESCRIBE datadog.hosts"
 
 ## `coral source`
 
-Manage configured sources, either the bundled ones, or your custom source specs.
+Manage configured sources, bundled source specs, workspace-local imports, and globally registered source specs.
 
 ### `coral source discover`
 
@@ -88,7 +88,7 @@ The output includes the source's secret storage route: `keychain` or
 
 ### `coral source info <NAME>`
 
-Show metadata for a source: whether it is installed, its origin, version, description, and inputs. Works for bundled sources and imported sources installed via `coral source add --file`.
+Show metadata for a source: whether it is installed, its origin, version, description, and inputs. Works for bundled sources, globally registered source specs, and imported sources installed via `coral source add --file`.
 
 ```shellscript
 coral source info datadog
@@ -106,10 +106,11 @@ coral source info datadog --verbose
 
 ### `coral source add <NAME>`
 
-Add a bundled source, update its credentials, or import a custom source spec.
+Add a bundled source, add a globally registered source spec by name, update stored credentials, or import a custom source spec into the current workspace.
 
 ```shellscript
 GITHUB_TOKEN=ghp_... coral source add github
+coral source add internal_crm
 coral source add --file ./local-messages.yaml
 ```
 
@@ -119,6 +120,11 @@ coral source add --file ./local-messages.yaml
 | --------------- | ---- | ------------------------ | ------------------------------------------------------------- |
 | `--file <PATH>` | path | required unless `<NAME>` | Source spec YAML file to import                               |
 | `--interactive` | flag | `false`                  | Prompt for source inputs instead of reading environment variables |
+
+When you pass `<NAME>`, Coral first looks for a bundled source with that name.
+If none exists, it looks in the global source-spec registry created by
+`coral source spec add --file`. When you pass `--file`, the manifest is imported
+only into the selected workspace.
 
 By default, Coral reads each declared input from an environment variable of the
 same name. If a required input is missing, the command exits with an error
@@ -153,6 +159,23 @@ Coral stores the source secrets in plaintext file storage and shows
 `file (plaintext)` in source output. Sources with no stored secret material show
 `none`.
 
+### `coral source spec`
+
+Manage source specs in the global registry. Registered specs are reusable
+install targets for any workspace.
+
+```shellscript
+coral source spec add --file ./internal-crm.yaml
+coral source spec list
+coral source add internal_crm --workspace work
+coral source spec remove internal_crm
+```
+
+`coral source spec remove <NAME>` removes the registry entry and its global
+manifest artifact. Existing workspace sources installed from that spec are not
+removed, but they become orphaned and fail validation or query loading until you
+register the spec again or remove and re-add the source.
+
 ### `coral source lint <FILE>`
 
 Validate a source spec YAML file without installing it. Checks YAML syntax, JSON schema conformance, and semantic rules such as duplicate columns or references to unknown filters.
@@ -185,9 +208,8 @@ workspace-scoped artifacts such as source manifests, local credential material,
 feedback reports, episode logs, and workspace-attributed local trace history.
 
 Imported source specs and source credential material are attached to the source
-installation in that workspace. Reusable global source specs and reusable
-credential references are separate concepts and are not represented by
-`coral workspace` today.
+installation in that workspace. Reusable global source specs are managed with
+`coral source spec` and are not removed when you delete a workspace.
 
 ### `coral workspace list`
 

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -63,7 +63,8 @@ coral sql "DESCRIBE datadog.hosts"
 
 ## `coral source`
 
-Manage configured sources, bundled source specs, and workspace-local imports.
+Manage installed sources, bundled source specs, and source specs imported into
+the selected workspace.
 
 ### `coral source discover`
 
@@ -159,23 +160,6 @@ Coral stores the source secrets in plaintext file storage and shows
 `file (plaintext)` in source output. Sources with no stored secret material show
 `none`.
 
-## `coral source-spec`
-
-Manage source specs in the global registry. Registered specs are reusable
-install targets for any workspace and are not scoped to `--workspace`.
-
-```shellscript
-coral source-spec add --file ./internal-crm.yaml
-coral source-spec list
-coral source add internal_crm --workspace work
-coral source-spec remove internal_crm
-```
-
-`coral source-spec remove <NAME>` removes the registry entry and its global
-manifest artifact. Existing workspace sources installed from that spec are not
-removed, but they become orphaned and fail validation or query loading until you
-register the spec again or remove and re-add the source.
-
 ### `coral source lint <FILE>`
 
 Validate a source spec YAML file without installing it. Checks YAML syntax, JSON schema conformance, and semantic rules such as duplicate columns or references to unknown filters.
@@ -200,6 +184,48 @@ Remove an installed source.
 ```shellscript
 coral source remove github
 ```
+
+## `coral source-spec`
+
+Manage source specs in the global registry. Registered specs are reusable
+install targets for any workspace and are not scoped to `--workspace`.
+
+### `coral source-spec list`
+
+List globally registered source specs.
+
+```shellscript
+coral source-spec list
+```
+
+### `coral source-spec add`
+
+Register a source spec in the global registry.
+
+```shellscript
+coral source-spec add --file ./internal-crm.yaml
+coral source add internal_crm --workspace work
+```
+
+#### Options
+
+| Option          | Type | Default  | Description                           |
+| --------------- | ---- | -------- | ------------------------------------- |
+| `--file <PATH>` | path | required | Source spec YAML file to register     |
+
+### `coral source-spec remove <NAME>`
+
+Remove a source spec from the global registry.
+
+```shellscript
+coral source-spec remove internal_crm
+```
+
+This removes the registry entry and its global manifest artifact. Existing
+workspace sources installed from that spec are not removed. Explicit validation
+for an orphaned source fails until you register the spec again or remove and
+re-add the source; query loading skips the orphaned source and continues with
+the rest of the workspace.
 
 ## `coral workspace`
 

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -63,7 +63,7 @@ coral sql "DESCRIBE datadog.hosts"
 
 ## `coral source`
 
-Manage configured sources, bundled source specs, workspace-local imports, and globally registered source specs.
+Manage configured sources, bundled source specs, and workspace-local imports.
 
 ### `coral source discover`
 
@@ -123,7 +123,7 @@ coral source add --file ./local-messages.yaml
 
 When you pass `<NAME>`, Coral first looks for a bundled source with that name.
 If none exists, it looks in the global source-spec registry created by
-`coral source spec add --file`. When you pass `--file`, the manifest is imported
+`coral source-spec add --file`. When you pass `--file`, the manifest is imported
 only into the selected workspace.
 
 By default, Coral reads each declared input from an environment variable of the
@@ -159,19 +159,19 @@ Coral stores the source secrets in plaintext file storage and shows
 `file (plaintext)` in source output. Sources with no stored secret material show
 `none`.
 
-### `coral source spec`
+## `coral source-spec`
 
 Manage source specs in the global registry. Registered specs are reusable
-install targets for any workspace.
+install targets for any workspace and are not scoped to `--workspace`.
 
 ```shellscript
-coral source spec add --file ./internal-crm.yaml
-coral source spec list
+coral source-spec add --file ./internal-crm.yaml
+coral source-spec list
 coral source add internal_crm --workspace work
-coral source spec remove internal_crm
+coral source-spec remove internal_crm
 ```
 
-`coral source spec remove <NAME>` removes the registry entry and its global
+`coral source-spec remove <NAME>` removes the registry entry and its global
 manifest artifact. Existing workspace sources installed from that spec are not
 removed, but they become orphaned and fail validation or query loading until you
 register the spec again or remove and re-add the source.
@@ -209,7 +209,7 @@ feedback reports, episode logs, and workspace-attributed local trace history.
 
 Imported source specs and source credential material are attached to the source
 installation in that workspace. Reusable global source specs are managed with
-`coral source spec` and are not removed when you delete a workspace.
+`coral source-spec` and are not removed when you delete a workspace.
 
 ### `coral workspace list`
 

--- a/apps/docs/reference/community-sources.mdx
+++ b/apps/docs/reference/community-sources.mdx
@@ -9,10 +9,9 @@ Community sources are source specs built and maintained by our community. These 
 [sources/community](https://github.com/withcoral/coral/tree/main/sources/community).
 
 <Note>
-  Community sources are not included in `coral source discover`, and `coral
-  source add <name>` only installs [bundled sources](/reference/bundled-sources).
-  Import community sources
-  with `coral source add --file`.
+  Community sources are not included in `coral source discover`. Import one directly
+  into the current workspace with `coral source add --file`, or register it globally
+  with `coral source spec add --file` and then install it by name with `coral source add <name>`.
 </Note>
 
 ## Install a community source

--- a/apps/docs/reference/community-sources.mdx
+++ b/apps/docs/reference/community-sources.mdx
@@ -11,7 +11,7 @@ Community sources are source specs built and maintained by our community. These 
 <Note>
   Community sources are not included in `coral source discover`. Import one directly
   into the current workspace with `coral source add --file`, or register it globally
-  with `coral source spec add --file` and then install it by name with `coral source add <name>`.
+  with `coral source-spec add --file` and then install it by name with `coral source add <name>`.
 </Note>
 
 ## Install a community source

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -330,6 +330,8 @@ message CreateSourceRequest {
   repeated SourceVariable variables = 3;
   // Source-owned secret values.
   repeated SourceSecret secrets = 4;
+  // Resolve manifest inputs from the app process environment.
+  bool resolve_inputs_from_environment = 5;
 }
 
 // Returns the installed source.

--- a/crates/coral-app/src/bootstrap/env.rs
+++ b/crates/coral-app/src/bootstrap/env.rs
@@ -49,6 +49,14 @@ fn coral_config_dir_override() -> Option<PathBuf> {
     std::env::var_os(CORAL_CONFIG_DIR).map(PathBuf::from)
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "coral-app is the single owner of process environment access."
+)]
+pub(crate) fn source_input_env_value(key: &str) -> Option<String> {
+    std::env::var(key).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{AppEnvironment, CORAL_CONFIG_DIR, coral_config_dir_override};

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -13,6 +13,7 @@ use crate::telemetry::{
 };
 use crate::workspaces::WorkspaceName;
 
+pub(crate) use env::source_input_env_value;
 #[cfg(test)]
 pub(crate) use error::MAX_STATUS_DETAIL_BYTES;
 pub(crate) use error::{app_status, core_status};

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -34,7 +34,7 @@ use coral_spec::{
 };
 use tonic::{Request, Response, Status};
 
-use crate::bootstrap::{AppError, app_status};
+use crate::bootstrap::{AppError, app_status, source_input_env_value};
 use crate::credentials::CredentialStorageKind;
 use crate::query::manager::QueryManager;
 use crate::sources::SourceName;
@@ -165,9 +165,26 @@ impl SourceServiceApi for SourceService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
+            let bindings = if request.resolve_inputs_from_environment {
+                if !request.variables.is_empty() || !request.secrets.is_empty() {
+                    return Err(app_status(AppError::InvalidInput(
+                        "resolve_inputs_from_environment cannot be combined with explicit variables or secrets"
+                            .to_string(),
+                    )));
+                }
+                let source = sources
+                    .get_source_info(&workspace_name, &source_name)
+                    .map_err(app_status)?;
+                let interactive_command =
+                    format!("coral source add --interactive {}", source.name.as_str());
+                source_bindings_from_environment(&source.inputs, &interactive_command)
+                    .map_err(app_status)?
+            } else {
+                source_bindings_from_proto(request.variables, request.secrets)
+            };
             let command = CreateSourceCommand {
                 name: source_name,
-                bindings: source_bindings_from_proto(request.variables, request.secrets),
+                bindings,
             };
             let response_workspace_name = workspace_name.clone();
             let installed = run_blocking_source_operation(move || {
@@ -484,6 +501,51 @@ fn source_bindings_from_proto(
             .collect(),
         secrets: secrets.into_iter().map(source_secret_from_proto).collect(),
     }
+}
+
+fn source_bindings_from_environment(
+    inputs: &[ManifestInputSpec],
+    interactive_command: &str,
+) -> Result<SourceBindings, AppError> {
+    let mut variables = Vec::new();
+    let mut secrets = Vec::new();
+    let mut missing = Vec::new();
+
+    for input in inputs {
+        let raw = source_input_env_value(&input.key).unwrap_or_default();
+        let value = if raw.is_empty() {
+            input.default_value.clone()
+        } else {
+            raw
+        };
+        if value.is_empty() {
+            if input.required {
+                missing.push(input.key.clone());
+            }
+            continue;
+        }
+        match input.kind {
+            ManifestInputKind::Variable => variables.push(SourceBinding {
+                key: input.key.clone(),
+                value,
+            }),
+            ManifestInputKind::Secret => secrets.push(SourceBinding {
+                key: input.key.clone(),
+                value,
+            }),
+        }
+    }
+
+    if !missing.is_empty() {
+        return Err(AppError::InvalidInput(format!(
+            "missing required environment variable{}: {}. Set the variable{} or run `{interactive_command}`.",
+            if missing.len() == 1 { "" } else { "s" },
+            missing.join(", "),
+            if missing.len() == 1 { "" } else { "s" },
+        )));
+    }
+
+    Ok(SourceBindings { variables, secrets })
 }
 
 fn source_variable_from_proto(variable: SourceVariable) -> SourceBinding {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -145,6 +145,7 @@ impl GrpcHarness {
                 name: name.to_string(),
                 variables: Vec::new(),
                 secrets: Vec::new(),
+                resolve_inputs_from_environment: false,
             }))
             .await
             .expect("create global source")

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -855,6 +855,7 @@ async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() 
                 key: "GITHUB_TOKEN".to_string(),
                 value: "fake-token".to_string(),
             }],
+            resolve_inputs_from_environment: false,
         }))
         .await
         .expect("create bundled github source");
@@ -1046,6 +1047,7 @@ async fn create_source_registers_tables() {
                 key: "GITHUB_TOKEN".to_string(),
                 value: "fake-token".to_string(),
             }],
+            resolve_inputs_from_environment: false,
         }))
         .await
         .expect("create bundled github source");
@@ -1054,6 +1056,54 @@ async fn create_source_registers_tables() {
     assert!(
         tables.iter().any(|table| table.schema_name == "github"),
         "github tables should register once the template secret dependency is provided"
+    );
+}
+
+#[tokio::test]
+async fn create_source_environment_resolution_reports_missing_inputs() {
+    let harness = GrpcHarness::new().await;
+    let base_key = format!("CORAL_TEST_REQUIRED_API_BASE_{}", std::process::id());
+    let token_key = format!("CORAL_TEST_REQUIRED_API_TOKEN_{}", std::process::id());
+    let manifest_yaml = fixture_manifest_with_required_inputs_yaml()
+        .replace("API_BASE", &base_key)
+        .replace("API_TOKEN", &token_key);
+    harness.register_source_spec(manifest_yaml).await;
+
+    let error = harness
+        .source_client()
+        .create_source(Request::new(CreateSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "required_messages".to_string(),
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            resolve_inputs_from_environment: true,
+        }))
+        .await
+        .expect_err("missing app-resolved env inputs should fail");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(
+        error
+            .message()
+            .contains("missing required environment variables"),
+        "expected missing env error, got {}",
+        error.message()
+    );
+    assert!(
+        error.message().contains(&base_key),
+        "expected missing base key in {}",
+        error.message()
+    );
+    assert!(
+        error.message().contains(&token_key),
+        "expected missing token key in {}",
+        error.message()
+    );
+    assert!(
+        error
+            .message()
+            .contains("coral source add --interactive required_messages"),
+        "expected interactive recovery command in {}",
+        error.message()
     );
 }
 
@@ -1071,6 +1121,7 @@ async fn create_source_missing_required_secret_returns_invalid_argument() {
                 value: "phoebe".to_string(),
             }],
             secrets: Vec::new(),
+            resolve_inputs_from_environment: false,
         }))
         .await
         .expect_err("missing bundled secret should fail");
@@ -1096,6 +1147,7 @@ async fn create_source_missing_required_variable_returns_invalid_argument() {
                 key: "SENTRY_TOKEN".to_string(),
                 value: "secret-token".to_string(),
             }],
+            resolve_inputs_from_environment: false,
         }))
         .await
         .expect_err("missing bundled variable should fail");
@@ -1130,6 +1182,7 @@ async fn create_source_unknown_input_returns_invalid_argument() {
                 key: "SENTRY_TOKEN".to_string(),
                 value: "secret-token".to_string(),
             }],
+            resolve_inputs_from_environment: false,
         }))
         .await
         .expect_err("unknown bundled input should fail");
@@ -1160,6 +1213,7 @@ async fn create_source_repeated_secret_returns_invalid_argument() {
                     value: "shadow-token".to_string(),
                 },
             ],
+            resolve_inputs_from_environment: false,
         }))
         .await
         .expect_err("repeated bundled secret should fail");
@@ -1188,6 +1242,7 @@ async fn create_source_does_not_persist_manifest_to_config_dir() {
                 key: "GITHUB_TOKEN".to_string(),
                 value: "fake-token".to_string(),
             }],
+            resolve_inputs_from_environment: false,
         }))
         .await
         .expect("create bundled github source")

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -71,6 +71,8 @@ enum Command {
     Sql(SqlArgs),
     /// Manage data sources
     Source(SourceArgs),
+    /// Manage globally registered source specs
+    SourceSpec(SourceSpecArgs),
     /// Manage workspaces
     Workspace(WorkspaceArgs),
     /// Interactive wizard to set up Coral and explore use cases
@@ -338,8 +340,6 @@ enum SourceCommand {
     },
     /// Add a new source
     Add(SourceAddArgs),
-    /// Manage globally registered source specs
-    Spec(SourceSpecArgs),
     /// Lint manifest file
     Lint { file: PathBuf },
     /// Test connectivity for a source
@@ -423,6 +423,7 @@ impl Command {
         match self {
             Command::Sql(_)
             | Command::Source(_)
+            | Command::SourceSpec(_)
             | Command::Workspace(_)
             | Command::Onboard
             | Command::McpStdio(_) => RequiredRuntime::AppClient,
@@ -617,6 +618,7 @@ async fn run_no_runtime_command(
         Command::Ui(args) => run_ui(args).await.map_err(Into::into),
         Command::Sql(_)
         | Command::Source(_)
+        | Command::SourceSpec(_)
         | Command::Workspace(_)
         | Command::Onboard
         | Command::McpStdio(_) => {
@@ -655,6 +657,7 @@ async fn run_app_command(
             print_batches(result.batches(), args.format)?;
         }
         Command::Source(args) => run_source(&app, workspace, args).await?,
+        Command::SourceSpec(args) => run_source_spec(&app, args).await?,
         Command::Workspace(args) => run_workspace(&app, args).await?,
         Command::Onboard => {
             onboard::run(&app, workspace).await?;
@@ -852,7 +855,6 @@ async fn run_source(
             source_ops::print_source_info(app, workspace, &name, verbose).await?;
         }
         SourceCommand::Add(args) => run_source_add(app, workspace, args).await?,
-        SourceCommand::Spec(args) => run_source_spec(app, args).await?,
         SourceCommand::Lint { file } => {
             source_ops::load_validated_manifest_file(&file)?;
             println!("Manifest is valid");
@@ -1148,6 +1150,26 @@ mod tests {
         let cli = Cli::try_parse_from(["coral", "source", "list"]).expect("source list parses");
 
         assert_eq!(cli.command.required_runtime(), RequiredRuntime::AppClient);
+    }
+
+    #[test]
+    fn source_spec_command_uses_app_runtime_without_workspace_selection() {
+        let cli =
+            Cli::try_parse_from(["coral", "source-spec", "list"]).expect("source-spec parses");
+
+        assert_eq!(cli.command.required_runtime(), RequiredRuntime::AppClient);
+        assert!(!cli.command.uses_selected_workspace());
+    }
+
+    #[test]
+    fn source_spec_command_is_not_nested_under_source() {
+        let error = Cli::try_parse_from(["coral", "source", "spec", "list"])
+            .expect_err("source spec should not be nested under source");
+
+        assert!(
+            error.to_string().contains("unrecognized subcommand"),
+            "unexpected parse error: {error}"
+        );
     }
 
     #[test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -29,7 +29,7 @@ use clap::{
 use clap_complete::{Shell, generate};
 use coral_api::v1::{
     CreateWorkspaceRequest, DeleteWorkspaceRequest, ExecuteSqlRequest, ListWorkspacesRequest,
-    Workspace,
+    Source, SourceInfo, SourceOrigin, Workspace,
 };
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
@@ -299,6 +299,29 @@ struct SourceAddArgs {
     interactive: bool,
 }
 
+#[derive(Debug, Args)]
+struct SourceSpecArgs {
+    #[command(subcommand)]
+    command: SourceSpecCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum SourceSpecCommand {
+    /// List globally registered source specs
+    List,
+    /// Register a source spec globally
+    Add {
+        /// Path to a manifest file
+        #[arg(long)]
+        file: PathBuf,
+    },
+    /// Remove a globally registered source spec
+    Remove {
+        /// Name of the source spec to remove
+        name: String,
+    },
+}
+
 #[derive(Debug, Subcommand)]
 enum SourceCommand {
     /// Discover available sources
@@ -315,6 +338,8 @@ enum SourceCommand {
     },
     /// Add a new source
     Add(SourceAddArgs),
+    /// Manage globally registered source specs
+    Spec(SourceSpecArgs),
     /// Lint manifest file
     Lint { file: PathBuf },
     /// Test connectivity for a source
@@ -827,6 +852,7 @@ async fn run_source(
             source_ops::print_source_info(app, workspace, &name, verbose).await?;
         }
         SourceCommand::Add(args) => run_source_add(app, workspace, args).await?,
+        SourceCommand::Spec(args) => run_source_spec(app, args).await?,
         SourceCommand::Lint { file } => {
             source_ops::load_validated_manifest_file(&file)?;
             println!("Manifest is valid");
@@ -843,6 +869,36 @@ async fn run_source(
         }
         SourceCommand::Remove { name } => {
             source_ops::remove_and_print(app, workspace, &name).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn run_source_spec(app: &AppClient, args: SourceSpecArgs) -> Result<(), CliError> {
+    match args.command {
+        SourceSpecCommand::List => {
+            let source_specs = source_ops::list_source_specs(app).await?;
+            if source_specs.is_empty() {
+                println!("No source specs registered.");
+            } else {
+                let rows = source_specs.into_iter().map(|source| {
+                    [
+                        source.name,
+                        source_ops::display_version(&source.version),
+                        source_ops::source_origin_label(source.origin).to_string(),
+                    ]
+                });
+                print_text_table(["Source", "Version", "Origin"], rows);
+            }
+        }
+        SourceSpecCommand::Add { file } => {
+            let (manifest_yaml, _manifest) = source_ops::load_validated_manifest_file(&file)?;
+            let source_spec = source_ops::register_source_spec(app, manifest_yaml).await?;
+            println!("Registered source spec {}", source_spec.name);
+        }
+        SourceSpecCommand::Remove { name } => {
+            let source_spec = source_ops::delete_source_spec(app, &name).await?;
+            println!("Removed source spec {}", source_spec.name);
         }
     }
     Ok(())
@@ -935,6 +991,60 @@ fn pad_cell(value: &str, width: usize, pad: bool) -> String {
     format!("{value}{}", " ".repeat(padding))
 }
 
+async fn resolve_named_source_candidate(
+    app: &AppClient,
+    workspace: &Workspace,
+    source_name: &str,
+) -> Result<SourceInfo, anyhow::Error> {
+    let discover = source_ops::discover_sources(app, workspace).await?;
+    if let Some(available) = discover
+        .into_iter()
+        .find(|source| source.name == source_name)
+    {
+        return Ok(available);
+    }
+
+    let available = source_ops::get_source_info(app, workspace, source_name).await?;
+    if SourceOrigin::try_from(available.origin) != Ok(SourceOrigin::GlobalSpec) {
+        return Err(anyhow::anyhow!(
+            "unknown bundled or global source spec '{source_name}'"
+        ));
+    }
+    Ok(available)
+}
+
+async fn install_named_source(
+    app: &AppClient,
+    workspace: &Workspace,
+    available: SourceInfo,
+    interactive: bool,
+) -> Result<Source, anyhow::Error> {
+    let inputs = available
+        .inputs
+        .iter()
+        .map(manifest_input_from_proto)
+        .collect::<Result<Vec<_>, _>>()?;
+    let origin = SourceOrigin::try_from(available.origin).unwrap_or(SourceOrigin::Unspecified);
+    match origin {
+        SourceOrigin::Bundled | SourceOrigin::GlobalSpec if interactive => {
+            let inputs = source_ops::prompt_for_inputs_with_credential_methods(&inputs)?;
+            source_ops::add_named_source_with_credentials(app, workspace, &available.name, inputs)
+                .await
+        }
+        SourceOrigin::Bundled | SourceOrigin::GlobalSpec => {
+            let (variables, secrets) = source_ops::collect_inputs_from_env(
+                &inputs,
+                format!("coral source add --interactive {}", available.name),
+            )?;
+            source_ops::add_named_source(app, workspace, &available.name, variables, secrets).await
+        }
+        SourceOrigin::Imported | SourceOrigin::Unspecified => Err(anyhow::anyhow!(
+            "source '{}' cannot be added by name; use --file for imported manifests",
+            available.name
+        )),
+    }
+}
+
 async fn run_source_add(
     app: &AppClient,
     workspace: &Workspace,
@@ -950,35 +1060,9 @@ async fn run_source_add(
     }
     let response = match (name, file) {
         (Some(name), None) => {
-            let bundled_name = source_ops::source_name_arg(Some(&name))?;
-            let discover = source_ops::discover_sources(app, workspace).await?;
-            let available = discover
-                .into_iter()
-                .find(|source| source.name == bundled_name)
-                .ok_or_else(|| anyhow::anyhow!("unknown bundled source '{bundled_name}'"))?;
-            let inputs = available
-                .inputs
-                .iter()
-                .map(manifest_input_from_proto)
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(anyhow::Error::from)?;
-            if interactive {
-                let inputs = source_ops::prompt_for_inputs_with_credential_methods(&inputs)?;
-                source_ops::add_named_source_with_credentials(
-                    app,
-                    workspace,
-                    &available.name,
-                    inputs,
-                )
-                .await?
-            } else {
-                let (variables, secrets) = source_ops::collect_inputs_from_env(
-                    &inputs,
-                    format!("coral source add --interactive {}", available.name),
-                )?;
-                source_ops::add_named_source(app, workspace, &available.name, variables, secrets)
-                    .await?
-            }
+            let source_name = source_ops::source_name_arg(Some(&name))?;
+            let available = resolve_named_source_candidate(app, workspace, &source_name).await?;
+            install_named_source(app, workspace, available, interactive).await?
         }
         (None, Some(file)) => {
             let (manifest_yaml, manifest) = source_ops::load_validated_manifest_file(&file)?;

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -1019,24 +1019,20 @@ async fn install_named_source(
     available: SourceInfo,
     interactive: bool,
 ) -> Result<Source, anyhow::Error> {
-    let inputs = available
-        .inputs
-        .iter()
-        .map(manifest_input_from_proto)
-        .collect::<Result<Vec<_>, _>>()?;
     let origin = SourceOrigin::try_from(available.origin).unwrap_or(SourceOrigin::Unspecified);
     match origin {
         SourceOrigin::Bundled | SourceOrigin::GlobalSpec if interactive => {
+            let inputs = available
+                .inputs
+                .iter()
+                .map(manifest_input_from_proto)
+                .collect::<Result<Vec<_>, _>>()?;
             let inputs = source_ops::prompt_for_inputs_with_credential_methods(&inputs)?;
             source_ops::add_named_source_with_credentials(app, workspace, &available.name, inputs)
                 .await
         }
         SourceOrigin::Bundled | SourceOrigin::GlobalSpec => {
-            let (variables, secrets) = source_ops::collect_inputs_from_env(
-                &inputs,
-                format!("coral source add --interactive {}", available.name),
-            )?;
-            source_ops::add_named_source(app, workspace, &available.name, variables, secrets).await
+            source_ops::add_named_source_from_environment(app, workspace, &available.name).await
         }
         SourceOrigin::Imported | SourceOrigin::Unspecified => Err(anyhow::anyhow!(
             "source '{}' cannot be added by name; use --file for imported manifests",

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -12,9 +12,10 @@ use anyhow::{Context as _, bail};
 use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
     CreateSourceRequest, CreateSourceWithOAuthRequest, CreateSourceWithOAuthResponse,
-    DeleteSourceRequest, DiscoverSourcesRequest, GetSourceInfoRequest, ImportSourceRequest,
-    ImportSourceResponse, ListSourcesRequest, OAuthCredentialInput, OAuthCredentialRetrieval,
-    QueryTestFailure, QueryTestSuccess, Source, SourceCredentialStorage, SourceInfo, SourceOrigin,
+    DeleteSourceRequest, DeleteSourceSpecRequest, DiscoverSourcesRequest, GetSourceInfoRequest,
+    ImportSourceRequest, ImportSourceResponse, ListSourceSpecsRequest, ListSourcesRequest,
+    OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess,
+    RegisterSourceSpecRequest, Source, SourceCredentialStorage, SourceInfo, SourceOrigin,
     SourceSecret, SourceVariable, ValidateSourceRequest, ValidateSourceResponse, Workspace,
     create_source_with_o_auth_response, import_source_response, query_test_result,
     source_input_spec::Input as ProtoSourceInput,
@@ -96,6 +97,45 @@ pub(crate) async fn list_sources(
         .await?
         .into_inner()
         .sources)
+}
+
+pub(crate) async fn list_source_specs(app: &AppClient) -> Result<Vec<SourceInfo>, anyhow::Error> {
+    Ok(app
+        .source_client()
+        .list_source_specs(Request::new(ListSourceSpecsRequest {}))
+        .await?
+        .into_inner()
+        .source_specs)
+}
+
+pub(crate) async fn register_source_spec(
+    app: &AppClient,
+    manifest_yaml: String,
+) -> Result<SourceInfo, anyhow::Error> {
+    let response = app
+        .source_client()
+        .register_source_spec(Request::new(RegisterSourceSpecRequest { manifest_yaml }))
+        .await?
+        .into_inner();
+    response
+        .source_spec
+        .ok_or_else(|| anyhow::anyhow!("register source spec response missing source_spec"))
+}
+
+pub(crate) async fn delete_source_spec(
+    app: &AppClient,
+    name: &str,
+) -> Result<SourceInfo, anyhow::Error> {
+    let response = app
+        .source_client()
+        .delete_source_spec(Request::new(DeleteSourceSpecRequest {
+            name: source_name_arg(Some(name))?,
+        }))
+        .await?
+        .into_inner();
+    response
+        .source_spec
+        .ok_or_else(|| anyhow::anyhow!("delete source spec response missing source_spec"))
 }
 
 pub(crate) async fn add_named_source(
@@ -522,6 +562,16 @@ pub(crate) async fn print_source_info(
     name: &str,
     verbose: bool,
 ) -> Result<(), anyhow::Error> {
+    let source = get_source_info(app, workspace, name).await?;
+    print_source_info_response(&source, verbose);
+    Ok(())
+}
+
+pub(crate) async fn get_source_info(
+    app: &AppClient,
+    workspace: &Workspace,
+    name: &str,
+) -> Result<SourceInfo, anyhow::Error> {
     let response = app
         .source_client()
         .get_source_info(Request::new(GetSourceInfoRequest {
@@ -533,8 +583,7 @@ pub(crate) async fn print_source_info(
     let source = response
         .source_info
         .ok_or_else(|| anyhow::anyhow!("get source info response missing source_info"))?;
-    print_source_info_response(&source, verbose);
-    Ok(())
+    Ok(source)
 }
 
 fn print_source_info_response(source: &SourceInfo, verbose: bool) {

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -16,8 +16,8 @@ use coral_api::v1::{
     ImportSourceRequest, ImportSourceResponse, ListSourceSpecsRequest, ListSourcesRequest,
     OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess,
     RegisterSourceSpecRequest, Source, SourceCredentialStorage, SourceInfo, SourceOrigin,
-    SourceSecret, SourceVariable, ValidateSourceRequest, ValidateSourceResponse, Workspace,
-    create_source_with_o_auth_response, import_source_response, query_test_result,
+    SourceSecret, SourceSpecInfo, SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
+    Workspace, create_source_with_o_auth_response, import_source_response, query_test_result,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::{AppClient, DecodedStatusError, decode_status_error};
@@ -99,7 +99,9 @@ pub(crate) async fn list_sources(
         .sources)
 }
 
-pub(crate) async fn list_source_specs(app: &AppClient) -> Result<Vec<SourceInfo>, anyhow::Error> {
+pub(crate) async fn list_source_specs(
+    app: &AppClient,
+) -> Result<Vec<SourceSpecInfo>, anyhow::Error> {
     Ok(app
         .source_client()
         .list_source_specs(Request::new(ListSourceSpecsRequest {}))
@@ -152,6 +154,28 @@ pub(crate) async fn add_named_source(
             name: name.to_string(),
             variables,
             secrets,
+            resolve_inputs_from_environment: false,
+        }))
+        .await?
+        .into_inner();
+    response
+        .source
+        .ok_or_else(|| anyhow::anyhow!("create source response missing source"))
+}
+
+pub(crate) async fn add_named_source_from_environment(
+    app: &AppClient,
+    workspace: &Workspace,
+    name: &str,
+) -> Result<Source, anyhow::Error> {
+    let response = app
+        .source_client()
+        .create_source(Request::new(CreateSourceRequest {
+            workspace: Some(workspace.clone()),
+            name: name.to_string(),
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            resolve_inputs_from_environment: true,
         }))
         .await?
         .into_inner();

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -1147,6 +1147,9 @@ async fn source_add_name_installs_global_source_when_not_bundled() {
     assert_eq!(create_requests.len(), 1, "expected one create_source call");
     assert_eq!(create_requests[0].name, "linear");
     assert_default_workspace(create_requests[0].workspace.as_ref());
+    assert!(create_requests[0].resolve_inputs_from_environment);
+    assert!(create_requests[0].variables.is_empty());
+    assert!(create_requests[0].secrets.is_empty());
     let validate_requests = server.validate_source_requests();
     assert_eq!(
         validate_requests.len(),
@@ -1159,7 +1162,7 @@ async fn source_add_name_installs_global_source_when_not_bundled() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn source_add_reports_missing_env_vars_without_interactive() {
+async fn source_add_requests_app_environment_resolution_without_interactive() {
     let server = MockServer::start().await;
 
     let assert = server
@@ -1167,21 +1170,19 @@ async fn source_add_reports_missing_env_vars_without_interactive() {
         .args(["source", "add", "github"])
         .env_remove("GITHUB_TOKEN")
         .assert()
-        .failure();
+        .success();
 
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
     assert!(
-        stderr.contains("missing required environment variable"),
-        "expected missing env var error: {stderr}"
+        stdout.contains("Added source github"),
+        "expected add confirmation: {stdout}"
     );
-    assert!(
-        stderr.contains("GITHUB_TOKEN"),
-        "expected missing env var to name GITHUB_TOKEN: {stderr}"
-    );
-    assert!(
-        stderr.contains("coral source add --interactive github"),
-        "expected exact interactive recovery command: {stderr}"
-    );
+    let create_requests = server.create_source_requests();
+    assert_eq!(create_requests.len(), 1, "expected one create_source call");
+    assert_eq!(create_requests[0].name, "github");
+    assert!(create_requests[0].resolve_inputs_from_environment);
+    assert!(create_requests[0].variables.is_empty());
+    assert!(create_requests[0].secrets.is_empty());
 
     server.shutdown().await;
 }

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -17,8 +17,8 @@ use arrow::record_batch::RecordBatch;
 #[cfg(feature = "embedded-ui")]
 use assert_cmd::Command;
 use coral_api::v1::{
-    DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, ListWorkspacesResponse,
-    Source, SourceCredentialStorage, SourceInfo, SourceOrigin, Workspace,
+    DiscoverSourcesResponse, ExecuteSqlResponse, ListSourceSpecsResponse, ListSourcesResponse,
+    ListWorkspacesResponse, Source, SourceCredentialStorage, SourceInfo, SourceOrigin, Workspace,
 };
 use tempfile::tempdir;
 use tonic::Code;
@@ -374,6 +374,122 @@ async fn source_discover_renders_empty_state() {
     let requests = server.discover_sources_requests();
     assert_eq!(requests.len(), 1, "expected one discover_sources call");
     assert_default_workspace(requests[0].workspace.as_ref());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_spec_list_renders_registered_specs() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "spec", "list"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert_eq!(
+        nonempty_lines(&stdout),
+        vec![
+            "Source  Version  Origin",
+            "------  -------  -----------",
+            "linear  3.0.0    global-spec",
+        ],
+        "expected source-spec registry list"
+    );
+    assert_eq!(
+        server.list_source_specs_requests().len(),
+        1,
+        "expected one list_source_specs call"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_spec_list_renders_empty_state() {
+    let server = MockServer::start_with_config(MockServerConfig::default().with_list_source_specs(
+        ListSourceSpecsResponse {
+            source_specs: Vec::new(),
+        },
+    ))
+    .await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "spec", "list"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert_eq!(stdout.trim(), "No source specs registered.");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_spec_add_registers_manifest() {
+    let server = MockServer::start().await;
+    let source_dir = tempdir().expect("source dir");
+    let manifest_file = source_dir.path().join("manifest.yaml");
+    std::fs::write(
+        &manifest_file,
+        r"
+name: linear
+version: 3.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: issues
+    description: Linear issues
+    request:
+      method: GET
+      path: /issues
+    columns:
+      - name: id
+        type: Utf8
+",
+    )
+    .expect("write manifest");
+
+    let assert = server
+        .cmd()
+        .args([
+            "source",
+            "spec",
+            "add",
+            "--file",
+            manifest_file.to_str().expect("manifest path utf8"),
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert_eq!(stdout.trim(), "Registered source spec linear");
+    let requests = server.register_source_spec_requests();
+    assert_eq!(requests.len(), 1, "expected one register_source_spec call");
+    assert!(requests[0].manifest_yaml.contains("name: linear"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_spec_remove_deletes_registered_spec() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "spec", "remove", "linear"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert_eq!(stdout.trim(), "Removed source spec linear");
+    let requests = server.delete_source_spec_requests();
+    assert_eq!(requests.len(), 1, "expected one delete_source_spec call");
+    assert_eq!(requests[0].name, "linear");
 
     server.shutdown().await;
 }
@@ -1001,6 +1117,46 @@ async fn source_remove_rejects_invalid_name() {
 // ---------------------------------------------------------------------------
 // Interactive-mode gating
 // ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_name_installs_global_source_when_not_bundled() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "add", "linear"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("Added source linear"),
+        "expected global source add confirmation: {stdout}"
+    );
+    let discover_requests = server.discover_sources_requests();
+    assert_eq!(
+        discover_requests.len(),
+        1,
+        "expected bundled discover before registry lookup"
+    );
+    assert_default_workspace(discover_requests[0].workspace.as_ref());
+    let info_requests = server.get_source_info_requests();
+    assert_eq!(info_requests.len(), 1, "expected one get_source_info call");
+    assert_eq!(info_requests[0].name, "linear");
+    let create_requests = server.create_source_requests();
+    assert_eq!(create_requests.len(), 1, "expected one create_source call");
+    assert_eq!(create_requests[0].name, "linear");
+    assert_default_workspace(create_requests[0].workspace.as_ref());
+    let validate_requests = server.validate_source_requests();
+    assert_eq!(
+        validate_requests.len(),
+        1,
+        "expected one validate_source call"
+    );
+    assert_eq!(validate_requests[0].name, "linear");
+
+    server.shutdown().await;
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn source_add_reports_missing_env_vars_without_interactive() {

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -384,7 +384,7 @@ async fn source_spec_list_renders_registered_specs() {
 
     let assert = server
         .cmd()
-        .args(["source", "spec", "list"])
+        .args(["source-spec", "list"])
         .assert()
         .success();
 
@@ -418,7 +418,7 @@ async fn source_spec_list_renders_empty_state() {
 
     let assert = server
         .cmd()
-        .args(["source", "spec", "list"])
+        .args(["source-spec", "list"])
         .assert()
         .success();
 
@@ -457,8 +457,7 @@ tables:
     let assert = server
         .cmd()
         .args([
-            "source",
-            "spec",
+            "source-spec",
             "add",
             "--file",
             manifest_file.to_str().expect("manifest path utf8"),
@@ -481,7 +480,7 @@ async fn source_spec_remove_deletes_registered_spec() {
 
     let assert = server
         .cmd()
-        .args(["source", "spec", "remove", "linear"])
+        .args(["source-spec", "remove", "linear"])
         .assert()
         .success();
 

--- a/xtask/src/docs/render.rs
+++ b/xtask/src/docs/render.rs
@@ -462,7 +462,7 @@ const COMMUNITY_INTRO: &str = concat!(
     "<Note>\n",
     "  Community sources are not included in `coral source discover`. Import one directly\n",
     "  into the current workspace with `coral source add --file`, or register it globally\n",
-    "  with `coral source spec add --file` and then install it by name with `coral source add <name>`.\n",
+    "  with `coral source-spec add --file` and then install it by name with `coral source add <name>`.\n",
     "</Note>\n",
 );
 

--- a/xtask/src/docs/render.rs
+++ b/xtask/src/docs/render.rs
@@ -460,10 +460,9 @@ const COMMUNITY_INTRO: &str = concat!(
     "[sources/community](https://github.com/withcoral/coral/tree/main/sources/community).\n",
     "\n",
     "<Note>\n",
-    "  Community sources are not included in `coral source discover`, and `coral\n",
-    "  source add <name>` only installs [bundled sources](/reference/bundled-sources).\n",
-    "  Import community sources\n",
-    "  with `coral source add --file`.\n",
+    "  Community sources are not included in `coral source discover`. Import one directly\n",
+    "  into the current workspace with `coral source add --file`, or register it globally\n",
+    "  with `coral source spec add --file` and then install it by name with `coral source add <name>`.\n",
     "</Note>\n",
 );
 

--- a/xtask/src/docs/snapshots/xtask__docs__render__tests__community_sources_page_renders_catalog.snap
+++ b/xtask/src/docs/snapshots/xtask__docs__render__tests__community_sources_page_renders_catalog.snap
@@ -15,7 +15,7 @@ Community sources are source specs built and maintained by our community. These 
 <Note>
   Community sources are not included in `coral source discover`. Import one directly
   into the current workspace with `coral source add --file`, or register it globally
-  with `coral source spec add --file` and then install it by name with `coral source add <name>`.
+  with `coral source-spec add --file` and then install it by name with `coral source add <name>`.
 </Note>
 
 ## Install a community source

--- a/xtask/src/docs/snapshots/xtask__docs__render__tests__community_sources_page_renders_catalog.snap
+++ b/xtask/src/docs/snapshots/xtask__docs__render__tests__community_sources_page_renders_catalog.snap
@@ -13,10 +13,9 @@ Community sources are source specs built and maintained by our community. These 
 [sources/community](https://github.com/withcoral/coral/tree/main/sources/community).
 
 <Note>
-  Community sources are not included in `coral source discover`, and `coral
-  source add <name>` only installs [bundled sources](/reference/bundled-sources).
-  Import community sources
-  with `coral source add --file`.
+  Community sources are not included in `coral source discover`. Import one directly
+  into the current workspace with `coral source add --file`, or register it globally
+  with `coral source spec add --file` and then install it by name with `coral source add <name>`.
 </Note>
 
 ## Install a community source


### PR DESCRIPTION
## Intent

Add the user-facing source-spec registry CLI on top of the app state and RPC layers, so reusable source specs can be registered once and installed into workspaces by name without presenting source specs as child operations of installed sources.

## What it enables

- Adds top-level `coral source-spec list`, `coral source-spec add --file`, and `coral source-spec remove` commands.
- Keeps source-spec registry commands global instead of workspace-scoped.
- Teaches `coral source add NAME` to try bundled sources first, then fall back to the global source-spec registry.
- Supports OAuth-backed source-spec installs through the same CLI flow as bundled/imported sources.
- Moves non-interactive named-source environment input resolution into `coral-app`, keeping process environment reads out of the CLI install path.
- Updates CLI, configuration, and generated community-source docs so the public surface matches the implementation.

## Usage examples

```bash
coral source-spec add --file ./internal-crm.yaml
coral source-spec list
coral source add internal_crm --workspace my-workspace
coral source-spec remove internal_crm
```

If a registered spec is removed while a workspace source still references it, that workspace source remains listed. Explicit validation for that source fails until the spec is re-registered or the source is removed and re-added, while query loading skips the orphaned source and continues with the rest of the workspace.

## Validation

- `make rust-checks`
- `npm run check --prefix ui`
- `make lint-proto`
- `make docs-check`
- `make perf-check` (`coral.tables` mean 249.8 ms, threshold 750 ms)
- Latest focused checks: `cargo fmt --all --check`
- Latest focused checks: `cargo test -p coral-cli --all-features source_spec_command --lib`
- Latest focused checks: `cargo test -p coral-cli --features cli-test-server --test cli_e2e source_spec`
- Latest focused checks: `cargo test -p xtask community_sources_page_renders_catalog`
