### PR TITLE
feat(app): bootstrap durable database

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -155,6 +155,46 @@ jobs:
       - name: Run make rust-checks
         run: make rust-checks
 
+  postgres-repository-tests:
+    name: Postgres repository tests
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.rust_checks == 'true' }}
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: coral-postgres-${{ runner.os }}
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run Postgres repository tests
+        env:
+          CORAL_TEST_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/postgres
+        run: |
+          cargo test --locked -p coral-app \
+            state::db::repositories::workspaces::tests::workspace_repository_round_trips_against_postgres \
+            -- --ignored
+
   windows-rust-smoke:
     name: Windows Rust smoke
     runs-on: windows-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,9 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -1070,7 +1073,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1236,10 +1239,13 @@ dependencies = [
  "prost",
  "regex",
  "reqwest 0.13.4",
+ "sea-query",
+ "sea-query-sqlx",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "sqlx",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1459,12 +1465,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1556,12 +1586,35 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1579,11 +1632,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1964,7 +2028,7 @@ dependencies = [
  "hex",
  "itertools",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "num-traits",
  "rand 0.9.4",
@@ -2393,6 +2457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,6 +2479,9 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -2550,6 +2623,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +2732,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2828,6 +2923,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,6 +2962,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3461,6 +3580,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3531,6 +3661,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3746,7 +3886,7 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
@@ -4185,7 +4325,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -4369,7 +4509,7 @@ version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -4728,7 +4868,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -4937,6 +5077,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sea-query"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d190cfb3bcceb8a8d7d04dee5a0c77f60c7627979cdcb47fdcb8934f009badf"
+dependencies = [
+ "sea-query-derive",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b0f466921cdd3cf4b89d5c3ac2173dba89a873ab395b123a645de181ec7537"
+dependencies = [
+ "darling 0.20.11",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
+name = "sea-query-sqlx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eaa419cdb9157da1361186b1959983eb2ea0dcb9a3c69dc45c449ecb2af8fef"
+dependencies = [
+ "sea-query",
+ "sqlx",
+]
+
+[[package]]
 name = "secret-service"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4947,7 +5120,7 @@ dependencies = [
  "futures-util",
  "generic-array",
  "getrandom 0.2.17",
- "hkdf",
+ "hkdf 0.12.4",
  "num",
  "once_cell",
  "serde",
@@ -5091,6 +5264,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5209,6 +5393,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snap"
@@ -5224,6 +5411,15 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -5246,6 +5442,178 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
+dependencies = [
+ "base64",
+ "bytes",
+ "cfg-if",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
+dependencies = [
+ "cfg-if",
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.11.3",
+ "dotenvy",
+ "either",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sha1",
+ "sha2 0.11.0",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "itoa",
+ "log",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
+dependencies = [
+ "atoi",
+ "flume",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -5278,6 +5646,17 @@ dependencies = [
  "libc",
  "psm",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -5756,6 +6135,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5875,10 +6255,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5951,6 +6352,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -6116,6 +6523,21 @@ checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.9"
 schemars = "1.2.1"
+sea-query = { version = "1", default-features = false, features = ["backend-postgres", "backend-sqlite", "derive", "thread-safe"] }
+sea-query-sqlx = { version = "0.9", default-features = false, features = ["sqlx-postgres", "sqlx-sqlite"] }
 sha2 = "0.10"
+sqlx = { version = "0.9", default-features = false, features = ["macros", "migrate", "postgres", "runtime-tokio", "sqlite", "tls-rustls"] }
 sqlparser = "0.59.0"
 strsim = "0.11"
 thiserror = "2"

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -40,8 +40,15 @@ root.
 - Keep `state/`, `credentials/`, `workspaces/`, `sources/`, `query/`, and
   `catalog/` as the main internal boundaries. Do not create new sub-boundaries
   unless they own durable, independent behavior.
-- Persist imported manifests as files under app-owned state; do not inline
-  them into `config.toml`.
+- Keep RDBMS-backed durable app-state infrastructure under `state/db`. The
+  initial DB bootstrap may coexist with filesystem-backed source behavior, but
+  repository wiring must keep SQLx pools, transactions, SeaQuery schema
+  identifiers, and row structs inside that module.
+- DB repository behavior should have shared tests that run against SQLite
+  locally and Postgres in CI through the repository harness.
+- Until the RDBMS migration phases replace the relevant stores, persist
+  imported manifests as files under app-owned state; do not inline them into
+  `config.toml`.
 - Persist DSL v4 imported manifests as authored intent plus durability
   normalization only. Descriptor hashes, generated OpenAPI metadata, semantic
   IR, projections, and package fingerprints belong in materialized artifacts
@@ -49,8 +56,8 @@ root.
 - Treat DSL v4 materialization as a user-chosen lifecycle event: generate at
   source add, never re-fetch descriptors or recompute projections implicitly
   during query/list/validate, and fail with re-add guidance when artifacts are
-  missing or incompatible. Do not add migration machinery until the lifecycle is
-  explicitly designed.
+  missing or incompatible. RDBMS migration machinery must preserve that
+  explicit lifecycle instead of silently refreshing artifacts.
 - User-facing runtime feature semantics belong in `coral_app::features`; raw
   config-file persistence, locking, and TOML extraction stay in `state/`.
 - Bundled installs persist source identity plus configured variables and

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -26,7 +26,10 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+sea-query.workspace = true
+sea-query-sqlx.workspace = true
 sha2.workspace = true
+sqlx.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { workspace = true, features = ["net"] }

--- a/crates/coral-app/build.rs
+++ b/crates/coral-app/build.rs
@@ -13,6 +13,10 @@ use std::path::{Path, PathBuf};
 
 fn main() {
     let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir"));
+    println!(
+        "cargo:rerun-if-changed={}",
+        manifest_dir.join("migrations").display()
+    );
     let bundled_root = manifest_dir.join("../../sources/core");
     println!("cargo:rerun-if-changed={}", bundled_root.display());
 

--- a/crates/coral-app/migrations/0001_db_bootstrap.sql
+++ b/crates/coral-app/migrations/0001_db_bootstrap.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS workspaces (
+    id TEXT PRIMARY KEY,
+    created_at_unix_nanos BIGINT NOT NULL
+);

--- a/crates/coral-app/src/bootstrap/env.rs
+++ b/crates/coral-app/src/bootstrap/env.rs
@@ -39,6 +39,10 @@ impl AppEnvironment {
             ..QueryRuntimeContext::default()
         }
     }
+
+    pub(crate) fn env_var(name: &str) -> Option<String> {
+        env_var(name)
+    }
 }
 
 #[expect(
@@ -47,6 +51,14 @@ impl AppEnvironment {
 )]
 fn coral_config_dir_override() -> Option<PathBuf> {
     std::env::var_os(CORAL_CONFIG_DIR).map(PathBuf::from)
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "coral-app is the single owner of process environment access."
+)]
+fn env_var(name: &str) -> Option<String> {
+    std::env::var(name).ok()
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -9,6 +9,7 @@ use tonic::{Code, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::credentials::CredentialsError;
+use crate::state::db::DbError;
 
 /// Errors surfaced by the local application layer.
 #[derive(Debug, thiserror::Error)]
@@ -65,9 +66,30 @@ pub enum AppError {
     /// Credential material access failed.
     #[error(transparent)]
     Credentials(#[from] CredentialsError),
+    /// Durable app-state database access failed.
+    #[error("database error: {0}")]
+    Database(String),
     /// The Coral config directory could not be discovered from defaults.
     #[error("failed to determine Coral config directory")]
     MissingConfigDir,
+}
+
+impl From<DbError> for AppError {
+    fn from(error: DbError) -> Self {
+        match error {
+            DbError::Config(detail) => {
+                Self::FailedPrecondition(format!("database configuration is invalid: {detail}"))
+            }
+            DbError::MissingDatabaseParent(path) => Self::FailedPrecondition(format!(
+                "database file parent directory is missing for {}",
+                path.display()
+            )),
+            DbError::Io(error) => Self::Io(error),
+            DbError::TomlDecode(error) => Self::TomlDecode(error),
+            DbError::Sqlx(error) => Self::Database(error.to_string()),
+            DbError::Migration(error) => Self::Database(error.to_string()),
+        }
+    }
 }
 
 /// Upper bound on the byte length of a `tonic::Status` message (detail).
@@ -213,7 +235,8 @@ fn app_code(error: &AppError) -> Code {
         | AppError::Json(_)
         | AppError::Transport(_)
         | AppError::TaskJoin(_)
-        | AppError::Credentials(_) => Code::Internal,
+        | AppError::Credentials(_)
+        | AppError::Database(_) => Code::Internal,
     }
 }
 

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -23,6 +23,11 @@ pub(crate) fn discover_app_state_layout(
     env::AppEnvironment::discover().app_state_layout(config_dir_override)
 }
 
+#[cfg(test)]
+pub(crate) fn env_var(name: &str) -> Option<String> {
+    env::AppEnvironment::env_var(name)
+}
+
 /// Loads installed source names for the default workspace from local config only.
 ///
 /// This is intentionally narrower than starting the local server and calling

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -53,6 +53,7 @@ use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
+use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
@@ -250,6 +251,20 @@ impl ServerBuilder {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir)?;
         layout.ensure()?;
+        let database_config = DatabaseConfig::load(&layout)?;
+        let database_config = match database_config {
+            DatabaseConfig::Sqlite { path } => ResolvedDatabaseConfig::Sqlite { path },
+            DatabaseConfig::Postgres { url_env } => {
+                let url = AppEnvironment::env_var(&url_env).ok_or_else(|| {
+                    AppError::FailedPrecondition(format!(
+                        "database backend 'postgres' requires environment variable `{url_env}`"
+                    ))
+                })?;
+                ResolvedDatabaseConfig::Postgres { url }
+            }
+        };
+        let coral_db = CoralDb::open(database_config).await?;
+        coral_db.migrate().await?;
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
             .trace_history

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -564,6 +564,7 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::Transport(_) => "TRANSPORT",
         AppError::TaskJoin(_) => "TASK_JOIN",
         AppError::Credentials(_) => "CREDENTIALS",
+        AppError::Database(_) => "DATABASE",
         AppError::MissingConfigDir => "MISSING_CONFIG_DIR",
     }
 }

--- a/crates/coral-app/src/state/db/backend.rs
+++ b/crates/coral-app/src/state/db/backend.rs
@@ -1,0 +1,17 @@
+use sqlx::{PgPool, SqlitePool};
+
+#[derive(Debug)]
+pub(super) enum CoralDbBackend {
+    Sqlite(SqliteCoralDb),
+    Postgres(PostgresCoralDb),
+}
+
+#[derive(Debug)]
+pub(super) struct SqliteCoralDb {
+    pub(super) pool: SqlitePool,
+}
+
+#[derive(Debug)]
+pub(super) struct PostgresCoralDb {
+    pub(super) pool: PgPool,
+}

--- a/crates/coral-app/src/state/db/config.rs
+++ b/crates/coral-app/src/state/db/config.rs
@@ -1,0 +1,153 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use super::DbError;
+use crate::state::AppStateLayout;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DatabaseConfig {
+    Sqlite { path: PathBuf },
+    Postgres { url_env: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ResolvedDatabaseConfig {
+    Sqlite { path: PathBuf },
+    Postgres { url: String },
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedConfig {
+    #[serde(default)]
+    database: Option<PersistedDatabaseConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedDatabaseConfig {
+    #[serde(default)]
+    backend: Option<PersistedDatabaseBackend>,
+    #[serde(default)]
+    path: Option<PathBuf>,
+    #[serde(default)]
+    url_env: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum PersistedDatabaseBackend {
+    Sqlite,
+    Postgres,
+}
+
+impl DatabaseConfig {
+    pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, DbError> {
+        if !layout.config_file().exists() {
+            return Ok(Self::default_sqlite(layout));
+        }
+
+        let raw = std::fs::read_to_string(layout.config_file())?;
+        let persisted: PersistedConfig = toml::from_str(&raw)?;
+        let Some(database) = persisted.database else {
+            return Ok(Self::default_sqlite(layout));
+        };
+
+        match database.backend.unwrap_or(PersistedDatabaseBackend::Sqlite) {
+            PersistedDatabaseBackend::Sqlite => {
+                let path = database.path.map_or_else(
+                    || layout.database_file(),
+                    |path| resolve_sqlite_path(layout, path),
+                );
+                Ok(Self::Sqlite { path })
+            }
+            PersistedDatabaseBackend::Postgres => {
+                let url_env = database.url_env.ok_or_else(|| {
+                    DbError::Config(
+                        "database backend 'postgres' requires [database].url_env".to_string(),
+                    )
+                })?;
+                Ok(Self::Postgres { url_env })
+            }
+        }
+    }
+
+    fn default_sqlite(layout: &AppStateLayout) -> Self {
+        Self::Sqlite {
+            path: layout.database_file(),
+        }
+    }
+}
+
+fn resolve_sqlite_path(layout: &AppStateLayout, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        return path;
+    }
+    layout.config_dir().join(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::DatabaseConfig;
+    use crate::state::AppStateLayout;
+
+    #[test]
+    fn defaults_to_sqlite_under_app_state() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+
+        let config = DatabaseConfig::load(&layout).expect("db config");
+
+        assert_eq!(
+            config,
+            DatabaseConfig::Sqlite {
+                path: layout.database_file()
+            }
+        );
+    }
+
+    #[test]
+    fn resolves_relative_sqlite_path_under_app_state() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        fs::create_dir_all(layout.config_dir()).expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[database]\nbackend = \"sqlite\"\npath = \"state/custom.db\"\n",
+        )
+        .expect("config");
+
+        let config = DatabaseConfig::load(&layout).expect("db config");
+
+        assert_eq!(
+            config,
+            DatabaseConfig::Sqlite {
+                path: layout.config_dir().join("state/custom.db")
+            }
+        );
+    }
+
+    #[test]
+    fn loads_postgres_url_env_name() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        fs::create_dir_all(layout.config_dir()).expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_DATABASE_URL\"\n",
+        )
+        .expect("config");
+
+        let config = DatabaseConfig::load(&layout).expect("db config");
+
+        assert_eq!(
+            config,
+            DatabaseConfig::Postgres {
+                url_env: "CORAL_DATABASE_URL".to_string()
+            }
+        );
+    }
+}

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -1,0 +1,59 @@
+use std::path::Path;
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+use super::backend::{CoralDbBackend, PostgresCoralDb, SqliteCoralDb};
+use super::{CoralTx, DbError, ResolvedDatabaseConfig};
+
+#[derive(Debug)]
+pub(crate) struct CoralDb {
+    pub(super) backend: CoralDbBackend,
+}
+
+impl CoralDb {
+    pub(crate) async fn open(config: ResolvedDatabaseConfig) -> Result<Self, DbError> {
+        match config {
+            ResolvedDatabaseConfig::Sqlite { path } => open_sqlite(&path).await,
+            ResolvedDatabaseConfig::Postgres { url } => open_postgres(&url).await,
+        }
+    }
+
+    pub(crate) async fn begin(&self) -> Result<CoralTx<'_>, DbError> {
+        CoralTx::begin(&self.backend).await
+    }
+
+    pub(crate) async fn ping(&self) -> Result<(), DbError> {
+        match &self.backend {
+            CoralDbBackend::Sqlite(db) => {
+                sqlx::query("SELECT 1").execute(&db.pool).await?;
+            }
+            CoralDbBackend::Postgres(db) => {
+                sqlx::query("SELECT 1").execute(&db.pool).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn open_sqlite(path: &Path) -> Result<CoralDb, DbError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| DbError::MissingDatabaseParent(path.to_path_buf()))?;
+    std::fs::create_dir_all(parent)?;
+
+    let options = SqliteConnectOptions::new()
+        .filename(path)
+        .create_if_missing(true);
+    let pool = SqlitePoolOptions::new().connect_with(options).await?;
+    Ok(CoralDb {
+        backend: CoralDbBackend::Sqlite(SqliteCoralDb { pool }),
+    })
+}
+
+async fn open_postgres(url: &str) -> Result<CoralDb, DbError> {
+    let pool = PgPoolOptions::new().connect(url).await?;
+    Ok(CoralDb {
+        backend: CoralDbBackend::Postgres(PostgresCoralDb { pool }),
+    })
+}

--- a/crates/coral-app/src/state/db/error.rs
+++ b/crates/coral-app/src/state/db/error.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DbError {
+    #[error("database configuration is invalid: {0}")]
+    Config(String),
+    #[error("database file parent directory is missing for {0}")]
+    MissingDatabaseParent(PathBuf),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    TomlDecode(#[from] toml::de::Error),
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error(transparent)]
+    Migration(#[from] sqlx::migrate::MigrateError),
+}

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -1,0 +1,16 @@
+use super::backend::CoralDbBackend;
+use super::{CoralDb, DbError};
+
+impl CoralDb {
+    pub(crate) async fn migrate(&self) -> Result<(), DbError> {
+        match &self.backend {
+            CoralDbBackend::Sqlite(db) => {
+                sqlx::migrate!("./migrations").run(&db.pool).await?;
+            }
+            CoralDbBackend::Postgres(db) => {
+                sqlx::migrate!("./migrations").run(&db.pool).await?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -1,0 +1,22 @@
+//! RDBMS-backed durable app-state infrastructure.
+
+#![expect(
+    dead_code,
+    reason = "Phase 1 lands the DB boundary and repository harness before later PRs wire managers to these repositories."
+)]
+
+mod backend;
+mod config;
+mod coral_db;
+mod error;
+mod migrations;
+mod repositories;
+mod schema;
+mod session;
+mod transaction;
+
+pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
+pub(crate) use coral_db::CoralDb;
+pub(crate) use error::DbError;
+pub(crate) use session::DbSession;
+pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -1,0 +1,146 @@
+use sea_query::{Expr, ExprTrait, Query};
+
+use crate::state::db::schema::Workspaces;
+use crate::state::db::{DbError, DbSession};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceRecord {
+    pub(crate) id: String,
+    pub(crate) created_at_unix_nanos: i64,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct WorkspaceRow {
+    id: String,
+    created_at_unix_nanos: i64,
+}
+
+impl From<WorkspaceRow> for WorkspaceRecord {
+    fn from(value: WorkspaceRow) -> Self {
+        Self {
+            id: value.id,
+            created_at_unix_nanos: value.created_at_unix_nanos,
+        }
+    }
+}
+
+pub(crate) struct WorkspacesRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> WorkspacesRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn ensure(
+        &mut self,
+        id: &str,
+        created_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        if self.get(id).await?.is_some() {
+            return Ok(());
+        }
+
+        let statement = Query::insert()
+            .into_table(Workspaces::Table)
+            .columns([Workspaces::Id, Workspaces::CreatedAtUnixNanos])
+            .values_panic([Expr::val(id.to_string()), Expr::val(created_at_unix_nanos)])
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn get(&mut self, id: &str) -> Result<Option<WorkspaceRecord>, DbError> {
+        let statement = Query::select()
+            .columns([Workspaces::Id, Workspaces::CreatedAtUnixNanos])
+            .from(Workspaces::Table)
+            .and_where(Expr::col(Workspaces::Id).eq(id))
+            .to_owned();
+        let row: Option<WorkspaceRow> = self.session.fetch_optional(statement).await?;
+        Ok(row.map(Into::into))
+    }
+
+    pub(crate) async fn list(&mut self) -> Result<Vec<WorkspaceRecord>, DbError> {
+        let statement = Query::select()
+            .columns([Workspaces::Id, Workspaces::CreatedAtUnixNanos])
+            .from(Workspaces::Table)
+            .order_by(Workspaces::Id, sea_query::Order::Asc)
+            .to_owned();
+        let rows: Vec<WorkspaceRow> = self.session.fetch_all(statement).await?;
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::WorkspaceRecord;
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+
+    #[tokio::test]
+    async fn workspace_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_workspace_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn workspace_repository_round_trips_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_workspace_repository_round_trip(&db).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        assert_eq!(path, layout.database_file());
+        assert!(!path.exists());
+
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    async fn assert_workspace_repository_round_trip(db: &CoralDb) {
+        db.ping().await.expect("ping database");
+
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure("default", 42)
+            .await
+            .expect("ensure workspace");
+        tx.commit().await.expect("commit tx");
+
+        let mut session = db;
+        let workspaces = session.workspaces().list().await.expect("list workspaces");
+
+        assert_eq!(
+            workspaces,
+            vec![WorkspaceRecord {
+                id: "default".to_string(),
+                created_at_unix_nanos: 42,
+            }]
+        );
+    }
+}

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -1,0 +1,8 @@
+use sea_query::Iden;
+
+#[derive(Iden)]
+pub(in crate::state::db) enum Workspaces {
+    Table,
+    Id,
+    CreatedAtUnixNanos,
+}

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -1,0 +1,156 @@
+use sea_query::{InsertStatement, SelectStatement};
+use sea_query_sqlx::SqlxBinder;
+use sqlx::postgres::PgRow;
+use sqlx::sqlite::SqliteRow;
+use sqlx::{FromRow, Postgres, Sqlite};
+
+use super::backend::CoralDbBackend;
+use super::{CoralDb, CoralTx, DbError};
+use crate::state::db::repositories::workspaces::WorkspacesRepo;
+
+pub(crate) trait DbSession {
+    async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError>;
+
+    async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>;
+
+    async fn fetch_all<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>;
+}
+
+pub(crate) trait DbRepos: DbSession + Sized {
+    fn workspaces(&mut self) -> WorkspacesRepo<'_, Self> {
+        WorkspacesRepo::new(self)
+    }
+}
+
+impl<T> DbRepos for T where T: DbSession + Sized {}
+
+impl DbSession for &CoralDb {
+    async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
+        execute_statement(&self.backend, statement).await
+    }
+
+    async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        fetch_optional_statement(&self.backend, statement).await
+    }
+
+    async fn fetch_all<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        fetch_all_statement(&self.backend, statement).await
+    }
+}
+
+impl DbSession for CoralTx<'_> {
+    async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
+        self.execute(statement).await
+    }
+
+    async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        self.fetch_optional(statement).await
+    }
+
+    async fn fetch_all<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        self.fetch_all(statement).await
+    }
+}
+
+pub(super) async fn execute_statement(
+    backend: &CoralDbBackend,
+    statement: InsertStatement,
+) -> Result<(), DbError> {
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                .execute(&db.pool)
+                .await?;
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                .execute(&db.pool)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) async fn fetch_optional_statement<T>(
+    backend: &CoralDbBackend,
+    statement: SelectStatement,
+) -> Result<Option<T>, DbError>
+where
+    T: Send + Unpin,
+    for<'r> T: FromRow<'r, SqliteRow>,
+    for<'r> T: FromRow<'r, PgRow>,
+{
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_optional(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_optional(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+    }
+}
+
+pub(super) async fn fetch_all_statement<T>(
+    backend: &CoralDbBackend,
+    statement: SelectStatement,
+) -> Result<Vec<T>, DbError>
+where
+    T: Send + Unpin,
+    for<'r> T: FromRow<'r, SqliteRow>,
+    for<'r> T: FromRow<'r, PgRow>,
+{
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_all(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_all(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+    }
+}

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -1,0 +1,115 @@
+use sea_query::{InsertStatement, SelectStatement};
+use sea_query_sqlx::SqlxBinder;
+use sqlx::postgres::PgRow;
+use sqlx::sqlite::SqliteRow;
+use sqlx::{FromRow, Postgres, Sqlite};
+
+use super::DbError;
+use super::backend::CoralDbBackend;
+
+pub(crate) struct CoralTx<'a> {
+    backend: CoralTxBackend<'a>,
+}
+
+enum CoralTxBackend<'a> {
+    Sqlite(sqlx::Transaction<'a, Sqlite>),
+    Postgres(sqlx::Transaction<'a, Postgres>),
+}
+
+impl<'a> CoralTx<'a> {
+    pub(super) async fn begin(backend: &'a CoralDbBackend) -> Result<Self, DbError> {
+        let backend = match backend {
+            CoralDbBackend::Sqlite(db) => CoralTxBackend::Sqlite(db.pool.begin().await?),
+            CoralDbBackend::Postgres(db) => CoralTxBackend::Postgres(db.pool.begin().await?),
+        };
+        Ok(Self { backend })
+    }
+
+    pub(crate) async fn commit(self) -> Result<(), DbError> {
+        match self.backend {
+            CoralTxBackend::Sqlite(tx) => tx.commit().await?,
+            CoralTxBackend::Postgres(tx) => tx.commit().await?,
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn rollback(self) -> Result<(), DbError> {
+        match self.backend {
+            CoralTxBackend::Sqlite(tx) => tx.rollback().await?,
+            CoralTxBackend::Postgres(tx) => tx.rollback().await?,
+        }
+        Ok(())
+    }
+
+    pub(super) async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&mut **tx)
+                    .await?;
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&mut **tx)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) async fn fetch_optional<T>(
+        &mut self,
+        statement: SelectStatement,
+    ) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_optional(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_optional(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+        }
+    }
+
+    pub(super) async fn fetch_all<T>(
+        &mut self,
+        statement: SelectStatement,
+    ) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_all(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_all(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+        }
+    }
+}

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -58,6 +58,10 @@ impl AppStateLayout {
         &self.config_dir
     }
 
+    pub(crate) fn database_file(&self) -> PathBuf {
+        self.config_dir.join("coral.db")
+    }
+
     pub(crate) fn state_lock(&self) -> &Path {
         &self.state_lock
     }
@@ -209,6 +213,7 @@ mod tests {
         let source_name = SourceName::parse("github").expect("source");
 
         assert_eq!(layout.config_file(), config_dir.join("config.toml"));
+        assert_eq!(layout.database_file(), config_dir.join("coral.db"));
         assert_eq!(
             layout.manifest_file(&workspace_name, &source_name),
             config_dir

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -1,6 +1,7 @@
 //! App-home state layout and persisted config ownership.
 
 mod config;
+pub(crate) mod db;
 mod layout;
 
 pub(crate) use config::{AppConfig, ConfigStore};

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -8,6 +8,7 @@
 
 use coral_api::v1::ListSourcesRequest;
 use coral_client::{AppClient, default_workspace, local::ServerBuilder};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use tonic::Request;
 
@@ -22,6 +23,7 @@ async fn server_lifecycle_can_repeat_within_process() {
             .start()
             .await
             .expect("start server");
+        assert_default_sqlite_db_is_migrated(&config_dir).await;
         let app = AppClient::connect(server.endpoint_uri())
             .await
             .expect("connect client");
@@ -39,4 +41,25 @@ async fn server_lifecycle_can_repeat_within_process() {
 
         server.shutdown().await.expect("shutdown server");
     }
+}
+
+async fn assert_default_sqlite_db_is_migrated(config_dir: &std::path::Path) {
+    let database_file = config_dir.join("coral.db");
+    assert!(
+        database_file.exists(),
+        "default SQLite database should exist"
+    );
+
+    let options = SqliteConnectOptions::new().filename(&database_file);
+    let pool = SqlitePoolOptions::new()
+        .connect_with(options)
+        .await
+        .expect("open created SQLite database");
+    let table_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'workspaces'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("inspect migrated schema");
+    assert_eq!(table_count, 1, "workspaces table should be migrated");
 }


### PR DESCRIPTION
## Intent

Establish the RDBMS foundation from the unified RDBMS implementation plan without changing existing filesystem-backed source behavior yet. This creates the app-owned database abstraction, default SQLite bootstrap path, Postgres config shape, migration runner, and first repository harness.

## What it enables

- Local startup opens and migrates a default SQLite database at `coral.db` under the app state root.
- `[database]` config can select SQLite by path or Postgres by `url_env`.
- `coral-app::state::db` owns SQLx pools, transactions, SeaQuery query execution, migrations, and crate-private repository wiring.
- Shared workspace repository tests run against SQLite locally, with a Postgres CI job for the ignored Postgres harness.
- Later PRs can move source/catalog state into DB transactions without leaking backend-specific SQLx types outside `state/db`.

## Usage examples

Default local mode requires no config:

```toml
# config.toml may omit [database]
```

Explicit SQLite path:

```toml
[database]
backend = "sqlite"
path = "coral.db"
```

Postgres mode:

```toml
[database]
backend = "postgres"
url_env = "CORAL_DATABASE_URL"
```

## Validation

- `cargo check --locked -p coral-app --tests`
- `cargo test --locked -p coral-app state::db`
- `cargo test --locked -p coral-app --test grpc server_lifecycle_can_repeat_within_process`
- `cargo clippy --locked -p coral-app --all-targets --all-features -- -D warnings`
- `make rust-checks`
