### PR TITLE
feat(app): bootstrap durable database

### DIFF
--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -39,7 +39,9 @@ url_env = "CORAL_DATABASE_URL"
 export CORAL_DATABASE_URL="postgres://coral:secret@db.example.com:5432/coral?sslmode=verify-full"
 ```
 
-Remote Postgres URLs must set `sslmode=verify-full` so Coral verifies the server identity. Loopback and local-socket Postgres URLs may omit TLS for local development.
+<Note>
+  Remote Postgres URLs must set `sslmode=verify-full` so Coral verifies the server identity. Loopback and local-socket Postgres URLs may omit TLS for local development.
+</Note>
 
 ## Workspaces
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -15,6 +15,32 @@ This state includes installed-source metadata and non-secret source variables. S
   Prefer the `coral source` commands for source state instead of editing workspace entries manually.
 </Note>
 
+## Database
+
+Coral stores durable app state in a local SQLite database named `coral.db` inside the local state directory by default. You do not need a `[database]` section for the default setup.
+
+Use `[database]` to choose an explicit backend. Relative SQLite paths resolve from the local state directory.
+
+```toml
+[database]
+backend = "sqlite"
+path = "state/coral.db"
+```
+
+For Postgres, store the connection URL in an environment variable and reference the variable name from `config.toml`.
+
+```toml
+[database]
+backend = "postgres"
+url_env = "CORAL_DATABASE_URL"
+```
+
+```shellscript
+export CORAL_DATABASE_URL="postgres://coral:secret@db.example.com:5432/coral?sslmode=verify-full"
+```
+
+Remote Postgres URLs must set `sslmode=verify-full` so Coral verifies the server identity. Loopback and local-socket Postgres URLs may omit TLS for local development.
+
 ## Workspaces
 
 Workspace metadata is stored under `[workspaces]`. The `default` workspace

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -40,8 +40,15 @@ root.
 - Keep `state/`, `credentials/`, `workspaces/`, `sources/`, `query/`, and
   `catalog/` as the main internal boundaries. Do not create new sub-boundaries
   unless they own durable, independent behavior.
-- Persist imported manifests as files under app-owned state; do not inline
-  them into `config.toml`.
+- Keep RDBMS-backed durable app-state infrastructure under `state/db`. The
+  initial DB bootstrap may coexist with filesystem-backed source behavior, but
+  repository wiring must keep SQLx pools, transactions, SeaQuery schema
+  identifiers, and row structs inside that module.
+- DB repository behavior should have shared tests that run against SQLite
+  locally and Postgres in CI through the repository harness.
+- Until the RDBMS migration phases replace the relevant stores, persist
+  imported manifests as files under app-owned state; do not inline them into
+  `config.toml`.
 - Persist DSL v4 imported manifests as authored intent plus durability
   normalization only. Descriptor hashes, generated OpenAPI metadata, semantic
   IR, projections, and package fingerprints belong in materialized artifacts
@@ -49,8 +56,8 @@ root.
 - Treat DSL v4 materialization as a user-chosen lifecycle event: generate at
   source add, never re-fetch descriptors or recompute projections implicitly
   during query/list/validate, and fail with re-add guidance when artifacts are
-  missing or incompatible. Do not add migration machinery until the lifecycle is
-  explicitly designed.
+  missing or incompatible. RDBMS migration machinery must preserve that
+  explicit lifecycle instead of silently refreshing artifacts.
 - User-facing runtime feature semantics belong in `coral_app::features`; raw
   config-file persistence, locking, and TOML extraction stay in `state/`.
 - Bundled installs persist source identity plus configured variables and

--- a/crates/coral-app/build.rs
+++ b/crates/coral-app/build.rs
@@ -13,6 +13,10 @@ use std::path::{Path, PathBuf};
 
 fn main() {
     let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir"));
+    println!(
+        "cargo:rerun-if-changed={}",
+        manifest_dir.join("migrations").display()
+    );
     let bundled_root = manifest_dir.join("../../sources/core");
     println!("cargo:rerun-if-changed={}", bundled_root.display());
 

--- a/crates/coral-app/migrations/0001_db_bootstrap.sql
+++ b/crates/coral-app/migrations/0001_db_bootstrap.sql
@@ -1,4 +1,4 @@
 CREATE TABLE IF NOT EXISTS workspaces (
-    id TEXT PRIMARY KEY,
+    id TEXT NOT NULL PRIMARY KEY,
     created_at_unix_nanos BIGINT NOT NULL
 );

--- a/crates/coral-app/migrations/0001_db_bootstrap.sql
+++ b/crates/coral-app/migrations/0001_db_bootstrap.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS workspaces (
+    id TEXT PRIMARY KEY,
+    created_at_unix_nanos BIGINT NOT NULL
+);

--- a/crates/coral-app/src/bootstrap/env.rs
+++ b/crates/coral-app/src/bootstrap/env.rs
@@ -1,5 +1,6 @@
 //! App-owned environment accessors for local runtime setup.
 
+use std::env::VarError;
 use std::path::PathBuf;
 
 use coral_engine::QueryRuntimeContext;
@@ -40,7 +41,7 @@ impl AppEnvironment {
         }
     }
 
-    pub(crate) fn env_var(name: &str) -> Option<String> {
+    pub(crate) fn env_var(name: &str) -> Result<Option<String>, VarError> {
         env_var(name)
     }
 }
@@ -57,8 +58,12 @@ fn coral_config_dir_override() -> Option<PathBuf> {
     clippy::disallowed_methods,
     reason = "coral-app is the single owner of process environment access."
 )]
-fn env_var(name: &str) -> Option<String> {
-    std::env::var(name).ok()
+fn env_var(name: &str) -> Result<Option<String>, VarError> {
+    match std::env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(VarError::NotPresent) => Ok(None),
+        Err(error @ VarError::NotUnicode(_)) => Err(error),
+    }
 }
 
 #[cfg(test)]
@@ -97,6 +102,37 @@ mod tests {
             .arg(
                 "bootstrap::env::tests::coral_config_dir_override_reads_env_once_through_app_accessor",
             )
+            .arg("--nocapture")
+            .status()
+            .expect("run subprocess");
+        assert!(status.success(), "subprocess should pass");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "This test intentionally controls process environment values to validate the app-owned accessor."
+    )]
+    fn env_var_preserves_non_utf8_errors() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt as _;
+
+        const RUN_FLAG: &str = "CORAL_RUN_NON_UTF8_ENV_TEST";
+        const VALUE_ENV: &str = "CORAL_NON_UTF8_ENV_TEST";
+
+        if std::env::var_os(RUN_FLAG).is_some() {
+            let error = AppEnvironment::env_var(VALUE_ENV)
+                .expect_err("non-UTF8 env var should be reported");
+            assert!(matches!(error, std::env::VarError::NotUnicode(_)));
+            return;
+        }
+
+        let status = std::process::Command::new(std::env::current_exe().expect("current exe"))
+            .env(RUN_FLAG, "1")
+            .env(VALUE_ENV, OsString::from_vec(vec![0xFF]))
+            .arg("--exact")
+            .arg("bootstrap::env::tests::env_var_preserves_non_utf8_errors")
             .arg("--nocapture")
             .status()
             .expect("run subprocess");

--- a/crates/coral-app/src/bootstrap/env.rs
+++ b/crates/coral-app/src/bootstrap/env.rs
@@ -39,6 +39,10 @@ impl AppEnvironment {
             ..QueryRuntimeContext::default()
         }
     }
+
+    pub(crate) fn env_var(name: &str) -> Option<String> {
+        env_var(name)
+    }
 }
 
 #[expect(
@@ -47,6 +51,14 @@ impl AppEnvironment {
 )]
 fn coral_config_dir_override() -> Option<PathBuf> {
     std::env::var_os(CORAL_CONFIG_DIR).map(PathBuf::from)
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "coral-app is the single owner of process environment access."
+)]
+fn env_var(name: &str) -> Option<String> {
+    std::env::var(name).ok()
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -10,6 +10,7 @@ use tonic::{Code, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::credentials::CredentialsError;
+use crate::state::db::DbError;
 
 /// Errors surfaced by the local application layer.
 #[derive(Debug, thiserror::Error)]
@@ -84,9 +85,30 @@ pub enum AppError {
     /// Credential material access failed.
     #[error(transparent)]
     Credentials(#[from] CredentialsError),
+    /// Durable app-state database access failed.
+    #[error("database error: {0}")]
+    Database(String),
     /// The Coral config directory could not be discovered from defaults.
     #[error("failed to determine Coral config directory")]
     MissingConfigDir,
+}
+
+impl From<DbError> for AppError {
+    fn from(error: DbError) -> Self {
+        match error {
+            DbError::Config(detail) => {
+                Self::FailedPrecondition(format!("database configuration is invalid: {detail}"))
+            }
+            DbError::MissingDatabaseParent(path) => Self::FailedPrecondition(format!(
+                "database file parent directory is missing for {}",
+                path.display()
+            )),
+            DbError::Io(error) => Self::Io(error),
+            DbError::TomlDecode(error) => Self::TomlDecode(error),
+            DbError::Sqlx(error) => Self::Database(error.to_string()),
+            DbError::Migration(error) => Self::Database(error.to_string()),
+        }
+    }
 }
 
 /// Upper bound on the byte length of a `tonic::Status` message (detail).
@@ -234,7 +256,8 @@ fn app_code(error: &AppError) -> Code {
         | AppError::Json(_)
         | AppError::Transport(_)
         | AppError::TaskJoin(_)
-        | AppError::Credentials(_) => Code::Internal,
+        | AppError::Credentials(_)
+        | AppError::Database(_) => Code::Internal,
     }
 }
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -258,11 +258,17 @@ impl ServerBuilder {
         let database_config = match database_config {
             DatabaseConfig::Sqlite { path } => ResolvedDatabaseConfig::Sqlite { path },
             DatabaseConfig::Postgres { url_env } => {
-                let url = AppEnvironment::env_var(&url_env).ok_or_else(|| {
-                    AppError::FailedPrecondition(format!(
-                        "database backend 'postgres' requires environment variable `{url_env}`"
-                    ))
-                })?;
+                let url = AppEnvironment::env_var(&url_env)
+                    .map_err(|_error| {
+                        AppError::FailedPrecondition(format!(
+                            "database backend 'postgres' requires environment variable `{url_env}` to contain valid UTF-8"
+                        ))
+                    })?
+                    .ok_or_else(|| {
+                        AppError::FailedPrecondition(format!(
+                            "database backend 'postgres' requires environment variable `{url_env}`"
+                        ))
+                    })?;
                 ResolvedDatabaseConfig::Postgres { url }
             }
         };

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -55,6 +55,7 @@ use crate::search::service::SearchService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
+use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
@@ -253,6 +254,20 @@ impl ServerBuilder {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir)?;
         layout.ensure()?;
+        let database_config = DatabaseConfig::load(&layout)?;
+        let database_config = match database_config {
+            DatabaseConfig::Sqlite { path } => ResolvedDatabaseConfig::Sqlite { path },
+            DatabaseConfig::Postgres { url_env } => {
+                let url = AppEnvironment::env_var(&url_env).ok_or_else(|| {
+                    AppError::FailedPrecondition(format!(
+                        "database backend 'postgres' requires environment variable `{url_env}`"
+                    ))
+                })?;
+                ResolvedDatabaseConfig::Postgres { url }
+            }
+        };
+        let coral_db = CoralDb::open(database_config).await?;
+        coral_db.migrate().await?;
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
             .trace_history

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -706,6 +706,7 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::Transport(_) => "TRANSPORT",
         AppError::TaskJoin(_) => "TASK_JOIN",
         AppError::Credentials(_) => "CREDENTIALS",
+        AppError::Database(_) => "DATABASE",
         AppError::MissingConfigDir => "MISSING_CONFIG_DIR",
     }
 }

--- a/crates/coral-app/src/state/db/backend.rs
+++ b/crates/coral-app/src/state/db/backend.rs
@@ -1,0 +1,17 @@
+use sqlx::{PgPool, SqlitePool};
+
+#[derive(Debug)]
+pub(super) enum CoralDbBackend {
+    Sqlite(SqliteCoralDb),
+    Postgres(PostgresCoralDb),
+}
+
+#[derive(Debug)]
+pub(super) struct SqliteCoralDb {
+    pub(super) pool: SqlitePool,
+}
+
+#[derive(Debug)]
+pub(super) struct PostgresCoralDb {
+    pub(super) pool: PgPool,
+}

--- a/crates/coral-app/src/state/db/config.rs
+++ b/crates/coral-app/src/state/db/config.rs
@@ -1,0 +1,153 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use super::DbError;
+use crate::state::AppStateLayout;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DatabaseConfig {
+    Sqlite { path: PathBuf },
+    Postgres { url_env: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ResolvedDatabaseConfig {
+    Sqlite { path: PathBuf },
+    Postgres { url: String },
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedConfig {
+    #[serde(default)]
+    database: Option<PersistedDatabaseConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedDatabaseConfig {
+    #[serde(default)]
+    backend: Option<PersistedDatabaseBackend>,
+    #[serde(default)]
+    path: Option<PathBuf>,
+    #[serde(default)]
+    url_env: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum PersistedDatabaseBackend {
+    Sqlite,
+    Postgres,
+}
+
+impl DatabaseConfig {
+    pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, DbError> {
+        if !layout.config_file().exists() {
+            return Ok(Self::default_sqlite(layout));
+        }
+
+        let raw = std::fs::read_to_string(layout.config_file())?;
+        let persisted: PersistedConfig = toml::from_str(&raw)?;
+        let Some(database) = persisted.database else {
+            return Ok(Self::default_sqlite(layout));
+        };
+
+        match database.backend.unwrap_or(PersistedDatabaseBackend::Sqlite) {
+            PersistedDatabaseBackend::Sqlite => {
+                let path = database.path.map_or_else(
+                    || layout.database_file(),
+                    |path| resolve_sqlite_path(layout, path),
+                );
+                Ok(Self::Sqlite { path })
+            }
+            PersistedDatabaseBackend::Postgres => {
+                let url_env = database.url_env.ok_or_else(|| {
+                    DbError::Config(
+                        "database backend 'postgres' requires [database].url_env".to_string(),
+                    )
+                })?;
+                Ok(Self::Postgres { url_env })
+            }
+        }
+    }
+
+    fn default_sqlite(layout: &AppStateLayout) -> Self {
+        Self::Sqlite {
+            path: layout.database_file(),
+        }
+    }
+}
+
+fn resolve_sqlite_path(layout: &AppStateLayout, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        return path;
+    }
+    layout.config_dir().join(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::DatabaseConfig;
+    use crate::state::AppStateLayout;
+
+    #[test]
+    fn defaults_to_sqlite_under_app_state() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+
+        let config = DatabaseConfig::load(&layout).expect("db config");
+
+        assert_eq!(
+            config,
+            DatabaseConfig::Sqlite {
+                path: layout.database_file()
+            }
+        );
+    }
+
+    #[test]
+    fn resolves_relative_sqlite_path_under_app_state() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        fs::create_dir_all(layout.config_dir()).expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[database]\nbackend = \"sqlite\"\npath = \"state/custom.db\"\n",
+        )
+        .expect("config");
+
+        let config = DatabaseConfig::load(&layout).expect("db config");
+
+        assert_eq!(
+            config,
+            DatabaseConfig::Sqlite {
+                path: layout.config_dir().join("state/custom.db")
+            }
+        );
+    }
+
+    #[test]
+    fn loads_postgres_url_env_name() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        fs::create_dir_all(layout.config_dir()).expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_DATABASE_URL\"\n",
+        )
+        .expect("config");
+
+        let config = DatabaseConfig::load(&layout).expect("db config");
+
+        assert_eq!(
+            config,
+            DatabaseConfig::Postgres {
+                url_env: "CORAL_DATABASE_URL".to_string()
+            }
+        );
+    }
+}

--- a/crates/coral-app/src/state/db/config.rs
+++ b/crates/coral-app/src/state/db/config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -20,17 +21,19 @@ pub(crate) enum ResolvedDatabaseConfig {
 #[derive(Debug, Deserialize)]
 struct PersistedConfig {
     #[serde(default)]
-    database: Option<PersistedDatabaseConfig>,
+    database: Option<RawPersistedDatabaseConfig>,
 }
 
 #[derive(Debug, Deserialize)]
-struct PersistedDatabaseConfig {
+struct RawPersistedDatabaseConfig {
     #[serde(default)]
     backend: Option<PersistedDatabaseBackend>,
     #[serde(default)]
     path: Option<PathBuf>,
     #[serde(default)]
     url_env: Option<String>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, toml::Value>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]
@@ -40,9 +43,53 @@ enum PersistedDatabaseBackend {
     Postgres,
 }
 
+#[derive(Debug)]
+enum PersistedDatabaseConfig {
+    Sqlite { path: Option<PathBuf> },
+    Postgres { url_env: String },
+}
+
+impl RawPersistedDatabaseConfig {
+    fn into_config(self) -> Result<PersistedDatabaseConfig, DbError> {
+        if let Some(field) = self.extra.keys().next() {
+            return Err(DbError::Config(format!(
+                "unsupported [database].{field} configuration key"
+            )));
+        }
+
+        let backend = self.backend.ok_or_else(|| {
+            DbError::Config("[database].backend is required when [database] is present".to_string())
+        })?;
+
+        match backend {
+            PersistedDatabaseBackend::Sqlite => {
+                if self.url_env.is_some() {
+                    return Err(DbError::Config(
+                        "database backend 'sqlite' does not support [database].url_env".to_string(),
+                    ));
+                }
+                Ok(PersistedDatabaseConfig::Sqlite { path: self.path })
+            }
+            PersistedDatabaseBackend::Postgres => {
+                if self.path.is_some() {
+                    return Err(DbError::Config(
+                        "database backend 'postgres' does not support [database].path".to_string(),
+                    ));
+                }
+                let url_env = self.url_env.ok_or_else(|| {
+                    DbError::Config(
+                        "database backend 'postgres' requires [database].url_env".to_string(),
+                    )
+                })?;
+                Ok(PersistedDatabaseConfig::Postgres { url_env })
+            }
+        }
+    }
+}
+
 impl DatabaseConfig {
     pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, DbError> {
-        if !layout.config_file().exists() {
+        if !layout.config_file().try_exists()? {
             return Ok(Self::default_sqlite(layout));
         }
 
@@ -52,22 +99,15 @@ impl DatabaseConfig {
             return Ok(Self::default_sqlite(layout));
         };
 
-        match database.backend.unwrap_or(PersistedDatabaseBackend::Sqlite) {
-            PersistedDatabaseBackend::Sqlite => {
-                let path = database.path.map_or_else(
+        match database.into_config()? {
+            PersistedDatabaseConfig::Sqlite { path } => {
+                let path = path.map_or_else(
                     || layout.database_file(),
                     |path| resolve_sqlite_path(layout, path),
                 );
                 Ok(Self::Sqlite { path })
             }
-            PersistedDatabaseBackend::Postgres => {
-                let url_env = database.url_env.ok_or_else(|| {
-                    DbError::Config(
-                        "database backend 'postgres' requires [database].url_env".to_string(),
-                    )
-                })?;
-                Ok(Self::Postgres { url_env })
-            }
+            PersistedDatabaseConfig::Postgres { url_env } => Ok(Self::Postgres { url_env }),
         }
     }
 
@@ -91,7 +131,7 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use super::DatabaseConfig;
+    use super::{DatabaseConfig, DbError};
     use crate::state::AppStateLayout;
 
     #[test]
@@ -149,5 +189,79 @@ mod tests {
                 url_env: "CORAL_DATABASE_URL".to_string()
             }
         );
+    }
+
+    #[test]
+    fn database_section_requires_explicit_backend() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        fs::create_dir_all(layout.config_dir()).expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[database]\nurl_env = \"CORAL_DATABASE_URL\"\n",
+        )
+        .expect("config");
+
+        let error = DatabaseConfig::load(&layout).expect_err("db config should reject backend");
+
+        assert!(
+            matches!(error, DbError::Config(ref detail) if detail.contains("[database].backend is required")),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn database_backend_rejects_unsupported_fields() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        fs::create_dir_all(layout.config_dir()).expect("config dir");
+
+        for (raw_config, expected_error) in [
+            (
+                "[database]\nbackend = \"sqlite\"\nurl_env = \"CORAL_DATABASE_URL\"\n",
+                "database backend 'sqlite' does not support [database].url_env",
+            ),
+            (
+                "[database]\nbackend = \"postgres\"\npath = \"coral.db\"\nurl_env = \"CORAL_DATABASE_URL\"\n",
+                "database backend 'postgres' does not support [database].path",
+            ),
+            (
+                "[database]\nbackend = \"sqlite\"\nurl_environment = \"CORAL_DATABASE_URL\"\n",
+                "unsupported [database].url_environment configuration key",
+            ),
+        ] {
+            fs::write(layout.config_file(), raw_config).expect("config");
+
+            let error = DatabaseConfig::load(&layout).expect_err("db config should reject field");
+
+            assert!(
+                matches!(error, DbError::Config(ref detail) if detail.contains(expected_error)),
+                "unexpected error for config {raw_config:?}: {error}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_file_metadata_errors_are_reported() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = tempdir().expect("temp dir");
+        let config_dir = temp.path().join("coral");
+        fs::create_dir_all(&config_dir).expect("config dir");
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+        let original_mode = fs::metadata(&config_dir)
+            .expect("config dir metadata")
+            .permissions()
+            .mode();
+        fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o000))
+            .expect("hide config dir");
+
+        let result = DatabaseConfig::load(&layout);
+
+        fs::set_permissions(&config_dir, fs::Permissions::from_mode(original_mode))
+            .expect("restore config dir");
+        let error = result.expect_err("db config should report metadata failure");
+        assert!(matches!(error, DbError::Io(_)), "unexpected error: {error}");
     }
 }

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -6,6 +6,7 @@ use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
 use super::backend::{CoralDbBackend, PostgresCoralDb, SqliteCoralDb};
 use super::{DbError, ResolvedDatabaseConfig};
+use crate::storage::fs as storage_fs;
 
 #[derive(Debug)]
 pub(crate) struct CoralDb {
@@ -34,14 +35,13 @@ impl CoralDb {
 }
 
 async fn open_sqlite(path: &Path) -> Result<CoralDb, DbError> {
-    let parent = path
-        .parent()
+    path.parent()
         .ok_or_else(|| DbError::MissingDatabaseParent(path.to_path_buf()))?;
-    std::fs::create_dir_all(parent)?;
+    storage_fs::ensure_file_private(path)?;
 
     let options = SqliteConnectOptions::new()
         .filename(path)
-        .create_if_missing(true);
+        .create_if_missing(false);
     let pool = SqlitePoolOptions::new().connect_with(options).await?;
     Ok(CoralDb {
         backend: CoralDbBackend::Sqlite(SqliteCoralDb { pool }),
@@ -108,6 +108,30 @@ fn postgres_ssl_mode_authenticates_server(ssl_mode: PgSslMode) -> bool {
 #[cfg(test)]
 mod tests {
     use super::postgres_connect_options;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn sqlite_open_creates_and_tightens_private_database_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let database_file = temp.path().join("state").join("coral.db");
+        for mode in [None, Some(0o644)] {
+            if let Some(mode) = mode {
+                std::fs::set_permissions(&database_file, std::fs::Permissions::from_mode(mode))
+                    .expect("loosen database permissions");
+            }
+            super::open_sqlite(&database_file)
+                .await
+                .expect("open sqlite");
+            let actual_mode = std::fs::metadata(&database_file)
+                .expect("database metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(actual_mode, 0o600);
+        }
+    }
 
     #[test]
     fn postgres_options_reject_remote_tcp_without_required_tls() {

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -21,6 +21,10 @@ impl CoralDb {
         }
     }
 
+    #[expect(
+        dead_code,
+        reason = "Phase 1 keeps an explicit database health probe for the server diagnostics wired in a later stack PR."
+    )]
     pub(crate) async fn ping(&self) -> Result<(), DbError> {
         match &self.backend {
             CoralDbBackend::Sqlite(db) => {

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -1,0 +1,163 @@
+use std::path::Path;
+use std::str::FromStr;
+
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions, PgSslMode};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+use super::backend::{CoralDbBackend, PostgresCoralDb, SqliteCoralDb};
+use super::{DbError, ResolvedDatabaseConfig};
+
+#[derive(Debug)]
+pub(crate) struct CoralDb {
+    pub(super) backend: CoralDbBackend,
+}
+
+impl CoralDb {
+    pub(crate) async fn open(config: ResolvedDatabaseConfig) -> Result<Self, DbError> {
+        match config {
+            ResolvedDatabaseConfig::Sqlite { path } => open_sqlite(&path).await,
+            ResolvedDatabaseConfig::Postgres { url } => open_postgres(&url).await,
+        }
+    }
+
+    pub(crate) async fn ping(&self) -> Result<(), DbError> {
+        match &self.backend {
+            CoralDbBackend::Sqlite(db) => {
+                sqlx::query("SELECT 1").execute(&db.pool).await?;
+            }
+            CoralDbBackend::Postgres(db) => {
+                sqlx::query("SELECT 1").execute(&db.pool).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn open_sqlite(path: &Path) -> Result<CoralDb, DbError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| DbError::MissingDatabaseParent(path.to_path_buf()))?;
+    std::fs::create_dir_all(parent)?;
+
+    let options = SqliteConnectOptions::new()
+        .filename(path)
+        .create_if_missing(true);
+    let pool = SqlitePoolOptions::new().connect_with(options).await?;
+    Ok(CoralDb {
+        backend: CoralDbBackend::Sqlite(SqliteCoralDb { pool }),
+    })
+}
+
+async fn open_postgres(url: &str) -> Result<CoralDb, DbError> {
+    let options = postgres_connect_options(url)?;
+    let pool = PgPoolOptions::new().connect_with(options).await?;
+    Ok(CoralDb {
+        backend: CoralDbBackend::Postgres(PostgresCoralDb { pool }),
+    })
+}
+
+fn postgres_connect_options(url: &str) -> Result<PgConnectOptions, DbError> {
+    let parsed_url = url::Url::parse(url)
+        .map_err(|error| DbError::Config(format!("invalid Postgres database URL: {error}")))?;
+    let explicit_ssl_mode = postgres_url_ssl_mode(&parsed_url)?;
+    let options = PgConnectOptions::from_str(parsed_url.as_str())
+        .map_err(|error| DbError::Config(format!("invalid Postgres database URL: {error}")))?;
+
+    if postgres_requires_tls(&options)
+        && !explicit_ssl_mode.is_some_and(postgres_ssl_mode_authenticates_server)
+    {
+        return Err(DbError::Config(
+            "remote Postgres database URLs must set sslmode=verify-full".to_string(),
+        ));
+    }
+
+    Ok(options)
+}
+
+fn postgres_url_ssl_mode(url: &url::Url) -> Result<Option<PgSslMode>, DbError> {
+    let mut ssl_mode = None;
+    for (key, value) in url.query_pairs() {
+        if key == "sslmode" || key == "ssl-mode" {
+            ssl_mode = Some(value.parse().map_err(|error| {
+                DbError::Config(format!("invalid Postgres database URL sslmode: {error}"))
+            })?);
+        }
+    }
+    Ok(ssl_mode)
+}
+
+fn postgres_requires_tls(options: &PgConnectOptions) -> bool {
+    !postgres_uses_local_socket(options) && !postgres_host_is_loopback(options.get_host())
+}
+
+fn postgres_uses_local_socket(options: &PgConnectOptions) -> bool {
+    options.get_socket().is_some() || options.get_host().starts_with('/')
+}
+
+fn postgres_host_is_loopback(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|addr| addr.is_loopback())
+}
+
+fn postgres_ssl_mode_authenticates_server(ssl_mode: PgSslMode) -> bool {
+    matches!(ssl_mode, PgSslMode::VerifyFull)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::postgres_connect_options;
+
+    #[test]
+    fn postgres_options_reject_remote_tcp_without_required_tls() {
+        let error = postgres_connect_options("postgres://coral:secret@db.example.com:5432/coral")
+            .expect_err("remote TCP without sslmode must be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("remote Postgres database URLs must set sslmode=verify-full"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn postgres_options_reject_remote_tcp_with_encryption_without_server_identity() {
+        for sslmode in ["require", "verify-ca"] {
+            let error = postgres_connect_options(&format!(
+                "postgres://coral:secret@db.example.com:5432/coral?sslmode={sslmode}"
+            ))
+            .expect_err("remote TCP without hostname-authenticated TLS must be rejected");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("remote Postgres database URLs must set sslmode=verify-full"),
+                "unexpected error for sslmode={sslmode}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn postgres_options_allow_remote_tcp_with_hostname_authenticated_tls() {
+        postgres_connect_options(
+            "postgres://coral:secret@db.example.com:5432/coral?sslmode=verify-full",
+        )
+        .expect("remote TCP with sslmode=verify-full should be accepted");
+    }
+
+    #[test]
+    fn postgres_options_accept_ssl_mode_alias() {
+        postgres_connect_options(
+            "postgres://coral:secret@db.example.com:5432/coral?ssl-mode=verify-full",
+        )
+        .expect("remote TCP with ssl-mode=verify-full should be accepted");
+    }
+
+    #[test]
+    fn postgres_options_allow_loopback_without_tls() {
+        postgres_connect_options("postgres://coral:secret@127.0.0.1:5432/coral")
+            .expect("loopback Postgres is allowed without TLS for local development and CI");
+    }
+}

--- a/crates/coral-app/src/state/db/error.rs
+++ b/crates/coral-app/src/state/db/error.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DbError {
+    #[error("database configuration is invalid: {0}")]
+    Config(String),
+    #[error("database file parent directory is missing for {0}")]
+    MissingDatabaseParent(PathBuf),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    TomlDecode(#[from] toml::de::Error),
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error(transparent)]
+    Migration(#[from] sqlx::migrate::MigrateError),
+}

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -1,0 +1,107 @@
+use super::backend::CoralDbBackend;
+use super::{CoralDb, DbError};
+
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+impl CoralDb {
+    pub(crate) async fn migrate(&self) -> Result<(), DbError> {
+        match &self.backend {
+            CoralDbBackend::Sqlite(db) => {
+                if sqlite_migrations_are_current(&db.pool).await? {
+                    return Ok(());
+                }
+                MIGRATOR.run(&db.pool).await?;
+            }
+            CoralDbBackend::Postgres(db) => {
+                if postgres_migrations_are_current(&db.pool).await? {
+                    return Ok(());
+                }
+                MIGRATOR.run(&db.pool).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn sqlite_migrations_are_current(pool: &sqlx::SqlitePool) -> Result<bool, DbError> {
+    let table_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '_sqlx_migrations'",
+    )
+    .fetch_one(pool)
+    .await?;
+    if table_count.0 == 0 {
+        return Ok(false);
+    }
+    let rows: Vec<(i64, Vec<u8>, bool)> =
+        sqlx::query_as("SELECT version, checksum, success FROM _sqlx_migrations ORDER BY version")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows_match_current_migrations(&rows))
+}
+
+async fn postgres_migrations_are_current(pool: &sqlx::PgPool) -> Result<bool, DbError> {
+    let table_exists: (Option<String>,) =
+        sqlx::query_as("SELECT to_regclass('_sqlx_migrations')::text")
+            .fetch_one(pool)
+            .await?;
+    if table_exists.0.is_none() {
+        return Ok(false);
+    }
+    let rows: Vec<(i64, Vec<u8>, bool)> =
+        sqlx::query_as("SELECT version, checksum, success FROM _sqlx_migrations ORDER BY version")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows_match_current_migrations(&rows))
+}
+
+fn rows_match_current_migrations(rows: &[(i64, Vec<u8>, bool)]) -> bool {
+    let migrations = MIGRATOR.migrations.as_ref();
+    rows.len() == migrations.len()
+        && rows
+            .iter()
+            .zip(migrations)
+            .all(|((version, checksum, success), migration)| {
+                *success
+                    && *version == migration.version
+                    && checksum.as_slice() == migration.checksum.as_ref()
+            })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MIGRATOR, rows_match_current_migrations};
+
+    #[test]
+    fn current_migration_rows_must_match_versions_checksums_and_success() {
+        let current_rows: Vec<_> = MIGRATOR
+            .migrations
+            .iter()
+            .map(|migration| {
+                (
+                    migration.version,
+                    migration.checksum.as_ref().to_vec(),
+                    true,
+                )
+            })
+            .collect();
+        assert!(rows_match_current_migrations(&current_rows));
+
+        let mut missing_row = current_rows.clone();
+        missing_row.pop();
+        assert!(!rows_match_current_migrations(&missing_row));
+
+        let mut failed_row = current_rows.clone();
+        failed_row
+            .first_mut()
+            .expect("at least one embedded migration")
+            .2 = false;
+        assert!(!rows_match_current_migrations(&failed_row));
+
+        let mut bad_checksum = current_rows;
+        bad_checksum
+            .first_mut()
+            .expect("at least one embedded migration")
+            .1 = b"not the embedded checksum".to_vec();
+        assert!(!rows_match_current_migrations(&bad_checksum));
+    }
+}

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -104,4 +104,23 @@ mod tests {
             .1 = b"not the embedded checksum".to_vec();
         assert!(!rows_match_current_migrations(&bad_checksum));
     }
+
+    #[tokio::test]
+    async fn sqlite_workspace_id_rejects_null() {
+        let pool = sqlx::SqlitePool::connect(":memory:")
+            .await
+            .expect("sqlite pool");
+        MIGRATOR.run(&pool).await.expect("run migrations");
+
+        let error =
+            sqlx::query("INSERT INTO workspaces (id, created_at_unix_nanos) VALUES (NULL, 0)")
+                .execute(&pool)
+                .await
+                .expect_err("workspace id must reject null");
+
+        assert!(
+            error.to_string().contains("NOT NULL"),
+            "unexpected error: {error}"
+        );
+    }
 }

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -1,10 +1,5 @@
 //! RDBMS-backed durable app-state infrastructure.
 
-#![expect(
-    dead_code,
-    reason = "Phase 1 lands the DB boundary and repository harness before later PRs wire managers to these repositories."
-)]
-
 mod backend;
 mod config;
 mod coral_db;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -1,0 +1,16 @@
+//! RDBMS-backed durable app-state infrastructure.
+
+#![expect(
+    dead_code,
+    reason = "Phase 1 lands the DB boundary and repository harness before later PRs wire managers to these repositories."
+)]
+
+mod backend;
+mod config;
+mod coral_db;
+mod error;
+mod migrations;
+
+pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
+pub(crate) use coral_db::CoralDb;
+pub(crate) use error::DbError;

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -74,6 +74,10 @@ impl AppStateLayout {
         &self.config_dir
     }
 
+    pub(crate) fn database_file(&self) -> PathBuf {
+        self.config_dir.join("coral.db")
+    }
+
     pub(crate) fn state_lock(&self) -> &Path {
         &self.state_lock
     }
@@ -268,6 +272,7 @@ mod tests {
         let source_name = SourceName::parse("github").expect("source");
 
         assert_eq!(layout.config_file(), config_dir.join("config.toml"));
+        assert_eq!(layout.database_file(), config_dir.join("coral.db"));
         assert_eq!(
             layout.manifest_file(&workspace_name, &source_name),
             config_dir

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -1,6 +1,7 @@
 //! App-home state layout and persisted config ownership.
 
 mod config;
+pub(crate) mod db;
 mod layout;
 
 pub(crate) use config::{AppConfig, ConfigStore};

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -42,10 +42,20 @@ pub(crate) fn ensure_file_private(path: &Path) -> io::Result<()> {
     match open_create_new_file_private(path) {
         Ok(_) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            set_file_permissions_private(path)
+            ensure_existing_file_private(path)
         }
         Err(error) => Err(error),
     }
+}
+
+fn ensure_existing_file_private(path: &Path) -> io::Result<()> {
+    if !fs::metadata(path)?.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("path exists and is not a regular file: {}", path.display()),
+        ));
+    }
+    set_file_permissions_private(path)
 }
 
 /// Write to a temp file then rename to avoid partial writes on crash.
@@ -278,7 +288,22 @@ fn set_file_permissions_private(_path: &Path) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::DirectoryBackup;
+    use super::{DirectoryBackup, ensure_file_private};
+
+    #[test]
+    fn ensure_file_private_rejects_existing_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("coral.db");
+        std::fs::create_dir(&path).expect("create directory at file path");
+
+        let error = ensure_file_private(&path).expect_err("directory should be rejected");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert!(
+            error.to_string().contains("not a regular file"),
+            "unexpected error: {error}"
+        );
+    }
 
     #[test]
     fn directory_backup_moves_and_restores_delete_target() {

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -49,7 +49,7 @@ pub(crate) fn ensure_file_private(path: &Path) -> io::Result<()> {
 }
 
 fn ensure_existing_file_private(path: &Path) -> io::Result<()> {
-    if !fs::metadata(path)?.is_file() {
+    if !fs::symlink_metadata(path)?.file_type().is_file() {
         return Err(io::Error::new(
             io::ErrorKind::AlreadyExists,
             format!("path exists and is not a regular file: {}", path.display()),
@@ -303,6 +303,34 @@ mod tests {
             error.to_string().contains("not a regular file"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn ensure_file_private_rejects_symlink_without_chmoding_target() {
+        use std::os::unix::fs::{PermissionsExt as _, symlink};
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let target = temp.path().join("target.db");
+        let link = temp.path().join("coral.db");
+        std::fs::write(&target, "existing database").expect("write target");
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644))
+            .expect("set target permissions");
+        symlink(&target, &link).expect("create symlink");
+
+        let error = ensure_file_private(&link).expect_err("symlink should be rejected");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert!(
+            error.to_string().contains("not a regular file"),
+            "unexpected error: {error}"
+        );
+        let target_mode = std::fs::metadata(&target)
+            .expect("target metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(target_mode, 0o644);
     }
 
     #[test]

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -35,6 +35,19 @@ pub(crate) fn create_new_file_private(path: &Path) -> io::Result<File> {
     open_create_new_file_private(path)
 }
 
+pub(crate) fn ensure_file_private(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        ensure_private_dir(parent)?;
+    }
+    match open_create_new_file_private(path) {
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            set_file_permissions_private(path)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 /// Write to a temp file then rename to avoid partial writes on crash.
 pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
     let temp_path = temp_path_for(path);


### PR DESCRIPTION
## Intent

Bootstrap the durable database foundation described in the RDBMS plan while keeping source/catalog migration out of this PR.

## What it enables

- Default local SQLite database at the app state layout's `coral.db`.
- Optional `[database]` config for SQLite paths and Postgres URLs read from an environment variable.
- Startup database opening and migration before managers are initialized.
- App-level database errors surfaced through the existing bootstrap/query error paths.
- Remote TCP Postgres URLs must authenticate the server with `sslmode=verify-full` before a pool is opened.

## Usage examples

Default SQLite needs no config.

```toml
[database]
backend = "sqlite"
path = "coral.db"
```

```toml
[database]
backend = "postgres"
url_env = "CORAL_DATABASE_URL"
```

```bash
export CORAL_DATABASE_URL='postgres://user:pass@db.example.com/coral?sslmode=verify-full'
```

## Validation

- `cargo check --locked -p coral-app --tests`
- `cargo test --locked -p coral-app state::db::coral_db::tests -- --nocapture`
- `cargo test --locked -p coral-app --test grpc server_lifecycle_rejects_postgres_config_without_url_env_value -- --nocapture`
- `make rust-checks` at the stack tip
- `review-swarm` security lane finding fixed by requiring `sslmode=verify-full` for remote Postgres

Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.