### PR TITLE
test(app): add database repository harness

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       github_actions: ${{ steps.filter.outputs.github_actions }}
       rust_checks: ${{ steps.filter.outputs.rust_checks }}
+      postgres_database_tests: ${{ steps.filter.outputs.postgres_database_tests }}
       release_workflow: ${{ steps.filter.outputs.release_workflow }}
       install-script: ${{ steps.filter.outputs.install-script }}
       ui-build: ${{ steps.filter.outputs.ui-build }}
@@ -66,6 +67,11 @@ jobs:
               - 'rust-toolchain'
               - 'crates/**'
               - 'xtask/**'
+            postgres_database_tests:
+              - '.github/workflows/validate.yml'
+              - 'crates/coral-app/migrations/**'
+              - 'crates/coral-app/src/state/db/**'
+              - 'crates/coral-app/tests/postgres_database_tests.rs'
             release_workflow:
               - '.github/workflows/release.yml'
             install-script:
@@ -173,7 +179,7 @@ jobs:
     name: Postgres database tests
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.rust_checks == 'true' }}
+    if: ${{ needs.changes.outputs.postgres_database_tests == 'true' }}
     services:
       postgres:
         image: postgres:17
@@ -205,11 +211,11 @@ jobs:
         env:
           CORAL_TEST_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/postgres
         run: |
-          cargo test --locked -p coral-app \
+          cargo test --locked -p coral-app --lib \
             state::db::repositories::workspaces::tests::workspace_repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
-            --test grpc server_lifecycle_can_start_with_postgres_database_config \
+            --test postgres_database_tests \
             -- --ignored
 
   windows-rust-smoke:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -169,6 +169,49 @@ jobs:
       - name: Run make rust-checks
         run: make rust-checks
 
+  postgres-database-tests:
+    name: Postgres database tests
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.rust_checks == 'true' }}
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: coral-postgres-${{ runner.os }}
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run Postgres database tests
+        env:
+          CORAL_TEST_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/postgres
+        run: |
+          cargo test --locked -p coral-app \
+            state::db::repositories::workspaces::tests::workspace_repository_round_trips_against_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
+            --test grpc server_lifecycle_can_start_with_postgres_database_config \
+            -- --ignored
+
   windows-rust-smoke:
     name: Windows Rust smoke
     runs-on: windows-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,15 @@
 ## Rules
 
 - Run `make rust-checks` before submitting PRs that include changes to Rust code.
+- For Postgres-backed database changes, run `make postgres-tests`. This starts
+  a local Docker Postgres, sets `CORAL_TEST_POSTGRES_URL` for the ignored
+  Postgres tests, and runs the repository harness plus server startup coverage.
+  Docker chooses an available localhost port by default, and each test run uses
+  a fresh database inside the reusable container; use `make postgres-url` to
+  print the server URL or `LOCAL_POSTGRES_PORT=55432 make postgres-start` when
+  you need a stable port. Use `make postgres-start` when you only need the
+  server, `make postgres-stop` when finished, and `make postgres-clean` to
+  remove the reusable container.
 - Run `make schema-check` before submitting PRs that touch generated source
   manifest schemas or the Rust helpers that generate them. Use
   `make schema-generate` to refresh generated schema files. The Validate

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-.PHONY: install ui-build rust-checks perf-check license-check lint-proto lint-sources fix-sources docs-generate docs-check schema-generate schema-check
+.PHONY: install ui-build rust-checks perf-check
+.PHONY: postgres-start postgres-url postgres-stop postgres-clean postgres-tests
+.PHONY: license-check lint-proto lint-sources fix-sources
+.PHONY: docs-generate docs-check schema-generate schema-check
+
+LOCAL_POSTGRES_IMAGE ?= postgres:17
+LOCAL_POSTGRES_CONTAINER ?= coral-test-postgres
+LOCAL_POSTGRES_PORT ?=
 
 install: ui-build
 	cargo install --path crates/coral-cli --locked
@@ -17,6 +24,92 @@ rust-checks:
 perf-check:
 	cargo build --locked -p coral-cli --release
 	cargo run --locked -p xtask --release -- perf-check --coral-bin target/release/coral
+
+# ----------------------------------------------------------------------------
+# Local Postgres-backed tests
+# ----------------------------------------------------------------------------
+# Starts a Docker Postgres matching CI's major version and runs the ignored
+# Postgres coverage against it. By default Docker chooses an available localhost
+# port, and postgres-tests creates a fresh database inside the container for
+# each run. Set LOCAL_POSTGRES_PORT=55432 if you need a stable host port.
+#
+#   make postgres-start   # start/wait for local Docker Postgres
+#   make postgres-url     # print the local Postgres connection URL
+#   make postgres-tests   # start Docker Postgres, then run Postgres tests
+#   make postgres-stop    # stop the local Docker Postgres container
+#   make postgres-clean   # remove the local Docker Postgres container
+
+postgres-start:
+	@set -eu; \
+	if ! command -v docker >/dev/null 2>&1; then \
+	  echo "docker is required to start local Postgres"; \
+	  exit 1; \
+	fi; \
+	if docker container inspect "$(LOCAL_POSTGRES_CONTAINER)" >/dev/null 2>&1; then \
+	  docker start "$(LOCAL_POSTGRES_CONTAINER)" >/dev/null; \
+	else \
+	  local_postgres_port="$(LOCAL_POSTGRES_PORT)"; \
+	  if [ -n "$$local_postgres_port" ]; then \
+	    port_arg="-p 127.0.0.1:$$local_postgres_port:5432"; \
+	  else \
+	    port_arg="-p 127.0.0.1::5432"; \
+	  fi; \
+	  docker run -d \
+	    --name "$(LOCAL_POSTGRES_CONTAINER)" \
+	    -e POSTGRES_PASSWORD=postgres \
+	    $$port_arg \
+	    "$(LOCAL_POSTGRES_IMAGE)" >/dev/null; \
+	fi; \
+	for _ in $$(seq 1 60); do \
+	  if docker exec "$(LOCAL_POSTGRES_CONTAINER)" pg_isready -U postgres >/dev/null 2>&1; then \
+	    host_port=$$(docker port "$(LOCAL_POSTGRES_CONTAINER)" 5432/tcp | sed -n 's/.*:\([0-9][0-9]*\)$$/\1/p' | head -n 1); \
+	    if [ -z "$$host_port" ]; then \
+	      echo "Could not determine local Postgres host port"; \
+	      exit 1; \
+	    fi; \
+	    echo "Postgres is ready at postgres://postgres:postgres@127.0.0.1:$$host_port/postgres"; \
+	    exit 0; \
+	  fi; \
+	  sleep 1; \
+	done; \
+	docker logs "$(LOCAL_POSTGRES_CONTAINER)" || true; \
+	echo "Postgres did not become ready"; \
+	exit 1
+
+postgres-url:
+	@set -eu; \
+	host_port=$$(docker port "$(LOCAL_POSTGRES_CONTAINER)" 5432/tcp | sed -n 's/.*:\([0-9][0-9]*\)$$/\1/p' | head -n 1); \
+	if [ -z "$$host_port" ]; then \
+	  echo "Local Postgres is not exposing 5432/tcp. Run make postgres-start first."; \
+	  exit 1; \
+	fi; \
+	echo "postgres://postgres:postgres@127.0.0.1:$$host_port/postgres"
+
+postgres-stop:
+	@docker stop "$(LOCAL_POSTGRES_CONTAINER)" >/dev/null 2>&1 || true
+
+postgres-clean:
+	@docker rm -f "$(LOCAL_POSTGRES_CONTAINER)" >/dev/null 2>&1 || true
+
+postgres-tests: postgres-start
+	@set -eu; \
+	host_port=$$(docker port "$(LOCAL_POSTGRES_CONTAINER)" 5432/tcp | sed -n 's/.*:\([0-9][0-9]*\)$$/\1/p' | head -n 1); \
+	if [ -z "$$host_port" ]; then \
+	  echo "Local Postgres is not exposing 5432/tcp"; \
+	  exit 1; \
+	fi; \
+	db_name="coral_test_$$(date +%s)_$$$$"; \
+	docker exec "$(LOCAL_POSTGRES_CONTAINER)" createdb -U postgres "$$db_name"; \
+	cleanup() { docker exec "$(LOCAL_POSTGRES_CONTAINER)" dropdb -U postgres --if-exists "$$db_name" >/dev/null 2>&1 || true; }; \
+	trap cleanup EXIT INT TERM; \
+	url="postgres://postgres:postgres@127.0.0.1:$$host_port/$$db_name"; \
+	echo "Running Postgres tests against $$url"; \
+	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app --lib \
+	  state::db::repositories::workspaces::tests::workspace_repository_round_trips_against_postgres \
+	  -- --ignored; \
+	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app \
+	  --test postgres_database_tests \
+	  -- --ignored
 
 # ----------------------------------------------------------------------------
 # Dependency license scan

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -26,6 +26,11 @@ pub(crate) fn discover_app_state_layout(
     env::AppEnvironment::discover().app_state_layout(config_dir_override)
 }
 
+#[cfg(test)]
+pub(crate) fn env_var(name: &str) -> Result<Option<String>, std::env::VarError> {
+    env::AppEnvironment::env_var(name)
+}
+
 /// Startup context for one workspace's MCP session.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceMcpStartupContext {

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -41,12 +41,6 @@
     )
 )]
 
-// Kept only so the dependency-bootstrap PR passes workspace unused-dependency
-// lints before the DB modules that use these crates land upstack.
-use sea_query as _;
-use sea_query_sqlx as _;
-use sqlx as _;
-
 /// Bootstrap entrypoints and local server assembly.
 pub mod bootstrap;
 mod catalog;

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -5,7 +5,7 @@ use sqlx::postgres::{PgConnectOptions, PgPoolOptions, PgSslMode};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
 use super::backend::{CoralDbBackend, PostgresCoralDb, SqliteCoralDb};
-use super::{DbError, ResolvedDatabaseConfig};
+use super::{CoralTx, DbError, ResolvedDatabaseConfig};
 use crate::storage::fs as storage_fs;
 
 #[derive(Debug)]
@@ -21,9 +21,23 @@ impl CoralDb {
         }
     }
 
-    #[expect(
-        dead_code,
-        reason = "Phase 1 keeps an explicit database health probe for the server diagnostics wired in a later stack PR."
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Repository harness uses transactions in tests before manager wiring lands in a later stack PR."
+        )
+    )]
+    pub(crate) async fn begin(&self) -> Result<CoralTx<'_>, DbError> {
+        CoralTx::begin(&self.backend).await
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 1 keeps an explicit database health probe for the server diagnostics wired in a later stack PR."
+        )
     )]
     pub(crate) async fn ping(&self) -> Result<(), DbError> {
         match &self.backend {

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -5,7 +5,34 @@ mod config;
 mod coral_db;
 mod error;
 mod migrations;
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Repository harness stays test-only until manager wiring lands in later stack PRs."
+    )
+)]
+mod repositories;
+mod schema;
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Database sessions stay test-only until repositories are wired into managers."
+    )
+)]
+mod session;
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Database transactions stay test-only until repositories are wired into managers."
+    )
+)]
+mod transaction;
 
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
+pub(crate) use session::DbSession;
+pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -3,25 +3,10 @@ use sea_query::{Expr, ExprTrait, OnConflict, Query};
 use crate::state::db::schema::Workspaces;
 use crate::state::db::{DbError, DbSession};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
 pub(crate) struct WorkspaceRecord {
     pub(crate) id: String,
     pub(crate) created_at_unix_nanos: i64,
-}
-
-#[derive(Debug, sqlx::FromRow)]
-struct WorkspaceRow {
-    id: String,
-    created_at_unix_nanos: i64,
-}
-
-impl From<WorkspaceRow> for WorkspaceRecord {
-    fn from(value: WorkspaceRow) -> Self {
-        Self {
-            id: value.id,
-            created_at_unix_nanos: value.created_at_unix_nanos,
-        }
-    }
 }
 
 pub(crate) struct WorkspacesRepo<'a, S> {
@@ -56,8 +41,7 @@ where
             .from(Workspaces::Table)
             .and_where(Expr::col(Workspaces::Id).eq(id))
             .to_owned();
-        let row: Option<WorkspaceRow> = self.session.fetch_optional(statement).await?;
-        Ok(row.map(Into::into))
+        self.session.fetch_optional(statement).await
     }
 
     pub(crate) async fn list(&mut self) -> Result<Vec<WorkspaceRecord>, DbError> {
@@ -66,8 +50,7 @@ where
             .from(Workspaces::Table)
             .order_by(Workspaces::Id, sea_query::Order::Asc)
             .to_owned();
-        let rows: Vec<WorkspaceRow> = self.session.fetch_all(statement).await?;
-        Ok(rows.into_iter().map(Into::into).collect())
+        self.session.fetch_all(statement).await
     }
 }
 
@@ -95,9 +78,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn workspace_repository_round_trips_against_postgres() {
-        let Some(url) =
-            bootstrap::env_var("CORAL_TEST_POSTGRES_URL").expect("read CORAL_TEST_POSTGRES_URL")
-        else {
+        let Some(url) = postgres_test_url() else {
             return;
         };
         let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
@@ -190,5 +171,11 @@ mod tests {
             .expect("system clock before Unix epoch")
             .as_nanos();
         format!("workspace_{}_{}", std::process::id(), nanos)
+    }
+
+    fn postgres_test_url() -> Option<String> {
+        bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
+            .filter(|value| !value.is_empty())
     }
 }

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -1,0 +1,194 @@
+use sea_query::{Expr, ExprTrait, OnConflict, Query};
+
+use crate::state::db::schema::Workspaces;
+use crate::state::db::{DbError, DbSession};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceRecord {
+    pub(crate) id: String,
+    pub(crate) created_at_unix_nanos: i64,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct WorkspaceRow {
+    id: String,
+    created_at_unix_nanos: i64,
+}
+
+impl From<WorkspaceRow> for WorkspaceRecord {
+    fn from(value: WorkspaceRow) -> Self {
+        Self {
+            id: value.id,
+            created_at_unix_nanos: value.created_at_unix_nanos,
+        }
+    }
+}
+
+pub(crate) struct WorkspacesRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> WorkspacesRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn ensure(
+        &mut self,
+        id: &str,
+        created_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(Workspaces::Table)
+            .columns([Workspaces::Id, Workspaces::CreatedAtUnixNanos])
+            .values_panic([Expr::val(id.to_string()), Expr::val(created_at_unix_nanos)])
+            .on_conflict(OnConflict::column(Workspaces::Id).do_nothing().to_owned())
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn get(&mut self, id: &str) -> Result<Option<WorkspaceRecord>, DbError> {
+        let statement = Query::select()
+            .columns([Workspaces::Id, Workspaces::CreatedAtUnixNanos])
+            .from(Workspaces::Table)
+            .and_where(Expr::col(Workspaces::Id).eq(id))
+            .to_owned();
+        let row: Option<WorkspaceRow> = self.session.fetch_optional(statement).await?;
+        Ok(row.map(Into::into))
+    }
+
+    pub(crate) async fn list(&mut self) -> Result<Vec<WorkspaceRecord>, DbError> {
+        let statement = Query::select()
+            .columns([Workspaces::Id, Workspaces::CreatedAtUnixNanos])
+            .from(Workspaces::Table)
+            .order_by(Workspaces::Id, sea_query::Order::Asc)
+            .to_owned();
+        let rows: Vec<WorkspaceRow> = self.session.fetch_all(statement).await?;
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use tempfile::tempdir;
+
+    use super::WorkspaceRecord;
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+
+    #[tokio::test]
+    async fn workspace_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_workspace_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn workspace_repository_round_trips_against_postgres() {
+        let Some(url) =
+            bootstrap::env_var("CORAL_TEST_POSTGRES_URL").expect("read CORAL_TEST_POSTGRES_URL")
+        else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_workspace_repository_round_trip(&db).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        assert_eq!(path, layout.database_file());
+        assert!(!path.exists());
+
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    async fn assert_workspace_repository_round_trip(db: &CoralDb) {
+        db.ping().await.expect("ping database");
+
+        let workspace_id = unique_workspace_id();
+        let missing_workspace_id = format!("{workspace_id}_missing");
+        let rolled_back_workspace_id = format!("{workspace_id}_rolled_back");
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(&workspace_id, 42)
+            .await
+            .expect("ensure workspace");
+        tx.workspaces()
+            .ensure(&workspace_id, 99)
+            .await
+            .expect("ensure existing workspace");
+        tx.commit().await.expect("commit tx");
+
+        let expected = WorkspaceRecord {
+            id: workspace_id.clone(),
+            created_at_unix_nanos: 42,
+        };
+        let mut session = db;
+        assert_eq!(
+            session
+                .workspaces()
+                .get(&workspace_id)
+                .await
+                .expect("get workspace"),
+            Some(expected.clone())
+        );
+        assert_eq!(
+            session
+                .workspaces()
+                .get(&missing_workspace_id)
+                .await
+                .expect("get missing workspace"),
+            None
+        );
+
+        let workspaces = session.workspaces().list().await.expect("list workspaces");
+        assert!(
+            workspaces.contains(&expected),
+            "workspace list did not contain expected record: {workspaces:?}"
+        );
+
+        let mut tx = db.begin().await.expect("begin rollback tx");
+        tx.workspaces()
+            .ensure(&rolled_back_workspace_id, 77)
+            .await
+            .expect("ensure rolled-back workspace");
+        tx.rollback().await.expect("rollback tx");
+        assert_eq!(
+            session
+                .workspaces()
+                .get(&rolled_back_workspace_id)
+                .await
+                .expect("get rolled-back workspace"),
+            None
+        );
+    }
+
+    fn unique_workspace_id() -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before Unix epoch")
+            .as_nanos();
+        format!("workspace_{}_{}", std::process::id(), nanos)
+    }
+}

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -1,0 +1,8 @@
+use sea_query::Iden;
+
+#[derive(Iden)]
+pub(in crate::state::db) enum Workspaces {
+    Table,
+    Id,
+    CreatedAtUnixNanos,
+}

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -1,0 +1,156 @@
+use sea_query::{InsertStatement, SelectStatement};
+use sea_query_sqlx::SqlxBinder;
+use sqlx::postgres::PgRow;
+use sqlx::sqlite::SqliteRow;
+use sqlx::{FromRow, Postgres, Sqlite};
+
+use super::backend::CoralDbBackend;
+use super::{CoralDb, CoralTx, DbError};
+use crate::state::db::repositories::workspaces::WorkspacesRepo;
+
+pub(crate) trait DbSession {
+    async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError>;
+
+    async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>;
+
+    async fn fetch_all<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>;
+}
+
+pub(crate) trait DbRepos: DbSession + Sized {
+    fn workspaces(&mut self) -> WorkspacesRepo<'_, Self> {
+        WorkspacesRepo::new(self)
+    }
+}
+
+impl<T> DbRepos for T where T: DbSession + Sized {}
+
+impl DbSession for &CoralDb {
+    async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
+        execute_statement(&self.backend, statement).await
+    }
+
+    async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        fetch_optional_statement(&self.backend, statement).await
+    }
+
+    async fn fetch_all<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        fetch_all_statement(&self.backend, statement).await
+    }
+}
+
+impl DbSession for CoralTx<'_> {
+    async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
+        self.execute(statement).await
+    }
+
+    async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        self.fetch_optional(statement).await
+    }
+
+    async fn fetch_all<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        self.fetch_all(statement).await
+    }
+}
+
+pub(super) async fn execute_statement(
+    backend: &CoralDbBackend,
+    statement: InsertStatement,
+) -> Result<(), DbError> {
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                .execute(&db.pool)
+                .await?;
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                .execute(&db.pool)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) async fn fetch_optional_statement<T>(
+    backend: &CoralDbBackend,
+    statement: SelectStatement,
+) -> Result<Option<T>, DbError>
+where
+    T: Send + Unpin,
+    for<'r> T: FromRow<'r, SqliteRow>,
+    for<'r> T: FromRow<'r, PgRow>,
+{
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_optional(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_optional(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+    }
+}
+
+pub(super) async fn fetch_all_statement<T>(
+    backend: &CoralDbBackend,
+    statement: SelectStatement,
+) -> Result<Vec<T>, DbError>
+where
+    T: Send + Unpin,
+    for<'r> T: FromRow<'r, SqliteRow>,
+    for<'r> T: FromRow<'r, PgRow>,
+{
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_all(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_all(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+    }
+}

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -1,0 +1,115 @@
+use sea_query::{InsertStatement, SelectStatement};
+use sea_query_sqlx::SqlxBinder;
+use sqlx::postgres::PgRow;
+use sqlx::sqlite::SqliteRow;
+use sqlx::{FromRow, Postgres, Sqlite};
+
+use super::DbError;
+use super::backend::CoralDbBackend;
+
+pub(crate) struct CoralTx<'a> {
+    backend: CoralTxBackend<'a>,
+}
+
+enum CoralTxBackend<'a> {
+    Sqlite(sqlx::Transaction<'a, Sqlite>),
+    Postgres(sqlx::Transaction<'a, Postgres>),
+}
+
+impl<'a> CoralTx<'a> {
+    pub(super) async fn begin(backend: &'a CoralDbBackend) -> Result<Self, DbError> {
+        let backend = match backend {
+            CoralDbBackend::Sqlite(db) => CoralTxBackend::Sqlite(db.pool.begin().await?),
+            CoralDbBackend::Postgres(db) => CoralTxBackend::Postgres(db.pool.begin().await?),
+        };
+        Ok(Self { backend })
+    }
+
+    pub(crate) async fn commit(self) -> Result<(), DbError> {
+        match self.backend {
+            CoralTxBackend::Sqlite(tx) => tx.commit().await?,
+            CoralTxBackend::Postgres(tx) => tx.commit().await?,
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn rollback(self) -> Result<(), DbError> {
+        match self.backend {
+            CoralTxBackend::Sqlite(tx) => tx.rollback().await?,
+            CoralTxBackend::Postgres(tx) => tx.rollback().await?,
+        }
+        Ok(())
+    }
+
+    pub(super) async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&mut **tx)
+                    .await?;
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&mut **tx)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) async fn fetch_optional<T>(
+        &mut self,
+        statement: SelectStatement,
+    ) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_optional(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_optional(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+        }
+    }
+
+    pub(super) async fn fetch_all<T>(
+        &mut self,
+        statement: SelectStatement,
+    ) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_all(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_all(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+        }
+    }
+}

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -13,7 +13,6 @@ use coral_client::{
     AppClient, default_workspace,
     local::{LocalServerError, ServerBuilder},
 };
-use sqlx::postgres::PgPoolOptions;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use tonic::Request;
@@ -88,31 +87,6 @@ async fn server_lifecycle_rejects_postgres_config_without_url_env_value() {
     }
 }
 
-#[tokio::test]
-#[ignore = "set CORAL_TEST_POSTGRES_URL to run configured Postgres startup coverage"]
-async fn server_lifecycle_can_start_with_postgres_database_config() {
-    let Some(database_url) = postgres_test_url() else {
-        return;
-    };
-    let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    fs::create_dir_all(&config_dir).expect("create config dir");
-    fs::write(
-        config_dir.join("config.toml"),
-        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n",
-    )
-    .expect("write config");
-
-    let server = ServerBuilder::new()
-        .with_config_dir(&config_dir)
-        .start()
-        .await
-        .expect("start server with Postgres config");
-    assert_postgres_db_is_migrated(&database_url).await;
-
-    server.shutdown().await.expect("shutdown server");
-}
-
 async fn assert_default_sqlite_db_is_migrated(config_dir: &std::path::Path) {
     let database_file = config_dir.join("coral.db");
     assert!(
@@ -132,27 +106,4 @@ async fn assert_default_sqlite_db_is_migrated(config_dir: &std::path::Path) {
     .await
     .expect("inspect migrated schema");
     assert_eq!(table_count, 1, "workspaces table should be migrated");
-}
-
-async fn assert_postgres_db_is_migrated(database_url: &str) {
-    let pool = PgPoolOptions::new()
-        .connect(database_url)
-        .await
-        .expect("open Postgres database");
-    let table_exists: bool =
-        sqlx::query_scalar("SELECT to_regclass('public.workspaces') IS NOT NULL")
-            .fetch_one(&pool)
-            .await
-            .expect("inspect migrated Postgres schema");
-    assert!(table_exists, "workspaces table should be migrated");
-}
-
-#[expect(
-    clippy::disallowed_methods,
-    reason = "The ignored Postgres integration test is explicitly gated by this CI/test-only variable."
-)]
-fn postgres_test_url() -> Option<String> {
-    std::env::var("CORAL_TEST_POSTGRES_URL")
-        .ok()
-        .filter(|value| !value.is_empty())
 }

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -1,0 +1,60 @@
+//! Pins gRPC server startup behavior for configured Postgres storage.
+
+#![allow(
+    unused_crate_dependencies,
+    reason = "Integration tests inherit the library crate's dependency set and intentionally exercise only a subset of it."
+)]
+
+use std::fs;
+
+use coral_client::local::ServerBuilder;
+use sqlx::postgres::PgPoolOptions;
+use tempfile::TempDir;
+
+#[tokio::test]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run configured Postgres startup coverage"]
+async fn server_lifecycle_can_start_with_postgres_database_config() {
+    let Some(database_url) = postgres_test_url() else {
+        return;
+    };
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n",
+    )
+    .expect("write config");
+
+    let server = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await
+        .expect("start server with Postgres config");
+    assert_postgres_db_is_migrated(&database_url).await;
+
+    server.shutdown().await.expect("shutdown server");
+}
+
+async fn assert_postgres_db_is_migrated(database_url: &str) {
+    let pool = PgPoolOptions::new()
+        .connect(database_url)
+        .await
+        .expect("open Postgres database");
+    let table_exists: bool =
+        sqlx::query_scalar("SELECT to_regclass('public.workspaces') IS NOT NULL")
+            .fetch_one(&pool)
+            .await
+            .expect("inspect migrated Postgres schema");
+    assert!(table_exists, "workspaces table should be migrated");
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "The ignored Postgres integration test is explicitly gated by this CI/test-only variable."
+)]
+fn postgres_test_url() -> Option<String> {
+    std::env::var("CORAL_TEST_POSTGRES_URL")
+        .ok()
+        .filter(|value| !value.is_empty())
+}


### PR DESCRIPTION
## Intent

Add the first repository/session/transaction harness on top of the durable database bootstrap, with SQLite and Postgres coverage.

## What it enables

- Crate-private `DbSession` and `CoralTx` wrappers for repository code.
- `WorkspacesRepo` as the first durable repository, using dialect-aware SeaQuery builders for `ensure`, `get`, and `list`.
- Atomic workspace creation with `ON CONFLICT DO NOTHING`.
- Shared SQLite/Postgres coverage for repository hit/miss reads and transaction rollback invisibility.
- CI coverage for Postgres repository behavior and configured Postgres `ServerBuilder` startup.
- A concrete harness for migrating source/catalog state in follow-up PRs without coupling callers directly to SQLx.

## Contributor behavior

For Postgres-backed database changes, contributors and agents must run `make postgres-tests` before submitting. It starts a local Docker Postgres instance, sets `CORAL_TEST_POSTGRES_URL` for the ignored repository and server-startup coverage, and provides `postgres-start`, `postgres-url`, `postgres-stop`, and `postgres-clean` helpers.

## Usage examples

No public user-facing surface changes in this PR.

Focused local checks:

```bash
cargo test --locked -p coral-app state::db
cargo test --locked -p coral-app --test grpc server_lifecycle_can_repeat_within_process
make postgres-tests
```

Postgres checks run in CI through `.github/workflows/validate.yml`.

## Validation

- `cargo test --locked -p coral-app state::db`
- `cargo test --locked -p coral-app --test grpc server_lifecycle_can_repeat_within_process`
- `make postgres-tests`
- `make rust-checks`
- `review-swarm` on the submitted RDBMS stack; accepted test-gap findings were fixed before final submission

Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.