### PR TITLE
refactor(mcp): align tool contracts with surface owners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ dependencies = [
  "opentelemetry",
  "regex",
  "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 regex.workspace = true
 rmcp.workspace = true
+schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -30,14 +30,15 @@ use tonic::{
 use crate::{
     McpOptions, McpQueryExample,
     surface::{
-        CatalogToolKind, SqlBatchValue, SqlQueryResultValue, ToolDescriptionContext,
-        build_tool_result, describe_table_arguments, describe_table_tool, describe_table_value,
-        feedback_tool, guide_resource, guide_resource_content, initial_instructions,
-        list_catalog_arguments, list_catalog_tool, list_catalog_value, list_columns_arguments,
-        list_columns_tool, list_columns_value, open_episode_arguments, open_episode_tool,
-        optional_episode_id_argument, required_string_argument, search_catalog_arguments,
-        search_catalog_tool, search_catalog_value, sql_arguments, sql_tool, status_to_error_data,
-        tables_resource, tables_resource_content, tool_error_from_status, tool_error_result,
+        CatalogToolKind, EpisodeOpenedValue, FeedbackStoredValue, SqlBatchValue,
+        SqlQueryResultValue, ToolDescriptionContext, build_tool_result, describe_table_arguments,
+        describe_table_tool, describe_table_value, feedback_arguments, feedback_tool,
+        guide_resource, guide_resource_content, initial_instructions, list_catalog_arguments,
+        list_catalog_tool, list_catalog_value, list_columns_arguments, list_columns_tool,
+        list_columns_value, open_episode_arguments, open_episode_tool,
+        optional_episode_id_argument, search_catalog_arguments, search_catalog_tool,
+        search_catalog_value, sql_arguments, sql_tool, status_to_error_data, tables_resource,
+        tables_resource_content, tool_error_from_status, tool_error_result,
         with_episode_id_argument,
     },
     telemetry,
@@ -57,21 +58,6 @@ enum ToolCallOutcome {
         operation: &'static str,
         status: tonic::Status,
     },
-}
-
-#[derive(Serialize)]
-struct FeedbackStoredValue {
-    feedback_id: String,
-    created_at: String,
-    message: &'static str,
-}
-
-#[derive(Serialize)]
-struct EpisodeOpenedValue {
-    episode_id: String,
-    parent_episode_id: Option<String>,
-    message: &'static str,
-    instructions: &'static str,
 }
 
 fn serialize_tool_value(value: impl Serialize) -> Result<Value, tonic::Status> {
@@ -557,14 +543,15 @@ impl CoralMcpServer {
                 }
             }
             "feedback" if self.options.feedback_enabled => {
-                let trying_to_do =
-                    required_string_argument(request.arguments.as_ref(), "trying_to_do")?;
-                let tried = required_string_argument(request.arguments.as_ref(), "tried")?;
-                let stuck = required_string_argument(request.arguments.as_ref(), "stuck")?;
+                let arguments = feedback_arguments(request.arguments.as_ref())?;
                 Ok(ToolCallOutcome::from_value_result(
                     "Feedback submission",
-                    self.submit_feedback_value(&trying_to_do, &tried, &stuck)
-                        .await,
+                    self.submit_feedback_value(
+                        &arguments.trying_to_do,
+                        &arguments.tried,
+                        &arguments.stuck,
+                    )
+                    .await,
                 ))
             }
             _ => Err(ErrorData::invalid_params(

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -30,16 +30,14 @@ use tonic::{
 use crate::{
     McpOptions, McpQueryExample,
     surface::{
-        CatalogToolKind, EpisodeOpenedValue, FeedbackStoredValue, SqlBatchValue,
-        SqlQueryResultValue, ToolDescriptionContext, build_tool_result, describe_table_arguments,
-        describe_table_tool, describe_table_value, feedback_arguments, feedback_tool,
-        guide_resource, guide_resource_content, initial_instructions, list_catalog_arguments,
-        list_catalog_tool, list_catalog_value, list_columns_arguments, list_columns_tool,
-        list_columns_value, open_episode_arguments, open_episode_tool,
-        optional_episode_id_argument, search_catalog_arguments, search_catalog_tool,
-        search_catalog_value, sql_arguments, sql_tool, status_to_error_data, tables_resource,
+        CatalogToolKind, EpisodeId, EpisodeOpenedValue, FeedbackStoredValue, SqlBatchValue,
+        SqlQueryResultValue, ToolDescriptionContext, ToolName, available_tools, build_tool_result,
+        describe_table_arguments, describe_table_value, feedback_arguments, guide_resource,
+        guide_resource_content, initial_instructions, list_catalog_arguments, list_catalog_value,
+        list_columns_arguments, list_columns_table_fallback_value, list_columns_value,
+        open_episode_arguments, optional_episode_id_argument, search_catalog_arguments,
+        search_catalog_value, sql_arguments, status_to_error_data, tables_resource,
         tables_resource_content, tool_error_from_status, tool_error_result,
-        with_episode_id_argument,
     },
     telemetry,
 };
@@ -79,7 +77,7 @@ impl ToolCallOutcome {
 
 #[derive(Debug, Default)]
 struct EpisodeTag {
-    episode_id: Option<String>,
+    episode_id: Option<EpisodeId>,
     episode_id_metadata: Option<MetadataValue<Ascii>>,
 }
 
@@ -93,7 +91,8 @@ impl EpisodeTag {
         }
         let episode_id = optional_episode_id_argument(arguments, "episode_id")?;
         let episode_id_metadata = episode_id
-            .as_deref()
+            .as_ref()
+            .map(EpisodeId::as_str)
             .map(|episode_id| {
                 episode_id.parse().map_err(|error| {
                     ErrorData::invalid_params(
@@ -110,8 +109,8 @@ impl EpisodeTag {
     }
 
     fn record_telemetry(&self, span: &tracing::Span) {
-        if let Some(episode_id) = self.episode_id.as_deref() {
-            telemetry::record_episode_id(span, episode_id);
+        if let Some(episode_id) = self.episode_id.as_ref() {
+            telemetry::record_episode_id(span, episode_id.as_str());
         }
     }
 
@@ -364,7 +363,7 @@ impl CoralMcpServer {
     async fn open_episode(
         &self,
         intent: &str,
-        parent_episode_id: Option<&str>,
+        parent_episode_id: Option<&EpisodeId>,
     ) -> Result<EpisodeOpenedValue, tonic::Status> {
         let episode_id = format!("ep_{}", uuid::Uuid::new_v4().simple());
         let mut episode_client = self.episode.clone();
@@ -373,12 +372,15 @@ impl CoralMcpServer {
                 workspace: Some(default_workspace()),
                 episode_id: episode_id.clone(),
                 intent: intent.to_string(),
-                parent_episode_id: parent_episode_id.unwrap_or_default().to_string(),
+                parent_episode_id: parent_episode_id
+                    .map(EpisodeId::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
             }))
             .await?;
         Ok(EpisodeOpenedValue {
-            episode_id,
-            parent_episode_id: parent_episode_id.map(str::to_string),
+            episode_id: EpisodeId::generated(episode_id),
+            parent_episode_id: parent_episode_id.cloned(),
             message: "Episode opened.",
             instructions: "Pass this episode_id as episode_id on subsequent Coral MCP tool calls for this work.",
         })
@@ -493,8 +495,8 @@ impl CoralMcpServer {
         span: &tracing::Span,
         episode_id_metadata: Option<MetadataValue<Ascii>>,
     ) -> Result<ToolCallOutcome, ErrorData> {
-        match request.name.as_ref() {
-            "sql" => {
+        match ToolName::from_str(request.name.as_ref()) {
+            Some(ToolName::Sql) => {
                 let arguments = sql_arguments(request.arguments.as_ref())?;
                 match self
                     .execute_sql_batch(arguments.queries, episode_id_metadata)
@@ -507,29 +509,29 @@ impl CoralMcpServer {
                     }),
                 }
             }
-            "list_catalog" => {
+            Some(ToolName::ListCatalog) => {
                 self.list_catalog_tool_result(request.arguments.as_ref())
                     .await
             }
-            "search_catalog" => {
+            Some(ToolName::SearchCatalog) => {
                 self.search_catalog_tool_result(request.arguments.as_ref())
                     .await
             }
-            "describe_table" => {
+            Some(ToolName::DescribeTable) => {
                 self.describe_table_tool_result(request.arguments.as_ref())
                     .await
             }
-            "list_columns" => {
+            Some(ToolName::ListColumns) => {
                 self.list_columns_tool_result(request.arguments.as_ref())
                     .await
             }
-            "open_episode" if self.options.episodes_enabled => {
+            Some(ToolName::OpenEpisode) if self.options.episodes_enabled => {
                 let arguments = open_episode_arguments(request.arguments.as_ref())?;
                 match self
-                    .open_episode(&arguments.intent, arguments.parent_episode_id.as_deref())
+                    .open_episode(&arguments.intent, arguments.parent_episode_id.as_ref())
                     .await
                     .and_then(|episode| {
-                        telemetry::record_episode_id(span, &episode.episode_id);
+                        telemetry::record_episode_id(span, episode.episode_id.as_str());
                         serialize_tool_value(episode)
                     }) {
                     Ok(value) => Ok(ToolCallOutcome::success(value)),
@@ -542,7 +544,7 @@ impl CoralMcpServer {
                     }),
                 }
             }
-            "feedback" if self.options.feedback_enabled => {
+            Some(ToolName::Feedback) if self.options.feedback_enabled => {
                 let arguments = feedback_arguments(request.arguments.as_ref())?;
                 Ok(ToolCallOutcome::from_value_result(
                     "Feedback submission",
@@ -554,10 +556,9 @@ impl CoralMcpServer {
                     .await,
                 ))
             }
-            _ => Err(ErrorData::invalid_params(
-                format!("tool '{}' not found", request.name),
-                None,
-            )),
+            None | Some(ToolName::OpenEpisode | ToolName::Feedback) => Err(
+                ErrorData::invalid_params(format!("tool '{}' not found", request.name), None),
+            ),
         }
     }
 
@@ -595,11 +596,13 @@ impl CoralMcpServer {
                     .load_table_description(&arguments.schema, &arguments.table)
                     .await
                 {
-                    Ok(response) => Ok(ToolCallOutcome::success(describe_table_value(
-                        &arguments.schema,
-                        &arguments.table,
-                        &response,
-                    ))),
+                    Ok(response) => {
+                        Ok(ToolCallOutcome::success(list_columns_table_fallback_value(
+                            &arguments.schema,
+                            &arguments.table,
+                            &response,
+                        )))
+                    }
                     Err(status) => Ok(ToolCallOutcome::ToolError {
                         operation: "Column listing",
                         status,
@@ -655,26 +658,11 @@ impl ServerHandler for CoralMcpServer {
                 visible_function_count,
                 source_names,
             );
-            let mut tools = vec![
-                sql_tool(&tool_context),
-                list_catalog_tool(&tool_context),
-                search_catalog_tool(&tool_context),
-                describe_table_tool(),
-                list_columns_tool(),
-            ];
-            if self.options.episodes_enabled {
-                tools = tools.into_iter().map(with_episode_id_argument).collect();
-                tools.push(open_episode_tool());
-            }
-            if self.options.feedback_enabled {
-                let feedback = feedback_tool();
-                let feedback = if self.options.episodes_enabled {
-                    with_episode_id_argument(feedback)
-                } else {
-                    feedback
-                };
-                tools.push(feedback);
-            }
+            let tools = available_tools(
+                &tool_context,
+                self.options.episodes_enabled,
+                self.options.feedback_enabled,
+            );
             Ok(ListToolsResult::with_all_items(tools))
         })
         .await
@@ -687,7 +675,8 @@ impl ServerHandler for CoralMcpServer {
     ) -> Result<CallToolResult, ErrorData> {
         let span =
             telemetry::call_tool_span(request.name.as_ref(), self.options.trace_parent.as_deref());
-        let inject_episode_metadata = request.name.as_ref() != "open_episode";
+        let inject_episode_metadata =
+            ToolName::from_str(request.name.as_ref()) != Some(ToolName::OpenEpisode);
         let episode_tag = EpisodeTag::from_tool_request(&self.options, request.arguments.as_ref());
         let outcome = match episode_tag {
             Ok(episode_tag) => {

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -495,7 +495,7 @@ impl CoralMcpServer {
         span: &tracing::Span,
         episode_id_metadata: Option<MetadataValue<Ascii>>,
     ) -> Result<ToolCallOutcome, ErrorData> {
-        match ToolName::from_str(request.name.as_ref()) {
+        match request.name.as_ref().parse::<ToolName>().ok() {
             Some(ToolName::Sql) => {
                 let arguments = sql_arguments(request.arguments.as_ref())?;
                 match self
@@ -676,7 +676,7 @@ impl ServerHandler for CoralMcpServer {
         let span =
             telemetry::call_tool_span(request.name.as_ref(), self.options.trace_parent.as_deref());
         let inject_episode_metadata =
-            ToolName::from_str(request.name.as_ref()) != Some(ToolName::OpenEpisode);
+            request.name.as_ref().parse::<ToolName>().ok() != Some(ToolName::OpenEpisode);
         let episode_tag = EpisodeTag::from_tool_request(&self.options, request.arguments.as_ref());
         let outcome = match episode_tag {
             Ok(episode_tag) => {

--- a/crates/coral-mcp/src/surface/arguments.rs
+++ b/crates/coral-mcp/src/surface/arguments.rs
@@ -8,8 +8,7 @@ pub(crate) fn required_string_argument(
     let value = arguments
         .and_then(|arguments| arguments.get(key))
         .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
+        .filter(|value| !value.trim().is_empty())
         .ok_or_else(|| {
             ErrorData::invalid_params(format!("missing string argument '{key}'"), None)
         })?;
@@ -29,12 +28,7 @@ pub(crate) fn optional_string_argument(
     let value = value.as_str().ok_or_else(|| {
         ErrorData::invalid_params(format!("argument '{key}' must be a string"), None)
     })?;
-    let value = value.trim();
-    if value.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(value.to_string()))
-    }
+    Ok(Some(value.to_string()))
 }
 
 pub(crate) fn optional_non_empty_string_argument(
@@ -50,8 +44,7 @@ pub(crate) fn optional_non_empty_string_argument(
     let value = value.as_str().ok_or_else(|| {
         ErrorData::invalid_params(format!("argument '{key}' must be a string"), None)
     })?;
-    let value = value.trim();
-    if value.is_empty() {
+    if value.trim().is_empty() {
         Err(ErrorData::invalid_params(
             format!("argument '{key}' must not be empty"),
             None,
@@ -72,4 +65,62 @@ pub(crate) fn optional_bool_argument(
     value.as_bool().ok_or_else(|| {
         ErrorData::invalid_params(format!("argument '{key}' must be a boolean"), None)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        optional_non_empty_string_argument, optional_string_argument, required_string_argument,
+    };
+    use serde_json::{Map, Value};
+
+    fn string_arguments(key: &str, value: &str) -> Map<String, Value> {
+        Map::from_iter([(key.to_string(), Value::String(value.to_string()))])
+    }
+
+    #[test]
+    fn required_string_argument_preserves_surrounding_whitespace() {
+        let arguments = string_arguments("pattern", " ^messages$ ");
+
+        let parsed =
+            required_string_argument(Some(&arguments), "pattern").expect("argument should parse");
+
+        assert_eq!(parsed, " ^messages$ ");
+    }
+
+    #[test]
+    fn required_string_argument_rejects_whitespace_only_values() {
+        let arguments = string_arguments("schema", "   ");
+
+        required_string_argument(Some(&arguments), "schema")
+            .expect_err("whitespace-only required argument should fail");
+    }
+
+    #[test]
+    fn optional_string_argument_preserves_exact_value() {
+        let arguments = string_arguments("schema", " local_messages ");
+
+        let parsed =
+            optional_string_argument(Some(&arguments), "schema").expect("argument should parse");
+
+        assert_eq!(parsed.as_deref(), Some(" local_messages "));
+    }
+
+    #[test]
+    fn optional_non_empty_string_argument_preserves_surrounding_whitespace() {
+        let arguments = string_arguments("pattern", " ^id$ ");
+
+        let parsed = optional_non_empty_string_argument(Some(&arguments), "pattern")
+            .expect("argument should parse");
+
+        assert_eq!(parsed.as_deref(), Some(" ^id$ "));
+    }
+
+    #[test]
+    fn optional_non_empty_string_argument_rejects_whitespace_only_values() {
+        let arguments = string_arguments("pattern", "   ");
+
+        optional_non_empty_string_argument(Some(&arguments), "pattern")
+            .expect_err("whitespace-only non-empty argument should fail");
+    }
 }

--- a/crates/coral-mcp/src/surface/arguments.rs
+++ b/crates/coral-mcp/src/surface/arguments.rs
@@ -1,0 +1,75 @@
+use rmcp::ErrorData;
+use serde_json::{Map, Value};
+
+pub(crate) fn required_string_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+) -> Result<String, ErrorData> {
+    let value = arguments
+        .and_then(|arguments| arguments.get(key))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            ErrorData::invalid_params(format!("missing string argument '{key}'"), None)
+        })?;
+    Ok(value.to_string())
+}
+
+pub(crate) fn optional_string_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+) -> Result<Option<String>, ErrorData> {
+    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let value = value.as_str().ok_or_else(|| {
+        ErrorData::invalid_params(format!("argument '{key}' must be a string"), None)
+    })?;
+    let value = value.trim();
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(value.to_string()))
+    }
+}
+
+pub(crate) fn optional_non_empty_string_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+) -> Result<Option<String>, ErrorData> {
+    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let value = value.as_str().ok_or_else(|| {
+        ErrorData::invalid_params(format!("argument '{key}' must be a string"), None)
+    })?;
+    let value = value.trim();
+    if value.is_empty() {
+        Err(ErrorData::invalid_params(
+            format!("argument '{key}' must not be empty"),
+            None,
+        ))
+    } else {
+        Ok(Some(value.to_string()))
+    }
+}
+
+pub(crate) fn optional_bool_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+    default: bool,
+) -> Result<bool, ErrorData> {
+    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
+        return Ok(default);
+    };
+    value.as_bool().ok_or_else(|| {
+        ErrorData::invalid_params(format!("argument '{key}' must be a boolean"), None)
+    })
+}

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -1,17 +1,26 @@
 use coral_api::v1::{
     ColumnSearchResult, DescribeTableResponse, ListCatalogResponse, ListColumnsResponse,
-    SearchCatalogResponse, Table as ProtoTable, TableFunction as ProtoTableFunction,
-    TableFunctionArgument as ProtoTableFunctionArgument,
+    PaginationResponse, SearchCatalogResponse, Table as ProtoTable,
+    TableFunction as ProtoTableFunction, TableFunctionArgument as ProtoTableFunctionArgument,
     TableFunctionResultColumn as ProtoTableFunctionResultColumn, TableSummary as ProtoTableSummary,
     catalog_item,
 };
-use serde::Serialize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use std::sync::Arc;
 
+use super::schema::tool_output_schema;
 use super::values::{
-    format_schema_table_equivalent, format_sql_identifier, insert_pagination_fields,
-    missing_table_summary_value, paged_collection_value,
+    MissingTableSummaryValue, format_schema_table_equivalent, format_sql_identifier,
 };
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CatalogToolKind {
+    Table,
+    TableFunction,
+}
 
 pub(crate) fn describe_table_value(
     schema: &str,
@@ -43,39 +52,39 @@ fn describe_missing_table_value(
 ) -> Value {
     let same_schema_tables = same_schema_tables
         .iter()
-        .map(missing_table_summary_value)
+        .map(MissingTableSummaryValue::from)
         .collect::<Vec<_>>();
     let suggestions = suggestions
         .iter()
-        .map(missing_table_summary_value)
+        .map(MissingTableSummaryValue::from)
         .collect::<Vec<_>>();
     let escaped_table = regex::escape(table);
     let search_arguments = if same_schema_tables.is_empty() {
         SuggestedCallArguments {
             pattern: Some(escaped_table),
             schema: None,
-            kind: Some("table"),
+            kind: Some(CatalogToolKind::Table),
             limit: None,
         }
     } else {
         SuggestedCallArguments {
             pattern: Some(escaped_table),
             schema: Some(schema),
-            kind: Some("table"),
+            kind: Some(CatalogToolKind::Table),
             limit: None,
         }
     };
     let mut suggested_calls = vec![SuggestedCall {
-        tool: "search_catalog",
+        tool: SuggestedCallTool::SearchCatalog,
         arguments: search_arguments,
     }];
     if !same_schema_tables.is_empty() {
         suggested_calls.push(SuggestedCall {
-            tool: "list_catalog",
+            tool: SuggestedCallTool::ListCatalog,
             arguments: SuggestedCallArguments {
                 pattern: None,
                 schema: Some(schema),
-                kind: Some("table"),
+                kind: Some(CatalogToolKind::Table),
                 limit: Some(10),
             },
         });
@@ -91,6 +100,10 @@ fn describe_missing_table_value(
     .expect("missing table value serializes")
 }
 
+pub(crate) fn describe_table_output_schema() -> Arc<Map<String, Value>> {
+    tool_output_schema::<DescribeTableOutputValue<'static>>()
+}
+
 pub(crate) fn search_catalog_value(response: &SearchCatalogResponse) -> Value {
     let pagination = response.pagination.unwrap_or_default();
     let items = response
@@ -98,7 +111,12 @@ pub(crate) fn search_catalog_value(response: &SearchCatalogResponse) -> Value {
         .iter()
         .filter_map(catalog_search_result_value)
         .collect::<Vec<_>>();
-    paged_collection_value("items", items, &pagination)
+    serde_json::to_value(CatalogSearchPageValue::new(items, &pagination))
+        .expect("catalog search page value serializes")
+}
+
+pub(crate) fn search_catalog_output_schema() -> Arc<Map<String, Value>> {
+    tool_output_schema::<CatalogSearchPageValue<'static>>()
 }
 
 pub(crate) fn list_catalog_value(response: &ListCatalogResponse) -> Value {
@@ -108,16 +126,19 @@ pub(crate) fn list_catalog_value(response: &ListCatalogResponse) -> Value {
         .iter()
         .filter_map(catalog_item_value)
         .collect::<Vec<_>>();
-    paged_collection_value("items", items, &pagination)
+    serde_json::to_value(CatalogPageValue::new(items, &pagination))
+        .expect("catalog page value serializes")
 }
 
-fn catalog_item_value(item: &coral_api::v1::CatalogItem) -> Option<Value> {
+pub(crate) fn list_catalog_output_schema() -> Arc<Map<String, Value>> {
+    tool_output_schema::<CatalogPageValue<'static>>()
+}
+
+fn catalog_item_value(item: &coral_api::v1::CatalogItem) -> Option<CatalogItemValue<'_>> {
     match item.item.as_ref()? {
-        catalog_item::Item::Table(table) => {
-            serde_json::to_value(CatalogTableItemValue::from(table)).ok()
-        }
+        catalog_item::Item::Table(table) => Some(CatalogItemValue::Table(table.into())),
         catalog_item::Item::TableFunction(function) => {
-            serde_json::to_value(CatalogTableFunctionItemValue::from(function)).ok()
+            Some(CatalogItemValue::TableFunction(function.into()))
         }
     }
 }
@@ -134,13 +155,23 @@ fn minimal_table_function_call_example(function: &ProtoTableFunction) -> String 
     format!("{reference}({required_arguments})")
 }
 
-fn catalog_search_result_value(result: &coral_api::v1::CatalogSearchResult) -> Option<Value> {
-    let mut value = catalog_item_value(result.item.as_ref()?)?;
-    value.as_object_mut()?.insert(
-        "matched_fields".to_string(),
-        serde_json::to_value(&result.matched_fields).ok()?,
-    );
-    Some(value)
+fn catalog_search_result_value(
+    result: &coral_api::v1::CatalogSearchResult,
+) -> Option<CatalogSearchItemValue<'_>> {
+    match result.item.as_ref()?.item.as_ref()? {
+        catalog_item::Item::Table(table) => {
+            Some(CatalogSearchItemValue::Table(CatalogTableSearchItemValue {
+                item: table.into(),
+                matched_fields: &result.matched_fields,
+            }))
+        }
+        catalog_item::Item::TableFunction(function) => Some(CatalogSearchItemValue::TableFunction(
+            CatalogTableFunctionSearchItemValue {
+                item: function.into(),
+                matched_fields: &result.matched_fields,
+            },
+        )),
+    }
 }
 
 pub(crate) fn list_columns_value(
@@ -154,30 +185,183 @@ pub(crate) fn list_columns_value(
         .iter()
         .filter_map(column_search_result_value)
         .collect::<Vec<_>>();
-    let mut value = Map::from_iter([
-        ("schema_name".to_string(), Value::from(schema)),
-        ("table_name".to_string(), Value::from(table)),
-        ("columns".to_string(), Value::Array(columns)),
-    ]);
-    insert_pagination_fields(&mut value, &pagination);
-    Value::Object(value)
+    serde_json::to_value(ListColumnsPageValue::new(
+        schema,
+        table,
+        columns,
+        &pagination,
+    ))
+    .expect("list columns page value serializes")
 }
 
-fn column_search_result_value(result: &ColumnSearchResult) -> Option<Value> {
+pub(crate) fn list_columns_output_schema() -> Arc<Map<String, Value>> {
+    tool_output_schema::<ListColumnsOutputValue<'static>>()
+}
+
+fn column_search_result_value(result: &ColumnSearchResult) -> Option<ColumnSearchValue<'_>> {
     let column = result.column.as_ref()?;
-    let Value::Object(mut value) = serde_json::to_value(ColumnValue::from(column)).ok()? else {
-        return None;
-    };
-    if !result.matched_fields.is_empty() {
-        value.insert(
-            "matched_fields".to_string(),
-            serde_json::to_value(&result.matched_fields).ok()?,
-        );
-    }
-    Some(Value::Object(value))
+    Some(ColumnSearchValue {
+        column_name: &column.name,
+        data_type: &column.data_type,
+        is_nullable: column.nullable,
+        is_virtual: column.is_virtual,
+        is_required_filter: column.is_required_filter,
+        description: &column.description,
+        ordinal_position: column.ordinal_position,
+        matched_fields: (!result.matched_fields.is_empty())
+            .then_some(result.matched_fields.as_slice()),
+    })
 }
 
-#[derive(Serialize)]
+#[derive(JsonSchema)]
+#[serde(untagged)]
+#[schemars(extend("type" = "object"))]
+#[expect(
+    dead_code,
+    reason = "schema-only enum for the describe_table output contract"
+)]
+enum DescribeTableOutputValue<'a> {
+    Found(FoundTableValue<'a>),
+    Missing(MissingTableValue<'a>),
+}
+
+#[derive(JsonSchema)]
+#[serde(untagged)]
+#[schemars(extend("type" = "object"))]
+#[expect(
+    dead_code,
+    reason = "schema-only enum for the list_columns output contract"
+)]
+enum ListColumnsOutputValue<'a> {
+    Page(ListColumnsPageValue<'a>),
+    Missing(MissingTableValue<'a>),
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct CatalogPageValue<'a> {
+    items: Vec<CatalogItemValue<'a>>,
+    #[schemars(range(min = 0))]
+    total: u32,
+    #[schemars(range(min = 1))]
+    limit: u32,
+    #[schemars(range(min = 0))]
+    offset: u32,
+    has_more: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_offset: Option<u32>,
+}
+
+impl<'a> CatalogPageValue<'a> {
+    fn new(items: Vec<CatalogItemValue<'a>>, pagination: &PaginationResponse) -> Self {
+        Self {
+            items,
+            total: pagination.total_count,
+            limit: pagination.limit,
+            offset: pagination.offset,
+            has_more: pagination.has_more,
+            next_offset: pagination.has_more.then_some(pagination.next_offset),
+        }
+    }
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct CatalogSearchPageValue<'a> {
+    items: Vec<CatalogSearchItemValue<'a>>,
+    #[schemars(range(min = 0))]
+    total: u32,
+    #[schemars(range(min = 1))]
+    limit: u32,
+    #[schemars(range(min = 0))]
+    offset: u32,
+    has_more: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_offset: Option<u32>,
+}
+
+impl<'a> CatalogSearchPageValue<'a> {
+    fn new(items: Vec<CatalogSearchItemValue<'a>>, pagination: &PaginationResponse) -> Self {
+        Self {
+            items,
+            total: pagination.total_count,
+            limit: pagination.limit,
+            offset: pagination.offset,
+            has_more: pagination.has_more,
+            next_offset: pagination.has_more.then_some(pagination.next_offset),
+        }
+    }
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct ListColumnsPageValue<'a> {
+    schema_name: &'a str,
+    table_name: &'a str,
+    columns: Vec<ColumnSearchValue<'a>>,
+    #[schemars(range(min = 0))]
+    total: u32,
+    #[schemars(range(min = 1))]
+    limit: u32,
+    #[schemars(range(min = 0))]
+    offset: u32,
+    has_more: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_offset: Option<u32>,
+}
+
+impl<'a> ListColumnsPageValue<'a> {
+    fn new(
+        schema_name: &'a str,
+        table_name: &'a str,
+        columns: Vec<ColumnSearchValue<'a>>,
+        pagination: &PaginationResponse,
+    ) -> Self {
+        Self {
+            schema_name,
+            table_name,
+            columns,
+            total: pagination.total_count,
+            limit: pagination.limit,
+            offset: pagination.offset,
+            has_more: pagination.has_more,
+            next_offset: pagination.has_more.then_some(pagination.next_offset),
+        }
+    }
+}
+
+#[derive(Serialize, JsonSchema)]
+#[serde(untagged)]
+enum CatalogItemValue<'a> {
+    Table(CatalogTableItemValue<'a>),
+    TableFunction(CatalogTableFunctionItemValue<'a>),
+}
+
+#[derive(Serialize, JsonSchema)]
+#[serde(untagged)]
+enum CatalogSearchItemValue<'a> {
+    Table(CatalogTableSearchItemValue<'a>),
+    TableFunction(CatalogTableFunctionSearchItemValue<'a>),
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct CatalogTableSearchItemValue<'a> {
+    #[serde(flatten)]
+    item: CatalogTableItemValue<'a>,
+    matched_fields: &'a [String],
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct CatalogTableFunctionSearchItemValue<'a> {
+    #[serde(flatten)]
+    item: CatalogTableFunctionItemValue<'a>,
+    matched_fields: &'a [String],
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct FoundTableValue<'a> {
     found: bool,
     schema_name: &'a str,
@@ -206,43 +390,55 @@ impl<'a> From<&'a ProtoTable> for FoundTableValue<'a> {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct MissingTableValue<'a> {
     found: bool,
     requested: RequestedTable<'a>,
     available_schemas: &'a [String],
-    same_schema_tables: Vec<Value>,
-    suggestions: Vec<Value>,
+    same_schema_tables: Vec<MissingTableSummaryValue<'a>>,
+    suggestions: Vec<MissingTableSummaryValue<'a>>,
     suggested_calls: Vec<SuggestedCall<'a>>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct RequestedTable<'a> {
     schema: &'a str,
     table: &'a str,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct SuggestedCall<'a> {
-    tool: &'static str,
+    tool: SuggestedCallTool,
     arguments: SuggestedCallArguments<'a>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum SuggestedCallTool {
+    SearchCatalog,
+    ListCatalog,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct SuggestedCallArguments<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pattern: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     schema: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    kind: Option<&'static str>,
+    kind: Option<CatalogToolKind>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<u32>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct CatalogTableItemValue<'a> {
-    kind: &'static str,
+    kind: CatalogTableKind,
     schema_name: &'a str,
     name: String,
     sql_reference: String,
@@ -253,7 +449,7 @@ struct CatalogTableItemValue<'a> {
 impl<'a> From<&'a ProtoTableSummary> for CatalogTableItemValue<'a> {
     fn from(table: &'a ProtoTableSummary) -> Self {
         Self {
-            kind: "table",
+            kind: CatalogTableKind::Table,
             schema_name: &table.schema_name,
             name: format!("{}.{}", table.schema_name, table.name),
             sql_reference: format_schema_table_equivalent(&table.schema_name, &table.name),
@@ -267,16 +463,24 @@ impl<'a> From<&'a ProtoTableSummary> for CatalogTableItemValue<'a> {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum CatalogTableKind {
+    Table,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct CatalogTableValue<'a> {
     table_name: &'a str,
     guide: &'a str,
     required_filters: &'a [String],
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct CatalogTableFunctionItemValue<'a> {
-    kind: &'static str,
+    kind: CatalogTableFunctionKind,
     schema_name: &'a str,
     name: String,
     sql_reference: String,
@@ -288,7 +492,7 @@ struct CatalogTableFunctionItemValue<'a> {
 impl<'a> From<&'a ProtoTableFunction> for CatalogTableFunctionItemValue<'a> {
     fn from(function: &'a ProtoTableFunction) -> Self {
         Self {
-            kind: "table_function",
+            kind: CatalogTableFunctionKind::TableFunction,
             schema_name: &function.schema_name,
             name: format!("{}.{}", function.schema_name, function.name),
             sql_reference: format_schema_table_equivalent(&function.schema_name, &function.name),
@@ -311,14 +515,22 @@ impl<'a> From<&'a ProtoTableFunction> for CatalogTableFunctionItemValue<'a> {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum CatalogTableFunctionKind {
+    TableFunction,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct CatalogTableFunctionValue<'a> {
     function_name: &'a str,
     arguments: Vec<TableFunctionArgumentValue<'a>>,
     result_columns: Vec<TableFunctionResultColumnValue<'a>>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct TableFunctionArgumentValue<'a> {
     name: &'a str,
     required: bool,
@@ -335,7 +547,8 @@ impl<'a> From<&'a ProtoTableFunctionArgument> for TableFunctionArgumentValue<'a>
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct TableFunctionResultColumnValue<'a> {
     column_name: &'a str,
     data_type: &'a str,
@@ -354,27 +567,17 @@ impl<'a> From<&'a ProtoTableFunctionResultColumn> for TableFunctionResultColumnV
     }
 }
 
-#[derive(Serialize)]
-struct ColumnValue<'a> {
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct ColumnSearchValue<'a> {
     column_name: &'a str,
     data_type: &'a str,
     is_nullable: bool,
     is_virtual: bool,
     is_required_filter: bool,
     description: &'a str,
+    #[schemars(range(min = 0))]
     ordinal_position: u32,
-}
-
-impl<'a> From<&'a coral_api::v1::Column> for ColumnValue<'a> {
-    fn from(column: &'a coral_api::v1::Column) -> Self {
-        Self {
-            column_name: &column.name,
-            data_type: &column.data_type,
-            is_nullable: column.nullable,
-            is_virtual: column.is_virtual,
-            is_required_filter: column.is_required_filter,
-            description: &column.description,
-            ordinal_position: column.ordinal_position,
-        }
-    }
+    #[serde(skip_serializing_if = "Option::is_none")]
+    matched_fields: Option<&'a [String]>,
 }

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -234,6 +234,7 @@ enum DescribeTableOutputValue<'a> {
 )]
 enum ListColumnsOutputValue<'a> {
     Page(ListColumnsPageValue<'a>),
+    Found(FoundTableValue<'a>),
     Missing(MissingTableValue<'a>),
 }
 

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -5,15 +5,32 @@ use coral_api::v1::{
     TableFunctionResultColumn as ProtoTableFunctionResultColumn, TableSummary as ProtoTableSummary,
     catalog_item,
 };
+use rmcp::{
+    ErrorData,
+    model::{Tool, ToolAnnotations},
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::sync::Arc;
 
-use super::schema::tool_output_schema;
+use super::arguments::{
+    optional_bool_argument, optional_non_empty_string_argument, optional_string_argument,
+    required_string_argument,
+};
+use super::context::ToolDescriptionContext;
+use super::discovery::{
+    DefaultPaginationInput, Pagination, SearchPaginationInput, parse_pagination,
+    parse_search_pagination,
+};
+use super::schema::{tool_input_schema, tool_output_schema};
+use super::tool_names::ToolName;
 use super::values::{
     MissingTableSummaryValue, format_schema_table_equivalent, format_sql_identifier,
 };
+
+const DEFAULT_IGNORE_CASE: bool = true;
+const DEFAULT_REQUIRED_ONLY: bool = false;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -22,34 +39,287 @@ pub(crate) enum CatalogToolKind {
     TableFunction,
 }
 
+#[derive(JsonSchema)]
+pub(crate) struct ListCatalogArguments {
+    #[schemars(description = "Optional exact SQL schema name to list.")]
+    pub(crate) schema: Option<String>,
+    #[schemars(
+        description = "Optional item kind to list. Omit or pass null to list all catalog items."
+    )]
+    pub(crate) kind: Option<CatalogToolKind>,
+    #[schemars(flatten, with = "DefaultPaginationInput")]
+    pub(crate) pagination: Pagination,
+}
+
+#[derive(JsonSchema)]
+pub(crate) struct SearchCatalogArguments {
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Rust regex pattern to match database catalog metadata."
+    )]
+    pub(crate) pattern: String,
+    #[schemars(description = "Optional exact SQL schema name to search.")]
+    pub(crate) schema: Option<String>,
+    #[schemars(
+        description = "Optional item kind to search. Omit or pass null to search all catalog items."
+    )]
+    pub(crate) kind: Option<CatalogToolKind>,
+    #[serde(default = "default_ignore_case")]
+    #[schemars(description = "Whether regex matching is case-insensitive. Defaults to true.")]
+    pub(crate) ignore_case: bool,
+    #[schemars(flatten, with = "SearchPaginationInput")]
+    pub(crate) pagination: Pagination,
+}
+
+#[derive(JsonSchema)]
+pub(crate) struct DescribeTableArguments {
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Exact SQL schema name."
+    )]
+    pub(crate) schema: String,
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Exact table name within the SQL schema."
+    )]
+    pub(crate) table: String,
+}
+
+#[derive(JsonSchema)]
+pub(crate) struct ListColumnsArguments {
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Exact SQL schema name."
+    )]
+    pub(crate) schema: String,
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Exact table name within the SQL schema."
+    )]
+    pub(crate) table: String,
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Optional Rust regex matched against column names, descriptions, and data types."
+    )]
+    pub(crate) pattern: Option<String>,
+    #[serde(default = "default_ignore_case")]
+    #[schemars(description = "Whether regex matching is case-insensitive. Defaults to true.")]
+    pub(crate) ignore_case: bool,
+    #[serde(default = "default_required_only")]
+    #[schemars(description = "Only return columns that are required filters. Defaults to false.")]
+    pub(crate) required_only: bool,
+    #[schemars(flatten, with = "DefaultPaginationInput")]
+    pub(crate) pagination: Pagination,
+}
+
+pub(crate) fn list_catalog_tool(context: &ToolDescriptionContext) -> Tool {
+    Tool::new(
+        ToolName::ListCatalog.as_str(),
+        format!(
+            "List database catalog items for Coral sources. {} {} table(s) and {} table function(s) are currently visible.",
+            context.connected_sources_sentence(),
+            context.visible_table_count,
+            context.visible_function_count
+        ),
+        tool_input_schema::<ListCatalogArguments>(),
+    )
+    .with_raw_output_schema(list_catalog_output_schema())
+    .with_annotations(
+        ToolAnnotations::with_title("List Catalog")
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(false),
+    )
+}
+
+pub(crate) fn search_catalog_tool(context: &ToolDescriptionContext) -> Tool {
+    Tool::new(
+        ToolName::SearchCatalog.as_str(),
+        search_catalog_description(context),
+        tool_input_schema::<SearchCatalogArguments>(),
+    )
+    .with_raw_output_schema(search_catalog_output_schema())
+    .with_annotations(
+        ToolAnnotations::with_title("Search Catalog")
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(false),
+    )
+}
+
+pub(crate) fn describe_table_tool() -> Tool {
+    Tool::new(
+        ToolName::DescribeTable.as_str(),
+        "Describe one database table without returning full column definitions.",
+        tool_input_schema::<DescribeTableArguments>(),
+    )
+    .with_raw_output_schema(describe_table_output_schema())
+    .with_annotations(
+        ToolAnnotations::with_title("Describe Table")
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(false),
+    )
+}
+
+pub(crate) fn list_columns_tool() -> Tool {
+    Tool::new(
+        ToolName::ListColumns.as_str(),
+        "List columns for one database table with optional regex and required-filter narrowing.",
+        tool_input_schema::<ListColumnsArguments>(),
+    )
+    .with_raw_output_schema(list_columns_output_schema())
+    .with_annotations(
+        ToolAnnotations::with_title("List Columns")
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(false),
+    )
+}
+
+pub(crate) fn list_catalog_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<ListCatalogArguments, ErrorData> {
+    Ok(ListCatalogArguments {
+        schema: optional_string_argument(arguments, "schema")?,
+        kind: optional_catalog_kind_argument(arguments)?,
+        pagination: parse_pagination(arguments)?,
+    })
+}
+
+pub(crate) fn search_catalog_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<SearchCatalogArguments, ErrorData> {
+    Ok(SearchCatalogArguments {
+        pattern: required_string_argument(arguments, "pattern")?,
+        schema: optional_string_argument(arguments, "schema")?,
+        kind: optional_catalog_kind_argument(arguments)?,
+        ignore_case: optional_bool_argument(arguments, "ignore_case", DEFAULT_IGNORE_CASE)?,
+        pagination: parse_search_pagination(arguments)?,
+    })
+}
+
+pub(crate) fn describe_table_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<DescribeTableArguments, ErrorData> {
+    Ok(DescribeTableArguments {
+        schema: required_string_argument(arguments, "schema")?,
+        table: required_string_argument(arguments, "table")?,
+    })
+}
+
+pub(crate) fn list_columns_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<ListColumnsArguments, ErrorData> {
+    Ok(ListColumnsArguments {
+        schema: required_string_argument(arguments, "schema")?,
+        table: required_string_argument(arguments, "table")?,
+        pattern: optional_non_empty_string_argument(arguments, "pattern")?,
+        ignore_case: optional_bool_argument(arguments, "ignore_case", DEFAULT_IGNORE_CASE)?,
+        required_only: optional_bool_argument(arguments, "required_only", DEFAULT_REQUIRED_ONLY)?,
+        pagination: parse_pagination(arguments)?,
+    })
+}
+
+fn optional_catalog_kind_argument(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<Option<CatalogToolKind>, ErrorData> {
+    let Some(kind) = optional_string_argument(arguments, "kind")? else {
+        return Ok(None);
+    };
+    serde_json::from_value(Value::String(kind))
+        .map(Some)
+        .map_err(|error| {
+            ErrorData::invalid_params(format!("invalid argument 'kind': {error}"), None)
+        })
+}
+
+fn search_catalog_description(context: &ToolDescriptionContext) -> String {
+    format!(
+        "Search database catalog metadata with a Rust regex across connected Coral sources/schemas. {} {} table(s) and {} table function(s) are currently visible.",
+        context.connected_sources_sentence(),
+        context.visible_table_count,
+        context.visible_function_count
+    )
+}
+
+fn default_ignore_case() -> bool {
+    DEFAULT_IGNORE_CASE
+}
+
+fn default_required_only() -> bool {
+    DEFAULT_REQUIRED_ONLY
+}
+
 pub(crate) fn describe_table_value(
     schema: &str,
     table: &str,
     response: &DescribeTableResponse,
 ) -> Value {
+    serde_json::to_value(describe_table_output(schema, table, response))
+        .expect("describe table output value serializes")
+}
+
+fn describe_table_output<'a>(
+    schema: &'a str,
+    table: &'a str,
+    response: &'a DescribeTableResponse,
+) -> DescribeTableOutput<'a> {
     if let Some(table) = &response.table {
-        return describe_found_table_value(table);
+        return DescribeTableOutput::Found(FoundTableValue::from(table));
     }
-    describe_missing_table_value(
+    DescribeTableOutput::Missing(missing_table_value(
         schema,
         table,
         &response.available_schemas,
         &response.same_schema_tables,
         &response.suggestions,
-    )
+    ))
 }
 
-fn describe_found_table_value(table: &ProtoTable) -> Value {
-    serde_json::to_value(FoundTableValue::from(table)).expect("found table value serializes")
-}
-
-fn describe_missing_table_value(
+pub(crate) fn list_columns_table_fallback_value(
     schema: &str,
     table: &str,
-    available_schemas: &[String],
-    same_schema_tables: &[ProtoTableSummary],
-    suggestions: &[ProtoTableSummary],
+    response: &DescribeTableResponse,
 ) -> Value {
+    serde_json::to_value(list_columns_table_fallback_output(schema, table, response))
+        .expect("list columns table fallback output value serializes")
+}
+
+fn list_columns_table_fallback_output<'a>(
+    schema: &'a str,
+    table: &'a str,
+    response: &'a DescribeTableResponse,
+) -> ListColumnsOutput<'a> {
+    if let Some(table) = &response.table {
+        return ListColumnsOutput::Found(FoundTableValue::from(table));
+    }
+    ListColumnsOutput::Missing(missing_table_value(
+        schema,
+        table,
+        &response.available_schemas,
+        &response.same_schema_tables,
+        &response.suggestions,
+    ))
+}
+
+fn missing_table_value<'a>(
+    schema: &'a str,
+    table: &'a str,
+    available_schemas: &'a [String],
+    same_schema_tables: &'a [ProtoTableSummary],
+    suggestions: &'a [ProtoTableSummary],
+) -> MissingTableValue<'a> {
     let same_schema_tables = same_schema_tables
         .iter()
         .map(MissingTableSummaryValue::from)
@@ -75,12 +345,12 @@ fn describe_missing_table_value(
         }
     };
     let mut suggested_calls = vec![SuggestedCall {
-        tool: SuggestedCallTool::SearchCatalog,
+        tool: CatalogSuggestedTool::SearchCatalog,
         arguments: search_arguments,
     }];
     if !same_schema_tables.is_empty() {
         suggested_calls.push(SuggestedCall {
-            tool: SuggestedCallTool::ListCatalog,
+            tool: CatalogSuggestedTool::ListCatalog,
             arguments: SuggestedCallArguments {
                 pattern: None,
                 schema: Some(schema),
@@ -89,19 +359,18 @@ fn describe_missing_table_value(
             },
         });
     }
-    serde_json::to_value(MissingTableValue {
+    MissingTableValue {
         found: false,
         requested: RequestedTable { schema, table },
         available_schemas,
         same_schema_tables,
         suggestions,
         suggested_calls,
-    })
-    .expect("missing table value serializes")
+    }
 }
 
 pub(crate) fn describe_table_output_schema() -> Arc<Map<String, Value>> {
-    tool_output_schema::<DescribeTableOutputValue<'static>>()
+    tool_output_schema::<DescribeTableOutput<'static>>()
 }
 
 pub(crate) fn search_catalog_value(response: &SearchCatalogResponse) -> Value {
@@ -185,17 +454,17 @@ pub(crate) fn list_columns_value(
         .iter()
         .filter_map(column_search_result_value)
         .collect::<Vec<_>>();
-    serde_json::to_value(ListColumnsPageValue::new(
+    serde_json::to_value(ListColumnsOutput::Page(ListColumnsPageValue::new(
         schema,
         table,
         columns,
         &pagination,
-    ))
+    )))
     .expect("list columns page value serializes")
 }
 
 pub(crate) fn list_columns_output_schema() -> Arc<Map<String, Value>> {
-    tool_output_schema::<ListColumnsOutputValue<'static>>()
+    tool_output_schema::<ListColumnsOutput<'static>>()
 }
 
 fn column_search_result_value(result: &ColumnSearchResult) -> Option<ColumnSearchValue<'_>> {
@@ -213,26 +482,18 @@ fn column_search_result_value(result: &ColumnSearchResult) -> Option<ColumnSearc
     })
 }
 
-#[derive(JsonSchema)]
+#[derive(Serialize, JsonSchema)]
 #[serde(untagged)]
 #[schemars(extend("type" = "object"))]
-#[expect(
-    dead_code,
-    reason = "schema-only enum for the describe_table output contract"
-)]
-enum DescribeTableOutputValue<'a> {
+enum DescribeTableOutput<'a> {
     Found(FoundTableValue<'a>),
     Missing(MissingTableValue<'a>),
 }
 
-#[derive(JsonSchema)]
+#[derive(Serialize, JsonSchema)]
 #[serde(untagged)]
 #[schemars(extend("type" = "object"))]
-#[expect(
-    dead_code,
-    reason = "schema-only enum for the list_columns output contract"
-)]
-enum ListColumnsOutputValue<'a> {
+enum ListColumnsOutput<'a> {
     Page(ListColumnsPageValue<'a>),
     Found(FoundTableValue<'a>),
     Missing(MissingTableValue<'a>),
@@ -412,13 +673,13 @@ struct RequestedTable<'a> {
 #[derive(Serialize, JsonSchema)]
 #[schemars(deny_unknown_fields)]
 struct SuggestedCall<'a> {
-    tool: SuggestedCallTool,
+    tool: CatalogSuggestedTool,
     arguments: SuggestedCallArguments<'a>,
 }
 
 #[derive(Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-enum SuggestedCallTool {
+enum CatalogSuggestedTool {
     SearchCatalog,
     ListCatalog,
 }
@@ -581,4 +842,67 @@ struct ColumnSearchValue<'a> {
     ordinal_position: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     matched_fields: Option<&'a [String]>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Map, Value};
+
+    use super::{
+        DEFAULT_IGNORE_CASE, DEFAULT_REQUIRED_ONLY, list_catalog_arguments, list_columns_arguments,
+        search_catalog_arguments,
+    };
+    use crate::surface::discovery::{
+        DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_OFFSET, DEFAULT_SEARCH_PAGINATION_LIMIT,
+    };
+
+    #[test]
+    fn catalog_kind_argument_accepts_null_as_all_kinds() {
+        let mut arguments = Map::new();
+        arguments.insert("kind".to_string(), Value::Null);
+        let list = list_catalog_arguments(Some(&arguments)).expect("list arguments");
+        assert_eq!(list.kind, None);
+
+        arguments.insert("pattern".to_string(), Value::String("issue".to_string()));
+        let search = search_catalog_arguments(Some(&arguments)).expect("search arguments");
+        assert_eq!(search.kind, None);
+    }
+
+    #[test]
+    fn list_columns_pattern_accepts_null_as_omitted() {
+        let arguments = Map::from_iter([
+            ("schema".to_string(), Value::String("github".to_string())),
+            ("table".to_string(), Value::String("issues".to_string())),
+            ("pattern".to_string(), Value::Null),
+        ]);
+
+        let parsed = list_columns_arguments(Some(&arguments)).expect("list columns args");
+
+        assert_eq!(parsed.pattern, None);
+    }
+
+    #[test]
+    fn catalog_argument_defaults_use_shared_constants() {
+        let search_arguments =
+            Map::from_iter([("pattern".to_string(), Value::String("issue".to_string()))]);
+
+        let search = search_catalog_arguments(Some(&search_arguments)).expect("search args");
+
+        assert_eq!(search.ignore_case, DEFAULT_IGNORE_CASE);
+        assert_eq!(search.pagination.limit, DEFAULT_SEARCH_PAGINATION_LIMIT);
+        assert_eq!(search.pagination.offset, DEFAULT_PAGINATION_OFFSET);
+
+        let list_columns_arguments = Map::from_iter([
+            ("schema".to_string(), Value::String("github".to_string())),
+            ("table".to_string(), Value::String("issues".to_string())),
+        ]);
+
+        let list_columns = super::list_columns_arguments(Some(&list_columns_arguments))
+            .expect("list columns args");
+
+        assert_eq!(list_columns.ignore_case, DEFAULT_IGNORE_CASE);
+        assert_eq!(list_columns.required_only, DEFAULT_REQUIRED_ONLY);
+        assert_eq!(list_columns.pagination.limit, DEFAULT_PAGINATION_LIMIT);
+        assert_eq!(list_columns.pagination.offset, DEFAULT_PAGINATION_OFFSET);
+    }
 }

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -55,7 +55,6 @@ pub(crate) struct ListCatalogArguments {
 pub(crate) struct SearchCatalogArguments {
     #[schemars(
         length(min = 1),
-        pattern(r"\S"),
         description = "Rust regex pattern to match database catalog metadata."
     )]
     pub(crate) pattern: String,
@@ -74,15 +73,10 @@ pub(crate) struct SearchCatalogArguments {
 
 #[derive(JsonSchema)]
 pub(crate) struct DescribeTableArguments {
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "Exact SQL schema name."
-    )]
+    #[schemars(length(min = 1), description = "Exact SQL schema name.")]
     pub(crate) schema: String,
     #[schemars(
         length(min = 1),
-        pattern(r"\S"),
         description = "Exact table name within the SQL schema."
     )]
     pub(crate) table: String,
@@ -90,21 +84,15 @@ pub(crate) struct DescribeTableArguments {
 
 #[derive(JsonSchema)]
 pub(crate) struct ListColumnsArguments {
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "Exact SQL schema name."
-    )]
+    #[schemars(length(min = 1), description = "Exact SQL schema name.")]
     pub(crate) schema: String,
     #[schemars(
         length(min = 1),
-        pattern(r"\S"),
         description = "Exact table name within the SQL schema."
     )]
     pub(crate) table: String,
     #[schemars(
         length(min = 1),
-        pattern(r"\S"),
         description = "Optional Rust regex matched against column names, descriptions, and data types."
     )]
     pub(crate) pattern: Option<String>,

--- a/crates/coral-mcp/src/surface/context.rs
+++ b/crates/coral-mcp/src/surface/context.rs
@@ -1,0 +1,31 @@
+use super::source_names::connected_source_names_text;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolDescriptionContext {
+    pub(crate) visible_table_count: usize,
+    pub(crate) visible_function_count: usize,
+    connected_source_names: Vec<String>,
+}
+
+impl ToolDescriptionContext {
+    pub(crate) fn new(
+        visible_table_count: usize,
+        visible_function_count: usize,
+        mut connected_source_names: Vec<String>,
+    ) -> Self {
+        connected_source_names.sort();
+        connected_source_names.dedup();
+        Self {
+            visible_table_count,
+            visible_function_count,
+            connected_source_names,
+        }
+    }
+
+    pub(crate) fn connected_sources_sentence(&self) -> String {
+        connected_source_names_text(&self.connected_source_names).map_or_else(
+            || "No connected user sources are currently configured.".to_string(),
+            |names| format!("Connected sources/schemas include: {names}."),
+        )
+    }
+}

--- a/crates/coral-mcp/src/surface/discovery.rs
+++ b/crates/coral-mcp/src/surface/discovery.rs
@@ -1,4 +1,5 @@
 use rmcp::ErrorData;
+use schemars::JsonSchema;
 use serde_json::{Map, Value};
 
 pub(crate) const MIN_PAGINATION_LIMIT: u32 = 1;
@@ -12,6 +13,46 @@ pub(crate) const DEFAULT_PAGINATION_OFFSET: u32 = 0;
 pub(crate) struct Pagination {
     pub(crate) limit: u32,
     pub(crate) offset: u32,
+}
+
+#[derive(JsonSchema)]
+#[expect(
+    dead_code,
+    reason = "schema-only struct for flattened default pagination inputs"
+)]
+pub(crate) struct DefaultPaginationInput {
+    #[serde(default = "default_pagination_limit")]
+    #[schemars(
+        range(min = MIN_PAGINATION_LIMIT, max = MAX_PAGINATION_LIMIT),
+        description = "Maximum items to return, from 1 to 200. Defaults to 50."
+    )]
+    limit: u32,
+    #[serde(default = "default_pagination_offset")]
+    #[schemars(
+        range(min = DEFAULT_PAGINATION_OFFSET, max = u32::MAX),
+        description = "Number of matching items to skip. Defaults to 0."
+    )]
+    offset: u32,
+}
+
+#[derive(JsonSchema)]
+#[expect(
+    dead_code,
+    reason = "schema-only struct for flattened search pagination inputs"
+)]
+pub(crate) struct SearchPaginationInput {
+    #[serde(default = "default_search_pagination_limit")]
+    #[schemars(
+        range(min = MIN_PAGINATION_LIMIT, max = MAX_SEARCH_PAGINATION_LIMIT),
+        description = "Maximum catalog items to return, from 1 to 100. Defaults to 20."
+    )]
+    limit: u32,
+    #[serde(default = "default_pagination_offset")]
+    #[schemars(
+        range(min = DEFAULT_PAGINATION_OFFSET, max = u32::MAX),
+        description = "Number of matching catalog items to skip. Defaults to 0."
+    )]
+    offset: u32,
 }
 
 pub(crate) fn parse_pagination(
@@ -78,4 +119,16 @@ fn optional_u32_argument(
             None,
         )
     })
+}
+
+fn default_pagination_limit() -> u32 {
+    DEFAULT_PAGINATION_LIMIT
+}
+
+fn default_search_pagination_limit() -> u32 {
+    DEFAULT_SEARCH_PAGINATION_LIMIT
+}
+
+fn default_pagination_offset() -> u32 {
+    DEFAULT_PAGINATION_OFFSET
 }

--- a/crates/coral-mcp/src/surface/discovery.rs
+++ b/crates/coral-mcp/src/surface/discovery.rs
@@ -1,8 +1,8 @@
 use rmcp::ErrorData;
 use serde_json::{Map, Value};
 
-const DEFAULT_LIMIT: u32 = 50;
-const MAX_LIMIT: u32 = 200;
+pub(crate) const DEFAULT_PAGINATION_LIMIT: u32 = 50;
+pub(crate) const MAX_PAGINATION_LIMIT: u32 = 200;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct Pagination {
@@ -13,7 +13,7 @@ pub(crate) struct Pagination {
 pub(crate) fn parse_pagination(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<Pagination, ErrorData> {
-    parse_pagination_with_limits(arguments, DEFAULT_LIMIT, MAX_LIMIT)
+    parse_pagination_with_limits(arguments, DEFAULT_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT)
 }
 
 pub(crate) fn parse_pagination_with_limits(

--- a/crates/coral-mcp/src/surface/discovery.rs
+++ b/crates/coral-mcp/src/surface/discovery.rs
@@ -1,8 +1,12 @@
 use rmcp::ErrorData;
 use serde_json::{Map, Value};
 
+pub(crate) const MIN_PAGINATION_LIMIT: u32 = 1;
 pub(crate) const DEFAULT_PAGINATION_LIMIT: u32 = 50;
 pub(crate) const MAX_PAGINATION_LIMIT: u32 = 200;
+pub(crate) const DEFAULT_SEARCH_PAGINATION_LIMIT: u32 = 20;
+pub(crate) const MAX_SEARCH_PAGINATION_LIMIT: u32 = 100;
+pub(crate) const DEFAULT_PAGINATION_OFFSET: u32 = 0;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct Pagination {
@@ -16,14 +20,36 @@ pub(crate) fn parse_pagination(
     parse_pagination_with_limits(arguments, DEFAULT_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT)
 }
 
-pub(crate) fn parse_pagination_with_limits(
+pub(crate) fn parse_search_pagination(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<Pagination, ErrorData> {
+    parse_pagination_with_limits(
+        arguments,
+        DEFAULT_SEARCH_PAGINATION_LIMIT,
+        MAX_SEARCH_PAGINATION_LIMIT,
+    )
+}
+
+fn parse_pagination_with_limits(
     arguments: Option<&Map<String, Value>>,
     default_limit: u32,
     max_limit: u32,
 ) -> Result<Pagination, ErrorData> {
     Ok(Pagination {
-        limit: optional_u32_argument(arguments, "limit", default_limit, 1, max_limit)?,
-        offset: optional_u32_argument(arguments, "offset", 0, 0, u32::MAX)?,
+        limit: optional_u32_argument(
+            arguments,
+            "limit",
+            default_limit,
+            MIN_PAGINATION_LIMIT,
+            max_limit,
+        )?,
+        offset: optional_u32_argument(
+            arguments,
+            "offset",
+            DEFAULT_PAGINATION_OFFSET,
+            DEFAULT_PAGINATION_OFFSET,
+            u32::MAX,
+        )?,
     })
 }
 

--- a/crates/coral-mcp/src/surface/episode.rs
+++ b/crates/coral-mcp/src/surface/episode.rs
@@ -72,7 +72,6 @@ impl EpisodeId {
 pub(crate) struct OpenEpisodeArguments {
     #[schemars(
         length(min = 1, max = CORAL_EPISODE_INTENT_MAX_CHARS),
-        pattern(r"\S"),
         description = "Natural-language description of the task this episode should group."
     )]
     pub(crate) intent: String,

--- a/crates/coral-mcp/src/surface/episode.rs
+++ b/crates/coral-mcp/src/surface/episode.rs
@@ -1,0 +1,181 @@
+use std::sync::Arc;
+
+use coral_api::{CORAL_EPISODE_ID_MAX_LEN, CORAL_EPISODE_INTENT_MAX_CHARS};
+use rmcp::{
+    ErrorData,
+    model::{Tool, ToolAnnotations},
+};
+use schemars::JsonSchema;
+use serde::Serialize;
+use serde_json::{Map, Value, json};
+
+use super::{
+    arguments::required_string_argument,
+    schema::{json_schema_value, tool_input_schema, tool_output_schema},
+    tool_names::ToolName,
+};
+
+const EPISODE_ID_ARGUMENT_DESCRIPTION: &str = "Optional episode id returned by open_episode. Pass it on subsequent Coral tool calls for the same task so Coral can attribute the call to that episode.";
+const EPISODE_ID_JSON_SCHEMA_PATTERN: &str = "^[!-~]+$";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(transparent)]
+#[schemars(transparent, inline)]
+pub(crate) struct EpisodeId(
+    #[schemars(
+        length(min = 1, max = CORAL_EPISODE_ID_MAX_LEN),
+        regex(pattern = EPISODE_ID_JSON_SCHEMA_PATTERN)
+    )]
+    String,
+);
+
+impl EpisodeId {
+    pub(crate) fn generated(value: String) -> Self {
+        debug_assert!(Self::is_valid(&value));
+        Self(value)
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn parse_argument(key: &str, value: &str) -> Result<Self, ErrorData> {
+        if value.is_empty() {
+            return Err(ErrorData::invalid_params(
+                format!("argument '{key}' must not be empty"),
+                None,
+            ));
+        }
+        if value.len() > CORAL_EPISODE_ID_MAX_LEN {
+            return Err(ErrorData::invalid_params(
+                format!("argument '{key}' must be at most {CORAL_EPISODE_ID_MAX_LEN} bytes"),
+                None,
+            ));
+        }
+        if !value.bytes().all(|byte| byte.is_ascii_graphic()) {
+            return Err(ErrorData::invalid_params(
+                format!("argument '{key}' must be graphic ASCII with no spaces or control bytes"),
+                None,
+            ));
+        }
+        Ok(Self(value.to_string()))
+    }
+
+    fn is_valid(value: &str) -> bool {
+        !value.is_empty()
+            && value.len() <= CORAL_EPISODE_ID_MAX_LEN
+            && value.bytes().all(|byte| byte.is_ascii_graphic())
+    }
+}
+
+#[derive(JsonSchema)]
+pub(crate) struct OpenEpisodeArguments {
+    #[schemars(
+        length(min = 1, max = CORAL_EPISODE_INTENT_MAX_CHARS),
+        pattern(r"\S"),
+        description = "Natural-language description of the task this episode should group."
+    )]
+    pub(crate) intent: String,
+    #[schemars(
+        description = "Optional parent episode id when this task is a child of an existing episode."
+    )]
+    pub(crate) parent_episode_id: Option<EpisodeId>,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct EpisodeOpenedValue {
+    pub(crate) episode_id: EpisodeId,
+    pub(crate) parent_episode_id: Option<EpisodeId>,
+    pub(crate) message: &'static str,
+    pub(crate) instructions: &'static str,
+}
+
+pub(crate) fn open_episode_tool() -> Tool {
+    Tool::new(
+        ToolName::OpenEpisode.as_str(),
+        "Open a Coral episode for the current task. Call this once at the start of a task, then pass the returned episode_id on subsequent Coral tool calls for that task.",
+        tool_input_schema::<OpenEpisodeArguments>(),
+    )
+    .with_raw_output_schema(tool_output_schema::<EpisodeOpenedValue>())
+    .with_annotations(
+        ToolAnnotations::with_title("Open Episode")
+            .read_only(false)
+            .destructive(false)
+            .idempotent(false)
+            .open_world(false),
+    )
+}
+
+pub(crate) fn open_episode_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<OpenEpisodeArguments, ErrorData> {
+    Ok(OpenEpisodeArguments {
+        intent: required_string_argument(arguments, "intent")?,
+        parent_episode_id: optional_episode_id_argument(arguments, "parent_episode_id")?,
+    })
+}
+
+pub(crate) fn optional_episode_id_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+) -> Result<Option<EpisodeId>, ErrorData> {
+    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let value = value.as_str().ok_or_else(|| {
+        ErrorData::invalid_params(format!("argument '{key}' must be a string"), None)
+    })?;
+    EpisodeId::parse_argument(key, value).map(Some)
+}
+
+pub(crate) fn with_episode_id_argument(mut tool: Tool) -> Tool {
+    add_episode_id_property(Arc::make_mut(&mut tool.input_schema));
+    tool
+}
+
+fn add_episode_id_property(schema: &mut Map<String, Value>) {
+    schema
+        .entry("properties")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .expect("tool input properties are an object")
+        .insert(
+            "episode_id".to_string(),
+            nullable_episode_id_schema(Some(EPISODE_ID_ARGUMENT_DESCRIPTION)),
+        );
+}
+
+fn nullable_episode_id_schema(description: Option<&str>) -> Value {
+    let mut schema = json_schema_value::<Option<EpisodeId>>();
+    if let Some(description) = description {
+        schema
+            .as_object_mut()
+            .expect("nullable episode id schema is an object")
+            .insert("description".to_string(), json!(description));
+    }
+    schema
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Map, Value};
+
+    use super::{EpisodeId, optional_episode_id_argument};
+
+    #[test]
+    fn episode_id_argument_accepts_valid_graphic_ascii() {
+        let arguments = Map::from_iter([(
+            "episode_id".to_string(),
+            Value::String("episode-1".to_string()),
+        )]);
+
+        let parsed = optional_episode_id_argument(Some(&arguments), "episode_id")
+            .expect("episode id should parse");
+
+        assert_eq!(parsed.as_ref().map(EpisodeId::as_str), Some("episode-1"));
+    }
+}

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -20,8 +20,13 @@ pub(crate) struct ToolError {
 }
 
 pub(crate) fn tool_error_result(error: ToolError, data: Option<Value>) -> CallToolResult {
-    let structured = serde_json::to_value(StructuredToolErrorValue { error, data })
-        .expect("tool error value serializes");
+    let structured = match data {
+        Some(data) => serde_json::to_value(ToolErrorWithData { error, data })
+            .expect("tool error value with data serializes"),
+        None => {
+            serde_json::to_value(ToolErrorValue { error }).expect("tool error value serializes")
+        }
+    };
     let mut result = CallToolResult::structured_error(structured);
     result.content = Vec::new();
     result
@@ -112,11 +117,16 @@ pub(crate) fn status_to_error_data(status: &tonic::Status) -> ErrorData {
     }
 }
 
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct ToolErrorWithData<T> {
+    pub(crate) error: ToolError,
+    pub(crate) data: T,
+}
+
 #[derive(Serialize)]
-struct StructuredToolErrorValue {
+struct ToolErrorValue {
     error: ToolError,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    data: Option<Value>,
 }
 
 #[derive(Serialize)]

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -1,10 +1,12 @@
 use coral_client::{DecodedStatusError, decode_status_error};
 use rmcp::{ErrorData, model::CallToolResult};
+use schemars::JsonSchema;
 use serde::Serialize;
-use serde_json::{Value, json};
+use serde_json::Value;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub(crate) struct ToolError {
     pub(crate) summary: String,
     pub(crate) detail: String,
@@ -23,23 +25,6 @@ pub(crate) fn tool_error_result(error: ToolError, data: Option<Value>) -> CallTo
     let mut result = CallToolResult::structured_error(structured);
     result.content = Vec::new();
     result
-}
-
-pub(crate) fn tool_error_output_schema() -> Value {
-    json!({
-        "type": "object",
-        "required": ["summary", "detail", "grpc_code", "retryable", "metadata"],
-        "additionalProperties": false,
-        "properties": {
-            "summary": { "type": "string" },
-            "detail": { "type": "string" },
-            "hint": { "type": "string" },
-            "grpc_code": { "type": "string" },
-            "reason": { "type": "string" },
-            "retryable": { "type": "boolean" },
-            "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
-        }
-    })
 }
 
 pub(crate) fn tool_error_from_status(operation: &str, status: &tonic::Status) -> ToolError {

--- a/crates/coral-mcp/src/surface/feedback.rs
+++ b/crates/coral-mcp/src/surface/feedback.rs
@@ -1,0 +1,66 @@
+use rmcp::model::{Tool, ToolAnnotations};
+use schemars::JsonSchema;
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use super::{
+    arguments::required_string_argument,
+    schema::{tool_input_schema, tool_output_schema},
+    tool_names::ToolName,
+};
+
+#[derive(JsonSchema)]
+pub(crate) struct FeedbackArguments {
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "What you were trying to do."
+    )]
+    pub(crate) trying_to_do: String,
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "What you already tried."
+    )]
+    pub(crate) tried: String,
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Where you got blocked."
+    )]
+    pub(crate) stuck: String,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct FeedbackStoredValue {
+    pub(crate) feedback_id: String,
+    pub(crate) created_at: String,
+    pub(crate) message: &'static str,
+}
+
+pub(crate) fn feedback_tool() -> Tool {
+    Tool::new(
+        ToolName::Feedback.as_str(),
+        "Submit feedback when you are blocked. Coral stores the report locally and uploads an anonymous copy, without user identifiers, to Coral's hosted feedback service to improve Coral's performance.",
+        tool_input_schema::<FeedbackArguments>(),
+    )
+    .with_raw_output_schema(tool_output_schema::<FeedbackStoredValue>())
+    .with_annotations(
+        ToolAnnotations::with_title("Store Feedback Report")
+            .read_only(false)
+            .destructive(false)
+            .idempotent(false)
+            .open_world(true),
+    )
+}
+
+pub(crate) fn feedback_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<FeedbackArguments, rmcp::ErrorData> {
+    Ok(FeedbackArguments {
+        trying_to_do: required_string_argument(arguments, "trying_to_do")?,
+        tried: required_string_argument(arguments, "tried")?,
+        stuck: required_string_argument(arguments, "stuck")?,
+    })
+}

--- a/crates/coral-mcp/src/surface/feedback.rs
+++ b/crates/coral-mcp/src/surface/feedback.rs
@@ -11,23 +11,11 @@ use super::{
 
 #[derive(JsonSchema)]
 pub(crate) struct FeedbackArguments {
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "What you were trying to do."
-    )]
+    #[schemars(length(min = 1), description = "What you were trying to do.")]
     pub(crate) trying_to_do: String,
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "What you already tried."
-    )]
+    #[schemars(length(min = 1), description = "What you already tried.")]
     pub(crate) tried: String,
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "Where you got blocked."
-    )]
+    #[schemars(length(min = 1), description = "Where you got blocked.")]
     pub(crate) stuck: String,
 }
 

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -1,40 +1,35 @@
 //! Focused helpers for the Coral MCP surface.
 
+mod arguments;
 mod catalog;
+mod context;
 mod discovery;
+mod episode;
 mod errors;
+mod feedback;
 mod resources;
 mod schema;
 mod source_names;
 mod sql;
+mod tool_names;
 mod tools;
 mod values;
 
 pub(crate) use catalog::{
-    CatalogToolKind, describe_table_output_schema, describe_table_value,
-    list_catalog_output_schema, list_catalog_value, list_columns_output_schema, list_columns_value,
-    search_catalog_output_schema, search_catalog_value,
+    CatalogToolKind, describe_table_arguments, describe_table_value, list_catalog_arguments,
+    list_catalog_value, list_columns_arguments, list_columns_table_fallback_value,
+    list_columns_value, search_catalog_arguments, search_catalog_value,
 };
-pub(crate) use discovery::{
-    DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_OFFSET, DEFAULT_SEARCH_PAGINATION_LIMIT,
-    MAX_PAGINATION_LIMIT, MAX_SEARCH_PAGINATION_LIMIT, MIN_PAGINATION_LIMIT, Pagination,
-    parse_pagination, parse_search_pagination,
+pub(crate) use context::ToolDescriptionContext;
+pub(crate) use episode::{
+    EpisodeId, EpisodeOpenedValue, open_episode_arguments, optional_episode_id_argument,
 };
-pub(crate) use errors::{
-    ToolError, ToolErrorWithData, status_to_error_data, tool_error_from_status, tool_error_result,
-};
+pub(crate) use errors::{status_to_error_data, tool_error_from_status, tool_error_result};
+pub(crate) use feedback::{FeedbackStoredValue, feedback_arguments};
 pub(crate) use resources::{
     guide_resource, guide_resource_content, initial_instructions, tables_resource,
     tables_resource_content,
 };
-pub(crate) use source_names::connected_source_names_text;
-pub(crate) use sql::{
-    SqlBatchValue, SqlQueryResultValue, sql_arguments, sql_input_schema, sql_output_schema,
-};
-pub(crate) use tools::{
-    EpisodeOpenedValue, FeedbackStoredValue, ToolDescriptionContext, build_tool_result,
-    describe_table_arguments, describe_table_tool, feedback_arguments, feedback_tool,
-    list_catalog_arguments, list_catalog_tool, list_columns_arguments, list_columns_tool,
-    open_episode_arguments, open_episode_tool, optional_episode_id_argument,
-    search_catalog_arguments, search_catalog_tool, sql_tool, with_episode_id_argument,
-};
+pub(crate) use sql::{SqlBatchValue, SqlQueryResultValue, sql_arguments};
+pub(crate) use tool_names::ToolName;
+pub(crate) use tools::{available_tools, build_tool_result};

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -16,11 +16,12 @@ pub(crate) use catalog::{
     search_catalog_output_schema, search_catalog_value,
 };
 pub(crate) use discovery::{
-    DEFAULT_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT, Pagination, parse_pagination,
-    parse_pagination_with_limits,
+    DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_OFFSET, DEFAULT_SEARCH_PAGINATION_LIMIT,
+    MAX_PAGINATION_LIMIT, MAX_SEARCH_PAGINATION_LIMIT, MIN_PAGINATION_LIMIT, Pagination,
+    parse_pagination, parse_search_pagination,
 };
 pub(crate) use errors::{
-    ToolError, status_to_error_data, tool_error_from_status, tool_error_result,
+    ToolError, ToolErrorWithData, status_to_error_data, tool_error_from_status, tool_error_result,
 };
 pub(crate) use resources::{
     guide_resource, guide_resource_content, initial_instructions, tables_resource,

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -11,12 +11,16 @@ mod tools;
 mod values;
 
 pub(crate) use catalog::{
-    describe_table_value, list_catalog_value, list_columns_value, search_catalog_value,
+    CatalogToolKind, describe_table_output_schema, describe_table_value,
+    list_catalog_output_schema, list_catalog_value, list_columns_output_schema, list_columns_value,
+    search_catalog_output_schema, search_catalog_value,
 };
-pub(crate) use discovery::{Pagination, parse_pagination, parse_pagination_with_limits};
+pub(crate) use discovery::{
+    DEFAULT_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT, Pagination, parse_pagination,
+    parse_pagination_with_limits,
+};
 pub(crate) use errors::{
-    ToolError, status_to_error_data, tool_error_from_status, tool_error_output_schema,
-    tool_error_result,
+    ToolError, status_to_error_data, tool_error_from_status, tool_error_result,
 };
 pub(crate) use resources::{
     guide_resource, guide_resource_content, initial_instructions, tables_resource,
@@ -27,9 +31,9 @@ pub(crate) use sql::{
     SqlBatchValue, SqlQueryResultValue, sql_arguments, sql_input_schema, sql_output_schema,
 };
 pub(crate) use tools::{
-    CatalogToolKind, ToolDescriptionContext, build_tool_result, describe_table_arguments,
-    describe_table_tool, feedback_tool, list_catalog_arguments, list_catalog_tool,
-    list_columns_arguments, list_columns_tool, open_episode_arguments, open_episode_tool,
-    optional_episode_id_argument, required_string_argument, search_catalog_arguments,
-    search_catalog_tool, sql_tool, with_episode_id_argument,
+    EpisodeOpenedValue, FeedbackStoredValue, ToolDescriptionContext, build_tool_result,
+    describe_table_arguments, describe_table_tool, feedback_arguments, feedback_tool,
+    list_catalog_arguments, list_catalog_tool, list_columns_arguments, list_columns_tool,
+    open_episode_arguments, open_episode_tool, optional_episode_id_argument,
+    search_catalog_arguments, search_catalog_tool, sql_tool, with_episode_id_argument,
 };

--- a/crates/coral-mcp/src/surface/schema.rs
+++ b/crates/coral-mcp/src/surface/schema.rs
@@ -1,12 +1,42 @@
 use std::sync::Arc;
 
+use schemars::JsonSchema;
 use serde_json::{Map, Value};
 
-pub(crate) fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
-    Arc::new(
-        value
-            .as_object()
-            .cloned()
-            .expect("tool schemas should be JSON objects"),
-    )
+pub(crate) fn tool_input_schema<T>() -> Arc<Map<String, Value>>
+where
+    T: JsonSchema + std::any::Any,
+{
+    rmcp::handler::server::tool::schema_for_input::<T>().unwrap_or_else(|error| {
+        panic!(
+            "invalid MCP input schema for {}: {error}",
+            std::any::type_name::<T>()
+        )
+    })
+}
+
+pub(crate) fn tool_output_schema<T>() -> Arc<Map<String, Value>>
+where
+    T: JsonSchema + std::any::Any,
+{
+    rmcp::handler::server::tool::schema_for_output::<T>().unwrap_or_else(|error| {
+        panic!(
+            "invalid MCP output schema for {}: {error}",
+            std::any::type_name::<T>()
+        )
+    })
+}
+
+pub(crate) fn json_schema_value<T>() -> Value
+where
+    T: JsonSchema,
+{
+    let mut schema = serde_json::to_value(schemars::schema_for!(T))
+        .expect("generated tool schema should serialize");
+    if let Some(object) = schema.as_object_mut() {
+        object.remove("$schema");
+        object.remove("title");
+        object.remove("description");
+    }
+    schema
 }

--- a/crates/coral-mcp/src/surface/sql.rs
+++ b/crates/coral-mcp/src/surface/sql.rs
@@ -18,7 +18,7 @@ const MAX_SQL_BATCH_RESULT_INDEX: usize = MAX_SQL_BATCH_QUERIES - 1;
 pub(crate) struct SqlArguments {
     #[schemars(
         length(min = 1, max = MAX_SQL_BATCH_QUERIES),
-        inner(length(min = 1), pattern(r"\S")),
+        inner(length(min = 1)),
         description = "One to ten independent read-only SQL statements to execute against Coral. Entries must not depend on one another's rows, errors, or side effects."
     )]
     pub(crate) queries: Vec<String>,

--- a/crates/coral-mcp/src/surface/sql.rs
+++ b/crates/coral-mcp/src/surface/sql.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::{ToolError, schema::tool_input_schema, schema::tool_output_schema};
+use super::{ToolError, ToolErrorWithData, schema::tool_input_schema, schema::tool_output_schema};
 
 pub(crate) const MAX_SQL_BATCH_QUERIES: usize = 10;
 const MAX_SQL_BATCH_RESULT_INDEX: usize = MAX_SQL_BATCH_QUERIES - 1;
@@ -60,18 +60,7 @@ pub(crate) enum SqlQueryResultValue {
 )]
 enum SqlToolOutputSchema {
     Success(SqlBatchValue),
-    PartialFailure(SqlPartialFailureOutput),
-}
-
-#[derive(JsonSchema)]
-#[schemars(deny_unknown_fields)]
-#[expect(
-    dead_code,
-    reason = "schema-only struct for the SQL partial-failure envelope"
-)]
-struct SqlPartialFailureOutput {
-    error: ToolError,
-    data: SqlBatchValue,
+    PartialFailure(ToolErrorWithData<SqlBatchValue>),
 }
 
 impl SqlBatchValue {

--- a/crates/coral-mcp/src/surface/sql.rs
+++ b/crates/coral-mcp/src/surface/sql.rs
@@ -1,33 +1,77 @@
 use std::{collections::HashMap, sync::Arc};
 
 use rmcp::ErrorData;
+use schemars::JsonSchema;
 use serde::Serialize;
-use serde_json::{Map, Value, json};
+use serde_json::{Map, Value};
 
-use super::{ToolError, schema::json_object_schema, tool_error_output_schema};
+use super::{ToolError, schema::tool_input_schema, schema::tool_output_schema};
 
 pub(crate) const MAX_SQL_BATCH_QUERIES: usize = 10;
 const MAX_SQL_BATCH_RESULT_INDEX: usize = MAX_SQL_BATCH_QUERIES - 1;
 
+#[derive(JsonSchema)]
 pub(crate) struct SqlArguments {
+    #[schemars(
+        length(min = 1, max = MAX_SQL_BATCH_QUERIES),
+        inner(length(min = 1), pattern(r"\S")),
+        description = "One to ten independent read-only SQL statements to execute against Coral. Entries must not depend on one another's rows, errors, or side effects."
+    )]
     pub(crate) queries: Vec<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub(crate) struct SqlBatchValue {
+    #[schemars(range(min = 1, max = MAX_SQL_BATCH_QUERIES))]
     total_count: usize,
+    #[schemars(range(min = 0, max = MAX_SQL_BATCH_QUERIES))]
     success_count: usize,
+    #[schemars(range(min = 0, max = MAX_SQL_BATCH_QUERIES))]
     error_count: usize,
+    #[schemars(length(min = 1, max = MAX_SQL_BATCH_QUERIES))]
     results: Vec<SqlQueryResultValue>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
 #[serde(tag = "status")]
 pub(crate) enum SqlQueryResultValue {
     #[serde(rename = "success")]
-    Success { index: usize, rows: Vec<Value> },
+    Success {
+        #[schemars(range(min = 0, max = MAX_SQL_BATCH_RESULT_INDEX))]
+        index: usize,
+        #[schemars(schema_with = "json_object_array_schema")]
+        rows: Vec<Value>,
+    },
     #[serde(rename = "error")]
-    Error { index: usize, error: ToolError },
+    Error {
+        #[schemars(range(min = 0, max = MAX_SQL_BATCH_RESULT_INDEX))]
+        index: usize,
+        error: ToolError,
+    },
+}
+
+#[derive(JsonSchema)]
+#[serde(untagged)]
+#[schemars(extend("type" = "object"))]
+#[expect(
+    dead_code,
+    reason = "schema-only enum for the SQL tool output contract"
+)]
+enum SqlToolOutputSchema {
+    Success(SqlBatchValue),
+    PartialFailure(SqlPartialFailureOutput),
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+#[expect(
+    dead_code,
+    reason = "schema-only struct for the SQL partial-failure envelope"
+)]
+struct SqlPartialFailureOutput {
+    error: ToolError,
+    data: SqlBatchValue,
 }
 
 impl SqlBatchValue {
@@ -129,86 +173,16 @@ pub(crate) fn sql_arguments(
 }
 
 pub(crate) fn sql_input_schema() -> Arc<Map<String, Value>> {
-    json_object_schema(&json!({
-        "type": "object",
-        "required": ["queries"],
-        "properties": {
-            "queries": {
-                "type": "array",
-                "description": "One to ten independent read-only SQL statements to execute against Coral. Entries must not depend on one another's rows, errors, or side effects.",
-                "minItems": 1,
-                "maxItems": MAX_SQL_BATCH_QUERIES,
-                "items": {
-                    "type": "string",
-                    "minLength": 1,
-                    "pattern": r"\S"
-                }
-            }
-        }
-    }))
+    tool_input_schema::<SqlArguments>()
 }
 
 pub(crate) fn sql_output_schema() -> Arc<Map<String, Value>> {
-    let result_index_max = MAX_SQL_BATCH_RESULT_INDEX;
-    json_object_schema(&json!({
-        "type": "object",
-        "oneOf": [
-            { "$ref": "#/$defs/sql_batch" },
-            {
-                "type": "object",
-                "required": ["error", "data"],
-                "additionalProperties": false,
-                "properties": {
-                    "error": { "$ref": "#/$defs/tool_error" },
-                    "data": { "$ref": "#/$defs/sql_batch" }
-                }
-            }
-        ],
-        "$defs": {
-            "sql_batch": sql_batch_output_schema(result_index_max),
-            "tool_error": tool_error_output_schema()
-        }
-    }))
+    tool_output_schema::<SqlToolOutputSchema>()
 }
 
-fn sql_batch_output_schema(result_index_max: usize) -> Value {
-    json!({
-        "type": "object",
-        "required": ["total_count", "success_count", "error_count", "results"],
-        "additionalProperties": false,
-        "properties": {
-            "total_count": { "type": "integer", "minimum": 1, "maximum": MAX_SQL_BATCH_QUERIES },
-            "success_count": { "type": "integer", "minimum": 0, "maximum": MAX_SQL_BATCH_QUERIES },
-            "error_count": { "type": "integer", "minimum": 0, "maximum": MAX_SQL_BATCH_QUERIES },
-            "results": {
-                "type": "array",
-                "minItems": 1,
-                "maxItems": MAX_SQL_BATCH_QUERIES,
-                "items": {
-                    "oneOf": [
-                        {
-                            "type": "object",
-                            "required": ["index", "status", "rows"],
-                            "additionalProperties": false,
-                            "properties": {
-                                "index": { "type": "integer", "minimum": 0, "maximum": result_index_max },
-                                "status": { "const": "success" },
-                                "rows": { "type": "array", "items": { "type": "object" } }
-                            }
-                        },
-                        {
-                            "type": "object",
-                            "required": ["index", "status", "error"],
-                            "additionalProperties": false,
-                            "properties": {
-                                "index": { "type": "integer", "minimum": 0, "maximum": result_index_max },
-                                "status": { "const": "error" },
-                                "error": { "$ref": "#/$defs/tool_error" }
-                            }
-                        }
-                    ]
-                }
-            }
-        },
+fn json_object_array_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "array",
+        "items": { "type": "object" }
     })
 }

--- a/crates/coral-mcp/src/surface/sql.rs
+++ b/crates/coral-mcp/src/surface/sql.rs
@@ -1,11 +1,15 @@
 use std::{collections::HashMap, sync::Arc};
 
 use rmcp::ErrorData;
+use rmcp::model::{Tool, ToolAnnotations};
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::{ToolError, ToolErrorWithData, schema::tool_input_schema, schema::tool_output_schema};
+use super::context::ToolDescriptionContext;
+use super::errors::{ToolError, ToolErrorWithData};
+use super::schema::{tool_input_schema, tool_output_schema};
+use super::tool_names::ToolName;
 
 pub(crate) const MAX_SQL_BATCH_QUERIES: usize = 10;
 const MAX_SQL_BATCH_RESULT_INDEX: usize = MAX_SQL_BATCH_QUERIES - 1;
@@ -161,6 +165,22 @@ pub(crate) fn sql_arguments(
     Ok(SqlArguments { queries })
 }
 
+pub(crate) fn sql_tool(context: &ToolDescriptionContext) -> Tool {
+    Tool::new(
+        ToolName::Sql.as_str(),
+        sql_tool_description(context),
+        sql_input_schema(),
+    )
+    .with_raw_output_schema(sql_output_schema())
+    .with_annotations(
+        ToolAnnotations::with_title("Run SQL")
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(true),
+    )
+}
+
 pub(crate) fn sql_input_schema() -> Arc<Map<String, Value>> {
     tool_input_schema::<SqlArguments>()
 }
@@ -174,4 +194,19 @@ fn json_object_array_schema(_generator: &mut schemars::SchemaGenerator) -> schem
         "type": "array",
         "items": { "type": "object" }
     })
+}
+
+fn sql_tool_description(context: &ToolDescriptionContext) -> String {
+    if context.visible_table_count == 0 {
+        format!(
+            "Execute 1 to 10 independent read-only SQL queries against the Coral database using queries[]. Each entry must be independent and must not depend on another entry's rows, errors, or side effects. {} No user tables are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first.",
+            context.connected_sources_sentence()
+        )
+    } else {
+        format!(
+            "Execute 1 to 10 independent read-only SQL queries against the Coral database across connected Coral sources/schemas using queries[]. Each entry must be independent and must not depend on another entry's rows, errors, or side effects. {} {} table(s) are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first. Use JOIN, CROSS JOIN, CTEs, subqueries, and aggregates inside one query when work is dependent.",
+            context.connected_sources_sentence(),
+            context.visible_table_count
+        )
+    }
 }

--- a/crates/coral-mcp/src/surface/tool_names.rs
+++ b/crates/coral-mcp/src/surface/tool_names.rs
@@ -1,3 +1,5 @@
+use std::{fmt, str::FromStr};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ToolName {
     Sql,
@@ -21,17 +23,30 @@ impl ToolName {
             Self::Feedback => "feedback",
         }
     }
+}
 
-    pub(crate) fn from_str(value: &str) -> Option<Self> {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct UnknownToolName;
+
+impl FromStr for ToolName {
+    type Err = UnknownToolName;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
-            "sql" => Some(Self::Sql),
-            "list_catalog" => Some(Self::ListCatalog),
-            "search_catalog" => Some(Self::SearchCatalog),
-            "describe_table" => Some(Self::DescribeTable),
-            "list_columns" => Some(Self::ListColumns),
-            "open_episode" => Some(Self::OpenEpisode),
-            "feedback" => Some(Self::Feedback),
-            _ => None,
+            "sql" => Ok(Self::Sql),
+            "list_catalog" => Ok(Self::ListCatalog),
+            "search_catalog" => Ok(Self::SearchCatalog),
+            "describe_table" => Ok(Self::DescribeTable),
+            "list_columns" => Ok(Self::ListColumns),
+            "open_episode" => Ok(Self::OpenEpisode),
+            "feedback" => Ok(Self::Feedback),
+            _ => Err(UnknownToolName),
         }
+    }
+}
+
+impl fmt::Display for ToolName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str((*self).as_str())
     }
 }

--- a/crates/coral-mcp/src/surface/tool_names.rs
+++ b/crates/coral-mcp/src/surface/tool_names.rs
@@ -1,0 +1,37 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ToolName {
+    Sql,
+    ListCatalog,
+    SearchCatalog,
+    DescribeTable,
+    ListColumns,
+    OpenEpisode,
+    Feedback,
+}
+
+impl ToolName {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Sql => "sql",
+            Self::ListCatalog => "list_catalog",
+            Self::SearchCatalog => "search_catalog",
+            Self::DescribeTable => "describe_table",
+            Self::ListColumns => "list_columns",
+            Self::OpenEpisode => "open_episode",
+            Self::Feedback => "feedback",
+        }
+    }
+
+    pub(crate) fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "sql" => Some(Self::Sql),
+            "list_catalog" => Some(Self::ListCatalog),
+            "search_catalog" => Some(Self::SearchCatalog),
+            "describe_table" => Some(Self::DescribeTable),
+            "list_columns" => Some(Self::ListColumns),
+            "open_episode" => Some(Self::OpenEpisode),
+            "feedback" => Some(Self::Feedback),
+            _ => None,
+        }
+    }
+}

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -253,6 +253,32 @@ mod tests {
         }
     }
 
+    #[test]
+    fn advertised_input_schemas_do_not_use_generic_nonblank_pattern() {
+        let context = ToolDescriptionContext::new(1, 0, Vec::new());
+
+        for tool in available_tools(&context, true, true) {
+            assert!(
+                !contains_pattern(&Value::Object(tool.input_schema.as_ref().clone()), r"\S"),
+                "tool '{}' should not advertise generic non-blank string patterns",
+                tool.name
+            );
+        }
+    }
+
+    fn contains_pattern(value: &Value, pattern: &str) -> bool {
+        match value {
+            Value::Object(object) => {
+                object.get("pattern").and_then(Value::as_str) == Some(pattern)
+                    || object
+                        .values()
+                        .any(|value| contains_pattern(value, pattern))
+            }
+            Value::Array(values) => values.iter().any(|value| contains_pattern(value, pattern)),
+            _ => false,
+        }
+    }
+
     fn tool_by_name<'a>(tools: &'a [Tool], name: &str) -> &'a Tool {
         tools
             .iter()

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -4,17 +4,24 @@ use rmcp::{
     ErrorData,
     model::{CallToolResult, Tool, ToolAnnotations},
 };
+use schemars::JsonSchema;
+use serde::Serialize;
 use serde_json::{Map, Value, json};
 
 use coral_api::{CORAL_EPISODE_ID_MAX_LEN, CORAL_EPISODE_INTENT_MAX_CHARS};
 
 use super::{
-    Pagination, connected_source_names_text, parse_pagination, parse_pagination_with_limits,
-    schema::json_object_schema, sql_input_schema, sql_output_schema,
+    CatalogToolKind, DEFAULT_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT, Pagination,
+    connected_source_names_text, describe_table_output_schema, list_catalog_output_schema,
+    list_columns_output_schema, parse_pagination, parse_pagination_with_limits,
+    schema::json_schema_value, schema::tool_input_schema, schema::tool_output_schema,
+    search_catalog_output_schema, sql_input_schema, sql_output_schema,
 };
 
 const EPISODE_ID_ARGUMENT_DESCRIPTION: &str = "Optional episode id returned by open_episode. Pass it on subsequent Coral tool calls for the same task so Coral can attribute the call to that episode.";
 const EPISODE_ID_JSON_SCHEMA_PATTERN: &str = "^[!-~]+$";
+const DEFAULT_SEARCH_LIMIT: u32 = 20;
+const MAX_SEARCH_LIMIT: u32 = 100;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ToolDescriptionContext {
@@ -46,43 +53,190 @@ impl ToolDescriptionContext {
     }
 }
 
+#[derive(JsonSchema)]
 pub(crate) struct ListCatalogArguments {
+    #[schemars(description = "Optional exact SQL schema name to list.")]
     pub(crate) schema: Option<String>,
+    #[schemars(
+        description = "Optional item kind to list. Omit or pass null to list all catalog items."
+    )]
     pub(crate) kind: Option<CatalogToolKind>,
+    #[schemars(flatten, with = "DefaultPaginationInput")]
     pub(crate) pagination: Pagination,
 }
 
+#[derive(JsonSchema)]
 pub(crate) struct SearchCatalogArguments {
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Rust regex pattern to match database catalog metadata."
+    )]
     pub(crate) pattern: String,
+    #[schemars(description = "Optional exact SQL schema name to search.")]
     pub(crate) schema: Option<String>,
+    #[schemars(
+        description = "Optional item kind to search. Omit or pass null to search all catalog items."
+    )]
     pub(crate) kind: Option<CatalogToolKind>,
+    #[serde(default = "default_true")]
+    #[schemars(description = "Whether regex matching is case-insensitive. Defaults to true.")]
     pub(crate) ignore_case: bool,
+    #[schemars(flatten, with = "SearchPaginationInput")]
     pub(crate) pagination: Pagination,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum CatalogToolKind {
-    Table,
-    TableFunction,
-}
-
+#[derive(JsonSchema)]
 pub(crate) struct DescribeTableArguments {
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Exact SQL schema name."
+    )]
     pub(crate) schema: String,
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Exact table name within the SQL schema."
+    )]
     pub(crate) table: String,
 }
 
+#[derive(JsonSchema)]
 pub(crate) struct ListColumnsArguments {
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Exact SQL schema name."
+    )]
     pub(crate) schema: String,
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Exact table name within the SQL schema."
+    )]
     pub(crate) table: String,
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Optional Rust regex matched against column names, descriptions, and data types."
+    )]
     pub(crate) pattern: Option<String>,
+    #[serde(default = "default_true")]
+    #[schemars(description = "Whether regex matching is case-insensitive. Defaults to true.")]
     pub(crate) ignore_case: bool,
+    #[serde(default)]
+    #[schemars(description = "Only return columns that are required filters. Defaults to false.")]
     pub(crate) required_only: bool,
+    #[schemars(flatten, with = "DefaultPaginationInput")]
     pub(crate) pagination: Pagination,
 }
 
+#[derive(JsonSchema)]
+pub(crate) struct FeedbackArguments {
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "What you were trying to do."
+    )]
+    pub(crate) trying_to_do: String,
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "What you already tried."
+    )]
+    pub(crate) tried: String,
+    #[schemars(
+        length(min = 1),
+        pattern(r"\S"),
+        description = "Where you got blocked."
+    )]
+    pub(crate) stuck: String,
+}
+
+#[derive(JsonSchema)]
 pub(crate) struct OpenEpisodeArguments {
+    #[schemars(
+        length(min = 1, max = CORAL_EPISODE_INTENT_MAX_CHARS),
+        pattern(r"\S"),
+        description = "Natural-language description of the task this episode should group."
+    )]
     pub(crate) intent: String,
+    #[schemars(
+        with = "Option<EpisodeIdSchema>",
+        description = "Optional parent episode id when this task is a child of an existing episode."
+    )]
     pub(crate) parent_episode_id: Option<String>,
+}
+
+#[derive(JsonSchema)]
+#[expect(
+    dead_code,
+    reason = "schema-only struct for flattened default pagination inputs"
+)]
+struct DefaultPaginationInput {
+    #[serde(default = "default_pagination_limit")]
+    #[schemars(
+        range(min = 1, max = MAX_PAGINATION_LIMIT),
+        description = "Maximum items to return, from 1 to 200. Defaults to 50."
+    )]
+    limit: u32,
+    #[serde(default)]
+    #[schemars(
+        range(min = 0, max = u32::MAX),
+        description = "Number of matching items to skip. Defaults to 0."
+    )]
+    offset: u32,
+}
+
+#[derive(JsonSchema)]
+#[expect(
+    dead_code,
+    reason = "schema-only struct for flattened search pagination inputs"
+)]
+struct SearchPaginationInput {
+    #[serde(default = "default_search_limit")]
+    #[schemars(
+        range(min = 1, max = MAX_SEARCH_LIMIT),
+        description = "Maximum catalog items to return, from 1 to 100. Defaults to 20."
+    )]
+    limit: u32,
+    #[serde(default)]
+    #[schemars(
+        range(min = 0, max = u32::MAX),
+        description = "Number of matching catalog items to skip. Defaults to 0."
+    )]
+    offset: u32,
+}
+
+#[derive(JsonSchema)]
+#[schemars(transparent, inline)]
+#[expect(dead_code, reason = "schema-only type for episode id constraints")]
+struct EpisodeIdSchema(
+    #[schemars(
+        length(min = 1, max = CORAL_EPISODE_ID_MAX_LEN),
+        regex(pattern = EPISODE_ID_JSON_SCHEMA_PATTERN)
+    )]
+    String,
+);
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct FeedbackStoredValue {
+    pub(crate) feedback_id: String,
+    pub(crate) created_at: String,
+    pub(crate) message: &'static str,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct EpisodeOpenedValue {
+    #[schemars(with = "EpisodeIdSchema")]
+    pub(crate) episode_id: String,
+    #[schemars(with = "Option<EpisodeIdSchema>")]
+    pub(crate) parent_episode_id: Option<String>,
+    pub(crate) message: &'static str,
+    pub(crate) instructions: &'static str,
 }
 
 pub(crate) fn sql_tool(context: &ToolDescriptionContext) -> Tool {
@@ -106,41 +260,7 @@ pub(crate) fn list_catalog_tool(context: &ToolDescriptionContext) -> Tool {
             context.visible_table_count,
             context.visible_function_count
         ),
-        json_object_schema(&json!({
-            "type": "object",
-            "properties": {
-                "schema": {
-                    "type": "string",
-                    "description": "Optional exact SQL schema name to list."
-                },
-                "kind": {
-                    "description": "Optional item kind to list. Omit or pass null to list all catalog items.",
-                    "anyOf": [
-                        {
-                            "type": "string",
-                            "enum": ["table", "table_function"]
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum catalog items to return, from 1 to 200. Defaults to 50.",
-                    "minimum": 1,
-                    "maximum": 200,
-                    "default": 50
-                },
-                "offset": {
-                    "type": "integer",
-                    "description": "Number of matching catalog items to skip. Defaults to 0.",
-                    "minimum": 0,
-                    "maximum": u32::MAX,
-                    "default": 0
-                }
-            }
-        })),
+        tool_input_schema::<ListCatalogArguments>(),
     )
     .with_raw_output_schema(list_catalog_output_schema())
     .with_annotations(
@@ -156,50 +276,7 @@ pub(crate) fn search_catalog_tool(context: &ToolDescriptionContext) -> Tool {
     Tool::new(
         "search_catalog",
         search_catalog_description(context),
-        json_object_schema(&json!({
-            "type": "object",
-            "required": ["pattern"],
-            "properties": {
-                "pattern": {
-                    "type": "string",
-                    "description": "Rust regex pattern to match database catalog metadata."
-                },
-                "schema": {
-                    "type": "string",
-                    "description": "Optional exact SQL schema name to search."
-                },
-                "kind": {
-                    "description": "Optional item kind to search. Omit or pass null to search all catalog items.",
-                    "anyOf": [
-                        {
-                            "type": "string",
-                            "enum": ["table", "table_function"]
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "ignore_case": {
-                    "type": "boolean",
-                    "description": "Whether regex matching is case-insensitive. Defaults to true."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum catalog items to return, from 1 to 100. Defaults to 20.",
-                    "minimum": 1,
-                    "maximum": 100,
-                    "default": 20
-                },
-                "offset": {
-                    "type": "integer",
-                    "description": "Number of matching catalog items to skip. Defaults to 0.",
-                    "minimum": 0,
-                    "maximum": u32::MAX,
-                    "default": 0
-                }
-            }
-        })),
+        tool_input_schema::<SearchCatalogArguments>(),
     )
     .with_raw_output_schema(search_catalog_output_schema())
     .with_annotations(
@@ -215,21 +292,9 @@ pub(crate) fn describe_table_tool() -> Tool {
     Tool::new(
         "describe_table",
         "Describe one database table without returning full column definitions.",
-        json_object_schema(&json!({
-            "type": "object",
-            "required": ["schema", "table"],
-            "properties": {
-                "schema": {
-                    "type": "string",
-                    "description": "Exact SQL schema name."
-                },
-                "table": {
-                    "type": "string",
-                    "description": "Exact table name within the SQL schema."
-                }
-            }
-        })),
+        tool_input_schema::<DescribeTableArguments>(),
     )
+    .with_raw_output_schema(describe_table_output_schema())
     .with_annotations(
         ToolAnnotations::with_title("Describe Table")
             .read_only(true)
@@ -243,46 +308,7 @@ pub(crate) fn list_columns_tool() -> Tool {
     Tool::new(
         "list_columns",
         "List columns for one database table with optional regex and required-filter narrowing.",
-        json_object_schema(&json!({
-            "type": "object",
-            "required": ["schema", "table"],
-            "properties": {
-                "schema": {
-                    "type": "string",
-                    "description": "Exact SQL schema name."
-                },
-                "table": {
-                    "type": "string",
-                    "description": "Exact table name within the SQL schema."
-                },
-                "pattern": {
-                    "type": "string",
-                    "description": "Optional Rust regex matched against column names, descriptions, and data types."
-                },
-                "ignore_case": {
-                    "type": "boolean",
-                    "description": "Whether regex matching is case-insensitive. Defaults to true."
-                },
-                "required_only": {
-                    "type": "boolean",
-                    "description": "Only return columns that are required filters. Defaults to false."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum columns to return, from 1 to 200. Defaults to 50.",
-                    "minimum": 1,
-                    "maximum": 200,
-                    "default": 50
-                },
-                "offset": {
-                    "type": "integer",
-                    "description": "Number of matching columns to skip. Defaults to 0.",
-                    "minimum": 0,
-                    "maximum": u32::MAX,
-                    "default": 0
-                }
-            }
-        })),
+        tool_input_schema::<ListColumnsArguments>(),
     )
     .with_raw_output_schema(list_columns_output_schema())
     .with_annotations(
@@ -298,25 +324,9 @@ pub(crate) fn feedback_tool() -> Tool {
     Tool::new(
         "feedback",
         "Submit feedback when you are blocked. Coral stores the report locally and uploads an anonymous copy, without user identifiers, to Coral's hosted feedback service to improve Coral's performance.",
-        json_object_schema(&json!({
-            "type": "object",
-            "required": ["trying_to_do", "tried", "stuck"],
-            "properties": {
-                "trying_to_do": {
-                    "type": "string",
-                    "description": "What you were trying to do."
-                },
-                "tried": {
-                    "type": "string",
-                    "description": "What you already tried."
-                },
-                "stuck": {
-                    "type": "string",
-                    "description": "Where you got blocked."
-                }
-            }
-        })),
+        tool_input_schema::<FeedbackArguments>(),
     )
+    .with_raw_output_schema(feedback_output_schema())
     .with_annotations(
         ToolAnnotations::with_title("Store Feedback Report")
             .read_only(false)
@@ -330,21 +340,7 @@ pub(crate) fn open_episode_tool() -> Tool {
     Tool::new(
         "open_episode",
         "Open a Coral episode for the current task. Call this once at the start of a task, then pass the returned episode_id on subsequent Coral tool calls for that task.",
-        json_object_schema(&json!({
-            "type": "object",
-            "required": ["intent"],
-            "properties": {
-                "intent": {
-                    "type": "string",
-                    "description": "Natural-language description of the task this episode should group.",
-                    "minLength": 1,
-                    "maxLength": CORAL_EPISODE_INTENT_MAX_CHARS
-                },
-                "parent_episode_id": nullable_episode_id_schema(Some(
-                    "Optional parent episode id when this task is a child of an existing episode."
-                ))
-            }
-        })),
+        tool_input_schema::<OpenEpisodeArguments>(),
     )
     .with_raw_output_schema(open_episode_output_schema())
     .with_annotations(
@@ -380,6 +376,16 @@ pub(crate) fn open_episode_arguments(
     })
 }
 
+pub(crate) fn feedback_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<FeedbackArguments, ErrorData> {
+    Ok(FeedbackArguments {
+        trying_to_do: required_string_argument(arguments, "trying_to_do")?,
+        tried: required_string_argument(arguments, "tried")?,
+        stuck: required_string_argument(arguments, "stuck")?,
+    })
+}
+
 pub(crate) fn list_catalog_arguments(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<ListCatalogArguments, ErrorData> {
@@ -398,7 +404,11 @@ pub(crate) fn search_catalog_arguments(
         schema: optional_string_argument(arguments, "schema")?,
         kind: optional_catalog_kind_argument(arguments)?,
         ignore_case: optional_bool_argument(arguments, "ignore_case", true)?,
-        pagination: parse_pagination_with_limits(arguments, 20, 100)?,
+        pagination: parse_pagination_with_limits(
+            arguments,
+            DEFAULT_SEARCH_LIMIT,
+            MAX_SEARCH_LIMIT,
+        )?,
     })
 }
 
@@ -408,14 +418,11 @@ fn optional_catalog_kind_argument(
     let Some(kind) = optional_string_argument(arguments, "kind")? else {
         return Ok(None);
     };
-    match kind.as_str() {
-        "table" => Ok(Some(CatalogToolKind::Table)),
-        "table_function" => Ok(Some(CatalogToolKind::TableFunction)),
-        _ => Err(ErrorData::invalid_params(
-            "argument 'kind' must be 'table' or 'table_function'",
-            None,
-        )),
-    }
+    serde_json::from_value(Value::String(kind))
+        .map(Some)
+        .map_err(|error| {
+            ErrorData::invalid_params(format!("invalid argument 'kind': {error}"), None)
+        })
 }
 
 pub(crate) fn describe_table_arguments(
@@ -504,6 +511,18 @@ fn search_catalog_description(context: &ToolDescriptionContext) -> String {
     )
 }
 
+fn default_true() -> bool {
+    true
+}
+
+fn default_pagination_limit() -> u32 {
+    DEFAULT_PAGINATION_LIMIT
+}
+
+fn default_search_limit() -> u32 {
+    DEFAULT_SEARCH_LIMIT
+}
+
 pub(crate) fn with_episode_id_argument(mut tool: Tool) -> Tool {
     add_episode_id_property(Arc::make_mut(&mut tool.input_schema));
     tool
@@ -522,14 +541,7 @@ fn add_episode_id_property(schema: &mut Map<String, Value>) {
 }
 
 fn nullable_episode_id_schema(description: Option<&str>) -> Value {
-    let mut schema = json!({
-        "anyOf": [
-            episode_id_string_schema(),
-            {
-                "type": "null"
-            }
-        ]
-    });
+    let mut schema = json_schema_value::<Option<EpisodeIdSchema>>();
     if let Some(description) = description {
         schema
             .as_object_mut()
@@ -539,365 +551,12 @@ fn nullable_episode_id_schema(description: Option<&str>) -> Value {
     schema
 }
 
-fn episode_id_string_schema() -> Value {
-    json!({
-        "type": "string",
-        "minLength": 1,
-        "maxLength": CORAL_EPISODE_ID_MAX_LEN,
-        "pattern": EPISODE_ID_JSON_SCHEMA_PATTERN
-    })
+fn feedback_output_schema() -> Arc<Map<String, Value>> {
+    tool_output_schema::<FeedbackStoredValue>()
 }
 
 fn open_episode_output_schema() -> Arc<Map<String, Value>> {
-    json_object_schema(&json!({
-        "type": "object",
-        "required": ["episode_id", "parent_episode_id", "message", "instructions"],
-        "additionalProperties": false,
-        "properties": {
-            "episode_id": episode_id_string_schema(),
-            "parent_episode_id": nullable_episode_id_schema(None),
-            "message": { "type": "string" },
-            "instructions": { "type": "string" }
-        }
-    }))
-}
-
-fn list_catalog_output_schema() -> Arc<Map<String, Value>> {
-    json_object_schema(&json!({
-        "type": "object",
-        "required": ["items", "total", "limit", "offset", "has_more"],
-        "additionalProperties": false,
-        "properties": {
-            "items": {
-                "type": "array",
-                "items": {
-                    "oneOf": [
-                        catalog_table_item_output_schema(),
-                        catalog_table_function_item_output_schema()
-                    ]
-                }
-            },
-            "total": {
-                "type": "integer",
-                "minimum": 0
-            },
-            "limit": {
-                "type": "integer",
-                "minimum": 1
-            },
-            "offset": {
-                "type": "integer",
-                "minimum": 0
-            },
-            "has_more": { "type": "boolean" },
-            "next_offset": {
-                "type": "integer",
-                "minimum": 0
-            }
-        }
-    }))
-}
-
-fn catalog_table_item_output_schema() -> Value {
-    json!({
-        "type": "object",
-        "required": ["kind", "schema_name", "name", "sql_reference", "description", "table"],
-        "additionalProperties": false,
-        "properties": {
-            "kind": { "enum": ["table"] },
-            "schema_name": { "type": "string" },
-            "name": { "type": "string" },
-            "sql_reference": { "type": "string" },
-            "description": { "type": "string" },
-            "table": {
-                "type": "object",
-                "required": ["table_name", "guide", "required_filters"],
-                "additionalProperties": false,
-                "properties": {
-                    "table_name": { "type": "string" },
-                    "guide": { "type": "string" },
-                    "required_filters": {
-                        "type": "array",
-                        "items": { "type": "string" }
-                    }
-                }
-            }
-        }
-    })
-}
-
-fn catalog_table_function_item_output_schema() -> Value {
-    json!({
-        "type": "object",
-        "required": [
-            "kind",
-            "schema_name",
-            "name",
-            "sql_reference",
-            "sql_call_example",
-            "description",
-            "table_function"
-        ],
-        "additionalProperties": false,
-        "properties": {
-            "kind": { "enum": ["table_function"] },
-            "schema_name": { "type": "string" },
-            "name": { "type": "string" },
-            "sql_reference": { "type": "string" },
-            "sql_call_example": { "type": "string" },
-            "description": { "type": "string" },
-            "table_function": {
-                "type": "object",
-                "required": ["function_name", "arguments", "result_columns"],
-                "additionalProperties": false,
-                "properties": {
-                    "function_name": { "type": "string" },
-                    "arguments": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["name", "required", "values"],
-                            "additionalProperties": false,
-                            "properties": {
-                                "name": { "type": "string" },
-                                "required": { "type": "boolean" },
-                                "values": {
-                                    "type": "array",
-                                    "items": { "type": "string" }
-                                }
-                            }
-                        }
-                    },
-                    "result_columns": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["column_name", "data_type", "is_nullable", "description"],
-                            "additionalProperties": false,
-                            "properties": {
-                                "column_name": { "type": "string" },
-                                "data_type": { "type": "string" },
-                                "is_nullable": { "type": "boolean" },
-                                "description": { "type": "string" }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    })
-}
-
-fn search_catalog_output_schema() -> Arc<Map<String, Value>> {
-    json_object_schema(&json!({
-        "type": "object",
-        "required": ["items", "total", "limit", "offset", "has_more"],
-        "additionalProperties": false,
-        "properties": {
-            "items": {
-                "type": "array",
-                "items": {
-                    "oneOf": [
-                        catalog_search_item_output_schema(catalog_table_item_output_schema()),
-                        catalog_search_item_output_schema(catalog_table_function_item_output_schema())
-                    ]
-                }
-            },
-            "total": {
-                "type": "integer",
-                "minimum": 0
-            },
-            "limit": {
-                "type": "integer",
-                "minimum": 1
-            },
-            "offset": {
-                "type": "integer",
-                "minimum": 0
-            },
-            "has_more": { "type": "boolean" },
-            "next_offset": {
-                "type": "integer",
-                "minimum": 0
-            }
-        }
-    }))
-}
-
-fn catalog_search_item_output_schema(mut schema: Value) -> Value {
-    let object = schema
-        .as_object_mut()
-        .expect("catalog item schema is an object");
-    object
-        .get_mut("required")
-        .and_then(Value::as_array_mut)
-        .expect("catalog item schema has required array")
-        .push(json!("matched_fields"));
-    object
-        .get_mut("properties")
-        .and_then(Value::as_object_mut)
-        .expect("catalog item schema has properties object")
-        .insert(
-            "matched_fields".to_string(),
-            json!({
-                "type": "array",
-                "items": {
-                    "type": "string",
-                    "enum": [
-                        "schema_name",
-                        "table_name",
-                        "function_name",
-                        "name",
-                        "description",
-                        "guide",
-                        "required_filters",
-                        "arguments",
-                        "result_columns"
-                    ]
-                }
-            }),
-        );
-    schema
-}
-
-fn list_columns_output_schema() -> Arc<Map<String, Value>> {
-    json_object_schema(&json!({
-        "type": "object",
-        "oneOf": [
-            list_columns_page_output_schema(),
-            missing_table_output_schema()
-        ]
-    }))
-}
-
-fn list_columns_page_output_schema() -> Value {
-    json!({
-        "type": "object",
-        "required": ["schema_name", "table_name", "columns", "total", "limit", "offset", "has_more"],
-        "additionalProperties": false,
-        "properties": {
-            "schema_name": { "type": "string" },
-            "table_name": { "type": "string" },
-            "columns": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "required": [
-                        "column_name",
-                        "data_type",
-                        "is_nullable",
-                        "is_virtual",
-                        "is_required_filter",
-                        "description",
-                        "ordinal_position"
-                    ],
-                    "additionalProperties": false,
-                    "properties": {
-                        "column_name": { "type": "string" },
-                        "data_type": { "type": "string" },
-                        "is_nullable": { "type": "boolean" },
-                        "is_virtual": { "type": "boolean" },
-                        "is_required_filter": { "type": "boolean" },
-                        "description": { "type": "string" },
-                        "ordinal_position": {
-                            "type": "integer",
-                            "minimum": 0
-                        },
-                        "matched_fields": {
-                            "type": "array",
-                            "minItems": 1,
-                            "items": {
-                                "type": "string",
-                                "enum": ["column_name", "description", "data_type"]
-                            }
-                        }
-                    }
-                }
-            },
-            "total": {
-                "type": "integer",
-                "minimum": 0
-            },
-            "limit": {
-                "type": "integer",
-                "minimum": 1
-            },
-            "offset": {
-                "type": "integer",
-                "minimum": 0
-            },
-            "has_more": { "type": "boolean" },
-            "next_offset": {
-                "type": "integer",
-                "minimum": 0
-            }
-        }
-    })
-}
-
-fn missing_table_output_schema() -> Value {
-    json!({
-        "type": "object",
-        "required": ["found", "requested", "available_schemas", "same_schema_tables", "suggestions", "suggested_calls"],
-        "additionalProperties": false,
-        "properties": {
-            "found": { "enum": [false] },
-            "requested": {
-                "type": "object",
-                "required": ["schema", "table"],
-                "additionalProperties": false,
-                "properties": {
-                    "schema": { "type": "string" },
-                    "table": { "type": "string" }
-                }
-            },
-            "available_schemas": {
-                "type": "array",
-                "items": { "type": "string" }
-            },
-            "same_schema_tables": {
-                "type": "array",
-                "items": missing_table_summary_output_schema()
-            },
-            "suggestions": {
-                "type": "array",
-                "items": missing_table_summary_output_schema()
-            },
-            "suggested_calls": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "required": ["tool", "arguments"],
-                    "additionalProperties": false,
-                    "properties": {
-                        "tool": {
-                            "type": "string",
-                            "enum": ["search_catalog", "list_catalog"]
-                        },
-                        "arguments": { "type": "object" }
-                    }
-                }
-            }
-        }
-    })
-}
-
-fn missing_table_summary_output_schema() -> Value {
-    json!({
-        "type": "object",
-        "required": ["schema_name", "table_name", "name", "description", "required_filters"],
-        "additionalProperties": false,
-        "properties": {
-            "schema_name": { "type": "string" },
-            "table_name": { "type": "string" },
-            "name": { "type": "string" },
-            "description": { "type": "string" },
-            "required_filters": {
-                "type": "array",
-                "items": { "type": "string" }
-            }
-        }
-    })
+    tool_output_schema::<EpisodeOpenedValue>()
 }
 
 pub(crate) fn optional_string_argument(
@@ -928,6 +587,9 @@ fn optional_non_empty_string_argument(
     let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
         return Ok(None);
     };
+    if value.is_null() {
+        return Ok(None);
+    }
     let value = value.as_str().ok_or_else(|| {
         ErrorData::invalid_params(format!("argument '{key}' must be a string"), None)
     })?;
@@ -999,6 +661,19 @@ mod tests {
         arguments.insert("pattern".to_string(), Value::String("issue".to_string()));
         let search = search_catalog_arguments(Some(&arguments)).expect("search arguments");
         assert_eq!(search.kind, None);
+    }
+
+    #[test]
+    fn list_columns_pattern_accepts_null_as_omitted() {
+        let arguments = Map::from_iter([
+            ("schema".to_string(), Value::String("github".to_string())),
+            ("table".to_string(), Value::String("issues".to_string())),
+            ("pattern".to_string(), Value::Null),
+        ]);
+
+        let parsed = super::list_columns_arguments(Some(&arguments)).expect("list columns args");
+
+        assert_eq!(parsed.pattern, None);
     }
 
     #[test]

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -1,481 +1,40 @@
-use std::sync::Arc;
+use rmcp::model::{CallToolResult, Tool};
+use serde_json::Value;
 
-use rmcp::{
-    ErrorData,
-    model::{CallToolResult, Tool, ToolAnnotations},
+use super::catalog::{
+    describe_table_tool, list_catalog_tool, list_columns_tool, search_catalog_tool,
 };
-use schemars::JsonSchema;
-use serde::Serialize;
-use serde_json::{Map, Value, json};
+use super::context::ToolDescriptionContext;
+use super::episode::{open_episode_tool, with_episode_id_argument};
+use super::feedback::feedback_tool;
+use super::sql::sql_tool;
 
-use coral_api::{CORAL_EPISODE_ID_MAX_LEN, CORAL_EPISODE_INTENT_MAX_CHARS};
-
-use super::{
-    CatalogToolKind, DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_OFFSET,
-    DEFAULT_SEARCH_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT, MAX_SEARCH_PAGINATION_LIMIT,
-    MIN_PAGINATION_LIMIT, Pagination, connected_source_names_text, describe_table_output_schema,
-    list_catalog_output_schema, list_columns_output_schema, parse_pagination,
-    parse_search_pagination, schema::json_schema_value, schema::tool_input_schema,
-    schema::tool_output_schema, search_catalog_output_schema, sql_input_schema, sql_output_schema,
-};
-
-const EPISODE_ID_ARGUMENT_DESCRIPTION: &str = "Optional episode id returned by open_episode. Pass it on subsequent Coral tool calls for the same task so Coral can attribute the call to that episode.";
-const EPISODE_ID_JSON_SCHEMA_PATTERN: &str = "^[!-~]+$";
-const DEFAULT_IGNORE_CASE: bool = true;
-const DEFAULT_REQUIRED_ONLY: bool = false;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ToolDescriptionContext {
-    pub(crate) visible_table_count: usize,
-    pub(crate) visible_function_count: usize,
-    connected_source_names: Vec<String>,
-}
-
-impl ToolDescriptionContext {
-    pub(crate) fn new(
-        visible_table_count: usize,
-        visible_function_count: usize,
-        mut connected_source_names: Vec<String>,
-    ) -> Self {
-        connected_source_names.sort();
-        connected_source_names.dedup();
-        Self {
-            visible_table_count,
-            visible_function_count,
-            connected_source_names,
-        }
+pub(crate) fn available_tools(
+    context: &ToolDescriptionContext,
+    episodes_enabled: bool,
+    feedback_enabled: bool,
+) -> Vec<Tool> {
+    let mut tools = vec![
+        sql_tool(context),
+        list_catalog_tool(context),
+        search_catalog_tool(context),
+        describe_table_tool(),
+        list_columns_tool(),
+    ];
+    if episodes_enabled {
+        tools = tools.into_iter().map(with_episode_id_argument).collect();
+        tools.push(open_episode_tool());
     }
-
-    fn connected_sources_sentence(&self) -> String {
-        connected_source_names_text(&self.connected_source_names).map_or_else(
-            || "No connected user sources are currently configured.".to_string(),
-            |names| format!("Connected sources/schemas include: {names}."),
-        )
+    if feedback_enabled {
+        let feedback = feedback_tool();
+        let feedback = if episodes_enabled {
+            with_episode_id_argument(feedback)
+        } else {
+            feedback
+        };
+        tools.push(feedback);
     }
-}
-
-#[derive(JsonSchema)]
-pub(crate) struct ListCatalogArguments {
-    #[schemars(description = "Optional exact SQL schema name to list.")]
-    pub(crate) schema: Option<String>,
-    #[schemars(
-        description = "Optional item kind to list. Omit or pass null to list all catalog items."
-    )]
-    pub(crate) kind: Option<CatalogToolKind>,
-    #[schemars(flatten, with = "DefaultPaginationInput")]
-    pub(crate) pagination: Pagination,
-}
-
-#[derive(JsonSchema)]
-pub(crate) struct SearchCatalogArguments {
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "Rust regex pattern to match database catalog metadata."
-    )]
-    pub(crate) pattern: String,
-    #[schemars(description = "Optional exact SQL schema name to search.")]
-    pub(crate) schema: Option<String>,
-    #[schemars(
-        description = "Optional item kind to search. Omit or pass null to search all catalog items."
-    )]
-    pub(crate) kind: Option<CatalogToolKind>,
-    #[serde(default = "default_ignore_case")]
-    #[schemars(description = "Whether regex matching is case-insensitive. Defaults to true.")]
-    pub(crate) ignore_case: bool,
-    #[schemars(flatten, with = "SearchPaginationInput")]
-    pub(crate) pagination: Pagination,
-}
-
-#[derive(JsonSchema)]
-pub(crate) struct DescribeTableArguments {
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "Exact SQL schema name."
-    )]
-    pub(crate) schema: String,
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "Exact table name within the SQL schema."
-    )]
-    pub(crate) table: String,
-}
-
-#[derive(JsonSchema)]
-pub(crate) struct ListColumnsArguments {
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "Exact SQL schema name."
-    )]
-    pub(crate) schema: String,
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "Exact table name within the SQL schema."
-    )]
-    pub(crate) table: String,
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "Optional Rust regex matched against column names, descriptions, and data types."
-    )]
-    pub(crate) pattern: Option<String>,
-    #[serde(default = "default_ignore_case")]
-    #[schemars(description = "Whether regex matching is case-insensitive. Defaults to true.")]
-    pub(crate) ignore_case: bool,
-    #[serde(default = "default_required_only")]
-    #[schemars(description = "Only return columns that are required filters. Defaults to false.")]
-    pub(crate) required_only: bool,
-    #[schemars(flatten, with = "DefaultPaginationInput")]
-    pub(crate) pagination: Pagination,
-}
-
-#[derive(JsonSchema)]
-pub(crate) struct FeedbackArguments {
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "What you were trying to do."
-    )]
-    pub(crate) trying_to_do: String,
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "What you already tried."
-    )]
-    pub(crate) tried: String,
-    #[schemars(
-        length(min = 1),
-        pattern(r"\S"),
-        description = "Where you got blocked."
-    )]
-    pub(crate) stuck: String,
-}
-
-#[derive(JsonSchema)]
-pub(crate) struct OpenEpisodeArguments {
-    #[schemars(
-        length(min = 1, max = CORAL_EPISODE_INTENT_MAX_CHARS),
-        pattern(r"\S"),
-        description = "Natural-language description of the task this episode should group."
-    )]
-    pub(crate) intent: String,
-    #[schemars(
-        with = "Option<EpisodeIdSchema>",
-        description = "Optional parent episode id when this task is a child of an existing episode."
-    )]
-    pub(crate) parent_episode_id: Option<String>,
-}
-
-#[derive(JsonSchema)]
-#[expect(
-    dead_code,
-    reason = "schema-only struct for flattened default pagination inputs"
-)]
-struct DefaultPaginationInput {
-    #[serde(default = "default_pagination_limit")]
-    #[schemars(
-        range(min = MIN_PAGINATION_LIMIT, max = MAX_PAGINATION_LIMIT),
-        description = "Maximum items to return, from 1 to 200. Defaults to 50."
-    )]
-    limit: u32,
-    #[serde(default = "default_pagination_offset")]
-    #[schemars(
-        range(min = DEFAULT_PAGINATION_OFFSET, max = u32::MAX),
-        description = "Number of matching items to skip. Defaults to 0."
-    )]
-    offset: u32,
-}
-
-#[derive(JsonSchema)]
-#[expect(
-    dead_code,
-    reason = "schema-only struct for flattened search pagination inputs"
-)]
-struct SearchPaginationInput {
-    #[serde(default = "default_search_pagination_limit")]
-    #[schemars(
-        range(min = MIN_PAGINATION_LIMIT, max = MAX_SEARCH_PAGINATION_LIMIT),
-        description = "Maximum catalog items to return, from 1 to 100. Defaults to 20."
-    )]
-    limit: u32,
-    #[serde(default = "default_pagination_offset")]
-    #[schemars(
-        range(min = DEFAULT_PAGINATION_OFFSET, max = u32::MAX),
-        description = "Number of matching catalog items to skip. Defaults to 0."
-    )]
-    offset: u32,
-}
-
-#[derive(JsonSchema)]
-#[schemars(transparent, inline)]
-#[expect(dead_code, reason = "schema-only type for episode id constraints")]
-struct EpisodeIdSchema(
-    #[schemars(
-        length(min = 1, max = CORAL_EPISODE_ID_MAX_LEN),
-        regex(pattern = EPISODE_ID_JSON_SCHEMA_PATTERN)
-    )]
-    String,
-);
-
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-pub(crate) struct FeedbackStoredValue {
-    pub(crate) feedback_id: String,
-    pub(crate) created_at: String,
-    pub(crate) message: &'static str,
-}
-
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-pub(crate) struct EpisodeOpenedValue {
-    #[schemars(with = "EpisodeIdSchema")]
-    pub(crate) episode_id: String,
-    #[schemars(with = "Option<EpisodeIdSchema>")]
-    pub(crate) parent_episode_id: Option<String>,
-    pub(crate) message: &'static str,
-    pub(crate) instructions: &'static str,
-}
-
-pub(crate) fn sql_tool(context: &ToolDescriptionContext) -> Tool {
-    Tool::new("sql", sql_tool_description(context), sql_input_schema())
-        .with_raw_output_schema(sql_output_schema())
-        .with_annotations(
-            ToolAnnotations::with_title("Run SQL")
-                .read_only(true)
-                .destructive(false)
-                .idempotent(true)
-                .open_world(true),
-        )
-}
-
-pub(crate) fn list_catalog_tool(context: &ToolDescriptionContext) -> Tool {
-    Tool::new(
-        "list_catalog",
-        format!(
-            "List database catalog items for Coral sources. {} {} table(s) and {} table function(s) are currently visible.",
-            context.connected_sources_sentence(),
-            context.visible_table_count,
-            context.visible_function_count
-        ),
-        tool_input_schema::<ListCatalogArguments>(),
-    )
-    .with_raw_output_schema(list_catalog_output_schema())
-    .with_annotations(
-        ToolAnnotations::with_title("List Catalog")
-            .read_only(true)
-            .destructive(false)
-            .idempotent(true)
-            .open_world(false),
-    )
-}
-
-pub(crate) fn search_catalog_tool(context: &ToolDescriptionContext) -> Tool {
-    Tool::new(
-        "search_catalog",
-        search_catalog_description(context),
-        tool_input_schema::<SearchCatalogArguments>(),
-    )
-    .with_raw_output_schema(search_catalog_output_schema())
-    .with_annotations(
-        ToolAnnotations::with_title("Search Catalog")
-            .read_only(true)
-            .destructive(false)
-            .idempotent(true)
-            .open_world(false),
-    )
-}
-
-pub(crate) fn describe_table_tool() -> Tool {
-    Tool::new(
-        "describe_table",
-        "Describe one database table without returning full column definitions.",
-        tool_input_schema::<DescribeTableArguments>(),
-    )
-    .with_raw_output_schema(describe_table_output_schema())
-    .with_annotations(
-        ToolAnnotations::with_title("Describe Table")
-            .read_only(true)
-            .destructive(false)
-            .idempotent(true)
-            .open_world(false),
-    )
-}
-
-pub(crate) fn list_columns_tool() -> Tool {
-    Tool::new(
-        "list_columns",
-        "List columns for one database table with optional regex and required-filter narrowing.",
-        tool_input_schema::<ListColumnsArguments>(),
-    )
-    .with_raw_output_schema(list_columns_output_schema())
-    .with_annotations(
-        ToolAnnotations::with_title("List Columns")
-            .read_only(true)
-            .destructive(false)
-            .idempotent(true)
-            .open_world(false),
-    )
-}
-
-pub(crate) fn feedback_tool() -> Tool {
-    Tool::new(
-        "feedback",
-        "Submit feedback when you are blocked. Coral stores the report locally and uploads an anonymous copy, without user identifiers, to Coral's hosted feedback service to improve Coral's performance.",
-        tool_input_schema::<FeedbackArguments>(),
-    )
-    .with_raw_output_schema(feedback_output_schema())
-    .with_annotations(
-        ToolAnnotations::with_title("Store Feedback Report")
-            .read_only(false)
-            .destructive(false)
-            .idempotent(false)
-            .open_world(true),
-    )
-}
-
-pub(crate) fn open_episode_tool() -> Tool {
-    Tool::new(
-        "open_episode",
-        "Open a Coral episode for the current task. Call this once at the start of a task, then pass the returned episode_id on subsequent Coral tool calls for that task.",
-        tool_input_schema::<OpenEpisodeArguments>(),
-    )
-    .with_raw_output_schema(open_episode_output_schema())
-    .with_annotations(
-        ToolAnnotations::with_title("Open Episode")
-            .read_only(false)
-            .destructive(false)
-            .idempotent(false)
-            .open_world(false),
-    )
-}
-
-pub(crate) fn required_string_argument(
-    arguments: Option<&Map<String, Value>>,
-    key: &str,
-) -> Result<String, ErrorData> {
-    let value = arguments
-        .and_then(|arguments| arguments.get(key))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            ErrorData::invalid_params(format!("missing string argument '{key}'"), None)
-        })?;
-    Ok(value.to_string())
-}
-
-pub(crate) fn open_episode_arguments(
-    arguments: Option<&Map<String, Value>>,
-) -> Result<OpenEpisodeArguments, ErrorData> {
-    Ok(OpenEpisodeArguments {
-        intent: required_string_argument(arguments, "intent")?,
-        parent_episode_id: optional_episode_id_argument(arguments, "parent_episode_id")?,
-    })
-}
-
-pub(crate) fn feedback_arguments(
-    arguments: Option<&Map<String, Value>>,
-) -> Result<FeedbackArguments, ErrorData> {
-    Ok(FeedbackArguments {
-        trying_to_do: required_string_argument(arguments, "trying_to_do")?,
-        tried: required_string_argument(arguments, "tried")?,
-        stuck: required_string_argument(arguments, "stuck")?,
-    })
-}
-
-pub(crate) fn list_catalog_arguments(
-    arguments: Option<&Map<String, Value>>,
-) -> Result<ListCatalogArguments, ErrorData> {
-    Ok(ListCatalogArguments {
-        schema: optional_string_argument(arguments, "schema")?,
-        kind: optional_catalog_kind_argument(arguments)?,
-        pagination: parse_pagination(arguments)?,
-    })
-}
-
-pub(crate) fn search_catalog_arguments(
-    arguments: Option<&Map<String, Value>>,
-) -> Result<SearchCatalogArguments, ErrorData> {
-    Ok(SearchCatalogArguments {
-        pattern: required_string_argument(arguments, "pattern")?,
-        schema: optional_string_argument(arguments, "schema")?,
-        kind: optional_catalog_kind_argument(arguments)?,
-        ignore_case: optional_bool_argument(arguments, "ignore_case", DEFAULT_IGNORE_CASE)?,
-        pagination: parse_search_pagination(arguments)?,
-    })
-}
-
-fn optional_catalog_kind_argument(
-    arguments: Option<&Map<String, Value>>,
-) -> Result<Option<CatalogToolKind>, ErrorData> {
-    let Some(kind) = optional_string_argument(arguments, "kind")? else {
-        return Ok(None);
-    };
-    serde_json::from_value(Value::String(kind))
-        .map(Some)
-        .map_err(|error| {
-            ErrorData::invalid_params(format!("invalid argument 'kind': {error}"), None)
-        })
-}
-
-pub(crate) fn describe_table_arguments(
-    arguments: Option<&Map<String, Value>>,
-) -> Result<DescribeTableArguments, ErrorData> {
-    Ok(DescribeTableArguments {
-        schema: required_string_argument(arguments, "schema")?,
-        table: required_string_argument(arguments, "table")?,
-    })
-}
-
-pub(crate) fn list_columns_arguments(
-    arguments: Option<&Map<String, Value>>,
-) -> Result<ListColumnsArguments, ErrorData> {
-    Ok(ListColumnsArguments {
-        schema: required_string_argument(arguments, "schema")?,
-        table: required_string_argument(arguments, "table")?,
-        pattern: optional_non_empty_string_argument(arguments, "pattern")?,
-        ignore_case: optional_bool_argument(arguments, "ignore_case", DEFAULT_IGNORE_CASE)?,
-        required_only: optional_bool_argument(arguments, "required_only", DEFAULT_REQUIRED_ONLY)?,
-        pagination: parse_pagination(arguments)?,
-    })
-}
-
-pub(crate) fn optional_episode_id_argument(
-    arguments: Option<&Map<String, Value>>,
-    key: &str,
-) -> Result<Option<String>, ErrorData> {
-    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
-        return Ok(None);
-    };
-    if value.is_null() {
-        return Ok(None);
-    }
-    let value = value.as_str().ok_or_else(|| {
-        ErrorData::invalid_params(format!("argument '{key}' must be a string"), None)
-    })?;
-    if value.is_empty() {
-        return Err(ErrorData::invalid_params(
-            format!("argument '{key}' must not be empty"),
-            None,
-        ));
-    }
-    if value.len() > CORAL_EPISODE_ID_MAX_LEN {
-        return Err(ErrorData::invalid_params(
-            format!("argument '{key}' must be at most {CORAL_EPISODE_ID_MAX_LEN} bytes"),
-            None,
-        ));
-    }
-    if !value.bytes().all(|byte| byte.is_ascii_graphic()) {
-        return Err(ErrorData::invalid_params(
-            format!("argument '{key}' must be graphic ASCII with no spaces or control bytes"),
-            None,
-        ));
-    }
-    Ok(Some(value.to_string()))
+    tools
 }
 
 pub(crate) fn build_tool_result(value: Value) -> CallToolResult {
@@ -484,155 +43,12 @@ pub(crate) fn build_tool_result(value: Value) -> CallToolResult {
     result
 }
 
-fn sql_tool_description(context: &ToolDescriptionContext) -> String {
-    if context.visible_table_count == 0 {
-        format!(
-            "Execute 1 to 10 independent read-only SQL queries against the Coral database using queries[]. Each entry must be independent and must not depend on another entry's rows, errors, or side effects. {} No user tables are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first.",
-            context.connected_sources_sentence()
-        )
-    } else {
-        format!(
-            "Execute 1 to 10 independent read-only SQL queries against the Coral database across connected Coral sources/schemas using queries[]. Each entry must be independent and must not depend on another entry's rows, errors, or side effects. {} {} table(s) are currently visible. You MUST prefer this tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources. Use catalog tools only to discover schemas, tables, functions, columns, and filters first. Use JOIN, CROSS JOIN, CTEs, subqueries, and aggregates inside one query when work is dependent.",
-            context.connected_sources_sentence(),
-            context.visible_table_count
-        )
-    }
-}
-
-fn search_catalog_description(context: &ToolDescriptionContext) -> String {
-    format!(
-        "Search database catalog metadata with a Rust regex across connected Coral sources/schemas. {} {} table(s) and {} table function(s) are currently visible.",
-        context.connected_sources_sentence(),
-        context.visible_table_count,
-        context.visible_function_count
-    )
-}
-
-fn default_ignore_case() -> bool {
-    DEFAULT_IGNORE_CASE
-}
-
-fn default_required_only() -> bool {
-    DEFAULT_REQUIRED_ONLY
-}
-
-fn default_pagination_limit() -> u32 {
-    DEFAULT_PAGINATION_LIMIT
-}
-
-fn default_search_pagination_limit() -> u32 {
-    DEFAULT_SEARCH_PAGINATION_LIMIT
-}
-
-fn default_pagination_offset() -> u32 {
-    DEFAULT_PAGINATION_OFFSET
-}
-
-pub(crate) fn with_episode_id_argument(mut tool: Tool) -> Tool {
-    add_episode_id_property(Arc::make_mut(&mut tool.input_schema));
-    tool
-}
-
-fn add_episode_id_property(schema: &mut Map<String, Value>) {
-    schema
-        .entry("properties")
-        .or_insert_with(|| json!({}))
-        .as_object_mut()
-        .expect("tool input properties are an object")
-        .insert(
-            "episode_id".to_string(),
-            nullable_episode_id_schema(Some(EPISODE_ID_ARGUMENT_DESCRIPTION)),
-        );
-}
-
-fn nullable_episode_id_schema(description: Option<&str>) -> Value {
-    let mut schema = json_schema_value::<Option<EpisodeIdSchema>>();
-    if let Some(description) = description {
-        schema
-            .as_object_mut()
-            .expect("nullable episode id schema is an object")
-            .insert("description".to_string(), json!(description));
-    }
-    schema
-}
-
-fn feedback_output_schema() -> Arc<Map<String, Value>> {
-    tool_output_schema::<FeedbackStoredValue>()
-}
-
-fn open_episode_output_schema() -> Arc<Map<String, Value>> {
-    tool_output_schema::<EpisodeOpenedValue>()
-}
-
-pub(crate) fn optional_string_argument(
-    arguments: Option<&Map<String, Value>>,
-    key: &str,
-) -> Result<Option<String>, ErrorData> {
-    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
-        return Ok(None);
-    };
-    if value.is_null() {
-        return Ok(None);
-    }
-    let value = value.as_str().ok_or_else(|| {
-        ErrorData::invalid_params(format!("argument '{key}' must be a string"), None)
-    })?;
-    let value = value.trim();
-    if value.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(value.to_string()))
-    }
-}
-
-fn optional_non_empty_string_argument(
-    arguments: Option<&Map<String, Value>>,
-    key: &str,
-) -> Result<Option<String>, ErrorData> {
-    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
-        return Ok(None);
-    };
-    if value.is_null() {
-        return Ok(None);
-    }
-    let value = value.as_str().ok_or_else(|| {
-        ErrorData::invalid_params(format!("argument '{key}' must be a string"), None)
-    })?;
-    let value = value.trim();
-    if value.is_empty() {
-        Err(ErrorData::invalid_params(
-            format!("argument '{key}' must not be empty"),
-            None,
-        ))
-    } else {
-        Ok(Some(value.to_string()))
-    }
-}
-
-fn optional_bool_argument(
-    arguments: Option<&Map<String, Value>>,
-    key: &str,
-    default: bool,
-) -> Result<bool, ErrorData> {
-    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
-        return Ok(default);
-    };
-    value.as_bool().ok_or_else(|| {
-        ErrorData::invalid_params(format!("argument '{key}' must be a boolean"), None)
-    })
-}
-
 #[cfg(test)]
 mod tests {
-    use serde_json::{Map, Value, json};
+    use rmcp::model::Tool;
+    use serde_json::{Value, json};
 
-    use super::{
-        DEFAULT_IGNORE_CASE, DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_OFFSET,
-        DEFAULT_REQUIRED_ONLY, DEFAULT_SEARCH_PAGINATION_LIMIT, EPISODE_ID_ARGUMENT_DESCRIPTION,
-        ToolDescriptionContext, build_tool_result, connected_source_names_text,
-        list_catalog_arguments, search_catalog_arguments, search_catalog_tool, sql_tool,
-        with_episode_id_argument,
-    };
+    use super::{ToolDescriptionContext, available_tools, build_tool_result};
 
     #[test]
     fn success_tool_result_uses_structured_content_only() {
@@ -659,61 +75,12 @@ mod tests {
     }
 
     #[test]
-    fn catalog_kind_argument_accepts_null_as_all_kinds() {
-        let mut arguments = Map::new();
-        arguments.insert("kind".to_string(), Value::Null);
-        let list = list_catalog_arguments(Some(&arguments)).expect("list arguments");
-        assert_eq!(list.kind, None);
-
-        arguments.insert("pattern".to_string(), Value::String("issue".to_string()));
-        let search = search_catalog_arguments(Some(&arguments)).expect("search arguments");
-        assert_eq!(search.kind, None);
-    }
-
-    #[test]
-    fn list_columns_pattern_accepts_null_as_omitted() {
-        let arguments = Map::from_iter([
-            ("schema".to_string(), Value::String("github".to_string())),
-            ("table".to_string(), Value::String("issues".to_string())),
-            ("pattern".to_string(), Value::Null),
-        ]);
-
-        let parsed = super::list_columns_arguments(Some(&arguments)).expect("list columns args");
-
-        assert_eq!(parsed.pattern, None);
-    }
-
-    #[test]
-    fn catalog_argument_defaults_use_shared_constants() {
-        let search_arguments =
-            Map::from_iter([("pattern".to_string(), Value::String("issue".to_string()))]);
-
-        let search = search_catalog_arguments(Some(&search_arguments)).expect("search args");
-
-        assert_eq!(search.ignore_case, DEFAULT_IGNORE_CASE);
-        assert_eq!(search.pagination.limit, DEFAULT_SEARCH_PAGINATION_LIMIT);
-        assert_eq!(search.pagination.offset, DEFAULT_PAGINATION_OFFSET);
-
-        let list_columns_arguments = Map::from_iter([
-            ("schema".to_string(), Value::String("github".to_string())),
-            ("table".to_string(), Value::String("issues".to_string())),
-        ]);
-
-        let list_columns = super::list_columns_arguments(Some(&list_columns_arguments))
-            .expect("list columns args");
-
-        assert_eq!(list_columns.ignore_case, DEFAULT_IGNORE_CASE);
-        assert_eq!(list_columns.required_only, DEFAULT_REQUIRED_ONLY);
-        assert_eq!(list_columns.pagination.limit, DEFAULT_PAGINATION_LIMIT);
-        assert_eq!(list_columns.pagination.offset, DEFAULT_PAGINATION_OFFSET);
-    }
-
-    #[test]
-    fn tool_descriptions_include_connected_sources() {
+    fn available_tools_include_connected_sources_in_descriptions() {
         let context =
             ToolDescriptionContext::new(42, 3, vec!["github".to_string(), "linear".to_string()]);
 
-        let sql_tool = sql_tool(&context);
+        let tools = available_tools(&context, false, false);
+        let sql_tool = tool_by_name(&tools, "sql");
         let sql_description = sql_tool.description.as_deref().expect("sql description");
         assert!(sql_description.contains("Connected sources/schemas include: github, linear"));
         assert!(sql_description.contains("42 table(s) are currently visible"));
@@ -737,26 +104,20 @@ mod tests {
         assert!(sql_input_description.contains("independent"));
         assert!(sql_tool.output_schema.is_some());
 
-        let search_description = search_catalog_tool(&context)
+        let search_description = tool_by_name(&tools, "search_catalog")
             .description
+            .as_deref()
             .expect("search description");
         assert!(search_description.contains("Connected sources/schemas include: github, linear"));
         assert!(search_description.contains("42 table(s) and 3 table function(s)"));
     }
 
     #[test]
-    fn with_episode_id_argument_decorates_tool_schema() {
+    fn available_tools_decorate_episode_aware_tools() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
-        let tool = sql_tool(&context);
-        let properties = tool
-            .input_schema
-            .get("properties")
-            .and_then(Value::as_object)
-            .expect("input properties");
-        assert!(!properties.contains_key("episode_id"));
-
-        let tool = with_episode_id_argument(tool);
-        let episode_id_schema = tool
+        let tools = available_tools(&context, true, false);
+        let sql_tool = tool_by_name(&tools, "sql");
+        let episode_id_schema = sql_tool
             .input_schema
             .get("properties")
             .and_then(Value::as_object)
@@ -765,21 +126,137 @@ mod tests {
 
         assert_eq!(
             episode_id_schema.get("description").and_then(Value::as_str),
-            Some(EPISODE_ID_ARGUMENT_DESCRIPTION)
+            Some(
+                "Optional episode id returned by open_episode. Pass it on subsequent Coral tool calls for the same task so Coral can attribute the call to that episode."
+            )
+        );
+
+        let open_episode = tool_by_name(&tools, "open_episode");
+        let properties = open_episode
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("open_episode properties");
+        assert!(!properties.contains_key("episode_id"));
+    }
+
+    #[test]
+    fn available_tools_add_feedback_last_when_enabled() {
+        let context = ToolDescriptionContext::new(1, 0, Vec::new());
+        let tools = available_tools(&context, true, true);
+
+        assert_eq!(
+            tools.last().map(|tool| tool.name.as_ref()),
+            Some("feedback")
+        );
+        let properties = tools
+            .last()
+            .expect("feedback tool")
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("feedback properties");
+        assert!(properties.contains_key("episode_id"));
+    }
+
+    #[test]
+    fn available_tools_keep_default_order() {
+        let context = ToolDescriptionContext::new(1, 0, Vec::new());
+        let tools = available_tools(&context, false, false);
+        let names = tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            names,
+            vec![
+                "sql",
+                "list_catalog",
+                "search_catalog",
+                "describe_table",
+                "list_columns"
+            ]
         );
     }
 
     #[test]
-    fn connected_source_names_are_not_capped_in_descriptions() {
+    fn tool_descriptions_do_not_cap_connected_source_names() {
         let names = (0..14)
             .map(|index| format!("source_{index:02}"))
             .collect::<Vec<_>>();
+        let context = ToolDescriptionContext::new(1, 0, names);
 
-        let text = connected_source_names_text(&names).expect("source names text");
+        let tools = available_tools(&context, false, false);
+        let description = tool_by_name(&tools, "sql")
+            .description
+            .as_deref()
+            .expect("sql description")
+            .to_string();
 
-        assert!(text.contains("source_00"));
-        assert!(text.contains("source_12"));
-        assert!(text.contains("source_13"));
-        assert!(!text.contains("and 2 more"));
+        assert!(description.contains("source_00"));
+        assert!(description.contains("source_12"));
+        assert!(description.contains("source_13"));
+        assert!(!description.contains("and 2 more"));
+    }
+
+    #[test]
+    fn available_tools_do_not_mutate_base_tool_schemas() {
+        let context = ToolDescriptionContext::new(1, 0, Vec::new());
+        let default_tools = available_tools(&context, false, false);
+        let episode_tools = available_tools(&context, true, false);
+
+        let default_properties = tool_by_name(&default_tools, "sql")
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("default properties");
+        let episode_properties = tool_by_name(&episode_tools, "sql")
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("episode properties");
+
+        assert!(!default_properties.contains_key("episode_id"));
+        assert!(episode_properties.contains_key("episode_id"));
+    }
+
+    #[test]
+    fn feedback_tool_is_not_decorated_when_episodes_are_disabled() {
+        let context = ToolDescriptionContext::new(1, 0, Vec::new());
+        let tools = available_tools(&context, false, true);
+        let feedback = tools.last().expect("feedback tool");
+        let properties = feedback
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("feedback properties");
+
+        assert_eq!(feedback.name, "feedback");
+        assert!(!properties.contains_key("episode_id"));
+    }
+
+    #[test]
+    fn all_advertised_tools_have_object_input_schemas() {
+        let context = ToolDescriptionContext::new(1, 0, Vec::new());
+
+        for tool in available_tools(&context, true, true) {
+            assert_eq!(
+                tool.input_schema.get("type"),
+                Some(&Value::String("object".into()))
+            );
+            assert!(
+                matches!(tool.input_schema.get("properties"), Some(Value::Object(_))),
+                "tool '{}' should advertise properties",
+                tool.name
+            );
+        }
+    }
+
+    fn tool_by_name<'a>(tools: &'a [Tool], name: &str) -> &'a Tool {
+        tools
+            .iter()
+            .find(|tool| tool.name == name)
+            .unwrap_or_else(|| panic!("tool '{name}' should be advertised"))
     }
 }

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -11,17 +11,18 @@ use serde_json::{Map, Value, json};
 use coral_api::{CORAL_EPISODE_ID_MAX_LEN, CORAL_EPISODE_INTENT_MAX_CHARS};
 
 use super::{
-    CatalogToolKind, DEFAULT_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT, Pagination,
-    connected_source_names_text, describe_table_output_schema, list_catalog_output_schema,
-    list_columns_output_schema, parse_pagination, parse_pagination_with_limits,
-    schema::json_schema_value, schema::tool_input_schema, schema::tool_output_schema,
-    search_catalog_output_schema, sql_input_schema, sql_output_schema,
+    CatalogToolKind, DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_OFFSET,
+    DEFAULT_SEARCH_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT, MAX_SEARCH_PAGINATION_LIMIT,
+    MIN_PAGINATION_LIMIT, Pagination, connected_source_names_text, describe_table_output_schema,
+    list_catalog_output_schema, list_columns_output_schema, parse_pagination,
+    parse_search_pagination, schema::json_schema_value, schema::tool_input_schema,
+    schema::tool_output_schema, search_catalog_output_schema, sql_input_schema, sql_output_schema,
 };
 
 const EPISODE_ID_ARGUMENT_DESCRIPTION: &str = "Optional episode id returned by open_episode. Pass it on subsequent Coral tool calls for the same task so Coral can attribute the call to that episode.";
 const EPISODE_ID_JSON_SCHEMA_PATTERN: &str = "^[!-~]+$";
-const DEFAULT_SEARCH_LIMIT: u32 = 20;
-const MAX_SEARCH_LIMIT: u32 = 100;
+const DEFAULT_IGNORE_CASE: bool = true;
+const DEFAULT_REQUIRED_ONLY: bool = false;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ToolDescriptionContext {
@@ -79,7 +80,7 @@ pub(crate) struct SearchCatalogArguments {
         description = "Optional item kind to search. Omit or pass null to search all catalog items."
     )]
     pub(crate) kind: Option<CatalogToolKind>,
-    #[serde(default = "default_true")]
+    #[serde(default = "default_ignore_case")]
     #[schemars(description = "Whether regex matching is case-insensitive. Defaults to true.")]
     pub(crate) ignore_case: bool,
     #[schemars(flatten, with = "SearchPaginationInput")]
@@ -122,10 +123,10 @@ pub(crate) struct ListColumnsArguments {
         description = "Optional Rust regex matched against column names, descriptions, and data types."
     )]
     pub(crate) pattern: Option<String>,
-    #[serde(default = "default_true")]
+    #[serde(default = "default_ignore_case")]
     #[schemars(description = "Whether regex matching is case-insensitive. Defaults to true.")]
     pub(crate) ignore_case: bool,
-    #[serde(default)]
+    #[serde(default = "default_required_only")]
     #[schemars(description = "Only return columns that are required filters. Defaults to false.")]
     pub(crate) required_only: bool,
     #[schemars(flatten, with = "DefaultPaginationInput")]
@@ -177,13 +178,13 @@ pub(crate) struct OpenEpisodeArguments {
 struct DefaultPaginationInput {
     #[serde(default = "default_pagination_limit")]
     #[schemars(
-        range(min = 1, max = MAX_PAGINATION_LIMIT),
+        range(min = MIN_PAGINATION_LIMIT, max = MAX_PAGINATION_LIMIT),
         description = "Maximum items to return, from 1 to 200. Defaults to 50."
     )]
     limit: u32,
-    #[serde(default)]
+    #[serde(default = "default_pagination_offset")]
     #[schemars(
-        range(min = 0, max = u32::MAX),
+        range(min = DEFAULT_PAGINATION_OFFSET, max = u32::MAX),
         description = "Number of matching items to skip. Defaults to 0."
     )]
     offset: u32,
@@ -195,15 +196,15 @@ struct DefaultPaginationInput {
     reason = "schema-only struct for flattened search pagination inputs"
 )]
 struct SearchPaginationInput {
-    #[serde(default = "default_search_limit")]
+    #[serde(default = "default_search_pagination_limit")]
     #[schemars(
-        range(min = 1, max = MAX_SEARCH_LIMIT),
+        range(min = MIN_PAGINATION_LIMIT, max = MAX_SEARCH_PAGINATION_LIMIT),
         description = "Maximum catalog items to return, from 1 to 100. Defaults to 20."
     )]
     limit: u32,
-    #[serde(default)]
+    #[serde(default = "default_pagination_offset")]
     #[schemars(
-        range(min = 0, max = u32::MAX),
+        range(min = DEFAULT_PAGINATION_OFFSET, max = u32::MAX),
         description = "Number of matching catalog items to skip. Defaults to 0."
     )]
     offset: u32,
@@ -403,12 +404,8 @@ pub(crate) fn search_catalog_arguments(
         pattern: required_string_argument(arguments, "pattern")?,
         schema: optional_string_argument(arguments, "schema")?,
         kind: optional_catalog_kind_argument(arguments)?,
-        ignore_case: optional_bool_argument(arguments, "ignore_case", true)?,
-        pagination: parse_pagination_with_limits(
-            arguments,
-            DEFAULT_SEARCH_LIMIT,
-            MAX_SEARCH_LIMIT,
-        )?,
+        ignore_case: optional_bool_argument(arguments, "ignore_case", DEFAULT_IGNORE_CASE)?,
+        pagination: parse_search_pagination(arguments)?,
     })
 }
 
@@ -441,8 +438,8 @@ pub(crate) fn list_columns_arguments(
         schema: required_string_argument(arguments, "schema")?,
         table: required_string_argument(arguments, "table")?,
         pattern: optional_non_empty_string_argument(arguments, "pattern")?,
-        ignore_case: optional_bool_argument(arguments, "ignore_case", true)?,
-        required_only: optional_bool_argument(arguments, "required_only", false)?,
+        ignore_case: optional_bool_argument(arguments, "ignore_case", DEFAULT_IGNORE_CASE)?,
+        required_only: optional_bool_argument(arguments, "required_only", DEFAULT_REQUIRED_ONLY)?,
         pagination: parse_pagination(arguments)?,
     })
 }
@@ -511,16 +508,24 @@ fn search_catalog_description(context: &ToolDescriptionContext) -> String {
     )
 }
 
-fn default_true() -> bool {
-    true
+fn default_ignore_case() -> bool {
+    DEFAULT_IGNORE_CASE
+}
+
+fn default_required_only() -> bool {
+    DEFAULT_REQUIRED_ONLY
 }
 
 fn default_pagination_limit() -> u32 {
     DEFAULT_PAGINATION_LIMIT
 }
 
-fn default_search_limit() -> u32 {
-    DEFAULT_SEARCH_LIMIT
+fn default_search_pagination_limit() -> u32 {
+    DEFAULT_SEARCH_PAGINATION_LIMIT
+}
+
+fn default_pagination_offset() -> u32 {
+    DEFAULT_PAGINATION_OFFSET
 }
 
 pub(crate) fn with_episode_id_argument(mut tool: Tool) -> Tool {
@@ -622,9 +627,11 @@ mod tests {
     use serde_json::{Map, Value, json};
 
     use super::{
-        EPISODE_ID_ARGUMENT_DESCRIPTION, ToolDescriptionContext, build_tool_result,
-        connected_source_names_text, list_catalog_arguments, search_catalog_arguments,
-        search_catalog_tool, sql_tool, with_episode_id_argument,
+        DEFAULT_IGNORE_CASE, DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_OFFSET,
+        DEFAULT_REQUIRED_ONLY, DEFAULT_SEARCH_PAGINATION_LIMIT, EPISODE_ID_ARGUMENT_DESCRIPTION,
+        ToolDescriptionContext, build_tool_result, connected_source_names_text,
+        list_catalog_arguments, search_catalog_arguments, search_catalog_tool, sql_tool,
+        with_episode_id_argument,
     };
 
     #[test]
@@ -674,6 +681,31 @@ mod tests {
         let parsed = super::list_columns_arguments(Some(&arguments)).expect("list columns args");
 
         assert_eq!(parsed.pattern, None);
+    }
+
+    #[test]
+    fn catalog_argument_defaults_use_shared_constants() {
+        let search_arguments =
+            Map::from_iter([("pattern".to_string(), Value::String("issue".to_string()))]);
+
+        let search = search_catalog_arguments(Some(&search_arguments)).expect("search args");
+
+        assert_eq!(search.ignore_case, DEFAULT_IGNORE_CASE);
+        assert_eq!(search.pagination.limit, DEFAULT_SEARCH_PAGINATION_LIMIT);
+        assert_eq!(search.pagination.offset, DEFAULT_PAGINATION_OFFSET);
+
+        let list_columns_arguments = Map::from_iter([
+            ("schema".to_string(), Value::String("github".to_string())),
+            ("table".to_string(), Value::String("issues".to_string())),
+        ]);
+
+        let list_columns = super::list_columns_arguments(Some(&list_columns_arguments))
+            .expect("list columns args");
+
+        assert_eq!(list_columns.ignore_case, DEFAULT_IGNORE_CASE);
+        assert_eq!(list_columns.required_only, DEFAULT_REQUIRED_ONLY);
+        assert_eq!(list_columns.pagination.limit, DEFAULT_PAGINATION_LIMIT);
+        assert_eq!(list_columns.pagination.offset, DEFAULT_PAGINATION_OFFSET);
     }
 
     #[test]

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -253,32 +253,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn advertised_input_schemas_do_not_use_generic_nonblank_pattern() {
-        let context = ToolDescriptionContext::new(1, 0, Vec::new());
-
-        for tool in available_tools(&context, true, true) {
-            assert!(
-                !contains_pattern(&Value::Object(tool.input_schema.as_ref().clone()), r"\S"),
-                "tool '{}' should not advertise generic non-blank string patterns",
-                tool.name
-            );
-        }
-    }
-
-    fn contains_pattern(value: &Value, pattern: &str) -> bool {
-        match value {
-            Value::Object(object) => {
-                object.get("pattern").and_then(Value::as_str) == Some(pattern)
-                    || object
-                        .values()
-                        .any(|value| contains_pattern(value, pattern))
-            }
-            Value::Array(values) => values.iter().any(|value| contains_pattern(value, pattern)),
-            _ => false,
-        }
-    }
-
     fn tool_by_name<'a>(tools: &'a [Tool], name: &str) -> &'a Tool {
         tools
             .iter()

--- a/crates/coral-mcp/src/surface/values.rs
+++ b/crates/coral-mcp/src/surface/values.rs
@@ -1,15 +1,11 @@
-use coral_api::v1::{PaginationResponse, TableSummary};
+use coral_api::v1::TableSummary;
+use schemars::JsonSchema;
 use serde::Serialize;
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 pub(crate) fn queryable_table_summary_value(table: &TableSummary) -> Value {
     serde_json::to_value(QueryableTableSummaryValue::from(table))
         .expect("queryable table summary value serializes")
-}
-
-pub(crate) fn missing_table_summary_value(table: &TableSummary) -> Value {
-    serde_json::to_value(MissingTableSummaryValue::from(table))
-        .expect("missing table summary value serializes")
 }
 
 pub(crate) fn queryable_table_summary_values(tables: &[TableSummary]) -> Vec<Value> {
@@ -23,32 +19,6 @@ pub(crate) fn queryable_table_summary_values(tables: &[TableSummary]) -> Vec<Val
             .cmp(&right.get("name").and_then(Value::as_str))
     });
     summaries
-}
-
-pub(crate) fn paged_collection_value(
-    collection_key: &str,
-    items: Vec<Value>,
-    pagination: &PaginationResponse,
-) -> Value {
-    let mut value = Map::from_iter([(collection_key.to_string(), Value::Array(items))]);
-    insert_pagination_fields(&mut value, pagination);
-    Value::Object(value)
-}
-
-pub(crate) fn insert_pagination_fields(
-    value: &mut Map<String, Value>,
-    pagination: &PaginationResponse,
-) {
-    value.insert("total".to_string(), Value::from(pagination.total_count));
-    value.insert("limit".to_string(), Value::from(pagination.limit));
-    value.insert("offset".to_string(), Value::from(pagination.offset));
-    value.insert("has_more".to_string(), Value::from(pagination.has_more));
-    if pagination.has_more {
-        value.insert(
-            "next_offset".to_string(),
-            Value::from(pagination.next_offset),
-        );
-    }
 }
 
 #[derive(Serialize)]
@@ -76,13 +46,14 @@ impl<'a> From<&'a TableSummary> for QueryableTableSummaryValue<'a> {
     }
 }
 
-#[derive(Serialize)]
-struct MissingTableSummaryValue<'a> {
-    schema_name: &'a str,
-    table_name: &'a str,
-    name: String,
-    description: &'a str,
-    required_filters: &'a [String],
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct MissingTableSummaryValue<'a> {
+    pub(crate) schema_name: &'a str,
+    pub(crate) table_name: &'a str,
+    pub(crate) name: String,
+    pub(crate) description: &'a str,
+    pub(crate) required_filters: &'a [String],
 }
 
 impl<'a> From<&'a TableSummary> for MissingTableSummaryValue<'a> {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -743,6 +743,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     let updated_tools = client.list_all_tools().await.expect("updated tools");
     let list_catalog_tool = tool_by_name(&updated_tools, "list_catalog");
     let search_catalog_tool = tool_by_name(&updated_tools, "search_catalog");
+    let describe_table_tool = tool_by_name(&updated_tools, "describe_table");
     let list_columns_tool = tool_by_name(&updated_tools, "list_columns");
     assert!(
         updated_tools[0]
@@ -974,7 +975,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     assert_eq!(described["column_count"], 3);
     assert!(described["columns_hint"].as_str().is_some());
     assert!(described["columns"].is_null());
-    assert_matches_output_schema(list_columns_tool, &described);
+    assert_matches_output_schema(describe_table_tool, &described);
 
     let missing_table = client
         .call_tool(

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -276,23 +276,27 @@ fn assert_tool_advertises_episode_id(tool: &Tool) {
 }
 
 fn assert_nullable_episode_id_schema(schema: &Value, label: &str) {
-    let any_of = schema
-        .get("anyOf")
-        .and_then(Value::as_array)
-        .unwrap_or_else(|| panic!("{label} episode id schema should use anyOf"));
-    let string_schema = any_of
-        .iter()
-        .find(|schema| schema.get("type") == Some(&json!("string")))
-        .unwrap_or_else(|| panic!("{label} episode id schema should accept strings"));
-    assert!(
-        any_of
-            .iter()
-            .any(|schema| schema.get("type") == Some(&json!("null"))),
-        "{label} episode id schema should accept null"
-    );
-    assert_eq!(string_schema["minLength"], json!(1));
-    assert_eq!(string_schema["maxLength"], json!(CORAL_EPISODE_ID_MAX_LEN));
-    assert_eq!(string_schema["pattern"], json!("^[!-~]+$"));
+    let compiled = JSONSchema::compile(schema)
+        .unwrap_or_else(|error| panic!("{label} episode id schema should compile: {error}"));
+    for valid in [json!(null), json!("episode-1")] {
+        if let Err(errors) = compiled.validate(&valid) {
+            let details = errors
+                .map(|error| error.to_string())
+                .collect::<Vec<_>>()
+                .join("; ");
+            panic!("{label} episode id schema rejected valid value {valid}: {details}");
+        }
+    }
+    for invalid in [
+        json!(""),
+        json!("episode with space"),
+        json!("x".repeat(CORAL_EPISODE_ID_MAX_LEN + 1)),
+    ] {
+        assert!(
+            compiled.validate(&invalid).is_err(),
+            "{label} episode id schema accepted invalid value {invalid}"
+        );
+    }
 }
 
 fn assert_tool_omits_episode_id(tool: &Tool) {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -278,7 +278,11 @@ fn assert_tool_advertises_episode_id(tool: &Tool) {
 fn assert_nullable_episode_id_schema(schema: &Value, label: &str) {
     let compiled = JSONSchema::compile(schema)
         .unwrap_or_else(|error| panic!("{label} episode id schema should compile: {error}"));
-    for valid in [json!(null), json!("episode-1")] {
+    for valid in [
+        json!(null),
+        json!("episode-1"),
+        json!("x".repeat(CORAL_EPISODE_ID_MAX_LEN)),
+    ] {
         if let Err(errors) = compiled.validate(&valid) {
             let details = errors
                 .map(|error| error.to_string())
@@ -291,6 +295,7 @@ fn assert_nullable_episode_id_schema(schema: &Value, label: &str) {
         json!(""),
         json!("episode with space"),
         json!("x".repeat(CORAL_EPISODE_ID_MAX_LEN + 1)),
+        json!("episode-é"),
     ] {
         assert!(
             compiled.validate(&invalid).is_err(),
@@ -969,6 +974,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     assert_eq!(described["column_count"], 3);
     assert!(described["columns_hint"].as_str().is_some());
     assert!(described["columns"].is_null());
+    assert_matches_output_schema(list_columns_tool, &described);
 
     let missing_table = client
         .call_tool(


### PR DESCRIPTION
## Summary

- Generate MCP tool input/output schemas from typed surface structs and enums instead of hard-coded JSON blobs.
- Move SQL, catalog, episode, feedback, tool-name, and shared argument contracts into the surface modules that enforce them.
- Share pagination defaults, episode-id validation, and structured tool-error envelopes so schemas and runtime behavior stay aligned.
- Fix follow-up schema drift and argument parsing issues found during review, including preserving exact MCP string arguments.

## Validation

- `cargo test -p coral-mcp --lib`
- `cargo test -p coral-cli --features cli-test-server --test mcp mcp_stdio_raw_tools_list_advertises_client_compatible_schemas`
- `cargo clippy -p coral-mcp --all-targets --all-features -- -D warnings`
- `make rust-checks`
