### PR TITLE
fix(app): enforce source catalog invariants

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -256,7 +256,7 @@ jobs:
       - name: Run Postgres database tests
         env:
           CORAL_TEST_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/postgres
-        run: make postgres-tests
+        run: make postgres-test-suite
 
   windows-rust-smoke:
     name: Windows Rust smoke
@@ -711,6 +711,7 @@ jobs:
       [
         changes,
         rust-checks,
+        postgres-database-tests,
         windows-rust-smoke,
         install-script,
         coral-ui-checks,
@@ -734,6 +735,7 @@ jobs:
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
           RUST_CHECKS_RESULT: ${{ needs.rust-checks.result }}
+          POSTGRES_DATABASE_TESTS_RESULT: ${{ needs.postgres-database-tests.result }}
           WINDOWS_RUST_SMOKE_RESULT: ${{ needs.windows-rust-smoke.result }}
           INSTALL_SCRIPT_RESULT: ${{ needs.install-script.result }}
           CORAL_UI_CHECKS_RESULT: ${{ needs.coral-ui-checks.result }}
@@ -752,6 +754,7 @@ jobs:
           jobs=(
             "changes:$CHANGES_RESULT"
             "rust-checks:$RUST_CHECKS_RESULT"
+            "postgres-database-tests:$POSTGRES_DATABASE_TESTS_RESULT"
             "windows-rust-smoke:$WINDOWS_RUST_SMOKE_RESULT"
             "install-script:$INSTALL_SCRIPT_RESULT"
             "coral-ui-checks:$CORAL_UI_CHECKS_RESULT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,17 +26,24 @@
 ## Rules
 
 - Run `make rust-checks` before submitting PRs that include changes to Rust code.
-- For Postgres-backed database changes, run `make postgres-tests`. Keep this as
-  the single entry point for local and CI Postgres coverage; do not duplicate
-  its Cargo test invocations in workflows or contributor instructions. The
-  target uses `CORAL_TEST_POSTGRES_URL` when supplied. Otherwise it starts a
-  local Docker Postgres and creates a fresh database inside the reusable
-  container. Docker chooses an available localhost port by default; use
+- For Postgres-backed database changes, run `make postgres-tests`. Keep
+  `postgres-test-suite` as the single home for the suite's Cargo invocations;
+  do not duplicate them in workflows or contributor instructions. The suite runs
+  the `state::db` unit-test namespace, repeating shared repository assertions
+  against Postgres, then runs the dedicated Postgres integration target for
+  migration and server startup coverage plus the xtask recovery contracts.
+  The recovery checks use xtask's `admin` feature. `postgres-tests` uses
+  `CORAL_TEST_POSTGRES_URL` when supplied. Otherwise it starts a local Docker
+  Postgres and creates a fresh database inside the reusable container. Docker
+  chooses an available localhost port by default; use
   `make postgres-url` to print the server URL or
   `LOCAL_POSTGRES_PORT=55432 make postgres-start` when you need a stable port.
   Use `make postgres-start` when you only need the server,
   `make postgres-stop` when finished, and `make postgres-clean` to remove the
-  reusable container.
+  reusable container. Write repository coverage as normal tests that always
+  assert SQLite behavior and repeat the same assertions against Postgres when
+  `CORAL_TEST_POSTGRES_URL` is set. Do not mark them ignored or enumerate
+  individual test functions in Make or CI.
 - Run `make schema-check` before submitting PRs that touch generated manifest
   schemas or the Rust helpers that generate them. Use
   `make schema-generate` to refresh generated schema files. The Validate

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: install docker-build coral-ui-docker-build coral-ui-docker-smoke coral-ui-docker-test coral-docker-stub-build coral-docker-smoke coral-docker-stub-test rust-checks perf-check
-.PHONY: postgres-start postgres-url postgres-stop postgres-clean postgres-tests
+.PHONY: postgres-start postgres-url postgres-stop postgres-clean postgres-test-suite postgres-tests
 .PHONY: license-check lint-proto lint-sources fix-sources
 .PHONY: docs-generate docs-check schema-generate schema-check
 
@@ -157,22 +157,25 @@ perf-check:
 	cargo run --locked -p xtask --release -- perf-check --coral-bin target/release/coral
 
 # ----------------------------------------------------------------------------
-# Local Postgres-backed tests
+# Postgres-backed tests
 # ----------------------------------------------------------------------------
-# Runs all ignored Postgres coverage through postgres-tests: the coral-app
-# database contracts and the xtask recovery contracts, which need
-# `--features admin` because the recovery module compiles only under it. When
-# CORAL_TEST_POSTGRES_URL is set, the target uses that database. Otherwise it
-# starts a Docker Postgres matching CI's major version and creates a fresh
-# database inside the reusable container. Docker chooses an available localhost
-# port by default; set LOCAL_POSTGRES_PORT=55432 if you need a stable host port.
+# postgres-test-suite runs the DB-owned coral-app unit tests and dedicated
+# Postgres integration target plus xtask recovery contracts against an existing
+# Postgres URL. The xtask checks need `--features admin` because the recovery
+# module compiles only under it. postgres-tests provisions the database first:
+# when CORAL_TEST_POSTGRES_URL is set it uses that database, otherwise it starts
+# a Docker Postgres matching CI's major version and creates a fresh database
+# inside the reusable container for each run. Docker chooses an available
+# localhost port by default; set LOCAL_POSTGRES_PORT=55432 if you need a stable
+# host port.
 #
-#   make postgres-start   # start/wait for local Docker Postgres
-#   make postgres-url     # print the local Postgres connection URL
-#   make postgres-tests   # provision locally, then run all Postgres tests
+#   make postgres-start       # start/wait for local Docker Postgres
+#   make postgres-url         # print the local Postgres connection URL
+#   make postgres-test-suite  # test against CORAL_TEST_POSTGRES_URL
+#   make postgres-tests       # provision locally, then run the suite
 #   CORAL_TEST_POSTGRES_URL=... make postgres-tests  # use an existing database
-#   make postgres-stop    # stop the local Docker Postgres container
-#   make postgres-clean   # remove the local Docker Postgres container
+#   make postgres-stop        # stop the local Docker Postgres container
+#   make postgres-clean       # remove the local Docker Postgres container
 
 postgres-start:
 	@set -eu; \
@@ -226,10 +229,21 @@ postgres-stop:
 postgres-clean:
 	@docker rm -f "$(LOCAL_POSTGRES_CONTAINER)" >/dev/null 2>&1 || true
 
+# The Cargo invocations that make up the Postgres suite, defined once so
+# postgres-test-suite and postgres-tests share a single source of truth without
+# a recursive $(MAKE) call inside a recipe. GNU make runs any recipe line
+# containing $(MAKE) even under -n/-t/-q, and the postgres-tests recipe is a
+# single continued line, so an inline sub-make would make
+# `make -n postgres-tests` execute the real suite.
+POSTGRES_SUITE_CARGO = cargo test --locked -p coral-app --lib 'state::db::' -- --test-threads=1 && cargo test --locked -p coral-app --test postgres_database_tests && cargo test --locked -p xtask --features admin --bin xtask -- --ignored
+
+postgres-test-suite:
+	@test -n "$${CORAL_TEST_POSTGRES_URL:-}" || \
+	  { echo "CORAL_TEST_POSTGRES_URL is required" >&2; exit 1; }
+	$(POSTGRES_SUITE_CARGO)
+
 # Provision the local container through a prerequisite rather than a recursive
-# $(MAKE) call inside the recipe. GNU make runs any recipe line containing
-# $(MAKE) even under -n/-t/-q, and this recipe is a single continued line, so an
-# inline sub-make would make `make -n postgres-tests` execute the real suite.
+# $(MAKE) call inside the recipe, for the reason described above.
 # CORAL_TEST_POSTGRES_URL reaches both this conditional and the recipe's shell
 # whether it is set in the environment or on the command line.
 POSTGRES_TESTS_PREREQS :=
@@ -254,14 +268,8 @@ postgres-tests: $(POSTGRES_TESTS_PREREQS)
 	fi; \
 	trap cleanup EXIT INT TERM; \
 	echo "Running Postgres tests against $$url"; \
-	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app --lib \
-	  contract_on_postgres \
-	  -- --ignored; \
-	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app \
-	  --test postgres_database_tests; \
-	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p xtask \
-	  --features admin --bin xtask \
-	  -- --ignored
+	export CORAL_TEST_POSTGRES_URL="$$url"; \
+	$(POSTGRES_SUITE_CARGO)
 
 # ----------------------------------------------------------------------------
 # Dependency license scan

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -74,8 +74,11 @@ root.
   columns. Put multi-repository transaction choreography in a focused
   `state/db/*_state.rs` operation; repositories expose the smallest reusable
   query primitives.
-- DB repository behavior should have shared tests that run against SQLite
-  locally and Postgres in CI through the repository harness.
+- DB repository tests should always assert SQLite behavior and repeat the same
+  assertions against Postgres when `CORAL_TEST_POSTGRES_URL` is set. Do not mark
+  Postgres branches ignored or enumerate individual test functions in the
+  repository harness; the Postgres suite selects the existing `state::db`
+  ownership namespace.
 - Until the RDBMS migration phases replace the relevant stores, persist
   imported manifests as files under app-owned state; do not inline them into
   `config.toml`.

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -61,7 +61,8 @@ async fn open_sqlite(path: &Path) -> Result<CoralDb, DbError> {
 
     let options = SqliteConnectOptions::new()
         .filename(path)
-        .create_if_missing(false);
+        .create_if_missing(false)
+        .foreign_keys(true);
     let pool = SqlitePoolOptions::new().connect_with(options).await?;
     Ok(CoralDb {
         backend: CoralDbBackend::Sqlite(SqliteCoralDb { pool }),

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -75,7 +75,9 @@ mod tests {
     use super::{MIGRATOR, rows_match_current_migrations};
     use crate::state::AppStateLayout;
     use crate::state::db::schema::{SourceSecretKeys, SourceVariables, Sources, Workspaces};
-    use crate::state::db::{CoralDb, DatabaseConfig, DbError, DbSession, ResolvedDatabaseConfig};
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, DbError, DbSession, DbWriteSession, ResolvedDatabaseConfig,
+    };
 
     #[test]
     fn current_migration_rows_must_match_versions_checksums_and_success() {
@@ -303,7 +305,7 @@ mod tests {
         let suffix = uuid::Uuid::new_v4().simple().to_string();
         let workspace_id = format!("workspace_{suffix}");
         let source_name = format!("source_{suffix}");
-        let mut session = db;
+        let mut session = db.begin().await.expect("begin migration contract tx");
 
         insert_source_catalog_rows(&mut session, &workspace_id, &source_name)
             .await
@@ -382,6 +384,10 @@ mod tests {
                 .expect("count secret keys after workspace delete"),
             0
         );
+        session
+            .rollback()
+            .await
+            .expect("rollback migration contract tx");
     }
 
     async fn insert_source_catalog_rows<S>(
@@ -548,7 +554,7 @@ mod tests {
         source_name: &str,
     ) -> Result<(), DbError>
     where
-        S: DbSession,
+        S: DbWriteSession,
     {
         session
             .execute(
@@ -563,7 +569,7 @@ mod tests {
 
     async fn delete_workspace<S>(session: &mut S, workspace_id: &str) -> Result<(), DbError>
     where
-        S: DbSession,
+        S: DbWriteSession,
     {
         session
             .execute(

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -75,9 +75,7 @@ mod tests {
     use super::{MIGRATOR, rows_match_current_migrations};
     use crate::state::AppStateLayout;
     use crate::state::db::schema::{SourceSecretKeys, SourceVariables, Sources, Workspaces};
-    use crate::state::db::{
-        CoralDb, DatabaseConfig, DbError, DbSession, DbWriteSession, ResolvedDatabaseConfig,
-    };
+    use crate::state::db::{CoralDb, DatabaseConfig, DbError, DbSession, ResolvedDatabaseConfig};
 
     #[test]
     fn current_migration_rows_must_match_versions_checksums_and_success() {
@@ -572,7 +570,7 @@ mod tests {
         source_name: &str,
     ) -> Result<(), DbError>
     where
-        S: DbWriteSession,
+        S: DbSession,
     {
         session
             .execute(
@@ -587,7 +585,7 @@ mod tests {
 
     async fn delete_workspace<S>(session: &mut S, workspace_id: &str) -> Result<(), DbError>
     where
-        S: DbWriteSession,
+        S: DbSession,
     {
         session
             .execute(
@@ -683,11 +681,10 @@ mod tests {
         S: DbSession,
     {
         Ok(session
-            .fetch_all::<(i64,)>(statement)
+            .fetch_all_scalars::<i64>(statement)
             .await?
             .into_iter()
             .next()
-            .expect("count row")
-            .0)
+            .expect("count row"))
     }
 }

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -328,7 +328,17 @@ mod tests {
                 .expect("read credential revision"),
             uuid::Uuid::nil().to_string()
         );
-        assert_source_catalog_uniqueness_contract(&mut session, &workspace_id, &source_name).await;
+        session
+            .commit()
+            .await
+            .expect("commit seed source catalog rows");
+
+        assert_source_catalog_uniqueness_contract(db, &workspace_id, &source_name).await;
+
+        let mut session = db
+            .begin()
+            .await
+            .expect("begin cascade migration contract tx");
 
         let alternate_workspace_id = format!("alternate_workspace_{suffix}");
         insert_source_catalog_rows(&mut session, &alternate_workspace_id, &source_name)
@@ -385,9 +395,9 @@ mod tests {
             0
         );
         session
-            .rollback()
+            .commit()
             .await
-            .expect("rollback migration contract tx");
+            .expect("commit cascade migration contract tx");
     }
 
     async fn insert_source_catalog_rows<S>(
@@ -405,37 +415,45 @@ mod tests {
         insert_source_secret_key_row(session, workspace_id, source_name, "API_TOKEN").await
     }
 
-    async fn assert_source_catalog_uniqueness_contract<S>(
-        session: &mut S,
+    async fn assert_source_catalog_uniqueness_contract(
+        db: &CoralDb,
         workspace_id: &str,
         source_name: &str,
-    ) where
-        S: DbSession,
-    {
+    ) {
+        let mut tx = db.begin().await.expect("begin duplicate source tx");
         assert!(
-            insert_source_row(session, workspace_id, source_name)
+            insert_source_row(&mut tx, workspace_id, source_name)
                 .await
                 .is_err(),
             "duplicate source identity should fail"
         );
+        tx.rollback().await.expect("rollback duplicate source tx");
+
+        let mut tx = db.begin().await.expect("begin duplicate variable tx");
         assert!(
-            insert_source_variable_row(session, workspace_id, source_name, "REGION", "eu-west-1")
+            insert_source_variable_row(&mut tx, workspace_id, source_name, "REGION", "eu-west-1")
                 .await
                 .is_err(),
             "duplicate source variable key should fail"
         );
+        tx.rollback().await.expect("rollback duplicate variable tx");
+
+        let mut tx = db.begin().await.expect("begin duplicate secret key tx");
         assert!(
-            insert_source_secret_key_row(session, workspace_id, source_name, "OTHER_TOKEN")
+            insert_source_secret_key_row(&mut tx, workspace_id, source_name, "OTHER_TOKEN")
                 .await
                 .is_ok(),
             "distinct source secret keys should be allowed"
         );
         assert!(
-            insert_source_secret_key_row(session, workspace_id, source_name, "API_TOKEN")
+            insert_source_secret_key_row(&mut tx, workspace_id, source_name, "API_TOKEN")
                 .await
                 .is_err(),
             "duplicate source secret key should fail"
         );
+        tx.rollback()
+            .await
+            .expect("rollback duplicate secret key tx");
     }
 
     async fn insert_workspace_row<S>(session: &mut S, workspace_id: &str) -> Result<(), DbError>

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -32,7 +32,7 @@ pub(crate) use repositories::identity_specs::{
 pub(crate) use repositories::state_migrations::LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID;
 pub(crate) use repositories::tasks::{TaskCompletionUpdate, TaskLifecycleState};
 pub(crate) use repositories::workspaces::InaccessibleWorkspaces;
-pub(crate) use session::{DbRepos, DbSession, DbWriteSession};
+pub(crate) use session::{DbRepos, DbSession};
 #[cfg(test)]
 pub(crate) use task_query_state::TaskQueryRelationRecord;
 pub(crate) use task_query_state::{TaskQueryRelationWrite, TaskQueryWrite, TaskQueryWriteResult};

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -32,7 +32,7 @@ pub(crate) use repositories::identity_specs::{
 pub(crate) use repositories::state_migrations::LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID;
 pub(crate) use repositories::tasks::{TaskCompletionUpdate, TaskLifecycleState};
 pub(crate) use repositories::workspaces::InaccessibleWorkspaces;
-pub(crate) use session::{DbRepos, DbSession};
+pub(crate) use session::{DbRepos, DbSession, DbWriteSession};
 #[cfg(test)]
 pub(crate) use task_query_state::TaskQueryRelationRecord;
 pub(crate) use task_query_state::{TaskQueryRelationWrite, TaskQueryWrite, TaskQueryWriteResult};

--- a/crates/coral-app/src/state/db/repositories/gui_onboarding.rs
+++ b/crates/coral-app/src/state/db/repositories/gui_onboarding.rs
@@ -102,7 +102,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn gui_onboarding_repository_round_trips_against_postgres() {
         let Some(url) = postgres_test_url() else {
             return;

--- a/crates/coral-app/src/state/db/repositories/identity_specs.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs.rs
@@ -1004,10 +1004,9 @@ mod tests {
     /// each backend resolves against its own partial-index inference rules, and
     /// document envelopes round-trip through a `BYTEA` column that `SQLite` stores
     /// under a different type affinity, so the tests above cannot stand in for this
-    /// coverage. CI selects this test by the shared
-    /// `contract_on_postgres` name filter.
+    /// coverage. `make postgres-tests` supplies the Postgres URL while selecting
+    /// the full `state::db` test namespace.
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn identity_spec_repository_contract_on_postgres() {
         let Some(url) = postgres_test_url() else {
             return;

--- a/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
@@ -51,7 +51,6 @@ async fn identity_spec_contract_preserves_preexisting_reserved_name_workspace() 
 }
 
 #[tokio::test]
-#[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared contract against Postgres"]
 async fn identity_spec_persistence_contract_on_postgres() {
     let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
         .expect("read CORAL_TEST_POSTGRES_URL")

--- a/crates/coral-app/src/state/db/repositories/identity_specs_negative_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs_negative_contract_tests.rs
@@ -21,7 +21,6 @@ async fn identity_spec_corruption_contract_holds_against_sqlite() {
 }
 
 #[tokio::test]
-#[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared corruption contract against Postgres"]
 async fn identity_spec_corruption_contract_on_postgres() {
     let Some(url) = postgres_test_url() else {
         return;

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -692,12 +692,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn source_repository_round_trips_against_sqlite() {
+    async fn source_repository_round_trips_across_configured_backends() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         let db = open_sqlite(&layout).await;
 
         assert_source_repository_round_trip(&db).await;
+        if let Some(db) = open_configured_postgres().await {
+            assert_source_repository_round_trip(&db).await;
+        }
     }
 
     #[tokio::test]
@@ -807,63 +810,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn source_repository_rejects_source_without_workspace_against_sqlite() {
+    async fn source_repository_rejects_source_without_workspace_across_configured_backends() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         let db = open_sqlite(&layout).await;
 
         assert_source_repository_rejects_source_without_workspace(&db).await;
+        if let Some(db) = open_configured_postgres().await {
+            assert_source_repository_rejects_source_without_workspace(&db).await;
+        }
     }
 
     #[tokio::test]
-    async fn source_repository_rejects_invalid_persisted_source_name_against_sqlite() {
+    async fn source_repository_rejects_invalid_persisted_source_name_across_configured_backends() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         let db = open_sqlite(&layout).await;
 
         assert_source_repository_rejects_invalid_persisted_source_name(&db).await;
-    }
-
-    #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
-    async fn source_repository_round_trips_against_postgres() {
-        let Some(url) = postgres_test_url() else {
-            return;
-        };
-        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
-            .await
-            .expect("open postgres");
-        db.migrate().await.expect("migrate postgres");
-
-        assert_source_repository_round_trip(&db).await;
-    }
-
-    #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run source repository invariant coverage against Postgres"]
-    async fn source_repository_rejects_source_without_workspace_against_postgres() {
-        let Some(url) = postgres_test_url() else {
-            return;
-        };
-        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
-            .await
-            .expect("open postgres");
-        db.migrate().await.expect("migrate postgres");
-
-        assert_source_repository_rejects_source_without_workspace(&db).await;
-    }
-
-    #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run source-name validation coverage against Postgres"]
-    async fn source_repository_rejects_invalid_persisted_source_name_against_postgres() {
-        let Some(url) = postgres_test_url() else {
-            return;
-        };
-        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
-            .await
-            .expect("open postgres");
-        db.migrate().await.expect("migrate postgres");
-
-        assert_source_repository_rejects_invalid_persisted_source_name(&db).await;
+        if let Some(db) = open_configured_postgres().await {
+            assert_source_repository_rejects_invalid_persisted_source_name(&db).await;
+        }
     }
 
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
@@ -876,6 +843,15 @@ mod tests {
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
         db
+    }
+
+    async fn open_configured_postgres() -> Option<CoralDb> {
+        let url = postgres_test_url()?;
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+        Some(db)
     }
 
     async fn assert_source_repository_round_trip(db: &CoralDb) {
@@ -1242,7 +1218,7 @@ mod tests {
 
     #[expect(
         clippy::disallowed_methods,
-        reason = "The ignored Postgres repository harness is explicitly gated by this CI/test-only variable."
+        reason = "The optional Postgres branch of the shared repository harness is gated by this CI/test-only variable."
     )]
     fn postgres_test_url() -> Option<String> {
         std::env::var("CORAL_TEST_POSTGRES_URL")

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -97,6 +97,56 @@ where
             .fetch_all(source_aggregate_statement(workspace_name, source_name))
             .await
     }
+}
+
+impl SourcesRepo<'_, CoralTx<'_>> {
+    pub(crate) async fn upsert_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        now_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let created_at_unix_nanos = self
+            .source_created_at(workspace_name, &source.name)
+            .await?
+            .unwrap_or(now_unix_nanos);
+        self.delete_source_rows(workspace_name, &source.name)
+            .await?;
+        self.insert_source(
+            workspace_name,
+            source,
+            created_at_unix_nanos,
+            now_unix_nanos,
+        )
+        .await?;
+        self.insert_source_variables(workspace_name, source).await?;
+        self.insert_source_secret_keys(workspace_name, source).await
+    }
+
+    pub(crate) async fn remove_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, DbError> {
+        let removed = self.get_source(workspace_name, source_name).await?;
+        self.delete_source_rows(workspace_name, source_name).await?;
+        Ok(removed)
+    }
+
+    async fn source_created_at(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<i64>, DbError> {
+        let statement = Query::select()
+            .column(Sources::CreatedAtUnixNanos)
+            .from(Sources::Table)
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
+            .to_owned();
+        let row: Option<SourceCreatedAtRow> = self.session.fetch_optional(statement).await?;
+        Ok(row.map(|row| row.created_at_unix_nanos))
+    }
 
     async fn source_created_at(
         &mut self,

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -16,7 +16,7 @@ use crate::credentials::CredentialStorageKind;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::db::schema::{SourceSecretKeys, SourceVariables, Sources};
-use crate::state::db::{DbError, DbSession, DbWriteSession};
+use crate::state::db::{CoralTx, DbError, DbSession};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug, sqlx::FromRow)]
@@ -69,19 +69,10 @@ where
             .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
             .order_by(Sources::Name, Order::Asc)
             .to_owned();
-<<<<<<< HEAD
-        let names: Vec<(String,)> = self.session.fetch_all(statement).await?;
+        let names: Vec<String> = self.session.fetch_all_scalars(statement).await?;
         names
             .into_iter()
-            .map(|(name,)| parse_source_name(&name).map(|name| name.as_str().to_string()))
-||||||| parent of fb89c98d1 (fix(app): validate persisted source catalog names)
-        let rows: Vec<SourceNameRow> = self.session.fetch_all(statement).await?;
-        Ok(rows.into_iter().map(|row| row.name).collect())
-=======
-        let rows: Vec<SourceNameRow> = self.session.fetch_all(statement).await?;
-        rows.into_iter()
-            .map(|row| parse_source_name(&row.name).map(|name| name.as_str().to_string()))
->>>>>>> fb89c98d1 (fix(app): validate persisted source catalog names)
+            .map(|name| parse_source_name(&name).map(|name| name.as_str().to_string()))
             .collect()
     }
 
@@ -319,10 +310,7 @@ impl SourceAggregate {
     }
 }
 
-impl<S> SourcesRepo<'_, S>
-where
-    S: DbWriteSession,
-{
+impl SourcesRepo<'_, CoralTx<'_>> {
     pub(crate) async fn upsert_source(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -490,14 +478,14 @@ async fn delete_source_secret_keys<S>(
     source_name: &SourceName,
 ) -> Result<(), DbError>
 where
-    S: DbWriteSession,
+    S: DbSession,
 {
     let statement = Query::delete()
         .from_table(SourceSecretKeys::Table)
         .and_where(Expr::col(SourceSecretKeys::WorkspaceId).eq(workspace_name.as_str()))
         .and_where(Expr::col(SourceSecretKeys::SourceName).eq(source_name.as_str()))
         .to_owned();
-    session.execute_delete(statement).await
+    session.execute(statement).await
 }
 
 async fn delete_source_variables<S>(
@@ -506,14 +494,14 @@ async fn delete_source_variables<S>(
     source_name: &SourceName,
 ) -> Result<(), DbError>
 where
-    S: DbWriteSession,
+    S: DbSession,
 {
     let statement = Query::delete()
         .from_table(SourceVariables::Table)
         .and_where(Expr::col(SourceVariables::WorkspaceId).eq(workspace_name.as_str()))
         .and_where(Expr::col(SourceVariables::SourceName).eq(source_name.as_str()))
         .to_owned();
-    session.execute_delete(statement).await
+    session.execute(statement).await
 }
 
 async fn delete_source<S>(
@@ -522,14 +510,14 @@ async fn delete_source<S>(
     source_name: &SourceName,
 ) -> Result<(), DbError>
 where
-    S: DbWriteSession,
+    S: DbSession,
 {
     let statement = Query::delete()
         .from_table(Sources::Table)
         .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
         .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
         .to_owned();
-    session.execute_delete(statement).await
+    session.execute(statement).await
 }
 
 fn parse_source_name(name: &str) -> Result<SourceName, DbError> {
@@ -680,6 +668,23 @@ mod tests {
             let result = {
                 let mut session = self.db;
                 session.fetch_all(statement).await
+            };
+            self.after_read().await;
+            result
+        }
+
+        async fn fetch_all_scalars<T>(
+            &mut self,
+            statement: SelectStatement,
+        ) -> Result<Vec<T>, DbError>
+        where
+            T: Send + Unpin,
+            for<'r> (T,): FromRow<'r, SqliteRow>,
+            for<'r> (T,): FromRow<'r, PgRow>,
+        {
+            let result = {
+                let mut session = self.db;
+                session.fetch_all_scalars(statement).await
             };
             self.after_read().await;
             result

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -16,7 +16,7 @@ use crate::credentials::CredentialStorageKind;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::db::schema::{SourceSecretKeys, SourceVariables, Sources};
-use crate::state::db::{CoralTx, DbError, DbSession};
+use crate::state::db::{DbError, DbSession, DbWriteSession};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug, sqlx::FromRow)]
@@ -96,52 +96,6 @@ where
         self.session
             .fetch_all(source_aggregate_statement(workspace_name, source_name))
             .await
-    }
-}
-
-impl SourcesRepo<'_, CoralTx<'_>> {
-    pub(crate) async fn upsert_source(
-        &mut self,
-        workspace_name: &WorkspaceName,
-        source: &InstalledSource,
-        now_unix_nanos: i64,
-    ) -> Result<(), DbError> {
-        let created_at_unix_nanos = self
-            .source_created_at(workspace_name, &source.name)
-            .await?
-            .unwrap_or(now_unix_nanos);
-        self.delete_source_rows(workspace_name, &source.name)
-            .await?;
-        self.insert_source(
-            workspace_name,
-            source,
-            created_at_unix_nanos,
-            now_unix_nanos,
-        )
-        .await?;
-        self.insert_source_variables(workspace_name, source).await?;
-        self.insert_source_secret_keys(workspace_name, source).await
-    }
-
-    pub(crate) async fn remove_source(
-        &mut self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Result<Option<InstalledSource>, DbError> {
-        let removed = self.get_source(workspace_name, source_name).await?;
-        self.delete_source_rows(workspace_name, source_name).await?;
-        Ok(removed)
-    }
-
-    async fn source_created_at(
-        &mut self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Result<Option<i64>, DbError> {
-        Ok(self
-            .source_row(workspace_name, source_name)
-            .await?
-            .map(|row| row.created_at_unix_nanos))
     }
 
     async fn source_created_at(
@@ -356,7 +310,10 @@ impl SourceAggregate {
     }
 }
 
-impl SourcesRepo<'_, CoralTx<'_>> {
+impl<S> SourcesRepo<'_, S>
+where
+    S: DbWriteSession,
+{
     pub(crate) async fn upsert_source(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -524,14 +481,14 @@ async fn delete_source_secret_keys<S>(
     source_name: &SourceName,
 ) -> Result<(), DbError>
 where
-    S: DbSession,
+    S: DbWriteSession,
 {
     let statement = Query::delete()
         .from_table(SourceSecretKeys::Table)
         .and_where(Expr::col(SourceSecretKeys::WorkspaceId).eq(workspace_name.as_str()))
         .and_where(Expr::col(SourceSecretKeys::SourceName).eq(source_name.as_str()))
         .to_owned();
-    session.execute(statement).await
+    session.execute_delete(statement).await
 }
 
 async fn delete_source_variables<S>(
@@ -540,14 +497,14 @@ async fn delete_source_variables<S>(
     source_name: &SourceName,
 ) -> Result<(), DbError>
 where
-    S: DbSession,
+    S: DbWriteSession,
 {
     let statement = Query::delete()
         .from_table(SourceVariables::Table)
         .and_where(Expr::col(SourceVariables::WorkspaceId).eq(workspace_name.as_str()))
         .and_where(Expr::col(SourceVariables::SourceName).eq(source_name.as_str()))
         .to_owned();
-    session.execute(statement).await
+    session.execute_delete(statement).await
 }
 
 async fn delete_source<S>(
@@ -556,14 +513,14 @@ async fn delete_source<S>(
     source_name: &SourceName,
 ) -> Result<(), DbError>
 where
-    S: DbSession,
+    S: DbWriteSession,
 {
     let statement = Query::delete()
         .from_table(Sources::Table)
         .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
         .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
         .to_owned();
-    session.execute(statement).await
+    session.execute_delete(statement).await
 }
 
 fn parse_source_name(name: &str) -> Result<SourceName, DbError> {
@@ -836,6 +793,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn source_repository_rejects_source_without_workspace_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+        let workspace = unique_workspace();
+        let source = source("orphan", None, [], [], None, SourceOrigin::Bundled);
+        let mut tx = db.begin().await.expect("begin tx");
+
+        let error = tx
+            .sources()
+            .upsert_source(&workspace, &source, 10)
+            .await
+            .expect_err("source rows must require an existing workspace");
+
+        assert!(
+            error.to_string().to_lowercase().contains("foreign key"),
+            "unexpected error: {error}"
+        );
+        tx.rollback().await.expect("rollback failed tx");
+    }
+
+    #[tokio::test]
     #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn source_repository_round_trips_against_postgres() {
         let Some(url) = postgres_test_url() else {
@@ -935,15 +914,7 @@ mod tests {
         assert_eq!(get_source(db, &workspace, &rolled_back.name).await, None);
 
         let zeta_name = zeta.name.clone();
-        let mut tx = db.begin().await.expect("begin remove tx");
-        assert_eq!(
-            tx.sources()
-                .remove_source(&workspace, &zeta_name)
-                .await
-                .expect("remove source"),
-            Some(zeta)
-        );
-        tx.commit().await.expect("commit remove");
+        assert_eq!(remove_source(db, &workspace, &zeta_name).await, Some(zeta));
         assert_eq!(get_source(db, &workspace, &zeta_name).await, None);
 
         assert_source_get_is_coherent_during_replacement(db).await;
@@ -1115,6 +1086,21 @@ mod tests {
             .get_source(workspace, source_name)
             .await
             .expect("get source")
+    }
+
+    async fn remove_source(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Option<InstalledSource> {
+        let mut tx = db.begin().await.expect("begin remove tx");
+        let removed = tx
+            .sources()
+            .remove_source(workspace, source_name)
+            .await
+            .expect("remove source");
+        tx.commit().await.expect("commit remove tx");
+        removed
     }
 
     fn source<const VARIABLES: usize, const SECRETS: usize>(

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -138,14 +138,10 @@ impl SourcesRepo<'_, CoralTx<'_>> {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<Option<i64>, DbError> {
-        let statement = Query::select()
-            .column(Sources::CreatedAtUnixNanos)
-            .from(Sources::Table)
-            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
-            .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
-            .to_owned();
-        let row: Option<SourceCreatedAtRow> = self.session.fetch_optional(statement).await?;
-        Ok(row.map(|row| row.created_at_unix_nanos))
+        Ok(self
+            .source_row(workspace_name, source_name)
+            .await?
+            .map(|row| row.created_at_unix_nanos))
     }
 
     async fn source_created_at(

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -567,9 +567,10 @@ mod tests {
     use sqlx::FromRow;
     use sqlx::postgres::PgRow;
     use sqlx::sqlite::SqliteRow;
-    use tempfile::tempdir;
+    use tempfile::{TempDir, tempdir};
     use tokio::sync::Barrier;
 
+    use crate::bootstrap;
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
@@ -693,12 +694,8 @@ mod tests {
 
     #[tokio::test]
     async fn source_repository_round_trips_across_configured_backends() {
-        let temp = tempdir().expect("temp dir");
-        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
-        let db = open_sqlite(&layout).await;
-
-        assert_source_repository_round_trip(&db).await;
-        if let Some(db) = open_configured_postgres().await {
+        let (_temp, databases) = configured_databases().await;
+        for db in databases {
             assert_source_repository_round_trip(&db).await;
         }
     }
@@ -811,26 +808,28 @@ mod tests {
 
     #[tokio::test]
     async fn source_repository_rejects_source_without_workspace_across_configured_backends() {
-        let temp = tempdir().expect("temp dir");
-        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
-        let db = open_sqlite(&layout).await;
-
-        assert_source_repository_rejects_source_without_workspace(&db).await;
-        if let Some(db) = open_configured_postgres().await {
+        let (_temp, databases) = configured_databases().await;
+        for db in databases {
             assert_source_repository_rejects_source_without_workspace(&db).await;
         }
     }
 
     #[tokio::test]
     async fn source_repository_rejects_invalid_persisted_source_name_across_configured_backends() {
-        let temp = tempdir().expect("temp dir");
-        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
-        let db = open_sqlite(&layout).await;
-
-        assert_source_repository_rejects_invalid_persisted_source_name(&db).await;
-        if let Some(db) = open_configured_postgres().await {
+        let (_temp, databases) = configured_databases().await;
+        for db in databases {
             assert_source_repository_rejects_invalid_persisted_source_name(&db).await;
         }
+    }
+
+    async fn configured_databases() -> (TempDir, Vec<CoralDb>) {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let mut databases = vec![open_sqlite(&layout).await];
+        if let Some(db) = open_configured_postgres().await {
+            databases.push(db);
+        }
+        (temp, databases)
     }
 
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
@@ -1216,13 +1215,9 @@ mod tests {
         WorkspaceName::parse(&format!("source-repository-{nanos}")).expect("workspace name")
     }
 
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "The optional Postgres branch of the shared repository harness is gated by this CI/test-only variable."
-    )]
     fn postgres_test_url() -> Option<String> {
-        std::env::var("CORAL_TEST_POSTGRES_URL")
-            .ok()
+        bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
             .filter(|value| !value.is_empty())
     }
 }

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -69,10 +69,19 @@ where
             .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
             .order_by(Sources::Name, Order::Asc)
             .to_owned();
+<<<<<<< HEAD
         let names: Vec<(String,)> = self.session.fetch_all(statement).await?;
         names
             .into_iter()
             .map(|(name,)| parse_source_name(&name).map(|name| name.as_str().to_string()))
+||||||| parent of fb89c98d1 (fix(app): validate persisted source catalog names)
+        let rows: Vec<SourceNameRow> = self.session.fetch_all(statement).await?;
+        Ok(rows.into_iter().map(|row| row.name).collect())
+=======
+        let rows: Vec<SourceNameRow> = self.session.fetch_all(statement).await?;
+        rows.into_iter()
+            .map(|row| parse_source_name(&row.name).map(|name| name.as_str().to_string()))
+>>>>>>> fb89c98d1 (fix(app): validate persisted source catalog names)
             .collect()
     }
 
@@ -797,21 +806,17 @@ mod tests {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         let db = open_sqlite(&layout).await;
-        let workspace = unique_workspace();
-        let source = source("orphan", None, [], [], None, SourceOrigin::Bundled);
-        let mut tx = db.begin().await.expect("begin tx");
 
-        let error = tx
-            .sources()
-            .upsert_source(&workspace, &source, 10)
-            .await
-            .expect_err("source rows must require an existing workspace");
+        assert_source_repository_rejects_source_without_workspace(&db).await;
+    }
 
-        assert!(
-            error.to_string().to_lowercase().contains("foreign key"),
-            "unexpected error: {error}"
-        );
-        tx.rollback().await.expect("rollback failed tx");
+    #[tokio::test]
+    async fn source_repository_rejects_invalid_persisted_source_name_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_source_repository_rejects_invalid_persisted_source_name(&db).await;
     }
 
     #[tokio::test]
@@ -826,6 +831,34 @@ mod tests {
         db.migrate().await.expect("migrate postgres");
 
         assert_source_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run source repository invariant coverage against Postgres"]
+    async fn source_repository_rejects_source_without_workspace_against_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_source_repository_rejects_source_without_workspace(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run source-name validation coverage against Postgres"]
+    async fn source_repository_rejects_invalid_persisted_source_name_against_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_source_repository_rejects_invalid_persisted_source_name(&db).await;
     }
 
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
@@ -1055,6 +1088,75 @@ mod tests {
             .await
             .expect("upsert source");
         tx.commit().await.expect("commit source write");
+    }
+
+    async fn assert_source_repository_rejects_source_without_workspace(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let source = source("orphan", None, [], [], None, SourceOrigin::Bundled);
+        let mut tx = db.begin().await.expect("begin tx");
+
+        let error = tx
+            .sources()
+            .upsert_source(&workspace, &source, 10)
+            .await
+            .expect_err("source rows must require an existing workspace");
+
+        assert!(
+            error.to_string().to_lowercase().contains("foreign key"),
+            "unexpected error: {error}"
+        );
+        tx.rollback().await.expect("rollback failed tx");
+    }
+
+    async fn assert_source_repository_rejects_invalid_persisted_source_name(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let invalid_source_name = "bad/name";
+        let mut tx = db.begin().await.expect("begin invalid source-name tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 10)
+            .await
+            .expect("ensure workspace");
+        tx.execute(
+            Query::insert()
+                .into_table(Sources::Table)
+                .columns([
+                    Sources::WorkspaceId,
+                    Sources::Name,
+                    Sources::Version,
+                    Sources::OriginKind,
+                    Sources::CredentialStorage,
+                    Sources::CreatedAtUnixNanos,
+                    Sources::UpdatedAtUnixNanos,
+                ])
+                .values_panic([
+                    Expr::val(workspace.as_str().to_string()),
+                    Expr::val(invalid_source_name),
+                    Expr::val(Option::<String>::None),
+                    Expr::val(SourceOrigin::Bundled.as_config_value()),
+                    Expr::val(Option::<String>::None),
+                    Expr::val(10),
+                    Expr::val(10),
+                ])
+                .to_owned(),
+        )
+        .await
+        .expect("insert invalid source-name row");
+
+        let error = tx
+            .sources()
+            .list_workspace_source_names(&workspace)
+            .await
+            .expect_err("invalid persisted source name should fail");
+        let DbError::CorruptData(message) = error else {
+            panic!("unexpected error: {error}");
+        };
+        assert!(
+            message.contains("invalid source name 'bad/name'"),
+            "unexpected error: {message}"
+        );
+        tx.rollback()
+            .await
+            .expect("rollback invalid source-name tx");
     }
 
     async fn source_names(db: &CoralDb, workspace: &WorkspaceName) -> Vec<String> {

--- a/crates/coral-app/src/state/db/repositories/state_migrations.rs
+++ b/crates/coral-app/src/state/db/repositories/state_migrations.rs
@@ -99,7 +99,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the repository contract against Postgres"]
     async fn state_migration_repository_contract_on_postgres() {
         let Some(url) = postgres_test_url() else {
             return;
@@ -163,7 +162,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run concurrent claims against Postgres"]
     async fn state_migration_repository_concurrency_contract_on_postgres() {
         let Some(url) = postgres_test_url() else {
             return;

--- a/crates/coral-app/src/state/db/repositories/task_queries.rs
+++ b/crates/coral-app/src/state/db/repositories/task_queries.rs
@@ -236,7 +236,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn task_query_repository_contract_on_postgres() {
         let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
             .expect("read CORAL_TEST_POSTGRES_URL")

--- a/crates/coral-app/src/state/db/repositories/tasks.rs
+++ b/crates/coral-app/src/state/db/repositories/tasks.rs
@@ -262,7 +262,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn task_repository_contract_on_postgres() {
         let Some(url) = postgres_test_url() else {
             return;

--- a/crates/coral-app/src/state/db/repositories/users.rs
+++ b/crates/coral-app/src/state/db/repositories/users.rs
@@ -203,7 +203,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared contract against Postgres"]
     async fn users_repository_contract_on_postgres() {
         let Some(db) = open_postgres().await else {
             return;
@@ -218,7 +217,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared contract against Postgres"]
     async fn users_repository_first_login_race_contract_on_postgres() {
         let Some(db) = open_postgres().await else {
             return;

--- a/crates/coral-app/src/state/db/repositories/workspace_members.rs
+++ b/crates/coral-app/src/state/db/repositories/workspace_members.rs
@@ -305,7 +305,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared contract against Postgres"]
     async fn workspace_members_repository_contract_on_postgres() {
         let Some(db) = open_postgres().await else {
             return;
@@ -320,7 +319,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared contract against Postgres"]
     async fn workspace_members_repository_add_race_contract_on_postgres() {
         let Some(db) = open_postgres().await else {
             return;
@@ -335,7 +333,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared contract against Postgres"]
     async fn local_ownership_repository_contract_on_postgres() {
         let Some(db) = open_postgres().await else {
             return;

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -1,4 +1,4 @@
-use sea_query::{DeleteStatement, SelectStatement};
+use sea_query::SelectStatement;
 use sea_query_sqlx::SqlxBinder;
 use sqlx::postgres::PgRow;
 use sqlx::sqlite::SqliteRow;
@@ -39,10 +39,12 @@ pub(crate) trait DbSession {
         T: Send + Unpin,
         for<'r> T: FromRow<'r, SqliteRow>,
         for<'r> T: FromRow<'r, PgRow>;
-}
 
-pub(crate) trait DbWriteSession: DbSession {
-    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError>;
+    async fn fetch_all_scalars<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> (T,): FromRow<'r, SqliteRow>,
+        for<'r> (T,): FromRow<'r, PgRow>;
 }
 
 pub(crate) trait DbRepos: DbSession + Sized {
@@ -137,11 +139,14 @@ impl DbSession for &CoralDb {
     {
         fetch_all_statement(&self.backend, statement).await
     }
-}
 
-impl DbWriteSession for CoralTx<'_> {
-    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError> {
-        self.execute(statement).await
+    async fn fetch_all_scalars<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> (T,): FromRow<'r, SqliteRow>,
+        for<'r> (T,): FromRow<'r, PgRow>,
+    {
+        fetch_all_scalar_statement(&self.backend, statement).await
     }
 }
 
@@ -176,6 +181,15 @@ impl DbSession for CoralTx<'_> {
         for<'r> T: FromRow<'r, PgRow>,
     {
         self.fetch_all(statement).await
+    }
+
+    async fn fetch_all_scalars<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> (T,): FromRow<'r, SqliteRow>,
+        for<'r> (T,): FromRow<'r, PgRow>,
+    {
+        self.fetch_all_scalars(statement).await
     }
 }
 
@@ -251,6 +265,33 @@ where
         CoralDbBackend::Postgres(db) => {
             let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
             sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_all(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+    }
+}
+
+pub(super) async fn fetch_all_scalar_statement<T>(
+    backend: &CoralDbBackend,
+    statement: SelectStatement,
+) -> Result<Vec<T>, DbError>
+where
+    T: Send + Unpin,
+    for<'r> (T,): FromRow<'r, SqliteRow>,
+    for<'r> (T,): FromRow<'r, PgRow>,
+{
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            sqlx::query_scalar_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_all(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            sqlx::query_scalar_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
                 .fetch_all(&db.pool)
                 .await
                 .map_err(Into::into)

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -1,4 +1,4 @@
-use sea_query::SelectStatement;
+use sea_query::{DeleteStatement, SelectStatement};
 use sea_query_sqlx::SqlxBinder;
 use sqlx::postgres::PgRow;
 use sqlx::sqlite::SqliteRow;
@@ -39,6 +39,10 @@ pub(crate) trait DbSession {
         T: Send + Unpin,
         for<'r> T: FromRow<'r, SqliteRow>,
         for<'r> T: FromRow<'r, PgRow>;
+}
+
+pub(crate) trait DbWriteSession: DbSession {
+    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError>;
 }
 
 pub(crate) trait DbRepos: DbSession + Sized {
@@ -132,6 +136,12 @@ impl DbSession for &CoralDb {
         for<'r> T: FromRow<'r, PgRow>,
     {
         fetch_all_statement(&self.backend, statement).await
+    }
+}
+
+impl DbWriteSession for CoralTx<'_> {
+    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError> {
+        self.execute(statement).await
     }
 }
 

--- a/crates/coral-app/src/state/db/trace_search_response_state.rs
+++ b/crates/coral-app/src/state/db/trace_search_response_state.rs
@@ -333,7 +333,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn trace_search_response_repository_round_trips_against_postgres() {
         let Some(url) = postgres_test_url() else {
             return;
@@ -457,7 +456,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to verify prune/delete parent locking on Postgres"]
     async fn trace_search_response_repository_round_trips_against_postgres_with_prune_delete_locking()
      {
         let Some(postgres_url) = postgres_test_url() else {

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -137,4 +137,31 @@ impl<'a> CoralTx<'a> {
             }
         }
     }
+
+    pub(super) async fn fetch_all_scalars<T>(
+        &mut self,
+        statement: SelectStatement,
+    ) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> (T,): FromRow<'r, SqliteRow>,
+        for<'r> (T,): FromRow<'r, PgRow>,
+    {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_scalar_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_all(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_scalar_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_all(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+        }
+    }
 }

--- a/crates/coral-app/src/state/db/user_state.rs
+++ b/crates/coral-app/src/state/db/user_state.rs
@@ -177,7 +177,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared contract against Postgres"]
     async fn login_provisioning_contract_on_postgres() {
         let Some(db) = open_postgres().await else {
             return;

--- a/crates/coral-app/src/state/db/workspace_state.rs
+++ b/crates/coral-app/src/state/db/workspace_state.rs
@@ -328,7 +328,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared contract against Postgres"]
     async fn workspace_state_contract_on_postgres() {
         let Some(db) = open_postgres().await else {
             return;
@@ -343,7 +342,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared contract against Postgres"]
     async fn workspace_owner_floor_race_contract_on_postgres() {
         let Some(db) = open_postgres().await else {
             return;


### PR DESCRIPTION
## Intent

Tighten the source-catalog DB repository before runtime managers start depending on it.

## What it enables

Keeps source catalog persistence on the single `DbSession`/`DbRepos` abstraction, validates persisted source catalog names, improves DB error clarity, and strengthens repository/migration invariants without introducing a separate write-session trait.

## Usage examples

Internal source catalog writes continue to use the same repository surface:

```rust
let mut tx = db.begin().await?;
tx.sources().upsert_source(&workspace, &source, now).await?;
tx.commit().await?;
```

Reads and writes share the same session abstraction; callers choose a transaction when they need atomicity.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p coral-app state::db::repositories::sources::tests`
- `cargo test -p coral-app state::db::import::tests`
