### PR TITLE
feat(app): import and mirror source catalog into database

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1049,7 +1049,8 @@ mod tests {
     use crate::sources::manager::SourceManager;
     use crate::state::db::{
         CoralDb, DatabaseConfig, DbRepos as _, InaccessibleWorkspaces,
-        LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID, ResolvedDatabaseConfig, run_state_migrations,
+        LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID, ResolvedDatabaseConfig, open_test_database,
+        run_state_migrations,
     };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::task::manager::TaskManager;
@@ -1125,18 +1126,12 @@ enabled = false
     }
 
     async fn test_db(layout: &AppStateLayout, config_store: &ConfigStore) -> Arc<CoralDb> {
-        let config = DatabaseConfig::load(layout).expect("db config");
-        let DatabaseConfig::Sqlite { path } = config else {
-            panic!("default test config should be sqlite");
-        };
-        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+        let db = open_test_database(layout)
             .await
-            .expect("open sqlite");
-        db.migrate().await.expect("migrate sqlite");
+            .expect("open test database");
         run_state_migrations(&db, config_store, layout)
             .await
             .expect("run state migrations");
-        let db = Arc::new(db);
         create_workspace(&db, &test_workspace()).await;
         db
     }
@@ -2085,6 +2080,7 @@ backend = "unsupported"
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            Arc::clone(&db),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let workspace_manager = WorkspaceManager::new_for_tests(
@@ -2247,6 +2243,7 @@ backend = "unsupported"
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            Arc::clone(&db),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let workspace_manager = WorkspaceManager::new_for_tests(
@@ -2385,6 +2382,7 @@ tables:
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            Arc::clone(&db),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let workspace_manager = WorkspaceManager::new_for_tests(
@@ -2520,6 +2518,7 @@ tables:
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            Arc::clone(&db),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
         let workspace_manager = WorkspaceManager::new_for_tests(

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -401,6 +401,7 @@ impl ServerBuilder {
             credential_manager.clone(),
             layout.clone(),
             workspace_lifecycle_lock.clone(),
+            Arc::clone(&coral_db),
             diagnostic_reporter.clone(),
         )
         .with_pool_registry(Arc::clone(&workspace_pool_registry))

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1003,7 +1003,6 @@ mod tests {
         reason = "JSON row assertions intentionally fail loudly in tests"
     )]
 
-    use std::collections::BTreeMap;
     use std::future::Future as _;
     use std::net::{Ipv4Addr, SocketAddr, TcpListener};
     use std::path::Path;
@@ -1046,9 +1045,7 @@ mod tests {
         ObservedValuesQueueJob, ObservedValuesSurfaceKind, SearchObservationHandle,
         SqliteObservedValuesStore,
     };
-    use crate::sources::SourceName;
     use crate::sources::manager::SourceManager;
-    use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::db::{
         CoralDb, DatabaseConfig, DbRepos as _, InaccessibleWorkspaces,
         LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID, ResolvedDatabaseConfig, run_state_migrations,
@@ -1061,7 +1058,7 @@ mod tests {
     use crate::transport::workspace_to_proto;
     use crate::users::manager::UserManager;
     use crate::workspaces::authorization::{LocalPrincipalPolicy, WorkspaceAuthorizer};
-    use crate::workspaces::{MemberRole, WorkspaceManager, WorkspaceName};
+    use crate::workspaces::{MemberRole, WorkspaceManager};
     use crate::{
         AwsEngineExtensionsProvider, LocalPrincipalProvider, NoopEngineExtensionsProvider,
         PrincipalKind,
@@ -2070,57 +2067,6 @@ backend = "unsupported"
                 .pending_queue_job_count(&workspace)
                 .expect("pending queue depth"),
             1
-        );
-    }
-
-    #[tokio::test]
-    async fn startup_imports_legacy_config_source_catalog_into_database() {
-        let temp = TempDir::new().expect("temp dir");
-        let config_dir = temp.path().join("coral-config");
-        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
-        layout.ensure().expect("layout dirs");
-        disable_internal_tracing(&config_dir);
-
-        let workspace = WorkspaceName::default();
-        let source = InstalledSource {
-            name: SourceName::parse("github").expect("source name"),
-            version: Some("1.2.3".to_string()),
-            variables: BTreeMap::from([(
-                "GITHUB_API_BASE".to_string(),
-                "https://api.github.com".to_string(),
-            )]),
-            secrets: vec!["GITHUB_TOKEN".to_string()],
-            credential_storage: None,
-            credential_revision: uuid::Uuid::nil(),
-            origin: SourceOrigin::Bundled,
-        };
-        ConfigStore::new(layout.clone())
-            .upsert_source(&workspace, source.clone())
-            .expect("seed legacy config source");
-
-        let server = ServerBuilder::new()
-            .with_config_dir(config_dir)
-            .start()
-            .await
-            .expect("start server");
-        server.shutdown().await.expect("shutdown");
-
-        let DatabaseConfig::Sqlite { path } =
-            DatabaseConfig::load(&layout).expect("load database config")
-        else {
-            panic!("default test config should be sqlite");
-        };
-        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
-            .await
-            .expect("open sqlite");
-        let mut session = &db;
-        assert_eq!(
-            session
-                .sources()
-                .get_source(&workspace, &source.name)
-                .await
-                .expect("get imported source"),
-            Some(source)
         );
     }
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1003,6 +1003,7 @@ mod tests {
         reason = "JSON row assertions intentionally fail loudly in tests"
     )]
 
+    use std::collections::BTreeMap;
     use std::future::Future as _;
     use std::net::{Ipv4Addr, SocketAddr, TcpListener};
     use std::path::Path;
@@ -1045,7 +1046,9 @@ mod tests {
         ObservedValuesQueueJob, ObservedValuesSurfaceKind, SearchObservationHandle,
         SqliteObservedValuesStore,
     };
+    use crate::sources::SourceName;
     use crate::sources::manager::SourceManager;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::db::{
         CoralDb, DatabaseConfig, DbRepos as _, InaccessibleWorkspaces,
         LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID, ResolvedDatabaseConfig, run_state_migrations,
@@ -1058,7 +1061,7 @@ mod tests {
     use crate::transport::workspace_to_proto;
     use crate::users::manager::UserManager;
     use crate::workspaces::authorization::{LocalPrincipalPolicy, WorkspaceAuthorizer};
-    use crate::workspaces::{MemberRole, WorkspaceManager};
+    use crate::workspaces::{MemberRole, WorkspaceManager, WorkspaceName};
     use crate::{
         AwsEngineExtensionsProvider, LocalPrincipalProvider, NoopEngineExtensionsProvider,
         PrincipalKind,
@@ -2067,6 +2070,57 @@ backend = "unsupported"
                 .pending_queue_job_count(&workspace)
                 .expect("pending queue depth"),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_imports_legacy_config_source_catalog_into_database() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+        layout.ensure().expect("layout dirs");
+        disable_internal_tracing(&config_dir);
+
+        let workspace = WorkspaceName::default();
+        let source = InstalledSource {
+            name: SourceName::parse("github").expect("source name"),
+            version: Some("1.2.3".to_string()),
+            variables: BTreeMap::from([(
+                "GITHUB_API_BASE".to_string(),
+                "https://api.github.com".to_string(),
+            )]),
+            secrets: vec!["GITHUB_TOKEN".to_string()],
+            credential_storage: None,
+            credential_revision: uuid::Uuid::nil(),
+            origin: SourceOrigin::Bundled,
+        };
+        ConfigStore::new(layout.clone())
+            .upsert_source(&workspace, source.clone())
+            .expect("seed legacy config source");
+
+        let server = ServerBuilder::new()
+            .with_config_dir(config_dir)
+            .start()
+            .await
+            .expect("start server");
+        server.shutdown().await.expect("shutdown");
+
+        let DatabaseConfig::Sqlite { path } =
+            DatabaseConfig::load(&layout).expect("load database config")
+        else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get imported source"),
+            Some(source)
         );
     }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1471,7 +1471,7 @@ mod tests {
     use crate::request_context::RequestContext;
     use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
     use crate::sources::model::SourceOrigin;
-    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
+    use crate::state::db::{CoralDb, open_test_database, run_state_migrations};
     use crate::task::activity::TaskActivityRecorder;
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
@@ -1518,8 +1518,8 @@ mod tests {
         .with_task_activity_recorder(TaskActivityRecorder::new(Arc::clone(&db)));
         QueryManagerFixture {
             _temp: temp,
-            manager,
             db,
+            manager,
         }
     }
 
@@ -1576,18 +1576,13 @@ mod tests {
     }
 
     async fn test_db(layout: &AppStateLayout, config_store: &ConfigStore) -> Arc<CoralDb> {
-        let config = DatabaseConfig::load(layout).expect("db config");
-        let DatabaseConfig::Sqlite { path } = config else {
-            panic!("default test config should be sqlite");
-        };
-        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+        let db = open_test_database(layout)
             .await
-            .expect("open sqlite");
-        db.migrate().await.expect("migrate sqlite");
+            .expect("open test database");
         run_state_migrations(&db, config_store, layout)
             .await
             .expect("run state migrations");
-        Arc::new(db)
+        db
     }
 
     async fn active_task_context(db: &Arc<CoralDb>) -> (TaskManager, RequestContext, String) {
@@ -2501,7 +2496,12 @@ mod tests {
         )
         .await;
         let workspace_name = test_workspace();
-        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        install_function_demo_source(
+            &fixture.manager,
+            &fixture.db,
+            &workspace_name,
+            fake_home.path(),
+        );
         let function_sql = r"/*
 name: demo_items
 schema: functions
@@ -2673,6 +2673,7 @@ tables:
             fixture.manager.config_store.clone(),
             fixture.manager.credential_manager.clone(),
             fixture.manager.layout.clone(),
+            Arc::clone(&fixture.db),
         );
         let workspace_name = test_workspace();
         let (tasks, request_context, _) = active_task_context(&fixture.db).await;
@@ -2803,6 +2804,7 @@ tables:
             fixture.manager.config_store.clone(),
             fixture.manager.credential_manager.clone(),
             fixture.manager.layout.clone(),
+            Arc::clone(&fixture.db),
         );
         let workspace_name = test_workspace();
         let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
@@ -2937,6 +2939,7 @@ surface:
             fixture.manager.config_store.clone(),
             fixture.manager.credential_manager.clone(),
             fixture.manager.layout.clone(),
+            Arc::clone(&fixture.db),
         );
         let workspace_name = test_workspace();
         let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
@@ -3032,6 +3035,7 @@ surface:
             fixture.manager.config_store.clone(),
             fixture.manager.credential_manager.clone(),
             fixture.manager.layout.clone(),
+            Arc::clone(&fixture.db),
         );
         let workspace_name = test_workspace();
         let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
@@ -3193,7 +3197,12 @@ paths:
         )
         .await;
         let workspace_name = test_workspace();
-        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        install_function_demo_source(
+            &fixture.manager,
+            &fixture.db,
+            &workspace_name,
+            fake_home.path(),
+        );
         let calls = Arc::new(AtomicUsize::new(0));
         let config_store = fixture.manager.config_store.clone();
         let lifecycle_lock = fixture.manager.lifecycle_lock.clone();
@@ -3262,7 +3271,12 @@ select text from function_demo.messages
         )
         .await;
         let workspace_name = test_workspace();
-        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        install_function_demo_source(
+            &fixture.manager,
+            &fixture.db,
+            &workspace_name,
+            fake_home.path(),
+        );
         let function_sql = r"/*
 name: messages_by_type
 schema: functions
@@ -3362,6 +3376,7 @@ where type = $kind
 
     fn install_function_demo_source(
         manager: &QueryManager,
+        db: &Arc<CoralDb>,
         workspace_name: &WorkspaceName,
         fake_home: &std::path::Path,
     ) {
@@ -3378,6 +3393,7 @@ where type = $kind
             manager.config_store.clone(),
             manager.credential_manager.clone(),
             manager.layout.clone(),
+            Arc::clone(db),
         );
         source_manager
             .import_source(
@@ -3528,7 +3544,12 @@ tables:
         )
         .await;
         let workspace_name = test_workspace();
-        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        install_function_demo_source(
+            &fixture.manager,
+            &fixture.db,
+            &workspace_name,
+            fake_home.path(),
+        );
         let failed_source =
             install_missing_v4_materialization_source(&fixture.manager, &workspace_name);
 
@@ -3559,7 +3580,12 @@ tables:
         )
         .await;
         let workspace_name = test_workspace();
-        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        install_function_demo_source(
+            &fixture.manager,
+            &fixture.db,
+            &workspace_name,
+            fake_home.path(),
+        );
 
         let summary = fixture
             .manager
@@ -3615,7 +3641,12 @@ tables:
         )
         .await;
         let workspace_name = test_workspace();
-        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        install_function_demo_source(
+            &fixture.manager,
+            &fixture.db,
+            &workspace_name,
+            fake_home.path(),
+        );
         let failed_source =
             install_corrupt_parquet_source(&fixture.manager, &workspace_name, fake_home.path());
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1518,8 +1518,8 @@ mod tests {
         .with_task_activity_recorder(TaskActivityRecorder::new(Arc::clone(&db)));
         QueryManagerFixture {
             _temp: temp,
-            db,
             manager,
+            db,
         }
     }
 

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -138,6 +138,10 @@ impl ImportSourceEventSender {
             .await
             .map_err(|_closed| AppError::FailedPrecondition(import_stream_closed_message()))
     }
+
+    async fn closed(&self) {
+        self.tx.closed().await;
+    }
 }
 
 impl PendingImportSourceWithCredentialsEvent {
@@ -1226,22 +1230,29 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source: InstalledSource,
     ) -> Result<(), AppError> {
-        self.config_store
-            .upsert_source_unlocked(workspace_name, source.clone())?;
         let db = Arc::clone(&self.db);
-        let workspace_name = workspace_name.clone();
+        let db_workspace_name = workspace_name.clone();
+        let db_source = source.clone();
         run_source_db_operation(async move {
             let mut tx = db.begin().await?;
             let now_unix_nanos = now_unix_nanos_i64()?;
-            tx.workspaces()
-                .ensure(workspace_name.as_str(), now_unix_nanos)
-                .await?;
+            if tx
+                .workspaces()
+                .get(db_workspace_name.as_str())
+                .await?
+                .is_none()
+            {
+                return Err(AppError::WorkspaceNotFound(db_workspace_name.to_string()));
+            }
             tx.sources()
-                .upsert_source(&workspace_name, &source, now_unix_nanos)
+                .upsert_source(&db_workspace_name, &db_source, now_unix_nanos)
                 .await?;
             tx.commit().await?;
             Ok(())
-        })
+        })?;
+        self.config_store
+            .upsert_source_unlocked(workspace_name, source)?;
+        Ok(())
     }
 
     fn remove_db_source_with_state_lock_held(
@@ -1335,45 +1346,49 @@ impl SourceManager {
             let authorization_events = events.clone();
             let callback_input_key = input_key.clone();
             let callback_events = events.clone();
-            let material = self
-                .oauth_credential_service
-                .authorize_with_callback(
-                    StartOAuthCredentialRequest {
-                        input_key: &input_key,
-                        oauth: config.oauth,
-                        source_inputs,
-                        credential_inputs,
-                    },
-                    move |authorization| {
-                        let events = authorization_events;
-                        async move {
-                            events
-                                .send(ImportSourceWithCredentialsEvent::Authorization {
-                                    input_key: authorization_input_key,
-                                    authorization_url: authorization.authorization_url,
-                                    expires_in_seconds: authorization.expires_in_seconds,
-                                    user_code: authorization.user_code,
-                                    verification_uri: authorization.verification_uri,
-                                    verification_uri_complete: authorization
-                                        .verification_uri_complete,
-                                })
-                                .await
-                        }
-                    },
-                    move || {
-                        let events = callback_events;
-                        async move {
-                            events
-                                .send(ImportSourceWithCredentialsEvent::CallbackReceived {
-                                    input_key: callback_input_key,
-                                })
-                                .await?;
-                            tokio::task::yield_now().await;
-                            Ok(())
-                        }
-                    },
-                )
-                .await?;
+            let cancellation_events = events.clone();
+            let authorization = self.oauth_credential_service.authorize_with_callback(
+                StartOAuthCredentialRequest {
+                    input_key: &input_key,
+                    oauth: config.oauth,
+                    source_inputs,
+                    credential_inputs,
+                },
+                move |authorization| {
+                    let events = authorization_events;
+                    async move {
+                        events
+                            .send(ImportSourceWithCredentialsEvent::Authorization {
+                                input_key: authorization_input_key,
+                                authorization_url: authorization.authorization_url,
+                                expires_in_seconds: authorization.expires_in_seconds,
+                                user_code: authorization.user_code,
+                                verification_uri: authorization.verification_uri,
+                                verification_uri_complete: authorization.verification_uri_complete,
+                            })
+                            .await
+                    }
+                },
+                move || {
+                    let events = callback_events;
+                    async move {
+                        events
+                            .send(ImportSourceWithCredentialsEvent::CallbackReceived {
+                                input_key: callback_input_key,
+                            })
+                            .await?;
+                        tokio::task::yield_now().await;
+                        Ok(())
+                    }
+                },
+            );
+            tokio::pin!(authorization);
+            let material = tokio::select! {
+                result = &mut authorization => result?,
+                () = cancellation_events.closed() => {
+                    return Err(AppError::FailedPrecondition(import_stream_closed_message()));
+                }
+            };
             events
                 .send(ImportSourceWithCredentialsEvent::Completed {
                     input_key: material.input_key.clone(),
@@ -3308,6 +3323,15 @@ surface:
             Err(crate::bootstrap::AppError::SourceNotFound(_))
         ));
         assert!(
+            config_store
+                .load_config()
+                .expect("load config after rejected import")
+                .legacy_workspace_records()
+                .into_iter()
+                .all(|workspace| workspace.name != workspace_name),
+            "workspace rejected by the database should not be synthesized in config"
+        );
+        assert!(
             !layout.source_dir(&workspace_name, &source_name).exists(),
             "source artifacts should be removed after database failure"
         );
@@ -4367,6 +4391,65 @@ surface:
             event_rx.try_recv().is_err(),
             "preflight validation should fail before OAuth retrieval starts"
         );
+    }
+
+    #[tokio::test]
+    async fn import_with_oauth_releases_listener_when_event_stream_closes() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let manager = source_manager_for_tests(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout,
+        );
+        let redirect_port = free_loopback_port();
+        let (event_tx, mut event_rx) = import_event_channel();
+        let workspace_name = default_workspace();
+        let revision = active_revision(&manager, &workspace_name).await;
+        let import = manager.import_source_with_credentials(
+            &workspace_name,
+            revision,
+            ImportSourceWithCredentialsCommand {
+                manifest_yaml: manifest_with_oauth_secret(
+                    "http://127.0.0.1:1/token",
+                    redirect_port,
+                ),
+                bindings: SourceBindings {
+                    variables: vec![SourceBinding {
+                        key: "API_BASE".to_string(),
+                        value: "https://api.example.test".to_string(),
+                    }],
+                    secrets: Vec::new(),
+                },
+                oauth_credential_retrievals: vec![SourceOAuthCredentialRetrieval {
+                    input_key: "API_TOKEN".to_string(),
+                    method_index: 0,
+                    credential_inputs: Vec::new(),
+                }],
+            },
+            event_tx,
+        );
+        tokio::pin!(import);
+
+        let authorization = tokio::select! {
+            event = event_rx.recv() => event.expect("authorization event").into_event(),
+            result = &mut import => panic!("import completed before authorization: {result:?}"),
+        };
+        assert!(matches!(
+            authorization,
+            ImportSourceWithCredentialsEvent::Authorization { .. }
+        ));
+        drop(event_rx);
+
+        let error = tokio::time::timeout(Duration::from_secs(1), &mut import)
+            .await
+            .expect("closed event stream should cancel OAuth promptly")
+            .expect_err("closed event stream should reject import");
+        assert!(error.to_string().contains("source import stream closed"));
+        StdTcpListener::bind(("127.0.0.1", redirect_port))
+            .expect("OAuth redirect listener should be released");
     }
 
     async fn callback(authorization_url: &str, redirect_port: u16) {

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -1,6 +1,7 @@
 //! Owns the source lifecycle workflow for the local app.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -29,6 +30,7 @@ use crate::sources::materialization::{
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::sources::{SourceName, ensure_database_source_feature_enabled};
+use crate::state::db::{CoralDb, DbRepos, now_unix_nanos_i64};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
 use crate::workspaces::{
@@ -43,6 +45,7 @@ use uuid::Uuid;
 #[derive(Clone)]
 pub(crate) struct SourceManager {
     config_store: ConfigStore,
+    db: Arc<CoralDb>,
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
     layout: AppStateLayout,
@@ -199,11 +202,16 @@ impl SourceManager {
         credential_manager: CredentialManager,
         layout: AppStateLayout,
     ) -> Self {
+        let db = Arc::new(open_test_sqlite_with_legacy_config(
+            layout.clone(),
+            config_store.clone(),
+        ));
         Self::new(
             config_store,
             credential_manager,
             layout,
             crate::workspaces::WorkspaceLifecycleLock::default(),
+            db,
         )
     }
 
@@ -213,12 +221,14 @@ impl SourceManager {
         credential_manager: CredentialManager,
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
+        db: Arc<CoralDb>,
     ) -> Self {
         Self::with_diagnostic_reporter(
             config_store,
             credential_manager,
             layout,
             lifecycle_lock,
+            db,
             SourceDiagnosticReporter::default(),
         )
         .with_database_sources_enabled(true)
@@ -229,10 +239,12 @@ impl SourceManager {
         credential_manager: CredentialManager,
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
+        db: Arc<CoralDb>,
         diagnostic_reporter: SourceDiagnosticReporter,
     ) -> Self {
         Self {
             config_store,
+            db,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
             layout,
@@ -718,6 +730,24 @@ impl SourceManager {
             }
             return Err(error);
         }
+        if let Err(error) = self.remove_db_source_with_state_lock_held(workspace_name, source_name)
+        {
+            let restore_dir_result = source_dir_backup.restore();
+            self.restore_source_rollback_state_with_state_lock_held(
+                workspace_name,
+                source_name,
+                Some(previous),
+                None,
+                &credential_guard,
+            );
+            if let Err(restore_error) = restore_dir_result {
+                return Err(AppError::FailedPrecondition(format!(
+                    "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
+                    source_dir_backup.backup_path().display()
+                )));
+            }
+            return Err(error);
+        }
         self.pool_registry
             .remove_catalog(workspace_name, source_name.as_str());
         source_dir_backup.commit()?;
@@ -910,9 +940,7 @@ impl SourceManager {
             },
             origin: request.origin,
         };
-        if let Err(error) = self
-            .config_store
-            .upsert_source_unlocked(workspace_name, stored.clone())
+        if let Err(error) = self.upsert_source_with_state_lock_held(workspace_name, stored.clone())
         {
             let restore_result = restore_materialization_backup(
                 &self.layout,
@@ -1194,6 +1222,47 @@ impl SourceManager {
         } else {
             self.credential_manager.default_write_storage().map(Some)
         }
+    }
+
+    fn upsert_source_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: InstalledSource,
+    ) -> Result<(), AppError> {
+        self.config_store
+            .upsert_source_unlocked(workspace_name, source.clone())?;
+        let db = Arc::clone(&self.db);
+        let workspace_name = workspace_name.clone();
+        run_source_db_operation(async move {
+            let mut tx = db.begin().await?;
+            let now_unix_nanos = now_unix_nanos_i64()?;
+            tx.workspaces()
+                .ensure(workspace_name.as_str(), now_unix_nanos)
+                .await?;
+            tx.sources()
+                .upsert_source(&workspace_name, &source, now_unix_nanos)
+                .await?;
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    fn remove_db_source_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), AppError> {
+        let db = Arc::clone(&self.db);
+        let workspace_name = workspace_name.clone();
+        let source_name = source_name.clone();
+        run_source_db_operation(async move {
+            let mut tx = db.begin().await?;
+            tx.sources()
+                .remove_source(&workspace_name, &source_name)
+                .await?;
+            tx.commit().await?;
+            Ok(())
+        })
     }
 
     fn validate_oauth_import_preflight(
@@ -1790,6 +1859,59 @@ fn cleanup_empty_parent(root: &std::path::Path, path: Option<&std::path::Path>) 
     }
 }
 
+fn run_source_db_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: Future<Output = Result<T, AppError>> + Send + 'static,
+{
+    fn run_on_runtime<T, F>(operation: F) -> Result<T, AppError>
+    where
+        F: Future<Output = Result<T, AppError>>,
+    {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "failed to create source database runtime: {error}"
+                ))
+            })?;
+        runtime.block_on(operation)
+    }
+
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return std::thread::spawn(move || run_on_runtime(operation))
+            .join()
+            .map_err(|_panic| {
+                AppError::FailedPrecondition(
+                    "source database operation thread panicked".to_string(),
+                )
+            })?;
+    }
+
+    run_on_runtime(operation)
+}
+
+#[cfg(test)]
+fn open_test_sqlite_with_legacy_config(
+    layout: AppStateLayout,
+    config_store: ConfigStore,
+) -> CoralDb {
+    run_source_db_operation(async move {
+        let config = crate::state::db::DatabaseConfig::load(&layout)?;
+        let crate::state::db::DatabaseConfig::Sqlite { path } = config else {
+            return Err(AppError::FailedPrecondition(
+                "default test config should be sqlite".to_string(),
+            ));
+        };
+        let db = CoralDb::open(crate::state::db::ResolvedDatabaseConfig::Sqlite { path }).await?;
+        db.migrate().await?;
+        crate::state::db::import_legacy_config(&db, &config_store).await?;
+        Ok(db)
+    })
+    .expect("open test source catalog database")
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
@@ -1825,6 +1947,7 @@ mod tests {
         FINGERPRINT_FILENAME, MaterializationInputs, PROJECTIONS_FILENAME,
     };
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
+    use crate::state::db::DbRepos;
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::{WorkspaceLifecycleRevision, WorkspaceName};
     use coral_spec::{
@@ -2209,12 +2332,8 @@ surface:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new(
-            config_store.clone(),
-            credential_manager,
-            layout.clone(),
-            crate::workspaces::WorkspaceLifecycleLock::default(),
-        );
+        let manager =
+            SourceManager::new_for_tests(config_store.clone(), credential_manager, layout.clone());
 
         let workspace_name = default_workspace();
         let original_manifest = manifest_without_secrets();
@@ -2299,11 +2418,10 @@ surface:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new(
-            config_store,
+        let manager = SourceManager::new_for_tests(
+            config_store.clone(),
             credential_manager.clone(),
-            layout,
-            crate::workspaces::WorkspaceLifecycleLock::default(),
+            layout.clone(),
         );
 
         let workspace_name = default_workspace();
@@ -2368,11 +2486,10 @@ surface:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new(
+        let manager = SourceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
-            layout,
-            crate::workspaces::WorkspaceLifecycleLock::default(),
+            layout.clone(),
         );
 
         let workspace_name = default_workspace();
@@ -2461,11 +2578,10 @@ surface:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new(
+        let manager = SourceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
-            layout,
-            crate::workspaces::WorkspaceLifecycleLock::default(),
+            layout.clone(),
         );
 
         let workspace_name = default_workspace();
@@ -2875,6 +2991,60 @@ surface:
                 .iter()
                 .any(|source| source.name.as_str() == "github_v4")
         );
+    }
+
+    #[test]
+    fn import_and_delete_source_mirror_database_catalog() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let workspace_name = default_workspace();
+
+        let imported = manager
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_without_secrets(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("import source");
+
+        let db = manager.db.clone();
+        let imported_workspace = workspace_name.clone();
+        let imported_name = imported.name.clone();
+        let database_source = super::run_source_db_operation(async move {
+            let mut session = db.as_ref();
+            Ok(session
+                .sources()
+                .get_source(&imported_workspace, &imported_name)
+                .await?)
+        })
+        .expect("read imported database source");
+        assert_eq!(database_source, Some(imported.clone()));
+
+        manager
+            .delete_source(&workspace_name, &imported.name)
+            .expect("delete source");
+
+        let db = manager.db.clone();
+        let deleted_workspace = workspace_name.clone();
+        let deleted_name = imported.name.clone();
+        let database_source = super::run_source_db_operation(async move {
+            let mut session = db.as_ref();
+            Ok(session
+                .sources()
+                .get_source(&deleted_workspace, &deleted_name)
+                .await?)
+        })
+        .expect("read deleted database source");
+        assert_eq!(database_source, None);
     }
 
     #[test]

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -201,16 +201,13 @@ impl SourceManager {
         config_store: ConfigStore,
         credential_manager: CredentialManager,
         layout: AppStateLayout,
+        db: Arc<CoralDb>,
     ) -> Self {
-        let db = Arc::new(open_test_sqlite_with_legacy_config(
-            layout.clone(),
-            config_store.clone(),
-        ));
         Self::new(
             config_store,
             credential_manager,
             layout,
-            crate::workspaces::WorkspaceLifecycleLock::default(),
+            WorkspaceLifecycleLock::default(),
             db,
         )
     }
@@ -1475,6 +1472,21 @@ impl SourceManager {
                 warn!("rollback: failed to restore source config: {e}");
             }
         } else {
+            match self
+                .config_store
+                .get_source_unlocked(workspace_name, source_name)
+            {
+                Ok(_) => {
+                    if let Err(e) = self
+                        .config_store
+                        .remove_source_unlocked(workspace_name, source_name)
+                    {
+                        warn!("rollback: failed to remove new source config: {e}");
+                    }
+                }
+                Err(AppError::SourceNotFound(_)) => {}
+                Err(e) => warn!("rollback: failed to inspect new source config: {e}"),
+            }
             let source_dir = self.layout.source_dir(workspace_name, source_name);
             if source_dir.exists()
                 && let Err(e) = std::fs::remove_dir_all(&source_dir)
@@ -1893,26 +1905,6 @@ where
 }
 
 #[cfg(test)]
-fn open_test_sqlite_with_legacy_config(
-    layout: AppStateLayout,
-    config_store: ConfigStore,
-) -> CoralDb {
-    run_source_db_operation(async move {
-        let config = crate::state::db::DatabaseConfig::load(&layout)?;
-        let crate::state::db::DatabaseConfig::Sqlite { path } = config else {
-            return Err(AppError::FailedPrecondition(
-                "default test config should be sqlite".to_string(),
-            ));
-        };
-        let db = CoralDb::open(crate::state::db::ResolvedDatabaseConfig::Sqlite { path }).await?;
-        db.migrate().await?;
-        crate::state::db::import_legacy_config(&db, &config_store).await?;
-        Ok(db)
-    })
-    .expect("open test source catalog database")
-}
-
-#[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::net::TcpListener as StdTcpListener;
@@ -1933,7 +1925,8 @@ mod tests {
         ImportSourceWithCredentialsEvent, PendingImportSourceWithCredentialsEvent,
         PersistSourceRequest, SourceBinding, SourceBindings, SourceManager,
         SourceOAuthCredentialRetrieval, ValidatedBindings, materialization_inputs_from_bindings,
-        normalize_binding_key, source_needs_stored_material_for_validation,
+        normalize_binding_key, run_source_db_operation,
+        source_needs_stored_material_for_validation,
     };
     use crate::bootstrap::AppError;
     use crate::credentials::{
@@ -1967,6 +1960,24 @@ mod tests {
             .revision_if_active_async(workspace_name)
             .await
             .expect("workspace lifecycle revision")
+    }
+
+    fn source_manager_for_tests(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+    ) -> SourceManager {
+        let db = run_source_db_operation({
+            let config_store = config_store.clone();
+            let layout = layout.clone();
+            async move {
+                let db = crate::state::db::open_test_database(&layout).await?;
+                crate::state::db::run_state_migrations(&db, &config_store, &layout).await?;
+                Ok(db)
+            }
+        })
+        .expect("open test database");
+        SourceManager::new_for_tests(config_store, credential_manager, layout, db)
     }
 
     fn manifest_with_secret() -> String {
@@ -2219,12 +2230,7 @@ tables:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new(
-            config_store,
-            credential_manager,
-            layout.clone(),
-            crate::workspaces::WorkspaceLifecycleLock::default(),
-        );
+        let manager = source_manager_for_tests(config_store, credential_manager, layout.clone());
         (manager, layout)
     }
 
@@ -2333,7 +2339,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
         let manager =
-            SourceManager::new_for_tests(config_store.clone(), credential_manager, layout.clone());
+            source_manager_for_tests(config_store.clone(), credential_manager, layout.clone());
 
         let workspace_name = default_workspace();
         let original_manifest = manifest_without_secrets();
@@ -2418,7 +2424,7 @@ surface:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new_for_tests(
+        let manager = source_manager_for_tests(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
@@ -2486,7 +2492,7 @@ surface:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new_for_tests(
+        let manager = source_manager_for_tests(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
@@ -2578,7 +2584,7 @@ surface:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new_for_tests(
+        let manager = source_manager_for_tests(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
@@ -2837,7 +2843,7 @@ surface:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
+        let manager = source_manager_for_tests(config_store, credential_manager, layout);
         let candidate = CandidateSource {
             name: SourceName::parse("coral_db").expect("source"),
             description: String::new(),
@@ -2897,8 +2903,7 @@ surface:
             CredentialStoragePreference::Keychain,
         );
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store.clone(), credential_manager, layout);
+        let manager = source_manager_for_tests(config_store.clone(), credential_manager, layout);
         let candidate = candidate_with_secret("OPTIONAL_TOKEN", false);
 
         config_store
@@ -2953,9 +2958,8 @@ surface:
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
         let search_observations = SearchObservationHandle::new(layout.clone());
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone())
-                .with_search_observation_handle(search_observations.clone());
+        let manager = source_manager_for_tests(config_store, credential_manager, layout.clone())
+            .with_search_observation_handle(search_observations.clone());
         let workspace_name = default_workspace();
         let source_name = SourceName::parse("github").expect("source name");
 
@@ -2980,8 +2984,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = source_manager_for_tests(config_store, credential_manager, layout.clone());
 
         let disabled = manager
             .discover_sources(&default_workspace())
@@ -3002,8 +3005,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = source_manager_for_tests(config_store, credential_manager, layout.clone());
         let workspace_name = default_workspace();
 
         let imported = manager
@@ -3059,8 +3061,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = source_manager_for_tests(config_store, credential_manager, layout.clone());
 
         let installed = manager
             .import_source(
@@ -3098,7 +3099,7 @@ surface:
             v4_openapi_fixture_with_defaulted_input_server_url(),
         )
         .expect("write fixture");
-        let manager = SourceManager::new_for_tests(
+        let manager = source_manager_for_tests(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout.clone(),
@@ -3136,7 +3137,7 @@ surface:
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         layout.ensure().expect("ensure layout");
-        let manager = SourceManager::new_for_tests(
+        let manager = source_manager_for_tests(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout,
@@ -3169,7 +3170,7 @@ surface:
         layout.ensure().expect("ensure layout");
         let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
         std::fs::write(&openapi_file, v4_openapi_fixture_with_metadata()).expect("write fixture");
-        let manager = SourceManager::new_for_tests(
+        let manager = source_manager_for_tests(
             ConfigStore::new(layout.clone()),
             CredentialManager::new(CredentialStore::new(layout.clone())),
             layout.clone(),
@@ -3208,8 +3209,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = source_manager_for_tests(config_store, credential_manager, layout.clone());
 
         let source_name = SourceName::parse("secured_messages").expect("source");
         let source_dir = layout.source_dir(&default_workspace(), &source_name);
@@ -3257,6 +3257,59 @@ surface:
                 .expect("list sources")
                 .is_empty(),
             "source config should not be persisted after rollback"
+        );
+    }
+
+    #[test]
+    fn import_new_source_removes_config_when_database_persistence_fails() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let db = run_source_db_operation({
+            let layout = layout.clone();
+            async move {
+                let db = crate::state::db::CoralDb::open(
+                    crate::state::db::ResolvedDatabaseConfig::Sqlite {
+                        path: layout.database_file(),
+                    },
+                )
+                .await?;
+                Ok(std::sync::Arc::new(db))
+            }
+        })
+        .expect("open unmigrated test database");
+        let manager = SourceManager::new_for_tests(
+            config_store.clone(),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout.clone(),
+            db,
+        );
+        let workspace_name = default_workspace();
+        let source_name = SourceName::parse("public_messages").expect("source");
+
+        let error = manager
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_without_secrets(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect_err("database persistence should fail without migrations");
+
+        assert!(
+            matches!(error, crate::bootstrap::AppError::Database(_)),
+            "unexpected error: {error:#}"
+        );
+        assert!(matches!(
+            config_store.get_source(&workspace_name, &source_name),
+            Err(crate::bootstrap::AppError::SourceNotFound(_))
+        ));
+        assert!(
+            !layout.source_dir(&workspace_name, &source_name).exists(),
+            "source artifacts should be removed after database failure"
         );
     }
 
@@ -3311,7 +3364,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
+        let manager = source_manager_for_tests(config_store, credential_manager, layout);
 
         let source = manager
             .import_source(
@@ -3348,7 +3401,7 @@ surface:
         );
         let credential_manager = CredentialManager::new(credential_store);
         let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout.clone());
+            source_manager_for_tests(config_store, credential_manager.clone(), layout.clone());
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
 
@@ -3418,8 +3471,7 @@ surface:
             CredentialStoragePreference::Keychain,
         );
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = source_manager_for_tests(config_store, credential_manager, layout.clone());
         let source_name = SourceName::parse("public_messages").expect("source");
 
         let source = manager
@@ -3460,7 +3512,7 @@ surface:
             CredentialStoragePreference::Keychain,
         );
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
+        let manager = source_manager_for_tests(config_store, credential_manager, layout);
 
         let error = manager
             .import_source(
@@ -3489,8 +3541,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = source_manager_for_tests(config_store, credential_manager, layout.clone());
 
         let source_name = SourceName::parse("secured_messages").expect("source");
         manager
@@ -3542,8 +3593,7 @@ surface:
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = source_manager_for_tests(config_store, credential_manager, layout.clone());
         let workspace = default_workspace();
 
         let first = manager
@@ -3601,8 +3651,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = source_manager_for_tests(config_store, credential_manager, layout.clone());
 
         let source_name = SourceName::parse("secured_messages").expect("source");
         manager
@@ -3650,8 +3699,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
+        let manager = source_manager_for_tests(config_store, credential_manager.clone(), layout);
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         credential_manager
@@ -3708,8 +3756,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let manager = source_manager_for_tests(config_store, credential_manager, layout.clone());
         let source_name = SourceName::parse("secured_messages").expect("source");
         let secret_path = layout.secret_file(&default_workspace(), &source_name);
         std::fs::create_dir_all(&secret_path).expect("create blocking secret directory");
@@ -3744,8 +3791,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
+        let manager = source_manager_for_tests(config_store, credential_manager.clone(), layout);
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         credential_manager
@@ -3812,7 +3858,7 @@ surface:
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store.clone());
         let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout.clone());
+            source_manager_for_tests(config_store, credential_manager.clone(), layout.clone());
         let workspace_name = default_workspace();
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
@@ -3908,7 +3954,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
         let manager =
-            SourceManager::new_for_tests(config_store.clone(), credential_manager, layout.clone());
+            source_manager_for_tests(config_store.clone(), credential_manager, layout.clone());
         let workspace_name = default_workspace();
         let revision = active_revision(&manager, &workspace_name).await;
         let deletion_marker = manager
@@ -3952,7 +3998,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
         let manager =
-            SourceManager::new_for_tests(config_store.clone(), credential_manager, layout.clone());
+            source_manager_for_tests(config_store.clone(), credential_manager, layout.clone());
         let fixture = OAuthFixture::new();
         let redirect_port = free_loopback_port();
         let (manifest_yaml, _) =
@@ -4042,8 +4088,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
+        let manager = source_manager_for_tests(config_store, credential_manager.clone(), layout);
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         let fixture = OAuthFixture::new();
@@ -4122,8 +4167,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
+        let manager = source_manager_for_tests(config_store, credential_manager.clone(), layout);
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         let fixture = OAuthFixture::new();
@@ -4201,8 +4245,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager =
-            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
+        let manager = source_manager_for_tests(config_store, credential_manager.clone(), layout);
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         manager
@@ -4280,7 +4323,7 @@ surface:
         let config_store = ConfigStore::new(layout.clone());
         let credential_store = CredentialStore::new(layout.clone());
         let credential_manager = CredentialManager::new(credential_store);
-        let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
+        let manager = source_manager_for_tests(config_store, credential_manager, layout);
         let redirect_port = free_loopback_port();
         let (event_tx, mut event_rx) = import_event_channel();
         let workspace_name = default_workspace();

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -864,8 +864,12 @@ mod tests {
         reason = "credential method order assertions intentionally fail loudly in tests"
     )]
 
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::sync::Arc;
+    use std::sync::mpsc as std_mpsc;
+    use std::thread;
+    use std::time::Duration;
 
     use super::*;
     use crate::identity::Principal;
@@ -1221,6 +1225,108 @@ mod tests {
             UNPARSEABLE_CONFIG,
             "a refused caller must not have rewritten installed source state"
         );
+    }
+
+    use tokio::sync::oneshot;
+    use tokio::task;
+    use uuid::Uuid;
+
+    use crate::state::{AppStateLayout, ConfigStore};
+
+    fn installed_source_for_tests() -> InstalledSource {
+        InstalledSource {
+            name: SourceName::parse("imported_messages").expect("source name"),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            credential_revision: Uuid::nil(),
+            origin: SourceOrigin::Imported,
+        }
+    }
+
+    /// The streaming import holds the exclusive app state lock across database awaits, while every
+    /// read path takes the same blocking shared lock straight from a runtime worker. Detaching the
+    /// import with `task::spawn` therefore wedges: the worker parked in `flock(2)` is the only one
+    /// that could repoll the lock holder. Driving it on the blocking pool keeps it schedulable.
+    ///
+    /// The scenario is driven on its own runtime from a helper thread so that a regression fails
+    /// the test on a wall-clock deadline instead of hanging: once the sole worker is parked in
+    /// `flock(2)` nothing is left to advance the runtime's timer, so `tokio::time::timeout` cannot
+    /// be the backstop here.
+    #[test]
+    fn streaming_import_completes_while_runtime_workers_block_on_the_state_lock() {
+        let (done_tx, done_rx) = std_mpsc::channel();
+        thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .build()
+                .expect("single-worker runtime");
+            let name = runtime.block_on(streaming_import_under_blocked_workers());
+            // The receiver is gone only when the deadline below already failed the test.
+            drop(done_tx.send(name));
+        });
+
+        let name = done_rx
+            .recv_timeout(Duration::from_secs(20))
+            .expect("streaming import must complete while the runtime worker is parked in flock");
+        assert_eq!(name, "imported_messages");
+    }
+
+    async fn streaming_import_under_blocked_workers() -> String {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout);
+
+        let (locked_tx, locked_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let import_store = config_store.clone();
+        let mut stream =
+            import_source_response_stream(WorkspaceName::default(), move |_events| async move {
+                // Mirrors `SourceManager::persist_source`: the exclusive state lock is taken up
+                // front and held across the awaited database work.
+                let state_lock = import_store
+                    .state_lock_exclusive()
+                    .expect("exclusive state lock");
+                locked_tx.send(()).expect("report exclusive state lock");
+                release_rx.await.expect("await state lock release");
+                drop(state_lock);
+                Ok(installed_source_for_tests())
+            });
+        locked_rx
+            .await
+            .expect("import should take the exclusive state lock");
+
+        // Occupy the runtime's only worker the way every read path does: a blocking shared state
+        // lock acquired directly inside an async task.
+        let (reader_started_tx, reader_started_rx) = std_mpsc::channel();
+        let reader_store = config_store.clone();
+        let reader = task::spawn(async move {
+            reader_started_tx.send(()).expect("report reader start");
+            drop(reader_store.state_lock_shared().expect("shared state lock"));
+        });
+        reader_started_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("reader task should start");
+        // Give the reader time to reach the blocking `flock(2)` call itself.
+        thread::sleep(Duration::from_millis(250));
+
+        release_tx
+            .send(())
+            .expect("release the exclusive state lock");
+
+        let response = stream
+            .next()
+            .await
+            .expect("import stream item")
+            .expect("import response");
+        reader.await.expect("reader task");
+        match response.event.expect("import event") {
+            import_source_response::Event::Source(source) => source.name,
+            other => panic!("expected a terminal source event, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -923,6 +923,7 @@ mod tests {
             credentials.clone(),
             layout.clone(),
             workspaces.lifecycle_lock(),
+            Arc::clone(&db),
         );
         let queries = QueryManager::new_for_tests(
             deployment.config_store,

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -47,8 +47,8 @@ use crate::sources::manager::{
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::transport::{
-    grpc_span, instrument_grpc, query_status, request_context, validate_source_response_to_proto,
-    workspace_name_from_proto, workspace_to_proto,
+    grpc_span, instrument_grpc, query_status, request_context, spawn_state_locked_operation,
+    validate_source_response_to_proto, workspace_name_from_proto, workspace_to_proto,
 };
 use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
 use crate::workspaces::{WorkspaceLifecycleRevision, WorkspaceManager, WorkspaceName};
@@ -470,9 +470,14 @@ where
     Fut: Future<Output = Result<InstalledSource, Status>> + Send + 'static,
 {
     let (event_tx, event_rx) = mpsc::channel(8);
+    let import = spawn_state_locked_operation(import(ImportSourceEventSender::new(event_tx)));
     Box::pin(ImportSourceResponseStream::new(
         event_rx,
-        Box::pin(import(ImportSourceEventSender::new(event_tx))),
+        Box::pin(async move {
+            import
+                .await
+                .map_err(|error| Status::internal(format!("source import task failed: {error}")))?
+        }),
         response_workspace_name,
     ))
 }

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -47,10 +47,6 @@ impl AppConfig {
         self.catalog.workspace_sources(workspace_name)
     }
 
-    pub(crate) fn source_catalog_entries(&self) -> Vec<(WorkspaceName, InstalledSource)> {
-        self.catalog.source_entries()
-    }
-
     pub(crate) fn get_source(
         &self,
         workspace_name: &WorkspaceName,
@@ -289,18 +285,6 @@ impl From<&InstalledFunction> for PersistedInstalledFunction {
 pub(crate) struct SourceCatalog(BTreeMap<WorkspaceName, BTreeMap<SourceName, InstalledSource>>);
 
 impl SourceCatalog {
-    pub(crate) fn source_entries(&self) -> Vec<(WorkspaceName, InstalledSource)> {
-        self.0
-            .iter()
-            .flat_map(|(workspace_name, sources)| {
-                sources
-                    .values()
-                    .cloned()
-                    .map(|source| (workspace_name.clone(), source))
-            })
-            .collect()
-    }
-
     pub(crate) fn workspace_sources(&self, workspace_name: &WorkspaceName) -> Vec<InstalledSource> {
         self.0
             .get(workspace_name)

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -605,6 +605,7 @@ impl ConfigStore {
         Ok(result)
     }
 
+    #[cfg(test)]
     fn update_config<T>(
         &self,
         update: impl FnOnce(&mut AppConfig) -> Result<T, AppError>,
@@ -636,17 +637,19 @@ impl ConfigStore {
         })
     }
 
-    /// Removes one workspace's entry, sources and functions from `config.toml`.
+    /// Removes one workspace's entry, sources and functions from `config.toml`
+    /// without taking the app state lock.
     ///
-    /// What comes back carries everything the removal took away, so a caller
-    /// whose next step fails can hand it to
-    /// [`Self::restore_workspace_config_entries`] rather than leave the file
-    /// disagreeing with the catalog it accompanies.
-    pub(crate) fn remove_workspace_config_entries(
+    /// Callers must already hold the state lock in exclusive mode. What comes
+    /// back carries everything the removal took away, so a caller whose next
+    /// step fails can hand it to
+    /// [`Self::restore_workspace_config_entries_unlocked`] rather than leave
+    /// the file disagreeing with the catalog it accompanies.
+    pub(crate) fn remove_workspace_config_entries_unlocked(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Option<RemovedWorkspaceConfig>, AppError> {
-        self.update_config(|config| {
+        self.update_config_unlocked(|config| {
             let removed = config.workspaces.remove(workspace_name);
             if removed {
                 let sources = config
@@ -675,17 +678,20 @@ impl ConfigStore {
         })
     }
 
-    /// Puts back everything [`Self::remove_workspace_config_entries`] removed.
+    /// Puts back everything
+    /// [`Self::remove_workspace_config_entries_unlocked`] removed without
+    /// taking the app state lock.
     ///
-    /// The removal is durable the moment it returns while the database
-    /// transaction it accompanies is not, so a deletion that fails to commit
-    /// needs a genuine inverse here — without one the workspace stays in the
-    /// catalog with its sources and functions gone from the file.
-    pub(crate) fn restore_workspace_config_entries(
+    /// Callers must already hold the state lock in exclusive mode. The removal
+    /// is durable the moment it returns while the database transaction it
+    /// accompanies is not, so a deletion that fails to commit needs a genuine
+    /// inverse here — without one the workspace stays in the catalog with its
+    /// sources and functions gone from the file.
+    pub(crate) fn restore_workspace_config_entries_unlocked(
         &self,
         removed: RemovedWorkspaceConfig,
     ) -> Result<(), AppError> {
-        self.update_config(|config| {
+        self.update_config_unlocked(|config| {
             let workspace_name = &removed.deleted.workspace.name;
             config.workspaces.insert(workspace_name.clone());
             for source in removed.deleted.sources {
@@ -696,6 +702,24 @@ impl ConfigStore {
             }
             Ok(())
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn remove_workspace_config_entries(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<RemovedWorkspaceConfig>, AppError> {
+        let _lock = self.state_lock_exclusive()?;
+        self.remove_workspace_config_entries_unlocked(workspace_name)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn restore_workspace_config_entries(
+        &self,
+        removed: RemovedWorkspaceConfig,
+    ) -> Result<(), AppError> {
+        let _lock = self.state_lock_exclusive()?;
+        self.restore_workspace_config_entries_unlocked(removed)
     }
 
     pub(crate) fn list_workspace_sources(
@@ -1766,6 +1790,49 @@ origin = "bundled"
                 "'{name}' must report nothing left to remove the second time"
             );
         }
+    }
+
+    #[test]
+    fn remove_workspace_config_entries_unlocked_runs_under_a_held_state_lock() {
+        let temp = TempDir::new().expect("temp dir");
+        let store = ConfigStore::new(test_layout(&temp));
+        let workspace_name = WorkspaceName::parse("work").expect("workspace");
+
+        store
+            .create_legacy_workspace_entry_for_tests(&workspace_name)
+            .expect("create legacy workspace entry");
+
+        // `FileLock::exclusive` opens a fresh file descriptor, so re-taking the
+        // state lock here would block the caller against itself. Run the call in
+        // a worker thread with a deadline so a regression fails instead of
+        // hanging the suite.
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let worker_store = store.clone();
+        let worker_workspace_name = workspace_name.clone();
+        std::thread::spawn(move || {
+            let _lock = worker_store
+                .state_lock_exclusive()
+                .expect("hold state lock exclusively");
+            let removed =
+                worker_store.remove_workspace_config_entries_unlocked(&worker_workspace_name);
+            sender
+                .send(removed.is_ok_and(|removed| removed.is_some()))
+                .expect("report unlocked config removal");
+        });
+
+        let removed = receiver
+            .recv_timeout(std::time::Duration::from_secs(30))
+            .expect("unlocked config removal should not take the state lock again");
+        assert!(removed);
+        assert!(
+            store
+                .load_config()
+                .expect("load config")
+                .workspaces
+                .list()
+                .iter()
+                .all(|workspace| workspace.name != workspace_name)
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -47,6 +47,10 @@ impl AppConfig {
         self.catalog.workspace_sources(workspace_name)
     }
 
+    pub(crate) fn source_catalog_entries(&self) -> Vec<(WorkspaceName, InstalledSource)> {
+        self.catalog.source_entries()
+    }
+
     pub(crate) fn get_source(
         &self,
         workspace_name: &WorkspaceName,
@@ -285,6 +289,18 @@ impl From<&InstalledFunction> for PersistedInstalledFunction {
 pub(crate) struct SourceCatalog(BTreeMap<WorkspaceName, BTreeMap<SourceName, InstalledSource>>);
 
 impl SourceCatalog {
+    pub(crate) fn source_entries(&self) -> Vec<(WorkspaceName, InstalledSource)> {
+        self.0
+            .iter()
+            .flat_map(|(workspace_name, sources)| {
+                sources
+                    .values()
+                    .cloned()
+                    .map(|source| (workspace_name.clone(), source))
+            })
+            .collect()
+    }
+
     pub(crate) fn workspace_sources(&self, workspace_name: &WorkspaceName) -> Vec<InstalledSource> {
         self.0
             .get(workspace_name)

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -8,12 +8,18 @@ use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::{WorkspaceName, WorkspaceRecord};
 
 const WORKSPACE_CATALOG_CUTOVER_ID: &str = "workspace_catalog_cutover_v1";
+const SOURCE_CATALOG_IMPORT_ID: &str = "source_catalog_import_v1";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct WorkspaceCatalogCutoverReport {
     pub(crate) workspace_count: usize,
-    pub(crate) source_count: usize,
     pub(crate) cutover_performed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SourceCatalogImportReport {
+    source_count: usize,
+    import_performed: bool,
 }
 
 pub(crate) async fn run_state_migrations(
@@ -22,6 +28,7 @@ pub(crate) async fn run_state_migrations(
     layout: &AppStateLayout,
 ) -> Result<(), AppError> {
     cutover_legacy_workspace_catalog(db, config_store, layout).await?;
+    import_config_source_catalog(db, config_store).await?;
     remove_legacy_task_jsonl(config_store, layout)?;
     Ok(())
 }
@@ -58,10 +65,8 @@ async fn cutover_legacy_workspace_catalog_at(
     {
         tx.rollback().await?;
         let mut session = db;
-        let (workspace_count, source_count) = database_catalog_counts(&mut session).await?;
         return Ok(WorkspaceCatalogCutoverReport {
-            workspace_count,
-            source_count,
+            workspace_count: session.workspaces().list().await?.len(),
             cutover_performed: false,
         });
     }
@@ -71,19 +76,10 @@ async fn cutover_legacy_workspace_catalog_at(
     if workspaces.is_empty() {
         workspaces = implicitly_provisioned_workspaces(layout)?;
     }
-    let source_entries = config.source_catalog_entries();
-
     let mut imported_workspaces = BTreeSet::new();
     import_legacy_workspaces(
         &mut tx,
         &workspaces,
-        now_unix_nanos,
-        &mut imported_workspaces,
-    )
-    .await?;
-    let source_count = import_legacy_source_catalog(
-        &mut tx,
-        &source_entries,
         now_unix_nanos,
         &mut imported_workspaces,
     )
@@ -94,7 +90,6 @@ async fn cutover_legacy_workspace_catalog_at(
 
     Ok(WorkspaceCatalogCutoverReport {
         workspace_count: imported_workspaces.len(),
-        source_count,
         cutover_performed: true,
     })
 }
@@ -167,6 +162,52 @@ fn implicitly_provisioned_workspaces(
     Ok(workspaces)
 }
 
+async fn import_config_source_catalog(
+    db: &CoralDb,
+    config_store: &ConfigStore,
+) -> Result<SourceCatalogImportReport, AppError> {
+    import_config_source_catalog_at(db, config_store, now_unix_nanos_i64()?).await
+}
+
+async fn import_config_source_catalog_at(
+    db: &CoralDb,
+    config_store: &ConfigStore,
+    now_unix_nanos: i64,
+) -> Result<SourceCatalogImportReport, AppError> {
+    let _state_lock = config_store.state_lock_exclusive()?;
+    let mut tx = db.begin().await?;
+    if !tx
+        .state_migrations()
+        .try_claim(SOURCE_CATALOG_IMPORT_ID, now_unix_nanos)
+        .await?
+    {
+        tx.rollback().await?;
+        return Ok(SourceCatalogImportReport {
+            source_count: 0,
+            import_performed: false,
+        });
+    }
+
+    let config = config_store.load_config_unlocked()?;
+    let source_entries = config
+        .legacy_workspace_records()
+        .into_iter()
+        .flat_map(|workspace| {
+            config
+                .workspace_sources(&workspace.name)
+                .into_iter()
+                .map(move |source| (workspace.name.clone(), source))
+        })
+        .collect::<Vec<_>>();
+    let source_count = import_config_sources(&mut tx, &source_entries, now_unix_nanos).await?;
+    tx.commit().await?;
+
+    Ok(SourceCatalogImportReport {
+        source_count,
+        import_performed: true,
+    })
+}
+
 async fn import_legacy_workspaces<S>(
     session: &mut S,
     workspaces: &[WorkspaceRecord],
@@ -186,19 +227,13 @@ where
     Ok(())
 }
 
-async fn import_legacy_source_catalog(
+async fn import_config_sources(
     session: &mut CoralTx<'_>,
     entries: &[(WorkspaceName, InstalledSource)],
     now_unix_nanos: i64,
-    imported_workspaces: &mut BTreeSet<WorkspaceName>,
 ) -> Result<usize, AppError> {
     let mut source_count = 0;
     for (workspace_name, source) in entries {
-        imported_workspaces.insert(workspace_name.clone());
-        session
-            .workspaces()
-            .ensure(workspace_name.as_str(), now_unix_nanos)
-            .await?;
         if session
             .sources()
             .get_source(workspace_name, &source.name)
@@ -207,6 +242,10 @@ async fn import_legacy_source_catalog(
         {
             continue;
         }
+        session
+            .workspaces()
+            .ensure(workspace_name.as_str(), now_unix_nanos)
+            .await?;
         session
             .sources()
             .upsert_source(workspace_name, source, now_unix_nanos)
@@ -217,7 +256,7 @@ async fn import_legacy_source_catalog(
             .await?;
         if imported.as_ref() != Some(source) {
             return Err(AppError::Database(format!(
-                "source catalog cutover failed validation for {workspace_name}:{}",
+                "source catalog import failed validation for {workspace_name}:{}",
                 source.name
             )));
         }
@@ -271,28 +310,6 @@ where
     )))
 }
 
-async fn database_catalog_counts<S>(session: &mut S) -> Result<(usize, usize), AppError>
-where
-    S: DbRepos,
-{
-    let workspaces = session.workspaces().list().await?;
-    let mut source_count = 0;
-    for workspace in &workspaces {
-        let workspace_name = WorkspaceName::parse(&workspace.id).map_err(|error| {
-            AppError::Database(format!(
-                "workspace catalog cutover state contains invalid workspace name '{}': {error}",
-                workspace.id
-            ))
-        })?;
-        source_count += session
-            .sources()
-            .list_workspace_source_names(&workspace_name)
-            .await?
-            .len();
-    }
-    Ok((workspaces.len(), source_count))
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -300,9 +317,10 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        WORKSPACE_CATALOG_CUTOVER_ID, WorkspaceCatalogCutoverReport,
-        cutover_legacy_workspace_catalog, cutover_legacy_workspace_catalog_at,
-        run_state_migrations,
+        SOURCE_CATALOG_IMPORT_ID, SourceCatalogImportReport, WORKSPACE_CATALOG_CUTOVER_ID,
+        WorkspaceCatalogCutoverReport, cutover_legacy_workspace_catalog,
+        cutover_legacy_workspace_catalog_at, import_config_source_catalog,
+        import_config_source_catalog_at, run_state_migrations,
     };
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
@@ -319,7 +337,7 @@ mod tests {
     const STAGED_DELETION_SUFFIX: &str = "7f1c5a4e-1d29-4f3a-9f2b-2c6d0f9a1b34";
 
     #[tokio::test]
-    async fn cuts_over_legacy_config_sources_into_database() {
+    async fn completed_workspace_cutover_does_not_skip_source_catalog_import() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
@@ -334,31 +352,32 @@ mod tests {
             SourceOrigin::Imported,
         );
         config_store
+            .create_legacy_workspace_entry_for_tests(&workspace)
+            .expect("create legacy workspace entry");
+        config_store
             .upsert_source(&workspace, source.clone())
             .expect("write config source");
         let db = open_sqlite(&layout).await;
 
-        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
+        cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
             .await
-            .expect("cut over legacy config");
+            .expect("cut over legacy workspace catalog");
 
-        assert_eq!(
-            report,
-            WorkspaceCatalogCutoverReport {
-                workspace_count: 1,
-                source_count: 1,
-                cutover_performed: true,
-            }
-        );
         let mut session = &db;
-        assert!(
+        assert_eq!(
             session
-                .workspaces()
-                .get(workspace.as_str())
+                .sources()
+                .get_source(&workspace, &source.name)
                 .await
-                .expect("get workspace")
-                .is_some()
+                .expect("get source before source import"),
+            None
         );
+
+        run_state_migrations(&db, &config_store, &layout)
+            .await
+            .expect("run state migrations after workspace cutover");
+
+        let mut session = &db;
         assert_eq!(
             session
                 .sources()
@@ -372,7 +391,14 @@ mod tests {
                 .state_migrations()
                 .has_completed(WORKSPACE_CATALOG_CUTOVER_ID)
                 .await
-                .expect("read cutover marker")
+                .expect("read workspace cutover marker")
+        );
+        assert!(
+            session
+                .state_migrations()
+                .has_completed(SOURCE_CATALOG_IMPORT_ID)
+                .await
+                .expect("read source import marker")
         );
     }
 
@@ -401,7 +427,6 @@ mod tests {
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 1,
-                source_count: 0,
                 cutover_performed: true,
             }
         );
@@ -421,12 +446,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cutover_preserves_existing_database_sources() {
+    async fn workspace_cutover_preserves_database_source_in_source_only_workspace() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
-        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let workspace = WorkspaceName::parse("source-only").expect("workspace");
         let existing = source("github", None, [], [], None, SourceOrigin::Bundled);
         let replacement = source(
             "github",
@@ -436,6 +461,9 @@ mod tests {
             Some(CredentialStorageKind::File),
             SourceOrigin::Imported,
         );
+        config_store
+            .create_legacy_workspace_entry_for_tests(&workspace)
+            .expect("create legacy workspace entry");
         config_store
             .upsert_source(&workspace, replacement)
             .expect("write config source");
@@ -453,16 +481,25 @@ mod tests {
             tx.commit().await.expect("commit seed tx");
         }
 
-        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
+        let cutover_report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 10)
             .await
-            .expect("cut over legacy config");
+            .expect("cut over legacy workspace catalog");
+        assert_eq!(
+            cutover_report,
+            WorkspaceCatalogCutoverReport {
+                workspace_count: 1,
+                cutover_performed: true,
+            }
+        );
+        let report = import_config_source_catalog_at(&db, &config_store, 11)
+            .await
+            .expect("import config source catalog");
 
         assert_eq!(
             report,
-            WorkspaceCatalogCutoverReport {
-                workspace_count: 1,
+            SourceCatalogImportReport {
                 source_count: 0,
-                cutover_performed: true,
+                import_performed: true,
             }
         );
         let mut session = &db;
@@ -477,31 +514,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cutover_imports_missing_config_sources_without_overwriting_existing() {
+    async fn source_import_adds_missing_sources_and_preserves_database_workspaces() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let default_workspace = WorkspaceName::parse("default").expect("workspace");
         let other_workspace = WorkspaceName::parse("other").expect("workspace");
+        let database_only_workspace = WorkspaceName::parse("database-only").expect("workspace");
         let existing_source = source("github", None, [], [], None, SourceOrigin::Bundled);
         let config_source = source("slack", None, [], [], None, SourceOrigin::Bundled);
         config_store
-            .create_legacy_workspace_entry_for_tests(&default_workspace)
-            .expect("create default config workspace");
-        config_store
             .create_legacy_workspace_entry_for_tests(&other_workspace)
-            .expect("create other config workspace");
+            .expect("create config workspace");
         config_store
             .upsert_source(&other_workspace, config_source.clone())
             .expect("write config source");
         let db = open_sqlite(&layout).await;
+        cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 5)
+            .await
+            .expect("cut over legacy workspace catalog");
         {
             let mut tx = db.begin().await.expect("begin seed tx");
             tx.workspaces()
                 .ensure(default_workspace.as_str(), 7)
                 .await
                 .expect("seed workspace");
+            tx.workspaces()
+                .ensure(database_only_workspace.as_str(), 7)
+                .await
+                .expect("seed database-only workspace");
             tx.sources()
                 .upsert_source(&default_workspace, &existing_source, 7)
                 .await
@@ -509,16 +551,15 @@ mod tests {
             tx.commit().await.expect("commit seed tx");
         }
 
-        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
+        let report = import_config_source_catalog_at(&db, &config_store, 11)
             .await
-            .expect("cut over legacy config");
+            .expect("import config source catalog");
 
         assert_eq!(
             report,
-            WorkspaceCatalogCutoverReport {
-                workspace_count: 2,
+            SourceCatalogImportReport {
                 source_count: 1,
-                cutover_performed: true,
+                import_performed: true,
             }
         );
         let mut session = &db;
@@ -537,6 +578,14 @@ mod tests {
                 .await
                 .expect("get imported source"),
             Some(config_source)
+        );
+        assert!(
+            session
+                .workspaces()
+                .get(database_only_workspace.as_str())
+                .await
+                .expect("get database-only workspace")
+                .is_some()
         );
     }
 
@@ -591,7 +640,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completed_cutover_does_not_reimport_legacy_config() {
+    async fn completed_workspace_cutover_does_not_reload_config() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
@@ -605,13 +654,12 @@ mod tests {
 
         let report = cutover_legacy_workspace_catalog(&db, &config_store, &layout)
             .await
-            .expect("marker should skip legacy config reload");
+            .expect("marker should skip workspace catalog reload");
 
         assert_eq!(
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 0,
-                source_count: 0,
                 cutover_performed: false,
             }
         );
@@ -643,7 +691,6 @@ mod tests {
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 0,
-                source_count: 0,
                 cutover_performed: true,
             }
         );
@@ -686,7 +733,6 @@ mod tests {
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 1,
-                source_count: 0,
                 cutover_performed: true,
             }
         );
@@ -723,7 +769,6 @@ mod tests {
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 1,
-                source_count: 0,
                 cutover_performed: true,
             }
         );
@@ -760,7 +805,6 @@ mod tests {
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 1,
-                source_count: 0,
                 cutover_performed: true,
             }
         );
@@ -843,6 +887,32 @@ mod tests {
 
         assert!(!first_legacy_file.exists());
         assert!(!second_legacy_file.exists());
+    }
+
+    #[tokio::test]
+    async fn completed_source_import_does_not_reload_config() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let db = open_sqlite(&layout).await;
+
+        import_config_source_catalog_at(&db, &config_store, 11)
+            .await
+            .expect("initial source import");
+        std::fs::write(layout.config_file(), "[[workspaces]\n").expect("corrupt config");
+
+        let report = import_config_source_catalog(&db, &config_store)
+            .await
+            .expect("source marker should skip config reload");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                source_count: 0,
+                import_performed: false,
+            }
+        );
     }
 
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 
+use sha2::{Digest as _, Sha256};
+
 use super::session::DbRepos;
 use super::{CoralDb, CoralTx, now_unix_nanos_i64};
 use crate::bootstrap::AppError;
@@ -28,7 +30,7 @@ pub(crate) async fn run_state_migrations(
     layout: &AppStateLayout,
 ) -> Result<(), AppError> {
     cutover_legacy_workspace_catalog(db, config_store, layout).await?;
-    import_config_source_catalog(db, config_store, now_unix_nanos_i64()?).await?;
+    import_config_source_catalog(db, config_store, layout, now_unix_nanos_i64()?).await?;
     remove_legacy_task_jsonl(config_store, layout)?;
     Ok(())
 }
@@ -160,13 +162,15 @@ fn implicitly_provisioned_workspaces(
 async fn import_config_source_catalog(
     db: &CoralDb,
     config_store: &ConfigStore,
+    layout: &AppStateLayout,
     now_unix_nanos: i64,
 ) -> Result<SourceCatalogImportReport, AppError> {
     let _state_lock = config_store.state_lock_exclusive()?;
     let mut tx = db.begin().await?;
+    let migration_id = source_catalog_import_id(layout);
     if !tx
         .state_migrations()
-        .try_claim(SOURCE_CATALOG_IMPORT_ID, now_unix_nanos)
+        .try_claim(&migration_id, now_unix_nanos)
         .await?
     {
         tx.rollback().await?;
@@ -194,6 +198,11 @@ async fn import_config_source_catalog(
         source_count,
         import_performed: true,
     })
+}
+
+fn source_catalog_import_id(layout: &AppStateLayout) -> String {
+    let digest = Sha256::digest(layout.config_dir().as_os_str().as_encoded_bytes());
+    format!("{SOURCE_CATALOG_IMPORT_ID}:{digest:x}")
 }
 
 async fn import_legacy_workspaces<S>(
@@ -288,9 +297,9 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        SOURCE_CATALOG_IMPORT_ID, SourceCatalogImportReport, WORKSPACE_CATALOG_CUTOVER_ID,
-        WorkspaceCatalogCutoverReport, cutover_legacy_workspace_catalog,
-        cutover_legacy_workspace_catalog_at, import_config_source_catalog, run_state_migrations,
+        SourceCatalogImportReport, WORKSPACE_CATALOG_CUTOVER_ID, WorkspaceCatalogCutoverReport,
+        cutover_legacy_workspace_catalog, cutover_legacy_workspace_catalog_at,
+        import_config_source_catalog, run_state_migrations, source_catalog_import_id,
     };
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
@@ -366,7 +375,7 @@ mod tests {
         assert!(
             session
                 .state_migrations()
-                .has_completed(SOURCE_CATALOG_IMPORT_ID)
+                .has_completed(&source_catalog_import_id(&layout))
                 .await
                 .expect("read source import marker")
         );
@@ -454,7 +463,7 @@ mod tests {
             tx.commit().await.expect("commit seed tx");
         }
 
-        let report = import_config_source_catalog(&db, &config_store, 11)
+        let report = import_config_source_catalog(&db, &config_store, &layout, 11)
             .await
             .expect("import config source catalog");
 
@@ -514,7 +523,7 @@ mod tests {
             tx.commit().await.expect("commit seed tx");
         }
 
-        let report = import_config_source_catalog(&db, &config_store, 11)
+        let report = import_config_source_catalog(&db, &config_store, &layout, 11)
             .await
             .expect("import config source catalog");
 
@@ -553,6 +562,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shared_database_imports_each_local_source_catalog_once() {
+        let temp = tempdir().expect("temp dir");
+        let first_layout =
+            AppStateLayout::discover(Some(temp.path().join("first"))).expect("first layout");
+        let second_layout =
+            AppStateLayout::discover(Some(temp.path().join("second"))).expect("second layout");
+        first_layout.ensure().expect("ensure first layout");
+        second_layout.ensure().expect("ensure second layout");
+        let first_store = ConfigStore::new(first_layout.clone());
+        let second_store = ConfigStore::new(second_layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let first_source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        let second_source = source("slack", None, [], [], None, SourceOrigin::Bundled);
+        for (store, source) in [
+            (&first_store, first_source.clone()),
+            (&second_store, second_source.clone()),
+        ] {
+            store
+                .create_legacy_workspace_entry_for_tests(&workspace)
+                .expect("create legacy workspace entry");
+            store
+                .upsert_source(&workspace, source)
+                .expect("write config source");
+        }
+        let db = open_sqlite(&first_layout).await;
+        cutover_legacy_workspace_catalog_at(&db, &first_store, &first_layout, 10)
+            .await
+            .expect("cut over shared workspace catalog");
+
+        let first_report = import_config_source_catalog(&db, &first_store, &first_layout, 11)
+            .await
+            .expect("import first local source catalog");
+        let second_report = import_config_source_catalog(&db, &second_store, &second_layout, 12)
+            .await
+            .expect("import second local source catalog");
+
+        assert_eq!(first_report.source_count, 1);
+        assert_eq!(second_report.source_count, 1);
+        assert_ne!(
+            source_catalog_import_id(&first_layout),
+            source_catalog_import_id(&second_layout)
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &first_source.name)
+                .await
+                .expect("get first source"),
+            Some(first_source)
+        );
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &second_source.name)
+                .await
+                .expect("get second source"),
+            Some(second_source)
+        );
+        assert!(
+            session
+                .state_migrations()
+                .has_completed(&source_catalog_import_id(&first_layout))
+                .await
+                .expect("read first import marker")
+        );
+        assert!(
+            session
+                .state_migrations()
+                .has_completed(&source_catalog_import_id(&second_layout))
+                .await
+                .expect("read second import marker")
+        );
+    }
+
+    #[tokio::test]
     async fn source_import_rejects_missing_workspace_without_marking_complete() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
@@ -574,7 +659,7 @@ mod tests {
             .await
             .expect("delete imported workspace");
 
-        let error = import_config_source_catalog(&db, &config_store, 11)
+        let error = import_config_source_catalog(&db, &config_store, &layout, 11)
             .await
             .expect_err("missing workspace should reject source import");
 
@@ -595,7 +680,7 @@ mod tests {
         assert!(
             !session
                 .state_migrations()
-                .has_completed(SOURCE_CATALOG_IMPORT_ID)
+                .has_completed(&source_catalog_import_id(&layout))
                 .await
                 .expect("read source import marker")
         );
@@ -895,12 +980,12 @@ mod tests {
         let config_store = ConfigStore::new(layout.clone());
         let db = open_sqlite(&layout).await;
 
-        import_config_source_catalog(&db, &config_store, 11)
+        import_config_source_catalog(&db, &config_store, &layout, 11)
             .await
             .expect("initial source import");
         std::fs::write(layout.config_file(), "[[workspaces]\n").expect("corrupt config");
 
-        let report = import_config_source_catalog(&db, &config_store, 12)
+        let report = import_config_source_catalog(&db, &config_store, &layout, 12)
             .await
             .expect("source marker should skip config reload");
 

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeSet;
 
 use super::session::DbRepos;
-use super::{CoralDb, now_unix_nanos_i64};
+use super::{CoralDb, CoralTx, now_unix_nanos_i64};
 use crate::bootstrap::AppError;
+use crate::sources::model::InstalledSource;
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::{WorkspaceName, WorkspaceRecord};
 
@@ -11,6 +12,7 @@ const WORKSPACE_CATALOG_CUTOVER_ID: &str = "workspace_catalog_cutover_v1";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct WorkspaceCatalogCutoverReport {
     pub(crate) workspace_count: usize,
+    pub(crate) source_count: usize,
     pub(crate) cutover_performed: bool,
 }
 
@@ -56,27 +58,44 @@ async fn cutover_legacy_workspace_catalog_at(
     {
         tx.rollback().await?;
         let mut session = db;
+        let (workspace_count, source_count) = database_catalog_counts(&mut session).await?;
         return Ok(WorkspaceCatalogCutoverReport {
-            workspace_count: session.workspaces().list().await?.len(),
+            workspace_count,
+            source_count,
             cutover_performed: false,
         });
     }
 
-    let mut workspaces = config_store
-        .load_config_unlocked()?
-        .legacy_workspace_records();
+    let config = config_store.load_config_unlocked()?;
+    let mut workspaces = config.legacy_workspace_records();
     if workspaces.is_empty() {
         workspaces = implicitly_provisioned_workspaces(layout)?;
     }
-    let workspace_count = workspaces.len();
+    let source_entries = config.source_catalog_entries();
+    let source_count = source_entries.len();
 
     tx.workspaces().delete_all().await?;
-    import_legacy_workspaces(&mut tx, &workspaces, now_unix_nanos).await?;
-    verify_workspace_parity(&mut tx, &workspaces).await?;
+    let mut imported_workspaces = BTreeSet::new();
+    import_legacy_workspaces(
+        &mut tx,
+        &workspaces,
+        now_unix_nanos,
+        &mut imported_workspaces,
+    )
+    .await?;
+    import_legacy_source_catalog(
+        &mut tx,
+        &source_entries,
+        now_unix_nanos,
+        &mut imported_workspaces,
+    )
+    .await?;
+    verify_workspace_parity(&mut tx, &imported_workspaces).await?;
     tx.commit().await?;
 
     Ok(WorkspaceCatalogCutoverReport {
-        workspace_count,
+        workspace_count: imported_workspaces.len(),
+        source_count,
         cutover_performed: true,
     })
 }
@@ -153,6 +172,7 @@ async fn import_legacy_workspaces<S>(
     session: &mut S,
     workspaces: &[WorkspaceRecord],
     now_unix_nanos: i64,
+    imported_workspaces: &mut BTreeSet<WorkspaceName>,
 ) -> Result<(), AppError>
 where
     S: DbRepos,
@@ -162,20 +182,51 @@ where
             .workspaces()
             .ensure(workspace.name.as_str(), now_unix_nanos)
             .await?;
+        imported_workspaces.insert(workspace.name.clone());
+    }
+    Ok(())
+}
+
+async fn import_legacy_source_catalog(
+    session: &mut CoralTx<'_>,
+    entries: &[(WorkspaceName, InstalledSource)],
+    now_unix_nanos: i64,
+    imported_workspaces: &mut BTreeSet<WorkspaceName>,
+) -> Result<(), AppError> {
+    for (workspace_name, source) in entries {
+        imported_workspaces.insert(workspace_name.clone());
+        session
+            .workspaces()
+            .ensure(workspace_name.as_str(), now_unix_nanos)
+            .await?;
+        session
+            .sources()
+            .upsert_source(workspace_name, source, now_unix_nanos)
+            .await?;
+        let imported = session
+            .sources()
+            .get_source(workspace_name, &source.name)
+            .await?;
+        if imported.as_ref() != Some(source) {
+            return Err(AppError::Database(format!(
+                "source catalog cutover failed validation for {workspace_name}:{}",
+                source.name
+            )));
+        }
     }
     Ok(())
 }
 
 async fn verify_workspace_parity<S>(
     session: &mut S,
-    legacy_workspaces: &[WorkspaceRecord],
+    imported_workspaces: &BTreeSet<WorkspaceName>,
 ) -> Result<(), AppError>
 where
     S: DbRepos,
 {
-    let expected = legacy_workspaces
+    let expected = imported_workspaces
         .iter()
-        .map(|workspace| workspace.name.as_str().to_string())
+        .map(|workspace| workspace.as_str().to_string())
         .collect::<BTreeSet<_>>();
     let actual = session
         .workspaces()
@@ -192,8 +243,32 @@ where
     )))
 }
 
+async fn database_catalog_counts<S>(session: &mut S) -> Result<(usize, usize), AppError>
+where
+    S: DbRepos,
+{
+    let workspaces = session.workspaces().list().await?;
+    let mut source_count = 0;
+    for workspace in &workspaces {
+        let workspace_name = WorkspaceName::parse(&workspace.id).map_err(|error| {
+            AppError::Database(format!(
+                "workspace catalog cutover state contains invalid workspace name '{}': {error}",
+                workspace.id
+            ))
+        })?;
+        source_count += session
+            .sources()
+            .list_workspace_source_names(&workspace_name)
+            .await?
+            .len();
+    }
+    Ok((workspaces.len(), source_count))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use tempfile::tempdir;
 
     use super::{
@@ -201,6 +276,9 @@ mod tests {
         cutover_legacy_workspace_catalog, cutover_legacy_workspace_catalog_at,
         run_state_migrations,
     };
+    use crate::credentials::CredentialStorageKind;
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::db::session::DbRepos;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
     use crate::state::{AppStateLayout, ConfigStore};
@@ -213,7 +291,65 @@ mod tests {
     const STAGED_DELETION_SUFFIX: &str = "7f1c5a4e-1d29-4f3a-9f2b-2c6d0f9a1b34";
 
     #[tokio::test]
-    async fn cuts_over_legacy_workspaces_into_database() {
+    async fn cuts_over_legacy_config_sources_into_database() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [("GITHUB_API_BASE", "https://api.github.com")],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::Keychain),
+            SourceOrigin::Imported,
+        );
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        let db = open_sqlite(&layout).await;
+
+        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
+            .await
+            .expect("cut over legacy config");
+
+        assert_eq!(
+            report,
+            WorkspaceCatalogCutoverReport {
+                workspace_count: 1,
+                source_count: 1,
+                cutover_performed: true,
+            }
+        );
+        let mut session = &db;
+        assert!(
+            session
+                .workspaces()
+                .get(workspace.as_str())
+                .await
+                .expect("get workspace")
+                .is_some()
+        );
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get source"),
+            Some(source)
+        );
+        assert!(
+            session
+                .state_migrations()
+                .has_completed(WORKSPACE_CATALOG_CUTOVER_ID)
+                .await
+                .expect("read cutover marker")
+        );
+    }
+
+    #[tokio::test]
+    async fn cuts_over_legacy_workspaces_without_sources() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
@@ -237,7 +373,8 @@ mod tests {
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 1,
-                cutover_performed: true
+                source_count: 0,
+                cutover_performed: true,
             }
         );
         assert_eq!(
@@ -266,11 +403,17 @@ mod tests {
             .create_legacy_workspace_entry_for_tests(&analytics_workspace)
             .expect("create legacy workspace entry");
         let db = open_sqlite(&layout).await;
+        let stale_workspace = WorkspaceName::parse("stale").expect("workspace");
+        let stale_source = source("stale_source", None, [], [], None, SourceOrigin::Bundled);
         let mut tx = db.begin().await.expect("begin stale seed tx");
         tx.workspaces()
-            .ensure("stale", 7)
+            .ensure(stale_workspace.as_str(), 7)
             .await
             .expect("seed stale workspace");
+        tx.sources()
+            .upsert_source(&stale_workspace, &stale_source, 7)
+            .await
+            .expect("seed stale source");
         tx.commit().await.expect("commit stale seed tx");
 
         cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
@@ -288,6 +431,14 @@ mod tests {
                 .map(|workspace| workspace.id)
                 .collect::<Vec<_>>(),
             vec!["analytics".to_string()]
+        );
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&stale_workspace, &stale_source.name)
+                .await
+                .expect("get stale source"),
+            None
         );
     }
 
@@ -312,7 +463,8 @@ mod tests {
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 0,
-                cutover_performed: false
+                source_count: 0,
+                cutover_performed: false,
             }
         );
     }
@@ -343,7 +495,8 @@ mod tests {
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 0,
-                cutover_performed: true
+                source_count: 0,
+                cutover_performed: true,
             }
         );
         let mut session = &db;
@@ -385,7 +538,8 @@ mod tests {
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 1,
-                cutover_performed: true
+                source_count: 0,
+                cutover_performed: true,
             }
         );
         assert_eq!(workspace_ids(&db).await, vec!["default".to_string()]);
@@ -421,7 +575,8 @@ mod tests {
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 1,
-                cutover_performed: true
+                source_count: 0,
+                cutover_performed: true,
             }
         );
         assert_eq!(workspace_ids(&db).await, vec!["default".to_string()]);
@@ -457,7 +612,8 @@ mod tests {
             report,
             WorkspaceCatalogCutoverReport {
                 workspace_count: 1,
-                cutover_performed: true
+                source_count: 0,
+                cutover_performed: true,
             }
         );
         assert_eq!(workspace_ids(&db).await, vec!["analytics".to_string()]);
@@ -551,5 +707,27 @@ mod tests {
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
         db
+    }
+
+    fn source<const V: usize, const S: usize>(
+        name: &str,
+        version: Option<&str>,
+        variables: [(&str, &str); V],
+        secrets: [&str; S],
+        credential_storage: Option<CredentialStorageKind>,
+        origin: SourceOrigin,
+    ) -> InstalledSource {
+        InstalledSource {
+            name: SourceName::parse(name).expect("source name"),
+            version: version.map(str::to_string),
+            variables: variables
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect::<BTreeMap<_, _>>(),
+            secrets: secrets.into_iter().map(str::to_string).collect(),
+            credential_storage,
+            credential_revision: uuid::Uuid::nil(),
+            origin,
+        }
     }
 }

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -28,7 +28,7 @@ pub(crate) async fn run_state_migrations(
     layout: &AppStateLayout,
 ) -> Result<(), AppError> {
     cutover_legacy_workspace_catalog(db, config_store, layout).await?;
-    import_config_source_catalog(db, config_store).await?;
+    import_config_source_catalog(db, config_store, now_unix_nanos_i64()?).await?;
     remove_legacy_task_jsonl(config_store, layout)?;
     Ok(())
 }
@@ -76,20 +76,15 @@ async fn cutover_legacy_workspace_catalog_at(
     if workspaces.is_empty() {
         workspaces = implicitly_provisioned_workspaces(layout)?;
     }
-    let mut imported_workspaces = BTreeSet::new();
-    import_legacy_workspaces(
-        &mut tx,
-        &workspaces,
-        now_unix_nanos,
-        &mut imported_workspaces,
-    )
-    .await?;
-    prune_stale_workspaces(&mut tx, &imported_workspaces).await?;
-    verify_workspace_parity(&mut tx, &imported_workspaces).await?;
+    let workspace_count = workspaces.len();
+
+    tx.workspaces().delete_all().await?;
+    import_legacy_workspaces(&mut tx, &workspaces, now_unix_nanos).await?;
+    verify_workspace_parity(&mut tx, &workspaces).await?;
     tx.commit().await?;
 
     Ok(WorkspaceCatalogCutoverReport {
-        workspace_count: imported_workspaces.len(),
+        workspace_count,
         cutover_performed: true,
     })
 }
@@ -165,13 +160,6 @@ fn implicitly_provisioned_workspaces(
 async fn import_config_source_catalog(
     db: &CoralDb,
     config_store: &ConfigStore,
-) -> Result<SourceCatalogImportReport, AppError> {
-    import_config_source_catalog_at(db, config_store, now_unix_nanos_i64()?).await
-}
-
-async fn import_config_source_catalog_at(
-    db: &CoralDb,
-    config_store: &ConfigStore,
     now_unix_nanos: i64,
 ) -> Result<SourceCatalogImportReport, AppError> {
     let _state_lock = config_store.state_lock_exclusive()?;
@@ -212,7 +200,6 @@ async fn import_legacy_workspaces<S>(
     session: &mut S,
     workspaces: &[WorkspaceRecord],
     now_unix_nanos: i64,
-    imported_workspaces: &mut BTreeSet<WorkspaceName>,
 ) -> Result<(), AppError>
 where
     S: DbRepos,
@@ -222,7 +209,6 @@ where
             .workspaces()
             .ensure(workspace.name.as_str(), now_unix_nanos)
             .await?;
-        imported_workspaces.insert(workspace.name.clone());
     }
     Ok(())
 }
@@ -235,6 +221,14 @@ async fn import_config_sources(
     let mut source_count = 0;
     for (workspace_name, source) in entries {
         if session
+            .workspaces()
+            .get(workspace_name.as_str())
+            .await?
+            .is_none()
+        {
+            return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
+        }
+        if session
             .sources()
             .get_source(workspace_name, &source.name)
             .await?
@@ -242,10 +236,6 @@ async fn import_config_sources(
         {
             continue;
         }
-        session
-            .workspaces()
-            .ensure(workspace_name.as_str(), now_unix_nanos)
-            .await?;
         session
             .sources()
             .upsert_source(workspace_name, source, now_unix_nanos)
@@ -265,35 +255,16 @@ async fn import_config_sources(
     Ok(source_count)
 }
 
-async fn prune_stale_workspaces<S>(
-    session: &mut S,
-    imported_workspaces: &BTreeSet<WorkspaceName>,
-) -> Result<(), AppError>
-where
-    S: DbRepos,
-{
-    let expected = imported_workspaces
-        .iter()
-        .map(WorkspaceName::as_str)
-        .collect::<BTreeSet<_>>();
-    for workspace in session.workspaces().list().await? {
-        if !expected.contains(workspace.id.as_str()) {
-            session.workspaces().delete(&workspace.id).await?;
-        }
-    }
-    Ok(())
-}
-
 async fn verify_workspace_parity<S>(
     session: &mut S,
-    imported_workspaces: &BTreeSet<WorkspaceName>,
+    legacy_workspaces: &[WorkspaceRecord],
 ) -> Result<(), AppError>
 where
     S: DbRepos,
 {
-    let expected = imported_workspaces
+    let expected = legacy_workspaces
         .iter()
-        .map(|workspace| workspace.as_str().to_string())
+        .map(|workspace| workspace.name.as_str().to_string())
         .collect::<BTreeSet<_>>();
     let actual = session
         .workspaces()
@@ -319,8 +290,7 @@ mod tests {
     use super::{
         SOURCE_CATALOG_IMPORT_ID, SourceCatalogImportReport, WORKSPACE_CATALOG_CUTOVER_ID,
         WorkspaceCatalogCutoverReport, cutover_legacy_workspace_catalog,
-        cutover_legacy_workspace_catalog_at, import_config_source_catalog,
-        import_config_source_catalog_at, run_state_migrations,
+        cutover_legacy_workspace_catalog_at, import_config_source_catalog, run_state_migrations,
     };
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
@@ -403,7 +373,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cuts_over_legacy_workspaces_without_sources() {
+    async fn cuts_over_legacy_workspaces_into_database() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
@@ -446,7 +416,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn workspace_cutover_preserves_database_source_in_source_only_workspace() {
+    async fn source_import_preserves_existing_database_source() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
@@ -468,6 +438,9 @@ mod tests {
             .upsert_source(&workspace, replacement)
             .expect("write config source");
         let db = open_sqlite(&layout).await;
+        cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 10)
+            .await
+            .expect("cut over legacy workspace catalog");
         {
             let mut tx = db.begin().await.expect("begin seed tx");
             tx.workspaces()
@@ -481,17 +454,7 @@ mod tests {
             tx.commit().await.expect("commit seed tx");
         }
 
-        let cutover_report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 10)
-            .await
-            .expect("cut over legacy workspace catalog");
-        assert_eq!(
-            cutover_report,
-            WorkspaceCatalogCutoverReport {
-                workspace_count: 1,
-                cutover_performed: true,
-            }
-        );
-        let report = import_config_source_catalog_at(&db, &config_store, 11)
+        let report = import_config_source_catalog(&db, &config_store, 11)
             .await
             .expect("import config source catalog");
 
@@ -551,7 +514,7 @@ mod tests {
             tx.commit().await.expect("commit seed tx");
         }
 
-        let report = import_config_source_catalog_at(&db, &config_store, 11)
+        let report = import_config_source_catalog(&db, &config_store, 11)
             .await
             .expect("import config source catalog");
 
@@ -590,6 +553,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn source_import_rejects_missing_workspace_without_marking_complete() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("missing").expect("workspace");
+        let source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        let db = open_sqlite(&layout).await;
+        cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 5)
+            .await
+            .expect("cut over legacy workspace catalog");
+        let mut session = &db;
+        session
+            .workspaces()
+            .delete(workspace.as_str())
+            .await
+            .expect("delete imported workspace");
+
+        let error = import_config_source_catalog(&db, &config_store, 11)
+            .await
+            .expect_err("missing workspace should reject source import");
+
+        assert!(matches!(
+            error,
+            crate::bootstrap::AppError::WorkspaceNotFound(ref actual)
+                if actual == workspace.as_str()
+        ));
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get rejected source"),
+            None
+        );
+        assert!(
+            !session
+                .state_migrations()
+                .has_completed(SOURCE_CATALOG_IMPORT_ID)
+                .await
+                .expect("read source import marker")
+        );
+    }
+
+    #[tokio::test]
     async fn cutover_resets_stale_shadow_database_rows() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
@@ -600,17 +612,11 @@ mod tests {
             .create_legacy_workspace_entry_for_tests(&analytics_workspace)
             .expect("create legacy workspace entry");
         let db = open_sqlite(&layout).await;
-        let stale_workspace = WorkspaceName::parse("stale").expect("workspace");
-        let stale_source = source("stale_source", None, [], [], None, SourceOrigin::Bundled);
         let mut tx = db.begin().await.expect("begin stale seed tx");
         tx.workspaces()
-            .ensure(stale_workspace.as_str(), 7)
+            .ensure("stale", 7)
             .await
             .expect("seed stale workspace");
-        tx.sources()
-            .upsert_source(&stale_workspace, &stale_source, 7)
-            .await
-            .expect("seed stale source");
         tx.commit().await.expect("commit stale seed tx");
 
         cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
@@ -629,18 +635,10 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["analytics".to_string()]
         );
-        assert_eq!(
-            session
-                .sources()
-                .get_source(&stale_workspace, &stale_source.name)
-                .await
-                .expect("get stale source"),
-            None
-        );
     }
 
     #[tokio::test]
-    async fn completed_workspace_cutover_does_not_reload_config() {
+    async fn completed_cutover_does_not_reimport_legacy_config() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
@@ -654,7 +652,7 @@ mod tests {
 
         let report = cutover_legacy_workspace_catalog(&db, &config_store, &layout)
             .await
-            .expect("marker should skip workspace catalog reload");
+            .expect("marker should skip legacy config reload");
 
         assert_eq!(
             report,
@@ -897,12 +895,12 @@ mod tests {
         let config_store = ConfigStore::new(layout.clone());
         let db = open_sqlite(&layout).await;
 
-        import_config_source_catalog_at(&db, &config_store, 11)
+        import_config_source_catalog(&db, &config_store, 11)
             .await
             .expect("initial source import");
         std::fs::write(layout.config_file(), "[[workspaces]\n").expect("corrupt config");
 
-        let report = import_config_source_catalog(&db, &config_store)
+        let report = import_config_source_catalog(&db, &config_store, 12)
             .await
             .expect("source marker should skip config reload");
 

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -72,9 +72,7 @@ async fn cutover_legacy_workspace_catalog_at(
         workspaces = implicitly_provisioned_workspaces(layout)?;
     }
     let source_entries = config.source_catalog_entries();
-    let source_count = source_entries.len();
 
-    tx.workspaces().delete_all().await?;
     let mut imported_workspaces = BTreeSet::new();
     import_legacy_workspaces(
         &mut tx,
@@ -83,13 +81,14 @@ async fn cutover_legacy_workspace_catalog_at(
         &mut imported_workspaces,
     )
     .await?;
-    import_legacy_source_catalog(
+    let source_count = import_legacy_source_catalog(
         &mut tx,
         &source_entries,
         now_unix_nanos,
         &mut imported_workspaces,
     )
     .await?;
+    prune_stale_workspaces(&mut tx, &imported_workspaces).await?;
     verify_workspace_parity(&mut tx, &imported_workspaces).await?;
     tx.commit().await?;
 
@@ -192,13 +191,22 @@ async fn import_legacy_source_catalog(
     entries: &[(WorkspaceName, InstalledSource)],
     now_unix_nanos: i64,
     imported_workspaces: &mut BTreeSet<WorkspaceName>,
-) -> Result<(), AppError> {
+) -> Result<usize, AppError> {
+    let mut source_count = 0;
     for (workspace_name, source) in entries {
         imported_workspaces.insert(workspace_name.clone());
         session
             .workspaces()
             .ensure(workspace_name.as_str(), now_unix_nanos)
             .await?;
+        if session
+            .sources()
+            .get_source(workspace_name, &source.name)
+            .await?
+            .is_some()
+        {
+            continue;
+        }
         session
             .sources()
             .upsert_source(workspace_name, source, now_unix_nanos)
@@ -212,6 +220,26 @@ async fn import_legacy_source_catalog(
                 "source catalog cutover failed validation for {workspace_name}:{}",
                 source.name
             )));
+        }
+        source_count += 1;
+    }
+    Ok(source_count)
+}
+
+async fn prune_stale_workspaces<S>(
+    session: &mut S,
+    imported_workspaces: &BTreeSet<WorkspaceName>,
+) -> Result<(), AppError>
+where
+    S: DbRepos,
+{
+    let expected = imported_workspaces
+        .iter()
+        .map(WorkspaceName::as_str)
+        .collect::<BTreeSet<_>>();
+    for workspace in session.workspaces().list().await? {
+        if !expected.contains(workspace.id.as_str()) {
+            session.workspaces().delete(&workspace.id).await?;
         }
     }
     Ok(())
@@ -389,6 +417,126 @@ mod tests {
                 .has_completed(WORKSPACE_CATALOG_CUTOVER_ID)
                 .await
                 .expect("read cutover marker")
+        );
+    }
+
+    #[tokio::test]
+    async fn cutover_preserves_existing_database_sources() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let existing = source("github", None, [], [], None, SourceOrigin::Bundled);
+        let replacement = source(
+            "github",
+            Some("1.2.3"),
+            [("OWNER", "coral")],
+            [],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        config_store
+            .upsert_source(&workspace, replacement)
+            .expect("write config source");
+        let db = open_sqlite(&layout).await;
+        {
+            let mut tx = db.begin().await.expect("begin seed tx");
+            tx.workspaces()
+                .ensure(workspace.as_str(), 7)
+                .await
+                .expect("seed workspace");
+            tx.sources()
+                .upsert_source(&workspace, &existing, 7)
+                .await
+                .expect("seed db source");
+            tx.commit().await.expect("commit seed tx");
+        }
+
+        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
+            .await
+            .expect("cut over legacy config");
+
+        assert_eq!(
+            report,
+            WorkspaceCatalogCutoverReport {
+                workspace_count: 1,
+                source_count: 0,
+                cutover_performed: true,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &existing.name)
+                .await
+                .expect("get preserved source"),
+            Some(existing)
+        );
+    }
+
+    #[tokio::test]
+    async fn cutover_imports_missing_config_sources_without_overwriting_existing() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let default_workspace = WorkspaceName::parse("default").expect("workspace");
+        let other_workspace = WorkspaceName::parse("other").expect("workspace");
+        let existing_source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        let config_source = source("slack", None, [], [], None, SourceOrigin::Bundled);
+        config_store
+            .create_legacy_workspace_entry_for_tests(&default_workspace)
+            .expect("create default config workspace");
+        config_store
+            .create_legacy_workspace_entry_for_tests(&other_workspace)
+            .expect("create other config workspace");
+        config_store
+            .upsert_source(&other_workspace, config_source.clone())
+            .expect("write config source");
+        let db = open_sqlite(&layout).await;
+        {
+            let mut tx = db.begin().await.expect("begin seed tx");
+            tx.workspaces()
+                .ensure(default_workspace.as_str(), 7)
+                .await
+                .expect("seed workspace");
+            tx.sources()
+                .upsert_source(&default_workspace, &existing_source, 7)
+                .await
+                .expect("seed db source");
+            tx.commit().await.expect("commit seed tx");
+        }
+
+        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
+            .await
+            .expect("cut over legacy config");
+
+        assert_eq!(
+            report,
+            WorkspaceCatalogCutoverReport {
+                workspace_count: 2,
+                source_count: 1,
+                cutover_performed: true,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&default_workspace, &existing_source.name)
+                .await
+                .expect("get existing source"),
+            Some(existing_source)
+        );
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&other_workspace, &config_source.name)
+                .await
+                .expect("get imported source"),
+            Some(config_source)
         );
     }
 

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -45,3 +45,17 @@ pub(crate) use workspace_state::{
     AddMemberOutcome, CreateWorkspaceOutcome, RemoveMemberOutcome, WorkspaceDeletion,
     WorkspaceMemberRecord,
 };
+
+#[cfg(test)]
+pub(crate) async fn open_test_database(
+    layout: &super::AppStateLayout,
+) -> Result<std::sync::Arc<CoralDb>, crate::bootstrap::AppError> {
+    let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(layout)? else {
+        return Err(crate::bootstrap::AppError::FailedPrecondition(
+            "default test database config should use SQLite".to_string(),
+        ));
+    };
+    let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path }).await?;
+    db.migrate().await?;
+    Ok(std::sync::Arc::new(db))
+}

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -100,12 +100,6 @@ where
             .to_owned();
         Ok(self.session.execute_rows_affected(statement).await? == 1)
     }
-
-    pub(crate) async fn delete_all(&mut self) -> Result<(), DbError> {
-        let statement = Query::delete().from_table(Workspaces::Table).to_owned();
-        self.session.execute(statement).await
-    }
-
     /// Reports the workspaces no authenticated caller can manage.
     ///
     /// Neither half has a reachable owner, which is what management needs:

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -165,6 +165,11 @@ impl WorkspacesRepo<'_, CoralTx<'_>> {
             .to_owned();
         Ok(DbSession::execute_rows_affected(self.session, statement).await? == 1)
     }
+
+    pub(crate) async fn delete_all(&mut self) -> Result<(), DbError> {
+        let statement = Query::delete().from_table(Workspaces::Table).to_owned();
+        self.session.execute(statement).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -92,13 +92,6 @@ pub(crate) trait DbRepos: DbSession + Sized {
         IdentitySpecDocumentsRepo::new(self)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "source catalog repository lands before manager wiring in the stacked PR sequence"
-        )
-    )]
     fn sources(&mut self) -> SourcesRepo<'_, Self> {
         SourcesRepo::new(self)
     }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -20,6 +20,7 @@ use coral_spec::{SearchLimitsSpec, SourceTableFunctionKind};
 use coral_telemetry::{GRPC_REQUEST_ERROR_MESSAGE, record_failure};
 use opentelemetry::propagation::Extractor;
 use opentelemetry::trace::Status as OtelStatus;
+use tokio::task;
 use tonic::codegen::{Service, http};
 use tonic::metadata::MetadataMap;
 use tonic::{Code, Request, Status};
@@ -309,6 +310,44 @@ pub(crate) fn request_context<T>(request: &Request<T>) -> Result<&RequestContext
         .extensions()
         .get::<RequestContext>()
         .ok_or_else(|| Status::internal("request context is unavailable"))
+}
+
+/// Drives an operation to completion off the runtime workers, on the blocking
+/// pool, carrying the caller's tracing span with it.
+///
+/// Every mutation that holds the exclusive app state file lock across a
+/// database await must be routed through this seam. `flock(2)` blocks the
+/// calling thread, and read paths take the shared state lock directly from
+/// async tasks, so enough concurrent readers park every runtime worker inside
+/// the syscall. A lock holder that needs a free worker to be repolled would
+/// then never reach the point where it releases the lock, and the process
+/// wedges permanently. Running the holder on the blocking pool keeps it
+/// schedulable no matter how many workers are parked.
+///
+/// Detaching also decouples the operation from caller cancellation, so
+/// filesystem and credential state that a mutation already staged still
+/// reaches its commit or rollback when the client disconnects.
+pub(crate) fn spawn_state_locked_operation<T, F>(operation: F) -> task::JoinHandle<T>
+where
+    T: Send + 'static,
+    F: Future<Output = T> + Send + 'static,
+{
+    let span = tracing::Span::current();
+    let runtime = tokio::runtime::Handle::current();
+    task::spawn_blocking(move || span.in_scope(|| runtime.block_on(operation)))
+}
+
+/// Awaits a state-lock-holding mutation spawned by
+/// [`spawn_state_locked_operation`] and maps its outcome onto a gRPC status.
+pub(crate) async fn run_state_locked_mutation<T, F>(operation: F) -> Result<T, Status>
+where
+    T: Send + 'static,
+    F: Future<Output = Result<T, AppError>> + Send + 'static,
+{
+    spawn_state_locked_operation(operation)
+        .await
+        .map_err(|error| Status::internal(format!("state operation task failed: {error}")))?
+        .map_err(app_status)
 }
 
 pub(crate) async fn instrument_grpc<T, F>(span: tracing::Span, future: F) -> Result<T, Status>

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -162,6 +162,12 @@ impl WorkspaceManager {
             })?;
 
         let (deleted, workspace_dir_backup) = {
+            // Global lock order: take the app state file lock before beginning a
+            // database transaction, never the other way around. Source install
+            // and removal take the same order, so inverting it here would let
+            // two processes sharing one config directory deadlock across the
+            // file lock and the database.
+            let state_lock = self.config_store.state_lock_exclusive()?;
             let Some(deletion) = self
                 .db
                 .begin_workspace_deletion(workspace_name.as_str())
@@ -171,7 +177,7 @@ impl WorkspaceManager {
             };
             let removed = match self
                 .config_store
-                .remove_workspace_config_entries(workspace_name)
+                .remove_workspace_config_entries_unlocked(workspace_name)
             {
                 Ok(removed) => removed,
                 Err(error) => {
@@ -208,6 +214,10 @@ impl WorkspaceManager {
                 RemovedWorkspaceConfig::into_deleted_workspace,
             );
             self.pool_registry.remove(workspace_name);
+            // Credential cleanup re-acquires the state lock through the file
+            // credential backend, and `flock` conflicts per open file
+            // description, so the guard must be released first.
+            drop(state_lock);
             self.remove_deleted_workspace_credentials(&deleted);
             // Staging comes last, and failing to move the directory only
             // warns. Everything above it is already durable, so an abort here
@@ -328,7 +338,8 @@ impl WorkspaceManager {
                 "workspace config restore failed for tests".to_string(),
             ));
         }
-        self.config_store.restore_workspace_config_entries(removed)
+        self.config_store
+            .restore_workspace_config_entries_unlocked(removed)
     }
 
     fn stage_deleted_workspace_dir(
@@ -1129,8 +1140,30 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn delete_workspace_commits_config_then_cleans_artifacts() {
+    /// Credential cleanup re-acquires the exclusive state lock, so `delete_workspace` must have
+    /// released its own guard first. A regression there deadlocks the deletion inside a blocking
+    /// `flock(2)` call, which no `tokio::time::timeout` can interrupt, so the scenario runs on a
+    /// helper thread behind a wall-clock deadline and fails instead of hanging the suite.
+    #[test]
+    fn delete_workspace_commits_config_then_cleans_artifacts() {
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("current-thread runtime");
+            let name = runtime.block_on(delete_workspace_and_clean_artifacts());
+            // The receiver is gone only when the deadline below already failed the test.
+            drop(done_tx.send(name));
+        });
+
+        let name = done_rx
+            .recv_timeout(std::time::Duration::from_secs(20))
+            .expect("workspace deletion must release the state lock before credential cleanup");
+        assert_eq!(name, "work");
+    }
+
+    async fn delete_workspace_and_clean_artifacts() -> String {
         let temp = TempDir::new().expect("temp dir");
         let layout = test_layout(&temp);
         let store = ConfigStore::new(layout.clone());
@@ -1222,6 +1255,56 @@ mod tests {
             &pool_registry_before_delete,
             &pool_registry_after_delete
         ));
+
+        deleted.name.to_string()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delete_workspace_waits_for_the_state_lock_before_opening_a_transaction() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let db = test_db(&layout).await;
+        let manager = WorkspaceManager::new(
+            store.clone(),
+            credential_manager,
+            layout,
+            None,
+            crate::workspaces::WorkspaceLifecycleLock::default(),
+            Arc::clone(&db),
+            SourceDiagnosticReporter::default(),
+        );
+        let doomed_name = WorkspaceName::parse("work").expect("workspace");
+        let other_name = WorkspaceName::parse("other").expect("workspace");
+        let owner = seed_user(&db, "owner").await;
+        manager
+            .create_workspace_for_user(&doomed_name, &owner)
+            .await
+            .expect("create workspace");
+
+        let state_lock = store.state_lock_exclusive().expect("hold state lock");
+        let delete_manager = manager.clone();
+        let delete =
+            tokio::spawn(async move { delete_manager.delete_workspace(&doomed_name).await });
+        // Give the deletion time to reach the state lock it cannot take yet.
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+        // The blocked deletion must not be holding a database write open, so an
+        // unrelated workspace write still completes.
+        tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            manager.create_workspace_for_user(&other_name, &owner),
+        )
+        .await
+        .expect("blocked deletion should not hold a database transaction")
+        .expect("create unrelated workspace");
+
+        drop(state_lock);
+        delete
+            .await
+            .expect("deletion task")
+            .expect("delete workspace");
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -622,7 +622,8 @@ mod tests {
     use crate::sources::materialization::{SourceDiagnosticReporter, SourceLoadDiagnosticStage};
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::db::{
-        CoralDb, DatabaseConfig, DbRepos, LoginIdentity, LoginProvisioning, ResolvedDatabaseConfig,
+        CoralDb, CreateWorkspaceOutcome, DatabaseConfig, DbRepos, LoginIdentity, LoginProvisioning,
+        ResolvedDatabaseConfig,
     };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::{
@@ -1290,15 +1291,18 @@ mod tests {
         // Give the deletion time to reach the state lock it cannot take yet.
         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
-        // The blocked deletion must not be holding a database write open, so an
-        // unrelated workspace write still completes.
-        tokio::time::timeout(
+        // Bypass the lifecycle gate held by the deletion and probe the database
+        // directly. The blocked deletion must not have opened a write
+        // transaction before reaching the state lock.
+        let created = tokio::time::timeout(
             std::time::Duration::from_secs(30),
-            manager.create_workspace_for_user(&other_name, &owner),
+            db.workspace_state()
+                .create_owned_by(other_name.as_str(), &owner, 1),
         )
         .await
         .expect("blocked deletion should not hold a database transaction")
         .expect("create unrelated workspace");
+        assert_eq!(created, CreateWorkspaceOutcome::Created);
 
         drop(state_lock);
         delete

--- a/crates/coral-app/src/workspaces/service.rs
+++ b/crates/coral-app/src/workspaces/service.rs
@@ -13,7 +13,8 @@ use tonic::{Request, Response, Status};
 use crate::bootstrap::{AppError, app_status};
 use crate::identity::PrincipalId;
 use crate::transport::{
-    grpc_span, instrument_grpc, request_context, workspace_name_from_proto, workspace_to_proto,
+    grpc_span, instrument_grpc, request_context, run_state_locked_mutation,
+    workspace_name_from_proto, workspace_to_proto,
 };
 use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
 use crate::workspaces::{
@@ -117,10 +118,12 @@ impl WorkspaceServiceApi for WorkspaceService {
                 .authorize(&principal, &workspace_name, WorkspaceAction::Manage)
                 .await
                 .map_err(app_status)?;
-            let workspace = workspaces
-                .delete_workspace(&workspace_name)
-                .await
-                .map_err(app_status)?;
+            // Workspace deletion holds the exclusive app state lock across its database
+            // awaits, so it must not be driven by a runtime worker.
+            let workspace = run_state_locked_mutation(async move {
+                workspaces.delete_workspace(&workspace_name).await
+            })
+            .await?;
             Ok(Response::new(DeleteWorkspaceResponse {
                 workspace: Some(workspace_record_to_proto(&workspace)),
             }))
@@ -263,14 +266,21 @@ fn member_role_from_proto(role: i32) -> Result<MemberRole, Status> {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::OpenOptions;
+    use std::path::Path;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
 
     use coral_api::v1::{
         AddWorkspaceMemberRequest, CreateWorkspaceRequest, DeleteWorkspaceRequest,
         ListWorkspaceMembersRequest, ListWorkspacesRequest, RemoveWorkspaceMemberRequest,
-        WorkspaceMember, WorkspaceRole,
+        Workspace, WorkspaceMember, WorkspaceRole,
     };
     use tempfile::TempDir;
+    use tokio::task;
     use tonic::{Code, Request, Status};
     use tonic_types::{ErrorDetail, StatusExt as _};
 
@@ -278,6 +288,7 @@ mod tests {
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::identity::{LOCAL_PRINCIPAL_ID, Principal, PrincipalKind};
     use crate::request_context::RequestContext;
+    use crate::sources::materialization::SourceDiagnosticReporter;
     use crate::state::db::{
         CoralDb, DatabaseConfig, DbRepos, LoginIdentity, LoginProvisioning, ResolvedDatabaseConfig,
         inaccessible_workspaces, migrate_local_ownership_once,
@@ -285,7 +296,7 @@ mod tests {
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::transport::workspace_to_proto;
     use crate::workspaces::authorization::WorkspaceAuthorizer;
-    use crate::workspaces::{MemberRole, WorkspaceManager, WorkspaceName};
+    use crate::workspaces::{MemberRole, WorkspaceLifecycleLock, WorkspaceManager, WorkspaceName};
 
     /// One workspace nobody in these tests is a member of, used wherever a name
     /// that was never created is needed.
@@ -1052,5 +1063,144 @@ mod tests {
                 _ => None,
             })
             .collect()
+    }
+
+    /// `WorkspaceManager::delete_workspace` holds the exclusive app state lock across its database
+    /// awaits, while every read path takes the same blocking shared lock straight from a runtime
+    /// worker. Running the manager call inline on the handler's worker therefore wedges: the worker
+    /// parked in `flock(2)` is the only one that could repoll the lock holder. Routing the call
+    /// through `run_state_locked_mutation` keeps it schedulable.
+    ///
+    /// The scenario runs on its own runtime from a helper thread so that a regression fails the
+    /// test on a wall-clock deadline instead of hanging: once the sole worker is parked in
+    /// `flock(2)` nothing is left to advance the runtime's timer, so `tokio::time::timeout` cannot
+    /// be the backstop here.
+    #[test]
+    fn delete_workspace_completes_while_runtime_workers_block_on_the_state_lock() {
+        let (done_tx, done_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .expect("single-worker runtime");
+            let name = runtime.block_on(delete_workspace_under_blocked_workers());
+            // The receiver is gone only when the deadline below already failed the test.
+            drop(done_tx.send(name));
+        });
+
+        let name = done_rx
+            .recv_timeout(Duration::from_secs(20))
+            .expect("workspace deletion must complete while the runtime worker is parked in flock");
+        assert_eq!(name, "work");
+    }
+
+    async fn delete_workspace_under_blocked_workers() -> String {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let db = open_test_db(&layout).await;
+        migrate_local_ownership_once(&db)
+            .await
+            .expect("provision the local principal");
+        let manager = WorkspaceManager::new(
+            config_store.clone(),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout.clone(),
+            None,
+            WorkspaceLifecycleLock::default(),
+            Arc::clone(&db),
+            SourceDiagnosticReporter::default(),
+        );
+        let workspace_name = WorkspaceName::parse("work").expect("workspace");
+        manager
+            .create_workspace_for_user(&workspace_name, LOCAL_PRINCIPAL_ID)
+            .await
+            .expect("create workspace");
+        let service = WorkspaceService::new(
+            manager,
+            WorkspaceAuthorizer::trusting_local_principal(Arc::clone(&db)),
+        );
+
+        let deletion_finished = Arc::new(AtomicBool::new(false));
+        let reader = task::spawn(park_worker_on_the_state_lock(
+            config_store,
+            layout,
+            Arc::clone(&deletion_finished),
+        ));
+
+        // gRPC handlers run as spawned tasks, so the handler itself must be driven by a runtime
+        // worker for this to reproduce what the server does.
+        let delete = task::spawn(async move {
+            let mut request = Request::new(DeleteWorkspaceRequest {
+                workspace: Some(Workspace {
+                    name: "work".to_string(),
+                }),
+            });
+            request
+                .extensions_mut()
+                .insert(RequestContext::new(Principal::local()));
+            service.delete_workspace(request).await
+        });
+        let response = delete
+            .await
+            .expect("delete task")
+            .expect("delete workspace");
+        deletion_finished.store(true, Ordering::Release);
+        reader.await.expect("reader task");
+
+        response
+            .into_inner()
+            .workspace
+            .expect("deleted workspace")
+            .name
+    }
+
+    /// Mimics a catalog or query read: take the blocking shared state lock directly inside an async
+    /// task, so the runtime worker running it parks inside `flock(2)` for as long as the deletion
+    /// holds the lock exclusively.
+    async fn park_worker_on_the_state_lock(
+        config_store: ConfigStore,
+        layout: AppStateLayout,
+        deletion_finished: Arc<AtomicBool>,
+    ) {
+        while !deletion_finished.load(Ordering::Acquire) {
+            if state_lock_is_held_exclusively(layout.state_lock()) {
+                drop(config_store.state_lock_shared().expect("shared state lock"));
+                return;
+            }
+            task::yield_now().await;
+        }
+    }
+
+    fn state_lock_is_held_exclusively(state_lock: &Path) -> bool {
+        let probe = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(state_lock)
+            .expect("open state lock for probing");
+        match probe.try_lock_shared() {
+            Ok(()) => {
+                probe.unlock().expect("release probed state lock");
+                false
+            }
+            Err(_) => true,
+        }
+    }
+
+    async fn open_test_db(layout: &AppStateLayout) -> Arc<CoralDb> {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        Arc::new(db)
     }
 }


### PR DESCRIPTION
## Intent

Add the first source-catalog migration step: DB persistence, startup/import backfill, and source lifecycle dual writes while legacy config remains the read authority.

## What it enables

Startup imports legacy workspace/source config into the database idempotently. Existing DB source rows are preserved so a later startup cannot clobber rows produced by live dual writes. Source import/create/delete still commit through legacy config and filesystem artifacts first, then mirror source rows into the database.

## Usage examples

No command or RPC shape changes. Existing source lifecycle calls continue to read from legacy config in this PR, but the `sources`, `source_variables`, and source-secret DB tables are kept ready for the read switch in follow-up PRs.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p coral-app state::db::import::tests`
- `cargo test -p coral-app sources::manager::tests::import_and_delete_source_mirror_database_catalog`
- `cargo test -p coral-app --test grpc source_lifecycle_tests::import_source_persists_and_lists`
