### PR TITLE
feat(app): read source catalog from database

### DIFF
--- a/crates/coral-app/src/search/observed/live_scope.rs
+++ b/crates/coral-app/src/search/observed/live_scope.rs
@@ -390,7 +390,11 @@ tables:
         credential_revision: Uuid,
     ) {
         let mut source = config_store
-            .get_source(workspace, source_name)
+            .load_config()
+            .expect("load config")
+            .workspace_sources(workspace)
+            .into_iter()
+            .find(|source| &source.name == source_name)
             .expect("installed source");
         source.credential_revision = credential_revision;
         config_store

--- a/crates/coral-app/src/search/observed/live_scope.rs
+++ b/crates/coral-app/src/search/observed/live_scope.rs
@@ -390,10 +390,7 @@ tables:
         credential_revision: Uuid,
     ) {
         let mut source = config_store
-            .list_workspace_sources(workspace)
-            .expect("list sources")
-            .into_iter()
-            .find(|source| &source.name == source_name)
+            .get_source(workspace, source_name)
             .expect("installed source");
         source.credential_revision = credential_revision;
         config_store

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -2026,6 +2026,11 @@ mod tests {
             async move {
                 let db = crate::state::db::open_test_database(&layout).await?;
                 crate::state::db::run_state_migrations(&db, &config_store, &layout).await?;
+                let mut tx = db.begin().await?;
+                tx.workspaces()
+                    .ensure(WorkspaceName::default().as_str(), 1)
+                    .await?;
+                tx.commit().await?;
                 Ok(db)
             }
         })

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -280,8 +280,7 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<InstalledSource>, AppError> {
         Ok(self
-            .config_store
-            .list_workspace_sources(workspace_name)?
+            .load_workspace_sources(workspace_name)?
             .into_iter()
             .map(|source| self.populate_source_version_or_keep(workspace_name, source))
             .collect())
@@ -292,10 +291,10 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
-        Ok(self.populate_source_version_or_keep(
-            workspace_name,
-            self.config_store.get_source(workspace_name, source_name)?,
-        ))
+        let source = self
+            .load_source(workspace_name, source_name)?
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))?;
+        Ok(self.populate_source_version_or_keep(workspace_name, source))
     }
 
     pub(crate) fn get_source_info(
@@ -303,7 +302,7 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<CandidateSource, AppError> {
-        match self.config_store.get_source(workspace_name, source_name) {
+        match self.get_source(workspace_name, source_name) {
             Ok(source) => {
                 return Ok(
                     resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
@@ -326,7 +325,7 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<CandidateSource>, AppError> {
-        let installed_sources = self.config_store.list_workspace_sources(workspace_name)?;
+        let installed_sources = self.load_workspace_sources(workspace_name)?;
         let installed = installed_sources
             .iter()
             .map(|source| source.name.clone())
@@ -1085,7 +1084,7 @@ impl SourceManager {
         let candidate_manifest = parse_source_manifest_yaml(manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let candidate_schema_names = runtime_schema_names(&candidate_manifest);
-        for installed in self.config_store.list_workspace_sources(workspace_name)? {
+        for installed in self.load_workspace_sources(workspace_name)? {
             if installed.name == *candidate_name {
                 continue;
             }
@@ -1110,10 +1109,8 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<bool, AppError> {
-        Ok(self
-            .config_store
-            .load_catalog()?
-            .contains(workspace_name, source_name))
+        self.load_source(workspace_name, source_name)
+            .map(|source| source.is_some())
     }
 
     fn read_source_material(
@@ -1145,25 +1142,21 @@ impl SourceManager {
         bindings: &SourceBindings,
         filled_secret_keys: &BTreeSet<String>,
     ) -> Result<BTreeMap<String, String>, AppError> {
-        let (credential_storage, persisted_secret_keys) = match self
-            .config_store
-            .get_source(workspace_name, &candidate.name)
-        {
-            Ok(source) => (
-                source.credential_storage_for_material(),
-                Some(source.secrets.iter().cloned().collect::<BTreeSet<_>>()),
-            ),
-            Err(AppError::SourceNotFound(_))
-                if self
+        let (credential_storage, persisted_secret_keys) =
+            match self.load_source(workspace_name, &candidate.name)? {
+                Some(source) => (
+                    source.credential_storage_for_material(),
+                    Some(source.secrets.iter().cloned().collect::<BTreeSet<_>>()),
+                ),
+                None if self
                     .layout
                     .secret_file(workspace_name, &candidate.name)
                     .exists() =>
-            {
-                (Some(CredentialStorageKind::File), None)
-            }
-            Err(AppError::SourceNotFound(_)) => (None, Some(BTreeSet::new())),
-            Err(error) => return Err(error),
-        };
+                {
+                    (Some(CredentialStorageKind::File), None)
+                }
+                None => (None, Some(BTreeSet::new())),
+            };
 
         if !source_needs_stored_material_for_validation(
             candidate,
@@ -1193,12 +1186,9 @@ impl SourceManager {
                 && input.required
                 && !bindings.secrets.contains_key(&input.key)
         });
-        let existing_storage = match self
-            .config_store
-            .get_source_unlocked(workspace_name, &candidate.name)
-        {
-            Ok(source) => source.credential_storage_for_material(),
-            Err(AppError::SourceNotFound(_)) if needs_stored_material => {
+        let existing_storage = match self.load_source(workspace_name, &candidate.name)? {
+            Some(source) => source.credential_storage_for_material(),
+            None if needs_stored_material => {
                 let legacy_secret_file = self.layout.secret_file(workspace_name, &candidate.name);
                 if legacy_secret_file.is_file() {
                     Some(CredentialStorageKind::File)
@@ -1206,8 +1196,7 @@ impl SourceManager {
                     None
                 }
             }
-            Err(AppError::SourceNotFound(_)) => None,
-            Err(error) => return Err(error),
+            None => None,
         };
         let stored_material = match existing_storage {
             Some(storage) => self.read_source_material(workspace_name, &candidate.name, storage)?,
@@ -1223,6 +1212,60 @@ impl SourceManager {
         } else {
             self.credential_manager.default_write_storage().map(Some)
         }
+    }
+
+    fn load_workspace_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        let db = Arc::clone(&self.db);
+        let workspace_name = workspace_name.clone();
+        run_source_db_operation(async move {
+            let mut session = db.as_ref();
+            Self::require_workspace(&mut session, &workspace_name).await?;
+            session
+                .sources()
+                .list_workspace_sources(&workspace_name)
+                .await
+                .map_err(AppError::from)
+        })
+    }
+
+    fn load_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, AppError> {
+        let db = Arc::clone(&self.db);
+        let workspace_name = workspace_name.clone();
+        let source_name = source_name.clone();
+        run_source_db_operation(async move {
+            let mut session = db.as_ref();
+            Self::require_workspace(&mut session, &workspace_name).await?;
+            session
+                .sources()
+                .get_source(&workspace_name, &source_name)
+                .await
+                .map_err(AppError::from)
+        })
+    }
+
+    async fn require_workspace<S>(
+        session: &mut S,
+        workspace_name: &WorkspaceName,
+    ) -> Result<(), AppError>
+    where
+        S: DbRepos,
+    {
+        if session
+            .workspaces()
+            .get(workspace_name.as_str())
+            .await?
+            .is_some()
+        {
+            return Ok(());
+        }
+        Err(AppError::WorkspaceNotFound(workspace_name.to_string()))
     }
 
     fn upsert_source_with_state_lock_held(
@@ -1409,13 +1452,8 @@ impl SourceManager {
         source_name: &SourceName,
         credential_material: &CredentialMaterialGuard<'_>,
     ) -> Result<Option<SourceRollbackState>, AppError> {
-        let source = match self
-            .config_store
-            .get_source_unlocked(workspace_name, source_name)
-        {
-            Ok(source) => source,
-            Err(AppError::SourceNotFound(_)) => return Ok(None),
-            Err(error) => return Err(error),
+        let Some(source) = self.load_source(workspace_name, source_name)? else {
+            return Ok(None);
         };
         let credential_material = source
             .credential_storage_for_material()
@@ -4004,7 +4042,7 @@ surface:
             matches!(error, crate::bootstrap::AppError::FailedPrecondition(ref message) if message.contains("retry the operation"))
         );
         assert!(
-            config_store
+            manager
                 .list_workspace_sources(&workspace_name)
                 .expect("list sources")
                 .is_empty()
@@ -4094,7 +4132,7 @@ surface:
         );
         fixture.token_server.await.expect("token server");
         assert!(
-            config_store
+            manager
                 .list_workspace_sources(&workspace_name)
                 .expect("list sources")
                 .is_empty()

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -4042,9 +4042,10 @@ surface:
             matches!(error, crate::bootstrap::AppError::FailedPrecondition(ref message) if message.contains("retry the operation"))
         );
         assert!(
-            manager
-                .list_workspace_sources(&workspace_name)
-                .expect("list sources")
+            config_store
+                .load_config()
+                .expect("load config")
+                .workspace_sources(&workspace_name)
                 .is_empty()
         );
         let source_name = SourceName::parse("public_messages").expect("source");
@@ -4132,9 +4133,10 @@ surface:
         );
         fixture.token_server.await.expect("token server");
         assert!(
-            manager
-                .list_workspace_sources(&workspace_name)
-                .expect("list sources")
+            config_store
+                .load_config()
+                .expect("load config")
+                .workspace_sources(&workspace_name)
                 .is_empty()
         );
         let source_name = SourceName::parse("secured_messages").expect("source");

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use coral_engine::{DependentJoinConfig, DependentJoinSourceConfig, MemorySize, QueryMemoryConfig};
 use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, InlineTable, Item, Value, value};
-use tracing::{info_span, warn};
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
@@ -303,16 +303,6 @@ impl SourceCatalog {
             .cloned()
     }
 
-    pub(crate) fn contains(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> bool {
-        self.0
-            .get(workspace_name)
-            .is_some_and(|sources| sources.contains_key(source_name))
-    }
-
     pub(crate) fn upsert_source(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -588,13 +578,6 @@ impl ConfigStore {
         self.load_config_unlocked().map(|config| config.catalog)
     }
 
-    pub(crate) fn load_catalog(&self) -> Result<SourceCatalog, AppError> {
-        let span = info_span!("coral.app.config.load_catalog");
-        let _guard = span.enter();
-        let _lock = self.state_lock_shared()?;
-        self.load_catalog_unlocked()
-    }
-
     fn update_config_unlocked<T>(
         &self,
         update: impl FnOnce(&mut AppConfig) -> Result<T, AppError>,
@@ -721,15 +704,6 @@ impl ConfigStore {
         let _lock = self.state_lock_exclusive()?;
         self.restore_workspace_config_entries_unlocked(removed)
     }
-
-    pub(crate) fn list_workspace_sources(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<Vec<InstalledSource>, AppError> {
-        let config = self.load_config()?;
-        Ok(config.workspace_sources(workspace_name))
-    }
-
     /// Loads one installed source without taking the app state lock.
     ///
     /// Callers must already hold the state lock while using source artifacts
@@ -1598,12 +1572,6 @@ origin = "bundled"
         let source_name = SourceName::parse("github").expect("source");
         let function_name = FunctionName::parse("review_queue").expect("function");
 
-        assert!(
-            store
-                .list_workspace_sources(&missing_workspace)
-                .expect("list source definitions")
-                .is_empty()
-        );
         assert!(matches!(
             store.get_source(&missing_workspace, &source_name),
             Err(AppError::SourceNotFound(_))
@@ -1679,12 +1647,11 @@ origin = "bundled"
         assert_eq!(deleted.workspace.name, workspace_name);
         assert_eq!(deleted.sources.len(), 1);
         assert_eq!(deleted.sources[0].name.as_str(), "github");
-        assert!(
-            store
-                .list_workspace_sources(&deleted.workspace.name)
-                .expect("list source definitions")
-                .is_empty()
-        );
+        let source_name = SourceName::parse("github").expect("source");
+        assert!(matches!(
+            store.get_source(&deleted.workspace.name, &source_name),
+            Err(AppError::SourceNotFound(_))
+        ));
         assert!(
             store
                 .list_workspace_functions(&deleted.workspace.name)
@@ -1736,12 +1703,13 @@ origin = "bundled"
         );
         assert_eq!(
             store
-                .list_workspace_sources(&workspace_name)
-                .expect("list source definitions")
-                .into_iter()
-                .map(|source| source.name)
-                .collect::<Vec<_>>(),
-            vec![SourceName::parse("github").expect("source")]
+                .get_source(
+                    &workspace_name,
+                    &SourceName::parse("github").expect("source")
+                )
+                .expect("get restored source")
+                .name,
+            SourceName::parse("github").expect("source")
         );
         assert_eq!(
             store

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -858,15 +858,14 @@ mod tests {
             }],
             "a failed commit leaves the workspace in the catalog"
         );
-        assert_eq!(
+        assert!(
             store
-                .list_workspace_sources(&workspace_name)
-                .expect("list workspace sources")
-                .into_iter()
-                .map(|source| source.name)
-                .collect::<Vec<_>>(),
-            vec![SourceName::parse("github").expect("source")],
-            "a workspace still in the catalog keeps its sources in the config"
+                .get_source(
+                    &workspace_name,
+                    &SourceName::parse("github").expect("source")
+                )
+                .is_ok(),
+            "a workspace still in the catalog keeps its sources in the config",
         );
     }
 
@@ -1224,12 +1223,10 @@ mod tests {
             .expect("delete workspace");
 
         assert_eq!(deleted.name, workspace_name);
-        assert!(
-            store
-                .list_workspace_sources(&workspace_name)
-                .expect("list source definitions")
-                .is_empty()
-        );
+        assert!(matches!(
+            store.get_source(&workspace_name, &source_name),
+            Err(crate::bootstrap::AppError::SourceNotFound(_))
+        ));
         assert!(
             !layout.workspace_dir(&workspace_name).exists(),
             "workspace artifact directory should be removed after config commit"

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -72,7 +72,7 @@ async fn import_source_persists_and_lists() {
 
 #[tokio::test]
 async fn list_and_get_sources_read_database_after_config_becomes_invalid() {
-    let harness = GrpcHarness::new().await;
+    let harness = GrpcHarness::with_workspace().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
     harness
         .import_source(manifest_yaml, Vec::new(), Vec::new())

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -71,6 +71,34 @@ async fn import_source_persists_and_lists() {
 }
 
 #[tokio::test]
+async fn list_and_get_sources_read_database_after_config_becomes_invalid() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    fs::write(harness.config_dir().join("config.toml"), "[[sources]\n").expect("corrupt config");
+
+    let listed = harness.list_sources().await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "local_messages");
+
+    let fetched = harness
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "local_messages".to_string(),
+        }))
+        .await
+        .expect("get source")
+        .into_inner()
+        .source
+        .expect("source response");
+    assert_eq!(fetched.name, "local_messages");
+}
+
+#[tokio::test]
 async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     let harness = GrpcHarness::with_workspace().await;
 


### PR DESCRIPTION
## Intent

Switch source manager/service reads to the database after startup backfill and dual writes are in place.

## What it enables

`ListSources`, `GetSource`, source discovery, source add validation, source delete rollback state, and credential-storage checks read installed source metadata from the DB. Dual writes to legacy config remain in place for this migration phase.

## Usage examples

No command or RPC shape changes. Source lifecycle APIs now continue to work from DB source metadata even if the legacy source catalog section becomes unreadable after startup import.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p coral-app --test grpc source_lifecycle_tests::list_and_get_sources_read_database_after_config_becomes_invalid`
- `cargo test -p coral-app sources::manager::tests::import_and_delete_source_mirror_database_catalog`
- `cargo test -p coral-app state::config::tests`
- `cargo test -p coral-app workspaces::manager::tests::delete_workspace_commits_config_then_cleans_artifacts`
