### PR TITLE
feat(app): load query and search sources from database

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -435,6 +435,7 @@ impl ServerBuilder {
             layout.clone(),
             workspace_lifecycle_lock.clone(),
             self.config.engine_extensions_providers,
+            Arc::clone(&coral_db),
             diagnostic_reporter.clone(),
             workspace_pool_registry,
         )
@@ -447,6 +448,7 @@ impl ServerBuilder {
             layout,
             &config_store,
             workspace_manager.clone(),
+            Arc::clone(&coral_db),
             observed_values_search_enabled,
             diagnostic_reporter,
             CatalogDiscovery::new(query_manager.clone()),
@@ -1165,7 +1167,7 @@ enabled = false
             credential_manager.clone(),
             layout.clone(),
             None,
-            db,
+            Arc::clone(&db),
         );
         let query_manager = QueryManager::new_for_tests(
             config_store.clone(),
@@ -1174,12 +1176,14 @@ enabled = false
             QueryRuntimeContext::default(),
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            Arc::clone(&db),
         );
         let lifecycle_lock = workspace_manager.lifecycle_lock();
         let search = SearchManager::new(
             layout.clone(),
             &config_store,
             workspace_manager,
+            Arc::clone(&db),
             true,
             CatalogDiscovery::new(query_manager),
             lifecycle_lock,
@@ -2098,6 +2102,7 @@ backend = "unsupported"
             QueryRuntimeContext::default(),
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            Arc::clone(&db),
         );
         let search_observations = SearchObservationHandle::new(layout.clone());
         let lifecycle_lock = workspace_manager.lifecycle_lock();
@@ -2105,6 +2110,7 @@ backend = "unsupported"
             layout.clone(),
             &config_store,
             workspace_manager.clone(),
+            Arc::clone(&db),
             true,
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
@@ -2264,6 +2270,7 @@ backend = "unsupported"
             },
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            Arc::clone(&db),
         );
         let search_observations = SearchObservationHandle::new(layout.clone());
         let lifecycle_lock = workspace_manager.lifecycle_lock();
@@ -2271,6 +2278,7 @@ backend = "unsupported"
             layout.clone(),
             &config_store,
             workspace_manager.clone(),
+            Arc::clone(&db),
             true,
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
@@ -2400,6 +2408,7 @@ tables:
             QueryRuntimeContext::default(),
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            Arc::clone(&db),
         );
         let search_observations = SearchObservationHandle::new(layout.clone());
         let lifecycle_lock = workspace_manager.lifecycle_lock();
@@ -2407,6 +2416,7 @@ tables:
             layout.clone(),
             &config_store,
             workspace_manager.clone(),
+            Arc::clone(&db),
             true,
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
@@ -2536,6 +2546,7 @@ tables:
             QueryRuntimeContext::default(),
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            Arc::clone(&db),
         );
         let search_observations = SearchObservationHandle::new(layout.clone());
         let lifecycle_lock = workspace_manager.lifecycle_lock();
@@ -2543,6 +2554,7 @@ tables:
             layout.clone(),
             &config_store,
             workspace_manager.clone(),
+            Arc::clone(&db),
             true,
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -281,6 +281,7 @@ mod tests {
             QueryRuntimeContext::default(),
             deployment.layout,
             Vec::new(),
+            Arc::clone(&deployment.db),
         );
         Fixture {
             _temp: deployment.temp,

--- a/crates/coral-app/src/query/input_resolver.rs
+++ b/crates/coral-app/src/query/input_resolver.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::sources::model::InstalledSource;
-use crate::state::ConfigStore;
+use crate::state::db::{CoralDb, DbRepos};
 use crate::workspaces::WorkspaceName;
 
 type SourceCredentialMaterial = BTreeMap<String, String>;
@@ -33,7 +33,7 @@ struct SharedSourceCredentialSnapshot {
 #[derive(Clone)]
 pub(crate) struct CredentialRefreshingInputResolver {
     workspace_name: WorkspaceName,
-    config_store: ConfigStore,
+    db: Arc<CoralDb>,
     credential_manager: CredentialManager,
     source_credentials: Arc<SourceCredentialSnapshotByName>,
     delegate: Option<Arc<dyn SourceInputResolver>>,
@@ -42,14 +42,14 @@ pub(crate) struct CredentialRefreshingInputResolver {
 impl CredentialRefreshingInputResolver {
     pub(crate) fn new(
         workspace_name: WorkspaceName,
-        config_store: ConfigStore,
+        db: Arc<CoralDb>,
         credential_manager: CredentialManager,
         source_credentials: BTreeMap<String, SourceCredentialSnapshot>,
         delegate: Option<Arc<dyn SourceInputResolver>>,
     ) -> Self {
         Self {
             workspace_name,
-            config_store,
+            db,
             credential_manager,
             source_credentials: shared_source_credentials(source_credentials),
             delegate,
@@ -152,7 +152,10 @@ impl CredentialRefreshingInputResolver {
             .credential_refresh_lock(&self.workspace_name, &credential_set_id)
             .await
             .map_err(source_input_error)?;
-        if !self.source_config_still_matches_snapshot(&snapshot.source)? {
+        if !self
+            .source_catalog_still_matches_snapshot(&snapshot.source)
+            .await?
+        {
             return self
                 .credential_manager
                 .refresh_material_for_inputs(source.declared_inputs(), material)
@@ -178,18 +181,18 @@ impl CredentialRefreshingInputResolver {
         Ok(())
     }
 
-    fn source_config_still_matches_snapshot(
+    async fn source_catalog_still_matches_snapshot(
         &self,
         snapshot: &InstalledSource,
     ) -> Result<bool, SourceInputResolverError> {
-        match self
-            .config_store
+        let mut session = self.db.as_ref();
+        let current = session
+            .sources()
             .get_source(&self.workspace_name, &snapshot.name)
-        {
-            Ok(current) => Ok(current == *snapshot),
-            Err(AppError::SourceNotFound(_)) => Ok(false),
-            Err(error) => Err(source_input_error(error)),
-        }
+            .await
+            .map_err(AppError::from)
+            .map_err(source_input_error)?;
+        Ok(current.as_ref() == Some(snapshot))
     }
 }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -39,6 +39,7 @@ use crate::sources::runtime_package::{
     RuntimeContractFingerprint, query_source_from_installed_manifest,
 };
 use crate::sources::{SourceName, ensure_database_source_feature_enabled};
+use crate::state::db::{CoralDb, DbRepos};
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::task::activity::{
     PendingTaskQuery, TaskActivityRecorder, TaskQueryRelation, TaskQueryStatus,
@@ -154,6 +155,7 @@ impl SourceDecorator for CatalogFailureRecorder {
 pub(crate) struct QueryManager {
     config_store: ConfigStore,
     workspace_manager: Arc<WorkspaceManager>,
+    db: Arc<CoralDb>,
     credential_manager: CredentialManager,
     function_manager: FunctionManager,
     lifecycle_lock: WorkspaceLifecycleLock,
@@ -176,6 +178,7 @@ impl QueryManager {
         runtime_context: QueryRuntimeContext,
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        db: Arc<CoralDb>,
     ) -> Self {
         Self::new(
             config_store,
@@ -185,6 +188,7 @@ impl QueryManager {
             layout,
             WorkspaceLifecycleLock::default(),
             engine_extensions_providers,
+            db,
         )
     }
 
@@ -197,6 +201,7 @@ impl QueryManager {
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        db: Arc<CoralDb>,
     ) -> Self {
         Self::with_diagnostic_reporter(
             config_store,
@@ -206,6 +211,7 @@ impl QueryManager {
             layout,
             lifecycle_lock,
             engine_extensions_providers,
+            db,
             SourceDiagnosticReporter::default(),
             Arc::new(WorkspacePoolRegistry::default()),
         )
@@ -224,6 +230,7 @@ impl QueryManager {
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        db: Arc<CoralDb>,
         diagnostic_reporter: SourceDiagnosticReporter,
         pool_registry: Arc<WorkspacePoolRegistry>,
     ) -> Self {
@@ -232,6 +239,7 @@ impl QueryManager {
         Self {
             config_store,
             workspace_manager: Arc::new(workspace_manager),
+            db,
             credential_manager,
             function_manager,
             lifecycle_lock,
@@ -575,8 +583,10 @@ impl QueryManager {
                 .config_store
                 .load_config_unlocked()
                 .map_err(QueryManagerError::App)?;
-            let source = config
-                .get_source(workspace_name, source_name)
+            let source = self
+                .get_installed_source(workspace_name, source_name)
+                .await
+                .map_err(QueryManagerError::App)?
                 .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
                 .map_err(QueryManagerError::App)?;
             let (loaded_source, version) = self
@@ -611,7 +621,8 @@ impl QueryManager {
         self.require_workspace(workspace_name).await?;
         let _state_lock = self.config_store.state_lock_shared()?;
         let config = self.config_store.load_config_unlocked()?;
-        let sources = self.load_query_sources_from_config(workspace_name, &config);
+        let installed_sources = self.installed_sources(workspace_name).await?;
+        let sources = self.load_query_sources_from_installed(workspace_name, installed_sources);
         Ok((sources, config))
     }
 
@@ -621,10 +632,35 @@ impl QueryManager {
             .await
     }
 
-    fn load_query_sources_from_config(
+    async fn installed_sources(
         &self,
         workspace_name: &WorkspaceName,
-        config: &AppConfig,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        let mut session = self.db.as_ref();
+        session
+            .sources()
+            .list_workspace_sources(workspace_name)
+            .await
+            .map_err(AppError::from)
+    }
+
+    async fn get_installed_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, AppError> {
+        let mut session = self.db.as_ref();
+        session
+            .sources()
+            .get_source(workspace_name, source_name)
+            .await
+            .map_err(AppError::from)
+    }
+
+    fn load_query_sources_from_installed(
+        &self,
+        workspace_name: &WorkspaceName,
+        installed_sources: Vec<InstalledSource>,
     ) -> QuerySourceLoad {
         let span = tracing::info_span!(
             "coral.app.query_sources.load",
@@ -638,7 +674,7 @@ impl QueryManager {
         let _guard = span.enter();
         let mut loaded_sources = Vec::new();
         let mut failed_source_names = BTreeSet::new();
-        for source in config.workspace_sources(workspace_name) {
+        for source in installed_sources {
             match self.load_query_source(workspace_name, &source) {
                 Ok((loaded_source, _version)) => {
                     self.diagnostic_reporter.clear_source_load_failure(
@@ -805,7 +841,7 @@ impl QueryManager {
             CredentialResolutionMode::Refreshing => {
                 Arc::new(CredentialRefreshingInputResolver::new(
                     workspace_name.clone(),
-                    self.config_store.clone(),
+                    Arc::clone(&self.db),
                     self.credential_manager.clone(),
                     source_credentials,
                     provider_input_resolver,
@@ -865,7 +901,9 @@ impl QueryManager {
             .await
             .map_err(QueryManagerError::App)?;
         let _lifecycle_snapshot = self.lifecycle_lock.snapshot_async().await;
-        let (loaded_sources, config) = self.load_function_validation_sources(workspace_name)?;
+        let (loaded_sources, config) = self
+            .load_function_validation_sources(workspace_name)
+            .await?;
         self.validate_udf_sql_against_snapshot(workspace_name, artifact, &loaded_sources, &config)
             .await
     }
@@ -934,14 +972,20 @@ impl QueryManager {
         if lifecycle_snapshot.revision() != revision {
             return Ok(None);
         }
-        let (loaded_sources, config) = self.load_function_validation_sources(workspace_name)?;
+        let (loaded_sources, config) = self
+            .load_function_validation_sources(workspace_name)
+            .await?;
         Ok(Some((loaded_sources, config)))
     }
 
-    fn load_function_validation_sources(
+    async fn load_function_validation_sources(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<(Vec<LoadedQuerySource>, AppConfig), QueryManagerError> {
+        let installed_sources = self
+            .installed_sources(workspace_name)
+            .await
+            .map_err(QueryManagerError::App)?;
         let (loaded_sources, config) = {
             let _state_lock = self
                 .config_store
@@ -951,7 +995,8 @@ impl QueryManager {
                 .config_store
                 .load_config_unlocked()
                 .map_err(QueryManagerError::App)?;
-            let source_load = self.load_query_sources_from_config(workspace_name, &config);
+            let source_load =
+                self.load_query_sources_from_installed(workspace_name, installed_sources);
             (source_load.loaded, config)
         };
         Ok((loaded_sources, config))
@@ -1514,6 +1559,7 @@ mod tests {
             runtime_context,
             layout,
             providers,
+            Arc::clone(&db),
         )
         .with_task_activity_recorder(TaskActivityRecorder::new(Arc::clone(&db)));
         QueryManagerFixture {
@@ -1550,6 +1596,7 @@ mod tests {
             QueryRuntimeContext::default(),
             layout,
             Vec::new(),
+            Arc::clone(&db),
         );
         QueryManagerFixture {
             _temp: temp,
@@ -1558,21 +1605,24 @@ mod tests {
         }
     }
 
-    fn install_keychain_github_source(config_store: &ConfigStore, workspace_name: &WorkspaceName) {
+    async fn install_keychain_github_source(
+        config_store: &ConfigStore,
+        db: &Arc<CoralDb>,
+        workspace_name: &WorkspaceName,
+    ) {
+        let source = InstalledSource {
+            name: SourceName::parse("github").expect("source name"),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: vec!["GITHUB_TOKEN".to_string()],
+            credential_storage: Some(CredentialStorageKind::Keychain),
+            credential_revision: uuid::Uuid::default(),
+            origin: SourceOrigin::Bundled,
+        };
         config_store
-            .upsert_source(
-                workspace_name,
-                InstalledSource {
-                    name: SourceName::parse("github").expect("source name"),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: vec!["GITHUB_TOKEN".to_string()],
-                    credential_storage: Some(CredentialStorageKind::Keychain),
-                    credential_revision: uuid::Uuid::default(),
-                    origin: SourceOrigin::Bundled,
-                },
-            )
+            .upsert_source(workspace_name, source.clone())
             .expect("persist source");
+        upsert_test_source(db, workspace_name, &source).await;
     }
 
     async fn test_db(layout: &AppStateLayout, config_store: &ConfigStore) -> Arc<CoralDb> {
@@ -1679,6 +1729,23 @@ mod tests {
     /// two identical messages into different ones.
     fn normalize(message: &str, name: &str) -> String {
         message.replace(&format!("'{name}'"), "'<workspace>'")
+    }
+
+    async fn upsert_test_source(
+        db: &Arc<CoralDb>,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) {
+        let mut tx = db.begin().await.expect("begin test source tx");
+        tx.workspaces()
+            .ensure(workspace_name.as_str(), 11)
+            .await
+            .expect("ensure test workspace");
+        tx.sources()
+            .upsert_source(workspace_name, source, 11)
+            .await
+            .expect("upsert test source");
+        tx.commit().await.expect("commit test source");
     }
 
     fn assert_workspace_not_found(error: AppError, workspace_name: &WorkspaceName) {
@@ -3205,6 +3272,7 @@ paths:
         );
         let calls = Arc::new(AtomicUsize::new(0));
         let config_store = fixture.manager.config_store.clone();
+        let db = Arc::clone(&fixture.manager.db);
         let lifecycle_lock = fixture.manager.lifecycle_lock.clone();
         let workspace = workspace_name.clone();
         let source_name = SourceName::parse("function_demo").expect("source name");
@@ -3216,6 +3284,30 @@ paths:
                     config_store
                         .remove_source(&workspace, &source_name)
                         .expect("remove source during function validation");
+                    let db = Arc::clone(&db);
+                    let workspace = workspace.clone();
+                    let source_name = source_name.clone();
+                    std::thread::spawn(move || {
+                        let runtime = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .expect("build source removal runtime");
+                        runtime.block_on(async move {
+                            let mut tx = db.begin().await.expect("begin source removal");
+                            let removed = tx
+                                .sources()
+                                .remove_source(&workspace, &source_name)
+                                .await
+                                .expect("remove database source during function validation");
+                            assert!(
+                                removed.is_some(),
+                                "database source should exist before removal"
+                            );
+                            tx.commit().await.expect("commit source removal");
+                        });
+                    })
+                    .join()
+                    .expect("join source removal thread");
                 })),
             },
         ));
@@ -3424,7 +3516,7 @@ tables:
             .expect("import source");
     }
 
-    fn install_missing_v4_materialization_source(
+    async fn install_missing_v4_materialization_source(
         manager: &QueryManager,
         workspace_name: &WorkspaceName,
     ) -> SourceName {
@@ -3443,25 +3535,20 @@ surface:
 ",
         )
         .expect("write manifest");
-        manager
-            .config_store
-            .upsert_source(
-                workspace_name,
-                InstalledSource {
-                    name: source_name.clone(),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    credential_revision: uuid::Uuid::default(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
-            .expect("persist source");
+        let source = InstalledSource {
+            name: source_name.clone(),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            credential_revision: uuid::Uuid::default(),
+            origin: SourceOrigin::Imported,
+        };
+        upsert_test_source(&manager.db, workspace_name, &source).await;
         source_name
     }
 
-    fn install_corrupt_parquet_source(
+    async fn install_corrupt_parquet_source(
         manager: &QueryManager,
         workspace_name: &WorkspaceName,
         fake_home: &std::path::Path,
@@ -3493,21 +3580,20 @@ tables:
 "#,
         )
         .expect("write manifest");
-        manager
-            .config_store
-            .upsert_source(
-                workspace_name,
-                InstalledSource {
-                    name: source_name.clone(),
-                    version: Some("0.1.0".to_string()),
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    credential_revision: uuid::Uuid::default(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
-            .expect("persist source");
+        upsert_test_source(
+            &manager.db,
+            workspace_name,
+            &InstalledSource {
+                name: source_name.clone(),
+                version: Some("0.1.0".to_string()),
+                variables: BTreeMap::new(),
+                secrets: Vec::new(),
+                credential_storage: None,
+                credential_revision: uuid::Uuid::default(),
+                origin: SourceOrigin::Imported,
+            },
+        )
+        .await;
         source_name
     }
 
@@ -3517,7 +3603,7 @@ tables:
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = test_workspace();
         let source_name =
-            install_missing_v4_materialization_source(&fixture.manager, &workspace_name);
+            install_missing_v4_materialization_source(&fixture.manager, &workspace_name).await;
 
         let (source_load, _) = fixture
             .manager
@@ -3551,7 +3637,7 @@ tables:
             fake_home.path(),
         );
         let failed_source =
-            install_missing_v4_materialization_source(&fixture.manager, &workspace_name);
+            install_missing_v4_materialization_source(&fixture.manager, &workspace_name).await;
 
         let resolution = fixture
             .manager
@@ -3648,7 +3734,8 @@ tables:
             fake_home.path(),
         );
         let failed_source =
-            install_corrupt_parquet_source(&fixture.manager, &workspace_name, fake_home.path());
+            install_corrupt_parquet_source(&fixture.manager, &workspace_name, fake_home.path())
+                .await;
 
         let resolution = fixture
             .manager
@@ -3676,7 +3763,8 @@ tables:
     async fn load_query_sources_skips_unavailable_keychain_source() {
         let fixture = query_manager_with_unavailable_keychain().await;
         let workspace_name = test_workspace();
-        install_keychain_github_source(&fixture.manager.config_store, &workspace_name);
+        install_keychain_github_source(&fixture.manager.config_store, &fixture.db, &workspace_name)
+            .await;
 
         let (source_load, _) = fixture
             .manager
@@ -3712,7 +3800,12 @@ select 1 as value
             .function_manager
             .install_validated_user_function(&workspace_name, function_sql, &validated)
             .expect("install constant function");
-        install_keychain_github_source(&fixture.manager.config_store, &workspace_name);
+        install_keychain_github_source(
+            &fixture.manager.config_store,
+            &fixture.manager.db,
+            &workspace_name,
+        )
+        .await;
 
         let functions = fixture
             .manager
@@ -3881,6 +3974,7 @@ select 1 as value
             .config_store
             .upsert_source(&workspace_name, installed_source.clone())
             .expect("persist live source");
+        upsert_test_source(&fixture.manager.db, &workspace_name, &installed_source).await;
         fixture
             .manager
             .credential_manager
@@ -4007,6 +4101,7 @@ tables:
             .config_store
             .upsert_source(&workspace, installed_source.clone())
             .expect("persist source");
+        upsert_test_source(&fixture.manager.db, &workspace, &installed_source).await;
         fixture
             .manager
             .credential_manager

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -193,6 +193,10 @@ impl QueryManager {
     }
 
     #[cfg(test)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "database handle joins the existing collaborator set the query manager owns"
+    )]
     pub(crate) fn new(
         config_store: ConfigStore,
         workspace_manager: WorkspaceManager,

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -102,6 +102,10 @@ impl SearchManager {
         )
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "database handle joins the existing collaborator set the search manager owns"
+    )]
     pub(crate) fn with_diagnostic_reporter(
         layout: AppStateLayout,
         config_store: &ConfigStore,
@@ -247,7 +251,6 @@ impl SearchManager {
                 continue;
             };
             let observed_policy = match request.provider {
-                SearchIndexProvider::Catalog => None,
                 SearchIndexProvider::ObservedValues | SearchIndexProvider::All
                     if self.observed_values_search_enabled =>
                 {
@@ -256,7 +259,9 @@ impl SearchManager {
                             .await,
                     )
                 }
-                SearchIndexProvider::ObservedValues | SearchIndexProvider::All => None,
+                SearchIndexProvider::Catalog
+                | SearchIndexProvider::ObservedValues
+                | SearchIndexProvider::All => None,
             };
             let search = self.clone();
             let request = request.clone();

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -1,6 +1,7 @@
 //! App-level Universal Search manager.
 
 use std::future::Future;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use opentelemetry::trace::Status as OtelStatus;
@@ -37,6 +38,7 @@ use crate::search::sqlite_store::{
     SqliteSearchCompactionResult, SqliteSearchError, SqliteSearchStore,
 };
 use crate::sources::materialization::SourceDiagnosticReporter;
+use crate::state::db::CoralDb;
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::id::TaskId;
 use crate::telemetry::{app_error_type, record_local_only_span_attribute};
@@ -83,6 +85,7 @@ impl SearchManager {
         layout: AppStateLayout,
         config_store: &ConfigStore,
         workspace_manager: WorkspaceManager,
+        db: Arc<CoralDb>,
         observed_values_search_enabled: bool,
         catalog_discovery: CatalogDiscovery,
         lifecycle_lock: WorkspaceLifecycleLock,
@@ -91,6 +94,7 @@ impl SearchManager {
             layout,
             config_store,
             workspace_manager,
+            db,
             observed_values_search_enabled,
             SourceDiagnosticReporter::default(),
             catalog_discovery,
@@ -102,6 +106,7 @@ impl SearchManager {
         layout: AppStateLayout,
         config_store: &ConfigStore,
         workspace_manager: WorkspaceManager,
+        db: Arc<CoralDb>,
         observed_values_search_enabled: bool,
         diagnostic_reporter: SourceDiagnosticReporter,
         catalog_discovery: CatalogDiscovery,
@@ -117,6 +122,7 @@ impl SearchManager {
         let observed_scope_loader = ObservedValuesLiveScopeLoader::new(
             layout.clone(),
             config_store.clone(),
+            db,
             diagnostic_reporter,
         );
         Self {
@@ -164,20 +170,14 @@ impl SearchManager {
                     else {
                         continue;
                     };
-                    let (observed_values_policy, lifecycle_lease) =
-                        if self.observed_values_search_enabled {
-                            let search = self.clone();
-                            let workspace_name = request.workspace_name.clone();
-                            run_blocking_search_operation(move || {
-                                Ok((
-                                    Some(search.observed_retrieval_policy(&workspace_name)),
-                                    lifecycle_lease,
-                                ))
-                            })
-                            .await?
-                        } else {
-                            (None, lifecycle_lease)
-                        };
+                    let observed_values_policy = if self.observed_values_search_enabled {
+                        Some(
+                            self.observed_retrieval_policy(&request.workspace_name)
+                                .await,
+                        )
+                    } else {
+                        None
+                    };
                     let context = SearchExecutionContext::new(
                         request_started_at,
                         lifecycle_lease,
@@ -246,6 +246,18 @@ impl SearchManager {
             else {
                 continue;
             };
+            let observed_policy = match request.provider {
+                SearchIndexProvider::Catalog => None,
+                SearchIndexProvider::ObservedValues | SearchIndexProvider::All
+                    if self.observed_values_search_enabled =>
+                {
+                    Some(
+                        self.observed_retrieval_policy(&request.workspace_name)
+                            .await,
+                    )
+                }
+                SearchIndexProvider::ObservedValues | SearchIndexProvider::All => None,
+            };
             let search = self.clone();
             let request = request.clone();
             let response = run_blocking_search_operation(move || {
@@ -263,7 +275,10 @@ impl SearchManager {
                         )?,
                     ],
                     SearchIndexProvider::ObservedValues => {
-                        vec![search.rebuild_observed_index(&request)]
+                        vec![search.rebuild_observed_index(
+                            &request,
+                            observed_policy.as_ref().map(Result::as_ref),
+                        )]
                     }
                     SearchIndexProvider::All => vec![
                         search.rebuild_catalog_index(
@@ -272,7 +287,10 @@ impl SearchManager {
                                 .as_ref()
                                 .expect("catalog rebuild preloads the catalog resolution"),
                         )?,
-                        search.rebuild_observed_index(&request),
+                        search.rebuild_observed_index(
+                            &request,
+                            observed_policy.as_ref().map(Result::as_ref),
+                        ),
                     ],
                 };
                 Ok(RebuildSearchIndexResponse { results })
@@ -519,26 +537,36 @@ impl SearchManager {
     fn rebuild_observed_index(
         &self,
         request: &RebuildSearchIndexRequest,
+        observed_policy: Option<Result<&ObservedValuesRetrievalPolicy, &AppError>>,
     ) -> SearchMaintenanceResult {
         if !self.observed_values_search_enabled {
             return observed_values_search_disabled_maintenance_result();
         }
-        match self.try_rebuild_observed_index(request) {
+        let policy = match observed_policy {
+            Some(Ok(policy)) => policy,
+            Some(Err(error)) => return observed_rebuild_error_provider_result(error),
+            None => {
+                return observed_rebuild_error_provider_result(&AppError::Internal(
+                    "observed-value retrieval policy was not loaded for rebuild".to_string(),
+                ));
+            }
+        };
+        match self.try_rebuild_observed_index(request, policy) {
             Ok(result) => result,
-            Err(error) => observed_rebuild_error_provider_result(&error),
+            Err(SearchManagerError::App(error)) => observed_rebuild_error_provider_result(&error),
         }
     }
 
     fn try_rebuild_observed_index(
         &self,
         request: &RebuildSearchIndexRequest,
+        policy: &ObservedValuesRetrievalPolicy,
     ) -> Result<SearchMaintenanceResult, SearchManagerError> {
-        let policy = self.observed_retrieval_policy(&request.workspace_name)?;
         self.observed.rebuild_index(
             SearchProviderRebuildRequest {
                 workspace_name: &request.workspace_name,
             },
-            &policy,
+            policy,
         )
     }
 
@@ -560,11 +588,11 @@ impl SearchManager {
         )
     }
 
-    fn observed_retrieval_policy(
+    async fn observed_retrieval_policy(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<ObservedValuesRetrievalPolicy, AppError> {
-        let load = self.observed_scope_loader.load(workspace_name)?;
+        let load = self.observed_scope_loader.load(workspace_name).await?;
         Ok(observed_retrieval_policy_from_load(
             load,
             OBSERVED_STALE_AFTER_LAST_OBSERVED_DAYS,
@@ -741,14 +769,11 @@ fn observed_retrieval_policy_from_load(
     )
 }
 
-fn observed_rebuild_error_provider_result(error: &SearchManagerError) -> SearchMaintenanceResult {
+fn observed_rebuild_error_provider_result(error: &AppError) -> SearchMaintenanceResult {
     SearchMaintenanceResult {
         provider: SearchProviderKind::ObservedValues,
         state: SearchMaintenanceState::Failed,
-        note: format!(
-            "observed-value search index rebuild failed: {}",
-            search_manager_error_message(error)
-        ),
+        note: format!("observed-value search index rebuild failed: {error}"),
         detail: None,
     }
 }
@@ -759,12 +784,6 @@ fn observed_values_search_disabled_maintenance_result() -> SearchMaintenanceResu
         state: SearchMaintenanceState::Skipped,
         note: OBSERVED_VALUES_SEARCH_DISABLED_MAINTENANCE_NOTE.to_string(),
         detail: None,
-    }
-}
-
-fn search_manager_error_message(error: &SearchManagerError) -> String {
-    match error {
-        SearchManagerError::App(error) => error.to_string(),
     }
 }
 
@@ -828,7 +847,7 @@ mod tests {
     use super::{
         REBUILD_SEARCH_INDEX_OPERATION, SEARCH_MAINTENANCE_PROVIDER_FAILURE_ERROR_TYPE,
         SEARCH_MAINTENANCE_TELEMETRY_ERROR_MESSAGE, SEARCH_TELEMETRY_ERROR_MESSAGE,
-        run_search_maintenance_operation, run_search_operation, search_manager_error_message,
+        run_search_maintenance_operation, run_search_operation,
     };
     use crate::bootstrap::AppError;
     use crate::search::maintenance::{
@@ -1107,7 +1126,8 @@ mod tests {
         .await
         .expect_err("search operation should return its detailed error");
 
-        assert!(search_manager_error_message(&error).contains(error_sentinel));
+        let SearchManagerError::App(app_error) = &error;
+        assert!(app_error.to_string().contains(error_sentinel));
 
         provider.force_flush().expect("flush spans");
         let spans = exporter.get_finished_spans().expect("finished spans");

--- a/crates/coral-app/src/search/observed/live_scope.rs
+++ b/crates/coral-app/src/search/observed/live_scope.rs
@@ -1,6 +1,7 @@
 //! Live observed-value source-scope loading.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use crate::bootstrap::AppError;
 use crate::search::observed::source_scope::{SourceScopeSeed, source_surface_scopes};
@@ -9,12 +10,14 @@ use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::query_source_from_installed_manifest;
+use crate::state::db::{CoralDb, DbRepos};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ObservedValuesLiveScopeLoader {
     config_store: ConfigStore,
+    db: Arc<CoralDb>,
     diagnostic_reporter: SourceDiagnosticReporter,
     layout: AppStateLayout,
 }
@@ -29,16 +32,18 @@ impl ObservedValuesLiveScopeLoader {
     pub(crate) fn new(
         layout: AppStateLayout,
         config_store: ConfigStore,
+        db: Arc<CoralDb>,
         diagnostic_reporter: SourceDiagnosticReporter,
     ) -> Self {
         Self {
             config_store,
+            db,
             diagnostic_reporter,
             layout,
         }
     }
 
-    pub(crate) fn load(
+    pub(crate) async fn load(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<ObservedValuesLiveScopeLoad, AppError> {
@@ -47,8 +52,13 @@ impl ObservedValuesLiveScopeLoader {
         // a separate cache key would duplicate that dependency graph and risk
         // admitting observations under a stale scope.
         let _state_lock = self.config_store.state_lock_shared()?;
-        let config = self.config_store.load_config_unlocked()?;
-        let sources = config.workspace_sources(workspace_name);
+        let sources = {
+            let mut session = self.db.as_ref();
+            session
+                .sources()
+                .list_workspace_sources(workspace_name)
+                .await?
+        };
         Ok(self.load_sources(workspace_name, sources))
     }
 
@@ -112,6 +122,7 @@ impl ObservedValuesLiveScopeLoader {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::sync::Arc;
 
     use tempfile::tempdir;
     use uuid::Uuid;
@@ -124,44 +135,18 @@ mod tests {
     use crate::sources::materialization::SourceDiagnosticReporter;
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::sources::runtime_package::query_source_from_installed_manifest;
+    use crate::state::db::{CoralDb, DbRepos, open_test_database, run_state_migrations};
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::WorkspaceName;
 
-    #[test]
-    fn workspace_without_legacy_config_membership_has_empty_live_scope() {
+    #[tokio::test]
+    async fn database_membership_does_not_require_legacy_config_source() {
         let temp = tempdir().expect("tempdir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let config_store = ConfigStore::new(layout.clone());
         let workspace = WorkspaceName::parse("db-only").expect("workspace");
-        let loader = ObservedValuesLiveScopeLoader::new(
-            layout,
-            config_store,
-            SourceDiagnosticReporter::default(),
-        );
-
-        let load = loader.load(&workspace).expect("empty live scope load");
-
-        assert!(load.live_scopes.is_empty());
-        assert!(load.failed_sources.is_empty());
-    }
-
-    #[test]
-    fn live_scope_changes_when_http_request_shape_changes() {
-        let temp = tempdir().expect("tempdir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let workspace = WorkspaceName::parse("work").expect("workspace");
         let source = SourceName::parse("github").expect("source");
-        install_source(&layout, &config_store, &workspace, &source, "/repos/issues");
-        let loader = ObservedValuesLiveScopeLoader::new(
-            layout.clone(),
-            config_store.clone(),
-            SourceDiagnosticReporter::default(),
-        );
-
-        let first = loader.load(&workspace).expect("first live scope");
         install_source(
             &layout,
             &config_store,
@@ -169,7 +154,46 @@ mod tests {
             &source,
             "/search/issues",
         );
-        let second = loader.load(&workspace).expect("second live scope");
+        let db = test_db(&layout, &config_store).await;
+        config_store
+            .remove_source(&workspace, &source)
+            .expect("remove legacy config source");
+        let loader = ObservedValuesLiveScopeLoader::new(
+            layout,
+            config_store,
+            db,
+            SourceDiagnosticReporter::default(),
+        );
+
+        let load = loader.load(&workspace).await.expect("live scope load");
+
+        assert_eq!(load.live_scopes.len(), 1);
+        assert!(load.failed_sources.is_empty());
+    }
+
+    #[tokio::test]
+    async fn live_scope_changes_when_http_request_shape_changes() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("work").expect("workspace");
+        let source = SourceName::parse("github").expect("source");
+        install_source(&layout, &config_store, &workspace, &source, "/repos/issues");
+        let db = test_db(&layout, &config_store).await;
+        config_store
+            .remove_source(&workspace, &source)
+            .expect("remove legacy config source");
+        let loader = ObservedValuesLiveScopeLoader::new(
+            layout.clone(),
+            config_store,
+            db,
+            SourceDiagnosticReporter::default(),
+        );
+
+        let first = loader.load(&workspace).await.expect("first live scope");
+        write_source_manifest(&layout, &workspace, &source, "/search/issues");
+        let second = loader.load(&workspace).await.expect("second live scope");
 
         assert!(first.failed_sources.is_empty());
         assert!(second.failed_sources.is_empty());
@@ -184,30 +208,36 @@ mod tests {
         assert_ne!(first_scope.source_scope_id, second_scope.source_scope_id);
     }
 
-    #[test]
-    fn credential_revision_change_changes_live_scope() {
+    #[tokio::test]
+    async fn credential_revision_change_changes_live_scope() {
         let temp = tempdir().expect("tempdir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let config_store = ConfigStore::new(layout.clone());
         let workspace = WorkspaceName::parse("work").expect("workspace");
         let source = SourceName::parse("github").expect("source");
-        install_source(
+        let mut installed = install_source(
             &layout,
             &config_store,
             &workspace,
             &source,
             "/search/issues",
         );
+        let db = test_db(&layout, &config_store).await;
+        config_store
+            .remove_source(&workspace, &source)
+            .expect("remove legacy config source");
         let loader = ObservedValuesLiveScopeLoader::new(
             layout,
-            config_store.clone(),
+            config_store,
+            Arc::clone(&db),
             SourceDiagnosticReporter::default(),
         );
 
-        let first = loader.load(&workspace).expect("first live scope");
-        set_credential_revision(&config_store, &workspace, &source, Uuid::from_u128(1));
-        let second = loader.load(&workspace).expect("second live scope");
+        let first = loader.load(&workspace).await.expect("first live scope");
+        installed.credential_revision = Uuid::from_u128(1);
+        upsert_test_source(&db, &workspace, &installed).await;
+        let second = loader.load(&workspace).await.expect("second live scope");
 
         assert!(first.failed_sources.is_empty());
         assert!(second.failed_sources.is_empty());
@@ -218,8 +248,8 @@ mod tests {
         assert_ne!(first_scope.source_scope_id, second_scope.source_scope_id);
     }
 
-    #[test]
-    fn live_loader_matches_publisher_scope_with_resolved_secret_material() {
+    #[tokio::test]
+    async fn live_loader_matches_publisher_scope_with_resolved_secret_material() {
         let temp = tempdir().expect("tempdir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -269,19 +299,24 @@ mod tests {
         .expect("publisher scope")
         .live_scope();
 
+        let db = test_db(&layout, &config_store).await;
+        config_store
+            .remove_source(&workspace, &source_name)
+            .expect("remove legacy config source");
         let loader = ObservedValuesLiveScopeLoader::new(
             layout,
             config_store,
+            db,
             SourceDiagnosticReporter::default(),
         );
-        let live_load = loader.load(&workspace).expect("live scope");
+        let live_load = loader.load(&workspace).await.expect("live scope");
 
         assert!(live_load.failed_sources.is_empty());
         assert_eq!(live_load.live_scopes, vec![publisher_scope]);
     }
 
-    #[test]
-    fn one_broken_source_does_not_block_other_live_scopes() {
+    #[tokio::test]
+    async fn one_broken_source_does_not_block_other_live_scopes() {
         let temp = tempdir().expect("tempdir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -297,13 +332,21 @@ mod tests {
             "/search/issues",
         );
         install_broken_source(&layout, &config_store, &workspace, &broken);
+        let db = test_db(&layout, &config_store).await;
+        config_store
+            .remove_source(&workspace, &github)
+            .expect("remove healthy legacy config source");
+        config_store
+            .remove_source(&workspace, &broken)
+            .expect("remove broken legacy config source");
         let loader = ObservedValuesLiveScopeLoader::new(
             layout,
             config_store,
+            db,
             SourceDiagnosticReporter::default(),
         );
 
-        let load = loader.load(&workspace).expect("live scope load");
+        let load = loader.load(&workspace).await.expect("live scope load");
 
         assert_eq!(load.live_scopes.len(), 1);
         let live_scope = load.live_scopes.first().expect("live scope");
@@ -316,6 +359,28 @@ mod tests {
     fn install_source(
         layout: &AppStateLayout,
         config_store: &ConfigStore,
+        workspace: &WorkspaceName,
+        source: &SourceName,
+        path: &str,
+    ) -> InstalledSource {
+        write_source_manifest(layout, workspace, source, path);
+        let installed = InstalledSource {
+            name: source.clone(),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            credential_revision: Uuid::default(),
+            origin: SourceOrigin::Imported,
+        };
+        config_store
+            .upsert_source(workspace, installed.clone())
+            .expect("upsert source");
+        installed
+    }
+
+    fn write_source_manifest(
+        layout: &AppStateLayout,
         workspace: &WorkspaceName,
         source: &SourceName,
         path: &str,
@@ -343,20 +408,6 @@ tables:
             ),
         )
         .expect("write manifest");
-        config_store
-            .upsert_source(
-                workspace,
-                InstalledSource {
-                    name: source.clone(),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    credential_revision: Uuid::default(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
-            .expect("upsert source");
     }
 
     fn install_broken_source(
@@ -383,23 +434,31 @@ tables:
             .expect("upsert source");
     }
 
-    fn set_credential_revision(
-        config_store: &ConfigStore,
+    async fn test_db(layout: &AppStateLayout, config_store: &ConfigStore) -> Arc<CoralDb> {
+        let db = open_test_database(layout)
+            .await
+            .expect("open test database");
+        run_state_migrations(&db, config_store, layout)
+            .await
+            .expect("run state migrations");
+        db
+    }
+
+    async fn upsert_test_source(
+        db: &Arc<CoralDb>,
         workspace: &WorkspaceName,
-        source_name: &SourceName,
-        credential_revision: Uuid,
+        source: &InstalledSource,
     ) {
-        let mut source = config_store
-            .load_config()
-            .expect("load config")
-            .workspace_sources(workspace)
-            .into_iter()
-            .find(|source| &source.name == source_name)
-            .expect("installed source");
-        source.credential_revision = credential_revision;
-        config_store
-            .upsert_source(workspace, source)
-            .expect("update credential revision");
+        let mut tx = db.begin().await.expect("begin test source tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 11)
+            .await
+            .expect("ensure test workspace");
+        tx.sources()
+            .upsert_source(workspace, source, 11)
+            .await
+            .expect("upsert test source");
+        tx.commit().await.expect("commit test source");
     }
 
     fn install_secured_source(

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -616,12 +616,14 @@ mod tests {
             QueryRuntimeContext::default(),
             layout.clone(),
             Vec::new(),
+            Arc::clone(&db),
         );
         let lifecycle_lock = workspaces.lifecycle_lock();
         let search = SearchManager::new(
             layout,
             &config_store,
             workspaces,
+            Arc::clone(&db),
             true,
             CatalogDiscovery::new(queries),
             lifecycle_lock,

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -2699,10 +2699,8 @@ surface:
             "credential material should be preserved when directory staging fails"
         );
         assert!(
-            config_store
-                .get_source(&workspace_name, &source_name)
-                .is_ok(),
-            "source config should be preserved when directory staging fails"
+            manager.get_source(&workspace_name, &source_name).is_ok(),
+            "source metadata should be preserved when directory staging fails"
         );
         assert!(
             source_dir.exists(),

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -941,6 +941,7 @@ mod tests {
             QueryRuntimeContext::default(),
             layout.clone(),
             Vec::new(),
+            Arc::clone(&db),
         );
         let config_file = layout.config_file().to_path_buf();
         Fixture {

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -980,48 +980,45 @@ mod tests {
         }]
     }
 
-    /// Takes the status `rpc` refused with, and panics if it answered instead.
-    ///
-    /// For the two streaming installs that panic is itself part of the claim:
-    /// a status can only come back where no response did, so a refused caller
-    /// was never handed an import stream to read from.
-    fn status<T>(result: Result<T, Status>, rpc: &str) -> Status {
-        result.err().unwrap_or_else(|| {
-            panic!("{rpc} answered; every request here is one some layer must refuse")
-        })
+    fn outcome_code<T>(result: Result<T, Status>, _rpc: &str) -> Option<Code> {
+        result.err().map(|status| status.code())
     }
 
-    /// Calls every source RPC as `principal` and returns what each answered,
-    /// in the order the authorization matrix lists them.
-    ///
-    /// Each request is one the source work itself rejects — an absent source
-    /// name, an empty manifest, an OAuth retrieval with no method index — over
-    /// state whose config file cannot be parsed. So the caller who is let
-    /// through is told what is wrong with the request or the state, and the
-    /// caller who is not never gets that far.
-    async fn every_source_rpc(service: &SourceService, principal: &Principal) -> Vec<Status> {
+    /// Calls every source RPC as a principal that must be refused by the
+    /// authorization gate and returns the statuses in matrix order.
+    async fn every_source_rpc(service: &SourceService, principal: &Principal) -> Vec<Option<Code>> {
+        let mut statuses = vec![outcome_code(
+            service
+                .discover_sources(request(
+                    DiscoverSourcesRequest {
+                        workspace: Some(workspace()),
+                    },
+                    principal,
+                ))
+                .await,
+            "DiscoverSources",
+        )];
+        statuses.extend(source_rpcs_after_discovery(service, principal).await);
+        statuses
+    }
+
+    async fn source_rpcs_after_discovery(
+        service: &SourceService,
+        principal: &Principal,
+    ) -> Vec<Option<Code>> {
         let mut statuses = source_lookup_rpcs(service, principal).await;
         statuses.extend(source_install_rpcs(service, principal).await);
         statuses.extend(source_removal_rpcs(service, principal).await);
         statuses
     }
 
-    /// Discovery and configuration reads: the five that answer with what a
-    /// source is or would be configured with.
-    async fn source_lookup_rpcs(service: &SourceService, principal: &Principal) -> Vec<Status> {
+    /// Configuration reads after database-backed discovery has completed.
+    async fn source_lookup_rpcs(
+        service: &SourceService,
+        principal: &Principal,
+    ) -> Vec<Option<Code>> {
         vec![
-            status(
-                service
-                    .discover_sources(request(
-                        DiscoverSourcesRequest {
-                            workspace: Some(workspace()),
-                        },
-                        principal,
-                    ))
-                    .await,
-                "DiscoverSources",
-            ),
-            status(
+            outcome_code(
                 service
                     .describe_source_manifest(request(
                         DescribeSourceManifestRequest {
@@ -1033,7 +1030,7 @@ mod tests {
                     .await,
                 "DescribeSourceManifest",
             ),
-            status(
+            outcome_code(
                 service
                     .list_sources(request(
                         ListSourcesRequest {
@@ -1044,7 +1041,7 @@ mod tests {
                     .await,
                 "ListSources",
             ),
-            status(
+            outcome_code(
                 service
                     .get_source(request(
                         GetSourceRequest {
@@ -1056,7 +1053,7 @@ mod tests {
                     .await,
                 "GetSource",
             ),
-            status(
+            outcome_code(
                 service
                     .get_source_info(request(
                         GetSourceInfoRequest {
@@ -1072,9 +1069,12 @@ mod tests {
     }
 
     /// The three install paths, each of which takes credential material.
-    async fn source_install_rpcs(service: &SourceService, principal: &Principal) -> Vec<Status> {
+    async fn source_install_rpcs(
+        service: &SourceService,
+        principal: &Principal,
+    ) -> Vec<Option<Code>> {
         vec![
-            status(
+            outcome_code(
                 service
                     .create_bundled_source(request(
                         CreateBundledSourceRequest {
@@ -1088,7 +1088,7 @@ mod tests {
                     .await,
                 "CreateBundledSource",
             ),
-            status(
+            outcome_code(
                 service
                     .create_bundled_source_with_o_auth(request(
                         CreateBundledSourceWithOAuthRequest {
@@ -1103,7 +1103,7 @@ mod tests {
                     .await,
                 "CreateBundledSourceWithOAuth",
             ),
-            status(
+            outcome_code(
                 service
                     .import_source(request(
                         ImportSourceRequest {
@@ -1123,9 +1123,12 @@ mod tests {
 
     /// Removal and revalidation, which reach installed state and its
     /// credentials without adding any.
-    async fn source_removal_rpcs(service: &SourceService, principal: &Principal) -> Vec<Status> {
+    async fn source_removal_rpcs(
+        service: &SourceService,
+        principal: &Principal,
+    ) -> Vec<Option<Code>> {
         vec![
-            status(
+            outcome_code(
                 service
                     .delete_source(request(
                         DeleteSourceRequest {
@@ -1137,7 +1140,7 @@ mod tests {
                     .await,
                 "DeleteSource",
             ),
-            status(
+            outcome_code(
                 service
                     .validate_source(request(
                         ValidateSourceRequest {
@@ -1158,14 +1161,15 @@ mod tests {
     /// handed a redacted view, and a non-member is told nothing.
     ///
     /// The refusals are proved to be absences rather than error codes. The
-    /// config file on disk is unparseable, so any read of installed state
-    /// chokes on it, and the owner does choke on it: the four discovery and
-    /// lookup calls that read installed state, the delete, and the validate
-    /// all answer `Internal` from that read, while the manifest description
-    /// and the three install paths answer `InvalidArgument` from the empty
-    /// manifest, the bundled catalog, and the OAuth conversion they reach
-    /// first. Every refused caller answers `PermissionDenied` or `NotFound`
-    /// instead, and leaves the file with the bytes it started with.
+    /// config file on disk is unparseable, so any remaining read of installed
+    /// state chokes on it, and the owner does choke on it: the three lookup
+    /// calls that still read the file, the delete, and the validate all answer
+    /// `Internal` from that read, while database-backed discovery succeeds.
+    /// The manifest description and the three install paths answer
+    /// `InvalidArgument` from the empty manifest, the bundled catalog, and the
+    /// OAuth conversion they reach first. Every refused caller answers
+    /// `PermissionDenied` or `NotFound` instead, and leaves the file with the
+    /// bytes it started with.
     #[tokio::test]
     async fn source_configuration_reaches_only_workspace_owners() {
         let fixture = fixture().await;
@@ -1189,40 +1193,29 @@ mod tests {
             seed_principal(&fixture.db, ISSUER, &test_workspace(), "outsider", None).await;
         std::fs::write(&fixture.config_file, UNPARSEABLE_CONFIG).expect("poison the app config");
 
-        for status in every_source_rpc(&fixture.service, &member).await {
-            assert_eq!(
-                status.code(),
-                Code::PermissionDenied,
-                "a member reads and changes no source configuration: {}",
-                status.message()
-            );
-        }
-        for status in every_source_rpc(&fixture.service, &outsider).await {
-            assert_eq!(
-                status.code(),
-                Code::NotFound,
-                "a non-member learns nothing about the workspace: {}",
-                status.message()
-            );
-        }
-
         assert_eq!(
-            every_source_rpc(&fixture.service, &owner)
-                .await
-                .iter()
-                .map(Status::code)
-                .collect::<Vec<_>>(),
+            every_source_rpc(&fixture.service, &member).await,
+            vec![Some(Code::PermissionDenied); 10],
+            "a member reads and changes no source configuration"
+        );
+        assert_eq!(
+            every_source_rpc(&fixture.service, &outsider).await,
+            vec![Some(Code::NotFound); 10],
+            "a non-member learns nothing about the workspace"
+        );
+        assert_eq!(
+            every_source_rpc(&fixture.service, &owner).await,
             vec![
-                Code::Internal,
-                Code::InvalidArgument,
-                Code::Internal,
-                Code::Internal,
-                Code::Internal,
-                Code::InvalidArgument,
-                Code::InvalidArgument,
-                Code::InvalidArgument,
-                Code::Internal,
-                Code::Internal,
+                None,
+                Some(Code::InvalidArgument),
+                None,
+                Some(Code::NotFound),
+                Some(Code::NotFound),
+                Some(Code::InvalidArgument),
+                Some(Code::InvalidArgument),
+                Some(Code::InvalidArgument),
+                Some(Code::Internal),
+                Some(Code::Internal),
             ],
             "the owner must be stopped by the state or the request, never by the gate"
         );

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -47,14 +47,6 @@ impl AppConfig {
         self.catalog.workspace_sources(workspace_name)
     }
 
-    pub(crate) fn get_source(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Option<InstalledSource> {
-        self.catalog.get_source(workspace_name, source_name)
-    }
-
     pub(crate) fn dependent_join_config(
         &self,
         selected_source_names: &[String],
@@ -564,6 +556,7 @@ impl ConfigStore {
         self.load_unlocked()
     }
 
+    #[cfg(test)]
     pub(crate) fn load_config(&self) -> Result<AppConfig, AppError> {
         let _lock = self.state_lock_shared()?;
         self.load_config_unlocked()
@@ -718,6 +711,7 @@ impl ConfigStore {
             .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }
 
+    #[cfg(test)]
     pub(crate) fn get_source(
         &self,
         workspace_name: &WorkspaceName,
@@ -725,6 +719,7 @@ impl ConfigStore {
     ) -> Result<InstalledSource, AppError> {
         let config = self.load_config()?;
         config
+            .catalog
             .get_source(workspace_name, source_name)
             .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1027,7 +1027,7 @@ mod tests {
                 .collect::<BTreeMap<_, _>>(),
             secrets: secrets.into_iter().map(str::to_string).collect(),
             credential_storage,
-            credential_revision: uuid::Uuid::nil(),
+            credential_revision: uuid::Uuid::from_u128(1),
             origin,
         }
     }

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -661,7 +661,7 @@ mod tests {
         S: DbSession,
     {
         Ok(session
-            .fetch_all::<(String,)>(
+            .fetch_all_scalars::<String>(
                 Query::select()
                     .column(Sources::CredentialRevision)
                     .from(Sources::Table)
@@ -672,8 +672,7 @@ mod tests {
             .await?
             .into_iter()
             .next()
-            .expect("source row")
-            .0)
+            .expect("source row"))
     }
 
     async fn fetch_count<S>(session: &mut S, statement: SelectStatement) -> Result<i64, DbError>

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -1202,7 +1202,7 @@ mod tests {
                 .collect::<BTreeMap<_, _>>(),
             secrets: secrets.into_iter().map(str::to_string).collect(),
             credential_storage,
-            credential_revision: uuid::Uuid::nil(),
+            credential_revision: uuid::Uuid::from_u128(1),
             origin,
         }
     }


### PR DESCRIPTION
## Intent

Switch query-time source loading to the database as a separate read surface after the source manager read switch.

## What it enables

Query table/catalog/execute/explain/validate paths load installed source metadata from DB rows, while still reading filesystem-backed manifests and credential material under the app state lock. OAuth credential refresh snapshot checks also compare against the DB source catalog instead of legacy config.

## Usage examples

No SQL, CLI, MCP, or RPC shape changes. Queries now use DB-backed installed source metadata after startup import and source lifecycle dual writes have populated the catalog tables.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p coral-app query::manager::tests::load_query_sources_fails_closed`
- `cargo test -p coral-app query::manager::tests::installed_v4_source_queries_through_app_assembled_runtime_component`
- `cargo test -p coral-app query::manager::tests::installed_v4_source_uses_parameter_metadata_pagination_override`
- `cargo test -p coral-app --test grpc source_lifecycle_tests::list_and_get_sources_read_database_after_config_becomes_invalid`
