### PR TITLE
fix(app): stop mirroring source catalog config

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,10 +270,7 @@ export CORAL_CONFIG_DIR=/path/to/coral-config
 
 Important files include:
 
-- `config.toml` for runtime settings such as feature flags, tracing, and
-  database bootstrap configuration
-- the local Coral database for installed-source metadata and non-secret
-  variables
+- `config.toml` for installed-source metadata and non-secret variables
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,10 @@ export CORAL_CONFIG_DIR=/path/to/coral-config
 
 Important files include:
 
-- `config.toml` for installed-source metadata and non-secret variables
+- `config.toml` for runtime settings such as feature flags, tracing, and
+  database bootstrap configuration
+- the local Coral database for installed-source metadata and non-secret
+  variables
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 

--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -363,8 +363,8 @@ On Windows, the default local state path is
 
 Important files include:
 
-- `config.toml` for installed-source metadata, non-secret variables, and runtime settings. See [Configuration](/reference/configuration).
-- `coral.db` for Coral's internal [local database](/reference/configuration#database).
+- `config.toml` for runtime settings such as feature flags, tracing, and database bootstrap configuration. See [Configuration](/reference/configuration).
+- `coral.db` for Coral's internal [local database](/reference/configuration#database), including installed-source metadata and non-secret variables.
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -7,12 +7,14 @@ Coral stores local configuration in `config.toml` inside its platform-specific [
 
 ## Managed state
 
-Coral writes source installation state to `config.toml` when you run commands such as `coral source add` and `coral source remove`.
+Coral stores source installation state in its local database when you run commands such as `coral source add` and `coral source remove`.
 
 This state includes installed-source metadata and non-secret source variables. Source secrets are stored separately within the same local trust boundary.
 
 <Note>
-  Prefer the `coral source` commands for source state instead of editing workspace entries manually.
+  Prefer the `coral source` commands for source state instead of editing
+  source entries manually. Current Coral releases no longer use
+  `[workspaces.*.sources.*]` entries in `config.toml` as the source catalog.
 </Note>
 
 ## Database
@@ -51,21 +53,10 @@ run `coral workspace create NAME`, and Coral never falls back to a name of its
 own. `default` is an ordinary name you may create, remove, and select like any
 other.
 
-What `config.toml` holds is the per-workspace installation state for the things
-you install into a workspace — sources and functions:
-
-```toml
-[workspaces.work.sources.github]
-version = "1.0.0"
-variables = {}
-secrets = ["GITHUB_TOKEN"]
-origin = "bundled"
-```
-
-Coral writes these tables when you run commands such as `coral source add`.
-Creating an empty workspace writes no `[workspaces.<name>]` scaffolding, so a
-workspace with nothing installed in it appears in `coral workspace list` without
-appearing in `config.toml`.
+`config.toml` may still contain per-workspace function definitions, but it does
+not mirror the workspace or source catalogs. Creating an empty workspace or
+installing a source therefore adds no `[workspaces.<name>]` or
+`[workspaces.<name>.sources.<source>]` scaffolding.
 
 There is no active-workspace key in `config.toml`; use `CORAL_WORKSPACE` for a
 shell default or `--workspace <NAME>` for one command, as described in
@@ -73,6 +64,17 @@ shell default or `--workspace <NAME>` for one command, as described in
 Source specs imported from files and source credential material remain scoped
 to the source installation in a workspace. Reusable global source specs and
 reusable credential references are not config objects today.
+
+Older `config.toml` source entries are imported into the database on startup and
+removed from `config.toml` after the import is validated. This source-catalog
+migration is one-way for current releases: downgrading to an older
+config-backed Coral build does not automatically restore those config entries.
+
+If you need to run an older build after this migration, re-add bundled sources
+with `coral source add <NAME>`. Re-add imported sources with
+`coral source add --file <PATH>`, using the existing manifest under the local
+state directory, such as
+`workspaces/<workspace>/sources/<source>/manifest.yaml`.
 
 ## Server
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1780,6 +1780,12 @@ mod tests {
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let db = test_db(&layout, &config_store).await;
+        let mut tx = db.begin().await.expect("begin workspace setup");
+        tx.workspaces()
+            .ensure(WorkspaceName::default().as_str(), 1)
+            .await
+            .expect("seed default workspace");
+        tx.commit().await.expect("commit workspace setup");
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1501,6 +1501,7 @@ mod tests {
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use coral_engine::{
         EngineExtensions, QueryExecutionProvenance, QueryTableFunctionUsage, QueryTableUsage,
@@ -1769,6 +1770,55 @@ mod tests {
         };
 
         assert_workspace_not_found(error, &missing_workspace);
+    }
+
+    #[tokio::test]
+    async fn load_query_sources_waits_for_state_lock() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let db = test_db(&layout, &config_store).await;
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let workspace_manager = WorkspaceManager::new_for_tests(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+            None,
+            Arc::clone(&db),
+        );
+        let guard = config_store
+            .state_lock_exclusive()
+            .expect("hold exclusive state lock");
+        let manager = QueryManager::new(
+            config_store,
+            workspace_manager,
+            credential_manager,
+            QueryRuntimeContext::default(),
+            layout,
+            WorkspaceLifecycleLock::default(),
+            Vec::new(),
+            db,
+        );
+
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            tokio::runtime::Runtime::new()
+                .expect("runtime")
+                .block_on(manager.load_query_sources(&WorkspaceName::default()))
+                .expect("load query sources");
+            done_tx.send(()).expect("send query load result");
+        });
+
+        assert!(matches!(
+            done_rx.recv_timeout(Duration::from_millis(300)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+        drop(guard);
+        done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("query load should finish after releasing state lock");
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -182,7 +182,7 @@ struct OAuthSourceInstallRequest {
 }
 
 struct SourceRollbackState {
-    source: InstalledSource,
+    credential_revision: Uuid,
     manifest_yaml: Option<String>,
     credential_material: Option<CredentialMaterialSnapshot>,
 }
@@ -672,15 +672,15 @@ impl SourceManager {
             .material_guard(workspace_name, &credential_set_id)?;
         let state_lock = self.config_store.state_lock_exclusive()?;
         let stored = self
-            .config_store
-            .get_source_unlocked(workspace_name, source_name)?;
+            .load_source(workspace_name, source_name)?
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))?;
         let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
         let credential_storage = stored.credential_storage_for_material();
         let credential_material = credential_storage
             .map(|storage| credential_guard.snapshot_material_with_state_lock_held(storage))
             .transpose()?;
         let previous = SourceRollbackState {
-            source: stored,
+            credential_revision: stored.credential_revision,
             manifest_yaml: match removed.origin {
                 SourceOrigin::Bundled => None,
                 SourceOrigin::Imported => Some(std::fs::read_to_string(
@@ -705,26 +705,6 @@ impl SourceManager {
             if let Err(restore_error) = restore_dir_result {
                 return Err(AppError::FailedPrecondition(format!(
                     "failed to remove source credentials for '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
-                    source_dir_backup.backup_path().display()
-                )));
-            }
-            return Err(error);
-        }
-        if let Err(error) = self
-            .config_store
-            .remove_source_unlocked(workspace_name, source_name)
-        {
-            let restore_dir_result = source_dir_backup.restore();
-            self.restore_source_rollback_state_with_state_lock_held(
-                workspace_name,
-                source_name,
-                Some(previous),
-                None,
-                &credential_guard,
-            );
-            if let Err(restore_error) = restore_dir_result {
-                return Err(AppError::FailedPrecondition(format!(
-                    "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
                     source_dir_backup.backup_path().display()
                 )));
             }
@@ -833,7 +813,7 @@ impl SourceManager {
             self.load_source_rollback_state(workspace_name, &source_name, &credential_guard)?;
         let previous_credential_revision = previous
             .as_ref()
-            .map(|state| state.source.credential_revision)
+            .map(|state| state.credential_revision)
             .unwrap_or_default();
         let is_new_install = previous.is_none();
         if let Err(error) =
@@ -1275,7 +1255,7 @@ impl SourceManager {
     ) -> Result<(), AppError> {
         let db = Arc::clone(&self.db);
         let db_workspace_name = workspace_name.clone();
-        let db_source = source.clone();
+        let db_source = source;
         run_source_db_operation(async move {
             let mut tx = db.begin().await?;
             let now_unix_nanos = now_unix_nanos_i64()?;
@@ -1293,8 +1273,6 @@ impl SourceManager {
             tx.commit().await?;
             Ok(())
         })?;
-        self.config_store
-            .upsert_source_unlocked(workspace_name, source)?;
         Ok(())
     }
 
@@ -1462,13 +1440,13 @@ impl SourceManager {
             })
             .transpose()?;
         Ok(Some(SourceRollbackState {
+            credential_revision: source.credential_revision,
             manifest_yaml: match source.origin {
                 SourceOrigin::Bundled => None,
                 SourceOrigin::Imported => Some(std::fs::read_to_string(
                     self.layout.manifest_file(workspace_name, source_name),
                 )?),
             },
-            source,
             credential_material,
         }))
     }
@@ -1518,28 +1496,7 @@ impl SourceManager {
                     }
                 }
             }
-            if let Err(e) = self
-                .config_store
-                .upsert_source_unlocked(workspace_name, previous.source)
-            {
-                warn!("rollback: failed to restore source config: {e}");
-            }
         } else {
-            match self
-                .config_store
-                .get_source_unlocked(workspace_name, source_name)
-            {
-                Ok(_) => {
-                    if let Err(e) = self
-                        .config_store
-                        .remove_source_unlocked(workspace_name, source_name)
-                    {
-                        warn!("rollback: failed to remove new source config: {e}");
-                    }
-                }
-                Err(AppError::SourceNotFound(_)) => {}
-                Err(e) => warn!("rollback: failed to inspect new source config: {e}"),
-            }
             let source_dir = self.layout.source_dir(workspace_name, source_name);
             if source_dir.exists()
                 && let Err(e) = std::fs::remove_dir_all(&source_dir)

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -3899,13 +3899,15 @@ surface:
                 },
             )
             .expect("install source");
+        let db = rusqlite::Connection::open(layout.database_file()).expect("open db");
+        db.execute_batch(
+            "CREATE TRIGGER fail_upsert BEFORE INSERT ON source_variables
+                 BEGIN SELECT RAISE(FAIL, 'injected failure'); END;",
+        )
+        .expect("install failure trigger");
         let refresh_lock = credential_store
             .credential_refresh_lock(&workspace_name, &credential_set_id)
             .expect("hold refresh lock");
-        let config_temp_path = layout
-            .config_file()
-            .with_file_name(format!("config.toml.tmp.{}", std::process::id()));
-        std::fs::create_dir_all(&config_temp_path).expect("block config save temp path");
         let (started_tx, started_rx) = std_mpsc::channel();
         let import_manager = manager.clone();
         let import_workspace = workspace_name.clone();
@@ -3945,8 +3947,8 @@ surface:
         import_handle
             .join()
             .expect("import thread")
-            .expect_err("blocked config save should fail import");
-        drop(std::fs::remove_dir_all(&config_temp_path));
+            .expect_err("blocked database write should fail import");
+        drop(db);
 
         let material = credential_manager
             .read_material(

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -1160,16 +1160,13 @@ mod tests {
     /// act — the reads included. A member is refused outright rather than
     /// handed a redacted view, and a non-member is told nothing.
     ///
-    /// The refusals are proved to be absences rather than error codes. The
-    /// config file on disk is unparseable, so any remaining read of installed
-    /// state chokes on it, and the owner does choke on it: the three lookup
-    /// calls that still read the file, the delete, and the validate all answer
-    /// `Internal` from that read, while database-backed discovery succeeds.
-    /// The manifest description and the three install paths answer
-    /// `InvalidArgument` from the empty manifest, the bundled catalog, and the
-    /// OAuth conversion they reach first. Every refused caller answers
-    /// `PermissionDenied` or `NotFound` instead, and leaves the file with the
-    /// bytes it started with.
+    /// The owner proves the gate let each request through by reaching its
+    /// underlying outcome: database-backed discovery and listing succeed;
+    /// absent get, info, and delete requests answer `NotFound`; validation
+    /// reaches the unparseable config and answers `Internal`; and manifest
+    /// description plus the three install paths answer `InvalidArgument`.
+    /// Every refused caller answers `PermissionDenied` or `NotFound` instead,
+    /// and leaves the file with the bytes it started with.
     #[tokio::test]
     async fn source_configuration_reaches_only_workspace_owners() {
         let fixture = fixture().await;
@@ -1214,7 +1211,7 @@ mod tests {
                 Some(Code::InvalidArgument),
                 Some(Code::InvalidArgument),
                 Some(Code::InvalidArgument),
-                Some(Code::Internal),
+                Some(Code::NotFound),
                 Some(Code::Internal),
             ],
             "the owner must be stopped by the state or the request, never by the gate"

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -284,6 +284,7 @@ impl SourceCatalog {
             .unwrap_or_default()
     }
 
+    #[cfg(test)]
     pub(crate) fn get_source(
         &self,
         workspace_name: &WorkspaceName,
@@ -306,6 +307,7 @@ impl SourceCatalog {
             .insert(source.name.clone(), source);
     }
 
+    #[cfg(test)]
     pub(crate) fn remove_source(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -562,13 +564,13 @@ impl ConfigStore {
         self.load_config_unlocked()
     }
 
-    /// Loads the source catalog without taking the app state lock.
-    ///
-    /// Callers must already hold the state lock in shared or exclusive mode
-    /// while using any filesystem-backed source artifacts derived from the
-    /// returned catalog.
-    pub(crate) fn load_catalog_unlocked(&self) -> Result<SourceCatalog, AppError> {
-        self.load_config_unlocked().map(|config| config.catalog)
+    pub(crate) fn clear_source_catalog_unlocked(&self) -> Result<(), AppError> {
+        let mut config = self.load_unlocked()?;
+        if config.catalog.0.is_empty() {
+            return Ok(());
+        }
+        config.catalog = SourceCatalog::default();
+        self.save_unlocked(&config)
     }
 
     fn update_config_unlocked<T>(
@@ -588,13 +590,6 @@ impl ConfigStore {
     ) -> Result<T, AppError> {
         let _lock = self.state_lock_exclusive()?;
         self.update_config_unlocked(update)
-    }
-
-    fn update_catalog_unlocked<T>(
-        &self,
-        update: impl FnOnce(&mut SourceCatalog) -> T,
-    ) -> Result<T, AppError> {
-        self.update_config_unlocked(|config| Ok(update(&mut config.catalog)))
     }
 
     #[cfg(test)]
@@ -697,19 +692,6 @@ impl ConfigStore {
         let _lock = self.state_lock_exclusive()?;
         self.restore_workspace_config_entries_unlocked(removed)
     }
-    /// Loads one installed source without taking the app state lock.
-    ///
-    /// Callers must already hold the state lock while using source artifacts
-    /// associated with the returned config entry.
-    pub(crate) fn get_source_unlocked(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Result<InstalledSource, AppError> {
-        self.load_catalog_unlocked()?
-            .get_source(workspace_name, source_name)
-            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
-    }
 
     #[cfg(test)]
     pub(crate) fn get_source(
@@ -724,17 +706,6 @@ impl ConfigStore {
             .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }
 
-    /// Upserts one installed source without taking the app state lock.
-    ///
-    /// Callers must already hold the state lock in exclusive mode.
-    pub(crate) fn upsert_source_unlocked(
-        &self,
-        workspace_name: &WorkspaceName,
-        source: InstalledSource,
-    ) -> Result<(), AppError> {
-        self.update_catalog_unlocked(|catalog| catalog.upsert_source(workspace_name, source))
-    }
-
     #[cfg(test)]
     pub(crate) fn upsert_source(
         &self,
@@ -744,19 +715,6 @@ impl ConfigStore {
         self.update_config(|config| {
             config.catalog.upsert_source(workspace_name, source);
             Ok(())
-        })
-    }
-
-    /// Removes one installed source without taking the app state lock.
-    ///
-    /// Callers must already hold the state lock in exclusive mode.
-    pub(crate) fn remove_source_unlocked(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Result<(), AppError> {
-        self.update_catalog_unlocked(|catalog| {
-            catalog.remove_source(workspace_name, source_name);
         })
     }
 

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -193,6 +193,7 @@ async fn import_config_source_catalog(
         .collect::<Vec<_>>();
     let source_count = import_config_sources(&mut tx, &source_entries, now_unix_nanos).await?;
     tx.commit().await?;
+    clear_legacy_source_catalog_config(config_store, source_entries.len());
 
     Ok(SourceCatalogImportReport {
         source_count,
@@ -290,6 +291,16 @@ where
     )))
 }
 
+fn clear_legacy_source_catalog_config(config_store: &ConfigStore, source_count: usize) {
+    if source_count != 0
+        && let Err(error) = config_store.clear_source_catalog_unlocked()
+    {
+        tracing::warn!(
+            detail = %error,
+            "source catalog imported into database but legacy config cleanup failed"
+        );
+    }
+}
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -363,7 +374,7 @@ mod tests {
                 .get_source(&workspace, &source.name)
                 .await
                 .expect("get source"),
-            Some(source)
+            Some(source.clone())
         );
         assert!(
             session
@@ -379,6 +390,10 @@ mod tests {
                 .await
                 .expect("read source import marker")
         );
+        assert!(matches!(
+            config_store.get_source(&workspace, &source.name),
+            Err(crate::bootstrap::AppError::SourceNotFound(_))
+        ));
     }
 
     #[tokio::test]
@@ -481,8 +496,12 @@ mod tests {
                 .get_source(&workspace, &existing.name)
                 .await
                 .expect("get preserved source"),
-            Some(existing)
+            Some(existing.clone())
         );
+        assert!(matches!(
+            config_store.get_source(&workspace, &existing.name),
+            Err(crate::bootstrap::AppError::SourceNotFound(_))
+        ));
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -580,6 +580,78 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cleanup_failure_does_not_fail_committed_source_import() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let db_path = temp.path().join("db").join("coral.db");
+        fs::create_dir_all(db_path.parent().expect("db parent")).expect("create db dir");
+        fs::write(
+            layout.config_file(),
+            format!(
+                "[database]\nbackend = \"sqlite\"\npath = \"{}\"\n",
+                db_path.display()
+            ),
+        )
+        .expect("write database config");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        drop(
+            config_store
+                .state_lock_exclusive()
+                .expect("create state lock before read-only config dir"),
+        );
+        let db = open_sqlite(&layout).await;
+        cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 10)
+            .await
+            .expect("cut over legacy workspace catalog");
+
+        fs::set_permissions(layout.config_dir(), fs::Permissions::from_mode(0o500))
+            .expect("make config dir read-only");
+        let report = import_config_source_catalog(&db, &config_store, 11).await;
+        fs::set_permissions(layout.config_dir(), fs::Permissions::from_mode(0o700))
+            .expect("restore config dir permissions");
+
+        assert_eq!(
+            report.expect("cleanup failure should not fail committed source import"),
+            SourceCatalogImportReport {
+                source_count: 1,
+                import_performed: true,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get imported source"),
+            Some(source.clone())
+        );
+        assert!(
+            session
+                .state_migrations()
+                .has_completed(SOURCE_CATALOG_IMPORT_ID)
+                .await
+                .expect("read source import marker")
+        );
+        assert_eq!(
+            config_store
+                .get_source(&workspace, &source.name)
+                .expect("legacy config source should remain after cleanup failure"),
+            source
+        );
+    }
+
     #[tokio::test]
     async fn shared_database_imports_each_local_source_catalog_once() {
         let temp = tempdir().expect("temp dir");

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -7,6 +7,7 @@ use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId};
 use crate::identity::Principal;
 use crate::sources::materialization::SourceDiagnosticReporter;
+use crate::sources::model::InstalledSource;
 use crate::state::db::{
     AddMemberOutcome, CoralDb, CreateWorkspaceOutcome, DbError, DbRepos, RemoveMemberOutcome,
     WorkspaceDeletion, WorkspaceMemberRecord, now_unix_nanos_i64,
@@ -168,6 +169,17 @@ impl WorkspaceManager {
             // two processes sharing one config directory deadlock across the
             // file lock and the database.
             let state_lock = self.config_store.state_lock_exclusive()?;
+            // Captured before the deletion transaction removes the workspace row,
+            // which cascades the source rows away. The exclusive state lock is
+            // already held, so the catalog cannot change between this read and
+            // the delete.
+            let db_sources = {
+                let mut session = self.db.as_ref();
+                session
+                    .sources()
+                    .list_workspace_sources(workspace_name)
+                    .await?
+            };
             let Some(deletion) = self
                 .db
                 .begin_workspace_deletion(workspace_name.as_str())
@@ -213,6 +225,7 @@ impl WorkspaceManager {
                 },
                 RemovedWorkspaceConfig::into_deleted_workspace,
             );
+            let deleted = Self::merge_deleted_sources(deleted, db_sources);
             self.pool_registry.remove(workspace_name);
             // Credential cleanup re-acquires the state lock through the file
             // credential backend, and `flock` conflicts per open file
@@ -240,6 +253,22 @@ impl WorkspaceManager {
         self.prune_deleted_workspace_traces(&deleted_workspace_name)
             .await;
         Ok(deleted.workspace)
+    }
+
+    fn merge_deleted_sources(
+        mut deleted: DeletedWorkspace,
+        db_sources: Vec<InstalledSource>,
+    ) -> DeletedWorkspace {
+        for source in db_sources {
+            if !deleted
+                .sources
+                .iter()
+                .any(|existing| existing.name == source.name)
+            {
+                deleted.sources.push(source);
+            }
+        }
+        deleted
     }
 
     /// Erases the credential material of a workspace that has just been deleted.

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -31,7 +31,7 @@ pub(crate) struct GrpcHarness {
     config_dir: PathBuf,
     local_trace_store_dir: Option<PathBuf>,
     app: AppClient,
-    _server: RunningServer,
+    server: RunningServer,
 }
 
 pub(crate) struct FailingHttpFixture {
@@ -89,6 +89,19 @@ impl GrpcHarness {
         .await
     }
 
+    pub(crate) async fn shutdown(self) {
+        let Self {
+            temp_dir,
+            config_dir,
+            local_trace_store_dir,
+            app,
+            server,
+        } = self;
+        drop(app);
+        server.shutdown().await.expect("shutdown server");
+        drop((temp_dir, config_dir, local_trace_store_dir));
+    }
+
     async fn start_with_parts(
         temp_dir: TempDir,
         config_dir: PathBuf,
@@ -125,7 +138,7 @@ impl GrpcHarness {
             config_dir,
             local_trace_store_dir,
             app,
-            _server: server,
+            server,
         }
     }
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -46,8 +46,7 @@ async fn import_source_persists_and_lists() {
 
     let config_raw =
         fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
-    assert!(config_raw.contains("[workspaces.default.sources.local_messages]"));
-    assert!(config_raw.contains("secrets = []"));
+    assert!(!config_raw.contains("[workspaces.default.sources.local_messages]"));
     assert!(!config_raw.contains("credential_storage"));
     assert!(!config_raw.contains("credential_set_id"));
     assert!(!config_raw.contains("[workspaces.default.credentials"));
@@ -96,6 +95,83 @@ async fn list_and_get_sources_read_database_after_config_becomes_invalid() {
         .source
         .expect("source response");
     assert_eq!(fetched.name, "local_messages");
+}
+
+#[tokio::test]
+async fn startup_import_preserves_non_default_workspace_sources() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"version = 1
+
+[workspaces.default.sources.default_messages]
+version = "0.1.0"
+variables = {}
+secrets = []
+origin = "imported"
+
+[workspaces.analytics.sources.analytics_messages]
+version = "0.1.0"
+variables = {}
+secrets = []
+origin = "imported"
+"#,
+    )
+    .expect("write config");
+
+    let default_manifest =
+        fixture_manifest_yaml(temp.path()).replace("local_messages", "default_messages");
+    let default_manifest_path = source_dir(&config_dir, "default_messages").join("manifest.yaml");
+    fs::create_dir_all(
+        default_manifest_path
+            .parent()
+            .expect("default manifest parent"),
+    )
+    .expect("create default source dir");
+    fs::write(default_manifest_path, default_manifest).expect("write default manifest");
+
+    let analytics_manifest =
+        fixture_manifest_yaml(temp.path()).replace("local_messages", "analytics_messages");
+    let analytics_manifest_path = config_dir
+        .join("workspaces")
+        .join("analytics")
+        .join("sources")
+        .join("analytics_messages")
+        .join("manifest.yaml");
+    fs::create_dir_all(
+        analytics_manifest_path
+            .parent()
+            .expect("analytics manifest parent"),
+    )
+    .expect("create analytics source dir");
+    fs::write(analytics_manifest_path, analytics_manifest).expect("write analytics manifest");
+
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+
+    let default_sources = harness.list_sources().await;
+    assert_eq!(default_sources.len(), 1);
+    assert_eq!(default_sources[0].name, "default_messages");
+
+    let analytics_sources = harness
+        .source_client()
+        .list_sources(Request::new(coral_api::v1::ListSourcesRequest {
+            workspace: Some(Workspace {
+                name: "analytics".to_string(),
+            }),
+        }))
+        .await
+        .expect("list analytics sources")
+        .into_inner()
+        .sources;
+    assert_eq!(analytics_sources.len(), 1);
+    assert_eq!(analytics_sources[0].name, "analytics_messages");
+
+    let config_raw =
+        fs::read_to_string(config_dir.join("config.toml")).expect("read cleaned config");
+    assert!(!config_raw.contains("[workspaces.default.sources.default_messages]"));
+    assert!(!config_raw.contains("[workspaces.analytics.sources.analytics_messages]"));
 }
 
 #[tokio::test]
@@ -1585,15 +1661,13 @@ origin = "imported"
         "trace history retention should be preserved"
     );
 
-    // The pre-existing source must still be present.
+    // Source catalog state is migrated to DB, not kept in config.
     assert!(
-        config_raw.contains("[workspaces.default.sources.demo]"),
-        "pre-existing source should be preserved"
+        !config_raw.contains("[workspaces.default.sources.demo]"),
+        "pre-existing source should be removed from config after DB import"
     );
-
-    // The newly imported source must now also be present.
     assert!(
-        config_raw.contains("[workspaces.default.sources.local_messages]"),
-        "newly added source should be in config"
+        !config_raw.contains("[workspaces.default.sources.local_messages]"),
+        "newly added source should not be mirrored to config"
     );
 }

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -98,80 +98,48 @@ async fn list_and_get_sources_read_database_after_config_becomes_invalid() {
 }
 
 #[tokio::test]
-async fn startup_import_preserves_non_default_workspace_sources() {
+async fn startup_import_lists_non_default_legacy_config_source() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
     fs::create_dir_all(&config_dir).expect("create config dir");
     fs::write(
         config_dir.join("config.toml"),
-        r#"version = 1
-
-[workspaces.default.sources.default_messages]
-version = "0.1.0"
-variables = {}
-secrets = []
-origin = "imported"
-
-[workspaces.analytics.sources.analytics_messages]
-version = "0.1.0"
-variables = {}
-secrets = []
-origin = "imported"
-"#,
+        "[workspaces.analytics.sources.analytics_messages]\norigin = \"imported\"\n",
     )
     .expect("write config");
-
-    let default_manifest =
-        fixture_manifest_yaml(temp.path()).replace("local_messages", "default_messages");
-    let default_manifest_path = source_dir(&config_dir, "default_messages").join("manifest.yaml");
-    fs::create_dir_all(
-        default_manifest_path
-            .parent()
-            .expect("default manifest parent"),
+    let source_dir = config_dir.join("workspaces/analytics/sources/analytics_messages");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(
+        source_dir.join("manifest.yaml"),
+        fixture_manifest_yaml(temp.path()).replace("local_messages", "analytics_messages"),
     )
-    .expect("create default source dir");
-    fs::write(default_manifest_path, default_manifest).expect("write default manifest");
-
-    let analytics_manifest =
-        fixture_manifest_yaml(temp.path()).replace("local_messages", "analytics_messages");
-    let analytics_manifest_path = config_dir
-        .join("workspaces")
-        .join("analytics")
-        .join("sources")
-        .join("analytics_messages")
-        .join("manifest.yaml");
-    fs::create_dir_all(
-        analytics_manifest_path
-            .parent()
-            .expect("analytics manifest parent"),
-    )
-    .expect("create analytics source dir");
-    fs::write(analytics_manifest_path, analytics_manifest).expect("write analytics manifest");
-
+    .expect("write analytics manifest");
     let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
-
-    let default_sources = harness.list_sources().await;
-    assert_eq!(default_sources.len(), 1);
-    assert_eq!(default_sources[0].name, "default_messages");
-
-    let analytics_sources = harness
+    let sources = harness
         .source_client()
         .list_sources(Request::new(coral_api::v1::ListSourcesRequest {
             workspace: Some(Workspace {
-                name: "analytics".to_string(),
+                name: "analytics".into(),
             }),
         }))
         .await
         .expect("list analytics sources")
         .into_inner()
         .sources;
-    assert_eq!(analytics_sources.len(), 1);
-    assert_eq!(analytics_sources[0].name, "analytics_messages");
-
-    let config_raw =
-        fs::read_to_string(config_dir.join("config.toml")).expect("read cleaned config");
-    assert!(!config_raw.contains("[workspaces.default.sources.default_messages]"));
-    assert!(!config_raw.contains("[workspaces.analytics.sources.analytics_messages]"));
+    assert_eq!(sources.len(), 1);
+    assert_eq!(sources[0].name, "analytics_messages");
+    let validated = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(Workspace {
+                name: "analytics".into(),
+            }),
+            name: "analytics_messages".into(),
+        }))
+        .await
+        .expect("validate analytics source")
+        .into_inner();
+    assert_eq!(validated.tables[0].schema_name, "analytics_messages");
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -386,6 +386,82 @@ async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
         !raw.contains("[workspaces.work"),
         "deleted workspace should be removed from config: {raw}"
     );
+
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("recreate workspace");
+    let sources = harness
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("list recreated workspace sources")
+        .into_inner()
+        .sources;
+    assert!(sources.is_empty(), "deleted DB sources should not reappear");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn delete_workspace_restores_db_sources_when_config_delete_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let db_path = temp.path().join("db").join("coral.db");
+    fs::create_dir_all(db_path.parent().expect("db parent")).expect("create db dir");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            "[database]\nbackend = \"sqlite\"\npath = \"{}\"\n",
+            db_path.display()
+        ),
+    )
+    .expect("write database config");
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("create workspace");
+    import_source_in_workspace(
+        &harness,
+        "work",
+        fixture_manifest_yaml(harness.temp_path()),
+        Vec::new(),
+        Vec::new(),
+    )
+    .await;
+    fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o500))
+        .expect("make config dir read-only");
+    let result = harness
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await;
+    fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o700))
+        .expect("restore config dir permissions");
+
+    result.expect_err("config delete should fail");
+    let sources = harness
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("list restored workspace sources")
+        .into_inner()
+        .sources;
+    assert!(sources.iter().any(|source| source.name == "local_messages"));
 }
 
 #[tokio::test]
@@ -634,6 +710,8 @@ async fn delete_workspace_removes_state_when_trace_cleanup_fails() {
 #[tokio::test]
 async fn delete_workspace_ignores_stale_trace_files_when_trace_history_disabled() {
     let _trace_store_guard = TRACE_STORE_DELETE_TEST_LOCK.lock().await;
+    GrpcHarness::new().await.shutdown().await;
+
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
     fs::create_dir_all(config_dir.join("telemetry").join("traces")).expect("create trace dir");


### PR DESCRIPTION
## Intent

Remove the temporary dual-source behavior after source catalog import, source service, query loading, and MCP source-name reads all use the DB.

## What it enables

Successful non-empty legacy import marks the config source catalog as consumed in the DB, clears legacy source catalog sections from `config.toml` when possible, and production source add/delete no longer mirrors installed source records back to config. If config cleanup fails after DB commit, later startup will not reimport stale config and resurrect deleted or overwritten DB catalog state. Empty legacy catalogs do not write the completion marker, so rollback-created config sources can still be imported on a later upgrade.

The one-way source-catalog migration and recovery path for older config-backed builds are now documented in README and the docs local-state/configuration pages.

## Usage examples

After importing or adding sources, current Coral reads installed-source metadata from the local DB instead of `[workspaces.*.sources.*]` config entries. If an older config-backed build must be run after migration, re-add bundled sources with `coral source add <NAME>` or imported sources with `coral source add --file <PATH>` using the existing manifest under the local state directory.

## Testing

- `make rust-checks`
- `make docs-check`
- `cargo test --locked -p coral-app state::db::import::tests -- --nocapture`
- `cargo test --locked -p coral-app bootstrap::tests::mcp_startup_context_imports_legacy_config_sources_into_database -- --exact --nocapture`
- `cargo test --locked -p coral-app --test grpc oauth_refresh_tests -- --nocapture`
- `cargo test --locked -p coral-app --test grpc source_lifecycle_tests::startup_import_preserves_non_default_workspace_sources -- --exact --nocapture`
- Review swarm, final stack run: `.context/review-swarm/20260630T170813Z-sauldhernandez-rdbms-source-catalog-cleanup-branch`; accepted findings: none. Supervisor rejected the credential-refresh/delete race finding because both paths share the credential refresh lock.

Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.