### PR TITLE
feat(app): persist imported manifests in database

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -33,7 +33,8 @@ use crate::query::input_resolver::{
 };
 use crate::search::observed::{SearchObservationHandle, SearchObservationSource};
 use crate::sources::catalog::{
-    resolve_installed_manifest, validate_imported_manifest_database_persistence,
+    load_bundled_source, resolve_installed_manifest_from_yaml,
+    validate_imported_manifest_database_persistence,
 };
 use crate::sources::materialization::{SourceDiagnosticReporter, SourceLoadDiagnosticStage};
 use crate::sources::model::{InstalledSource, SourceOrigin};
@@ -597,6 +598,7 @@ impl QueryManager {
                 .map_err(QueryManagerError::App)?;
             let (loaded_source, version) = self
                 .load_query_source(workspace_name, &source)
+                .await
                 .map_err(QueryManagerError::App)?;
             (source, loaded_source, version, config)
         };
@@ -628,7 +630,9 @@ impl QueryManager {
         let _state_lock = self.config_store.state_lock_shared()?;
         let config = self.config_store.load_config_unlocked()?;
         let installed_sources = self.installed_sources(workspace_name).await?;
-        let sources = self.load_query_sources_from_installed(workspace_name, installed_sources);
+        let sources = self
+            .load_query_sources_from_installed(workspace_name, installed_sources)
+            .await;
         Ok((sources, config))
     }
 
@@ -663,7 +667,34 @@ impl QueryManager {
             .map_err(AppError::from)
     }
 
-    fn load_query_sources_from_installed(
+    async fn resolve_source_manifest(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<crate::sources::catalog::InstalledSourceManifest, AppError> {
+        let manifest_yaml = match source.origin {
+            crate::sources::model::SourceOrigin::Bundled => {
+                load_bundled_source(&source.name)?.manifest_yaml
+            }
+            crate::sources::model::SourceOrigin::Imported => {
+                let mut session = self.db.as_ref();
+                session
+                    .source_manifests()
+                    .get(workspace_name, &source.name)
+                    .await?
+                    .map(|record| record.manifest_yaml)
+                    .ok_or_else(|| {
+                        AppError::SourceNotFound(format!(
+                            "manifest for imported source '{workspace_name}:{}'",
+                            source.name
+                        ))
+                    })?
+            }
+        };
+        resolve_installed_manifest_from_yaml(source, &manifest_yaml)
+    }
+
+    async fn load_query_sources_from_installed(
         &self,
         workspace_name: &WorkspaceName,
         installed_sources: Vec<InstalledSource>,
@@ -677,30 +708,34 @@ impl QueryManager {
             coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE,
             workspace_name.as_str(),
         );
-        let _guard = span.enter();
-        let mut loaded_sources = Vec::new();
-        let mut failed_source_names = BTreeSet::new();
-        for source in installed_sources {
-            match self.load_query_source(workspace_name, &source) {
-                Ok((loaded_source, _version)) => {
-                    self.diagnostic_reporter.clear_source_load_failure(
-                        SourceLoadDiagnosticStage::Query,
-                        workspace_name,
-                        &source.name,
-                    );
-                    loaded_sources.push(loaded_source);
-                }
-                Err(error) => {
-                    failed_source_names.insert(source.name.to_string());
-                    self.diagnostic_reporter.report_source_load_failure(
-                        SourceLoadDiagnosticStage::Query,
-                        workspace_name,
-                        &source.name,
-                        &error.to_string(),
-                    );
+        let (loaded_sources, failed_source_names) = async {
+            let mut loaded_sources = Vec::new();
+            let mut failed_source_names = BTreeSet::new();
+            for source in installed_sources {
+                match self.load_query_source(workspace_name, &source).await {
+                    Ok((loaded_source, _version)) => {
+                        self.diagnostic_reporter.clear_source_load_failure(
+                            SourceLoadDiagnosticStage::Query,
+                            workspace_name,
+                            &source.name,
+                        );
+                        loaded_sources.push(loaded_source);
+                    }
+                    Err(error) => {
+                        failed_source_names.insert(source.name.to_string());
+                        self.diagnostic_reporter.report_source_load_failure(
+                            SourceLoadDiagnosticStage::Query,
+                            workspace_name,
+                            &source.name,
+                            &error.to_string(),
+                        );
+                    }
                 }
             }
+            (loaded_sources, failed_source_names)
         }
+        .instrument(span.clone())
+        .await;
         span.record("source.count", loaded_sources.len());
         QuerySourceLoad {
             loaded: loaded_sources,
@@ -708,12 +743,12 @@ impl QueryManager {
         }
     }
 
-    fn load_query_source(
+    async fn load_query_source(
         &self,
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
     ) -> Result<(LoadedQuerySource, Option<String>), AppError> {
-        let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
+        let installed = self.resolve_source_manifest(workspace_name, source).await?;
         let source_spec = &installed.source_spec;
         ensure_database_source_feature_enabled(source_spec, self.database_sources_enabled)?;
         if source.origin == SourceOrigin::Imported {
@@ -1007,8 +1042,9 @@ impl QueryManager {
                 .config_store
                 .load_config_unlocked()
                 .map_err(QueryManagerError::App)?;
-            let source_load =
-                self.load_query_sources_from_installed(workspace_name, installed_sources);
+            let source_load = self
+                .load_query_sources_from_installed(workspace_name, installed_sources)
+                .await;
             (source_load.loaded, config)
         };
         Ok((loaded_sources, config))
@@ -1749,6 +1785,15 @@ mod tests {
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
     ) {
+        upsert_test_source_with_manifest(db, workspace_name, source, None).await;
+    }
+
+    async fn upsert_test_source_with_manifest(
+        db: &Arc<CoralDb>,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        manifest_yaml: Option<&str>,
+    ) {
         let mut tx = db.begin().await.expect("begin test source tx");
         tx.workspaces()
             .ensure(workspace_name.as_str(), 11)
@@ -1758,6 +1803,12 @@ mod tests {
             .upsert_source(workspace_name, source, 11)
             .await
             .expect("upsert test source");
+        if let Some(manifest_yaml) = manifest_yaml {
+            tx.source_manifests()
+                .upsert(workspace_name, &source.name, manifest_yaml, 11)
+                .await
+                .expect("upsert test source manifest");
+        }
         tx.commit().await.expect("commit test source");
     }
 
@@ -2690,15 +2741,7 @@ select text from function_demo.messages
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = test_workspace();
         let source_name = SourceName::parse("optional_auth").expect("source name");
-        let manifest_path = fixture
-            .manager
-            .layout
-            .manifest_file(&workspace_name, &source_name);
-        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
-            .expect("create source dir");
-        std::fs::write(
-            &manifest_path,
-            r"
+        let manifest_yaml = r"
 name: optional_auth
 version: 0.1.0
 dsl_version: 3
@@ -2729,9 +2772,7 @@ tables:
     columns:
       - name: id
         type: Utf8
-",
-        )
-        .expect("write manifest");
+";
         let source = InstalledSource {
             name: source_name.clone(),
             version: Some("0.1.0".to_string()),
@@ -2741,11 +2782,13 @@ tables:
             credential_revision: uuid::Uuid::default(),
             origin: SourceOrigin::Imported,
         };
-        fixture
-            .manager
-            .config_store
-            .upsert_source(&workspace_name, source.clone())
-            .expect("persist source");
+        upsert_test_source_with_manifest(
+            &fixture.manager.db,
+            &workspace_name,
+            &source,
+            Some(manifest_yaml),
+        )
+        .await;
         fixture
             .manager
             .credential_manager
@@ -2760,6 +2803,7 @@ tables:
         let (loaded_source, _) = fixture
             .manager
             .load_query_source(&workspace_name, &source)
+            .await
             .expect("optional secret should load when present");
 
         assert_eq!(
@@ -2924,15 +2968,7 @@ tables:
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = WorkspaceName::default();
         let source_name = SourceName::parse("transport_guard").expect("source name");
-        let manifest_path = fixture
-            .manager
-            .layout
-            .manifest_file(&workspace_name, &source_name);
-        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
-            .expect("create source dir");
-        std::fs::write(
-            &manifest_path,
-            r#"
+        let manifest_yaml = r#"
 name: transport_guard
 version: 0.1.0
 dsl_version: 3
@@ -2957,9 +2993,7 @@ tables:
     columns:
       - name: id
         type: Utf8
-"#,
-        )
-        .expect("write manifest");
+"#;
         let source = InstalledSource {
             name: source_name.clone(),
             version: Some("0.1.0".to_string()),
@@ -2972,10 +3006,18 @@ tables:
             credential_revision: uuid::Uuid::default(),
             origin: SourceOrigin::Imported,
         };
+        upsert_test_source_with_manifest(
+            &fixture.manager.db,
+            &workspace_name,
+            &source,
+            Some(manifest_yaml),
+        )
+        .await;
 
         let error = fixture
             .manager
             .load_query_source(&workspace_name, &source)
+            .await
             .expect_err("persisted imported cleartext credential endpoint should fail");
 
         assert!(error.to_string().contains("base_url must use https"));
@@ -3191,6 +3233,7 @@ surface:
         let error = fixture
             .manager
             .load_query_source(&workspace_name, &source)
+            .await
             .expect_err("identity-gated source must fail closed");
 
         assert!(matches!(
@@ -3652,20 +3695,13 @@ tables:
         workspace_name: &WorkspaceName,
     ) -> SourceName {
         let source_name = SourceName::parse("github_v4_missing_artifacts").expect("source name");
-        let manifest_path = manager.layout.manifest_file(workspace_name, &source_name);
-        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
-            .expect("create source dir");
-        std::fs::write(
-            &manifest_path,
-            r"
+        let manifest_yaml = r"
 name: github_v4_missing_artifacts
 dsl_version: 4
 surface:
     type: openapi
     url: https://example.com/openapi.yaml
-",
-        )
-        .expect("write manifest");
+";
         let source = InstalledSource {
             name: source_name.clone(),
             version: None,
@@ -3675,7 +3711,8 @@ surface:
             credential_revision: uuid::Uuid::default(),
             origin: SourceOrigin::Imported,
         };
-        upsert_test_source(&manager.db, workspace_name, &source).await;
+        upsert_test_source_with_manifest(&manager.db, workspace_name, &source, Some(manifest_yaml))
+            .await;
         source_name
     }
 
@@ -3690,12 +3727,7 @@ surface:
             .expect("write corrupt parquet");
 
         let source_name = SourceName::parse("corrupt_parquet").expect("source name");
-        let manifest_path = manager.layout.manifest_file(workspace_name, &source_name);
-        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
-            .expect("create source dir");
-        std::fs::write(
-            &manifest_path,
-            r#"
+        let manifest_yaml = r#"
 name: corrupt_parquet
 version: 0.1.0
 dsl_version: 3
@@ -3708,10 +3740,8 @@ tables:
       location: file://~/corrupt-parquet/
       glob: "**/*.parquet"
     columns: []
-"#,
-        )
-        .expect("write manifest");
-        upsert_test_source(
+"#;
+        upsert_test_source_with_manifest(
             &manager.db,
             workspace_name,
             &InstalledSource {
@@ -3723,6 +3753,7 @@ tables:
                 credential_revision: uuid::Uuid::default(),
                 origin: SourceOrigin::Imported,
             },
+            Some(manifest_yaml),
         )
         .await;
         source_name
@@ -4200,14 +4231,7 @@ tables:
             credential_revision: uuid::Uuid::new_v4(),
             origin: SourceOrigin::Imported,
         };
-        std::fs::create_dir_all(fixture.manager.layout.source_dir(&workspace, &source_name))
-            .expect("source directory");
-        std::fs::write(
-            fixture
-                .manager
-                .layout
-                .manifest_file(&workspace, &source_name),
-            r"
+        let manifest_yaml = r"
 name: secured_messages
 version: 0.1.0
 dsl_version: 3
@@ -4224,15 +4248,14 @@ tables:
     columns:
       - name: id
         type: Utf8
-",
+";
+        upsert_test_source_with_manifest(
+            &fixture.manager.db,
+            &workspace,
+            &installed_source,
+            Some(manifest_yaml),
         )
-        .expect("write manifest");
-        fixture
-            .manager
-            .config_store
-            .upsert_source(&workspace, installed_source.clone())
-            .expect("persist source");
-        upsert_test_source(&fixture.manager.db, &workspace, &installed_source).await;
+        .await;
         fixture
             .manager
             .credential_manager
@@ -4246,6 +4269,7 @@ tables:
         let first = fixture
             .manager
             .load_query_source(&workspace, &installed_source)
+            .await
             .expect("first runtime")
             .0;
 
@@ -4262,6 +4286,7 @@ tables:
         let refreshed = fixture
             .manager
             .load_query_source(&workspace, &installed_source)
+            .await
             .expect("refreshed runtime")
             .0;
 

--- a/crates/coral-app/src/search/observed/live_scope.rs
+++ b/crates/coral-app/src/search/observed/live_scope.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 use crate::bootstrap::AppError;
 use crate::search::observed::source_scope::{SourceScopeSeed, source_surface_scopes};
 use crate::search::observed::{ObservedValuesLiveScope, ObservedValuesLiveScopeLoadFailure};
-use crate::sources::catalog::resolve_installed_manifest;
+use crate::sources::catalog::{load_bundled_source, resolve_installed_manifest_from_yaml};
 use crate::sources::materialization::SourceDiagnosticReporter;
-use crate::sources::model::InstalledSource;
+use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::sources::runtime_package::query_source_from_installed_manifest;
 use crate::state::db::{CoralDb, DbRepos};
 use crate::state::{AppStateLayout, ConfigStore};
@@ -59,10 +59,10 @@ impl ObservedValuesLiveScopeLoader {
                 .list_workspace_sources(workspace_name)
                 .await?
         };
-        Ok(self.load_sources(workspace_name, sources))
+        Ok(self.load_sources(workspace_name, sources).await)
     }
 
-    fn load_sources(
+    async fn load_sources(
         &self,
         workspace_name: &WorkspaceName,
         sources: Vec<InstalledSource>,
@@ -71,7 +71,7 @@ impl ObservedValuesLiveScopeLoader {
         let mut failed_sources = Vec::new();
         for source in sources {
             let source_name = source.name.as_str().to_string();
-            match self.load_source_scopes(workspace_name, &source) {
+            match self.load_source_scopes(workspace_name, &source).await {
                 Ok(source_scopes) => live_scopes.extend(source_scopes),
                 Err(error) => {
                     tracing::debug!(
@@ -93,12 +93,29 @@ impl ObservedValuesLiveScopeLoader {
         }
     }
 
-    fn load_source_scopes(
+    async fn load_source_scopes(
         &self,
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
     ) -> Result<Vec<ObservedValuesLiveScope>, AppError> {
-        let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
+        let manifest_yaml = match source.origin {
+            SourceOrigin::Bundled => load_bundled_source(&source.name)?.manifest_yaml,
+            SourceOrigin::Imported => {
+                let mut session = self.db.as_ref();
+                session
+                    .source_manifests()
+                    .get(workspace_name, &source.name)
+                    .await?
+                    .map(|record| record.manifest_yaml)
+                    .ok_or_else(|| {
+                        AppError::SourceNotFound(format!(
+                            "manifest for imported source '{workspace_name}:{}'",
+                            source.name
+                        ))
+                    })?
+            }
+        };
+        let installed = resolve_installed_manifest_from_yaml(source, &manifest_yaml)?;
         let loaded_runtime = query_source_from_installed_manifest(
             &self.layout,
             workspace_name,
@@ -155,6 +172,8 @@ mod tests {
             "/search/issues",
         );
         let db = test_db(&layout, &config_store).await;
+        std::fs::remove_file(layout.manifest_file(&workspace, &source))
+            .expect("remove legacy manifest");
         config_store
             .remove_source(&workspace, &source)
             .expect("remove legacy config source");
@@ -179,20 +198,29 @@ mod tests {
         let config_store = ConfigStore::new(layout.clone());
         let workspace = WorkspaceName::parse("work").expect("workspace");
         let source = SourceName::parse("github").expect("source");
-        install_source(&layout, &config_store, &workspace, &source, "/repos/issues");
+        let installed =
+            install_source(&layout, &config_store, &workspace, &source, "/repos/issues");
         let db = test_db(&layout, &config_store).await;
+        std::fs::remove_file(layout.manifest_file(&workspace, &source))
+            .expect("remove legacy manifest");
         config_store
             .remove_source(&workspace, &source)
             .expect("remove legacy config source");
         let loader = ObservedValuesLiveScopeLoader::new(
             layout.clone(),
             config_store,
-            db,
+            Arc::clone(&db),
             SourceDiagnosticReporter::default(),
         );
 
         let first = loader.load(&workspace).await.expect("first live scope");
-        write_source_manifest(&layout, &workspace, &source, "/search/issues");
+        upsert_test_source_with_manifest(
+            &db,
+            &workspace,
+            &installed,
+            &source_manifest_yaml(&source, "/search/issues"),
+        )
+        .await;
         let second = loader.load(&workspace).await.expect("second live scope");
 
         assert!(first.failed_sources.is_empty());
@@ -331,14 +359,20 @@ mod tests {
             &github,
             "/search/issues",
         );
-        install_broken_source(&layout, &config_store, &workspace, &broken);
         let db = test_db(&layout, &config_store).await;
+        let broken_source = InstalledSource {
+            name: broken.clone(),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            credential_revision: Uuid::default(),
+            origin: SourceOrigin::Imported,
+        };
+        upsert_test_source_with_manifest(&db, &workspace, &broken_source, "name: [").await;
         config_store
             .remove_source(&workspace, &github)
             .expect("remove healthy legacy config source");
-        config_store
-            .remove_source(&workspace, &broken)
-            .expect("remove broken legacy config source");
         let loader = ObservedValuesLiveScopeLoader::new(
             layout,
             config_store,
@@ -388,8 +422,14 @@ mod tests {
         std::fs::create_dir_all(layout.source_dir(workspace, source)).expect("source dir");
         std::fs::write(
             layout.manifest_file(workspace, source),
-            format!(
-                r"
+            source_manifest_yaml(source, path),
+        )
+        .expect("write manifest");
+    }
+
+    fn source_manifest_yaml(source: &SourceName, path: &str) -> String {
+        format!(
+            r"
 name: {source}
 version: 1.0.0
 dsl_version: 3
@@ -405,33 +445,7 @@ tables:
       - name: title
         type: Utf8
 "
-            ),
         )
-        .expect("write manifest");
-    }
-
-    fn install_broken_source(
-        layout: &AppStateLayout,
-        config_store: &ConfigStore,
-        workspace: &WorkspaceName,
-        source: &SourceName,
-    ) {
-        std::fs::create_dir_all(layout.source_dir(workspace, source)).expect("source dir");
-        std::fs::write(layout.manifest_file(workspace, source), "name: [").expect("write manifest");
-        config_store
-            .upsert_source(
-                workspace,
-                InstalledSource {
-                    name: source.clone(),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    credential_revision: Uuid::default(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
-            .expect("upsert source");
     }
 
     async fn test_db(layout: &AppStateLayout, config_store: &ConfigStore) -> Arc<CoralDb> {
@@ -458,6 +472,28 @@ tables:
             .upsert_source(workspace, source, 11)
             .await
             .expect("upsert test source");
+        tx.commit().await.expect("commit test source");
+    }
+
+    async fn upsert_test_source_with_manifest(
+        db: &Arc<CoralDb>,
+        workspace: &WorkspaceName,
+        source: &InstalledSource,
+        manifest_yaml: &str,
+    ) {
+        let mut tx = db.begin().await.expect("begin test source tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 11)
+            .await
+            .expect("ensure test workspace");
+        tx.sources()
+            .upsert_source(workspace, source, 11)
+            .await
+            .expect("upsert test source");
+        tx.source_manifests()
+            .upsert(workspace, &source.name, manifest_yaml, 11)
+            .await
+            .expect("upsert test source manifest");
         tx.commit().await.expect("commit test source");
     }
 

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -65,8 +65,10 @@ pub(crate) fn load_bundled_source(name: &SourceName) -> Result<BundledSourceMani
     })
 }
 
-/// Resolve the effective installed manifest and verify it still matches the
-/// installed source identity in app state.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "removed by the v4 runtime follow-up")
+)]
 pub(crate) fn resolve_installed_manifest(
     workspace_name: &WorkspaceName,
     source: &InstalledSource,

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -20,8 +20,8 @@ use crate::credentials::{
 use crate::search::observed::SearchObservationHandle;
 use crate::search::sqlite_store::SqliteSearchStore;
 use crate::sources::catalog::{
-    describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
-    validate_imported_manifest_database_persistence,
+    InstalledSourceManifest, describe_manifest, list_bundled_sources, load_bundled_source,
+    resolve_installed_manifest_from_yaml, validate_imported_manifest_database_persistence,
     validate_imported_manifest_database_persistence_shape,
 };
 use crate::sources::materialization::{
@@ -281,11 +281,12 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<InstalledSource>, AppError> {
-        Ok(self
-            .load_workspace_sources(workspace_name)?
-            .into_iter()
-            .map(|source| self.populate_source_version_or_keep(workspace_name, source))
-            .collect())
+        let sources = self.load_workspace_sources(workspace_name)?;
+        let mut populated = Vec::with_capacity(sources.len());
+        for source in sources {
+            populated.push(self.populate_source_version_or_keep(workspace_name, source));
+        }
+        Ok(populated)
     }
 
     pub(crate) fn get_source(
@@ -306,9 +307,9 @@ impl SourceManager {
     ) -> Result<CandidateSource, AppError> {
         match self.get_source(workspace_name, source_name) {
             Ok(source) => {
-                return Ok(
-                    resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
-                );
+                return Ok(self
+                    .resolve_source_manifest(workspace_name, &source)?
+                    .candidate);
             }
             Err(AppError::SourceNotFound(_)) => {}
             Err(error) => return Err(error),
@@ -696,12 +697,8 @@ impl SourceManager {
             .transpose()?;
         let previous = SourceRollbackState {
             credential_revision: stored.credential_revision,
-            manifest_yaml: match removed.origin {
-                SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
-            },
+            manifest_yaml: self
+                .source_manifest_yaml_for_rollback_with_state_lock_held(workspace_name, &removed)?,
             credential_material,
         };
         let source_dir_backup = fs::DirectoryBackup::move_for_delete(&source_dir, source_name)?;
@@ -936,8 +933,11 @@ impl SourceManager {
             },
             origin: request.origin,
         };
-        if let Err(error) = self.upsert_source_with_state_lock_held(workspace_name, stored.clone())
-        {
+        if let Err(error) = self.upsert_source_with_state_lock_held(
+            workspace_name,
+            stored.clone(),
+            request.manifest_yaml,
+        ) {
             let restore_result = restore_materialization_backup(
                 &self.layout,
                 workspace_name,
@@ -1085,7 +1085,7 @@ impl SourceManager {
                 continue;
             }
             let installed_manifest =
-                resolve_installed_manifest(workspace_name, &installed, &self.layout)?;
+                self.resolve_source_manifest_with_state_lock_held(workspace_name, &installed)?;
             let installed_schema_names = runtime_schema_names(&installed_manifest.source_spec);
             if let Some(schema_name) = candidate_schema_names
                 .intersection(&installed_schema_names)
@@ -1268,7 +1268,21 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         source: InstalledSource,
+        manifest_yaml: Option<&str>,
     ) -> Result<(), AppError> {
+        let manifest_yaml = match source.origin {
+            SourceOrigin::Bundled => None,
+            SourceOrigin::Imported => {
+                let manifest_yaml = manifest_yaml.ok_or_else(|| {
+                    AppError::FailedPrecondition(format!(
+                        "imported source '{}' is missing manifest YAML for database persistence",
+                        source.name
+                    ))
+                })?;
+                validate_imported_manifest_database_persistence(manifest_yaml, &source.variables)?;
+                Some(manifest_yaml.to_string())
+            }
+        };
         let db = Arc::clone(&self.db);
         let db_workspace_name = workspace_name.clone();
         let db_source = source;
@@ -1286,6 +1300,16 @@ impl SourceManager {
             tx.sources()
                 .upsert_source(&db_workspace_name, &db_source, now_unix_nanos)
                 .await?;
+            if let Some(manifest_yaml) = manifest_yaml.as_deref() {
+                tx.source_manifests()
+                    .upsert(
+                        &db_workspace_name,
+                        &db_source.name,
+                        manifest_yaml,
+                        now_unix_nanos,
+                    )
+                    .await?;
+            }
             tx.commit().await?;
             Ok(())
         })?;
@@ -1308,6 +1332,70 @@ impl SourceManager {
             tx.commit().await?;
             Ok(())
         })
+    }
+
+    fn resolve_source_manifest(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<InstalledSourceManifest, AppError> {
+        let _state_lock = self.config_store.state_lock_shared()?;
+        self.resolve_source_manifest_with_state_lock_held(workspace_name, source)
+    }
+
+    fn resolve_source_manifest_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<InstalledSourceManifest, AppError> {
+        let manifest_yaml =
+            self.source_manifest_yaml_with_state_lock_held(workspace_name, source)?;
+        resolve_installed_manifest_from_yaml(source, &manifest_yaml)
+    }
+
+    fn source_manifest_yaml_for_rollback_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<Option<String>, AppError> {
+        match source.origin {
+            SourceOrigin::Bundled => Ok(None),
+            SourceOrigin::Imported => {
+                match self.source_manifest_yaml_with_state_lock_held(workspace_name, source) {
+                    Ok(manifest_yaml) => Ok(Some(manifest_yaml)),
+                    Err(AppError::SourceNotFound(_)) => Ok(None),
+                    Err(error) => Err(error),
+                }
+            }
+        }
+    }
+
+    fn source_manifest_yaml_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<String, AppError> {
+        match source.origin {
+            SourceOrigin::Bundled => Ok(load_bundled_source(&source.name)?.manifest_yaml),
+            SourceOrigin::Imported => {
+                let db = Arc::clone(&self.db);
+                let workspace_name = workspace_name.clone();
+                let source_name = source.name.clone();
+                run_source_db_operation(async move {
+                    let mut session = db.as_ref();
+                    session
+                        .source_manifests()
+                        .get(&workspace_name, &source_name)
+                        .await?
+                        .map(|record| record.manifest_yaml)
+                        .ok_or_else(|| {
+                            AppError::SourceNotFound(format!(
+                                "manifest for imported source '{workspace_name}:{source_name}'"
+                            ))
+                        })
+                })
+            }
+        }
     }
 
     fn validate_oauth_import_preflight(
@@ -1457,12 +1545,8 @@ impl SourceManager {
             .transpose()?;
         Ok(Some(SourceRollbackState {
             credential_revision: source.credential_revision,
-            manifest_yaml: match source.origin {
-                SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
-            },
+            manifest_yaml: self
+                .source_manifest_yaml_for_rollback_with_state_lock_held(workspace_name, &source)?,
             credential_material,
         }))
     }
@@ -1555,7 +1639,8 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         mut source: InstalledSource,
     ) -> Result<InstalledSource, AppError> {
-        source.version = resolve_installed_manifest(workspace_name, &source, &self.layout)?
+        source.version = self
+            .resolve_source_manifest_with_state_lock_held(workspace_name, &source)?
             .candidate
             .version;
         Ok(source)

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -759,10 +759,16 @@ async fn search_reports_partial_catalog_coverage_and_recovers_after_source_repai
     harness
         .import_source(repair_manifest.clone(), Vec::new(), Vec::new())
         .await;
-    let broken_manifest = harness
-        .config_dir()
-        .join("workspaces/default/sources/searchable/manifest.yaml");
-    fs::write(&broken_manifest, "name: [invalid").expect("break installed manifest");
+    let app_db = rusqlite::Connection::open(harness.config_dir().join("coral.db"))
+        .expect("open app database");
+    app_db
+        .execute(
+            "UPDATE source_manifests SET manifest_yaml = ?1 \
+             WHERE workspace_id = ?2 AND source_name = ?3",
+            rusqlite::params!["name: [invalid", "default", "searchable"],
+        )
+        .expect("break installed database manifest");
+    drop(app_db);
 
     let degraded = harness
         .search_client()
@@ -791,7 +797,9 @@ async fn search_reports_partial_catalog_coverage_and_recovers_after_source_repai
     assert!(!coverage.has_more);
     assert!(status.note.contains("searchable"));
 
-    fs::write(&broken_manifest, repair_manifest).expect("repair installed manifest");
+    harness
+        .import_source(repair_manifest, Vec::new(), Vec::new())
+        .await;
     let recovered = harness
         .search_client()
         .search(Request::new(SearchRequest {

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -88,8 +88,12 @@ async fn import_source_persists_and_lists() {
 
     let installed_manifest =
         source_dir(harness.config_dir(), "local_messages").join("manifest.yaml");
+    assert!(
+        installed_manifest.exists(),
+        "DB-backed imports should keep a legacy manifest for rollback compatibility"
+    );
     assert_eq!(
-        fs::read_to_string(&installed_manifest).expect("read installed manifest"),
+        fs::read_to_string(&installed_manifest).expect("read legacy manifest"),
         manifest_yaml
     );
 
@@ -1547,7 +1551,7 @@ origin = "imported"
             name: "demo".to_string(),
         }))
         .await
-        .expect_err("missing manifest file should fail");
+        .expect_err("missing manifest file should fail at source resolution");
     assert_eq!(error.code(), tonic::Code::NotFound);
 }
 
@@ -1574,6 +1578,13 @@ enabled = false
         harness
             .import_source(manifest_yaml, Vec::new(), Vec::new())
             .await;
+        let installed_manifest =
+            source_dir(harness.config_dir(), "local_messages").join("manifest.yaml");
+        fs::remove_file(&installed_manifest).expect("remove compatibility manifest");
+        assert!(
+            !installed_manifest.exists(),
+            "restart coverage must not rely on a legacy manifest file"
+        );
         let rows = harness
             .execute_sql_rows("SELECT COUNT(*) AS n FROM local_messages.messages")
             .await;
@@ -1655,6 +1666,108 @@ async fn import_rolls_back_on_config_write_failure() {
     assert_eq!(error.code(), tonic::Code::Internal);
     assert!(!source_dir(harness.config_dir(), "secured_messages").exists());
     assert!(harness.list_sources().await.is_empty());
+    let config_raw =
+        fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    assert!(!config_raw.contains("[workspaces.default.sources.secured_messages]"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn overwrite_restores_previous_source_on_config_write_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    let original_manifest = fixture_manifest_with_inputs_yaml();
+    harness
+        .import_source(
+            original_manifest.clone(),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "old-token".to_string(),
+            }],
+        )
+        .await;
+    let updated_manifest = original_manifest.replace("0.1.0", "0.2.0");
+
+    fs::set_permissions(harness.config_dir(), fs::Permissions::from_mode(0o500))
+        .expect("make config dir read-only");
+    let error = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: updated_manifest,
+            variables: vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
+            secrets: vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "new-token".to_string(),
+            }],
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("config write should fail");
+
+    fs::set_permissions(harness.config_dir(), fs::Permissions::from_mode(0o700))
+        .expect("restore config dir permissions");
+
+    assert_eq!(error.code(), tonic::Code::Internal);
+    let listed = harness.list_sources().await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "secured_messages");
+    assert_eq!(listed[0].version, "0.1.0");
+
+    let fetched = harness
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "secured_messages".to_string(),
+        }))
+        .await
+        .expect("get source after rollback")
+        .into_inner()
+        .source
+        .expect("source after rollback");
+    assert_eq!(fetched.version, "0.1.0");
+
+    let installed_manifest =
+        source_dir(harness.config_dir(), "secured_messages").join("manifest.yaml");
+    assert!(
+        installed_manifest.exists(),
+        "DB-backed rollback should restore legacy manifest files"
+    );
+    assert_eq!(
+        fs::read_to_string(&installed_manifest).expect("read restored manifest"),
+        original_manifest
+    );
+    let validated = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "secured_messages".to_string(),
+        }))
+        .await
+        .expect("source should validate after rollback")
+        .into_inner();
+    assert_eq!(validated.tables.len(), 1);
+    let secret_path = source_dir(harness.config_dir(), "secured_messages").join("secrets.env");
+    let secret_material = fs::read_to_string(&secret_path).expect("read restored secrets");
+    assert!(
+        secret_material.contains("API_TOKEN=old-token"),
+        "{secret_material}"
+    );
+    assert!(
+        !secret_material.contains("API_TOKEN=new-token"),
+        "{secret_material}"
+    );
 }
 
 #[cfg(unix)]
@@ -1696,18 +1809,31 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
             name: "secured_messages".to_string(),
         }))
         .await
-        .expect_err("manifest cleanup should fail");
+        .expect_err("source directory cleanup should fail");
 
     fs::set_permissions(&sources_root, fs::Permissions::from_mode(0o700))
         .expect("restore sources dir permissions");
 
     assert_eq!(error.code(), tonic::Code::Internal);
-    assert!(manifest_path.exists(), "manifest should be restored");
+    assert!(
+        manifest_path.exists(),
+        "DB-backed rollback should restore legacy manifest files"
+    );
     assert!(secret_path.exists(), "secret file should be restored");
 
     let listed = harness.list_sources().await;
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].name, "secured_messages");
+    let validated = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "secured_messages".to_string(),
+        }))
+        .await
+        .expect("source should still validate from DB manifest")
+        .into_inner();
+    assert_eq!(validated.tables.len(), 1);
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -1680,6 +1680,7 @@ async fn overwrite_restores_previous_source_on_config_write_failure() {
     let config_dir = temp.path().join("coral-config");
     fs::create_dir_all(&config_dir).expect("create config dir");
     let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    harness.seed_workspace().await;
     let original_manifest = fixture_manifest_with_inputs_yaml();
     harness
         .import_source(

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -553,7 +553,7 @@ origin = "imported"
         .workspace
         .expect("delete workspace response");
     assert_eq!(deleted.name, "work");
-    assert_eq!(workspace_names(&harness).await, vec!["default"]);
+    assert!(workspace_names(&harness).await.is_empty());
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -5,7 +5,7 @@ use coral_api::v1::{
     CreateWorkspaceRequest, DeleteWorkspaceRequest, DeleteWorkspaceResponse, GetCurrentUserRequest,
     ImportSourceRequest, ListSourcesRequest, ListUsersRequest, ListWorkspaceMembersRequest,
     ListWorkspaceMembersResponse, ListWorkspacesRequest, Source, SourceSecret, SourceVariable,
-    WorkspaceRole, import_source_response,
+    ValidateSourceRequest, WorkspaceRole, import_source_response,
 };
 use coral_client::AppClient;
 use prost::Message as _;
@@ -347,13 +347,11 @@ async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
     .await;
     assert_eq!(imported.name, "local_messages");
 
-    let source_dir = harness
-        .config_dir()
-        .join("workspaces")
-        .join("work")
-        .join("sources")
-        .join("local_messages");
-    assert!(source_dir.exists(), "import should create source artifacts");
+    let workspace_dir = harness.config_dir().join("workspaces").join("work");
+    let artifact = workspace_dir.join("artifacts").join("marker");
+    fs::create_dir_all(artifact.parent().expect("artifact parent")).expect("create artifact dir");
+    fs::write(&artifact, "workspace artifact").expect("write workspace artifact");
+    assert!(artifact.exists(), "test should create a workspace artifact");
 
     let deleted = harness
         .workspace_client()
@@ -372,8 +370,8 @@ async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
         "deleting the only workspace leaves the deployment with none",
     );
     assert!(
-        !source_dir.exists(),
-        "delete should remove workspace artifacts"
+        !workspace_dir.exists(),
+        "delete should remove workspace artifact directory"
     );
     assert_eq!(
         workspace_root_entries(harness.config_dir()),
@@ -462,6 +460,100 @@ async fn delete_workspace_restores_db_sources_when_config_delete_fails() {
         .into_inner()
         .sources;
     assert!(sources.iter().any(|source| source.name == "local_messages"));
+    let validated = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(workspace("work")),
+            name: "local_messages".to_string(),
+        }))
+        .await
+        .expect("restored source should validate")
+        .into_inner();
+    assert_eq!(validated.tables.len(), 1);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn delete_workspace_handles_imported_source_without_manifest_row() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let db_path = temp.path().join("db").join("coral.db");
+    fs::create_dir_all(db_path.parent().expect("db parent")).expect("create db dir");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            r#"
+[database]
+backend = "sqlite"
+path = "{}"
+
+[workspaces.work.sources.demo]
+version = "0.1.0"
+origin = "imported"
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write database config");
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+    let sources = harness
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("list degraded imported source")
+        .into_inner()
+        .sources;
+    assert!(sources.iter().any(|source| source.name == "demo"));
+
+    fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o500))
+        .expect("make config dir read-only");
+    let result = harness
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await;
+    fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o700))
+        .expect("restore config dir permissions");
+
+    result.expect_err("config delete should fail");
+    let sources = harness
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("list restored degraded source")
+        .into_inner()
+        .sources;
+    assert!(sources.iter().any(|source| source.name == "demo"));
+    let error = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(workspace("work")),
+            name: "demo".to_string(),
+        }))
+        .await
+        .expect_err("restored degraded source should still report missing manifest");
+    assert_eq!(error.code(), tonic::Code::NotFound);
+
+    let deleted = harness
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("delete degraded workspace")
+        .into_inner()
+        .workspace
+        .expect("delete workspace response");
+    assert_eq!(deleted.name, "work");
+    assert_eq!(workspace_names(&harness).await, vec!["default"]);
 }
 
 #[tokio::test]
@@ -789,13 +881,15 @@ async fn delete_workspace_succeeds_when_backup_cleanup_fails_after_config_delete
 
     let workspace_dir = harness.config_dir().join("workspaces").join("work");
     let sources_root = workspace_dir.join("sources");
-    assert!(
+    fs::create_dir_all(sources_root.join("secured_messages"))
+        .expect("create legacy source artifact dir");
+    fs::write(
         sources_root
             .join("secured_messages")
-            .join("secrets.env")
-            .exists(),
-        "import should persist file-backed credential material"
-    );
+            .join("legacy-artifact"),
+        "legacy",
+    )
+    .expect("write legacy source artifact");
     fs::set_permissions(&sources_root, fs::Permissions::from_mode(0o500))
         .expect("make nested sources dir read-only");
 


### PR DESCRIPTION
## Intent
Wire imported manifest persistence into source lifecycle and query loading so imported manifests are written and read through the database.

## What it enables
Coral no longer depends on `sources/<workspace>/<source>/manifest.yaml` once an imported source is installed into DB-backed state.

## Usage examples
Run `coral source add --file ./source.yaml`, delete the legacy manifest file after migration, then `coral source info <name>` still resolves the source.

## Validation
Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.