### PR TITLE
feat(app): clean up legacy v4 materializations after verified import

### DIFF
--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -26,8 +26,13 @@ use serde_json::{Value, json};
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
+use crate::credential_transport::validate_credential_endpoint_transport;
 use crate::hash::sha256_hex;
 use crate::sources::SourceName;
+use crate::sources::catalog::{
+    template_references_secret_input, validate_auth_spec_for_database_persistence,
+    validate_headers_for_database_persistence,
+};
 use crate::state::db::{MaterializationRecord, MaterializationSurfaceRecord};
 use crate::state::{
     AppStateLayout, V4OperationMetadataFile, V4OperationMetadataOrigin, V4ProjectionCatalogFile,
@@ -1418,7 +1423,7 @@ fn app_error_from_core(error: coral_engine::CoreError) -> AppError {
     }
 }
 
-fn validate_materialized_surface_base_url(
+pub(crate) fn validate_materialized_surface_base_url(
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
     bytes: &[u8],
@@ -1448,7 +1453,30 @@ fn validate_materialized_surface_base_url(
         &base_url,
         "derived OpenAPI server",
     )
-    .map_err(|error| AppError::FailedPrecondition(error.to_string()))
+    .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
+    let input_kinds = manifest
+        .declared_inputs
+        .iter()
+        .map(|input| (input.key.clone(), input.kind))
+        .collect::<BTreeMap<_, _>>();
+    let mut needs_transport_guard = validate_auth_spec_for_database_persistence(
+        &input_kinds,
+        "surface auth",
+        &openapi_runtime.auth,
+    )?;
+    needs_transport_guard |= validate_headers_for_database_persistence(
+        &input_kinds,
+        "surface request_headers",
+        &openapi_runtime.request_headers,
+    )?;
+    needs_transport_guard |= template_references_secret_input(&input_kinds, &base_url);
+    if needs_transport_guard {
+        validate_credential_endpoint_transport(
+            "surface derived OpenAPI server base_url",
+            base_url.raw(),
+        )?;
+    }
+    Ok(())
 }
 
 fn read_descriptor(surface: &coral_spec::v4::V4Surface) -> Result<Vec<u8>, AppError> {

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -25,6 +25,7 @@ use crate::hash::sha256_hex;
 use crate::sources::catalog::InstalledSourceManifest;
 use crate::sources::materialization::{
     LoadedV4Materialization, SourceDiagnosticReporter, incompatible_materialization_error,
+    validate_materialized_surface_base_url,
 };
 use crate::sources::model::InstalledSource;
 use crate::workspaces::WorkspaceName;
@@ -536,6 +537,7 @@ fn surface_base_url(
             ))
         })?,
     };
+    validate_materialized_surface_base_url(manifest, surface, &bytes)?;
     let metadata = openapi_document_metadata(&bytes).map_err(|error| {
         AppError::FailedPrecondition(format!(
             "failed to derive base_url for DSL v4 surface: {error}"

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -428,13 +428,16 @@ async fn import_filesystem_v4_materializations(
             .filter(|source| source.origin == SourceOrigin::Imported)
         {
             let materialized_dir = layout.v4_materialized_dir(&workspace_name, &source.name);
-            if !materialized_dir.exists()
-                || session
-                    .materializations()
-                    .get(&workspace_name, &source.name)
-                    .await?
-                    .is_some()
+            if !materialized_dir.exists() {
+                continue;
+            }
+            if session
+                .materializations()
+                .get(&workspace_name, &source.name)
+                .await?
+                .is_some()
             {
+                remove_v4_materialization_dir(&materialized_dir);
                 continue;
             }
             let Some(manifest_yaml) = session
@@ -480,6 +483,7 @@ async fn import_filesystem_v4_materializations(
                 continue;
             }
             upsert_imported_v4_materialization(db, &workspace_name, &source.name, &record).await?;
+            remove_v4_materialization_dir(&materialized_dir);
         }
     }
     Ok(())
@@ -537,6 +541,20 @@ async fn upsert_imported_v4_materialization(
 
 fn is_unique_constraint_error(error: &DbError) -> bool {
     matches!(error, DbError::Sqlx(sqlx::Error::Database(database_error)) if database_error.is_unique_violation())
+}
+
+fn remove_v4_materialization_dir(materialized_dir: &std::path::Path) {
+    match fs::remove_dir_all(materialized_dir) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => {
+            tracing::warn!(
+                path = %materialized_dir.display(),
+                detail = %error,
+                "DSL v4 materialization imported into database but legacy artifact cleanup failed"
+            );
+        }
+    }
 }
 
 fn read_imported_manifest_file(
@@ -604,7 +622,10 @@ mod tests {
     };
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::db::session::DbRepos;
-    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, MaterializationRecord, MaterializationSurfaceRecord,
+        ResolvedDatabaseConfig,
+    };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::storage::fs::DELETION_BACKUP_INFIX;
     use crate::workspaces::WorkspaceName;
@@ -1734,6 +1755,214 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn backfills_v4_materialization_for_already_imported_database_source() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source(
+            "github_v4_import",
+            Some("0.1.0"),
+            [],
+            [],
+            None,
+            SourceOrigin::Imported,
+        );
+        let (manifest_yaml, materialized_dir) = install_legacy_v4_materialization(
+            &layout,
+            &workspace,
+            &source.name,
+            &temp.path().join("openapi.yaml"),
+        );
+
+        let db = open_sqlite(&layout).await;
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("upsert source");
+        tx.source_manifests()
+            .upsert(&workspace, &source.name, &manifest_yaml, 7)
+            .await
+            .expect("upsert source manifest");
+        assert!(
+            tx.state_migrations()
+                .try_claim(WORKSPACE_CATALOG_CUTOVER_ID, 7)
+                .await
+                .expect("claim workspace cutover")
+        );
+        assert!(
+            tx.state_migrations()
+                .try_claim(SOURCE_CATALOG_IMPORT_ID, 7)
+                .await
+                .expect("claim source import")
+        );
+        tx.commit().await.expect("commit source");
+
+        run_state_migrations(&db, &config_store, &layout)
+            .await
+            .expect("backfill materialization");
+
+        let mut session = &db;
+        let materialization = session
+            .materializations()
+            .get(&workspace, &source.name)
+            .await
+            .expect("get materialization")
+            .expect("materialization");
+        assert_eq!(materialization.surfaces.len(), 1);
+        assert!(
+            !materialized_dir.exists(),
+            "legacy materialized directory should be cleaned after DB backfill"
+        );
+    }
+
+    #[tokio::test]
+    async fn imports_config_v4_source_and_legacy_materialization_in_one_pass() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source(
+            "github_v4_config",
+            Some("0.1.0"),
+            [],
+            [],
+            None,
+            SourceOrigin::Imported,
+        );
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        let (manifest_yaml, materialized_dir) = install_legacy_v4_materialization(
+            &layout,
+            &workspace,
+            &source.name,
+            &temp.path().join("openapi.yaml"),
+        );
+        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
+        let db = open_sqlite(&layout).await;
+
+        run_state_migrations(&db, &config_store, &layout)
+            .await
+            .expect("import source and materialization");
+
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get imported source"),
+            Some(source.clone())
+        );
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get source manifest")
+                .expect("source manifest")
+                .manifest_yaml,
+            manifest_yaml
+        );
+        assert_eq!(
+            session
+                .materializations()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get materialization")
+                .expect("materialization")
+                .surfaces
+                .len(),
+            1
+        );
+        assert!(!materialized_dir.exists());
+        assert!(
+            config_store
+                .load_config_unlocked()
+                .expect("legacy config should be cleaned")
+                .workspace_sources(&workspace)
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_v4_materialization_backfill_race_is_benign_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+        let workspace = WorkspaceName::parse(&format!("race{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace");
+        let source = source("race_v4", None, [], [], None, SourceOrigin::Imported);
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("upsert source");
+        tx.commit().await.expect("commit source");
+        let winner_record = MaterializationRecord {
+            materialization_version: "v4".into(),
+            fingerprint_yaml: "winner-fingerprint".into(),
+            projections_yaml: "projections".into(),
+            diagnostics_yaml: "diagnostics".into(),
+            created_at_unix_nanos: 11,
+            surfaces: vec![MaterializationSurfaceRecord {
+                surface_id: "rest".into(),
+                source_document_raw: b"{}".to_vec(),
+                source_document_yaml: "{}".into(),
+                semantic_ir_yaml: "{}".into(),
+                operation_metadata_yaml: "metadata: true\n".into(),
+            }],
+        };
+        let mut loser_record = winner_record.clone();
+        loser_record.fingerprint_yaml = "loser-fingerprint".into();
+        let mut tx = db.begin().await.expect("begin winner tx");
+        tx.materializations()
+            .upsert(&workspace, &source.name, &winner_record)
+            .await
+            .expect("insert uncommitted winner materialization");
+        let loser =
+            super::upsert_imported_v4_materialization(&db, &workspace, &source.name, &loser_record);
+        tokio::pin!(loser);
+
+        if tokio::time::timeout(std::time::Duration::from_millis(250), &mut loser)
+            .await
+            .is_ok()
+        {
+            panic!("loser backfill completed before the winner transaction committed");
+        }
+        tx.commit().await.expect("commit winner materialization");
+        loser
+            .await
+            .expect("loser backfill recovers after unique violation");
+        let mut session = &db;
+        assert_eq!(
+            session
+                .materializations()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get materialization")
+                .expect("materialization"),
+            winner_record
+        );
+    }
+
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
         let config = DatabaseConfig::load(layout).expect("db config");
         let DatabaseConfig::Sqlite { path } = config else {
@@ -1821,5 +2050,83 @@ inputs: { API_BASE: { kind: variable }, API_TOKEN: { kind: secret } }
 auth: { type: HeaderAuth, headers: [{ name: Authorization, from: template, template: "Bearer {{input.API_TOKEN}}" }] }"#,
             1,
         )
+    }
+
+    fn install_legacy_v4_materialization(
+        layout: &AppStateLayout,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        descriptor_file: &std::path::Path,
+    ) -> (String, std::path::PathBuf) {
+        fs::write(descriptor_file, openapi_fixture()).expect("write OpenAPI fixture");
+        let manifest_yaml = v4_manifest_yaml(source_name.as_str(), descriptor_file);
+        let parsed_manifest = parse_source_manifest_yaml(&manifest_yaml)
+            .expect("parse manifest")
+            .as_v4()
+            .expect("v4 manifest")
+            .clone();
+        let build = build_v4_materialization_tmp(
+            layout,
+            workspace,
+            source_name,
+            &manifest_yaml,
+            &parsed_manifest,
+            &MaterializationInputs::default(),
+            "test",
+        )
+        .expect("build materialization");
+        replace_or_retire_v4_materialization(layout, workspace, source_name, Some(&build.temp_dir))
+            .expect("install legacy materialization");
+        let materialized_dir = layout.v4_materialized_dir(workspace, source_name);
+        assert!(materialized_dir.exists());
+        (manifest_yaml, materialized_dir)
+    }
+
+    fn v4_manifest_yaml(name: &str, descriptor_file: &std::path::Path) -> String {
+        format!(
+            r"
+name: {name}
+dsl_version: 4
+surface:
+  type: openapi
+  file: {}
+",
+            descriptor_file.display()
+        )
+    }
+
+    fn openapi_fixture() -> &'static str {
+        r"
+openapi: 3.0.3
+info:
+  title: GitHub
+servers:
+  - url: https://api.example.com
+paths:
+  /issues:
+    get:
+      operationId: issues/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: integer}
+                    title: {type: string}
+"
+    }
+
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "The Postgres import harness is explicitly gated by this CI/test-only variable."
+    )]
+    fn postgres_test_url() -> Option<String> {
+        std::env::var("CORAL_TEST_POSTGRES_URL")
+            .ok()
+            .filter(|value| !value.is_empty())
     }
 }

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1658,7 +1658,7 @@ mod tests {
         let healthy_descriptor = temp.path().join("healthy-openapi.json");
         fs::write(&healthy_descriptor, OPENAPI_FIXTURE).expect("write OpenAPI fixture");
         let healthy_manifest = format!(
-            "name: {}\ndsl_version: 4\nsurfaces:\n- id: rest\n  type: openapi\n  file: {}\n",
+            "name: {}\ndsl_version: 4\nsurface:\n  type: openapi\n  file: {}\n",
             healthy.name,
             healthy_descriptor.display()
         );

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1795,13 +1795,13 @@ mod tests {
             tx.state_migrations()
                 .try_claim(WORKSPACE_CATALOG_CUTOVER_ID, 7)
                 .await
-                .expect("claim workspace cutover")
+                .expect("mark workspace cutover complete")
         );
         assert!(
             tx.state_migrations()
                 .try_claim(SOURCE_CATALOG_IMPORT_ID, 7)
                 .await
-                .expect("claim source import")
+                .expect("mark source import complete")
         );
         tx.commit().await.expect("commit source");
 
@@ -1927,7 +1927,7 @@ mod tests {
                 source_document_raw: b"{}".to_vec(),
                 source_document_yaml: "{}".into(),
                 semantic_ir_yaml: "{}".into(),
-                operation_metadata_yaml: "metadata: true\n".into(),
+                operation_metadata_yaml: "{}".into(),
             }],
         };
         let mut loser_record = winner_record.clone();

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -1022,6 +1022,21 @@ impl Drop for FailingHttpFixture {
     }
 }
 
+pub(crate) async fn issues_http_fixture(auth_header: &[&str]) -> wiremock::MockServer {
+    let server = wiremock::MockServer::start().await;
+    let auth_header = auth_header.to_vec();
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::headers("Authorization", auth_header))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .append_header("Content-Type", "application/json")
+                .set_body_string(r#"[{"id":1,"title":"Stored materialization"}]"#),
+        )
+        .mount(&server)
+        .await;
+    server
+}
+
 pub(crate) fn fixture_manifest_yaml(root: &Path) -> String {
     fixture_manifest_with_test_queries_yaml(root, &[])
 }

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -203,6 +203,7 @@ async fn startup_import_backfills_legacy_v4_materialization() {
 
     {
         let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        harness.seed_workspace().await;
         harness
             .import_source(
                 manifest_yaml,

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -4,7 +4,7 @@
     reason = "test code: assertion-style indexing is idiomatic in tests"
 )]
 
-use std::fs;
+use std::{fs, path::Path};
 
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
@@ -16,6 +16,8 @@ use coral_api::v1::{
     source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
+use sqlx::Row as _;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use tonic::Request;
 
@@ -23,7 +25,8 @@ use crate::harness::{
     FailingHttpFixture, GrpcHarness, default_workspace, fixture_function_only_manifest_yaml,
     fixture_manifest_with_inputs_yaml, fixture_manifest_with_multiple_tables_yaml,
     fixture_manifest_with_required_inputs_yaml, fixture_manifest_with_test_queries_yaml,
-    fixture_manifest_yaml, invalid_manifest_yaml, source_dir,
+    fixture_manifest_yaml, fixture_v4_openapi_manifest_yaml, invalid_manifest_yaml,
+    issues_http_fixture, source_dir,
 };
 
 fn auth_manifest_yaml(inputs: &str, auth: &str) -> String {
@@ -55,6 +58,13 @@ fn secret_auth_manifest_yaml_at(base_url: &str) -> String {
         base_url,
         "inputs:\n  API_TOKEN:\n    kind: secret\n",
         "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n",
+    )
+}
+
+fn v4_secret_auth_manifest(manifest_yaml: &str) -> String {
+    manifest_yaml.replace(
+        "type: openapi",
+        "type: openapi\n  inputs:\n    API_TOKEN:\n      kind: secret\n  auth:\n    type: BasicAuth\n    username: bot\n    password: \"{{input.API_TOKEN}}\"",
     )
 }
 
@@ -177,6 +187,108 @@ async fn startup_import_lists_non_default_legacy_config_source() {
         .expect("validate analytics source")
         .into_inner();
     assert_eq!(validated.tables[0].schema_name, "analytics_messages");
+}
+
+#[tokio::test]
+async fn startup_import_backfills_legacy_v4_materialization() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let issues_http = issues_http_fixture(&["Basic Ym90OnNlY3JldC10b2tlbg=="]).await;
+    let (manifest_yaml, openapi_file) =
+        fixture_v4_openapi_manifest_yaml(temp.path(), &issues_http.uri());
+    let manifest_yaml = v4_secret_auth_manifest(&manifest_yaml);
+
+    {
+        let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        harness
+            .import_source(
+                manifest_yaml,
+                Vec::new(),
+                vec![SourceSecret {
+                    key: "API_TOKEN".into(),
+                    value: "secret-token".into(),
+                }],
+            )
+            .await;
+        harness.shutdown().await;
+    }
+    write_legacy_github_v4_materialization_from_db(&config_dir, &config_dir).await;
+    fs::remove_file(openapi_file).expect("remove authored descriptor");
+
+    let pool = sqlite_pool(&config_dir).await;
+    sqlx::query("DELETE FROM materializations WHERE workspace_id = ? AND source_name = ?")
+        .bind("default")
+        .bind("github_v4_query")
+        .execute(&pool)
+        .await
+        .expect("delete materialization row");
+    pool.close().await;
+
+    {
+        let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        assert_github_v4_query_works(&harness).await;
+        assert!(
+            !source_dir(&config_dir, "github_v4_query")
+                .join("materialized/v4")
+                .exists()
+        );
+        harness.shutdown().await;
+    }
+    let legacy_config_dir = temp.path().join("legacy-coral-config");
+    write_legacy_github_v4_materialization_from_db(&config_dir, &legacy_config_dir).await;
+    let current_source_dir = source_dir(&config_dir, "github_v4_query");
+    let legacy_source_dir = source_dir(&legacy_config_dir, "github_v4_query");
+    fs::copy(
+        current_source_dir.join("manifest.yaml"),
+        legacy_source_dir.join("manifest.yaml"),
+    )
+    .expect("copy legacy source manifest");
+    fs::write(
+        legacy_source_dir.join("secrets.env"),
+        "API_TOKEN=secret-token\n",
+    )
+    .expect("write legacy source secrets");
+    fs::write(
+        legacy_config_dir.join("config.toml"),
+        r#"version = 1
+
+[credentials]
+storage = "file"
+
+[workspaces.default.sources.github_v4_query]
+variables = {}
+secrets = ["API_TOKEN"]
+origin = "imported"
+"#,
+    )
+    .expect("write legacy source config");
+
+    let harness = GrpcHarness::start_with_config_dir(legacy_config_dir.clone()).await;
+    assert_github_v4_query_works(&harness).await;
+    assert!(
+        !source_dir(&legacy_config_dir, "github_v4_query")
+            .join("materialized/v4")
+            .exists()
+    );
+    harness
+        .import_source(
+            fixture_manifest_yaml(harness.temp_path()).replace("local_messages", "github_v4_query"),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+    let pool = sqlite_pool(&legacy_config_dir).await;
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM materializations WHERE workspace_id = ? AND source_name = ?",
+    )
+    .bind("default")
+    .bind("github_v4_query")
+    .fetch_one(&pool)
+    .await
+    .expect("count materializations after non-v4 reimport");
+    assert_eq!(count, 0);
+    pool.close().await;
+    harness.shutdown().await;
 }
 
 #[tokio::test]
@@ -351,6 +463,22 @@ async fn import_rejects_cleartext_secret_endpoint_without_database_state() {
         .expect_err("cleartext credential endpoint should fail");
     assert_eq!(error.code(), tonic::Code::InvalidArgument);
     assert!(error.message().contains("base_url"));
+    harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: v4_secret_auth_manifest(
+                &fixture_v4_openapi_manifest_yaml(harness.temp_path(), "http://api.example.com").0,
+            ),
+            variables: Vec::new(),
+            secrets: vec![SourceSecret {
+                key: "API_TOKEN".into(),
+                value: "secret-token".into(),
+            }],
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("cleartext derived credential endpoint should fail");
     assert!(harness.list_sources().await.is_empty());
 }
 
@@ -865,6 +993,95 @@ async fn import_source_missing_required_secret_returns_invalid_argument() {
             .message()
             .contains("missing required source secret 'API_TOKEN'")
     );
+}
+
+async fn assert_github_v4_query_works(harness: &GrpcHarness) {
+    let validated = harness.validate_source("github_v4_query").await;
+    assert_eq!(validated.tables.len(), 1);
+    assert_eq!(validated.tables[0].schema_name, "github_v4_query");
+    assert_eq!(validated.tables[0].name, "issues");
+    assert_eq!(
+        harness
+            .execute_sql_rows("SELECT id, title FROM github_v4_query.issues")
+            .await,
+        vec![serde_json::json!({"id": 1, "title": "Stored materialization"})]
+    );
+}
+
+async fn write_legacy_github_v4_materialization_from_db(
+    database_config_dir: &Path,
+    legacy_config_dir: &Path,
+) {
+    let pool = sqlite_pool(database_config_dir).await;
+    let row = sqlx::query(
+        "SELECT fingerprint_yaml, projections_yaml, diagnostics_yaml \
+         FROM materializations WHERE workspace_id = ? AND source_name = ?",
+    )
+    .bind("default")
+    .bind("github_v4_query")
+    .fetch_one(&pool)
+    .await
+    .expect("load materialization row");
+    let materialized_dir = source_dir(legacy_config_dir, "github_v4_query").join("materialized/v4");
+    fs::create_dir_all(&materialized_dir).expect("create legacy materialized dir");
+    fs::write(
+        materialized_dir.join("fingerprint.yaml"),
+        row.get::<String, _>("fingerprint_yaml"),
+    )
+    .expect("write legacy fingerprint");
+    fs::write(
+        materialized_dir.join("projections.yaml"),
+        row.get::<String, _>("projections_yaml"),
+    )
+    .expect("write legacy projections");
+    fs::write(
+        materialized_dir.join("diagnostics.yaml"),
+        row.get::<String, _>("diagnostics_yaml"),
+    )
+    .expect("write legacy diagnostics");
+
+    let surfaces = sqlx::query(
+        "SELECT surface_id, source_document_raw, source_document_yaml, semantic_ir_yaml \
+         FROM materialization_surfaces WHERE workspace_id = ? AND source_name = ? \
+         ORDER BY surface_id",
+    )
+    .bind("default")
+    .bind("github_v4_query")
+    .fetch_all(&pool)
+    .await
+    .expect("load materialization surfaces");
+    for surface in surfaces {
+        let surface_dir = materialized_dir
+            .join("surfaces")
+            .join(surface.get::<String, _>("surface_id"));
+        fs::create_dir_all(&surface_dir).expect("create legacy surface dir");
+        fs::write(
+            surface_dir.join("source-document.raw"),
+            surface.get::<Vec<u8>, _>("source_document_raw"),
+        )
+        .expect("write legacy raw source document");
+        fs::write(
+            surface_dir.join("source-document.yaml"),
+            surface.get::<String, _>("source_document_yaml"),
+        )
+        .expect("write legacy source document");
+        fs::write(
+            surface_dir.join("semantic-ir.yaml"),
+            surface.get::<String, _>("semantic_ir_yaml"),
+        )
+        .expect("write legacy semantic IR");
+    }
+    pool.close().await;
+}
+
+async fn sqlite_pool(config_dir: &Path) -> sqlx::SqlitePool {
+    let options = SqliteConnectOptions::new()
+        .filename(config_dir.join("coral.db"))
+        .foreign_keys(true);
+    SqlitePoolOptions::new()
+        .connect_with(options)
+        .await
+        .expect("open sqlite db")
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -62,10 +62,13 @@ fn secret_auth_manifest_yaml_at(base_url: &str) -> String {
 }
 
 fn v4_secret_auth_manifest(manifest_yaml: &str) -> String {
-    manifest_yaml.replace(
+    // DSL v4 declares inputs at the manifest root; only the transport auth
+    // belongs to the surface.
+    let with_surface_auth = manifest_yaml.replace(
         "type: openapi",
-        "type: openapi\n  inputs:\n    API_TOKEN:\n      kind: secret\n  auth:\n    type: BasicAuth\n    username: bot\n    password: \"{{input.API_TOKEN}}\"",
-    )
+        "type: openapi\n  auth:\n    type: BasicAuth\n    username: bot\n    password: \"{{input.API_TOKEN}}\"",
+    );
+    format!("inputs:\n  API_TOKEN:\n    kind: secret\n{with_surface_auth}")
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -1044,37 +1044,38 @@ async fn write_legacy_github_v4_materialization_from_db(
     )
     .expect("write legacy diagnostics");
 
-    let surfaces = sqlx::query(
-        "SELECT surface_id, source_document_raw, source_document_yaml, semantic_ir_yaml \
+    let surface = sqlx::query(
+        "SELECT surface_id, source_document_raw, source_document_yaml, semantic_ir_yaml, \
+         operation_metadata_yaml \
          FROM materialization_surfaces WHERE workspace_id = ? AND source_name = ? \
          ORDER BY surface_id",
     )
     .bind("default")
     .bind("github_v4_query")
-    .fetch_all(&pool)
+    .fetch_one(&pool)
     .await
-    .expect("load materialization surfaces");
-    for surface in surfaces {
-        let surface_dir = materialized_dir
-            .join("surfaces")
-            .join(surface.get::<String, _>("surface_id"));
-        fs::create_dir_all(&surface_dir).expect("create legacy surface dir");
-        fs::write(
-            surface_dir.join("source-document.raw"),
-            surface.get::<Vec<u8>, _>("source_document_raw"),
-        )
-        .expect("write legacy raw source document");
-        fs::write(
-            surface_dir.join("source-document.yaml"),
-            surface.get::<String, _>("source_document_yaml"),
-        )
-        .expect("write legacy source document");
-        fs::write(
-            surface_dir.join("semantic-ir.yaml"),
-            surface.get::<String, _>("semantic_ir_yaml"),
-        )
-        .expect("write legacy semantic IR");
-    }
+    .expect("load materialization surface");
+    assert_eq!(surface.get::<String, _>("surface_id"), "surface");
+    fs::write(
+        materialized_dir.join("source-document.raw"),
+        surface.get::<Vec<u8>, _>("source_document_raw"),
+    )
+    .expect("write legacy raw source document");
+    fs::write(
+        materialized_dir.join("source-document.yaml"),
+        surface.get::<String, _>("source_document_yaml"),
+    )
+    .expect("write legacy source document");
+    fs::write(
+        materialized_dir.join("semantic-ir.yaml"),
+        surface.get::<String, _>("semantic_ir_yaml"),
+    )
+    .expect("write legacy semantic IR");
+    fs::write(
+        materialized_dir.join("operation-metadata.yaml"),
+        surface.get::<String, _>("operation_metadata_yaml"),
+    )
+    .expect("write legacy operation metadata");
     pool.close().await;
 }
 


### PR DESCRIPTION
## Intent
Finish the v4 materialization migration story by removing legacy materialized/v4 directories only after the imported database materialization row is verified.

## What it enables
This keeps database-backed startup import as the durable steady state with no stale legacy artifacts, restores cleartext secret-endpoint rejection for imported v4 manifests, and makes concurrent Postgres backfill race coverage visible in CI.

## Usage
Automatic at startup import for legacy v4 sources with filesystem materialization artifacts.