### PR TITLE
feat(app): persist feedback reports in database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,6 +1561,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sqlx",
  "tempfile",
  "thiserror",
  "tokio",

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -60,7 +60,8 @@ use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::sources::service::SourceService;
 use crate::state::db::{
     CoralDb, DatabaseConfig, InaccessibleWorkspaces, ResolvedDatabaseConfig,
-    inaccessible_workspaces, migrate_local_ownership_once, run_state_migrations,
+    import_filesystem_feedback_reports, inaccessible_workspaces, migrate_local_ownership_once,
+    run_state_migrations,
 };
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::manager::TaskManager;
@@ -388,6 +389,7 @@ impl ServerBuilder {
             init_server_telemetry(&layout, self.config.enable_stderr_logs)?;
         apply_local_principal_policy(&coral_db, local_principal).await?;
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
+        import_filesystem_feedback_reports(&coral_db, &layout).await?;
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
@@ -416,8 +418,11 @@ impl ServerBuilder {
             diagnostic_reporter.clone(),
         )
         .with_pool_registry(Arc::clone(&workspace_pool_registry));
-        let feedback_manager =
-            FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
+        let feedback_manager = FeedbackManager::with_db(
+            layout.clone(),
+            self.config.feedback_publisher,
+            Arc::clone(&coral_db),
+        );
         let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&coral_db)));
         let task_activity = crate::task::activity::TaskActivityRecorder::new(Arc::clone(&coral_db));
         let body_capture_max_bytes = telemetry_config

--- a/crates/coral-app/src/feedback/manager.rs
+++ b/crates/coral-app/src/feedback/manager.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -9,6 +10,7 @@ use crate::feedback::publisher::FeedbackPublisher;
 #[cfg(test)]
 use crate::feedback::publisher::NoopFeedbackPublisher;
 use crate::state::AppStateLayout;
+use crate::state::db::{CoralDb, DbRepos, FeedbackReportRecord};
 use crate::storage::fs::{self as storage_fs, FileLock};
 use crate::task::id::TaskId;
 use crate::workspaces::WorkspaceName;
@@ -73,6 +75,7 @@ struct PersistedFeedbackReport<'a> {
 pub(crate) struct FeedbackManager {
     layout: AppStateLayout,
     publisher: Arc<dyn FeedbackPublisher>,
+    catalog_db: Option<Arc<CoralDb>>,
 }
 
 impl FeedbackManager {
@@ -81,11 +84,28 @@ impl FeedbackManager {
         Self::with_publisher(layout, Arc::new(NoopFeedbackPublisher))
     }
 
+    #[cfg(test)]
     pub(crate) fn with_publisher(
         layout: AppStateLayout,
         publisher: Arc<dyn FeedbackPublisher>,
     ) -> Self {
-        Self { layout, publisher }
+        Self {
+            layout,
+            publisher,
+            catalog_db: None,
+        }
+    }
+
+    pub(crate) fn with_db(
+        layout: AppStateLayout,
+        publisher: Arc<dyn FeedbackPublisher>,
+        catalog_db: Arc<CoralDb>,
+    ) -> Self {
+        Self {
+            layout,
+            publisher,
+            catalog_db: Some(catalog_db),
+        }
     }
 
     pub(crate) fn submit_feedback(
@@ -119,6 +139,19 @@ impl FeedbackManager {
     }
 
     fn append_report(&self, report: &FeedbackReport) -> Result<(), AppError> {
+        if let Some(db) = self.catalog_db.clone() {
+            let workspace = report.workspace.clone();
+            let record = feedback_record(report)?;
+            return run_feedback_db_operation(async move {
+                let mut tx = db.begin().await?;
+                if tx.workspaces().get(workspace.as_str()).await?.is_none() {
+                    return Err(AppError::WorkspaceNotFound(workspace.to_string()));
+                }
+                tx.feedback_reports().append(&workspace, &record).await?;
+                tx.commit().await?;
+                Ok(())
+            });
+        }
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
         let file = self.layout.feedback_reports_file(&report.workspace);
         let task_id = report.task_id.map(|task_id| task_id.to_string());
@@ -136,6 +169,55 @@ impl FeedbackManager {
         storage_fs::append_file_private(&file, &line)?;
         Ok(())
     }
+}
+
+fn feedback_record(report: &FeedbackReport) -> Result<FeedbackReportRecord, AppError> {
+    let created_at_unix_nanos = report.created_at.timestamp_nanos_opt().ok_or_else(|| {
+        AppError::FailedPrecondition("feedback timestamp exceeds nanosecond range".to_string())
+    })?;
+    Ok(FeedbackReportRecord {
+        id: report.id.clone(),
+        created_at_unix_nanos,
+        trying_to_do: report.trying_to_do.clone(),
+        tried: report.tried.clone(),
+        stuck: report.stuck.clone(),
+        publish_status: None,
+        publish_error: None,
+        published_at_unix_nanos: None,
+    })
+}
+
+fn run_feedback_db_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: Future<Output = Result<T, AppError>> + Send + 'static,
+{
+    fn run_on_runtime<T, F>(operation: F) -> Result<T, AppError>
+    where
+        F: Future<Output = Result<T, AppError>>,
+    {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "failed to create feedback database runtime: {error}"
+                ))
+            })?;
+        runtime.block_on(operation)
+    }
+
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return std::thread::spawn(move || run_on_runtime(operation))
+            .join()
+            .map_err(|_panic| {
+                AppError::FailedPrecondition(
+                    "feedback database operation thread panicked".to_string(),
+                )
+            })?;
+    }
+
+    run_on_runtime(operation)
 }
 
 fn required_text(field: &str, value: &str) -> Result<String, AppError> {
@@ -161,8 +243,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{FeedbackManager, FeedbackReport, FeedbackUpload};
-    use crate::feedback::publisher::FeedbackPublisher;
+    use crate::feedback::publisher::{FeedbackPublisher, NoopFeedbackPublisher};
     use crate::state::AppStateLayout;
+    use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
     use crate::workspaces::WorkspaceName;
 
     #[tokio::test]
@@ -214,6 +297,95 @@ mod tests {
             error
                 .to_string()
                 .contains("missing string argument 'tried'")
+        );
+        assert!(!layout.feedback_reports_file(&workspace).exists());
+    }
+
+    #[tokio::test]
+    async fn submit_feedback_with_db_appends_database_record_without_jsonl() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default feedback test DB should be sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let workspace = WorkspaceName::default();
+        let mut tx = db.begin().await.expect("begin workspace tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.commit().await.expect("commit workspace tx");
+        let manager = FeedbackManager::with_db(
+            layout.clone(),
+            Arc::new(NoopFeedbackPublisher),
+            Arc::clone(&db),
+        );
+
+        let submission = manager
+            .submit_feedback(&workspace, " trying ", " tried ", " stuck ", None)
+            .expect("feedback should submit");
+
+        let mut session = db.as_ref();
+        let reports = session
+            .feedback_reports()
+            .list_workspace_reports(&workspace)
+            .await
+            .expect("list DB feedback reports");
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].id, submission.report.id);
+        assert_eq!(reports[0].trying_to_do, "trying");
+        assert!(
+            !layout.feedback_reports_file(&workspace).exists(),
+            "DB-backed feedback writes should not append legacy JSONL"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_feedback_with_db_rejects_missing_workspace_without_creating_it() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default feedback test DB should be sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let workspace = WorkspaceName::parse("missing").expect("workspace");
+        let manager = FeedbackManager::with_db(
+            layout.clone(),
+            Arc::new(NoopFeedbackPublisher),
+            Arc::clone(&db),
+        );
+
+        let error = manager
+            .submit_feedback(&workspace, "trying", "tried", "stuck", None)
+            .expect_err("feedback should reject missing workspace");
+
+        assert!(
+            error.to_string().contains("workspace 'missing' not found"),
+            "unexpected error: {error}"
+        );
+        let mut session = db.as_ref();
+        assert!(
+            session
+                .workspaces()
+                .get(workspace.as_str())
+                .await
+                .expect("get workspace")
+                .is_none()
         );
         assert!(!layout.feedback_reports_file(&workspace).exists());
     }

--- a/crates/coral-app/src/feedback/manager.rs
+++ b/crates/coral-app/src/feedback/manager.rs
@@ -181,6 +181,7 @@ fn feedback_record(report: &FeedbackReport) -> Result<FeedbackReportRecord, AppE
         trying_to_do: report.trying_to_do.clone(),
         tried: report.tried.clone(),
         stuck: report.stuck.clone(),
+        task_id: report.task_id.map(|task_id| task_id.to_string()),
         publish_status: None,
         publish_error: None,
         published_at_unix_nanos: None,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1076,22 +1076,20 @@ impl QueryManager {
             .installed_sources(workspace_name)
             .await
             .map_err(QueryManagerError::App)?;
-        let (loaded_sources, config) = {
+        let config = {
             let _state_lock = self
                 .config_store
                 .state_lock_shared()
                 .map_err(QueryManagerError::App)?;
-            let config = self
-                .config_store
+            self.config_store
                 .load_config_unlocked()
-                .map_err(QueryManagerError::App)?;
-            let source_load = self
-                .load_query_sources_from_installed(workspace_name, installed_sources)
-                .await
-                .map_err(QueryManagerError::App)?;
-            (source_load.loaded, config)
+                .map_err(QueryManagerError::App)?
         };
-        Ok((loaded_sources, config))
+        let source_load = self
+            .load_query_sources_from_installed(workspace_name, installed_sources)
+            .await
+            .map_err(QueryManagerError::App)?;
+        Ok((source_load.loaded, config))
     }
 
     async fn validate_udf_sql_against_snapshot(

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -569,6 +569,7 @@ struct PersistedFeedbackReport {
     trying_to_do: String,
     tried: String,
     stuck: String,
+    task_id: Option<String>,
 }
 
 pub(crate) async fn import_filesystem_feedback_reports(
@@ -722,6 +723,7 @@ fn parse_legacy_feedback_report_line(
         trying_to_do: record.trying_to_do,
         tried: record.tried,
         stuck: record.stuck,
+        task_id: record.task_id,
         publish_status: None,
         publish_error: None,
         published_at_unix_nanos: None,
@@ -2235,6 +2237,17 @@ mod tests {
         assert!(invalid_workspace_file.exists());
         assert!(rollback_file.exists());
         let mut session = &db;
+        assert_eq!(
+            session
+                .feedback_reports()
+                .get(&healthy, "feedback-1")
+                .await
+                .expect("get imported feedback report")
+                .expect("imported feedback report")
+                .task_id
+                .as_deref(),
+            Some("550e8400-e29b-41d4-a716-446655440000")
+        );
         assert!(
             session
                 .workspaces()
@@ -2306,7 +2319,7 @@ mod tests {
 
     fn feedback_jsonl(workspace: &str, id: &str) -> String {
         format!(
-            r#"{{"id":"{id}","workspace":"{workspace}","created_at":"2026-06-30T12:00:00Z","trying_to_do":"trying","tried":"tried","stuck":"stuck"}}
+            r#"{{"id":"{id}","workspace":"{workspace}","created_at":"2026-06-30T12:00:00Z","trying_to_do":"trying","tried":"tried","stuck":"stuck","task_id":"550e8400-e29b-41d4-a716-446655440000"}}
 "#
         )
     }
@@ -2323,6 +2336,7 @@ mod tests {
             trying_to_do: trying_to_do.to_string(),
             tried: "tried".to_string(),
             stuck: "stuck".to_string(),
+            task_id: None,
             publish_status: None,
             publish_error: None,
             published_at_unix_nanos: None,

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -572,6 +572,13 @@ struct PersistedFeedbackReport {
     task_id: Option<String>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum FeedbackImportOutcome {
+    Imported,
+    AlreadyPresent,
+    WorkspaceMissing,
+}
+
 pub(crate) async fn import_filesystem_feedback_reports(
     db: &CoralDb,
     layout: &AppStateLayout,
@@ -609,8 +616,17 @@ pub(crate) async fn import_filesystem_feedback_reports(
             }
         }
         for record in records {
-            if insert_imported_feedback_report(db, &workspace_name, &record).await? {
-                imported += 1;
+            match insert_imported_feedback_report(db, &workspace_name, &record).await? {
+                FeedbackImportOutcome::Imported => imported += 1,
+                FeedbackImportOutcome::AlreadyPresent => {}
+                FeedbackImportOutcome::WorkspaceMissing => {
+                    has_unimported_rows = true;
+                    tracing::warn!(
+                        path = %path.display(),
+                        %workspace_name,
+                        "legacy feedback JSONL retained because its workspace no longer exists"
+                    );
+                }
             }
         }
         if has_unimported_rows {
@@ -629,15 +645,21 @@ async fn insert_imported_feedback_report(
     db: &CoralDb,
     workspace_name: &WorkspaceName,
     record: &FeedbackReportRecord,
-) -> Result<bool, AppError> {
+) -> Result<FeedbackImportOutcome, AppError> {
     let mut tx = db.begin().await?;
-    tx.workspaces()
-        .ensure(workspace_name.as_str(), record.created_at_unix_nanos)
-        .await?;
+    if tx
+        .workspaces()
+        .get(workspace_name.as_str())
+        .await?
+        .is_none()
+    {
+        tx.rollback().await?;
+        return Ok(FeedbackImportOutcome::WorkspaceMissing);
+    }
     match tx.feedback_reports().append(workspace_name, record).await {
         Ok(()) => {
             tx.commit().await?;
-            Ok(true)
+            Ok(FeedbackImportOutcome::Imported)
         }
         Err(error) if is_unique_constraint_error(&error) => {
             tx.rollback().await?;
@@ -648,7 +670,7 @@ async fn insert_imported_feedback_report(
                 .await?
                 .is_some()
             {
-                Ok(false)
+                Ok(FeedbackImportOutcome::AlreadyPresent)
             } else {
                 Err(error.into())
             }
@@ -2198,6 +2220,7 @@ mod tests {
         let default = WorkspaceName::parse("default").expect("workspace");
         let healthy = WorkspaceName::parse("healthy").expect("workspace");
         let corrupt = WorkspaceName::parse("corrupt").expect("workspace");
+        let deleted = WorkspaceName::parse("deleted").expect("workspace");
         let retained_file = layout.feedback_reports_file(&default);
         let healthy_file = layout.feedback_reports_file(&healthy);
         write_feedback_reports_file(
@@ -2205,6 +2228,8 @@ mod tests {
             &format!("{}not json\n", feedback_jsonl("default", "feedback-1")),
         );
         write_feedback_reports_file(&healthy_file, &feedback_jsonl("healthy", "feedback-1"));
+        let deleted_file = layout.feedback_reports_file(&deleted);
+        write_feedback_reports_file(&deleted_file, &feedback_jsonl("deleted", "feedback-1"));
         let corrupt_file = layout.feedback_reports_file(&corrupt);
         fs::create_dir_all(corrupt_file.parent().expect("reports parent"))
             .expect("create reports parent");
@@ -2225,6 +2250,16 @@ mod tests {
             .join("reports.jsonl");
         write_feedback_reports_file(&rollback_file, &feedback_jsonl("rollback", "feedback-1"));
         let db = open_sqlite(&layout).await;
+        let mut tx = db.begin().await.expect("begin workspace seed");
+        tx.workspaces()
+            .ensure(default.as_str(), 1)
+            .await
+            .expect("seed default workspace");
+        tx.workspaces()
+            .ensure(healthy.as_str(), 1)
+            .await
+            .expect("seed healthy workspace");
+        tx.commit().await.expect("commit workspace seed");
 
         let imported = import_filesystem_feedback_reports(&db, &layout)
             .await
@@ -2233,6 +2268,7 @@ mod tests {
         assert_eq!(imported, 2);
         assert!(retained_file.exists());
         assert!(!healthy_file.exists());
+        assert!(deleted_file.exists());
         assert!(corrupt_file.exists());
         assert!(invalid_workspace_file.exists());
         assert!(rollback_file.exists());
@@ -2247,6 +2283,14 @@ mod tests {
                 .task_id
                 .as_deref(),
             Some("550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert!(
+            session
+                .workspaces()
+                .get(deleted.as_str())
+                .await
+                .unwrap()
+                .is_none()
         );
         assert!(
             session
@@ -2293,7 +2337,10 @@ mod tests {
             panic!("loser feedback import completed before winner commit");
         }
         tx.commit().await.expect("commit winner feedback");
-        assert!(!import.await.expect("loser import should recover"));
+        assert_eq!(
+            import.await.expect("loser import should recover"),
+            super::FeedbackImportOutcome::AlreadyPresent
+        );
         let mut session = &db;
         assert_eq!(
             session

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -2,6 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::ErrorKind;
 
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
 use sha2::{Digest as _, Sha256};
 
 use super::session::DbRepos;
@@ -13,9 +15,11 @@ use crate::sources::materialization::{
     SourceDiagnosticReporter, load_v4_materialization_from_record, materialization_record_from_dir,
 };
 use crate::sources::model::{InstalledSource, SourceOrigin};
+use crate::state::db::FeedbackReportRecord;
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::{WorkspaceName, WorkspaceRecord};
 use coral_spec::parse_source_manifest_yaml;
+use uuid::Uuid;
 
 const WORKSPACE_CATALOG_CUTOVER_ID: &str = "workspace_catalog_cutover_v1";
 const SOURCE_CATALOG_IMPORT_ID: &str = "source_catalog_import_v1";
@@ -557,6 +561,225 @@ fn remove_v4_materialization_dir(materialized_dir: &std::path::Path) {
     }
 }
 
+#[derive(Debug, Deserialize)]
+struct PersistedFeedbackReport {
+    id: String,
+    workspace: String,
+    created_at: String,
+    trying_to_do: String,
+    tried: String,
+    stuck: String,
+}
+
+pub(crate) async fn import_filesystem_feedback_reports(
+    db: &CoralDb,
+    layout: &AppStateLayout,
+) -> Result<usize, AppError> {
+    let mut imported = 0;
+    for workspace_name in filesystem_feedback_workspaces(layout)? {
+        let path = layout.feedback_reports_file(&workspace_name);
+        if !path.exists() {
+            continue;
+        }
+        let raw = match fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(error) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    detail = %error,
+                    "skipping legacy feedback JSONL import because the file could not be read"
+                );
+                continue;
+            }
+        };
+        let mut records = Vec::new();
+        let mut has_unimported_rows = false;
+        for (index, line) in raw
+            .lines()
+            .enumerate()
+            .filter(|(_index, line)| !line.trim().is_empty())
+        {
+            if let Some(record) =
+                parse_legacy_feedback_report_line(&path, workspace_name.as_str(), index + 1, line)
+            {
+                records.push(record);
+            } else {
+                has_unimported_rows = true;
+            }
+        }
+        for record in records {
+            if insert_imported_feedback_report(db, &workspace_name, &record).await? {
+                imported += 1;
+            }
+        }
+        if has_unimported_rows {
+            tracing::warn!(
+                path = %path.display(),
+                "legacy feedback JSONL retained because at least one row was not imported"
+            );
+        } else {
+            remove_feedback_reports_file(&path);
+        }
+    }
+    Ok(imported)
+}
+
+async fn insert_imported_feedback_report(
+    db: &CoralDb,
+    workspace_name: &WorkspaceName,
+    record: &FeedbackReportRecord,
+) -> Result<bool, AppError> {
+    let mut tx = db.begin().await?;
+    tx.workspaces()
+        .ensure(workspace_name.as_str(), record.created_at_unix_nanos)
+        .await?;
+    match tx.feedback_reports().append(workspace_name, record).await {
+        Ok(()) => {
+            tx.commit().await?;
+            Ok(true)
+        }
+        Err(error) if is_unique_constraint_error(&error) => {
+            tx.rollback().await?;
+            let mut session = db;
+            if session
+                .feedback_reports()
+                .get(workspace_name, &record.id)
+                .await?
+                .is_some()
+            {
+                Ok(false)
+            } else {
+                Err(error.into())
+            }
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn parse_legacy_feedback_report_line(
+    path: &std::path::Path,
+    file_workspace: &str,
+    line_number: usize,
+    line: &str,
+) -> Option<FeedbackReportRecord> {
+    let record = match serde_json::from_str::<PersistedFeedbackReport>(line) {
+        Ok(record) => record,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                line = line_number,
+                %error,
+                "leaving invalid feedback report record in legacy JSONL"
+            );
+            return None;
+        }
+    };
+    let workspace = match WorkspaceName::parse(&record.workspace) {
+        Ok(workspace) => workspace,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                line = line_number,
+                %error,
+                "leaving feedback report with invalid workspace in legacy JSONL"
+            );
+            return None;
+        }
+    };
+    if workspace.as_str() != file_workspace {
+        tracing::warn!(
+            path = %path.display(),
+            line = line_number,
+            report_workspace = %workspace,
+            file_workspace,
+            "leaving feedback report stored under a different workspace in legacy JSONL"
+        );
+        return None;
+    }
+    let created_at = match DateTime::parse_from_rfc3339(&record.created_at) {
+        Ok(created_at) => created_at.with_timezone(&Utc),
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                line = line_number,
+                %error,
+                "leaving feedback report with invalid timestamp in legacy JSONL"
+            );
+            return None;
+        }
+    };
+    let Some(created_at_unix_nanos) = created_at.timestamp_nanos_opt() else {
+        tracing::warn!(
+            path = %path.display(),
+            line = line_number,
+            "leaving feedback report with out-of-range timestamp in legacy JSONL"
+        );
+        return None;
+    };
+    Some(FeedbackReportRecord {
+        id: record.id,
+        created_at_unix_nanos,
+        trying_to_do: record.trying_to_do,
+        tried: record.tried,
+        stuck: record.stuck,
+        publish_status: None,
+        publish_error: None,
+        published_at_unix_nanos: None,
+    })
+}
+
+fn filesystem_feedback_workspaces(layout: &AppStateLayout) -> Result<Vec<WorkspaceName>, AppError> {
+    let root = layout.workspaces_root();
+    let mut workspaces = Vec::new();
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(workspaces),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        if is_workspace_delete_rollback_dir(&name) {
+            continue;
+        }
+        match WorkspaceName::parse(&name) {
+            Ok(workspace) => workspaces.push(workspace),
+            Err(error) => tracing::warn!(
+                path = %entry.path().display(),
+                detail = %error,
+                "skipping legacy feedback import for invalid workspace directory"
+            ),
+        }
+    }
+    Ok(workspaces)
+}
+
+fn is_workspace_delete_rollback_dir(name: &str) -> bool {
+    let Some((_workspace_name, rollback_id)) = name.split_once(".delete.rollback.") else {
+        return false;
+    };
+    Uuid::parse_str(rollback_id).is_ok()
+}
+
+fn remove_feedback_reports_file(path: &std::path::Path) {
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                detail = %error,
+                "feedback reports imported into database but legacy JSONL cleanup failed"
+            );
+        }
+    }
+}
+
 fn read_imported_manifest_file(
     layout: &AppStateLayout,
     workspace_name: &WorkspaceName,
@@ -613,7 +836,8 @@ mod tests {
     use super::{
         SourceCatalogImportReport, WORKSPACE_CATALOG_CUTOVER_ID, WorkspaceCatalogCutoverReport,
         cutover_legacy_workspace_catalog, cutover_legacy_workspace_catalog_at,
-        import_config_source_catalog, run_state_migrations, source_catalog_import_id,
+        import_config_source_catalog, import_filesystem_feedback_reports, run_state_migrations,
+        source_catalog_import_id,
     };
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
@@ -623,8 +847,8 @@ mod tests {
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::db::session::DbRepos;
     use crate::state::db::{
-        CoralDb, DatabaseConfig, MaterializationRecord, MaterializationSurfaceRecord,
-        ResolvedDatabaseConfig,
+        CoralDb, DatabaseConfig, FeedbackReportRecord, MaterializationRecord,
+        MaterializationSurfaceRecord, ResolvedDatabaseConfig,
     };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::storage::fs::DELETION_BACKUP_INFIX;
@@ -1799,7 +2023,7 @@ mod tests {
         );
         assert!(
             tx.state_migrations()
-                .try_claim(SOURCE_CATALOG_IMPORT_ID, 7)
+                .try_claim(&source_catalog_import_id(&layout), 7)
                 .await
                 .expect("mark source import complete")
         );
@@ -1963,6 +2187,111 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn feedback_import_skips_bad_legacy_state_and_imports_healthy_rows() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let default = WorkspaceName::parse("default").expect("workspace");
+        let healthy = WorkspaceName::parse("healthy").expect("workspace");
+        let corrupt = WorkspaceName::parse("corrupt").expect("workspace");
+        let retained_file = layout.feedback_reports_file(&default);
+        let healthy_file = layout.feedback_reports_file(&healthy);
+        write_feedback_reports_file(
+            &retained_file,
+            &format!("{}not json\n", feedback_jsonl("default", "feedback-1")),
+        );
+        write_feedback_reports_file(&healthy_file, &feedback_jsonl("healthy", "feedback-1"));
+        let corrupt_file = layout.feedback_reports_file(&corrupt);
+        fs::create_dir_all(corrupt_file.parent().expect("reports parent"))
+            .expect("create reports parent");
+        fs::write(&corrupt_file, b"{\xff").expect("write invalid UTF-8 JSONL");
+        let invalid_workspace_file = layout
+            .workspaces_root()
+            .join(r"bad\workspace")
+            .join("feedback")
+            .join("reports.jsonl");
+        write_feedback_reports_file(
+            &invalid_workspace_file,
+            &feedback_jsonl(r"bad\workspace", "feedback-1"),
+        );
+        let rollback_file = layout
+            .workspaces_root()
+            .join(format!("rollback.delete.rollback.{}", uuid::Uuid::new_v4()))
+            .join("feedback")
+            .join("reports.jsonl");
+        write_feedback_reports_file(&rollback_file, &feedback_jsonl("rollback", "feedback-1"));
+        let db = open_sqlite(&layout).await;
+
+        let imported = import_filesystem_feedback_reports(&db, &layout)
+            .await
+            .expect("import feedback reports");
+
+        assert_eq!(imported, 2);
+        assert!(retained_file.exists());
+        assert!(!healthy_file.exists());
+        assert!(corrupt_file.exists());
+        assert!(invalid_workspace_file.exists());
+        assert!(rollback_file.exists());
+        let mut session = &db;
+        assert!(
+            session
+                .workspaces()
+                .get("rollback")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_feedback_report_import_race_is_benign_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+        let workspace = WorkspaceName::parse(&format!("feedback{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace");
+        let winner = feedback_record("feedback-1", "winner");
+        let mut tx = db.begin().await.expect("begin workspace tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), winner.created_at_unix_nanos)
+            .await
+            .expect("ensure workspace");
+        tx.commit().await.expect("commit workspace");
+        let mut tx = db.begin().await.expect("begin winner tx");
+        tx.feedback_reports()
+            .append(&workspace, &winner)
+            .await
+            .expect("insert uncommitted winner feedback");
+        let mut loser = winner.clone();
+        loser.trying_to_do = "loser".into();
+        let import = super::insert_imported_feedback_report(&db, &workspace, &loser);
+        tokio::pin!(import);
+
+        if tokio::time::timeout(std::time::Duration::from_millis(250), &mut import)
+            .await
+            .is_ok()
+        {
+            panic!("loser feedback import completed before winner commit");
+        }
+        tx.commit().await.expect("commit winner feedback");
+        assert!(!import.await.expect("loser import should recover"));
+        let mut session = &db;
+        assert_eq!(
+            session
+                .feedback_reports()
+                .get(&workspace, &winner.id)
+                .await
+                .expect("get feedback report"),
+            Some(winner)
+        );
+    }
+
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
         let config = DatabaseConfig::load(layout).expect("db config");
         let DatabaseConfig::Sqlite { path } = config else {
@@ -1973,6 +2302,31 @@ mod tests {
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
         db
+    }
+
+    fn feedback_jsonl(workspace: &str, id: &str) -> String {
+        format!(
+            r#"{{"id":"{id}","workspace":"{workspace}","created_at":"2026-06-30T12:00:00Z","trying_to_do":"trying","tried":"tried","stuck":"stuck"}}
+"#
+        )
+    }
+
+    fn write_feedback_reports_file(path: &std::path::Path, contents: &str) {
+        fs::create_dir_all(path.parent().expect("reports parent")).expect("create reports parent");
+        fs::write(path, contents).expect("write feedback JSONL");
+    }
+
+    fn feedback_record(id: &str, trying_to_do: &str) -> FeedbackReportRecord {
+        FeedbackReportRecord {
+            id: id.to_string(),
+            created_at_unix_nanos: 42,
+            trying_to_do: trying_to_do.to_string(),
+            tried: "tried".to_string(),
+            stuck: "stuck".to_string(),
+            publish_status: None,
+            publish_error: None,
+            published_at_unix_nanos: None,
+        }
     }
 
     fn source<const V: usize, const S: usize>(

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -22,12 +22,8 @@ pub(crate) use clock::now_unix_nanos_i64;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
-pub(crate) use import::run_state_migrations;
+pub(crate) use import::{import_filesystem_feedback_reports, run_state_migrations};
 pub(crate) use ownership_bootstrap::{inaccessible_workspaces, migrate_local_ownership_once};
-#[expect(
-    unused_imports,
-    reason = "Feedback runtime branches import this from the state::db boundary once restacked."
-)]
 pub(crate) use repositories::feedback_reports::FeedbackReportRecord;
 pub(crate) use repositories::identity_specs::{
     IdentitySpecDocumentRecord, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -107,13 +107,6 @@ pub(crate) trait DbRepos: DbSession + Sized {
         MaterializationsRepo::new(self)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "feedback repository lands before runtime wiring in the stacked PR sequence"
-        )
-    )]
     fn feedback_reports(&mut self) -> FeedbackReportsRepo<'_, Self> {
         FeedbackReportsRepo::new(self)
     }

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -38,6 +38,7 @@ coral-telemetry.workspace = true
 coral-spec.workspace = true
 jsonschema.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
+sqlx.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tonic-types.workspace = true

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -2439,10 +2439,6 @@ async fn add_function_is_create_only() {
 }
 
 #[tokio::test]
-#[expect(
-    clippy::too_many_lines,
-    reason = "End-to-end feedback coverage verifies the advertised surface, persistence, result contract, and validation together."
-)]
 async fn mcp_feedback_tool_persists_blocked_agent_report() {
     let temp = TempDir::new().expect("temp dir");
     let session = start_session_with_options(

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -2562,7 +2562,7 @@ async fn assert_feedback_row_matches(db: &sqlx::SqlitePool, feedback_id: &str) {
             .await
             .expect("feedback row should exist");
     assert_eq!(record.get::<String, _>("id"), feedback_id);
-    assert_eq!(record.get::<String, _>("workspace_id"), "default");
+    assert_eq!(record.get::<String, _>("workspace_id"), TEST_WORKSPACE);
     assert_eq!(record.get::<String, _>("trying_to_do"), "Fix failing tests");
     assert_eq!(
         record.get::<String, _>("tried"),
@@ -2606,17 +2606,18 @@ async fn mcp_feedback_tool_always_accepts_task_context() {
         .await
         .expect("task-tagged feedback");
     assert_eq!(feedback.is_error, Some(false));
-    assert_eq!(
-        feedback.structured_content.expect("structured content")["message"],
-        "Feedback report stored."
-    );
+    let structured = feedback.structured_content.expect("structured content");
+    assert_eq!(structured["message"], "Feedback report stored.");
 
-    let raw =
-        fs::read_to_string(feedback_reports_path(temp.path())).expect("feedback file should exist");
-    let records = raw.lines().collect::<Vec<_>>();
-    assert_eq!(records.len(), 1);
-    let record: Value = serde_json::from_str(records[0]).expect("feedback JSONL should parse");
-    assert_eq!(record["task_id"], task_id);
+    let db = open_feedback_database(&temp).await;
+    let record = sqlx::query("select task_id from feedback_reports")
+        .fetch_one(&db)
+        .await
+        .expect("feedback row should exist");
+    assert_eq!(
+        record.get::<Option<String>, _>("task_id").as_deref(),
+        Some(task_id.as_str())
+    );
 
     let invalid_task_id = client
         .call_tool(

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -35,6 +35,7 @@ use rmcp::{
     service::RunningService,
 };
 use serde_json::{Map, Value, json};
+use sqlx::{Row, sqlite::SqliteConnectOptions};
 use tempfile::TempDir;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status, transport::Server};
@@ -2512,22 +2513,12 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
     assert_eq!(structured["message"], "Feedback report stored.");
     assert!(structured.get("upload").is_none());
 
-    let raw =
-        fs::read_to_string(feedback_reports_path(temp.path())).expect("feedback file should exist");
-    let records = raw.lines().collect::<Vec<_>>();
-    assert_eq!(records.len(), 1);
-    let record: Value = serde_json::from_str(records[0]).expect("feedback JSONL should parse");
-    assert_eq!(record["id"], structured["feedback_id"]);
-    assert_eq!(record["workspace"], TEST_WORKSPACE);
-    assert_eq!(record["trying_to_do"], "Fix failing tests");
-    assert_eq!(
-        record["tried"],
-        "Ran cargo test and inspected the failing assertion"
-    );
-    assert_eq!(
-        record["stuck"],
-        "The fixture shape does not match the documented contract"
-    );
+    let db = open_feedback_database(&temp).await;
+    assert_feedback_row_matches(
+        &db,
+        structured["feedback_id"].as_str().expect("feedback id"),
+    )
+    .await;
 
     let blank_feedback = client
         .call_tool(
@@ -2548,11 +2539,43 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             .contains("missing string argument 'tried'")
     );
 
-    let raw_after_error = fs::read_to_string(feedback_reports_path(temp.path()))
-        .expect("feedback file should still exist");
-    assert_eq!(raw_after_error.lines().count(), 1);
+    let count = sqlx::query("select count(*) as count from feedback_reports")
+        .fetch_one(&db)
+        .await
+        .expect("count feedback rows")
+        .get::<i64, _>("count");
+    assert_eq!(count, 1);
 
     session.shutdown().await;
+}
+
+async fn open_feedback_database(temp: &TempDir) -> sqlx::SqlitePool {
+    sqlx::SqlitePool::connect_with(
+        SqliteConnectOptions::new()
+            .filename(temp.path().join("coral-config/coral.db"))
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open feedback database")
+}
+
+async fn assert_feedback_row_matches(db: &sqlx::SqlitePool, feedback_id: &str) {
+    let record =
+        sqlx::query("select id, workspace_id, trying_to_do, tried, stuck from feedback_reports")
+            .fetch_one(db)
+            .await
+            .expect("feedback row should exist");
+    assert_eq!(record.get::<String, _>("id"), feedback_id);
+    assert_eq!(record.get::<String, _>("workspace_id"), "default");
+    assert_eq!(record.get::<String, _>("trying_to_do"), "Fix failing tests");
+    assert_eq!(
+        record.get::<String, _>("tried"),
+        "Ran cargo test and inspected the failing assertion"
+    );
+    assert_eq!(
+        record.get::<String, _>("stuck"),
+        "The fixture shape does not match the documented contract"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Intent
Persist new feedback reports through the database when DB-backed state is available.

## What it enables
Feedback reporting no longer writes new records to the legacy JSONL file in the DB-backed local state path.

## Usage examples
Submit feedback through the MCP feedback tool; the report is appended to the `feedback_reports` table instead of `feedback.jsonl`.

## Validation
Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.