### PR TITLE
feat(app): add credential encryption primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "windows-native-keyring-store",
  "wiremock",
  "zbus-secret-service-keyring-store",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,7 @@ dependencies = [
  "prost",
  "regex",
  "reqwest 0.13.4",
+ "ring",
  "rusqlite",
  "sea-query",
  "sea-query-sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ urlencoding = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
 walkdir = "2"
 wiremock = "0.6"
+zeroize = "1.8"
 
 coral-api = { path = "crates/coral-api" }
 coral-app = { path = "crates/coral-app" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ parquet = { version = "58.1.0", features = ["arrow"] }
 prost = "0.14.1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "charset", "form", "http2", "json", "query", "rustls", "system-proxy"] }
 regex = "1"
+ring = "0.17.14"
 rmcp = { version = "1.6.0", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 rusqlite = { version = "0.37", features = ["bundled"] }
 rust-embed = { version = "8", features = ["mime-guess"] }

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -46,6 +46,7 @@ tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
 uuid.workspace = true
+zeroize.workspace = true
 
 coral-api.workspace = true
 coral-auth-aws = { path = "../auth/aws" }

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -24,6 +24,7 @@ opentelemetry_sdk.workspace = true
 regex.workspace = true
 reqwest.workspace = true
 rusqlite.workspace = true
+ring.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -26,6 +26,7 @@ pub(crate) fn discover_app_state_layout(
     env::AppEnvironment::discover().app_state_layout(config_dir_override)
 }
 
+#[cfg(test)]
 pub(crate) fn env_var(name: &str) -> Result<Option<String>, std::env::VarError> {
     env::AppEnvironment::env_var(name)
 }

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -26,7 +26,6 @@ pub(crate) fn discover_app_state_layout(
     env::AppEnvironment::discover().app_state_layout(config_dir_override)
 }
 
-#[cfg(test)]
 pub(crate) fn env_var(name: &str) -> Result<Option<String>, std::env::VarError> {
     env::AppEnvironment::env_var(name)
 }

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -7,7 +7,7 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Mutex;
 
 use base64::Engine as _;
@@ -18,7 +18,6 @@ use tracing::warn;
 use zeroize::{Zeroize as _, Zeroizing};
 
 use super::CredentialsError;
-use crate::bootstrap;
 use crate::sources::SourceName;
 use crate::state::AppStateLayout;
 use crate::storage::fs as storage_fs;
@@ -56,6 +55,34 @@ impl Drop for CredentialEncryptionKey {
 }
 
 impl CredentialEncryptionKey {
+    pub(crate) fn from_encoded_material(raw: &str) -> Result<Self, CredentialsError> {
+        let trimmed = raw.trim();
+        let Some(encoded) = trimmed.strip_prefix(&format!("{KEY_FILE_VERSION}:")) else {
+            return Err(CredentialsError::Crypto(
+                "unsupported credential encryption key version".to_string(),
+            ));
+        };
+        let decoded = Zeroizing::new(
+            base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .map_err(|error| {
+                    CredentialsError::Crypto(format!("invalid encryption key: {error}"))
+                })?,
+        );
+        if decoded.len() != KEY_LEN {
+            return Err(CredentialsError::Crypto(format!(
+                "credential encryption key has invalid length {}",
+                decoded.len()
+            )));
+        }
+        let mut bytes = [0_u8; KEY_LEN];
+        bytes.copy_from_slice(decoded.as_slice());
+        Ok(Self {
+            key_id: key_id_for_bytes(&bytes),
+            bytes,
+        })
+    }
+
     #[cfg(test)]
     pub(crate) fn from_static_bytes_for_test(bytes: [u8; KEY_LEN]) -> Self {
         Self {
@@ -75,43 +102,34 @@ pub(crate) trait CredentialKeyProvider: Send + Sync {
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError>;
 }
 
-/// Local credential encryption key provider.
-/// Shared-Postgres deployments MUST provision the same KEK on every server via
-/// `[credentials].encryption_key_env`; the local file key is single-config-dir only.
+/// Resolves an explicitly supplied key or falls back to a key file scoped to
+/// this app-state config directory. Callers own config and environment resolution.
 #[derive(Debug, Clone)]
 pub(crate) struct LocalFileCredentialKeyProvider {
     path: PathBuf,
-    config_file: PathBuf,
+    provided_key: Option<CredentialEncryptionKey>,
 }
 
 impl LocalFileCredentialKeyProvider {
-    pub(crate) fn new(layout: &AppStateLayout) -> Self {
+    pub(crate) fn new(
+        layout: &AppStateLayout,
+        provided_key: Option<CredentialEncryptionKey>,
+    ) -> Self {
         Self {
             path: layout.credential_encryption_key_file(),
-            config_file: layout.config_file().to_path_buf(),
+            provided_key,
         }
     }
 
-    fn load_configured_key(&self) -> Result<Option<CredentialEncryptionKey>, CredentialsError> {
-        let Some(env_name) = configured_key_env(&self.config_file)? else {
-            return Ok(None);
-        };
-        let raw = bootstrap::env_var(&env_name)
-            .map_err(|error| {
-                CredentialsError::Crypto(format!(
-                    "credential encryption key environment variable `{env_name}` is invalid: {error}"
-                ))
-            })?
-            .ok_or_else(|| {
-                CredentialsError::Crypto(format!(
-                    "credential encryption key environment variable `{env_name}` is not set"
-                ))
-            })?;
-        decode_key_material(&raw).map(Some).map_err(|error| {
-            CredentialsError::Crypto(format!(
-                "invalid credential encryption key from environment variable `{env_name}`: {error}"
-            ))
-        })
+    fn load_key(&self) -> Result<Option<CredentialEncryptionKey>, CredentialsError> {
+        match std::fs::read_to_string(&self.path) {
+            Ok(raw) => {
+                let raw = Zeroizing::new(raw);
+                CredentialEncryptionKey::from_encoded_material(raw.as_str()).map(Some)
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
     }
 
     fn load_or_create_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
@@ -124,48 +142,48 @@ impl LocalFileCredentialKeyProvider {
         let lock_path = self.path.with_extension("key.lock");
         let _process_guard = FileLock::exclusive(&lock_path)?;
 
-        match std::fs::read_to_string(&self.path) {
-            Ok(raw) => decode_key_material(&raw),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                let bytes = random_array::<KEY_LEN>()?;
-                let encoded = format!(
-                    "{KEY_FILE_VERSION}:{}\n",
-                    base64::engine::general_purpose::STANDARD.encode(bytes)
-                );
-                storage_fs::write_atomic(&self.path, encoded.as_bytes())?;
-                warn!(
-                    path = %self.path.display(),
-                    "created local credential encryption key; shared-Postgres deployments must provision the same KEK on every server"
-                );
-                Ok(CredentialEncryptionKey {
-                    key_id: key_id_for_bytes(&bytes),
-                    bytes,
-                })
-            }
-            Err(error) => Err(error.into()),
+        if let Some(key) = self.load_key()? {
+            return Ok(key);
         }
+
+        let bytes = Zeroizing::new(random_array::<KEY_LEN>()?);
+        let mut encoded = Zeroizing::new(format!("{KEY_FILE_VERSION}:"));
+        base64::engine::general_purpose::STANDARD.encode_string(bytes.as_slice(), &mut encoded);
+        encoded.push('\n');
+        storage_fs::write_atomic(&self.path, encoded.as_bytes())?;
+        warn!(
+            path = %self.path.display(),
+            "created local credential encryption key"
+        );
+        Ok(CredentialEncryptionKey {
+            key_id: key_id_for_bytes(&bytes),
+            bytes: *bytes,
+        })
     }
 }
 
 impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
     fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
-        if let Some(key) = self.load_configured_key()? {
-            return Ok(key);
+        if let Some(key) = &self.provided_key {
+            return Ok(key.clone());
         }
         self.load_or_create_key()
     }
 
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
-        let key = self
-            .load_configured_key()?
-            .map_or_else(|| self.load_or_create_key(), Ok)?;
-        if key.key_id == key_id {
-            Ok(key)
-        } else {
-            Err(CredentialsError::Crypto(format!(
-                "credential encryption key '{key_id}' is unavailable"
-            )))
+        if let Some(key) = &self.provided_key
+            && key.key_id == key_id
+        {
+            return Ok(key.clone());
         }
+        if let Some(key) = self.load_key()?
+            && key.key_id == key_id
+        {
+            return Ok(key);
+        }
+        Err(CredentialsError::Crypto(format!(
+            "credential encryption key '{key_id}' is unavailable"
+        )))
     }
 }
 
@@ -180,8 +198,14 @@ pub(crate) struct EncryptedCredentialDocument {
     pub(crate) aad_version: i64,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-struct PlaintextCredentialDocument {
+#[derive(serde::Serialize)]
+struct PlaintextCredentialDocument<'a> {
+    version: u32,
+    values: &'a BTreeMap<String, String>,
+}
+
+#[derive(serde::Deserialize)]
+struct DecryptedCredentialDocument {
     version: u32,
     values: BTreeMap<String, String>,
 }
@@ -199,7 +223,7 @@ pub(crate) fn encrypt_credential_values(
 
     let plaintext = PlaintextCredentialDocument {
         version: CREDENTIAL_DOCUMENT_VERSION,
-        values: values.clone(),
+        values,
     };
     let mut document_bytes = Zeroizing::new(
         serde_json::to_vec(&plaintext)
@@ -239,7 +263,7 @@ pub(crate) fn decrypt_credential_values(
 ) -> Result<BTreeMap<String, String>, CredentialsError> {
     let plaintext =
         decrypt_credential_document_bytes(workspace_name, source_name, document, key_provider)?;
-    let decoded: PlaintextCredentialDocument = serde_json::from_slice(&plaintext)
+    let decoded: DecryptedCredentialDocument = serde_json::from_slice(&plaintext)
         .map_err(|error| CredentialsError::Parse(error.to_string()))?;
     if decoded.version != CREDENTIAL_DOCUMENT_VERSION {
         return Err(CredentialsError::Parse(format!(
@@ -488,51 +512,64 @@ fn random_array<const N: usize>() -> Result<[u8; N], CredentialsError> {
     Ok(bytes)
 }
 
-fn configured_key_env(config_file: &Path) -> Result<Option<String>, CredentialsError> {
-    if !config_file.exists() {
-        return Ok(None);
-    }
-    let raw = std::fs::read_to_string(config_file)?;
-    let config: toml::Value =
-        toml::from_str(&raw).map_err(|error| CredentialsError::Parse(error.to_string()))?;
-    let Some(value) = config
-        .get("credentials")
-        .and_then(|credentials| credentials.get("encryption_key_env"))
-    else {
-        return Ok(None);
-    };
-    value
-        .as_str()
-        .map(|env| Some(env.to_string()))
-        .ok_or_else(|| {
-            CredentialsError::Parse("[credentials].encryption_key_env must be a string".to_string())
-        })
-}
-
-fn decode_key_material(raw: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
-    let trimmed = raw.trim();
-    let Some(encoded) = trimmed.strip_prefix(&format!("{KEY_FILE_VERSION}:")) else {
-        return Err(CredentialsError::Crypto(
-            "unsupported credential encryption key version".to_string(),
-        ));
-    };
-    let decoded = base64::engine::general_purpose::STANDARD
-        .decode(encoded)
-        .map_err(|error| CredentialsError::Crypto(format!("invalid encryption key: {error}")))?;
-    let bytes: [u8; KEY_LEN] = decoded.try_into().map_err(|decoded: Vec<u8>| {
-        CredentialsError::Crypto(format!(
-            "credential encryption key has invalid length {}",
-            decoded.len()
-        ))
-    })?;
-    Ok(CredentialEncryptionKey {
-        key_id: key_id_for_bytes(&bytes),
-        bytes,
-    })
-}
-
 fn key_id_for_bytes(bytes: &[u8; KEY_LEN]) -> String {
     let digest = Sha256::digest(bytes);
     let hex = format!("{digest:x}");
     format!("local-file-{}", hex.get(..16).unwrap_or(hex.as_str()))
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine as _;
+    use tempfile::tempdir;
+
+    use super::{
+        CredentialEncryptionKey, CredentialKeyProvider, KEY_FILE_VERSION, KEY_LEN,
+        LocalFileCredentialKeyProvider,
+    };
+    use crate::state::AppStateLayout;
+
+    #[test]
+    fn provided_key_does_not_create_a_local_key_file() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let encoded = format!(
+            "{KEY_FILE_VERSION}:{}",
+            base64::engine::general_purpose::STANDARD.encode([7_u8; KEY_LEN])
+        );
+        let key = CredentialEncryptionKey::from_encoded_material(&encoded).expect("encoded key");
+        let provider = LocalFileCredentialKeyProvider::new(&layout, Some(key));
+
+        let first = provider.active_key().expect("provided key");
+        let second = provider.key(first.key_id()).expect("provided key by id");
+
+        assert_eq!(first, second);
+        assert!(!layout.credential_encryption_key_file().exists());
+    }
+
+    #[test]
+    fn missing_key_lookup_does_not_create_a_local_key_file() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let provider = LocalFileCredentialKeyProvider::new(&layout, None);
+
+        let error = provider.key("missing-key").expect_err("missing key");
+
+        assert!(error.to_string().contains("is unavailable"));
+        assert!(!layout.credential_encryption_key_file().exists());
+    }
+
+    #[test]
+    fn provided_key_keeps_existing_file_key_available_for_rewrap() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let file_key = LocalFileCredentialKeyProvider::new(&layout, None)
+            .active_key()
+            .expect("file key");
+        let provided_key = CredentialEncryptionKey::from_static_bytes_for_test([9_u8; KEY_LEN]);
+        let provider = LocalFileCredentialKeyProvider::new(&layout, Some(provided_key.clone()));
+
+        assert_eq!(provider.active_key().expect("provided key"), provided_key);
+        assert_eq!(provider.key(file_key.key_id()).expect("file key"), file_key);
+    }
 }

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -1,4 +1,15 @@
-//! Application-level envelope encryption for DB-backed credential material.
+//! Envelope encryption uses one key for credential data and another for that key.
+//!
+//! # Terminology
+//! - AEAD means authenticated encryption with associated data; the AEAD used here,
+//!   AES-256-GCM, is Advanced Encryption Standard with a 256-bit key in Galois/Counter Mode.
+//! - A DEK (data-encryption key) encrypts one document; a longer-lived KEK
+//!   (key-encryption key) wraps it. Rewrapping encrypts it with a replacement KEK.
+//! - AAD (additional authenticated data) is unencrypted but authenticated context,
+//!   binding documents to workspace/source and wrapped DEKs to KEK identifiers.
+//! - A nonce ("number used once") is a public, per-key unique encryption input.
+//! - SHA-256 (Secure Hash Algorithm, 256-bit) derives non-secret KEK identifiers;
+//!   it does not encrypt data.
 
 #![expect(
     dead_code,

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -1,0 +1,459 @@
+//! Application-level envelope encryption for DB-backed credential material.
+
+#![expect(
+    dead_code,
+    reason = "Credential DB runtime wiring lands in a later stack branch; this branch isolates cryptographic primitives for review."
+)]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use base64::Engine as _;
+use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey};
+use ring::rand::{SecureRandom as _, SystemRandom};
+use sha2::{Digest as _, Sha256};
+
+use super::CredentialsError;
+use crate::sources::SourceName;
+use crate::state::AppStateLayout;
+use crate::storage::fs as storage_fs;
+use crate::storage::fs::FileLock;
+use crate::workspaces::WorkspaceName;
+
+pub(crate) const CREDENTIAL_DOCUMENT_ALGORITHM: &str = "AES-256-GCM";
+pub(crate) const CREDENTIAL_DOCUMENT_AAD_VERSION: i64 = 1;
+
+const CREDENTIAL_DOCUMENT_VERSION: u32 = 1;
+const KEY_FILE_VERSION: &str = "v1";
+const KEY_LEN: usize = 32;
+const NONCE_LEN: usize = 12;
+
+static LOCAL_KEY_FILE_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CredentialEncryptionKey {
+    key_id: String,
+    bytes: [u8; KEY_LEN],
+}
+
+impl CredentialEncryptionKey {
+    #[cfg(test)]
+    pub(crate) fn from_static_bytes_for_test(bytes: [u8; KEY_LEN]) -> Self {
+        Self {
+            key_id: key_id_for_bytes(&bytes),
+            bytes,
+        }
+    }
+
+    pub(crate) fn key_id(&self) -> &str {
+        self.key_id.as_str()
+    }
+}
+
+pub(crate) trait CredentialKeyProvider: Send + Sync {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError>;
+
+    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError>;
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LocalFileCredentialKeyProvider {
+    path: PathBuf,
+}
+
+impl LocalFileCredentialKeyProvider {
+    pub(crate) fn new(layout: &AppStateLayout) -> Self {
+        Self {
+            path: layout.credential_encryption_key_file(),
+        }
+    }
+
+    fn load_or_create_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        let _thread_guard = LOCAL_KEY_FILE_LOCK.lock().map_err(|_error| {
+            CredentialsError::Crypto("credential encryption key lock is poisoned".to_string())
+        })?;
+        if let Some(parent) = self.path.parent() {
+            storage_fs::ensure_private_dir(parent)?;
+        }
+        let lock_path = self.path.with_extension("key.lock");
+        let _process_guard = FileLock::exclusive(&lock_path)?;
+
+        match std::fs::read_to_string(&self.path) {
+            Ok(raw) => decode_key_file(&raw),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let bytes = random_array::<KEY_LEN>()?;
+                let encoded = format!(
+                    "{KEY_FILE_VERSION}:{}\n",
+                    base64::engine::general_purpose::STANDARD.encode(bytes)
+                );
+                storage_fs::write_atomic(&self.path, encoded.as_bytes())?;
+                Ok(CredentialEncryptionKey {
+                    key_id: key_id_for_bytes(&bytes),
+                    bytes,
+                })
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        self.load_or_create_key()
+    }
+
+    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+        let key = self.load_or_create_key()?;
+        if key.key_id == key_id {
+            Ok(key)
+        } else {
+            Err(CredentialsError::Crypto(format!(
+                "credential encryption key '{key_id}' is unavailable"
+            )))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EncryptedCredentialDocument {
+    pub(crate) ciphertext: Vec<u8>,
+    pub(crate) nonce: Vec<u8>,
+    pub(crate) wrapped_dek: Vec<u8>,
+    pub(crate) wrapped_dek_nonce: Vec<u8>,
+    pub(crate) key_id: String,
+    pub(crate) algorithm: String,
+    pub(crate) aad_version: i64,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PlaintextCredentialDocument {
+    version: u32,
+    values: BTreeMap<String, String>,
+}
+
+pub(crate) fn encrypt_credential_values(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    values: &BTreeMap<String, String>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<EncryptedCredentialDocument, CredentialsError> {
+    let kek = key_provider.active_key()?;
+    let dek = random_array::<KEY_LEN>()?;
+    let nonce = random_array::<NONCE_LEN>()?;
+    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
+
+    let plaintext = PlaintextCredentialDocument {
+        version: CREDENTIAL_DOCUMENT_VERSION,
+        values: values.clone(),
+    };
+    let mut document_bytes = serde_json::to_vec(&plaintext)
+        .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+    seal(
+        &dek,
+        &nonce,
+        credential_document_aad(workspace_name, source_name),
+        &mut document_bytes,
+    )?;
+
+    let mut wrapped_dek = dek.to_vec();
+    seal(
+        &kek.bytes,
+        &wrapped_dek_nonce,
+        credential_dek_aad(kek.key_id()),
+        &mut wrapped_dek,
+    )?;
+
+    Ok(EncryptedCredentialDocument {
+        ciphertext: document_bytes,
+        nonce: nonce.to_vec(),
+        wrapped_dek,
+        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
+        key_id: kek.key_id,
+        algorithm: CREDENTIAL_DOCUMENT_ALGORITHM.to_string(),
+        aad_version: CREDENTIAL_DOCUMENT_AAD_VERSION,
+    })
+}
+
+pub(crate) fn decrypt_credential_values(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    document: &EncryptedCredentialDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<BTreeMap<String, String>, CredentialsError> {
+    let plaintext =
+        decrypt_credential_document_bytes(workspace_name, source_name, document, key_provider)?;
+    let decoded: PlaintextCredentialDocument = serde_json::from_slice(&plaintext)
+        .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+    if decoded.version != CREDENTIAL_DOCUMENT_VERSION {
+        return Err(CredentialsError::Parse(format!(
+            "unsupported credential document version {}",
+            decoded.version
+        )));
+    }
+    Ok(decoded.values)
+}
+
+pub(crate) fn rewrap_credential_document(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    document: &EncryptedCredentialDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Option<EncryptedCredentialDocument>, CredentialsError> {
+    validate_document_metadata(document)?;
+    let old_kek = key_provider.key(&document.key_id)?;
+    let active_kek = key_provider.active_key()?;
+    if old_kek.key_id == active_kek.key_id {
+        return Ok(None);
+    }
+
+    let dek = unwrap_dek(document, &old_kek)?;
+    let mut document_probe = document.ciphertext.clone();
+    if open(
+        &dek,
+        document.nonce.as_slice(),
+        credential_document_aad(workspace_name, source_name),
+        &mut document_probe,
+    )
+    .is_err()
+    {
+        // Documents written before this rotation-safe envelope shape bound the
+        // payload AAD to the KEK id. Re-encrypt those once so future rotations
+        // only need to rewrap the DEK.
+        let values =
+            decrypt_credential_values(workspace_name, source_name, document, key_provider)?;
+        return encrypt_credential_values(workspace_name, source_name, &values, key_provider)
+            .map(Some);
+    }
+
+    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
+    let mut wrapped_dek = dek;
+    seal(
+        &active_kek.bytes,
+        &wrapped_dek_nonce,
+        credential_dek_aad(active_kek.key_id()),
+        &mut wrapped_dek,
+    )?;
+
+    Ok(Some(EncryptedCredentialDocument {
+        ciphertext: document.ciphertext.clone(),
+        nonce: document.nonce.clone(),
+        wrapped_dek,
+        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
+        key_id: active_kek.key_id,
+        algorithm: document.algorithm.clone(),
+        aad_version: document.aad_version,
+    }))
+}
+
+fn decrypt_credential_document_bytes(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    document: &EncryptedCredentialDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Vec<u8>, CredentialsError> {
+    validate_document_metadata(document)?;
+    let kek = key_provider.key(&document.key_id)?;
+    let dek = unwrap_dek(document, &kek)?;
+
+    let mut ciphertext = document.ciphertext.clone();
+    match open(
+        &dek,
+        document.nonce.as_slice(),
+        credential_document_aad(workspace_name, source_name),
+        &mut ciphertext,
+    ) {
+        Ok(plaintext) => Ok(plaintext.to_vec()),
+        Err(primary_error) => {
+            let mut legacy_ciphertext = document.ciphertext.clone();
+            match open(
+                &dek,
+                document.nonce.as_slice(),
+                legacy_credential_document_aad(workspace_name, source_name, &document.key_id),
+                &mut legacy_ciphertext,
+            ) {
+                Ok(plaintext) => Ok(plaintext.to_vec()),
+                Err(_) => Err(primary_error),
+            }
+        }
+    }
+}
+
+fn unwrap_dek(
+    document: &EncryptedCredentialDocument,
+    kek: &CredentialEncryptionKey,
+) -> Result<Vec<u8>, CredentialsError> {
+    let mut dek = document.wrapped_dek.clone();
+    match open(
+        &kek.bytes,
+        document.wrapped_dek_nonce.as_slice(),
+        credential_dek_aad(&document.key_id),
+        &mut dek,
+    ) {
+        Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
+        Err(primary_error) => {
+            let mut legacy_dek = document.wrapped_dek.clone();
+            match open(
+                &kek.bytes,
+                document.wrapped_dek_nonce.as_slice(),
+                legacy_credential_dek_aad(&document.key_id),
+                &mut legacy_dek,
+            ) {
+                Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
+                Err(_) => Err(primary_error),
+            }
+        }
+    }
+}
+
+fn validate_dek_plaintext(dek_plaintext: &[u8]) -> Result<Vec<u8>, CredentialsError> {
+    if dek_plaintext.len() != KEY_LEN {
+        return Err(CredentialsError::Crypto(format!(
+            "credential document DEK has invalid length {}",
+            dek_plaintext.len()
+        )));
+    }
+    Ok(dek_plaintext.to_vec())
+}
+
+fn validate_document_metadata(
+    document: &EncryptedCredentialDocument,
+) -> Result<(), CredentialsError> {
+    if document.algorithm != CREDENTIAL_DOCUMENT_ALGORITHM {
+        return Err(CredentialsError::Crypto(format!(
+            "unsupported credential encryption algorithm '{}'",
+            document.algorithm
+        )));
+    }
+    if document.aad_version != CREDENTIAL_DOCUMENT_AAD_VERSION {
+        return Err(CredentialsError::Crypto(format!(
+            "unsupported credential AAD version {}",
+            document.aad_version
+        )));
+    }
+    Ok(())
+}
+
+fn seal(
+    key_bytes: &[u8],
+    nonce_bytes: &[u8; NONCE_LEN],
+    aad: Vec<u8>,
+    in_out: &mut Vec<u8>,
+) -> Result<(), CredentialsError> {
+    let key = LessSafeKey::new(
+        UnboundKey::new(&aead::AES_256_GCM, key_bytes)
+            .map_err(|_error| CredentialsError::Crypto("invalid AES-256-GCM key".to_string()))?,
+    );
+    key.seal_in_place_append_tag(
+        Nonce::assume_unique_for_key(*nonce_bytes),
+        Aad::from(aad),
+        in_out,
+    )
+    .map_err(|_error| CredentialsError::Crypto("AES-256-GCM seal failed".to_string()))
+}
+
+fn open<'a>(
+    key_bytes: &[u8],
+    nonce_bytes: &[u8],
+    aad: Vec<u8>,
+    in_out: &'a mut [u8],
+) -> Result<&'a [u8], CredentialsError> {
+    let nonce = nonce_bytes.try_into().map_err(|_error| {
+        CredentialsError::Crypto("invalid AES-256-GCM nonce length".to_string())
+    })?;
+    let key = LessSafeKey::new(
+        UnboundKey::new(&aead::AES_256_GCM, key_bytes)
+            .map_err(|_error| CredentialsError::Crypto("invalid AES-256-GCM key".to_string()))?,
+    );
+    key.open_in_place(Nonce::assume_unique_for_key(nonce), Aad::from(aad), in_out)
+        .map(|plaintext| &*plaintext)
+        .map_err(|_error| CredentialsError::Crypto("AES-256-GCM open failed".to_string()))
+}
+
+fn credential_document_aad(workspace_name: &WorkspaceName, source_name: &SourceName) -> Vec<u8> {
+    let aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION.to_string();
+    encode_aad_fields(
+        "coral-credential-document",
+        &[
+            aad_version.as_str(),
+            workspace_name.as_str(),
+            source_name.as_str(),
+            CREDENTIAL_DOCUMENT_ALGORITHM,
+        ],
+    )
+}
+
+fn legacy_credential_document_aad(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    key_id: &str,
+) -> Vec<u8> {
+    format!(
+        "coral-credential-document:v{}:{}:{}:{}:{}",
+        CREDENTIAL_DOCUMENT_AAD_VERSION,
+        workspace_name.as_str(),
+        source_name.as_str(),
+        CREDENTIAL_DOCUMENT_ALGORITHM,
+        key_id
+    )
+    .into_bytes()
+}
+
+fn credential_dek_aad(key_id: &str) -> Vec<u8> {
+    let aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION.to_string();
+    encode_aad_fields("coral-credential-dek", &[aad_version.as_str(), key_id])
+}
+
+fn legacy_credential_dek_aad(key_id: &str) -> Vec<u8> {
+    format!("coral-credential-dek:v{CREDENTIAL_DOCUMENT_AAD_VERSION}:{key_id}").into_bytes()
+}
+
+fn encode_aad_fields(domain: &str, fields: &[&str]) -> Vec<u8> {
+    let mut aad = Vec::new();
+    aad.extend_from_slice(domain.as_bytes());
+    aad.push(0);
+    for field in fields {
+        let bytes = field.as_bytes();
+        aad.extend_from_slice(&(bytes.len() as u64).to_be_bytes());
+        aad.extend_from_slice(bytes);
+    }
+    aad
+}
+
+fn random_array<const N: usize>() -> Result<[u8; N], CredentialsError> {
+    let mut bytes = [0_u8; N];
+    SystemRandom::new().fill(&mut bytes).map_err(|_error| {
+        CredentialsError::Crypto("secure random generation failed".to_string())
+    })?;
+    Ok(bytes)
+}
+
+fn decode_key_file(raw: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+    let trimmed = raw.trim();
+    let Some(encoded) = trimmed.strip_prefix(&format!("{KEY_FILE_VERSION}:")) else {
+        return Err(CredentialsError::Crypto(
+            "unsupported credential encryption key file version".to_string(),
+        ));
+    };
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|error| {
+            CredentialsError::Crypto(format!("invalid encryption key file: {error}"))
+        })?;
+    let bytes: [u8; KEY_LEN] = decoded.try_into().map_err(|decoded: Vec<u8>| {
+        CredentialsError::Crypto(format!(
+            "credential encryption key has invalid length {}",
+            decoded.len()
+        ))
+    })?;
+    Ok(CredentialEncryptionKey {
+        key_id: key_id_for_bytes(&bytes),
+        bytes,
+    })
+}
+
+fn key_id_for_bytes(bytes: &[u8; KEY_LEN]) -> String {
+    let digest = Sha256::digest(bytes);
+    let hex = format!("{digest:x}");
+    format!("local-file-{}", hex.get(..16).unwrap_or(hex.as_str()))
+}

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -6,15 +6,19 @@
 )]
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::fmt;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use base64::Engine as _;
 use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey};
 use ring::rand::{SecureRandom as _, SystemRandom};
 use sha2::{Digest as _, Sha256};
+use tracing::warn;
+use zeroize::{Zeroize as _, Zeroizing};
 
 use super::CredentialsError;
+use crate::bootstrap;
 use crate::sources::SourceName;
 use crate::state::AppStateLayout;
 use crate::storage::fs as storage_fs;
@@ -31,10 +35,24 @@ const NONCE_LEN: usize = 12;
 
 static LOCAL_KEY_FILE_LOCK: Mutex<()> = Mutex::new(());
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct CredentialEncryptionKey {
     key_id: String,
     bytes: [u8; KEY_LEN],
+}
+
+impl fmt::Debug for CredentialEncryptionKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CredentialEncryptionKey")
+            .field("key_id", &self.key_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for CredentialEncryptionKey {
+    fn drop(&mut self) {
+        self.bytes.zeroize();
+    }
 }
 
 impl CredentialEncryptionKey {
@@ -57,16 +75,43 @@ pub(crate) trait CredentialKeyProvider: Send + Sync {
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError>;
 }
 
+/// Local credential encryption key provider.
+/// Shared-Postgres deployments MUST provision the same KEK on every server via
+/// `[credentials].encryption_key_env`; the local file key is single-config-dir only.
 #[derive(Debug, Clone)]
 pub(crate) struct LocalFileCredentialKeyProvider {
     path: PathBuf,
+    config_file: PathBuf,
 }
 
 impl LocalFileCredentialKeyProvider {
     pub(crate) fn new(layout: &AppStateLayout) -> Self {
         Self {
             path: layout.credential_encryption_key_file(),
+            config_file: layout.config_file().to_path_buf(),
         }
+    }
+
+    fn load_configured_key(&self) -> Result<Option<CredentialEncryptionKey>, CredentialsError> {
+        let Some(env_name) = configured_key_env(&self.config_file)? else {
+            return Ok(None);
+        };
+        let raw = bootstrap::env_var(&env_name)
+            .map_err(|error| {
+                CredentialsError::Crypto(format!(
+                    "credential encryption key environment variable `{env_name}` is invalid: {error}"
+                ))
+            })?
+            .ok_or_else(|| {
+                CredentialsError::Crypto(format!(
+                    "credential encryption key environment variable `{env_name}` is not set"
+                ))
+            })?;
+        decode_key_material(&raw).map(Some).map_err(|error| {
+            CredentialsError::Crypto(format!(
+                "invalid credential encryption key from environment variable `{env_name}`: {error}"
+            ))
+        })
     }
 
     fn load_or_create_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
@@ -80,7 +125,7 @@ impl LocalFileCredentialKeyProvider {
         let _process_guard = FileLock::exclusive(&lock_path)?;
 
         match std::fs::read_to_string(&self.path) {
-            Ok(raw) => decode_key_file(&raw),
+            Ok(raw) => decode_key_material(&raw),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 let bytes = random_array::<KEY_LEN>()?;
                 let encoded = format!(
@@ -88,6 +133,10 @@ impl LocalFileCredentialKeyProvider {
                     base64::engine::general_purpose::STANDARD.encode(bytes)
                 );
                 storage_fs::write_atomic(&self.path, encoded.as_bytes())?;
+                warn!(
+                    path = %self.path.display(),
+                    "created local credential encryption key; shared-Postgres deployments must provision the same KEK on every server"
+                );
                 Ok(CredentialEncryptionKey {
                     key_id: key_id_for_bytes(&bytes),
                     bytes,
@@ -100,11 +149,16 @@ impl LocalFileCredentialKeyProvider {
 
 impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
     fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        if let Some(key) = self.load_configured_key()? {
+            return Ok(key);
+        }
         self.load_or_create_key()
     }
 
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
-        let key = self.load_or_create_key()?;
+        let key = self
+            .load_configured_key()?
+            .map_or_else(|| self.load_or_create_key(), Ok)?;
         if key.key_id == key_id {
             Ok(key)
         } else {
@@ -139,7 +193,7 @@ pub(crate) fn encrypt_credential_values(
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<EncryptedCredentialDocument, CredentialsError> {
     let kek = key_provider.active_key()?;
-    let dek = random_array::<KEY_LEN>()?;
+    let dek = Zeroizing::new(random_array::<KEY_LEN>()?);
     let nonce = random_array::<NONCE_LEN>()?;
     let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
 
@@ -147,16 +201,18 @@ pub(crate) fn encrypt_credential_values(
         version: CREDENTIAL_DOCUMENT_VERSION,
         values: values.clone(),
     };
-    let mut document_bytes = serde_json::to_vec(&plaintext)
-        .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+    let mut document_bytes = Zeroizing::new(
+        serde_json::to_vec(&plaintext)
+            .map_err(|error| CredentialsError::Parse(error.to_string()))?,
+    );
     seal(
-        &dek,
+        &*dek,
         &nonce,
         credential_document_aad(workspace_name, source_name),
         &mut document_bytes,
     )?;
 
-    let mut wrapped_dek = dek.to_vec();
+    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
     seal(
         &kek.bytes,
         &wrapped_dek_nonce,
@@ -165,11 +221,11 @@ pub(crate) fn encrypt_credential_values(
     )?;
 
     Ok(EncryptedCredentialDocument {
-        ciphertext: document_bytes,
+        ciphertext: std::mem::take(&mut *document_bytes),
         nonce: nonce.to_vec(),
-        wrapped_dek,
+        wrapped_dek: std::mem::take(&mut *wrapped_dek),
         wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
-        key_id: kek.key_id,
+        key_id: kek.key_id.clone(),
         algorithm: CREDENTIAL_DOCUMENT_ALGORITHM.to_string(),
         aad_version: CREDENTIAL_DOCUMENT_AAD_VERSION,
     })
@@ -208,12 +264,12 @@ pub(crate) fn rewrap_credential_document(
     }
 
     let dek = unwrap_dek(document, &old_kek)?;
-    let mut document_probe = document.ciphertext.clone();
+    let mut document_probe = Zeroizing::new(document.ciphertext.clone());
     if open(
-        &dek,
+        &*dek,
         document.nonce.as_slice(),
         credential_document_aad(workspace_name, source_name),
-        &mut document_probe,
+        document_probe.as_mut_slice(),
     )
     .is_err()
     {
@@ -227,7 +283,7 @@ pub(crate) fn rewrap_credential_document(
     }
 
     let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
-    let mut wrapped_dek = dek;
+    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
     seal(
         &active_kek.bytes,
         &wrapped_dek_nonce,
@@ -238,9 +294,9 @@ pub(crate) fn rewrap_credential_document(
     Ok(Some(EncryptedCredentialDocument {
         ciphertext: document.ciphertext.clone(),
         nonce: document.nonce.clone(),
-        wrapped_dek,
+        wrapped_dek: std::mem::take(&mut *wrapped_dek),
         wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
-        key_id: active_kek.key_id,
+        key_id: active_kek.key_id.clone(),
         algorithm: document.algorithm.clone(),
         aad_version: document.aad_version,
     }))
@@ -251,28 +307,28 @@ fn decrypt_credential_document_bytes(
     source_name: &SourceName,
     document: &EncryptedCredentialDocument,
     key_provider: &dyn CredentialKeyProvider,
-) -> Result<Vec<u8>, CredentialsError> {
+) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
     validate_document_metadata(document)?;
     let kek = key_provider.key(&document.key_id)?;
     let dek = unwrap_dek(document, &kek)?;
 
-    let mut ciphertext = document.ciphertext.clone();
+    let mut ciphertext = Zeroizing::new(document.ciphertext.clone());
     match open(
-        &dek,
+        &*dek,
         document.nonce.as_slice(),
         credential_document_aad(workspace_name, source_name),
-        &mut ciphertext,
+        ciphertext.as_mut_slice(),
     ) {
-        Ok(plaintext) => Ok(plaintext.to_vec()),
+        Ok(plaintext) => Ok(Zeroizing::new(plaintext.to_vec())),
         Err(primary_error) => {
-            let mut legacy_ciphertext = document.ciphertext.clone();
+            let mut legacy_ciphertext = Zeroizing::new(document.ciphertext.clone());
             match open(
-                &dek,
+                &*dek,
                 document.nonce.as_slice(),
                 legacy_credential_document_aad(workspace_name, source_name, &document.key_id),
-                &mut legacy_ciphertext,
+                legacy_ciphertext.as_mut_slice(),
             ) {
-                Ok(plaintext) => Ok(plaintext.to_vec()),
+                Ok(plaintext) => Ok(Zeroizing::new(plaintext.to_vec())),
                 Err(_) => Err(primary_error),
             }
         }
@@ -282,22 +338,22 @@ fn decrypt_credential_document_bytes(
 fn unwrap_dek(
     document: &EncryptedCredentialDocument,
     kek: &CredentialEncryptionKey,
-) -> Result<Vec<u8>, CredentialsError> {
-    let mut dek = document.wrapped_dek.clone();
+) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
+    let mut dek = Zeroizing::new(document.wrapped_dek.clone());
     match open(
         &kek.bytes,
         document.wrapped_dek_nonce.as_slice(),
         credential_dek_aad(&document.key_id),
-        &mut dek,
+        dek.as_mut_slice(),
     ) {
         Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
         Err(primary_error) => {
-            let mut legacy_dek = document.wrapped_dek.clone();
+            let mut legacy_dek = Zeroizing::new(document.wrapped_dek.clone());
             match open(
                 &kek.bytes,
                 document.wrapped_dek_nonce.as_slice(),
                 legacy_credential_dek_aad(&document.key_id),
-                &mut legacy_dek,
+                legacy_dek.as_mut_slice(),
             ) {
                 Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
                 Err(_) => Err(primary_error),
@@ -306,14 +362,18 @@ fn unwrap_dek(
     }
 }
 
-fn validate_dek_plaintext(dek_plaintext: &[u8]) -> Result<Vec<u8>, CredentialsError> {
+fn validate_dek_plaintext(
+    dek_plaintext: &[u8],
+) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
     if dek_plaintext.len() != KEY_LEN {
         return Err(CredentialsError::Crypto(format!(
             "credential document DEK has invalid length {}",
             dek_plaintext.len()
         )));
     }
-    Ok(dek_plaintext.to_vec())
+    let mut dek = [0_u8; KEY_LEN];
+    dek.copy_from_slice(dek_plaintext);
+    Ok(Zeroizing::new(dek))
 }
 
 fn validate_document_metadata(
@@ -428,18 +488,37 @@ fn random_array<const N: usize>() -> Result<[u8; N], CredentialsError> {
     Ok(bytes)
 }
 
-fn decode_key_file(raw: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+fn configured_key_env(config_file: &Path) -> Result<Option<String>, CredentialsError> {
+    if !config_file.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(config_file)?;
+    let config: toml::Value =
+        toml::from_str(&raw).map_err(|error| CredentialsError::Parse(error.to_string()))?;
+    let Some(value) = config
+        .get("credentials")
+        .and_then(|credentials| credentials.get("encryption_key_env"))
+    else {
+        return Ok(None);
+    };
+    value
+        .as_str()
+        .map(|env| Some(env.to_string()))
+        .ok_or_else(|| {
+            CredentialsError::Parse("[credentials].encryption_key_env must be a string".to_string())
+        })
+}
+
+fn decode_key_material(raw: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
     let trimmed = raw.trim();
     let Some(encoded) = trimmed.strip_prefix(&format!("{KEY_FILE_VERSION}:")) else {
         return Err(CredentialsError::Crypto(
-            "unsupported credential encryption key file version".to_string(),
+            "unsupported credential encryption key version".to_string(),
         ));
     };
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(encoded)
-        .map_err(|error| {
-            CredentialsError::Crypto(format!("invalid encryption key file: {error}"))
-        })?;
+        .map_err(|error| CredentialsError::Crypto(format!("invalid encryption key: {error}")))?;
     let bytes: [u8; KEY_LEN] = decoded.try_into().map_err(|decoded: Vec<u8>| {
         CredentialsError::Crypto(format!(
             "credential encryption key has invalid length {}",

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -1,6 +1,7 @@
 //! Internal credential-set identity and lifecycle helpers.
 
 pub(crate) mod config;
+pub(crate) mod encryption;
 pub(crate) mod oauth;
 mod store;
 

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -25,6 +25,8 @@ pub enum CredentialsError {
     Io(#[from] io::Error),
     #[error("invalid credential material: {0}")]
     Parse(String),
+    #[error("credential encryption failed: {0}")]
+    Crypto(String),
     #[error("credential storage unavailable: {0}")]
     Unavailable(String),
     #[error("credential snapshot storage mismatch: snapshot is {snapshot}, requested {requested}")]

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -130,6 +130,10 @@ impl AppStateLayout {
             .join(INSTALLED_FUNCTION_FILE_NAME)
     }
 
+    pub(crate) fn credential_encryption_key_file(&self) -> PathBuf {
+        self.config_dir.join("credentials").join("encryption.key")
+    }
+
     pub(crate) fn search_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.workspace_dir(workspace_name).join("search")
     }


### PR DESCRIPTION
## Intent

Add application-level envelope encryption primitives for database credential documents. This PR defines the cryptographic and local key-provider primitives; database repository and runtime wiring land in later stack branches.

## What it enables

Credential values can be encrypted with a fresh per-document data-encryption key. A longer-lived key-encryption key protects that document key, while authenticated context binds the encrypted payload to its workspace and source. This design allows key rotation without re-encrypting current-format credential payloads.

## Terminology

- **Envelope encryption**: a two-level design in which a data-encryption key encrypts the payload and a key-encryption key encrypts that data key.
- **AEAD (authenticated encryption with associated data)**: encryption that provides confidentiality and detects tampering with both ciphertext and selected unencrypted context.
- **AES-256-GCM (Advanced Encryption Standard with a 256-bit key in Galois/Counter Mode)**: the AEAD algorithm used by this implementation.
- **DEK (data-encryption key)**: a fresh per-document key that encrypts the credential values.
- **KEK (key-encryption key)**: the longer-lived active key that encrypts, or **wraps**, each DEK. It can be supplied explicitly or loaded from an on-demand local fallback key file.
- **AAD (additional authenticated data)**: unencrypted context included in the authentication check. The document AAD contains its format version, workspace, source, and algorithm; the wrapped-DEK AAD contains its format version and KEK identifier. Decryption fails if this context changes.
- **Nonce (number used once)**: a public value that must be unique for each encryption performed with a given key. The document and wrapped DEK use separate random nonces.
- **Rewrap**: decrypt a DEK with its previous KEK and wrap it with the active KEK. Current-format document ciphertext stays unchanged; the legacy AAD format is migrated once.
- **SHA-256 (Secure Hash Algorithm with a 256-bit digest)**: used only to derive a non-secret identifier for a KEK, not to encrypt credential material.

## Usage examples

When a later database-storage branch saves source credentials, it can use these primitives to:

1. Resolve the active KEK, creating the local fallback key on demand only when no explicit key is supplied.
2. Generate a fresh DEK and nonce, then encrypt the credential values with AES-256-GCM and workspace/source AAD.
3. Wrap the DEK with the KEK and a separate nonce.
4. Pass the resulting in-memory encrypted document to the database repository for persistence.

This PR does not itself persist encrypted credential documents or wire encryption into the credential runtime.

## Validation

Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.
