### PR TITLE
feat(app): store credentials in encrypted database documents

### DIFF
--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -48,6 +48,7 @@ impl CredentialMaterialSnapshot {
 pub(crate) enum CredentialStorageKind {
     File,
     Keychain,
+    Database,
 }
 
 impl CredentialStorageKind {
@@ -55,6 +56,7 @@ impl CredentialStorageKind {
         match self {
             Self::File => "file",
             Self::Keychain => "keychain",
+            Self::Database => "database",
         }
     }
 }
@@ -73,6 +75,7 @@ pub(crate) enum CredentialStoragePreference {
     Auto,
     File,
     Keychain,
+    Database,
 }
 
 /// Result of replacing credential material.
@@ -242,6 +245,16 @@ impl CredentialManager {
         inputs: &[ManifestInputSpec],
         material: &mut BTreeMap<String, String>,
     ) -> Result<(), AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self
+                .refresh_and_persist_database_oauth_material(
+                    workspace_name,
+                    credential_set_id,
+                    inputs,
+                    material,
+                )
+                .await;
+        }
         for input in inputs {
             if self.refresh_oauth_input_material(input, material).await? {
                 *material = self.persist_refreshed_oauth_material(
@@ -251,6 +264,37 @@ impl CredentialManager {
                     &input.key,
                     material,
                 )?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn refresh_and_persist_database_oauth_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        inputs: &[ManifestInputSpec],
+        material: &mut BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
+        for input in inputs {
+            loop {
+                let current = self
+                    .store
+                    .read_database_material_for_update(workspace_name, credential_set_id)?;
+                let mut next = current.values;
+                if !self.refresh_oauth_input_material(input, &mut next).await? {
+                    *material = next;
+                    break;
+                }
+                if self.store.replace_database_material_if_current(
+                    workspace_name,
+                    credential_set_id,
+                    current.document_version,
+                    &next,
+                )? {
+                    *material = next;
+                    break;
+                }
             }
         }
         Ok(())

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
+use std::future::Future;
 use std::io;
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
@@ -10,10 +11,15 @@ use sha2::{Digest as _, Sha256};
 
 use crate::bootstrap::AppError;
 use crate::state::AppStateLayout;
+use crate::state::db::{CoralDb, CredentialDocumentRecord, CredentialDocumentWrite, DbRepos};
 use crate::storage::fs as storage_fs;
 use crate::storage::fs::FileLock;
 use crate::workspaces::WorkspaceName;
 
+use super::encryption::{
+    CredentialKeyProvider, EncryptedCredentialDocument, decrypt_credential_values,
+    encrypt_credential_values, rewrap_credential_document,
+};
 use super::{
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialStoragePreference,
 };
@@ -48,6 +54,11 @@ impl EncodedCredentialMaterial {
 struct CredentialSetRef<'a> {
     workspace_name: &'a WorkspaceName,
     credential_set_id: &'a CredentialSetId,
+}
+
+pub(super) struct DatabaseCredentialMaterial {
+    pub(super) values: BTreeMap<String, String>,
+    pub(super) document_version: Option<i64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -153,6 +164,8 @@ pub(crate) struct CredentialStore {
     preference: CredentialStoragePreference,
     file: Arc<dyn CredentialMaterialBackend>,
     keychain: Arc<dyn CredentialMaterialBackend>,
+    database: Option<Arc<CoralDb>>,
+    key_provider: Option<Arc<dyn CredentialKeyProvider>>,
 }
 
 impl CredentialStore {
@@ -171,7 +184,25 @@ impl CredentialStore {
             preference,
             file: Arc::new(FileCredentialBackend::new(layout)),
             keychain: Arc::new(KeychainCredentialBackend::new(config_namespace)),
+            database: None,
+            key_provider: None,
         }
+    }
+
+    #[expect(
+        dead_code,
+        reason = "database credential store construction is wired by the next stacked branch"
+    )]
+    pub(crate) fn with_database(
+        layout: AppStateLayout,
+        preference: CredentialStoragePreference,
+        database: Arc<CoralDb>,
+        key_provider: Arc<dyn CredentialKeyProvider>,
+    ) -> Self {
+        let mut store = Self::with_preference(layout, preference);
+        store.database = Some(database);
+        store.key_provider = Some(key_provider);
+        store
     }
 
     #[cfg(test)]
@@ -185,6 +216,8 @@ impl CredentialStore {
             preference,
             file: Arc::new(FileCredentialBackend::new(layout)),
             keychain,
+            database: None,
+            key_provider: None,
         }
     }
 
@@ -219,6 +252,9 @@ impl CredentialStore {
         storage: CredentialStorageKind,
         values: &BTreeMap<String, String>,
     ) -> Result<(), AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.replace_database_material(workspace_name, credential_set_id, values);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -246,6 +282,9 @@ impl CredentialStore {
         storage: CredentialStorageKind,
         values: &BTreeMap<String, String>,
     ) -> Result<(), AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.replace_database_material(workspace_name, credential_set_id, values);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -271,12 +310,15 @@ impl CredentialStore {
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
-        update: F,
+        mut update: F,
     ) -> Result<R, AppError>
     where
-        F: FnOnce(BTreeMap<String, String>) -> Result<(BTreeMap<String, String>, R), AppError>,
+        F: FnMut(BTreeMap<String, String>) -> Result<(BTreeMap<String, String>, R), AppError>,
     {
         tracing::trace!(%credential_set_id, %storage, "updating credential material");
+        if storage == CredentialStorageKind::Database {
+            return self.update_database_material(workspace_name, credential_set_id, update);
+        }
         let current = self.read_material(workspace_name, credential_set_id, storage)?;
         let (next, result) = update(current)?;
         self.replace_material(workspace_name, credential_set_id, storage, &next)?;
@@ -288,12 +330,15 @@ impl CredentialStore {
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
-        update: F,
+        mut update: F,
     ) -> Result<R, AppError>
     where
-        F: FnOnce(BTreeMap<String, String>) -> Result<(BTreeMap<String, String>, R), AppError>,
+        F: FnMut(BTreeMap<String, String>) -> Result<(BTreeMap<String, String>, R), AppError>,
     {
         tracing::trace!(%credential_set_id, %storage, "updating credential material with state lock held");
+        if storage == CredentialStorageKind::Database {
+            return self.update_database_material(workspace_name, credential_set_id, update);
+        }
         let current = self.read_material(workspace_name, credential_set_id, storage)?;
         let (next, result) = update(current)?;
         self.replace_material_with_state_lock_held(
@@ -324,6 +369,9 @@ impl CredentialStore {
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
     ) -> Result<BTreeMap<String, String>, AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.read_database_material(workspace_name, credential_set_id);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -348,6 +396,9 @@ impl CredentialStore {
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
     ) -> Result<CredentialMaterialSnapshot, AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.snapshot_database_material(workspace_name, credential_set_id);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -368,6 +419,9 @@ impl CredentialStore {
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
     ) -> Result<CredentialMaterialSnapshot, AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.snapshot_database_material(workspace_name, credential_set_id);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -390,6 +444,9 @@ impl CredentialStore {
         snapshot: &CredentialMaterialSnapshot,
     ) -> Result<(), AppError> {
         let storage = snapshot.storage();
+        if storage == CredentialStorageKind::Database {
+            return self.restore_database_material(workspace_name, credential_set_id, snapshot);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -411,6 +468,9 @@ impl CredentialStore {
         snapshot: &CredentialMaterialSnapshot,
     ) -> Result<(), AppError> {
         let storage = snapshot.storage();
+        if storage == CredentialStorageKind::Database {
+            return self.restore_database_material(workspace_name, credential_set_id, snapshot);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -432,6 +492,9 @@ impl CredentialStore {
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
     ) -> Result<(), AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.remove_database_material(workspace_name, credential_set_id);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -452,6 +515,9 @@ impl CredentialStore {
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
     ) -> Result<(), AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.remove_database_material(workspace_name, credential_set_id);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -467,7 +533,14 @@ impl CredentialStore {
     }
 
     pub(crate) fn default_write_storage(&self) -> Result<CredentialStorageKind, CredentialsError> {
+        if self.database.is_some() {
+            return Ok(CredentialStorageKind::Database);
+        }
         match self.preference {
+            CredentialStoragePreference::Database => Err(CredentialsError::Unavailable(
+                "database credential storage is configured, but the database backend is not available"
+                    .to_string(),
+            )),
             CredentialStoragePreference::File => Ok(CredentialStorageKind::File),
             CredentialStoragePreference::Keychain => {
                 self.keychain
@@ -489,8 +562,334 @@ impl CredentialStore {
         match storage {
             CredentialStorageKind::File => self.file.as_ref(),
             CredentialStorageKind::Keychain => self.keychain.as_ref(),
+            CredentialStorageKind::Database => {
+                unreachable!("database credential storage bypasses legacy material backends")
+            }
         }
     }
+
+    fn database_parts(&self) -> Result<(Arc<CoralDb>, Arc<dyn CredentialKeyProvider>), AppError> {
+        let database = self.database.clone().ok_or_else(|| {
+            AppError::Credentials(CredentialsError::Unavailable(
+                "database credential storage is not configured".to_string(),
+            ))
+        })?;
+        let key_provider = self.key_provider.clone().ok_or_else(|| {
+            AppError::Credentials(CredentialsError::Unavailable(
+                "credential encryption key provider is not configured".to_string(),
+            ))
+        })?;
+        Ok((database, key_provider))
+    }
+
+    fn read_database_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+    ) -> Result<BTreeMap<String, String>, AppError> {
+        let (database, key_provider) = self.database_parts()?;
+        let workspace_name = workspace_name.clone();
+        let source_name = credential_set_id.source_name()?;
+        run_credential_db_operation(async move {
+            let mut session = database.as_ref();
+            let Some(record) = session
+                .credential_documents()
+                .get(&workspace_name, &source_name)
+                .await?
+            else {
+                return Ok(BTreeMap::new());
+            };
+            let expected_document_version = record.document_version;
+            let document = encrypted_document_from_record(record);
+            let kek = key_provider.key(&document.key_id)?;
+            let values = decrypt_credential_values(&workspace_name, &source_name, &document, &kek)
+                .map_err(AppError::from)?;
+            if let Some(rewrapped) = rewrap_credential_document(
+                &workspace_name,
+                &source_name,
+                &document,
+                key_provider.as_ref(),
+            )? {
+                let now_unix_nanos = now_unix_nanos_i64()?;
+                let mut tx = database.begin().await?;
+                tx.credential_documents()
+                    .rewrap_if_current(
+                        &workspace_name,
+                        &source_name,
+                        expected_document_version,
+                        &credential_document_write_from_encrypted(rewrapped),
+                        now_unix_nanos,
+                    )
+                    .await?;
+                tx.commit().await?;
+            }
+            Ok(values)
+        })
+    }
+
+    pub(super) fn read_database_material_for_update(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+    ) -> Result<DatabaseCredentialMaterial, AppError> {
+        let (database, key_provider) = self.database_parts()?;
+        let workspace_name = workspace_name.clone();
+        let source_name = credential_set_id.source_name()?;
+        run_credential_db_operation(async move {
+            let mut session = database.as_ref();
+            let Some(record) = session
+                .credential_documents()
+                .get(&workspace_name, &source_name)
+                .await?
+            else {
+                return Ok(DatabaseCredentialMaterial {
+                    values: BTreeMap::new(),
+                    document_version: None,
+                });
+            };
+            let document_version = record.document_version;
+            let document = encrypted_document_from_record(record);
+            let kek = key_provider.key(&document.key_id)?;
+            let values = decrypt_credential_values(&workspace_name, &source_name, &document, &kek)
+                .map_err(AppError::from)?;
+            Ok(DatabaseCredentialMaterial {
+                values,
+                document_version: Some(document_version),
+            })
+        })
+    }
+
+    fn replace_database_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        values: &BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
+        if values.is_empty() {
+            return self.remove_database_material(workspace_name, credential_set_id);
+        }
+        loop {
+            let current =
+                self.read_database_material_for_update(workspace_name, credential_set_id)?;
+            if self.replace_database_material_if_current(
+                workspace_name,
+                credential_set_id,
+                current.document_version,
+                values,
+            )? {
+                return Ok(());
+            }
+        }
+    }
+
+    pub(super) fn replace_database_material_if_current(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        expected_document_version: Option<i64>,
+        values: &BTreeMap<String, String>,
+    ) -> Result<bool, AppError> {
+        if values.is_empty() {
+            self.remove_database_material(workspace_name, credential_set_id)?;
+            return Ok(true);
+        }
+        let (database, key_provider) = self.database_parts()?;
+        let workspace_name = workspace_name.clone();
+        let source_name = credential_set_id.source_name()?;
+        let values = values.clone();
+        run_credential_db_operation(async move {
+            let now_unix_nanos = now_unix_nanos_i64()?;
+            let encrypted = encrypt_credential_values(
+                &workspace_name,
+                &source_name,
+                &values,
+                key_provider.as_ref(),
+            )?;
+            let mut tx = database.begin().await?;
+            tx.workspaces()
+                .ensure(workspace_name.as_str(), now_unix_nanos)
+                .await?;
+            let write = credential_document_write_from_encrypted(encrypted);
+            let applied = match expected_document_version {
+                Some(version) => {
+                    tx.credential_documents()
+                        .replace_if_current(
+                            &workspace_name,
+                            &source_name,
+                            version,
+                            &write,
+                            now_unix_nanos,
+                        )
+                        .await?
+                }
+                None => {
+                    tx.credential_documents()
+                        .insert_if_absent(&workspace_name, &source_name, &write, now_unix_nanos)
+                        .await?
+                }
+            };
+            tx.commit().await?;
+            Ok(applied)
+        })
+    }
+
+    fn update_database_material<F, R>(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        mut update: F,
+    ) -> Result<R, AppError>
+    where
+        F: FnMut(BTreeMap<String, String>) -> Result<(BTreeMap<String, String>, R), AppError>,
+    {
+        loop {
+            let current =
+                self.read_database_material_for_update(workspace_name, credential_set_id)?;
+            let (next, result) = update(current.values)?;
+            if next.is_empty() {
+                self.remove_database_material(workspace_name, credential_set_id)?;
+                return Ok(result);
+            }
+            if self.replace_database_material_if_current(
+                workspace_name,
+                credential_set_id,
+                current.document_version,
+                &next,
+            )? {
+                return Ok(result);
+            }
+        }
+    }
+
+    fn snapshot_database_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+    ) -> Result<CredentialMaterialSnapshot, AppError> {
+        let values = self.read_database_material(workspace_name, credential_set_id)?;
+        if values.is_empty() {
+            return Ok(CredentialMaterialSnapshot::new(
+                CredentialStorageKind::Database,
+                None,
+            ));
+        }
+        let bytes = serde_json::to_vec(&values)
+            .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+        Ok(CredentialMaterialSnapshot::new(
+            CredentialStorageKind::Database,
+            Some(bytes),
+        ))
+    }
+
+    fn restore_database_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), AppError> {
+        if snapshot.storage() != CredentialStorageKind::Database {
+            return Err(CredentialsError::SnapshotStorageMismatch {
+                snapshot: snapshot.storage().as_config_value(),
+                requested: CredentialStorageKind::Database.as_config_value(),
+            }
+            .into());
+        }
+        let Some(bytes) = snapshot.material() else {
+            return self.remove_database_material(workspace_name, credential_set_id);
+        };
+        let values = serde_json::from_slice::<BTreeMap<String, String>>(bytes)
+            .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+        self.replace_database_material(workspace_name, credential_set_id, &values)
+    }
+
+    fn remove_database_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+    ) -> Result<(), AppError> {
+        let (database, _) = self.database_parts()?;
+        let workspace_name = workspace_name.clone();
+        let source_name = credential_set_id.source_name()?;
+        run_credential_db_operation(async move {
+            let mut tx = database.begin().await?;
+            tx.credential_documents()
+                .remove(&workspace_name, &source_name)
+                .await?;
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+}
+
+fn run_credential_db_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: Future<Output = Result<T, AppError>> + Send + 'static,
+{
+    fn run_on_runtime<T, F>(operation: F) -> Result<T, AppError>
+    where
+        F: Future<Output = Result<T, AppError>>,
+    {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "failed to create credential database runtime: {error}"
+                ))
+            })?;
+        runtime.block_on(operation)
+    }
+
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return std::thread::spawn(move || run_on_runtime(operation))
+            .join()
+            .map_err(|_panic| {
+                AppError::FailedPrecondition(
+                    "credential database operation thread panicked".to_string(),
+                )
+            })?;
+    }
+
+    run_on_runtime(operation)
+}
+
+fn credential_document_write_from_encrypted(
+    document: EncryptedCredentialDocument,
+) -> CredentialDocumentWrite {
+    CredentialDocumentWrite {
+        ciphertext: document.ciphertext,
+        nonce: document.nonce,
+        wrapped_dek: document.wrapped_dek,
+        wrapped_dek_nonce: document.wrapped_dek_nonce,
+        key_id: document.key_id,
+        algorithm: document.algorithm,
+        aad_version: document.binding_version,
+    }
+}
+
+fn encrypted_document_from_record(record: CredentialDocumentRecord) -> EncryptedCredentialDocument {
+    EncryptedCredentialDocument {
+        ciphertext: record.ciphertext,
+        nonce: record.nonce,
+        wrapped_dek: record.wrapped_dek,
+        wrapped_dek_nonce: record.wrapped_dek_nonce,
+        key_id: record.key_id,
+        algorithm: record.algorithm,
+        binding_version: record.aad_version,
+    }
+}
+
+fn now_unix_nanos_i64() -> Result<i64, AppError> {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| AppError::FailedPrecondition(format!("system clock error: {error}")))?
+        .as_nanos();
+    i64::try_from(nanos).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "system clock timestamp exceeds i64 nanoseconds: {error}"
+        ))
+    })
 }
 
 fn contextualize_storage_error<T>(
@@ -1042,6 +1441,9 @@ fn encode_values(
                 .map(EncodedCredentialMaterial)
                 .map_err(|error| CredentialsError::Parse(error.to_string()))
         }
+        CredentialStorageKind::Database => Err(CredentialsError::Crypto(
+            "database credential material is encrypted directly from values".to_string(),
+        )),
     }
 }
 
@@ -1066,6 +1468,10 @@ fn decode_values(
             }
             Ok(document.values)
         }
+        CredentialStorageKind::Database => Err(CredentialsError::Crypto(
+            "database credential material is decrypted directly from credential documents"
+                .to_string(),
+        )),
     }
 }
 

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -533,14 +533,19 @@ impl CredentialStore {
     }
 
     pub(crate) fn default_write_storage(&self) -> Result<CredentialStorageKind, CredentialsError> {
-        if self.database.is_some() {
-            return Ok(CredentialStorageKind::Database);
-        }
+        // An explicitly configured preference wins even when a database backend
+        // is attached; only `Auto` may resolve to database storage on its own.
         match self.preference {
-            CredentialStoragePreference::Database => Err(CredentialsError::Unavailable(
-                "database credential storage is configured, but the database backend is not available"
-                    .to_string(),
-            )),
+            CredentialStoragePreference::Database => {
+                if self.database.is_some() {
+                    Ok(CredentialStorageKind::Database)
+                } else {
+                    Err(CredentialsError::Unavailable(
+                        "database credential storage is configured, but the database backend is not available"
+                            .to_string(),
+                    ))
+                }
+            }
             CredentialStoragePreference::File => Ok(CredentialStorageKind::File),
             CredentialStoragePreference::Keychain => {
                 self.keychain
@@ -548,13 +553,18 @@ impl CredentialStore {
                     .map_err(configured_keychain_unavailable)?;
                 Ok(CredentialStorageKind::Keychain)
             }
-            CredentialStoragePreference::Auto => match self.keychain.probe() {
-                Ok(()) => Ok(CredentialStorageKind::Keychain),
-                Err(error) => {
-                    tracing::warn!(detail = %error, "keychain unavailable; using plaintext file credential storage");
-                    Ok(CredentialStorageKind::File)
+            CredentialStoragePreference::Auto => {
+                if self.database.is_some() {
+                    return Ok(CredentialStorageKind::Database);
                 }
-            },
+                match self.keychain.probe() {
+                    Ok(()) => Ok(CredentialStorageKind::Keychain),
+                    Err(error) => {
+                        tracing::warn!(detail = %error, "keychain unavailable; using plaintext file credential storage");
+                        Ok(CredentialStorageKind::File)
+                    }
+                }
+            }
         }
     }
 

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -533,19 +533,14 @@ impl CredentialStore {
     }
 
     pub(crate) fn default_write_storage(&self) -> Result<CredentialStorageKind, CredentialsError> {
-        // An explicitly configured preference wins even when a database backend
-        // is attached; only `Auto` may resolve to database storage on its own.
+        if self.database.is_some() {
+            return Ok(CredentialStorageKind::Database);
+        }
         match self.preference {
-            CredentialStoragePreference::Database => {
-                if self.database.is_some() {
-                    Ok(CredentialStorageKind::Database)
-                } else {
-                    Err(CredentialsError::Unavailable(
-                        "database credential storage is configured, but the database backend is not available"
-                            .to_string(),
-                    ))
-                }
-            }
+            CredentialStoragePreference::Database => Err(CredentialsError::Unavailable(
+                "database credential storage is configured, but the database backend is not available"
+                    .to_string(),
+            )),
             CredentialStoragePreference::File => Ok(CredentialStorageKind::File),
             CredentialStoragePreference::Keychain => {
                 self.keychain
@@ -553,18 +548,13 @@ impl CredentialStore {
                     .map_err(configured_keychain_unavailable)?;
                 Ok(CredentialStorageKind::Keychain)
             }
-            CredentialStoragePreference::Auto => {
-                if self.database.is_some() {
-                    return Ok(CredentialStorageKind::Database);
+            CredentialStoragePreference::Auto => match self.keychain.probe() {
+                Ok(()) => Ok(CredentialStorageKind::Keychain),
+                Err(error) => {
+                    tracing::warn!(detail = %error, "keychain unavailable; using plaintext file credential storage");
+                    Ok(CredentialStorageKind::File)
                 }
-                match self.keychain.probe() {
-                    Ok(()) => Ok(CredentialStorageKind::Keychain),
-                    Err(error) => {
-                        tracing::warn!(detail = %error, "keychain unavailable; using plaintext file credential storage");
-                        Ok(CredentialStorageKind::File)
-                    }
-                }
-            }
+            },
         }
     }
 

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -692,7 +692,7 @@ fn proto_source_credential_storage(
     match storage {
         Some(CredentialStorageKind::File) => ProtoSourceCredentialStorage::File,
         Some(CredentialStorageKind::Keychain) => ProtoSourceCredentialStorage::Keychain,
-        None => ProtoSourceCredentialStorage::Unspecified,
+        Some(CredentialStorageKind::Database) | None => ProtoSourceCredentialStorage::Unspecified,
     }
 }
 

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -52,6 +52,14 @@ impl CoralDb {
             CoralDbBackend::Postgres(db) => db.pool.close().await,
         }
     }
+
+    #[expect(
+        dead_code,
+        reason = "database credential bootstrap uses this in the next stacked branch"
+    )]
+    pub(crate) fn is_postgres(&self) -> bool {
+        matches!(self.backend, CoralDbBackend::Postgres(_))
+    }
 }
 
 async fn open_sqlite(path: &Path) -> Result<CoralDb, DbError> {

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -322,7 +322,7 @@ mod tests {
             .expect("insert source catalog rows");
         session
             .credential_documents()
-            .upsert(&workspace, &source, &credential_document_write(), 5)
+            .insert_if_absent(&workspace, &source, &credential_document_write(), 5)
             .await
             .expect("insert credential document row");
         assert_eq!(
@@ -410,7 +410,7 @@ mod tests {
             .expect("reinsert source catalog rows");
         session
             .credential_documents()
-            .upsert(&workspace, &source, &credential_document_write(), 5)
+            .insert_if_absent(&workspace, &source, &credential_document_write(), 5)
             .await
             .expect("reinsert credential document row");
         delete_workspace(&mut session, &workspace_id)

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -24,10 +24,6 @@ pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::{import_filesystem_feedback_reports, run_state_migrations};
 pub(crate) use ownership_bootstrap::{inaccessible_workspaces, migrate_local_ownership_once};
-#[expect(
-    unused_imports,
-    reason = "Credential runtime branches consume these once restacked."
-)]
 pub(crate) use repositories::credential_documents::{
     CredentialDocumentRecord, CredentialDocumentWrite,
 };

--- a/crates/coral-app/src/state/db/repositories/credential_documents.rs
+++ b/crates/coral-app/src/state/db/repositories/credential_documents.rs
@@ -121,17 +121,16 @@ impl<S> CredentialDocumentsRepo<'_, S>
 where
     S: DbSession,
 {
-    pub(crate) async fn upsert(
+    pub(crate) async fn insert_if_absent(
         &mut self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
         document: &CredentialDocumentWrite,
         now_unix_nanos: i64,
-    ) -> Result<CredentialDocumentRecord, DbError> {
-        let current_document_version = Expr::col((
-            CredentialDocuments::Table,
-            CredentialDocuments::DocumentVersion,
-        ));
+    ) -> Result<bool, DbError> {
+        if self.get(workspace_name, source_name).await?.is_some() {
+            return Ok(false);
+        }
         let statement = Query::insert()
             .into_table(CredentialDocuments::Table)
             .columns([
@@ -167,33 +166,18 @@ where
                     CredentialDocuments::WorkspaceId,
                     CredentialDocuments::SourceName,
                 ])
-                .value(
-                    CredentialDocuments::DocumentVersion,
-                    Expr::case(current_document_version.clone().eq(i64::MAX), Expr::null())
-                        .finally(current_document_version.add(1)),
-                )
-                .update_columns([
-                    CredentialDocuments::Ciphertext,
-                    CredentialDocuments::Nonce,
-                    CredentialDocuments::WrappedDek,
-                    CredentialDocuments::WrappedDekNonce,
-                    CredentialDocuments::KeyId,
-                    CredentialDocuments::Algorithm,
-                    CredentialDocuments::AadVersion,
-                    CredentialDocuments::UpdatedAtUnixNanos,
-                ])
+                .do_nothing()
                 .to_owned(),
             )
             .to_owned();
         self.session.execute(statement).await?;
-        self.get(workspace_name, source_name).await?.ok_or_else(|| {
-            DbError::CorruptData(format!(
-                "credential document upsert did not return a row for {workspace_name}:{source_name}"
-            ))
-        })
+        Ok(self
+            .get(workspace_name, source_name)
+            .await?
+            .is_some_and(|record| document_matches_record(document, &record)))
     }
 
-    pub(crate) async fn rewrap_if_current(
+    pub(crate) async fn replace_if_current(
         &mut self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
@@ -253,6 +237,24 @@ where
         Ok(self.session.execute_rows_affected(statement).await? == 1)
     }
 
+    pub(crate) async fn rewrap_if_current(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        expected_document_version: i64,
+        document: &CredentialDocumentWrite,
+        now_unix_nanos: i64,
+    ) -> Result<bool, DbError> {
+        self.replace_if_current(
+            workspace_name,
+            source_name,
+            expected_document_version,
+            document,
+            now_unix_nanos,
+        )
+        .await
+    }
+
     pub(crate) async fn remove(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -282,6 +284,20 @@ fn record_columns() -> [CredentialDocuments; 10] {
         CredentialDocuments::CreatedAtUnixNanos,
         CredentialDocuments::UpdatedAtUnixNanos,
     ]
+}
+
+fn document_matches_record(
+    document: &CredentialDocumentWrite,
+    record: &CredentialDocumentRecord,
+) -> bool {
+    record.document_version == 1
+        && record.ciphertext == document.ciphertext
+        && record.nonce == document.nonce
+        && record.wrapped_dek == document.wrapped_dek
+        && record.wrapped_dek_nonce == document.wrapped_dek_nonce
+        && record.key_id == document.key_id
+        && record.algorithm == document.algorithm
+        && record.aad_version == document.aad_version
 }
 
 #[cfg(test)]
@@ -339,6 +355,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn credential_document_repository_rejects_document_without_workspace_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("missing").expect("source name");
+
+        let mut tx = db.begin().await.expect("begin tx");
+        let error = tx
+            .credential_documents()
+            .insert_if_absent(
+                &workspace,
+                &source_name,
+                &document_write("key-1", b"secret"),
+                10,
+            )
+            .await
+            .expect_err("credential document rows must require an existing workspace");
+
+        assert!(
+            error.to_string().to_lowercase().contains("foreign key"),
+            "unexpected error: {error}"
+        );
+        tx.rollback().await.expect("rollback failed tx");
+    }
+
+    #[tokio::test]
     async fn credential_document_repository_round_trips_against_postgres() {
         let Some(url) = postgres_test_url() else {
             return;
@@ -357,20 +404,26 @@ mod tests {
 
         let mut tx = db.begin().await.expect("begin tx");
         seed_source(&mut tx, &workspace, &source_name).await;
-        upsert_document(&mut tx, &workspace, &source_name, "key-1", b"first", 10).await;
+        assert!(insert_document(&mut tx, &workspace, &source_name, "key-1", b"first", 10).await);
         tx.commit().await.expect("commit first document");
 
         let mut tx = db.begin().await.expect("begin replacement tx");
-        let replacement = upsert_document(
-            &mut tx,
-            &workspace,
-            &source_name,
-            "key-2",
-            b"replacement",
-            20,
-        )
-        .await;
+        assert!(
+            replace_document(
+                &mut tx,
+                &workspace,
+                &source_name,
+                1,
+                "key-2",
+                b"replacement",
+                20
+            )
+            .await
+        );
         tx.commit().await.expect("commit replacement document");
+        let replacement = get_document(db, &workspace, &source_name)
+            .await
+            .expect("replacement document");
 
         assert_document(&replacement, 2, "key-2", b"replacement", 10, 20);
         let debug = format!(
@@ -491,23 +544,44 @@ mod tests {
             .expect("get credential document")
     }
 
-    async fn upsert_document(
+    async fn insert_document(
         tx: &mut CoralTx<'_>,
         workspace: &WorkspaceName,
         source_name: &SourceName,
         key_id: &str,
         ciphertext: &[u8],
         now_unix_nanos: i64,
-    ) -> CredentialDocumentRecord {
+    ) -> bool {
         tx.credential_documents()
-            .upsert(
+            .insert_if_absent(
                 workspace,
                 source_name,
                 &document_write(key_id, ciphertext),
                 now_unix_nanos,
             )
             .await
-            .expect("upsert credential document")
+            .expect("insert credential document")
+    }
+
+    async fn replace_document(
+        tx: &mut CoralTx<'_>,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        expected_document_version: i64,
+        key_id: &str,
+        ciphertext: &[u8],
+        now_unix_nanos: i64,
+    ) -> bool {
+        tx.credential_documents()
+            .replace_if_current(
+                workspace,
+                source_name,
+                expected_document_version,
+                &document_write(key_id, ciphertext),
+                now_unix_nanos,
+            )
+            .await
+            .expect("replace credential document")
     }
 
     async fn rewrap_document(

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -605,6 +605,7 @@ fn parse_credential_storage(storage: &str) -> Result<CredentialStorageKind, DbEr
     match storage {
         "file" => Ok(CredentialStorageKind::File),
         "keychain" => Ok(CredentialStorageKind::Keychain),
+        "database" => Ok(CredentialStorageKind::Database),
         other => Err(DbError::CorruptData(format!(
             "invalid credential storage '{other}'"
         ))),

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -111,6 +111,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
     fn feedback_reports(&mut self) -> FeedbackReportsRepo<'_, Self> {
         FeedbackReportsRepo::new(self)
     }
+
+    fn credential_documents(&mut self) -> CredentialDocumentsRepo<'_, Self> {
+        CredentialDocumentsRepo::new(self)
+    }
 }
 
 impl<T> DbRepos for T where T: DbSession + Sized {}

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -80,9 +80,15 @@ pub(crate) async fn start_standalone_server(
         },
         engine_extensions_providers,
     );
-    crate::serve::start(builder, mcp_options, mcp_surface_provider)
-        .await
-        .map_err(Into::into)
+    // The database-backed state store makes this startup future large enough
+    // to trigger Clippy's `large_futures` lint when it is awaited inline.
+    Box::pin(crate::serve::start(
+        builder,
+        mcp_options,
+        mcp_surface_provider,
+    ))
+    .await
+    .map_err(Into::into)
 }
 
 fn configure_server_builder(

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -586,13 +586,13 @@ fn shutdown_failures_retain_every_component_in_order() {
 async fn auth_disabled_companion_serves_and_shuts_down() {
     let temp = TempDir::new().expect("temp dir");
     write_auth_disabled_config(&temp);
-    let server = start(
+    let server = Box::pin(start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
         Some(Arc::new(TestMcpProvider)),
-    )
+    ))
     .await
     .expect("start composite server");
     let grpc_addr = grpc_addr(&server);
@@ -647,13 +647,13 @@ async fn opted_in_auth_disabled_companion_serves_off_loopback() {
         "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\n\
          bind = '0.0.0.0:0'\nallow_unauthenticated_non_loopback = true\n",
     );
-    let server = start(
+    let server = Box::pin(start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
         None,
-    )
+    ))
     .await
     .expect("start composite server with the exposure opt-in");
     assert!(!server.mcp_http_authentication_enabled());
@@ -675,7 +675,7 @@ async fn opted_in_auth_disabled_companion_serves_off_loopback() {
 async fn companion_uses_supplied_mcp_options() {
     let temp = TempDir::new().expect("temp dir");
     write_auth_disabled_config(&temp);
-    let server = start(
+    let server = Box::pin(start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
@@ -684,7 +684,7 @@ async fn companion_uses_supplied_mcp_options() {
             ..McpOptions::default()
         },
         None,
-    )
+    ))
     .await
     .expect("start composite server");
     let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
@@ -709,13 +709,13 @@ async fn oauth_and_mcp_companions_serve_and_release_all_listeners() {
         SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
         Some(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))),
     );
-    let server = start(
+    let server = Box::pin(start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
         None,
-    )
+    ))
     .await
     .expect("start composite server");
     let grpc_addr = grpc_addr(&server);
@@ -753,14 +753,14 @@ async fn oauth_start_failure_releases_the_started_grpc_listener() {
     // lapses between selection and bind: a parallel process cannot claim it, so
     // startup fails on the occupied OAuth port and must release the gRPC
     // listener afterward.
-    let result = start(
+    let result = Box::pin(start(
         ServerBuilder::standalone_grpc(grpc_addr)
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads()
             .with_prebound_grpc_listener(grpc_listener),
         McpOptions::default(),
         None,
-    )
+    ))
     .await;
     let Err(error) = result else {
         panic!("occupied OAuth address must fail startup");
@@ -781,13 +781,13 @@ async fn session_authenticated_companion_gates_grpc_and_mcp() {
         EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
             .expect("P-256 signing key");
     write_session_config(&temp, signing_key.as_ref());
-    let server = start(
+    let server = Box::pin(start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
         None,
-    )
+    ))
     .await
     .expect("start authenticated composite server");
     assert!(server.grpc_authentication_enabled());
@@ -896,13 +896,13 @@ async fn session_authenticated_companion_scopes_mcp_to_the_urls_workspace() {
         EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
             .expect("P-256 signing key");
     write_session_config(&temp, signing_key.as_ref());
-    let server = start(
+    let server = Box::pin(start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
         None,
-    )
+    ))
     .await
     .expect("start authenticated composite server");
     let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
@@ -1018,13 +1018,13 @@ async fn coral_ui_only_audience_authenticates_private_grpc_without_mcp_http() {
             .expect("P-256 signing key");
     write_coral_ui_only_session_config(&temp, signing_key.as_ref());
 
-    let server = start(
+    let server = Box::pin(start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
         Some(Arc::new(UnexpectedMcpProvider)),
-    )
+    ))
     .await
     .expect("start Coral UI-only authenticated server");
 
@@ -1079,13 +1079,13 @@ async fn session_failures_and_restart_are_fail_closed() {
         "forged-token",
     );
 
-    let server = start(
+    let server = Box::pin(start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
         None,
-    )
+    ))
     .await
     .expect("start authenticated composite server");
     let mcp_endpoint = format!(
@@ -1106,13 +1106,13 @@ async fn session_failures_and_restart_are_fail_closed() {
     assert_authenticated_surfaces(&server, &mcp_endpoint, &valid).await;
     Box::pin(server.shutdown()).await.expect("first shutdown");
 
-    let restarted = start(
+    let restarted = Box::pin(start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
         None,
-    )
+    ))
     .await
     .expect("restart authenticated composite server");
     let restarted_mcp = format!(
@@ -1138,13 +1138,13 @@ async fn mcp_start_failure_releases_started_oauth_and_grpc_listeners() {
     let temp = TempDir::new().expect("temp dir");
     write_oauth_config(&temp, oauth_addr, Some(mcp_addr));
 
-    let result = start(
+    let result = Box::pin(start(
         ServerBuilder::standalone_grpc(grpc_addr)
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
         None,
-    )
+    ))
     .await;
     let Err(error) = result else {
         panic!("occupied MCP address must fail startup");


### PR DESCRIPTION
## Intent
Route credential storage through encrypted database documents when DB-backed state is active.

## What it enables
New source credentials are stored in encrypted DB rows, while read/snapshot/restore/remove operations continue to use the existing credential-store contract.

## Usage examples
Run `coral source add github` and provide `GITHUB_TOKEN`; Coral stores the material in the credential document table instead of creating a legacy secret file.

## Validation
Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.