### PR TITLE
feat(app): import legacy credential material into database

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -65,8 +65,8 @@ use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::sources::service::SourceService;
 use crate::state::db::{
     CoralDb, DatabaseConfig, InaccessibleWorkspaces, ResolvedDatabaseConfig,
-    import_filesystem_feedback_reports, inaccessible_workspaces, migrate_local_ownership_once,
-    run_state_migrations,
+    import_filesystem_feedback_reports, import_legacy_credential_material, inaccessible_workspaces,
+    migrate_local_ownership_once, run_state_migrations,
 };
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::manager::TaskManager;
@@ -396,6 +396,7 @@ impl ServerBuilder {
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
         import_filesystem_feedback_reports(&coral_db, &layout).await?;
         let credential_store = init_credential_store(&layout, &coral_db)?;
+        import_legacy_credential_material(coral_db.as_ref(), &layout, &credential_store).await?;
         let credential_manager = CredentialManager::new(credential_store);
         let workspace_lifecycle_lock = WorkspaceLifecycleLock::default();
         let workspace_pool_registry = Arc::new(WorkspacePoolRegistry::default());

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -807,6 +807,15 @@ async fn import_legacy_credential_material_with_store(
                     continue;
                 }
             };
+            if material.is_empty() {
+                tracing::warn!(
+                    workspace_name = %workspace_name,
+                    source_name = %source.name,
+                    %storage,
+                    "skipping legacy credential material import because the legacy credential material is empty; re-add the source if credentials are still required"
+                );
+                continue;
+            }
             match database_store.replace_material(
                 &workspace_name,
                 &credential_set_id,
@@ -861,9 +870,7 @@ async fn import_legacy_credential_material_with_store(
                     continue;
                 }
             }
-            if !material.is_empty() {
-                imported += 1;
-            }
+            imported += 1;
             let mut updated = source.clone();
             updated.credential_storage = Some(CredentialStorageKind::Database);
             let mut tx = db.begin().await?;
@@ -2605,6 +2612,78 @@ mod tests {
             .await
             .expect("rerun legacy credential import");
         assert_eq!(imported, 0);
+    }
+
+    #[tokio::test]
+    async fn skips_missing_legacy_file_credentials_without_marking_source_database_backed() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        let db = Arc::new(open_sqlite(&layout).await);
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("upsert source");
+        tx.commit().await.expect("commit source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let legacy_store =
+            CredentialStore::with_preference(layout.clone(), CredentialStoragePreference::File);
+        let database_store = CredentialStore::with_database(
+            layout.clone(),
+            CredentialStoragePreference::Auto,
+            Arc::clone(&db),
+            Arc::new(LocalFileCredentialKeyProvider::with_source(
+                &layout,
+                None,
+                CredentialEncryptionKeySource::File,
+            )),
+        );
+
+        let imported = import_legacy_credential_material_with_store(
+            db.as_ref(),
+            &database_store,
+            &legacy_store,
+        )
+        .await
+        .expect("import legacy credentials");
+
+        assert_eq!(imported, 0);
+        let mut session = db.as_ref();
+        let updated = session
+            .sources()
+            .get_source(&workspace, &source_name)
+            .await
+            .expect("get source")
+            .expect("source");
+        assert_eq!(
+            updated.credential_storage,
+            Some(CredentialStorageKind::File)
+        );
+        assert_eq!(
+            database_store
+                .read_material(
+                    &workspace,
+                    &credential_set_id,
+                    CredentialStorageKind::Database
+                )
+                .expect("read missing database material"),
+            BTreeMap::new()
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -9,6 +9,7 @@ use sha2::{Digest as _, Sha256};
 use super::session::DbRepos;
 use super::{CoralDb, CoralTx, DbError, MaterializationRecord, now_unix_nanos_i64};
 use crate::bootstrap::AppError;
+use crate::credentials::{CredentialSetId, CredentialStorageKind, CredentialStore};
 use crate::sources::SourceName;
 use crate::sources::catalog::validate_imported_manifest_database_persistence;
 use crate::sources::materialization::{
@@ -752,6 +753,174 @@ fn parse_legacy_feedback_report_line(
     })
 }
 
+pub(crate) async fn import_legacy_credential_material(
+    db: &CoralDb,
+    layout: &AppStateLayout,
+    database_store: &CredentialStore,
+) -> Result<usize, AppError> {
+    let legacy_store = CredentialStore::with_preference(
+        layout.clone(),
+        crate::credentials::CredentialStoragePreference::Auto,
+    );
+    import_legacy_credential_material_with_store(db, database_store, &legacy_store).await
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps credential import decisions together"
+)]
+async fn import_legacy_credential_material_with_store(
+    db: &CoralDb,
+    database_store: &CredentialStore,
+    legacy_store: &CredentialStore,
+) -> Result<usize, AppError> {
+    let mut imported = 0;
+    let mut session = db;
+    for workspace in session.workspaces().list().await? {
+        let workspace_name = WorkspaceName::parse(&workspace.id)?;
+        let sources = session
+            .sources()
+            .list_workspace_sources(&workspace_name)
+            .await?;
+        for source in sources {
+            let Some(storage) = source.credential_storage_for_material() else {
+                continue;
+            };
+            if storage == CredentialStorageKind::Database {
+                continue;
+            }
+            let credential_set_id = CredentialSetId::for_source(&source.name);
+            let material = match legacy_store.read_material(
+                &workspace_name,
+                &credential_set_id,
+                storage,
+            ) {
+                Ok(material) => material,
+                Err(error) => {
+                    tracing::warn!(
+                        workspace_name = %workspace_name,
+                        source_name = %source.name,
+                        %storage,
+                        detail = %error,
+                        "skipping legacy credential material import; re-add the source if credentials are still required"
+                    );
+                    continue;
+                }
+            };
+            match database_store.replace_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::Database,
+                &material,
+            ) {
+                Ok(()) => {}
+                Err(error @ AppError::Database(_)) => return Err(error),
+                Err(_error) => {
+                    tracing::warn!(
+                        workspace_name = %workspace_name,
+                        source_name = %source.name,
+                        %storage,
+                        "skipping legacy credential material import because database credential write could not be verified"
+                    );
+                    continue;
+                }
+            }
+            match database_store.read_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::Database,
+            ) {
+                Ok(imported_material) if imported_material == material => {}
+                Ok(_) => {
+                    tracing::warn!(
+                        workspace_name = %workspace_name,
+                        source_name = %source.name,
+                        %storage,
+                        "skipping legacy credential cleanup because database credential readback did not match legacy material"
+                    );
+                    remove_unverified_database_credential(
+                        database_store,
+                        &workspace_name,
+                        &credential_set_id,
+                    )?;
+                    continue;
+                }
+                Err(error @ AppError::Database(_)) => return Err(error),
+                Err(_error) => {
+                    tracing::warn!(
+                        workspace_name = %workspace_name,
+                        source_name = %source.name,
+                        %storage,
+                        "skipping legacy credential cleanup because database credential readback failed"
+                    );
+                    remove_unverified_database_credential(
+                        database_store,
+                        &workspace_name,
+                        &credential_set_id,
+                    )?;
+                    continue;
+                }
+            }
+            if !material.is_empty() {
+                imported += 1;
+            }
+            let mut updated = source.clone();
+            updated.credential_storage = Some(CredentialStorageKind::Database);
+            let mut tx = db.begin().await?;
+            tx.sources()
+                .upsert_source(&workspace_name, &updated, now_unix_nanos_i64()?)
+                .await?;
+            tx.commit().await?;
+            remove_legacy_credential_material(
+                legacy_store,
+                &workspace_name,
+                &credential_set_id,
+                storage,
+            );
+        }
+    }
+    Ok(imported)
+}
+
+fn remove_unverified_database_credential(
+    database_store: &CredentialStore,
+    workspace_name: &WorkspaceName,
+    credential_set_id: &CredentialSetId,
+) -> Result<(), AppError> {
+    match database_store.remove_material(
+        workspace_name,
+        credential_set_id,
+        CredentialStorageKind::Database,
+    ) {
+        Ok(()) => Ok(()),
+        Err(error @ AppError::Database(_)) => Err(error),
+        Err(_error) => {
+            tracing::warn!(
+                %workspace_name,
+                %credential_set_id,
+                "failed to remove unverified database credential document"
+            );
+            Ok(())
+        }
+    }
+}
+
+fn remove_legacy_credential_material(
+    legacy_store: &CredentialStore,
+    workspace_name: &WorkspaceName,
+    credential_set_id: &CredentialSetId,
+    storage: CredentialStorageKind,
+) {
+    if let Err(_error) = legacy_store.remove_material(workspace_name, credential_set_id, storage) {
+        tracing::warn!(
+            %workspace_name,
+            %credential_set_id,
+            %storage,
+            "credential material imported into database but legacy cleanup failed"
+        );
+    }
+}
+
 fn filesystem_feedback_workspaces(layout: &AppStateLayout) -> Result<Vec<WorkspaceName>, AppError> {
     let root = layout.workspaces_root();
     let mut workspaces = Vec::new();
@@ -854,16 +1023,25 @@ fn clear_legacy_source_catalog_config(config_store: &ConfigStore, source_count: 
 mod tests {
     use std::collections::BTreeMap;
     use std::fs;
+    use std::sync::Arc;
 
     use tempfile::tempdir;
 
     use super::{
         SourceCatalogImportReport, WORKSPACE_CATALOG_CUTOVER_ID, WorkspaceCatalogCutoverReport,
         cutover_legacy_workspace_catalog, cutover_legacy_workspace_catalog_at,
-        import_config_source_catalog, import_filesystem_feedback_reports, run_state_migrations,
-        source_catalog_import_id,
+        import_config_source_catalog, import_filesystem_feedback_reports,
+        import_legacy_credential_material, import_legacy_credential_material_with_store,
+        run_state_migrations, source_catalog_import_id,
     };
-    use crate::credentials::CredentialStorageKind;
+    use crate::credentials::config::CredentialEncryptionKeySource;
+    use crate::credentials::encryption::{
+        CredentialEncryptionKey, CredentialKeyProvider, LocalFileCredentialKeyProvider,
+    };
+    use crate::credentials::{
+        CredentialSetId, CredentialStorageKind, CredentialStoragePreference, CredentialStore,
+        CredentialsError,
+    };
     use crate::sources::SourceName;
     use crate::sources::materialization::{
         MaterializationInputs, build_v4_materialization_tmp, replace_or_retire_v4_materialization,
@@ -885,6 +1063,21 @@ mod tests {
     /// these tests plant read exactly as `move_for_delete` would have written
     /// them.
     const STAGED_DELETION_SUFFIX: &str = "7f1c5a4e-1d29-4f3a-9f2b-2c6d0f9a1b34";
+
+    #[derive(Clone)]
+    struct WriteOnlyKeyProvider(CredentialEncryptionKey);
+
+    impl CredentialKeyProvider for WriteOnlyKeyProvider {
+        fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+            Ok(self.0.clone())
+        }
+
+        fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+            Err(CredentialsError::Crypto(format!(
+                "test key '{key_id}' unavailable"
+            )))
+        }
+    }
 
     #[tokio::test]
     async fn completed_workspace_cutover_does_not_skip_source_catalog_import() {
@@ -2352,6 +2545,311 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn imports_legacy_file_credentials_into_database() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        let db = Arc::new(open_sqlite(&layout).await);
+        seed_source(&db, &workspace, &source).await;
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let legacy_store =
+            CredentialStore::with_preference(layout.clone(), CredentialStoragePreference::File);
+        let material = BTreeMap::from([("GITHUB_TOKEN".to_string(), "secret-token".to_string())]);
+        legacy_store
+            .replace_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &material,
+            )
+            .expect("write legacy credential file");
+        let database_store = database_store(&layout, &db);
+
+        let imported = import_legacy_credential_material(db.as_ref(), &layout, &database_store)
+            .await
+            .expect("import legacy credentials");
+
+        assert_eq!(imported, 1);
+        assert_eq!(
+            db_source(&db, &workspace, &source_name)
+                .await
+                .credential_storage,
+            Some(CredentialStorageKind::Database)
+        );
+        assert_eq!(
+            database_store
+                .read_material(
+                    &workspace,
+                    &credential_set_id,
+                    CredentialStorageKind::Database
+                )
+                .expect("read database material"),
+            material
+        );
+        assert!(
+            !layout.secret_file(&workspace, &source_name).exists(),
+            "legacy secrets.env should be removed after DB import"
+        );
+        let imported = import_legacy_credential_material(db.as_ref(), &layout, &database_store)
+            .await
+            .expect("rerun legacy credential import");
+        assert_eq!(imported, 0);
+    }
+
+    #[tokio::test]
+    async fn imports_keychain_backed_credentials_into_database() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::Keychain),
+            SourceOrigin::Imported,
+        );
+        let db = Arc::new(open_sqlite(&layout).await);
+        seed_source(&db, &workspace, &source).await;
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let legacy_store = CredentialStore::with_available_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Keychain,
+        );
+        let material = BTreeMap::from([("GITHUB_TOKEN".to_string(), "secret-token".to_string())]);
+        legacy_store
+            .replace_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::Keychain,
+                &material,
+            )
+            .expect("write legacy keychain material");
+        let database_store = database_store(&layout, &db);
+
+        let imported = import_legacy_credential_material_with_store(
+            db.as_ref(),
+            &database_store,
+            &legacy_store,
+        )
+        .await
+        .expect("import legacy credentials");
+
+        assert_eq!(imported, 1);
+        assert_eq!(
+            db_source(&db, &workspace, &source_name)
+                .await
+                .credential_storage,
+            Some(CredentialStorageKind::Database)
+        );
+        assert_eq!(
+            database_store
+                .read_material(
+                    &workspace,
+                    &credential_set_id,
+                    CredentialStorageKind::Database
+                )
+                .expect("read database material"),
+            material
+        );
+        assert!(
+            legacy_store
+                .read_material(
+                    &workspace,
+                    &credential_set_id,
+                    CredentialStorageKind::Keychain
+                )
+                .expect("read legacy keychain material")
+                .is_empty(),
+            "legacy keychain material should be removed after verified DB import"
+        );
+    }
+
+    #[tokio::test]
+    async fn skips_corrupt_legacy_file_credentials() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        let db = Arc::new(open_sqlite(&layout).await);
+        seed_source(&db, &workspace, &source).await;
+        let secret_file = layout.secret_file(&workspace, &source_name);
+        fs::create_dir_all(secret_file.parent().expect("secret parent"))
+            .expect("create secret parent");
+        fs::write(&secret_file, "GITHUB_TOKEN\n").expect("write corrupt secrets");
+        let database_store = database_store(&layout, &db);
+
+        let imported = import_legacy_credential_material(db.as_ref(), &layout, &database_store)
+            .await
+            .expect("import legacy credentials");
+
+        assert_eq!(imported, 0);
+        assert_eq!(
+            db_source(&db, &workspace, &source_name)
+                .await
+                .credential_storage,
+            Some(CredentialStorageKind::File)
+        );
+        assert!(secret_file.exists());
+        assert!(
+            database_store
+                .read_material(
+                    &workspace,
+                    &CredentialSetId::for_source(&source_name),
+                    CredentialStorageKind::Database
+                )
+                .expect("read database material")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn keeps_legacy_file_when_database_readback_fails() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        let db = Arc::new(open_sqlite(&layout).await);
+        seed_source(&db, &workspace, &source).await;
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let legacy_store =
+            CredentialStore::with_preference(layout.clone(), CredentialStoragePreference::File);
+        let material = BTreeMap::from([("GITHUB_TOKEN".to_string(), "secret-token".to_string())]);
+        legacy_store
+            .replace_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &material,
+            )
+            .expect("write legacy credential file");
+        let key = CredentialEncryptionKey::from_static_bytes_for_test([41; 32]);
+        let database_store = CredentialStore::with_database(
+            layout.clone(),
+            CredentialStoragePreference::Auto,
+            Arc::clone(&db),
+            Arc::new(WriteOnlyKeyProvider(key)),
+        );
+
+        let imported = import_legacy_credential_material(db.as_ref(), &layout, &database_store)
+            .await
+            .expect("import legacy credentials");
+
+        assert_eq!(imported, 0);
+        assert_eq!(
+            db_source(&db, &workspace, &source_name)
+                .await
+                .credential_storage,
+            Some(CredentialStorageKind::File)
+        );
+        assert!(layout.secret_file(&workspace, &source_name).exists());
+        let mut session = db.as_ref();
+        assert!(
+            session
+                .credential_documents()
+                .get(&workspace, &source_name)
+                .await
+                .expect("get credential document")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_credential_import_race_is_benign_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+                .await
+                .expect("open postgres"),
+        );
+        db.migrate().await.expect("migrate postgres");
+        let workspace = WorkspaceName::parse(&format!("cred{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        seed_source(&db, &workspace, &source).await;
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let material = BTreeMap::from([("GITHUB_TOKEN".to_string(), "secret-token".to_string())]);
+        CredentialStore::with_preference(layout.clone(), CredentialStoragePreference::File)
+            .replace_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &material,
+            )
+            .expect("write legacy credential file");
+        let first = database_store(&layout, &db);
+        let second = first.clone();
+
+        let (first_import, second_import) = tokio::join!(
+            import_legacy_credential_material(db.as_ref(), &layout, &first),
+            import_legacy_credential_material(db.as_ref(), &layout, &second)
+        );
+
+        first_import.expect("first import");
+        second_import.expect("second import");
+        assert_eq!(
+            first
+                .read_material(
+                    &workspace,
+                    &credential_set_id,
+                    CredentialStorageKind::Database
+                )
+                .expect("read database material"),
+            material
+        );
+        assert_eq!(
+            db_source(&db, &workspace, &source_name)
+                .await
+                .credential_storage,
+            Some(CredentialStorageKind::Database)
+        );
+        assert!(!layout.secret_file(&workspace, &source_name).exists());
+    }
+
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
         let config = DatabaseConfig::load(layout).expect("db config");
         let DatabaseConfig::Sqlite { path } = config else {
@@ -2362,6 +2860,46 @@ mod tests {
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
         db
+    }
+
+    fn database_store(layout: &AppStateLayout, db: &Arc<CoralDb>) -> CredentialStore {
+        CredentialStore::with_database(
+            layout.clone(),
+            CredentialStoragePreference::Auto,
+            Arc::clone(db),
+            Arc::new(LocalFileCredentialKeyProvider::with_source(
+                layout,
+                None,
+                CredentialEncryptionKeySource::File,
+            )),
+        )
+    }
+
+    async fn seed_source(db: &CoralDb, workspace: &WorkspaceName, source: &InstalledSource) {
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(workspace, source, 7)
+            .await
+            .expect("upsert source");
+        tx.commit().await.expect("commit source");
+    }
+
+    async fn db_source(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> InstalledSource {
+        let mut session = db;
+        session
+            .sources()
+            .get_source(workspace, source_name)
+            .await
+            .expect("get source")
+            .expect("source")
     }
 
     fn feedback_jsonl(workspace: &str, id: &str) -> String {

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -816,12 +816,20 @@ async fn import_legacy_credential_material_with_store(
                 );
                 continue;
             }
-            match database_store.replace_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::Database,
-                &material,
-            ) {
+            let write_store = database_store.clone();
+            let write_workspace = workspace_name.clone();
+            let write_credential_set = credential_set_id.clone();
+            let write_material = material.clone();
+            match run_blocking_credential_import_operation(move || {
+                write_store.replace_material(
+                    &write_workspace,
+                    &write_credential_set,
+                    CredentialStorageKind::Database,
+                    &write_material,
+                )
+            })
+            .await
+            {
                 Ok(()) => {}
                 Err(error @ AppError::Database(_)) => return Err(error),
                 Err(_error) => {
@@ -834,11 +842,18 @@ async fn import_legacy_credential_material_with_store(
                     continue;
                 }
             }
-            match database_store.read_material(
-                &workspace_name,
-                &credential_set_id,
-                CredentialStorageKind::Database,
-            ) {
+            let read_store = database_store.clone();
+            let read_workspace = workspace_name.clone();
+            let read_credential_set = credential_set_id.clone();
+            match run_blocking_credential_import_operation(move || {
+                read_store.read_material(
+                    &read_workspace,
+                    &read_credential_set,
+                    CredentialStorageKind::Database,
+                )
+            })
+            .await
+            {
                 Ok(imported_material) if imported_material == material => {}
                 Ok(_) => {
                     tracing::warn!(
@@ -851,7 +866,8 @@ async fn import_legacy_credential_material_with_store(
                         database_store,
                         &workspace_name,
                         &credential_set_id,
-                    )?;
+                    )
+                    .await?;
                     continue;
                 }
                 Err(error @ AppError::Database(_)) => return Err(error),
@@ -866,7 +882,8 @@ async fn import_legacy_credential_material_with_store(
                         database_store,
                         &workspace_name,
                         &credential_set_id,
-                    )?;
+                    )
+                    .await?;
                     continue;
                 }
             }
@@ -889,16 +906,34 @@ async fn import_legacy_credential_material_with_store(
     Ok(imported)
 }
 
-fn remove_unverified_database_credential(
+async fn run_blocking_credential_import_operation<T>(
+    operation: impl FnOnce() -> Result<T, AppError> + Send + 'static,
+) -> Result<T, AppError>
+where
+    T: Send + 'static,
+{
+    // CredentialStore's database API is synchronous; keep its SQLx bridge off
+    // Tokio workers so concurrent imports can continue through commit.
+    tokio::task::spawn_blocking(operation).await?
+}
+
+async fn remove_unverified_database_credential(
     database_store: &CredentialStore,
     workspace_name: &WorkspaceName,
     credential_set_id: &CredentialSetId,
 ) -> Result<(), AppError> {
-    match database_store.remove_material(
-        workspace_name,
-        credential_set_id,
-        CredentialStorageKind::Database,
-    ) {
+    let remove_store = database_store.clone();
+    let remove_workspace = workspace_name.clone();
+    let remove_credential_set = credential_set_id.clone();
+    match run_blocking_credential_import_operation(move || {
+        remove_store.remove_material(
+            &remove_workspace,
+            &remove_credential_set,
+            CredentialStorageKind::Database,
+        )
+    })
+    .await
+    {
         Ok(()) => Ok(()),
         Err(error @ AppError::Database(_)) => Err(error),
         Err(_error) => {
@@ -1039,7 +1074,7 @@ mod tests {
         cutover_legacy_workspace_catalog, cutover_legacy_workspace_catalog_at,
         import_config_source_catalog, import_filesystem_feedback_reports,
         import_legacy_credential_material, import_legacy_credential_material_with_store,
-        run_state_migrations, source_catalog_import_id,
+        run_blocking_credential_import_operation, run_state_migrations, source_catalog_import_id,
     };
     use crate::credentials::config::CredentialEncryptionKeySource;
     use crate::credentials::encryption::{
@@ -2910,16 +2945,19 @@ mod tests {
 
         first_import.expect("first import");
         second_import.expect("second import");
-        assert_eq!(
-            first
-                .read_material(
-                    &workspace,
-                    &credential_set_id,
-                    CredentialStorageKind::Database
-                )
-                .expect("read database material"),
-            material
-        );
+        let read_store = first.clone();
+        let read_workspace = workspace.clone();
+        let read_credential_set = credential_set_id.clone();
+        let stored_material = run_blocking_credential_import_operation(move || {
+            read_store.read_material(
+                &read_workspace,
+                &read_credential_set,
+                CredentialStorageKind::Database,
+            )
+        })
+        .await
+        .expect("read database material");
+        assert_eq!(stored_material, material);
         assert_eq!(
             db_source(&db, &workspace, &source_name)
                 .await

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -22,7 +22,9 @@ pub(crate) use clock::now_unix_nanos_i64;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
-pub(crate) use import::{import_filesystem_feedback_reports, run_state_migrations};
+pub(crate) use import::{
+    import_filesystem_feedback_reports, import_legacy_credential_material, run_state_migrations,
+};
 pub(crate) use ownership_bootstrap::{inaccessible_workspaces, migrate_local_ownership_once};
 pub(crate) use repositories::credential_documents::{
     CredentialDocumentRecord, CredentialDocumentWrite,


### PR DESCRIPTION
## Intent
Migrate existing file/keychain credential material into encrypted database documents.

## What it enables
Users keep existing installed source credentials after the DB-backed state migration, and source metadata is updated to read future credentials from the database.

## Usage examples
Start Coral with an existing source that has `secrets.env` or keychain material; startup imports it and future queries use the encrypted DB document.

## Validation
Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.