### PR TITLE
feat(app): index trace summaries in database

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -83,6 +83,7 @@ jobs:
               - 'Makefile'
               - 'crates/coral-app/migrations/**'
               - 'crates/coral-app/src/state/db/**'
+              - 'crates/coral-app/src/telemetry/service.rs'
               - 'crates/coral-app/tests/grpc/source_lifecycle_tests.rs'
               - 'crates/coral-app/tests/postgres_database_tests.rs'
               # The xtask recovery contracts run in this job too, against the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,9 @@
   `postgres-test-suite` as the single home for the suite's Cargo invocations;
   do not duplicate them in workflows or contributor instructions. The suite runs
   the `state::db` unit-test namespace, repeating shared repository assertions
-  against Postgres, then runs the source-lifecycle integration namespace, the
-  dedicated Postgres integration target for migration and server startup
-  coverage, plus the xtask recovery contracts.
+  against Postgres, then runs the DB-backed telemetry service and source-lifecycle
+  namespaces, the dedicated Postgres integration target for migration and server
+  startup coverage, plus the xtask recovery contracts.
   The recovery checks use xtask's `admin` feature. `postgres-tests` uses
   `CORAL_TEST_POSTGRES_URL` when supplied. Otherwise it starts a local Docker
   Postgres and creates a fresh database inside the reusable container. Docker

--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,8 @@ perf-check:
 # ----------------------------------------------------------------------------
 # Postgres-backed tests
 # ----------------------------------------------------------------------------
-# postgres-test-suite runs the DB-owned coral-app unit tests and dedicated
-# Postgres integration target plus xtask recovery contracts against an existing
+# postgres-test-suite runs DB-backed coral-app test namespaces, the dedicated
+# Postgres integration target, and xtask recovery contracts against an existing
 # Postgres URL. The xtask checks need `--features admin` because the recovery
 # module compiles only under it. postgres-tests provisions the database first:
 # when CORAL_TEST_POSTGRES_URL is set it uses that database, otherwise it starts
@@ -235,7 +235,7 @@ postgres-clean:
 # containing $(MAKE) even under -n/-t/-q, and the postgres-tests recipe is a
 # single continued line, so an inline sub-make would make
 # `make -n postgres-tests` execute the real suite.
-POSTGRES_SUITE_CARGO = cargo test --locked -p coral-app --lib 'state::db::' -- --test-threads=1 && cargo test --locked -p coral-app --test grpc 'source_lifecycle_tests::' && cargo test --locked -p coral-app --test postgres_database_tests && cargo test --locked -p xtask --features admin --bin xtask -- --ignored
+POSTGRES_SUITE_CARGO = cargo test --locked -p coral-app --lib 'state::db::' -- --test-threads=1 && cargo test --locked -p coral-app --lib 'telemetry::service::tests::' && cargo test --locked -p coral-app --test grpc 'source_lifecycle_tests::' && cargo test --locked -p coral-app --test postgres_database_tests && cargo test --locked -p xtask --features admin --bin xtask -- --ignored
 
 postgres-test-suite:
 	@test -n "$${CORAL_TEST_POSTGRES_URL:-}" || \

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -72,10 +72,8 @@ use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::manager::TaskManager;
 use crate::task::service::TaskService;
 use crate::task::store::TaskStore;
-use crate::telemetry::TelemetryConfig;
-#[cfg(test)]
-use crate::telemetry::TraceManager;
 use crate::telemetry::service::TraceService;
+use crate::telemetry::{InstalledLocalTraceStore, TelemetryConfig};
 use crate::transport::GrpcRequestContextLayer;
 use crate::users::manager::UserManager;
 use crate::users::service::UserService;
@@ -392,19 +390,15 @@ impl ServerBuilder {
         let config_store = ConfigStore::new(layout.clone());
         let (coral_db, authorization_server) =
             bootstrap_database(&layout, &config_store, session_auth).await?;
-        let (telemetry_config, active_trace_store) =
-            init_server_telemetry(&layout, self.config.enable_stderr_logs)?;
-        let sync_trace_store = active_trace_store.clone();
+        let (telemetry_config, active_trace_store) = init_server_telemetry(
+            &layout,
+            self.config.enable_stderr_logs,
+            Arc::clone(&coral_db),
+        )?;
         apply_local_principal_policy(&coral_db, local_principal).await?;
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
-        import_filesystem_feedback_reports(&coral_db, &layout).await?;
-        if let Some(store) = sync_trace_store.as_ref() {
-            TraceService::sync_summaries(store.dir.clone(), store.retention, coral_db.as_ref())
-                .await
-                .map_err(|error| {
-                    AppError::Database(format!("trace summary import failed: {error}"))
-                })?;
-        }
+        import_filesystem_feedback_reports(coral_db.as_ref(), &layout).await?;
+        backfill_trace_summaries(active_trace_store.as_ref(), coral_db.as_ref()).await?;
         let credential_store = init_credential_store(&layout, &coral_db)?;
         import_legacy_credential_material(coral_db.as_ref(), &layout, &credential_store).await?;
         let credential_manager = CredentialManager::new(credential_store);
@@ -624,6 +618,7 @@ fn build_authorization_server(
 fn init_server_telemetry(
     layout: &AppStateLayout,
     enable_stderr_logs: bool,
+    db: Arc<CoralDb>,
 ) -> Result<
     (
         TelemetryConfig,
@@ -636,8 +631,12 @@ fn init_server_telemetry(
         .trace_history
         .enabled
         .then(|| layout.local_trace_store_dir());
-    let installed_trace_store =
-        crate::telemetry::init_tracing(&config, enable_stderr_logs, local_trace_store_dir)?;
+    let installed_trace_store = crate::telemetry::init_tracing(
+        &config,
+        enable_stderr_logs,
+        local_trace_store_dir,
+        Some(db),
+    )?;
     let active_trace_store = config
         .trace_history
         .enabled
@@ -671,6 +670,19 @@ async fn init_database(layout: &AppStateLayout) -> Result<CoralDb, AppError> {
     let coral_db = CoralDb::open(database_config).await?;
     coral_db.migrate().await?;
     Ok(coral_db)
+}
+
+async fn backfill_trace_summaries(
+    store: Option<&InstalledLocalTraceStore>,
+    coral_db: &CoralDb,
+) -> Result<(), AppError> {
+    let Some(store) = store else {
+        return Ok(());
+    };
+    TraceService::backfill_summaries(store.dir.clone(), store.retention, coral_db)
+        .await
+        .map(|_| ())
+        .map_err(|error| AppError::Database(format!("trace summary import failed: {error}")))
 }
 
 fn init_credential_store(

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -72,8 +72,10 @@ use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::manager::TaskManager;
 use crate::task::service::TaskService;
 use crate::task::store::TaskStore;
+use crate::telemetry::TelemetryConfig;
+#[cfg(test)]
+use crate::telemetry::TraceManager;
 use crate::telemetry::service::TraceService;
-use crate::telemetry::{TelemetryConfig, TraceManager};
 use crate::transport::GrpcRequestContextLayer;
 use crate::users::manager::UserManager;
 use crate::users::service::UserService;
@@ -392,9 +394,17 @@ impl ServerBuilder {
             bootstrap_database(&layout, &config_store, session_auth).await?;
         let (telemetry_config, active_trace_store) =
             init_server_telemetry(&layout, self.config.enable_stderr_logs)?;
+        let sync_trace_store = active_trace_store.clone();
         apply_local_principal_policy(&coral_db, local_principal).await?;
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
         import_filesystem_feedback_reports(&coral_db, &layout).await?;
+        if let Some(store) = sync_trace_store.as_ref() {
+            TraceService::sync_summaries(store.dir.clone(), store.retention, coral_db.as_ref())
+                .await
+                .map_err(|error| {
+                    AppError::Database(format!("trace summary import failed: {error}"))
+                })?;
+        }
         let credential_store = init_credential_store(&layout, &coral_db)?;
         import_legacy_credential_material(coral_db.as_ref(), &layout, &credential_store).await?;
         let credential_manager = CredentialManager::new(credential_store);
@@ -468,6 +478,7 @@ impl ServerBuilder {
             active_trace_store,
             workspace_manager.clone(),
             workspace_authorizer.clone(),
+            &coral_db,
         );
         let mut server = start_server(
             ServerDependencies {
@@ -639,12 +650,15 @@ fn trace_components_for_store(
     active_trace_store: Option<crate::telemetry::InstalledLocalTraceStore>,
     workspaces: WorkspaceManager,
     workspace_authorizer: WorkspaceAuthorizer,
+    db: &Arc<CoralDb>,
 ) -> TraceServerComponents {
     active_trace_store.map_or_else(TraceServerComponents::default, |store| {
         TraceServerComponents {
             local_trace_store_dir: Some(store.dir.clone()),
-            service: Some(TraceService::new(
-                TraceManager::new(store.dir, store.retention),
+            service: Some(TraceService::with_db(
+                store.dir,
+                store.retention,
+                Arc::clone(db),
                 workspaces,
                 workspace_authorizer,
             )),

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -1974,7 +1974,7 @@ mod tests {
                     variables: BTreeMap::new(),
                     secrets: vec!["GITHUB_TOKEN".to_string()],
                     credential_storage: Some(CredentialStorageKind::Database),
-                    credential_revision: uuid::Uuid::default(),
+                    credential_revision: uuid::Uuid::from_u128(1),
                     origin: SourceOrigin::Bundled,
                 },
                 1,

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -272,6 +272,7 @@ fn validate_v4_source_for_database_persistence(
     }
     Ok(())
 }
+
 fn candidate_from_manifest(
     manifest: &ValidatedSourceManifest,
     origin: SourceOrigin,

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -18,10 +18,6 @@ mod transaction;
 mod user_state;
 mod workspace_state;
 
-#[expect(
-    unused_imports,
-    reason = "trace summary repository lands before runtime wiring in the stacked PR sequence"
-)]
 pub(crate) use crate::telemetry::TraceSummaryRecord;
 pub(crate) use clock::now_unix_nanos_i64;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};

--- a/crates/coral-app/src/state/db/repositories/credential_documents.rs
+++ b/crates/coral-app/src/state/db/repositories/credential_documents.rs
@@ -646,7 +646,7 @@ mod tests {
             variables: std::collections::BTreeMap::default(),
             secrets: vec!["GITHUB_TOKEN".to_string()],
             credential_storage: None,
-            credential_revision: uuid::Uuid::default(),
+            credential_revision: uuid::Uuid::from_u128(1),
             origin: SourceOrigin::Imported,
         };
         tx.workspaces()

--- a/crates/coral-app/src/state/db/repositories/trace_summaries.rs
+++ b/crates/coral-app/src/state/db/repositories/trace_summaries.rs
@@ -226,19 +226,6 @@ where
             .to_owned();
         self.session.execute(statement).await
     }
-
-    pub(crate) async fn delete(
-        &mut self,
-        workspace_id: &str,
-        trace_id: &str,
-    ) -> Result<(), DbError> {
-        let statement = Query::delete()
-            .from_table(TraceSummaries::Table)
-            .and_where(Expr::col(TraceSummaries::WorkspaceId).eq(workspace_id))
-            .and_where(Expr::col(TraceSummaries::TraceId).eq(trace_id))
-            .to_owned();
-        self.session.execute(statement).await
-    }
 }
 
 fn record_columns() -> [TraceSummaries; 14] {

--- a/crates/coral-app/src/state/db/repositories/trace_summaries.rs
+++ b/crates/coral-app/src/state/db/repositories/trace_summaries.rs
@@ -132,12 +132,52 @@ where
         let rows: Vec<TraceSummaryRow> = self.session.fetch_all(statement).await?;
         rows.into_iter().map(TryInto::try_into).collect()
     }
+
+    pub(crate) async fn list_for_workspace(
+        &mut self,
+        workspace_id: &str,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<TraceSummaryRecord>, DbError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let statement = Query::select()
+            .columns(record_columns())
+            .from(TraceSummaries::Table)
+            .and_where(Expr::col(TraceSummaries::WorkspaceId).eq(workspace_id))
+            .order_by(TraceSummaries::EndTimeUnixNanos, Order::Desc)
+            .order_by(TraceSummaries::TraceId, Order::Asc)
+            .limit(limit_to_u64(limit)?)
+            .offset(limit_to_u64(offset)?)
+            .to_owned();
+        let rows: Vec<TraceSummaryRow> = self.session.fetch_all(statement).await?;
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
 }
 
 impl<S> TraceSummariesRepo<'_, S>
 where
     S: DbSession,
 {
+    pub(crate) async fn replace_all(
+        &mut self,
+        summaries: &[TraceSummaryRecord],
+    ) -> Result<(), DbError> {
+        for summary in summaries {
+            row_count_to_db(summary)?;
+            summary_workspace_id(summary)?;
+        }
+
+        let statement = Query::delete().from_table(TraceSummaries::Table).to_owned();
+        self.session.execute(statement).await?;
+        for summary in summaries {
+            self.upsert(summary).await?;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn upsert(&mut self, summary: &TraceSummaryRecord) -> Result<(), DbError> {
         let row_count = row_count_to_db(summary)?;
         let workspace_id = summary_workspace_id(summary)?;
@@ -409,6 +449,7 @@ mod tests {
 
         let updated = update_first_summary(first);
         assert_update_and_failed_replacement(db, &updated).await;
+        assert_replace_all_validates_before_delete(db, &updated, &second).await;
         cleanup_workspace(
             db,
             updated.workspace_id.as_deref().expect("first workspace"),
@@ -519,6 +560,33 @@ mod tests {
                 .await
                 .expect("get updated summary"),
             Some(updated.clone())
+        );
+    }
+
+    async fn assert_replace_all_validates_before_delete(
+        db: &CoralDb,
+        existing: &TraceSummaryRecord,
+        other: &TraceSummaryRecord,
+    ) {
+        let invalid = TraceSummaryRecord {
+            trace_id: "trace-invalid".to_string(),
+            row_count: i64::MAX as u64 + 1,
+            ..existing.clone()
+        };
+        let mut tx = db.begin().await.expect("begin replace all failure tx");
+        assert!(
+            matches!(
+                tx.trace_summaries().replace_all(&[invalid]).await,
+                Err(DbError::CorruptData(_))
+            ),
+            "replace_all should validate summaries before deleting existing index rows"
+        );
+        tx.commit().await.expect("commit failed replacement no-op");
+
+        let mut session = db;
+        assert_eq!(
+            fixture_summaries(&mut session, existing, other).await,
+            vec![other.clone(), existing.clone()]
         );
     }
 

--- a/crates/coral-app/src/state/db/repositories/trace_summaries.rs
+++ b/crates/coral-app/src/state/db/repositories/trace_summaries.rs
@@ -6,7 +6,7 @@
     )
 )]
 
-use sea_query::{Expr, ExprTrait, OnConflict, Order, Query};
+use sea_query::{Alias, Expr, ExprTrait, OnConflict, Order, Query};
 
 use crate::state::db::schema::TraceSummaries;
 use crate::state::db::{DbError, DbSession};
@@ -126,6 +126,7 @@ where
             .from(TraceSummaries::Table)
             .order_by(TraceSummaries::EndTimeUnixNanos, Order::Desc)
             .order_by(TraceSummaries::TraceId, Order::Asc)
+            .order_by(TraceSummaries::WorkspaceId, Order::Asc)
             .limit(limit_to_u64(limit)?)
             .offset(limit_to_u64(offset)?)
             .to_owned();
@@ -161,23 +162,6 @@ impl<S> TraceSummariesRepo<'_, S>
 where
     S: DbSession,
 {
-    pub(crate) async fn replace_all(
-        &mut self,
-        summaries: &[TraceSummaryRecord],
-    ) -> Result<(), DbError> {
-        for summary in summaries {
-            row_count_to_db(summary)?;
-            summary_workspace_id(summary)?;
-        }
-
-        let statement = Query::delete().from_table(TraceSummaries::Table).to_owned();
-        self.session.execute(statement).await?;
-        for summary in summaries {
-            self.upsert(summary).await?;
-        }
-        Ok(())
-    }
-
     pub(crate) async fn upsert(&mut self, summary: &TraceSummaryRecord) -> Result<(), DbError> {
         let row_count = row_count_to_db(summary)?;
         let workspace_id = summary_workspace_id(summary)?;
@@ -232,8 +216,26 @@ where
                         TraceSummaries::OperationName,
                         TraceSummaries::InvocationKind,
                     ])
+                    .action_and_where(
+                        Expr::col((TraceSummaries::Table, TraceSummaries::EndTimeUnixNanos)).lte(
+                            Expr::col((Alias::new("excluded"), TraceSummaries::EndTimeUnixNanos)),
+                        ),
+                    )
                     .to_owned(),
             )
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn delete(
+        &mut self,
+        workspace_id: &str,
+        trace_id: &str,
+    ) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(TraceSummaries::Table)
+            .and_where(Expr::col(TraceSummaries::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(TraceSummaries::TraceId).eq(trace_id))
             .to_owned();
         self.session.execute(statement).await
     }
@@ -449,7 +451,6 @@ mod tests {
 
         let updated = update_first_summary(first);
         assert_update_and_failed_replacement(db, &updated).await;
-        assert_replace_all_validates_before_delete(db, &updated, &second).await;
         cleanup_workspace(
             db,
             updated.workspace_id.as_deref().expect("first workspace"),
@@ -560,33 +561,6 @@ mod tests {
                 .await
                 .expect("get updated summary"),
             Some(updated.clone())
-        );
-    }
-
-    async fn assert_replace_all_validates_before_delete(
-        db: &CoralDb,
-        existing: &TraceSummaryRecord,
-        other: &TraceSummaryRecord,
-    ) {
-        let invalid = TraceSummaryRecord {
-            trace_id: "trace-invalid".to_string(),
-            row_count: i64::MAX as u64 + 1,
-            ..existing.clone()
-        };
-        let mut tx = db.begin().await.expect("begin replace all failure tx");
-        assert!(
-            matches!(
-                tx.trace_summaries().replace_all(&[invalid]).await,
-                Err(DbError::CorruptData(_))
-            ),
-            "replace_all should validate summaries before deleting existing index rows"
-        );
-        tx.commit().await.expect("commit failed replacement no-op");
-
-        let mut session = db;
-        assert_eq!(
-            fixture_summaries(&mut session, existing, other).await,
-            vec![other.clone(), existing.clone()]
         );
     }
 

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -117,13 +117,6 @@ pub(crate) trait DbRepos: DbSession + Sized {
         CredentialDocumentsRepo::new(self)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "trace summary repository lands before runtime wiring in the stacked PR sequence"
-        )
-    )]
     fn trace_summaries(&mut self) -> TraceSummariesRepo<'_, Self> {
         TraceSummariesRepo::new(self)
     }

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -2,7 +2,7 @@
 
 mod query_stream;
 
-use std::collections::{HashMap, HashSet, hash_map::Entry};
+use std::collections::{BTreeSet, HashMap, HashSet, hash_map::Entry};
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -733,6 +733,16 @@ impl TraceStore {
             .map_err(|source| TraceStoreError::Worker { source })?
     }
 
+    pub(crate) async fn list_all_traces_tolerant(
+        &self,
+        scope: TraceScope,
+    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+        let traces = self.clone();
+        task::spawn_blocking(move || traces.list_all_traces_tolerant_sync(&scope))
+            .await
+            .map_err(|source| TraceStoreError::Worker { source })?
+    }
+
     pub(crate) async fn get_trace(
         &self,
         trace_id: String,
@@ -831,7 +841,62 @@ impl TraceStore {
         query_stream::list(self, limit, offset, scope)
     }
 
-    fn get_trace_sync(
+    fn list_all_traces_tolerant_sync(
+        &self,
+        scope: &TraceScope,
+    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+        if let Err(error) = self.prune_expired() {
+            tracing::warn!("skipping local trace retention prune before summary backfill: {error}");
+        }
+        let files = self.jsonl_files_by_modified()?;
+        let mut spans_by_id = HashMap::new();
+        let mut traces: HashMap<String, TraceListAggregate> = HashMap::new();
+
+        for file in files {
+            match read_list_spans_file(&file.path) {
+                Ok(spans) => {
+                    for span in spans {
+                        record_list_span(span, scope, &mut spans_by_id, &mut traces);
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        path = %file.path.display(),
+                        "skipping unreadable local trace file during summary backfill: {error}"
+                    );
+                }
+            }
+        }
+
+        let mut summaries = traces
+            .into_values()
+            .filter(|aggregate| aggregate.in_scope)
+            .map(TraceListAggregate::into_summary)
+            .collect::<Vec<_>>();
+        sort_summaries(&mut summaries);
+        Ok(summaries)
+    }
+
+    pub(crate) fn workspace_trace_summaries_sync(
+        &self,
+        trace_id: &str,
+    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+        let detail = self.get_trace_sync(trace_id, &TraceScope::Host)?;
+        let workspaces = detail
+            .spans
+            .iter()
+            .filter_map(|span| workspace_attribute(&span.attributes_json))
+            .collect::<BTreeSet<_>>();
+        workspaces
+            .into_iter()
+            .map(|workspace| {
+                self.get_trace_sync(trace_id, &TraceScope::workspaces([workspace.as_str()]))
+                    .map(|detail| detail.summary)
+            })
+            .collect()
+    }
+
+    pub(crate) fn get_trace_sync(
         &self,
         trace_id: &str,
         scope: &TraceScope,

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -1,9 +1,9 @@
 //! Tracing and OpenTelemetry initialization for the local Coral process.
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use opentelemetry::metrics::MeterProvider as _;
@@ -17,7 +17,8 @@ use opentelemetry_sdk::logs::{BatchLogProcessor, SdkLoggerProvider};
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::{
-    BatchSpanProcessor, SdkTracerProvider, SpanData, SpanExporter, TracerProviderBuilder,
+    BatchConfigBuilder, BatchSpanProcessor, SdkTracerProvider, SpanData, SpanExporter,
+    TracerProviderBuilder,
 };
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use tracing_subscriber::Layer as _;
@@ -33,6 +34,7 @@ pub mod metrics;
 pub(crate) mod service;
 
 use crate::bootstrap::AppError;
+use crate::state::db::{CoralDb, DbError, DbRepos};
 use crate::workspaces::WorkspaceName;
 pub use config::TelemetryConfig;
 use config::{DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER};
@@ -40,6 +42,7 @@ pub(crate) use local_store::{
     StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceQueryHistoryEntry,
     TraceQueryTableFunctionUsage, TraceQueryTableUsage, TraceStoreError, TraceSummaryRecord,
 };
+#[cfg(test)]
 pub(crate) use manager::TraceManager;
 
 static INIT: OnceLock<Result<TracingInitState, String>> = OnceLock::new();
@@ -48,6 +51,8 @@ static LOGGER_PROVIDER: Mutex<Option<SdkLoggerProvider>> = Mutex::new(None);
 static METER_PROVIDER: Mutex<Option<SdkMeterProvider>> = Mutex::new(None);
 
 const METRICS_INTERVAL: Duration = Duration::from_secs(5);
+const LOCAL_TRACE_BATCH_DELAY: Duration = Duration::from_millis(50);
+const LOCAL_TRACE_MAX_EXPORT_BATCH_SIZE: usize = 64;
 const OTLP_TRACE_DENIED_TARGETS: &[&str] = &["coral.http.body", "coral.mcp.body"];
 const OTLP_STRIPPED_SPAN_ATTRIBUTE_PREFIXES: &[&str] =
     &[coral_telemetry::LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX];
@@ -160,6 +165,13 @@ struct TargetFilteringSpanExporter<E> {
     stripped_attribute_prefixes: &'static [&'static str],
 }
 
+#[derive(Debug)]
+struct LocalTraceSpanExporter {
+    inner: local_store::JsonlSpanExporter,
+    trace_store: local_store::TraceStore,
+    db: Option<Arc<CoralDb>>,
+}
+
 impl<E> TargetFilteringSpanExporter<E> {
     fn new(inner: E, targets: Targets) -> Self {
         Self {
@@ -240,6 +252,94 @@ fn strip_attributes_with_prefixes(attributes: &mut Vec<OtelKeyValue>, prefixes: 
             .iter()
             .any(|prefix| attribute.key.as_str().starts_with(prefix))
     });
+}
+
+impl LocalTraceSpanExporter {
+    fn new(
+        store: &InstalledLocalTraceStore,
+        db: Option<Arc<CoralDb>>,
+    ) -> Result<Self, local_store::LocalTraceStoreError> {
+        Ok(Self {
+            inner: local_store::JsonlSpanExporter::new(store.dir.clone(), store.retention)?,
+            trace_store: local_store::TraceStore::with_retention(
+                store.dir.clone(),
+                store.retention,
+            ),
+            db,
+        })
+    }
+}
+
+impl SpanExporter for LocalTraceSpanExporter {
+    async fn export(&self, batch: Vec<SpanData>) -> opentelemetry_sdk::error::OTelSdkResult {
+        let trace_ids = batch
+            .iter()
+            .map(|span| span.span_context.trace_id().to_string())
+            .collect::<BTreeSet<_>>();
+        let result = self.inner.export(batch).await;
+        if result.is_ok()
+            && let Some(db) = self.db.as_deref()
+        {
+            for trace_id in trace_ids {
+                match self.trace_store.workspace_trace_summaries_sync(&trace_id) {
+                    Ok(summaries) => {
+                        for summary in summaries {
+                            if let Err(error) = upsert_trace_summary_blocking(db, &summary) {
+                                tracing::warn!(
+                                    %trace_id,
+                                    detail = %error,
+                                    "failed to update database trace summary after span export"
+                                );
+                            }
+                        }
+                    }
+                    Err(error) => tracing::warn!(
+                        %trace_id,
+                        "failed to read local trace summary after span export: {error}"
+                    ),
+                }
+            }
+        }
+        result
+    }
+
+    fn shutdown_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.inner.shutdown_with_timeout(timeout)
+    }
+
+    fn force_flush(&mut self) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.inner.force_flush()
+    }
+
+    fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
+        self.inner.set_resource(resource);
+    }
+}
+
+async fn upsert_trace_summary(
+    db: &CoralDb,
+    summary: &local_store::TraceSummaryRecord,
+) -> Result<(), DbError> {
+    let mut tx = db.begin().await?;
+    tx.trace_summaries().upsert(summary).await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+fn upsert_trace_summary_blocking(
+    db: &CoralDb,
+    summary: &local_store::TraceSummaryRecord,
+) -> Result<(), String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("failed to create trace summary export runtime: {error}"))?;
+    runtime
+        .block_on(upsert_trace_summary(db, summary))
+        .map_err(|error| error.to_string())
 }
 
 fn span_matches_targets(span: &SpanData, targets: &Targets) -> bool {
@@ -431,14 +531,23 @@ fn add_otlp_trace_exporter(
 fn add_local_trace_exporter(
     builder: TracerProviderBuilder,
     store: &InstalledLocalTraceStore,
+    db: Option<Arc<CoralDb>>,
 ) -> Result<TracerProviderBuilder, AppError> {
-    let exporter = local_store::JsonlSpanExporter::new(store.dir.clone(), store.retention)
+    let exporter = LocalTraceSpanExporter::new(store, db)
         .map_err(|e| AppError::InvalidInput(e.to_string()))?;
     let (internal_trace_targets, _) =
         build_trace_targets(DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOCAL_TRACE_FILTER);
     let exporter = TargetFilteringSpanExporter::new(exporter, internal_trace_targets)
         .excluding_rpc_services(LOCAL_TRACE_EXCLUDED_RPC_SERVICES);
-    Ok(builder.with_simple_exporter(exporter))
+    let batch_config = BatchConfigBuilder::default()
+        .with_scheduled_delay(LOCAL_TRACE_BATCH_DELAY)
+        .with_max_export_batch_size(LOCAL_TRACE_MAX_EXPORT_BATCH_SIZE)
+        .build();
+    Ok(builder.with_span_processor(
+        BatchSpanProcessor::builder(exporter)
+            .with_batch_config(batch_config)
+            .build(),
+    ))
 }
 
 pub(crate) fn list_local_query_history(
@@ -583,10 +692,11 @@ pub(crate) fn init_tracing(
     config: &TelemetryConfig,
     enable_stderr_logs: bool,
     internal_trace_store_dir: Option<PathBuf>,
+    db: Option<Arc<CoralDb>>,
 ) -> Result<Option<InstalledLocalTraceStore>, AppError> {
     let state = INIT
         .get_or_init(|| {
-            try_init_tracing(config, enable_stderr_logs, internal_trace_store_dir)
+            try_init_tracing(config, enable_stderr_logs, internal_trace_store_dir, db)
                 .map_err(|e| e.to_string())
         })
         .as_ref()
@@ -598,6 +708,7 @@ fn try_init_tracing(
     config: &TelemetryConfig,
     enable_stderr_logs: bool,
     internal_trace_store_dir: Option<PathBuf>,
+    db: Option<Arc<CoralDb>>,
 ) -> Result<TracingInitState, AppError> {
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
     let endpoint = configured_otlp_endpoint(config);
@@ -640,7 +751,7 @@ fn try_init_tracing(
         }
 
         if let Some(store) = local_trace_store.as_ref() {
-            builder = add_local_trace_exporter(builder, store)?;
+            builder = add_local_trace_exporter(builder, store, db)?;
         }
 
         let provider = builder.build();

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -328,15 +328,10 @@ async fn list_database_traces(
                     valid_seen = valid_seen.saturating_add(1);
                     retained_rows += 1;
                 }
-                Err(TraceManagerError::NotFound { .. }) => {
-                    if let Err(error) = delete_trace_summary(db, &summary).await {
-                        retained_rows += 1;
-                        tracing::warn!(
-                            trace_id = %summary.trace_id,
-                            "failed to prune stale database trace summary: {error}"
-                        );
-                    }
-                }
+                // Raw spans are host-local even when the database is shared.
+                // A local miss therefore cannot prove that the summary is
+                // stale: another server may still own the trace detail.
+                Err(TraceManagerError::NotFound { .. }) => retained_rows += 1,
                 Err(error) => return Err(trace_manager_status(error)),
             }
             if summaries.len() == limit {
@@ -346,18 +341,6 @@ async fn list_database_traces(
         db_offset = db_offset.saturating_add(retained_rows);
     }
     Ok(summaries)
-}
-
-async fn delete_trace_summary(db: &CoralDb, summary: &TraceSummaryRecord) -> Result<(), DbError> {
-    let Some(workspace_id) = summary.workspace_id.as_deref() else {
-        return Ok(());
-    };
-    let mut tx = db.begin().await?;
-    tx.trace_summaries()
-        .delete(workspace_id, &summary.trace_id)
-        .await?;
-    tx.commit().await?;
-    Ok(())
 }
 
 fn normalize_page_size(page_size: i32) -> usize {
@@ -1204,7 +1187,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exported_summary_is_visible_and_pruned_without_retained_details() {
+    async fn exported_summary_is_hidden_but_retained_without_local_details() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         let db = Arc::new(open_sqlite(&layout).await);
@@ -1270,13 +1253,16 @@ mod tests {
 
         assert!(response.traces.is_empty());
         let mut session = db.as_ref();
-        assert!(
+        assert_eq!(
             session
                 .trace_summaries()
                 .list(10, 0)
                 .await
                 .expect("list trace summaries")
-                .is_empty()
+                .into_iter()
+                .map(|summary| summary.trace_id)
+                .collect::<Vec<_>>(),
+            vec!["trace-1"]
         );
     }
 

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -1,5 +1,9 @@
 //! Implements the gRPC `TraceService` for local trace inspection.
 
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
 use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
 use coral_api::v1::{
     GetTraceRequest, GetTraceResponse, ListTracesRequest, ListTracesResponse, TraceInvocationKind,
@@ -9,12 +13,13 @@ use tonic::{Code, Request, Response, Status};
 
 use crate::bootstrap::{AppError, app_status};
 use crate::identity::{Principal, PrincipalKind};
+use crate::state::db::{CoralDb, DbError, DbRepos};
 use crate::telemetry::local_store::{
     StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceDetailRecord,
-    TraceScope, TraceSpanRecord, TraceSummaryRecord,
+    TraceScope, TraceSpanRecord, TraceStore, TraceStoreError, TraceSummaryRecord,
 };
 use crate::telemetry::manager::{
-    GetTraceQuery, ListTracesQuery, TraceListView, TraceManager, TraceManagerError,
+    GetTraceQuery, ListTracesQuery, TraceListPage, TraceListView, TraceManager, TraceManagerError,
 };
 use crate::transport::{grpc_span, instrument_grpc, request_context};
 use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
@@ -30,15 +35,26 @@ const MAX_TRACE_PAGE_SIZE: usize = 200;
 /// this is 200 pages of scrolling — and pagination stops advertising a token
 /// before it, so an honest client never meets the refusal.
 const MAX_TRACE_PAGE_OFFSET: usize = 10_000;
+const TRACE_SUMMARY_INDEX_PAGE_SIZE: usize = 200;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum TraceSummaryIndexError {
+    #[error(transparent)]
+    Store(#[from] TraceStoreError),
+    #[error(transparent)]
+    Database(#[from] DbError),
+}
 
 #[derive(Clone)]
 pub(crate) struct TraceService {
     traces: TraceManager,
     workspaces: WorkspaceManager,
     authorizer: WorkspaceAuthorizer,
+    db: Option<Arc<CoralDb>>,
 }
 
 impl TraceService {
+    #[cfg(test)]
     pub(crate) const fn new(
         trace_manager: TraceManager,
         workspaces: WorkspaceManager,
@@ -48,6 +64,7 @@ impl TraceService {
             traces: trace_manager,
             workspaces,
             authorizer,
+            db: None,
         }
     }
 
@@ -102,6 +119,30 @@ impl TraceService {
             owned.iter().map(WorkspaceName::as_str),
         ))
     }
+
+    pub(crate) fn with_db(
+        trace_store_file: PathBuf,
+        retention: Duration,
+        db: Arc<CoralDb>,
+        workspaces: WorkspaceManager,
+        authorizer: WorkspaceAuthorizer,
+    ) -> Self {
+        Self {
+            traces: TraceManager::new(trace_store_file, retention),
+            workspaces,
+            authorizer,
+            db: Some(db),
+        }
+    }
+
+    pub(crate) async fn sync_summaries(
+        trace_store_file: PathBuf,
+        retention: Duration,
+        db: &CoralDb,
+    ) -> Result<usize, TraceSummaryIndexError> {
+        let traces = TraceStore::with_retention(trace_store_file, retention);
+        sync_trace_summaries(db, &traces).await
+    }
 }
 
 #[tonic::async_trait]
@@ -116,6 +157,9 @@ impl TraceServiceApi for TraceService {
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace = workspace_filter_from_proto(request.workspace.as_ref())?;
+            let workspace_name = workspace
+                .as_ref()
+                .map(|workspace| workspace.as_str().to_string());
             // Settled before the rest of the request is parsed, so a caller who
             // may not read these traces cannot learn anything from the
             // request's own validation.
@@ -123,16 +167,35 @@ impl TraceServiceApi for TraceService {
             let page_size = normalize_page_size(request.page_size);
             let offset = parse_page_token(&request.page_token)?;
             let view = trace_list_view_from_proto(request.view)?;
-            let page = service
-                .traces
-                .list_traces(ListTracesQuery {
-                    view,
-                    scope,
-                    page_size,
-                    offset,
-                })
-                .await
-                .map_err(trace_manager_status)?;
+            let page = match (view, service.db.as_ref(), workspace_name.as_deref()) {
+                (TraceListView::All, Some(db), Some(workspace_name)) => {
+                    let mut session = db.as_ref();
+                    let mut summaries = session
+                        .trace_summaries()
+                        .list_for_workspace(workspace_name, page_size.saturating_add(1), offset)
+                        .await
+                        .map_err(trace_database_status)?;
+                    let next_offset =
+                        (summaries.len() > page_size).then(|| offset.saturating_add(page_size));
+                    if next_offset.is_some() {
+                        summaries.truncate(page_size);
+                    }
+                    TraceListPage {
+                        traces: summaries,
+                        next_offset,
+                    }
+                }
+                (view, _, _) => service
+                    .traces
+                    .list_traces(ListTracesQuery {
+                        view,
+                        scope,
+                        page_size,
+                        offset,
+                    })
+                    .await
+                    .map_err(trace_manager_status)?,
+            };
             Ok(Response::new(ListTracesResponse {
                 traces: page
                     .traces
@@ -183,6 +246,46 @@ impl TraceServiceApi for TraceService {
     }
 }
 
+async fn sync_trace_summaries(
+    db: &CoralDb,
+    traces: &TraceStore,
+) -> Result<usize, TraceSummaryIndexError> {
+    let mut session = db;
+    let workspaces = session.workspaces().list().await?;
+    let mut summaries = Vec::new();
+    for workspace in workspaces {
+        let scope = TraceScope::workspaces([workspace.id.as_str()]);
+        summaries.extend(current_trace_summaries(traces, &scope).await?);
+    }
+    let imported = summaries.len();
+    let mut tx = db.begin().await?;
+    tx.trace_summaries().replace_all(&summaries).await?;
+    tx.commit().await?;
+    Ok(imported)
+}
+
+async fn current_trace_summaries(
+    traces: &TraceStore,
+    scope: &TraceScope,
+) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+    let mut summaries = Vec::new();
+    loop {
+        let page = traces
+            .list_traces(
+                TRACE_SUMMARY_INDEX_PAGE_SIZE,
+                summaries.len(),
+                scope.clone(),
+            )
+            .await?;
+        let page_len = page.len();
+        summaries.extend(page);
+        if page_len < TRACE_SUMMARY_INDEX_PAGE_SIZE {
+            break;
+        }
+    }
+    Ok(summaries)
+}
+
 fn normalize_page_size(page_size: i32) -> usize {
     if page_size <= 0 {
         DEFAULT_TRACE_PAGE_SIZE
@@ -229,6 +332,14 @@ fn workspace_filter_from_proto(
     workspace
         .map(|workspace| WorkspaceName::parse(&workspace.name).map_err(app_status))
         .transpose()
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "used directly as a map_err adapter across tonic service handlers"
+)]
+fn trace_database_status(error: DbError) -> Status {
+    Status::new(Code::Internal, error.to_string())
 }
 
 fn trace_manager_status(error: TraceManagerError) -> Status {
@@ -321,6 +432,7 @@ fn trace_invocation_kind_to_proto(kind: StoredTraceInvocationKind) -> TraceInvoc
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::Duration;
@@ -331,17 +443,18 @@ mod tests {
         TraceOperationKind, TraceView, Workspace,
     };
     use serde_json::json;
-    use tempfile::TempDir;
+    use tempfile::{TempDir, tempdir};
     use tonic::{Code, Request};
 
     use super::{
-        TraceService, normalize_page_size, parse_page_token, trace_invocation_kind_to_proto,
+        TraceService, TraceStore, normalize_page_size, parse_page_token, sync_trace_summaries,
+        trace_invocation_kind_to_proto,
     };
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::identity::{Principal, PrincipalKind};
     use crate::request_context::RequestContext;
     use crate::state::db::{
-        CoralDb, DbRepos, LoginIdentity, LoginProvisioning, ResolvedDatabaseConfig,
+        CoralDb, DatabaseConfig, DbRepos, LoginIdentity, LoginProvisioning, ResolvedDatabaseConfig,
     };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::telemetry::{TraceManager, local_store::StoredTraceInvocationKind};
@@ -960,5 +1073,87 @@ mod tests {
             "trace_state": "",
             "is_remote": false
         })
+    }
+
+    #[tokio::test]
+    async fn sync_summaries_rebuilds_database_index_from_jsonl() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+        let mut tx = db.begin().await.expect("begin workspace tx");
+        tx.workspaces()
+            .ensure("default", 1)
+            .await
+            .expect("ensure default workspace");
+        tx.commit().await.expect("commit default workspace");
+        let trace_dir = temp.path().join("traces");
+        write_trace(&trace_dir, "trace-1", 1, 2);
+
+        let traces = TraceStore::with_retention(trace_dir.clone(), Duration::from_mins(1));
+        assert_eq!(
+            sync_trace_summaries(&db, &traces)
+                .await
+                .expect("sync trace summaries"),
+            1
+        );
+        let mut session = &db;
+        let summaries = session
+            .trace_summaries()
+            .list(10, 0)
+            .await
+            .expect("list trace summaries");
+        assert_eq!(summaries.len(), 1);
+        let summary = summaries.first().expect("trace summary");
+        assert_eq!(summary.trace_id, "trace-1");
+        assert_eq!(summary.query, "SELECT 1");
+        assert_eq!(summary.row_count, 1);
+        assert!(summary.row_count_recorded);
+
+        fs::remove_dir_all(&trace_dir).expect("remove raw trace store");
+        assert_eq!(
+            sync_trace_summaries(&db, &traces)
+                .await
+                .expect("resync empty trace store"),
+            0
+        );
+        assert!(
+            session
+                .trace_summaries()
+                .list(10, 0)
+                .await
+                .expect("list empty trace summaries")
+                .is_empty()
+        );
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    fn write_trace(dir: &std::path::Path, trace_id: &str, start: i64, end: i64) {
+        fs::create_dir_all(dir).expect("create trace dir");
+        let record = json!({
+            "trace_id": trace_id,
+            "span_id": "span-1",
+            "parent_span_id": null,
+            "name": "coral.query",
+            "status": "ok",
+            "start_time_unix_nanos": start,
+            "end_time_unix_nanos": end,
+            "attributes_json": r#"{"sql":"SELECT 1","row_count":1,"workspace":"default"}"#,
+        });
+        fs::write(
+            dir.join(format!("spans-{start:020}-test-{trace_id}.jsonl")),
+            format!("{record}\n"),
+        )
+        .expect("write trace");
     }
 }

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -11,12 +11,13 @@ use coral_api::v1::{
 };
 use tonic::{Code, Request, Response, Status};
 
+use super::upsert_trace_summary;
 use crate::bootstrap::{AppError, app_status};
 use crate::identity::{Principal, PrincipalKind};
-use crate::state::db::{CoralDb, DbError, DbRepos};
+use crate::state::db::{CoralDb, DbError, DbRepos, TraceSummaryRecord};
 use crate::telemetry::local_store::{
     StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceDetailRecord,
-    TraceScope, TraceSpanRecord, TraceStore, TraceStoreError, TraceSummaryRecord,
+    TraceScope, TraceSpanRecord, TraceStore,
 };
 use crate::telemetry::manager::{
     GetTraceQuery, ListTracesQuery, TraceListPage, TraceListView, TraceManager, TraceManagerError,
@@ -36,14 +37,6 @@ const MAX_TRACE_PAGE_SIZE: usize = 200;
 /// before it, so an honest client never meets the refusal.
 const MAX_TRACE_PAGE_OFFSET: usize = 10_000;
 const TRACE_SUMMARY_INDEX_PAGE_SIZE: usize = 200;
-
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum TraceSummaryIndexError {
-    #[error(transparent)]
-    Store(#[from] TraceStoreError),
-    #[error(transparent)]
-    Database(#[from] DbError),
-}
 
 #[derive(Clone)]
 pub(crate) struct TraceService {
@@ -135,13 +128,13 @@ impl TraceService {
         }
     }
 
-    pub(crate) async fn sync_summaries(
+    pub(crate) async fn backfill_summaries(
         trace_store_file: PathBuf,
         retention: Duration,
         db: &CoralDb,
-    ) -> Result<usize, TraceSummaryIndexError> {
+    ) -> Result<usize, DbError> {
         let traces = TraceStore::with_retention(trace_store_file, retention);
-        sync_trace_summaries(db, &traces).await
+        backfill_trace_summaries(db, &traces).await
     }
 }
 
@@ -169,12 +162,14 @@ impl TraceServiceApi for TraceService {
             let view = trace_list_view_from_proto(request.view)?;
             let page = match (view, service.db.as_ref(), workspace_name.as_deref()) {
                 (TraceListView::All, Some(db), Some(workspace_name)) => {
-                    let mut session = db.as_ref();
-                    let mut summaries = session
-                        .trace_summaries()
-                        .list_for_workspace(workspace_name, page_size.saturating_add(1), offset)
-                        .await
-                        .map_err(trace_database_status)?;
+                    let mut summaries = list_database_traces(
+                        &service.traces,
+                        db.as_ref(),
+                        workspace_name,
+                        page_size.saturating_add(1),
+                        offset,
+                    )
+                    .await?;
                     let next_offset =
                         (summaries.len() > page_size).then(|| offset.saturating_add(page_size));
                     if next_offset.is_some() {
@@ -246,44 +241,123 @@ impl TraceServiceApi for TraceService {
     }
 }
 
-async fn sync_trace_summaries(
-    db: &CoralDb,
-    traces: &TraceStore,
-) -> Result<usize, TraceSummaryIndexError> {
+async fn backfill_trace_summaries(db: &CoralDb, traces: &TraceStore) -> Result<usize, DbError> {
     let mut session = db;
     let workspaces = session.workspaces().list().await?;
-    let mut summaries = Vec::new();
+    let mut imported = 0;
     for workspace in workspaces {
         let scope = TraceScope::workspaces([workspace.id.as_str()]);
-        summaries.extend(current_trace_summaries(traces, &scope).await?);
+        let summaries = match traces.list_all_traces_tolerant(scope).await {
+            Ok(summaries) => summaries,
+            Err(error) => {
+                tracing::warn!(
+                    workspace_id = %workspace.id,
+                    "skipping local trace summary backfill: {error}"
+                );
+                continue;
+            }
+        };
+        for summary in summaries {
+            if summary.workspace_id.is_none() {
+                tracing::warn!(
+                    trace_id = %summary.trace_id,
+                    workspace_id = %workspace.id,
+                    "skipping local trace summary backfill without workspace"
+                );
+                continue;
+            }
+            upsert_trace_summary(db, &summary).await?;
+            imported += 1;
+        }
     }
-    let imported = summaries.len();
-    let mut tx = db.begin().await?;
-    tx.trace_summaries().replace_all(&summaries).await?;
-    tx.commit().await?;
     Ok(imported)
 }
 
-async fn current_trace_summaries(
-    traces: &TraceStore,
-    scope: &TraceScope,
-) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+async fn list_database_traces(
+    traces: &TraceManager,
+    db: &CoralDb,
+    workspace_name: &str,
+    limit: usize,
+    offset: usize,
+) -> Result<Vec<TraceSummaryRecord>, Status> {
     let mut summaries = Vec::new();
-    loop {
-        let page = traces
-            .list_traces(
-                TRACE_SUMMARY_INDEX_PAGE_SIZE,
-                summaries.len(),
-                scope.clone(),
-            )
-            .await?;
-        let page_len = page.len();
-        summaries.extend(page);
-        if page_len < TRACE_SUMMARY_INDEX_PAGE_SIZE {
+    let mut db_offset = 0;
+    let mut valid_seen = 0;
+    while summaries.len() < limit {
+        let mut session = db;
+        let page = session
+            .trace_summaries()
+            .list_for_workspace(workspace_name, TRACE_SUMMARY_INDEX_PAGE_SIZE, db_offset)
+            .await
+            .map_err(trace_database_status)?;
+        if page.is_empty() {
             break;
         }
+        let mut retained_rows = 0;
+        for summary in page {
+            let workspace_id = summary.workspace_id.as_deref().ok_or_else(|| {
+                Status::new(
+                    Code::Internal,
+                    format!(
+                        "database trace summary '{}' is missing workspace_id",
+                        summary.trace_id
+                    ),
+                )
+            })?;
+            let workspace = WorkspaceName::parse(workspace_id).map_err(|error| {
+                Status::new(
+                    Code::Internal,
+                    format!(
+                        "database trace summary '{}' has invalid workspace_id: {error}",
+                        summary.trace_id
+                    ),
+                )
+            })?;
+            match traces
+                .get_trace(GetTraceQuery {
+                    trace_id: summary.trace_id.clone(),
+                    scope: TraceScope::workspaces([workspace.as_str()]),
+                    view: TraceListView::All,
+                })
+                .await
+            {
+                Ok(_trace) => {
+                    if valid_seen >= offset {
+                        summaries.push(summary);
+                    }
+                    valid_seen = valid_seen.saturating_add(1);
+                    retained_rows += 1;
+                }
+                Err(TraceManagerError::NotFound { .. }) => {
+                    if let Err(error) = delete_trace_summary(db, &summary).await {
+                        retained_rows += 1;
+                        tracing::warn!(
+                            trace_id = %summary.trace_id,
+                            "failed to prune stale database trace summary: {error}"
+                        );
+                    }
+                }
+                Err(error) => return Err(trace_manager_status(error)),
+            }
+            if summaries.len() == limit {
+                break;
+            }
+        }
+        db_offset = db_offset.saturating_add(retained_rows);
     }
     Ok(summaries)
+}
+
+async fn delete_trace_summary(db: &CoralDb, summary: &TraceSummaryRecord) -> Result<(), DbError> {
+    let Some(workspace_id) = summary.workspace_id.as_deref() else {
+        return Ok(());
+    };
+    let mut tx = db.begin().await?;
+    tx.trace_summaries()
+        .delete(workspace_id, &summary.trace_id)
+        .await?;
+    tx.commit().await?;
+    Ok(())
 }
 
 fn normalize_page_size(page_size: i32) -> usize {
@@ -447,7 +521,7 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        TraceService, TraceStore, normalize_page_size, parse_page_token, sync_trace_summaries,
+        TraceService, TraceStore, backfill_trace_summaries, normalize_page_size, parse_page_token,
         trace_invocation_kind_to_proto,
     };
     use crate::credentials::{CredentialManager, CredentialStore};
@@ -457,7 +531,11 @@ mod tests {
         CoralDb, DatabaseConfig, DbRepos, LoginIdentity, LoginProvisioning, ResolvedDatabaseConfig,
     };
     use crate::state::{AppStateLayout, ConfigStore};
-    use crate::telemetry::{TraceManager, local_store::StoredTraceInvocationKind};
+    use crate::telemetry::local_store::TraceScope;
+    use crate::telemetry::{
+        StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceManager,
+        TraceSummaryRecord,
+    };
     use crate::workspaces::authorization::{LocalPrincipalPolicy, WorkspaceAuthorizer};
     use crate::workspaces::{MemberRole, WorkspaceManager, WorkspaceName};
 
@@ -1076,24 +1154,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sync_summaries_rebuilds_database_index_from_jsonl() {
+    async fn backfill_summaries_adds_local_rows_without_replacing_database_rows() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         let db = open_sqlite(&layout).await;
-        let mut tx = db.begin().await.expect("begin workspace tx");
-        tx.workspaces()
-            .ensure("default", 1)
-            .await
-            .expect("ensure default workspace");
-        tx.commit().await.expect("commit default workspace");
         let trace_dir = temp.path().join("traces");
-        write_trace(&trace_dir, "trace-1", 1, 2);
+        write_trace(&trace_dir, "trace-1", "work", 1, 2);
+        ensure_workspace(&db, "work").await;
+        let remote = summary("remote-trace", "remote", 10);
+        insert_summary(&db, &remote).await;
 
         let traces = TraceStore::with_retention(trace_dir.clone(), Duration::from_mins(1));
         assert_eq!(
-            sync_trace_summaries(&db, &traces)
+            backfill_trace_summaries(&db, &traces)
                 .await
-                .expect("sync trace summaries"),
+                .expect("backfill trace summaries"),
             1
         );
         let mut session = &db;
@@ -1102,28 +1177,157 @@ mod tests {
             .list(10, 0)
             .await
             .expect("list trace summaries");
-        assert_eq!(summaries.len(), 1);
-        let summary = summaries.first().expect("trace summary");
-        assert_eq!(summary.trace_id, "trace-1");
-        assert_eq!(summary.query, "SELECT 1");
-        assert_eq!(summary.row_count, 1);
-        assert!(summary.row_count_recorded);
+        assert_eq!(
+            summaries
+                .iter()
+                .map(|summary| summary.trace_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["remote-trace", "trace-1"]
+        );
 
         fs::remove_dir_all(&trace_dir).expect("remove raw trace store");
         assert_eq!(
-            sync_trace_summaries(&db, &traces)
+            backfill_trace_summaries(&db, &traces)
                 .await
-                .expect("resync empty trace store"),
+                .expect("backfill empty trace store"),
             0
         );
+        assert_eq!(
+            session
+                .trace_summaries()
+                .list(10, 0)
+                .await
+                .expect("list preserved trace summaries")
+                .len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn exported_summary_is_visible_and_pruned_without_retained_details() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = Arc::new(open_sqlite(&layout).await);
+        let trace_dir = temp.path().join("traces");
+        write_trace(&trace_dir, "trace-1", "work", 1, 2);
+        ensure_workspace(db.as_ref(), "work").await;
+        let traces = TraceStore::with_retention(trace_dir.clone(), Duration::from_mins(1));
+        let trace = traces
+            .get_trace("trace-1".to_string(), TraceScope::workspaces(["work"]))
+            .await
+            .expect("trace detail");
+        super::super::upsert_trace_summary(db.as_ref(), &trace.summary)
+            .await
+            .expect("upsert exported summary");
+
+        let workspaces = WorkspaceManager::new_for_tests(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout,
+            None,
+            Arc::clone(&db),
+        );
+        let service = TraceService::with_db(
+            trace_dir.clone(),
+            Duration::from_mins(1),
+            Arc::clone(&db),
+            workspaces,
+            WorkspaceAuthorizer::with_local_principal_policy(
+                Arc::clone(&db),
+                LocalPrincipalPolicy::ImplicitOwner,
+            ),
+        );
+        let response = TraceServiceApi::list_traces(
+            &service,
+            local(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
+                workspace: Some(workspace_proto("work")),
+                view: TraceView::Unspecified as i32,
+            }),
+        )
+        .await
+        .expect("list traces")
+        .into_inner();
+
+        assert_eq!(response.traces.len(), 1);
+        let trace = response.traces.into_iter().next().expect("trace summary");
+        assert_eq!(trace.trace_id, "trace-1");
+
+        fs::remove_dir_all(&trace_dir).expect("remove raw trace store");
+        let response = TraceServiceApi::list_traces(
+            &service,
+            local(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
+                workspace: Some(workspace_proto("work")),
+                view: TraceView::Unspecified as i32,
+            }),
+        )
+        .await
+        .expect("list traces")
+        .into_inner();
+
+        assert!(response.traces.is_empty());
+        let mut session = db.as_ref();
         assert!(
             session
                 .trace_summaries()
                 .list(10, 0)
                 .await
-                .expect("list empty trace summaries")
+                .expect("list trace summaries")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn backfill_summaries_preserves_existing_postgres_rows() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let local_workspace = format!("trace_local_{suffix}");
+        let remote_workspace = format!("trace_remote_{suffix}");
+        let local_trace = format!("local_trace_{suffix}");
+        let remote_trace = format!("remote_trace_{suffix}");
+        let temp = tempdir().expect("temp dir");
+        let trace_dir = temp.path().join("traces");
+        write_trace(&trace_dir, &local_trace, &local_workspace, 1, 2);
+        ensure_workspace(&db, &local_workspace).await;
+        insert_summary(&db, &summary(&remote_trace, &remote_workspace, 10)).await;
+
+        let traces = TraceStore::with_retention(trace_dir, Duration::from_mins(1));
+        assert_eq!(
+            backfill_trace_summaries(&db, &traces)
+                .await
+                .expect("backfill trace summaries"),
+            1
+        );
+
+        let mut session = &db;
+        assert!(
+            session
+                .trace_summaries()
+                .get(&local_trace)
+                .await
+                .expect("get local trace")
+                .is_some()
+        );
+        assert!(
+            session
+                .trace_summaries()
+                .get(&remote_trace)
+                .await
+                .expect("get remote trace")
+                .is_some()
+        );
+
+        cleanup_workspace(&db, &local_workspace).await;
+        cleanup_workspace(&db, &remote_workspace).await;
     }
 
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
@@ -1138,18 +1342,94 @@ mod tests {
         db
     }
 
-    fn write_trace(dir: &std::path::Path, trace_id: &str, start: i64, end: i64) {
+    async fn insert_summary(db: &CoralDb, summary: &TraceSummaryRecord) {
+        let mut tx = db.begin().await.expect("begin tx");
+        ensure_workspace_in_session(&mut tx, summary.workspace_id.as_deref().expect("workspace"))
+            .await;
+        tx.trace_summaries()
+            .upsert(summary)
+            .await
+            .expect("upsert trace summary");
+        tx.commit().await.expect("commit trace summary");
+    }
+
+    async fn ensure_workspace(db: &CoralDb, workspace_id: &str) {
+        let mut tx = db.begin().await.expect("begin tx");
+        ensure_workspace_in_session(&mut tx, workspace_id).await;
+        tx.commit().await.expect("commit workspace");
+    }
+
+    async fn cleanup_workspace(db: &CoralDb, workspace_id: &str) {
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .delete(workspace_id)
+            .await
+            .expect("remove workspace");
+        tx.commit().await.expect("commit cleanup");
+    }
+
+    async fn ensure_workspace_in_session<S>(session: &mut S, workspace_id: &str)
+    where
+        S: crate::state::db::DbSession,
+    {
+        session
+            .workspaces()
+            .ensure(workspace_id, 1)
+            .await
+            .expect("ensure workspace");
+    }
+
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "The Postgres trace harness is explicitly gated by this CI/test-only variable."
+    )]
+    fn postgres_test_url() -> Option<String> {
+        std::env::var("CORAL_TEST_POSTGRES_URL")
+            .ok()
+            .filter(|value| !value.is_empty())
+    }
+
+    fn summary(trace_id: &str, workspace_id: &str, end_time_unix_nanos: i64) -> TraceSummaryRecord {
+        TraceSummaryRecord {
+            trace_id: trace_id.to_string(),
+            workspace_id: Some(workspace_id.to_string()),
+            root_span_id: "span-1".to_string(),
+            name: "coral.query".to_string(),
+            query: "SELECT 1".to_string(),
+            status: StoredTraceStatus::Ok,
+            start_time_unix_nanos: end_time_unix_nanos - 1,
+            end_time_unix_nanos,
+            duration_nanos: 1,
+            span_count: 1,
+            row_count: 1,
+            row_count_recorded: true,
+            operation_kind: StoredTraceOperationKind::Unspecified,
+            operation_name: String::new(),
+            invocation_kind: StoredTraceInvocationKind::Unspecified,
+        }
+    }
+
+    fn write_trace(
+        dir: &std::path::Path,
+        trace_id: &str,
+        workspace_id: &str,
+        start: i64,
+        end: i64,
+    ) {
         fs::create_dir_all(dir).expect("create trace dir");
-        let record = json!({
-            "trace_id": trace_id,
-            "span_id": "span-1",
-            "parent_span_id": null,
-            "name": "coral.query",
-            "status": "ok",
-            "start_time_unix_nanos": start,
-            "end_time_unix_nanos": end,
-            "attributes_json": r#"{"sql":"SELECT 1","row_count":1,"workspace":"default"}"#,
-        });
+        let attributes_json = serde_json::to_string(
+            &json!({
+                "sql": "SELECT 1",
+                "row_count": 1,
+                "workspace": workspace_id,
+            })
+            .to_string(),
+        )
+        .expect("encode attributes");
+        let duration = end - start;
+        let record = format!(
+            r#"{{"trace_id":"{trace_id}","span_id":"span-1","parent_span_id":null,"parent_span_is_remote":false,"name":"coral.query","kind":"internal","status":"ok","status_message":null,"start_time_unix_nanos":{start},"end_time_unix_nanos":{end},"duration_nanos":{duration},"attributes_json":{attributes_json},"events_json":"[]","links_json":"[]","resource_json":"{{}}","scope_name":"test","scope_version":null,"scope_schema_url":null,"scope_attributes_json":"{{}}","trace_flags":0,"trace_state":"","is_remote":false}}"#
+        );
         fs::write(
             dir.join(format!("spans-{start:020}-test-{trace_id}.jsonl")),
             format!("{record}\n"),

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -695,6 +695,17 @@ impl SharedDeployment {
         pool.close().await;
     }
 
+    pub(crate) async fn seed_trace_summary(&self, workspace_id: &str, trace_id: &str) {
+        let pool = self.app_database().await;
+        sqlx::query("INSERT INTO trace_summaries (trace_id, workspace_id, root_span_id, name, query, status, start_time_unix_nanos, end_time_unix_nanos, duration_nanos, span_count, row_count, operation_kind, operation_name, invocation_kind) VALUES (?, ?, 'root', 'coral.query', 'SELECT 1', 'ok', 1, 2, 1, 1, 1, 'unspecified', '', 'unspecified')")
+            .bind(trace_id)
+            .bind(workspace_id)
+            .execute(&pool)
+            .await
+            .expect("seed a trace summary");
+        pool.close().await;
+    }
+
     /// Every membership on record as `(workspace, user, role)`, read from the
     /// deployment's own state rather than through a listing that answers only
     /// for the caller who asked — and which the local principal is answered

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -1323,7 +1323,7 @@ async fn insert_trace_summary(config_dir: &Path, workspace_id: &str, trace_id: &
         .execute(&pool)
         .await
         .expect("insert workspace");
-    sqlx::query("INSERT INTO trace_summaries (trace_id, workspace_id, root_span_id, name, query, status, start_time_unix_nanos, end_time_unix_nanos, duration_nanos, span_count, row_count) VALUES (?1, ?2, 'root', 'coral.query', 'SELECT 1', 'ok', 1, 2, 1, 1, 1)")
+    sqlx::query("INSERT INTO trace_summaries (trace_id, workspace_id, root_span_id, name, query, status, start_time_unix_nanos, end_time_unix_nanos, duration_nanos, span_count, row_count, operation_kind, operation_name, invocation_kind) VALUES (?1, ?2, 'root', 'coral.query', 'SELECT 1', 'ok', 1, 2, 1, 1, 1, 'unspecified', '', 'unspecified')")
         .bind(trace_id)
         .bind(workspace_id)
     .execute(&pool)

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, path::Path};
 
 use coral_api::CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND;
 use coral_api::v1::{
@@ -10,6 +10,7 @@ use coral_api::v1::{
 use coral_client::AppClient;
 use prost::Message as _;
 use serde_json::json;
+use sqlx::Row as _;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use tonic::{Code, Request, Response, Status};
@@ -593,6 +594,7 @@ async fn delete_workspace_removes_workspace_trace_history() {
             + "\n",
     )
     .expect("write local trace history");
+    insert_trace_summary(harness.config_dir(), "work", "work-trace").await;
 
     let deleted = harness
         .workspace_client()
@@ -618,6 +620,10 @@ async fn delete_workspace_removes_workspace_trace_history() {
     assert!(
         raw.contains("unscoped-trace"),
         "unscoped trace should remain in local trace history: {raw}"
+    );
+    assert_eq!(
+        trace_summary_count(harness.config_dir(), "work", "work-trace").await,
+        0
     );
 }
 
@@ -1308,4 +1314,40 @@ fn local_trace_line(
         "attributes_json": attributes.to_string(),
     })
     .to_string()
+}
+
+async fn insert_trace_summary(config_dir: &Path, workspace_id: &str, trace_id: &str) {
+    let pool = sqlite_pool(config_dir).await;
+    sqlx::query("INSERT OR IGNORE INTO workspaces (id, created_at_unix_nanos) VALUES (?1, 1)")
+        .bind(workspace_id)
+        .execute(&pool)
+        .await
+        .expect("insert workspace");
+    sqlx::query("INSERT INTO trace_summaries (trace_id, workspace_id, root_span_id, name, query, status, start_time_unix_nanos, end_time_unix_nanos, duration_nanos, span_count, row_count) VALUES (?1, ?2, 'root', 'coral.query', 'SELECT 1', 'ok', 1, 2, 1, 1, 1)")
+        .bind(trace_id)
+        .bind(workspace_id)
+    .execute(&pool)
+    .await
+    .expect("insert trace summary");
+}
+
+async fn trace_summary_count(config_dir: &Path, workspace_id: &str, trace_id: &str) -> i64 {
+    let pool = sqlite_pool(config_dir).await;
+    let row = sqlx::query(
+        "SELECT COUNT(*) AS count FROM trace_summaries WHERE workspace_id = ?1 AND trace_id = ?2",
+    )
+    .bind(workspace_id)
+    .bind(trace_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count trace summaries");
+    row.get("count")
+}
+
+async fn sqlite_pool(config_dir: &Path) -> sqlx::SqlitePool {
+    let options = SqliteConnectOptions::new().filename(config_dir.join("coral.db"));
+    SqlitePoolOptions::new()
+        .connect_with(options)
+        .await
+        .expect("open sqlite db")
 }

--- a/crates/coral-app/tests/grpc_workspace_trace_feature_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_trace_feature_access.rs
@@ -304,6 +304,12 @@ async fn an_owner_reads_the_traces_of_the_workspaces_they_own() {
             ("tf-own-host-trace", None),
         ],
     );
+    deployment
+        .seed_trace_summary("tf-own-mine", "tf-own-mine-trace")
+        .await;
+    deployment
+        .seed_trace_summary("tf-own-theirs", "tf-own-theirs-trace")
+        .await;
     let owner = person(&deployment, &ada).await;
 
     let named = owner

--- a/crates/coral-app/tests/telemetry_local_trace_lifecycle.rs
+++ b/crates/coral-app/tests/telemetry_local_trace_lifecycle.rs
@@ -93,7 +93,7 @@ fn write_trace(dir: &Path, trace_id: &str) {
         "start_time_unix_nanos": 1,
         "end_time_unix_nanos": 2,
         "duration_nanos": 1,
-        "attributes_json": "{}",
+        "attributes_json": json!({ "workspace": "default" }).to_string(),
         "events_json": "[]",
         "links_json": "[]",
         "resource_json": "{}",


### PR DESCRIPTION
## Intent
Index local trace summaries into the database for the trace service.

## What it enables
Trace list requests can rebuild and page over a database summary index while GetTrace still reads full span detail from JSONL.

## Usage examples
Run queries with trace history enabled, then request trace history from the API; ListTraces serves summaries from the DB-backed index.

## Validation
Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.