### PR TITLE
fix(app): preserve source dependents on upsert

### DIFF
--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -337,7 +337,9 @@ impl SourcesRepo<'_, CoralTx<'_>> {
         self.delete_imported_manifest_for_non_imported_source(workspace_name, source)
             .await?;
         self.insert_source_variables(workspace_name, source).await?;
-        self.insert_source_secret_keys(workspace_name, source).await
+        self.insert_source_secret_keys(workspace_name, source)
+            .await?;
+        Ok(())
     }
 
     pub(crate) async fn remove_source(
@@ -499,7 +501,13 @@ where
         .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
         .and_where(Expr::col(Sources::Name).eq(source.name.as_str()))
         .to_owned();
-    session.execute(statement).await
+    if session.execute_rows_affected(statement).await? == 1 {
+        return Ok(());
+    }
+    Err(DbError::CorruptData(format!(
+        "source '{workspace_name}:{}' was deleted while being updated",
+        source.name
+    )))
 }
 
 async fn insert_source_variable<S>(
@@ -783,6 +791,7 @@ mod tests {
         for db in databases {
             assert_source_repository_round_trip(&db).await;
             assert_source_upsert_preserves_dependent_records(&db).await;
+            assert_source_update_rejects_deleted_existing_source(&db).await;
         }
     }
 
@@ -906,6 +915,19 @@ mod tests {
         for db in databases {
             assert_source_repository_rejects_invalid_persisted_source_name(&db).await;
         }
+    }
+
+    #[tokio::test]
+    async fn source_delete_upsert_race_cannot_resurrect_database_credentials_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_source_delete_upsert_race_cannot_resurrect_database_credentials(&db).await;
     }
 
     async fn configured_databases() -> (TempDir, Vec<CoralDb>) {
@@ -1249,6 +1271,108 @@ mod tests {
         );
         assert_eq!(source_manifest(db, &workspace, &original.name).await, None);
         assert!(!credential_document(db, &workspace, &original.name).await);
+    }
+
+    async fn assert_source_update_rejects_deleted_existing_source(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let with_secret = source(
+            "deleted_source",
+            Some("1.0.1"),
+            [("API_BASE", "https://api.example.test")],
+            ["API_TOKEN"],
+            Some(CredentialStorageKind::Database),
+            SourceOrigin::Imported,
+        );
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 10)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &with_secret, 20)
+            .await
+            .expect("insert source");
+        tx.sources()
+            .remove_source(&workspace, &with_secret.name)
+            .await
+            .expect("delete source");
+        let error = super::update_source(&mut tx, &workspace, &with_secret, 21)
+            .await
+            .expect_err("deleted source update should fail");
+        assert!(matches!(error, DbError::CorruptData(_)), "{error}");
+        tx.rollback().await.expect("rollback failed update");
+        assert_eq!(get_source(db, &workspace, &with_secret.name).await, None);
+    }
+
+    async fn assert_source_delete_upsert_race_cannot_resurrect_database_credentials(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let source_name = SourceName::parse("race_source").expect("source name");
+        let provisional = source(
+            source_name.as_str(),
+            Some("1.0.0"),
+            [("API_BASE", "https://api.example.test")],
+            [],
+            Some(CredentialStorageKind::Database),
+            SourceOrigin::Imported,
+        );
+        let with_secret = source(
+            source_name.as_str(),
+            Some("1.0.1"),
+            [("API_BASE", "https://api2.example.test")],
+            ["API_TOKEN"],
+            Some(CredentialStorageKind::Database),
+            SourceOrigin::Imported,
+        );
+        let mut setup = db.begin().await.expect("begin setup");
+        setup
+            .workspaces()
+            .ensure(workspace.as_str(), 10)
+            .await
+            .expect("ensure workspace");
+        setup
+            .sources()
+            .upsert_source(&workspace, &provisional, 20)
+            .await
+            .expect("upsert provisional source");
+        let inserted = setup
+            .credential_documents()
+            .insert_if_absent(&workspace, &source_name, &credential_document_write(), 21)
+            .await
+            .expect("upsert credential document");
+        assert!(inserted);
+        setup
+            .sources()
+            .upsert_source(&workspace, &with_secret, 22)
+            .await
+            .expect("upsert source with secret metadata");
+        setup.commit().await.expect("commit setup");
+
+        let mut stale_upsert = db.begin().await.expect("begin stale upsert");
+        stale_upsert
+            .sources()
+            .source_created_at(&workspace, &source_name)
+            .await
+            .expect("read created_at")
+            .expect("source created_at");
+        let mut delete = db.begin().await.expect("begin delete");
+        delete
+            .sources()
+            .remove_source(&workspace, &source_name)
+            .await
+            .expect("delete source");
+        delete.commit().await.expect("commit delete");
+
+        let error = super::update_source(&mut stale_upsert, &workspace, &with_secret, 30)
+            .await
+            .expect_err("stale update must fail after concurrent delete");
+        assert!(matches!(error, DbError::CorruptData(_)), "{error}");
+        stale_upsert
+            .rollback()
+            .await
+            .expect("rollback stale upsert");
+
+        assert_eq!(get_source(db, &workspace, &source_name).await, None);
+        assert!(!credential_document(db, &workspace, &source_name).await);
     }
 
     async fn assert_source_repository_rejects_source_without_workspace(db: &CoralDb) {

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -15,7 +15,9 @@ use sea_query::{
 use crate::credentials::CredentialStorageKind;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
-use crate::state::db::schema::{SourceManifests, SourceSecretKeys, SourceVariables, Sources};
+use crate::state::db::schema::{
+    CredentialDocuments, SourceManifests, SourceSecretKeys, SourceVariables, Sources,
+};
 use crate::state::db::{CoralTx, DbError, DbSession};
 use crate::workspaces::WorkspaceName;
 
@@ -330,7 +332,7 @@ impl SourcesRepo<'_, CoralTx<'_>> {
             )
             .await?;
         }
-        self.delete_source_detail_rows(workspace_name, &source.name)
+        self.delete_source_child_rows(workspace_name, &source.name)
             .await?;
         self.delete_imported_manifest_for_non_imported_source(workspace_name, source)
             .await?;
@@ -392,18 +394,33 @@ impl SourcesRepo<'_, CoralTx<'_>> {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<(), DbError> {
-        self.delete_source_detail_rows(workspace_name, source_name)
+        self.delete_source_child_rows(workspace_name, source_name)
+            .await?;
+        self.delete_source_credential_document(workspace_name, source_name)
             .await?;
         delete_source(self.session, workspace_name, source_name).await
     }
 
-    async fn delete_source_detail_rows(
+    async fn delete_source_child_rows(
         &mut self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<(), DbError> {
         delete_source_secret_keys(self.session, workspace_name, source_name).await?;
         delete_source_variables(self.session, workspace_name, source_name).await
+    }
+
+    async fn delete_source_credential_document(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(CredentialDocuments::Table)
+            .and_where(Expr::col(CredentialDocuments::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(CredentialDocuments::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        self.session.execute(statement).await
     }
 }
 
@@ -642,6 +659,7 @@ mod tests {
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::AppStateLayout;
+    use crate::state::db::CredentialDocumentWrite;
     use crate::state::db::schema::Sources;
     use crate::state::db::session::{DbRepos, DbSession};
     use crate::state::db::{CoralDb, DatabaseConfig, DbError, ResolvedDatabaseConfig};
@@ -764,6 +782,7 @@ mod tests {
         let (_temp, databases) = configured_databases().await;
         for db in databases {
             assert_source_repository_round_trip(&db).await;
+            assert_source_upsert_preserves_dependent_records(&db).await;
         }
     }
 
@@ -986,7 +1005,7 @@ mod tests {
             Some(alpha_replacement.clone())
         );
         assert_eq!(
-            source_manifest_yaml(db, &workspace, &alpha_replacement.name).await,
+            source_manifest(db, &workspace, &alpha_replacement.name).await,
             Some(alpha_manifest.to_string())
         );
 
@@ -1002,7 +1021,7 @@ mod tests {
             Some(alpha_bundled.clone())
         );
         assert_eq!(
-            source_manifest_yaml(db, &workspace, &alpha_bundled.name).await,
+            source_manifest(db, &workspace, &alpha_bundled.name).await,
             None
         );
 
@@ -1166,6 +1185,72 @@ mod tests {
         tx.commit().await.expect("commit source write");
     }
 
+    async fn assert_source_upsert_preserves_dependent_records(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let original = source(
+            "imported",
+            Some("1.0.0"),
+            [("API_BASE", "https://api.example.test")],
+            ["API_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        let manifest_yaml = "name: imported\ndsl_version: 3\nbackend: http\nbase_url: https://api.example.test\ntables: []\n";
+
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 10)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &original, 20)
+            .await
+            .expect("upsert source");
+        tx.source_manifests()
+            .upsert(&workspace, &original.name, manifest_yaml, 30)
+            .await
+            .expect("upsert manifest");
+        let inserted = tx
+            .credential_documents()
+            .insert_if_absent(&workspace, &original.name, &credential_document_write(), 31)
+            .await
+            .expect("upsert credential document");
+        assert!(inserted);
+        tx.commit().await.expect("commit source");
+
+        let replacement = source(
+            "imported",
+            Some("1.0.1"),
+            [("API_BASE", "https://api2.example.test")],
+            ["API_TOKEN", "SECOND_TOKEN"],
+            Some(CredentialStorageKind::Database),
+            SourceOrigin::Imported,
+        );
+        let mut tx = db.begin().await.expect("begin replacement");
+        tx.sources()
+            .upsert_source(&workspace, &replacement, 40)
+            .await
+            .expect("replace source");
+        tx.commit().await.expect("commit replacement");
+
+        assert_eq!(
+            get_source(db, &workspace, &replacement.name).await,
+            Some(replacement.clone())
+        );
+        assert_eq!(
+            source_manifest(db, &workspace, &original.name).await,
+            Some(manifest_yaml.to_string())
+        );
+        assert!(credential_document(db, &workspace, &original.name).await);
+
+        assert_eq!(
+            remove_source(db, &workspace, &replacement.name).await,
+            Some(replacement)
+        );
+        assert_eq!(source_manifest(db, &workspace, &original.name).await, None);
+        assert!(!credential_document(db, &workspace, &original.name).await);
+    }
+
     async fn assert_source_repository_rejects_source_without_workspace(db: &CoralDb) {
         let workspace = unique_workspace();
         let source = source("orphan", None, [], [], None, SourceOrigin::Bundled);
@@ -1266,7 +1351,7 @@ mod tests {
             .expect("get source")
     }
 
-    async fn source_manifest_yaml(
+    async fn source_manifest(
         db: &CoralDb,
         workspace: &WorkspaceName,
         source_name: &SourceName,
@@ -1278,6 +1363,20 @@ mod tests {
             .await
             .expect("get source manifest")
             .map(|record| record.manifest_yaml)
+    }
+
+    async fn credential_document(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> bool {
+        let mut session = db;
+        session
+            .credential_documents()
+            .get(workspace, source_name)
+            .await
+            .expect("get credential document")
+            .is_some()
     }
 
     async fn remove_source(
@@ -1314,6 +1413,18 @@ mod tests {
             credential_storage,
             credential_revision: uuid::Uuid::from_u128(1),
             origin,
+        }
+    }
+
+    fn credential_document_write() -> CredentialDocumentWrite {
+        CredentialDocumentWrite {
+            ciphertext: b"ciphertext".to_vec(),
+            nonce: b"nonce".to_vec(),
+            wrapped_dek: b"wrapped-dek".to_vec(),
+            wrapped_dek_nonce: b"wrapped-dek-nonce".to_vec(),
+            key_id: "key-id".to_string(),
+            algorithm: "xchacha20poly1305".to_string(),
+            aad_version: 1,
         }
     }
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -450,6 +450,79 @@ async fn import_duplicate_source_overwrites_existing_source() {
 }
 
 #[tokio::test]
+async fn import_duplicate_source_preserves_database_credentials() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_with_inputs_yaml();
+    let variables = || {
+        vec![SourceVariable {
+            key: "API_BASE".to_string(),
+            value: "https://example.com".to_string(),
+        }]
+    };
+
+    let imported = harness
+        .import_source(
+            manifest_yaml.clone(),
+            variables(),
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "secret-token".to_string(),
+            }],
+        )
+        .await;
+    assert_eq!(
+        imported.credential_storage,
+        SourceCredentialStorage::Database as i32
+    );
+
+    let reimported = harness
+        .import_source(
+            manifest_yaml.replace("0.1.0", "0.2.0"),
+            variables(),
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(reimported.version, "0.2.0");
+    assert_eq!(
+        reimported.credential_storage,
+        SourceCredentialStorage::Database as i32
+    );
+    assert_eq!(reimported.secrets.len(), 1);
+    assert_eq!(reimported.secrets[0].key, "API_TOKEN");
+
+    let reimported_again = harness
+        .import_source(
+            fixture_manifest_with_inputs_yaml().replace("0.1.0", "0.3.0"),
+            variables(),
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(reimported_again.version, "0.3.0");
+
+    let fetched = harness
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "secured_messages".to_string(),
+        }))
+        .await
+        .expect("get duplicate imported source")
+        .into_inner()
+        .source
+        .expect("get source response");
+    assert_eq!(fetched.version, "0.3.0");
+    assert_eq!(
+        fetched.credential_storage,
+        SourceCredentialStorage::Database as i32
+    );
+    assert_eq!(fetched.secrets.len(), 1);
+    assert_eq!(fetched.secrets[0].key, "API_TOKEN");
+
+    let validated = harness.validate_source("secured_messages").await;
+    assert_eq!(validated.tables.len(), 1);
+}
+
+#[tokio::test]
 async fn import_invalid_manifest_returns_invalid_argument() {
     let harness = GrpcHarness::with_workspace().await;
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -451,7 +451,7 @@ async fn import_duplicate_source_overwrites_existing_source() {
 
 #[tokio::test]
 async fn import_duplicate_source_preserves_database_credentials() {
-    let harness = GrpcHarness::new().await;
+    let harness = GrpcHarness::with_workspace().await;
     let manifest_yaml = fixture_manifest_with_inputs_yaml();
     let variables = || {
         vec![SourceVariable {


### PR DESCRIPTION
## Intent
Fix source upserts so updating source metadata does not delete dependent DB records.

## What it enables
Credential-storage migration and source re-add flows can update the source row while preserving imported manifests and v4 materializations.

## Usage examples
Re-add or migrate an imported source; the source variables/secrets are replaced, but the stored imported manifest remains available.

## Validation
Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.