### PR TITLE
docs(app): document database-backed local state

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -255,10 +255,25 @@ jobs:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      - name: Install Postgres client
+        run: sudo apt-get update && sudo apt-get install --yes postgresql-client
+
       - name: Run Postgres database tests
         env:
           CORAL_TEST_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/postgres
-        run: make postgres-test-suite
+          CORAL_TEST_POSTGRES_SERVER_LIFECYCLE_URL: postgres://postgres:postgres@localhost:5432/coral_server_lifecycle
+          PGPASSWORD: postgres
+        run: |
+          cleanup_lifecycle_db() {
+            psql --host localhost --username postgres --dbname postgres \
+              --command 'DROP DATABASE IF EXISTS coral_server_lifecycle WITH (FORCE);'
+          }
+          trap cleanup_lifecycle_db EXIT
+          cleanup_lifecycle_db
+          psql --host localhost --username postgres --dbname postgres \
+            --command 'CREATE DATABASE coral_server_lifecycle;'
+
+          make postgres-test-suite
 
   windows-rust-smoke:
     name: Windows Rust smoke

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@
   startup coverage, plus the xtask recovery contracts.
   The recovery checks use xtask's `admin` feature. `postgres-tests` uses
   `CORAL_TEST_POSTGRES_URL` when supplied. Otherwise it starts a local Docker
-  Postgres and creates a fresh database inside the reusable container. Docker
-  chooses an available localhost port by default; use
+  Postgres and creates fresh suite and server-lifecycle databases inside the
+  reusable container. Docker chooses an available localhost port by default; use
   `make postgres-url` to print the server URL or
   `LOCAL_POSTGRES_PORT=55432 make postgres-start` when you need a stable port.
   Use `make postgres-start` when you only need the server,

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ postgres-clean:
 # containing $(MAKE) even under -n/-t/-q, and the postgres-tests recipe is a
 # single continued line, so an inline sub-make would make
 # `make -n postgres-tests` execute the real suite.
-POSTGRES_SUITE_CARGO = cargo test --locked -p coral-app --lib 'state::db::' -- --test-threads=1 && cargo test --locked -p coral-app --lib 'telemetry::service::tests::' && cargo test --locked -p coral-app --test grpc 'source_lifecycle_tests::' && cargo test --locked -p coral-app --test postgres_database_tests && cargo test --locked -p xtask --features admin --bin xtask -- --ignored
+POSTGRES_SUITE_CARGO = cargo test --locked -p coral-app --lib 'state::db::' -- --test-threads=1 && cargo test --locked -p coral-app --lib 'telemetry::service::tests::' && cargo test --locked -p coral-app --test grpc 'source_lifecycle_tests::' && CORAL_TEST_POSTGRES_URL="$${CORAL_TEST_POSTGRES_SERVER_LIFECYCLE_URL:-$${CORAL_TEST_POSTGRES_URL}}" cargo test --locked -p coral-app --test postgres_database_tests && cargo test --locked -p xtask --features admin --bin xtask -- --ignored
 
 postgres-test-suite:
 	@test -n "$${CORAL_TEST_POSTGRES_URL:-}" || \
@@ -254,6 +254,7 @@ endif
 postgres-tests: $(POSTGRES_TESTS_PREREQS)
 	@set -eu; \
 	url="$${CORAL_TEST_POSTGRES_URL:-}"; \
+	lifecycle_url="$${CORAL_TEST_POSTGRES_SERVER_LIFECYCLE_URL:-}"; \
 	cleanup() { :; }; \
 	if [ -z "$$url" ]; then \
 	  host_port=$$(docker port "$(LOCAL_POSTGRES_CONTAINER)" 5432/tcp | sed -n 's/.*:\([0-9][0-9]*\)$$/\1/p' | head -n 1); \
@@ -262,13 +263,20 @@ postgres-tests: $(POSTGRES_TESTS_PREREQS)
 	    exit 1; \
 	  fi; \
 	  db_name="coral_test_$$(date +%s)_$$$$"; \
+	  lifecycle_db_name="$${db_name}_lifecycle"; \
 	  docker exec "$(LOCAL_POSTGRES_CONTAINER)" createdb -U postgres "$$db_name"; \
-	  cleanup() { docker exec "$(LOCAL_POSTGRES_CONTAINER)" dropdb -U postgres --if-exists "$$db_name" >/dev/null 2>&1 || true; }; \
+	  docker exec "$(LOCAL_POSTGRES_CONTAINER)" createdb -U postgres "$$lifecycle_db_name"; \
+	  cleanup() { \
+	    docker exec "$(LOCAL_POSTGRES_CONTAINER)" dropdb -U postgres --if-exists "$$lifecycle_db_name" >/dev/null 2>&1 || true; \
+	    docker exec "$(LOCAL_POSTGRES_CONTAINER)" dropdb -U postgres --if-exists "$$db_name" >/dev/null 2>&1 || true; \
+	  }; \
 	  url="postgres://postgres:postgres@127.0.0.1:$$host_port/$$db_name"; \
+	  lifecycle_url="postgres://postgres:postgres@127.0.0.1:$$host_port/$$lifecycle_db_name"; \
 	fi; \
 	trap cleanup EXIT INT TERM; \
 	echo "Running Postgres tests against $$url"; \
 	export CORAL_TEST_POSTGRES_URL="$$url"; \
+	export CORAL_TEST_POSTGRES_SERVER_LIFECYCLE_URL="$${lifecycle_url:-$$url}"; \
 	$(POSTGRES_SUITE_CARGO)
 
 # ----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -270,9 +270,15 @@ export CORAL_CONFIG_DIR=/path/to/coral-config
 
 Important files include:
 
-- `config.toml` for installed-source metadata and non-secret variables
-- imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
-- source secrets stored separately within the same local trust boundary
+- `config.toml` for runtime settings such as feature flags, tracing, and
+  database bootstrap configuration
+- `coral.db`, the default local Coral database for installed-source metadata,
+  imported source specs, DSL v4 materialization metadata, feedback reports,
+  trace summaries, encrypted credential documents, and non-secret variables
+- `credentials/encryption.key`, the local key material used to protect
+  encrypted credential documents
+- `telemetry/traces`, the local raw trace span store when trace history is
+  enabled
 
 Bundled source specs are not copied into the config directory. Coral resolves
 them from the current binary when you validate or query a bundled source, so

--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -364,9 +364,9 @@ On Windows, the default local state path is
 Important files include:
 
 - `config.toml` for runtime settings such as feature flags, tracing, and database bootstrap configuration. See [Configuration](/reference/configuration).
-- `coral.db` for Coral's internal [local database](/reference/configuration#database), including installed-source metadata and non-secret variables.
-- imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
-- source secrets stored separately within the same local trust boundary
+- `coral.db`, the default [local database](/reference/configuration#database) for installed-source metadata, imported source specs, DSL v4 materialization metadata, feedback reports, trace summaries, encrypted credential documents, and non-secret variables
+- `credentials/encryption.key`, the local key material used to protect encrypted credential documents
+- `telemetry/traces`, the local raw trace span store when trace history is enabled
 
 <Note>
   [Bundled source](/reference/bundled-sources) specs are not copied into the

--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -365,7 +365,7 @@ Important files include:
 
 - `config.toml` for runtime settings such as feature flags, tracing, and database bootstrap configuration. See [Configuration](/reference/configuration).
 - `coral.db`, the default [local database](/reference/configuration#database) for installed-source metadata, imported source specs, DSL v4 materialization metadata, feedback reports, trace summaries, encrypted credential documents, and non-secret variables
-- `credentials/encryption.key`, the local key material used to protect encrypted credential documents
+- `credentials/encryption.key`, the local file-backed key material used to protect encrypted credential documents when file KEK sourcing is active
 - `telemetry/traces`, the local raw trace span store when trace history is enabled
 
 <Note>

--- a/apps/docs/project/security.mdx
+++ b/apps/docs/project/security.mdx
@@ -19,8 +19,9 @@ This release is intended for single-user local use:
   which MCP clients or scripts may call Coral.
 - Coral stores configuration under the local Coral config directory, which
   defaults to the platform config directory and can be changed with
-  `CORAL_CONFIG_DIR`. Source secrets default to OS credential storage when the
-  local keychain is usable, with plaintext file storage available as fallback.
+  `CORAL_CONFIG_DIR`. New source secrets are stored as encrypted documents in
+  Coral's configured database and protected by local key material in that
+  directory.
 - CLI and MCP queries run through the same local runtime. The internal gRPC
   server binds to loopback, and the MCP server uses stdio transport.
 
@@ -36,6 +37,12 @@ clients can route source-specific requests to Coral during discovery.
 Secret values are not returned through `coral.inputs`; secret rows show only
 whether a value is configured.
 
+The default SQLite database stays under the local Coral config directory. If
+you configure Postgres, treat the Postgres server, network path, and connection
+URL as part of Coral's trusted local-state boundary. Installed-source metadata,
+imported source specs, non-secret variables, trace summaries, and encrypted
+credential documents are written to that database.
+
 ## What Coral protects against
 
 Coral's current protections are aimed at accidental exposure within that local
@@ -43,12 +50,14 @@ trust boundary:
 
 - Source secrets are stored separately from non-secret source variables and are
   never written into `config.toml`.
-- By default, sources use the operating-system credential store when Coral
-  can successfully write, read, and delete a probe item. On macOS this uses
-  Keychain; on Windows, Credential Manager; on Linux, Secret Service.
-- If keychain probing fails in `auto` mode, Coral stores source secrets in
-  plaintext local files and reports the route as `file (plaintext)` in source
-  output.
+- Source secrets are encrypted before they are written to Coral's configured
+  database. The database stores ciphertext, nonces, wrapped data-encryption
+  keys, and key identifiers; the local key material lives under
+  `credentials/encryption.key`.
+- Older file-backed credential material from `secrets.env` is imported into
+  encrypted database documents during startup when Coral can read it.
+- Older keychain-backed sources keep using keychain storage until you replace
+  their credentials or re-add the source.
 - State files written by Coral use private file permissions on Unix systems.
   On Windows, Coral stores local state under
   `%APPDATA%\withcoral\coral\config` by default and relies on the user's
@@ -104,25 +113,18 @@ matter for a threat model:
 [Shared server access control](/guides/shared-server-access-control) covers all
 of this in operational detail, including recovery.
 
-## Secret storage configuration
+## Secret storage
 
-Coral reads the credential storage preference from `config.toml`:
-
-```toml
-[credentials]
-storage = "auto"
-```
-
-Supported values:
-
-| Value | Behavior |
-| --- | --- |
-| `auto` | Default. Use keychain when the probe succeeds; otherwise use plaintext file storage. |
-| `keychain` | Require OS credential storage. If unavailable, source installation fails. |
-| `file` | Store source secrets in plaintext `secrets.env` files under Coral's config directory. |
+New source installs store source secrets in encrypted database documents. The
+source catalog records whether an installed source has stored secret material;
+`coral source list` and `coral source info <NAME>` report this as
+`database (encrypted)` for new encrypted material, `keychain` for legacy
+keychain-backed sources, or `none`.
 
 <Note>
-Changing the global preference does not rewrite existing credentials. To update those, remove and re-add the source you want to update.
+Keep `coral.db` and `credentials/encryption.key` together when backing up or
+moving local Coral state. Losing the key material means encrypted source secrets
+cannot be decrypted.
 </Note>
 
 ## What you still need to trust
@@ -139,10 +141,15 @@ you configure; it does not make an otherwise untrusted local agent safe.
   token, so prefer read-only and least-privilege credentials.
 - A custom source spec can direct Coral to make HTTP requests or read local file
   locations declared by that spec. Only install source specs you trust.
+- If you configure Postgres, anyone who can read that database can inspect
+  source metadata, imported specs, non-secret variables, trace summaries, and
+  encrypted credential documents. Anyone who can also read
+  `credentials/encryption.key` should be treated as able to decrypt stored
+  source secrets.
 - Anyone who can control your user account should be treated as able to use the
-  configured sources. If a source uses file-backed secret storage, anyone who
-  can read your local Coral config directory should also be treated as able to
-  read its stored source secrets.
+  configured sources. Anyone who can read both Coral's configured database and
+  its credential encryption key should also be treated as able to decrypt stored
+  source secrets.
 - Coral does not attempt to protect against a compromised machine, compromised
   MCP client, malicious shell environment, or malicious upstream API response.
 
@@ -151,8 +158,12 @@ you configure; it does not make an otherwise untrusted local agent safe.
 - Scope provider tokens to the minimum data your workflow needs.
 - Put Coral's config directory on a local disk protected by your operating
   system account controls.
+- Keep Postgres on a host and network path you trust. Remote Postgres URLs must
+  use hostname-verified TLS; loopback Postgres without TLS is intended for
+  local development and CI.
 - Use `coral source list` or `coral source info <NAME>` to inspect whether a
-  source uses `keychain` or `file (plaintext)` secret storage.
+  source has encrypted database-backed secret storage or a legacy keychain
+  route.
 - Review custom source specs before installing them, especially `base_url`,
   `auth`, and file `location` fields.
 - Configure `coral mcp-stdio` only in MCP clients you are comfortable allowing

--- a/apps/docs/project/security.mdx
+++ b/apps/docs/project/security.mdx
@@ -52,12 +52,14 @@ trust boundary:
   never written into `config.toml`.
 - Source secrets are encrypted before they are written to Coral's configured
   database. The database stores ciphertext, nonces, wrapped data-encryption
-  keys, and key identifiers; the local key material lives under
-  `credentials/encryption.key`.
-- Older file-backed credential material from `secrets.env` is imported into
-  encrypted database documents during startup when Coral can read it.
-- Older keychain-backed sources keep using keychain storage until you replace
-  their credentials or re-add the source.
+  keys, and key identifiers. The local KEK comes from
+  `[credentials].encryption_key_env`, the OS keychain, or
+  `credentials/encryption.key`, depending on
+  `[credentials].encryption_key_source`.
+- Older file-backed and keychain-backed credential material is imported into
+  encrypted database documents during startup when Coral can read and verify
+  it. Coral retains the legacy material if the database write cannot be
+  verified.
 - State files written by Coral use private file permissions on Unix systems.
   On Windows, Coral stores local state under
   `%APPDATA%\withcoral\coral\config` by default and relies on the user's
@@ -118,13 +120,15 @@ of this in operational detail, including recovery.
 New source installs store source secrets in encrypted database documents. The
 source catalog records whether an installed source has stored secret material;
 `coral source list` and `coral source info <NAME>` report this as
-`database (encrypted)` for new encrypted material, `keychain` for legacy
-keychain-backed sources, or `none`.
+`database (encrypted)` for encrypted material, `keychain` for a legacy
+keychain route that has not been migrated, or `none`.
 
 <Note>
-Keep `coral.db` and `credentials/encryption.key` together when backing up or
-moving local Coral state. Losing the key material means encrypted source secrets
-cannot be decrypted.
+Keep `coral.db` and the active credential encryption key together when backing
+up or moving local Coral state. For file-backed KEKs, that means
+`credentials/encryption.key`; for env or keychain-backed KEKs, preserve the
+same `v1:<base64>` key material. Losing the key material means encrypted source
+secrets cannot be decrypted.
 </Note>
 
 ## What you still need to trust
@@ -143,9 +147,8 @@ you configure; it does not make an otherwise untrusted local agent safe.
   locations declared by that spec. Only install source specs you trust.
 - If you configure Postgres, anyone who can read that database can inspect
   source metadata, imported specs, non-secret variables, trace summaries, and
-  encrypted credential documents. Anyone who can also read
-  `credentials/encryption.key` should be treated as able to decrypt stored
-  source secrets.
+  encrypted credential documents. Anyone who can also read the active KEK
+  should be treated as able to decrypt stored source secrets.
 - Anyone who can control your user account should be treated as able to use the
   configured sources. Anyone who can read both Coral's configured database and
   its credential encryption key should also be treated as able to decrypt stored

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -253,8 +253,9 @@ List sources currently installed.
 coral source list
 ```
 
-The output includes the source's secret storage route: `keychain` or
-`file (plaintext)`.
+The output includes the source's stored-secret route, such as
+`database (encrypted)`, `keychain` for legacy keychain-backed sources, or
+`none`.
 
 ### `coral source info <NAME>`
 
@@ -317,11 +318,9 @@ coral source add --interactive github
 
 If the source is already installed, running this command again replaces its stored credentials with the new values you provide. After installation, it prints the discovered tables and runs any optional top-level `test_queries` declared in the source spec to validate the connection. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
 
-Sources use OS credential storage by default when Coral can write, read, and
-delete a keychain probe item. If the keychain is unavailable in `auto` mode,
-Coral stores the source secrets in plaintext file storage and shows
-`file (plaintext)` in source output. Sources with no stored secret material show
-`none`.
+New sources with stored secret material show `database (encrypted)` in source
+output. Legacy keychain-backed sources may still show `keychain`, and sources
+with no stored secret material show `none`.
 
 ### `coral source lint <FILE>`
 
@@ -350,9 +349,9 @@ coral source remove github
 
 ## `coral workspace`
 
-Manage local workspaces. Workspaces isolate installed source metadata and
-workspace-scoped artifacts such as source manifests, local credential material,
-feedback reports, and workspace-attributed local trace history.
+Manage local workspaces. Workspaces isolate installed source metadata and specs,
+source-scoped credential material, feedback reports, search projections, and
+workspace-attributed local trace history.
 
 Imported source specs and source credential material are attached to the source
 installation in that workspace. Reusable global source specs and reusable

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -254,8 +254,8 @@ coral source list
 ```
 
 The output includes the source's stored-secret route, such as
-`database (encrypted)`, `keychain` for legacy keychain-backed sources, or
-`none`.
+`database (encrypted)`, `keychain` for a legacy route that has not been
+migrated, or `none`.
 
 ### `coral source info <NAME>`
 
@@ -318,9 +318,9 @@ coral source add --interactive github
 
 If the source is already installed, running this command again replaces its stored credentials with the new values you provide. After installation, it prints the discovered tables and runs any optional top-level `test_queries` declared in the source spec to validate the connection. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
 
-New sources with stored secret material show `database (encrypted)` in source
-output. Legacy keychain-backed sources may still show `keychain`, and sources
-with no stored secret material show `none`.
+Sources with encrypted secret material show `database (encrypted)` in source
+output. A legacy keychain route that could not be migrated may still show
+`keychain`, and sources with no stored secret material show `none`.
 
 ### `coral source lint <FILE>`
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -7,9 +7,17 @@ Coral stores local configuration in `config.toml` inside its platform-specific [
 
 ## Managed state
 
-Coral stores source installation state in its local database when you run commands such as `coral source add` and `coral source remove`.
+Coral writes runtime configuration to `config.toml` and durable app state to
+the local database.
 
-This state includes installed-source metadata and non-secret source variables. Source secrets are stored separately within the same local trust boundary.
+The database stores installed-source metadata, imported source specs, DSL v4
+materialization metadata, feedback reports, trace summaries, and non-secret
+source variables. New source secrets are stored as encrypted
+database documents within the same local trust boundary.
+
+Raw trace span JSONL and optional HTTP/MCP body captures remain outside the
+database. Trace summaries are indexed in the database from the local trace span
+store.
 
 <Note>
   Prefer the `coral source` commands for source state instead of editing

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -75,14 +75,55 @@ reusable credential references are not config objects today.
 
 Older `config.toml` source entries are imported into the database on startup and
 removed from `config.toml` after the import is validated. This source-catalog
-migration is one-way for current releases: downgrading to an older
-config-backed Coral build does not automatically restore those config entries.
+migration is one-way for current releases: the first successful
+database-backed startup stamps `config.toml` with the migrated config version,
+and unsupported future config
+versions fail closed instead of being interpreted as older filesystem-backed
+state.
 
-If you need to run an older build after this migration, re-add bundled sources
-with `coral source add <NAME>`. Re-add imported sources with
-`coral source add --file <PATH>`, using the existing manifest under the local
-state directory, such as
-`workspaces/<workspace>/sources/<source>/manifest.yaml`.
+Successful startup import also deletes verified legacy credential and state
+artifacts after their database rows are written. That includes file-backed
+`secrets.env` material, migrated keychain entries, legacy feedback JSONL, and
+legacy DSL v4 materialization directories. If you roll back to an older build,
+use a separate state directory or re-add bundled sources with
+`coral source add <NAME>`, re-add imported sources with
+`coral source add --file <PATH>`, and re-provide credentials.
+
+Raw trace span JSONL and optional HTTP/MCP body captures remain outside the
+database. Trace summaries are indexed in the database from the local trace span
+store.
+
+## Credential encryption keys
+
+Encrypted database credential documents are protected by a key-encryption key
+(KEK). Configure that KEK before enabling shared Postgres:
+
+```toml
+[credentials]
+encryption_key_env = "CORAL_CREDENTIAL_KEK"
+encryption_key_source = "auto"
+```
+
+If `encryption_key_env` is set, Coral reads that environment variable first.
+The value must be `v1:<base64>`, where the base64 payload decodes to 32 bytes
+of key material. Missing or invalid environment material fails closed; Coral
+does not fall back to another KEK source after an explicit env key is
+configured.
+
+If no env key is configured, `encryption_key_source` controls local KEK
+selection:
+
+| Value | Behavior |
+| ----- | -------- |
+| `auto` | Reuses an existing `credentials/encryption.key` file if one exists. Otherwise prefers the OS keychain. If keychain access is unavailable, logs a warning and creates the file key. |
+| `keychain` | Uses the OS keychain and fails closed when keychain access is unavailable. Keychains are per host, so shared-Postgres deployments must pre-seed every server with the same key material before use. |
+| `file` | Uses `credentials/encryption.key` under the local state directory. |
+| `vault` | Reserved for external vault-backed KEKs and currently fails closed because it is not implemented. |
+
+For shared Postgres, every Coral server that can read or write encrypted
+credential documents must use the same KEK before Postgres is enabled. If two
+servers create different auto-generated local keys, each server can create
+documents the other cannot decrypt.
 
 ## Server
 

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -50,7 +50,6 @@ root.
   `catalog/` as the main internal boundaries. Do not create new sub-boundaries
   unless they own durable, independent behavior.
 - Keep RDBMS-backed durable app-state infrastructure under `state/db`. The
-  initial DB bootstrap may coexist with filesystem-backed source behavior, but
   repository wiring must keep SQLx pools, transactions, SeaQuery schema
   identifiers, and row structs inside that module.
 - Give an independently identified entity one stable ID as its sole primary
@@ -79,9 +78,17 @@ root.
   Postgres branches ignored or enumerate individual test functions in the
   repository harness; the Postgres suite selects existing module and target
   boundaries instead.
-- Until the RDBMS migration phases replace the relevant stores, persist
-  imported manifests as files under app-owned state; do not inline them into
-  `config.toml`.
+- Treat the local database as the durable store for source catalog metadata,
+  imported manifests, DSL v4 materialization records, encrypted credential
+  documents, feedback reports, and trace summaries. Legacy filesystem
+  artifacts are migration inputs only unless a test explicitly constructs a
+  filesystem-backed manager.
+- Legacy file-backed source credential material migrates into encrypted
+  database documents. Legacy keychain-backed source credential material remains
+  keychain-routed until the source credentials are replaced.
+- Keep raw trace spans and optional HTTP/MCP body captures out of the database.
+  The database may index trace summaries derived from the local trace span
+  store.
 - Persist DSL v4 imported manifests as authored intent plus durability
   normalization only. Descriptor hashes, generated OpenAPI metadata, semantic
   IR, projections, and package fingerprints belong in materialized artifacts

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -83,9 +83,9 @@ root.
   documents, feedback reports, and trace summaries. Legacy filesystem
   artifacts are migration inputs only unless a test explicitly constructs a
   filesystem-backed manager.
-- Legacy file-backed source credential material migrates into encrypted
-  database documents. Legacy keychain-backed source credential material remains
-  keychain-routed until the source credentials are replaced.
+- Readable legacy file-backed and keychain-backed source credential material
+  migrates into encrypted database documents. Retain legacy material unless the
+  database write and readback are verified.
 - Keep raw trace spans and optional HTTP/MCP body captures out of the database.
   The database may index trace summaries derived from the local trace span
   store.

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -16,6 +16,8 @@ use crate::telemetry::{
 use crate::workspaces::WorkspaceName;
 
 #[cfg(test)]
+pub(crate) use env::AppEnvironment;
+#[cfg(test)]
 pub(crate) use error::MAX_STATUS_DETAIL_BYTES;
 pub(crate) use error::{app_status, core_status, status_with_bounded_detail};
 

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -1177,6 +1177,12 @@ mod tests {
     #[test]
     #[ignore = "uses the native OS keychain; run manually on hosts with keychain access"]
     fn native_keychain_key_provider_round_trips_key_material() {
+        if !matches!(
+            crate::bootstrap::AppEnvironment::env_var("CORAL_RUN_NATIVE_KEYCHAIN_TESTS"),
+            Ok(Some(_))
+        ) {
+            return;
+        }
         let (_temp, layout) = temp_layout();
         let first = KeychainCredentialKeyProvider::new(&layout)
             .active_key()

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -66,6 +66,8 @@ fn default_config_version() -> u32 {
     1
 }
 
+const DATABASE_MIGRATED_CONFIG_VERSION: u32 = 2;
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct PersistedAppConfig {
     #[serde(default = "default_config_version")]
@@ -571,12 +573,13 @@ impl ConfigStore {
         self.load_config_unlocked()
     }
 
-    pub(crate) fn clear_source_catalog_unlocked(&self) -> Result<(), AppError> {
+    pub(crate) fn finalize_database_migration_unlocked(&self) -> Result<(), AppError> {
         let mut config = self.load_unlocked()?;
-        if config.catalog.0.is_empty() {
+        if config.catalog.0.is_empty() && config.version >= DATABASE_MIGRATED_CONFIG_VERSION {
             return Ok(());
         }
         config.catalog = SourceCatalog::default();
+        config.version = DATABASE_MIGRATED_CONFIG_VERSION;
         self.save_unlocked(&config)
     }
 
@@ -1005,6 +1008,12 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
     type Error = AppError;
 
     fn try_from(value: PersistedAppConfig) -> Result<Self, Self::Error> {
+        if !matches!(value.version, 1 | DATABASE_MIGRATED_CONFIG_VERSION) {
+            return Err(AppError::FailedPrecondition(format!(
+                "unsupported config.toml version {}; upgrade Coral or use a compatible state directory",
+                value.version
+            )));
+        }
         let mut workspaces = WorkspaceCatalog::default();
         let mut catalog = SourceCatalog::default();
         let mut functions = FunctionCatalog::default();
@@ -1354,6 +1363,23 @@ version = 1
                 .map(|workspace| workspace.name.as_str().to_string())
                 .collect::<Vec<_>>(),
             vec!["work".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_config_version() {
+        let raw = "version = 3\n";
+
+        let error = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(raw).expect("config should parse"),
+        )
+        .expect_err("unsupported config version should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported config.toml version 3"),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -190,6 +190,7 @@ async fn import_config_source_catalog(
         .await?
     {
         tx.rollback().await?;
+        finalize_database_migrated_config(config_store);
         return Ok(SourceCatalogImportReport {
             source_count: 0,
             import_performed: false,
@@ -210,7 +211,7 @@ async fn import_config_source_catalog(
     let source_count =
         import_config_sources(&mut tx, layout, &source_entries, now_unix_nanos).await?;
     tx.commit().await?;
-    clear_legacy_source_catalog_config(config_store, source_entries.len());
+    finalize_database_migrated_config(config_store);
 
     Ok(SourceCatalogImportReport {
         source_count,
@@ -1051,16 +1052,15 @@ fn read_optional_imported_manifest_file(
     }
 }
 
-fn clear_legacy_source_catalog_config(config_store: &ConfigStore, source_count: usize) {
-    if source_count != 0
-        && let Err(error) = config_store.clear_source_catalog_unlocked()
-    {
+fn finalize_database_migrated_config(config_store: &ConfigStore) {
+    if let Err(error) = config_store.finalize_database_migration_unlocked() {
         tracing::warn!(
             detail = %error,
-            "source catalog imported into database but legacy config cleanup failed"
+            "source catalog imported into database but legacy config finalization failed"
         );
     }
 }
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -1205,6 +1205,15 @@ mod tests {
             layout.manifest_file(&workspace, &source.name).exists(),
             "legacy manifest file should be preserved for rollback compatibility"
         );
+        let raw_config =
+            fs::read_to_string(layout.config_file()).expect("read migrated config.toml");
+        assert!(
+            raw_config.contains("version = 2"),
+            "successful database import should stamp migrated config version: {raw_config}"
+        );
+        config_store
+            .load_config_unlocked()
+            .expect("current config reader should accept migrated version");
     }
 
     #[tokio::test]
@@ -2379,7 +2388,8 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_v4_materialization_backfill_race_is_benign_postgres() {
-        let Some(url) = postgres_test_url() else {
+        let Ok(Some(url)) = crate::bootstrap::AppEnvironment::env_var("CORAL_TEST_POSTGRES_URL")
+        else {
             return;
         };
         let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
@@ -2539,7 +2549,8 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_feedback_report_import_race_is_benign_postgres() {
-        let Some(url) = postgres_test_url() else {
+        let Ok(Some(url)) = crate::bootstrap::AppEnvironment::env_var("CORAL_TEST_POSTGRES_URL")
+        else {
             return;
         };
         let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
@@ -2901,7 +2912,8 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_credential_import_race_is_benign_postgres() {
-        let Some(url) = postgres_test_url() else {
+        let Ok(Some(url)) = crate::bootstrap::AppEnvironment::env_var("CORAL_TEST_POSTGRES_URL")
+        else {
             return;
         };
         let temp = tempdir().expect("temp dir");
@@ -3188,15 +3200,5 @@ paths:
                     id: {type: integer}
                     title: {type: string}
 "
-    }
-
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "The Postgres import harness is explicitly gated by this CI/test-only variable."
-    )]
-    fn postgres_test_url() -> Option<String> {
-        std::env::var("CORAL_TEST_POSTGRES_URL")
-            .ok()
-            .filter(|value| !value.is_empty())
     }
 }

--- a/crates/coral-app/src/state/db/repositories/credential_documents.rs
+++ b/crates/coral-app/src/state/db/repositories/credential_documents.rs
@@ -404,7 +404,8 @@ mod tests {
 
     #[tokio::test]
     async fn credential_document_repository_round_trips_against_postgres() {
-        let Some(url) = postgres_test_url() else {
+        let Ok(Some(url)) = crate::bootstrap::AppEnvironment::env_var("CORAL_TEST_POSTGRES_URL")
+        else {
             return;
         };
         let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
@@ -735,15 +736,5 @@ mod tests {
             algorithm: "AES-256-GCM".to_string(),
             aad_version: CREDENTIAL_DOCUMENT_BINDING_VERSION,
         }
-    }
-
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "The Postgres repository harness is explicitly gated by this CI/test-only variable."
-    )]
-    fn postgres_test_url() -> Option<String> {
-        std::env::var("CORAL_TEST_POSTGRES_URL")
-            .ok()
-            .filter(|value| !value.is_empty())
     }
 }

--- a/crates/coral-app/src/state/db/repositories/feedback_reports.rs
+++ b/crates/coral-app/src/state/db/repositories/feedback_reports.rs
@@ -173,7 +173,8 @@ mod tests {
 
     #[tokio::test]
     async fn feedback_report_repository_round_trips_against_postgres() {
-        let Some(url) = postgres_test_url() else {
+        let Ok(Some(url)) = crate::bootstrap::AppEnvironment::env_var("CORAL_TEST_POSTGRES_URL")
+        else {
             return;
         };
         let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
@@ -340,15 +341,5 @@ mod tests {
             publish_error: None,
             published_at_unix_nanos: Some(99),
         }
-    }
-
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "The Postgres repository harness is explicitly gated by this CI/test-only variable."
-    )]
-    fn postgres_test_url() -> Option<String> {
-        std::env::var("CORAL_TEST_POSTGRES_URL")
-            .ok()
-            .filter(|value| !value.is_empty())
     }
 }

--- a/crates/coral-app/src/state/db/repositories/trace_summaries.rs
+++ b/crates/coral-app/src/state/db/repositories/trace_summaries.rs
@@ -391,7 +391,8 @@ mod tests {
 
     #[tokio::test]
     async fn trace_summary_repository_round_trips_against_postgres() {
-        let Some(url) = postgres_test_url() else {
+        let Ok(Some(url)) = crate::bootstrap::AppEnvironment::env_var("CORAL_TEST_POSTGRES_URL")
+        else {
             return;
         };
         let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
@@ -598,15 +599,5 @@ mod tests {
             .await
             .expect("delete test workspace");
         tx.commit().await.expect("commit cleanup tx");
-    }
-
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "The Postgres repository harness is explicitly gated by this CI/test-only variable."
-    )]
-    fn postgres_test_url() -> Option<String> {
-        std::env::var("CORAL_TEST_POSTGRES_URL")
-            .ok()
-            .filter(|value| !value.is_empty())
     }
 }

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -1268,7 +1268,8 @@ mod tests {
 
     #[tokio::test]
     async fn backfill_summaries_preserves_existing_postgres_rows() {
-        let Some(url) = postgres_test_url() else {
+        let Ok(Some(url)) = crate::bootstrap::AppEnvironment::env_var("CORAL_TEST_POSTGRES_URL")
+        else {
             return;
         };
         let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
@@ -1363,16 +1364,6 @@ mod tests {
             .ensure(workspace_id, 1)
             .await
             .expect("ensure workspace");
-    }
-
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "The Postgres trace harness is explicitly gated by this CI/test-only variable."
-    )]
-    fn postgres_test_url() -> Option<String> {
-        std::env::var("CORAL_TEST_POSTGRES_URL")
-            .ok()
-            .filter(|value| !value.is_empty())
     }
 
     fn summary(trace_id: &str, workspace_id: &str, end_time_unix_nanos: i64) -> TraceSummaryRecord {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -90,10 +90,6 @@ impl GrpcHarness {
         .await
     }
 
-    #[expect(
-        dead_code,
-        reason = "resilience coverage lands with the hardening docs PR in the stacked sequence"
-    )]
     pub(crate) async fn start_with_owned_config_dir(
         temp_dir: TempDir,
         config_dir: PathBuf,

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -6,17 +6,22 @@
 
 use std::fs;
 
-use coral_api::v1::{ExecuteSqlRequest, SourceSecret, SourceVariable};
+use coral_api::v1::ExecuteSqlRequest;
 use coral_client::{batches_to_json_rows, decode_execute_sql_response};
+use tempfile::TempDir;
 use tonic::Request;
 
 use crate::harness::{
     GrpcHarness, default_workspace, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml,
+    source_dir,
 };
 
 #[tokio::test]
 async fn broken_source_does_not_block_healthy_sources() {
-    let harness = GrpcHarness::with_workspace().await;
+    let temp_dir = TempDir::new().expect("config root");
+    let config_dir = temp_dir.path().join("coral-config");
+    seed_broken_secured_messages_source(&config_dir);
+    let harness = GrpcHarness::start_with_owned_config_dir(temp_dir, config_dir).await;
 
     harness
         .import_source(
@@ -25,30 +30,6 @@ async fn broken_source_does_not_block_healthy_sources() {
             Vec::new(),
         )
         .await;
-    harness
-        .import_source(
-            fixture_manifest_with_inputs_yaml(),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: "https://example.com".to_string(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "secret-token".to_string(),
-            }],
-        )
-        .await;
-
-    fs::remove_file(
-        harness
-            .config_dir()
-            .join("workspaces")
-            .join("default")
-            .join("sources")
-            .join("secured_messages")
-            .join("secrets.env"),
-    )
-    .expect("remove broken source secret file");
 
     let tables = harness.list_tables().await;
     assert!(
@@ -94,4 +75,27 @@ async fn broken_source_does_not_block_healthy_sources() {
         .await
         .expect_err("broken source query should fail");
     assert_eq!(broken.code(), tonic::Code::NotFound);
+}
+
+fn seed_broken_secured_messages_source(config_dir: &std::path::Path) {
+    fs::create_dir_all(config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"version = 1
+
+[workspaces.default.sources.secured_messages]
+version = "0.1.0"
+variables = { API_BASE = "https://example.com" }
+secrets = ["API_TOKEN"]
+origin = "imported"
+"#,
+    )
+    .expect("write legacy source config");
+    let source_dir = source_dir(config_dir, "secured_messages");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(
+        source_dir.join("manifest.yaml"),
+        fixture_manifest_with_inputs_yaml(),
+    )
+    .expect("write manifest");
 }

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -595,6 +595,41 @@ async fn source_list_renders_configured_sources() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn source_list_renders_database_credential_storage() {
+    let server = MockServer::start_with_config(MockServerConfig::default().with_list_sources(
+        ListSourcesResponse {
+            sources: vec![Source {
+                workspace: Some(Workspace {
+                    name: "default".to_string(),
+                }),
+                name: "database_source".to_string(),
+                version: "3.0.0".to_string(),
+                secrets: Vec::new(),
+                variables: Vec::new(),
+                origin: SourceOrigin::Imported as i32,
+                credential_storage: SourceCredentialStorage::Database as i32,
+            }],
+        },
+    ))
+    .await;
+
+    let assert = server.cmd().args(["source", "list"]).assert().success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert_eq!(
+        nonempty_lines(&stdout),
+        vec![
+            "Source           Version  Origin    Secrets",
+            "---------------  -------  --------  --------------------",
+            "database_source  3.0.0    imported  database (encrypted)",
+        ],
+        "expected database-backed source list"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn source_list_renders_dash_for_missing_authored_version() {
     let server = MockServer::start_with_config(MockServerConfig::default().with_list_sources(
         ListSourcesResponse {
@@ -737,6 +772,34 @@ async fn source_info_renders_metadata_for_installed_source() {
     assert_eq!(requests.len(), 1, "expected one get_source_info call");
     assert_eq!(requests[0].name, "github");
     assert_test_workspace(requests[0].workspace.as_ref());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_info_renders_database_credential_storage() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "info", "database_source"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("database_source"),
+        "expected source name: {stdout}"
+    );
+    assert!(
+        stdout.contains("Secrets:     database (encrypted)"),
+        "expected database credential storage label: {stdout}"
+    );
+
+    let requests = server.get_source_info_requests();
+    assert_eq!(requests.len(), 1, "expected one get_source_info call");
+    assert_eq!(requests[0].name, "database_source");
+    assert_default_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -599,8 +599,8 @@ async fn source_list_renders_database_credential_storage() {
     let server = MockServer::start_with_config(MockServerConfig::default().with_list_sources(
         ListSourcesResponse {
             sources: vec![Source {
-                workspace: Some(Workspace {
-                    name: "default".to_string(),
+                workspace: Some(coral_api::v1::Workspace {
+                    name: TEST_WORKSPACE.to_string(),
                 }),
                 name: "database_source".to_string(),
                 version: "3.0.0".to_string(),
@@ -799,7 +799,7 @@ async fn source_info_renders_database_credential_storage() {
     let requests = server.get_source_info_requests();
     assert_eq!(requests.len(), 1, "expected one get_source_info call");
     assert_eq!(requests[0].name, "database_source");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -608,6 +608,15 @@ fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
             origin: SourceOrigin::Imported as i32,
             credential_storage: SourceCredentialStorage::File as i32,
         }),
+        "database_source" => Ok(SourceInfo {
+            name: "database_source".to_string(),
+            description: "Database-backed source".to_string(),
+            version: "3.0.0".to_string(),
+            inputs: Vec::new(),
+            installed: true,
+            origin: SourceOrigin::Imported as i32,
+            credential_storage: SourceCredentialStorage::Database as i32,
+        }),
         "versionless" => Ok(SourceInfo {
             name: "versionless".to_string(),
             description: String::new(),


### PR DESCRIPTION
## Intent
Document DB-backed local state and add CI coverage for Postgres repository tests.

## What it enables
Contributors and agents know that `coral-app` owns durable database-backed state, and CI exercises the repository harness against Postgres.

## Usage examples
Configure `[database] backend = "postgres"` with a `url_env`, or rely on the default SQLite `coral.db`; contributors can run `cargo test --locked -p coral-app state::db::repositories -- --ignored` with `CORAL_TEST_POSTGRES_URL`.

## Validation
Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.