### PR TITLE
test(app): cover database bootstrap lifecycle

### DIFF
--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -53,10 +53,17 @@ async fn server_lifecycle_can_repeat_within_process() {
 async fn server_lifecycle_rejects_postgres_config_without_url_env_value() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
+    let missing_url_env = format!(
+        "CORAL_TEST_POSTGRES_URL_MISSING_FOR_SERVER_START_{}",
+        uuid::Uuid::new_v4()
+            .simple()
+            .to_string()
+            .to_ascii_uppercase()
+    );
     fs::create_dir_all(&config_dir).expect("create config dir");
     fs::write(
         config_dir.join("config.toml"),
-        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL_MISSING_FOR_SERVER_START\"\n",
+        format!("[database]\nbackend = \"postgres\"\nurl_env = \"{missing_url_env}\"\n"),
     )
     .expect("write config");
 
@@ -74,7 +81,7 @@ async fn server_lifecycle_rejects_postgres_config_without_url_env_value() {
 
     match error {
         LocalServerError::FailedPrecondition(detail) => assert!(
-            detail.contains("CORAL_TEST_POSTGRES_URL_MISSING_FOR_SERVER_START"),
+            detail.contains(&missing_url_env),
             "unexpected detail: {detail}"
         ),
         other => panic!("unexpected error: {other}"),

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -6,8 +6,15 @@
 //! `OnceLock` and flushed by the owning binary or test harness via
 //! `coral_app::shutdown_tracing` at process exit.
 
+use std::fs;
+
 use coral_api::v1::ListSourcesRequest;
-use coral_client::{AppClient, default_workspace, local::ServerBuilder};
+use coral_client::{
+    AppClient, default_workspace,
+    local::{LocalServerError, ServerBuilder},
+};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use tonic::Request;
 
@@ -22,6 +29,7 @@ async fn server_lifecycle_can_repeat_within_process() {
             .start()
             .await
             .expect("start server");
+        assert_default_sqlite_db_is_migrated(&config_dir).await;
         let app = AppClient::connect(server.endpoint_uri())
             .await
             .expect("connect client");
@@ -39,4 +47,105 @@ async fn server_lifecycle_can_repeat_within_process() {
 
         server.shutdown().await.expect("shutdown server");
     }
+}
+
+#[tokio::test]
+async fn server_lifecycle_rejects_postgres_config_without_url_env_value() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL_MISSING_FOR_SERVER_START\"\n",
+    )
+    .expect("write config");
+
+    let result = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await;
+    let error = match result {
+        Err(error) => error,
+        Ok(server) => {
+            server.shutdown().await.expect("shutdown unexpected server");
+            panic!("server start should fail without configured Postgres URL env var");
+        }
+    };
+
+    match error {
+        LocalServerError::FailedPrecondition(detail) => assert!(
+            detail.contains("CORAL_TEST_POSTGRES_URL_MISSING_FOR_SERVER_START"),
+            "unexpected detail: {detail}"
+        ),
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run configured Postgres startup coverage"]
+async fn server_lifecycle_can_start_with_postgres_database_config() {
+    let Some(database_url) = postgres_test_url() else {
+        return;
+    };
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n",
+    )
+    .expect("write config");
+
+    let server = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await
+        .expect("start server with Postgres config");
+    assert_postgres_db_is_migrated(&database_url).await;
+
+    server.shutdown().await.expect("shutdown server");
+}
+
+async fn assert_default_sqlite_db_is_migrated(config_dir: &std::path::Path) {
+    let database_file = config_dir.join("coral.db");
+    assert!(
+        database_file.exists(),
+        "default SQLite database should exist"
+    );
+
+    let options = SqliteConnectOptions::new().filename(&database_file);
+    let pool = SqlitePoolOptions::new()
+        .connect_with(options)
+        .await
+        .expect("open created SQLite database");
+    let table_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'workspaces'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("inspect migrated schema");
+    assert_eq!(table_count, 1, "workspaces table should be migrated");
+}
+
+async fn assert_postgres_db_is_migrated(database_url: &str) {
+    let pool = PgPoolOptions::new()
+        .connect(database_url)
+        .await
+        .expect("open Postgres database");
+    let table_exists: bool =
+        sqlx::query_scalar("SELECT to_regclass('public.workspaces') IS NOT NULL")
+            .fetch_one(&pool)
+            .await
+            .expect("inspect migrated Postgres schema");
+    assert!(table_exists, "workspaces table should be migrated");
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "The ignored Postgres integration test is explicitly gated by this CI/test-only variable."
+)]
+fn postgres_test_url() -> Option<String> {
+    std::env::var("CORAL_TEST_POSTGRES_URL")
+        .ok()
+        .filter(|value| !value.is_empty())
 }


### PR DESCRIPTION
## Intent

Keep durable database bootstrap lifecycle coverage separate from the core DB bootstrap implementation so the stack stays reviewable under the PR size cap.

## What it enables

This verifies repeat in-process startup, default SQLite migration, missing Postgres URL env handling, and configured Postgres startup coverage without bloating the bootstrap implementation PR.

## Usage examples

Run local lifecycle coverage:

```shell
cargo test --locked -p coral-app server_lifecycle -- --nocapture
```

Run the ignored live Postgres startup coverage by setting `CORAL_TEST_POSTGRES_URL` before invoking the ignored test.

## Validation

Review-swarm run `.context/review-swarm/20260701T075247Z-sauldhernandez-rdbms-hardening-docs-ci-branch`; final pass recorded 0 active findings and 0 supervisor questions.

- `cargo test --locked -p coral-app server_lifecycle -- --nocapture`
- `make rust-checks`
