### PR TITLE
feat(app): persist workspace state

### DIFF
--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -96,6 +96,9 @@ pub const CORAL_EPISODE_INTENT_MAX_CHARS: usize = 4096;
 /// Machine-readable reason for a configured source lookup miss.
 pub const CORAL_ERROR_REASON_SOURCE_NOT_FOUND: &str = "SOURCE_NOT_FOUND";
 
+/// Machine-readable reason for a configured workspace lookup miss.
+pub const CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND: &str = "WORKSPACE_NOT_FOUND";
+
 /// Reserved `ErrorInfo.metadata` key for a one-line error summary.
 pub const CORAL_ERROR_METADATA_SUMMARY: &str = "summary";
 

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -3,6 +3,7 @@
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_DETAIL, CORAL_ERROR_METADATA_HINT,
     CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+    CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND,
 };
 use coral_engine::{CoreError, StatusCode};
 use tonic::{Code, Status};
@@ -16,6 +17,12 @@ pub enum AppError {
     /// A requested source was not found in config.
     #[error("source '{0}' not found")]
     SourceNotFound(String),
+    /// A requested workspace was not found in config.
+    #[error("workspace '{0}' not found")]
+    WorkspaceNotFound(String),
+    /// A requested workspace already exists in config.
+    #[error("workspace '{0}' already exists")]
+    WorkspaceAlreadyExists(String),
     /// Caller-supplied input was invalid.
     #[error("invalid input: {0}")]
     InvalidInput(String),
@@ -107,16 +114,16 @@ fn truncate_status_detail(detail: String) -> String {
     reason = "used directly as a map_err adapter across tonic service handlers"
 )]
 pub(crate) fn app_status(error: AppError) -> Status {
-    if matches!(error, AppError::SourceNotFound(_)) {
-        // The `reason` alone discriminates `SOURCE_NOT_FOUND` from other
-        // `Code::NotFound` causes (e.g. `io::ErrorKind::NotFound` raised
-        // when a manifest file is missing). The qualified name already
-        // appears in the truncated status message; we deliberately do
-        // not duplicate it into structured metadata so unbounded
-        // identifiers cannot push the `grpc-status-details-bin` trailer
-        // past the h2 `MAX_HEADER_LIST_SIZE` budget.
+    let not_found_reason = match &error {
+        AppError::SourceNotFound(_) => Some(CORAL_ERROR_REASON_SOURCE_NOT_FOUND),
+        AppError::WorkspaceNotFound(_) => Some(CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND),
+        _ => None,
+    };
+    if let Some(reason) = not_found_reason {
+        // The `reason` alone discriminates typed Coral misses from other
+        // `Code::NotFound` causes without echoing unbounded identifiers.
         let details = vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
-            CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+            reason,
             CORAL_ERROR_DOMAIN,
             std::collections::HashMap::new(),
         ))];
@@ -194,7 +201,8 @@ fn grpc_code(status: StatusCode) -> Code {
 
 fn app_code(error: &AppError) -> Code {
     match error {
-        AppError::SourceNotFound(_) => Code::NotFound,
+        AppError::SourceNotFound(_) | AppError::WorkspaceNotFound(_) => Code::NotFound,
+        AppError::WorkspaceAlreadyExists(_) => Code::AlreadyExists,
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
         | AppError::MissingOrIncompatibleV4Materialization { .. }

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -268,6 +268,28 @@ mod tests {
     }
 
     #[test]
+    fn app_status_attaches_structured_reason_for_workspace_not_found() {
+        let status = app_status(AppError::WorkspaceNotFound("work".to_string()));
+        assert_eq!(status.code(), Code::NotFound);
+
+        let details = status.get_error_details_vec();
+        let info = details
+            .iter()
+            .find_map(|detail| match detail {
+                ErrorDetail::ErrorInfo(info) => Some(info),
+                _ => None,
+            })
+            .expect("workspace-not-found status must carry an ErrorInfo detail");
+        assert_eq!(info.reason, CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND);
+        assert_eq!(info.domain, CORAL_ERROR_DOMAIN);
+        assert!(
+            info.metadata.is_empty(),
+            "WORKSPACE_NOT_FOUND must not carry unbounded identifier metadata: {:?}",
+            info.metadata
+        );
+    }
+
+    #[test]
     fn app_status_does_not_attach_structured_reason_for_io_not_found() {
         let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "manifest missing");
         let status = app_status(AppError::Io(io_error));

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -388,7 +388,6 @@ impl CredentialMaterialGuard<'_> {
         )
     }
 
-    #[cfg(test)]
     pub(crate) fn remove_material(&self, storage: CredentialStorageKind) -> Result<(), AppError> {
         self.manager
             .store

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -424,7 +424,6 @@ impl CredentialStore {
         Ok(())
     }
 
-    #[cfg(test)]
     pub(crate) fn remove_material(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -252,6 +252,9 @@ impl QueryManager {
                 .config_store
                 .load_config_unlocked()
                 .map_err(QueryManagerError::App)?;
+            config
+                .require_workspace(workspace_name)
+                .map_err(QueryManagerError::App)?;
             let source = config
                 .get_source(workspace_name, source_name)
                 .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
@@ -302,6 +305,7 @@ impl QueryManager {
             source.count = tracing::field::Empty,
         );
         let _guard = span.enter();
+        config.require_workspace(workspace_name)?;
         let mut loaded_sources = Vec::new();
         for source in config.workspace_sources(workspace_name) {
             match self.load_query_source(workspace_name, &source) {
@@ -654,6 +658,8 @@ fn query_error_message(error: &QueryManagerError) -> String {
 fn app_error_type(error: &AppError) -> &'static str {
     match error {
         AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
+        AppError::WorkspaceNotFound(_) => "WORKSPACE_NOT_FOUND",
+        AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",
         AppError::InvalidInput(_) => "INVALID_INPUT",
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
         AppError::MissingOrIncompatibleV4Materialization { .. } => {
@@ -762,6 +768,55 @@ mod tests {
         QueryManagerFixture {
             _temp: temp,
             manager,
+        }
+    }
+
+    fn assert_workspace_not_found(error: AppError, workspace_name: &WorkspaceName) {
+        match error {
+            AppError::WorkspaceNotFound(actual) => assert_eq!(actual, workspace_name.as_str()),
+            error => panic!("expected WorkspaceNotFound for '{workspace_name}', got {error}"),
+        }
+    }
+
+    #[test]
+    fn load_query_sources_fails_closed_for_missing_workspace() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        let missing_workspace = WorkspaceName::parse("missing").expect("workspace");
+        let config = fixture
+            .manager
+            .config_store
+            .load_config()
+            .expect("load config");
+
+        let error = fixture
+            .manager
+            .load_query_sources_from_config(&missing_workspace, &config)
+            .expect_err("missing workspace should fail closed");
+
+        assert_workspace_not_found(error, &missing_workspace);
+    }
+
+    #[tokio::test]
+    async fn validate_source_fails_with_workspace_not_found_for_missing_workspace() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        let missing_workspace = WorkspaceName::parse("missing").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source");
+
+        let result = fixture
+            .manager
+            .validate_source(&missing_workspace, &source_name)
+            .await;
+        let Err(error) = result else {
+            panic!("missing workspace should fail before source lookup");
+        };
+
+        match error {
+            QueryManagerError::App(error) => {
+                assert_workspace_not_found(error, &missing_workspace);
+            }
+            QueryManagerError::Core(error) => {
+                panic!("expected app error for missing workspace, got {error}");
+            }
         }
     }
 

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -480,10 +480,12 @@ impl SourceManager {
             },
             credential_material,
         };
+        let source_dir_backup = fs::DirectoryBackup::move_for_delete(&source_dir, source_name)?;
         if let Some(credential_storage) = credential_storage
             && let Err(error) =
                 credential_guard.remove_material_with_state_lock_held(credential_storage)
         {
+            let restore_dir_result = source_dir_backup.restore();
             self.restore_source_rollback_state_with_state_lock_held(
                 workspace_name,
                 source_name,
@@ -491,22 +493,14 @@ impl SourceManager {
                 None,
                 &credential_guard,
             );
+            if let Err(restore_error) = restore_dir_result {
+                return Err(AppError::FailedPrecondition(format!(
+                    "failed to remove source credentials for '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
+                    source_dir_backup.backup_path().display()
+                )));
+            }
             return Err(error);
         }
-        let source_dir_backup = match fs::DirectoryBackup::move_for_delete(&source_dir, source_name)
-        {
-            Ok(backup) => backup,
-            Err(error) => {
-                self.restore_source_rollback_state_with_state_lock_held(
-                    workspace_name,
-                    source_name,
-                    Some(previous),
-                    None,
-                    &credential_guard,
-                );
-                return Err(error.into());
-            }
-        };
         if let Err(error) = self
             .config_store
             .remove_source_unlocked(workspace_name, source_name)
@@ -1999,6 +1993,81 @@ tables:
             )
             .expect("read material after delete");
         assert!(material.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn delete_source_preserves_credentials_when_directory_staging_fails() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let manager = SourceManager::new(config_store.clone(), credential_manager.clone(), layout);
+
+        let workspace_name = default_workspace();
+        manager
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings {
+                        variables: Vec::new(),
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "secret-token".to_string(),
+                        }],
+                    },
+                },
+            )
+            .expect("initial import");
+
+        let source_name = SourceName::parse("secured_messages").expect("source");
+        let source_dir = manager.layout.source_dir(&workspace_name, &source_name);
+        let source_parent = source_dir.parent().expect("source parent");
+        let original_permissions = std::fs::metadata(source_parent)
+            .expect("source parent metadata")
+            .permissions();
+        let mut readonly_permissions = original_permissions.clone();
+        readonly_permissions.set_mode(0o500);
+        std::fs::set_permissions(source_parent, readonly_permissions)
+            .expect("make source parent unwritable");
+
+        let delete_result = manager.delete_source(&workspace_name, &source_name);
+
+        std::fs::set_permissions(source_parent, original_permissions)
+            .expect("restore source parent permissions");
+        let error = delete_result.expect_err("directory staging should fail");
+        assert!(
+            matches!(error, crate::bootstrap::AppError::Io(_)),
+            "unexpected delete error: {error}"
+        );
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let material = credential_manager
+            .read_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
+            .expect("read credential material after staging failure");
+        assert_eq!(
+            material.get("API_TOKEN").map(String::as_str),
+            Some("secret-token"),
+            "credential material should be preserved when directory staging fails"
+        );
+        assert!(
+            config_store
+                .get_source(&workspace_name, &source_name)
+                .is_ok(),
+            "source config should be preserved when directory staging fails"
+        );
+        assert!(
+            source_dir.exists(),
+            "source directory should remain when staging fails"
+        );
     }
 
     fn manifest_with_oauth_secret(token_url: &str, redirect_port: u16) -> String {

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -32,7 +32,6 @@ use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthC
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
-use uuid::Uuid;
 
 #[derive(Clone)]
 pub(crate) struct SourceManager {
@@ -481,14 +480,23 @@ impl SourceManager {
             },
             credential_material,
         };
-        let source_dir_backup =
-            source_dir.with_file_name(format!("{source_name}.delete.rollback.{}", Uuid::new_v4()));
-        let had_source_dir = source_dir.exists();
-        if had_source_dir {
-            if source_dir_backup.exists() {
-                std::fs::remove_dir_all(&source_dir_backup)?;
-            }
-            if let Err(error) = std::fs::rename(&source_dir, &source_dir_backup) {
+        if let Some(credential_storage) = credential_storage
+            && let Err(error) =
+                credential_guard.remove_material_with_state_lock_held(credential_storage)
+        {
+            self.restore_source_rollback_state_with_state_lock_held(
+                workspace_name,
+                source_name,
+                Some(previous),
+                None,
+                &credential_guard,
+            );
+            return Err(error);
+        }
+        let source_dir_backup = match fs::DirectoryBackup::move_for_delete(&source_dir, source_name)
+        {
+            Ok(backup) => backup,
+            Err(error) => {
                 self.restore_source_rollback_state_with_state_lock_held(
                     workspace_name,
                     source_name,
@@ -498,20 +506,12 @@ impl SourceManager {
                 );
                 return Err(error.into());
             }
-        }
+        };
         if let Err(error) = self
             .config_store
             .remove_source_unlocked(workspace_name, source_name)
         {
-            if had_source_dir
-                && source_dir_backup.exists()
-                && let Err(restore_error) = std::fs::rename(&source_dir_backup, &source_dir)
-            {
-                return Err(AppError::FailedPrecondition(format!(
-                    "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
-                    source_dir_backup.display()
-                )));
-            }
+            let restore_dir_result = source_dir_backup.restore();
             self.restore_source_rollback_state_with_state_lock_held(
                 workspace_name,
                 source_name,
@@ -519,33 +519,15 @@ impl SourceManager {
                 None,
                 &credential_guard,
             );
-            return Err(error);
-        }
-        if let Some(credential_storage) = credential_storage
-            && let Err(error) =
-                credential_guard.remove_material_with_state_lock_held(credential_storage)
-        {
-            if had_source_dir
-                && source_dir_backup.exists()
-                && let Err(restore_error) = std::fs::rename(&source_dir_backup, &source_dir)
-            {
+            if let Err(restore_error) = restore_dir_result {
                 return Err(AppError::FailedPrecondition(format!(
                     "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
-                    source_dir_backup.display()
+                    source_dir_backup.backup_path().display()
                 )));
             }
-            self.restore_source_rollback_state_with_state_lock_held(
-                workspace_name,
-                source_name,
-                Some(previous),
-                None,
-                &credential_guard,
-            );
             return Err(error);
         }
-        if source_dir_backup.exists() {
-            std::fs::remove_dir_all(&source_dir_backup)?;
-        }
+        source_dir_backup.commit()?;
         cleanup_empty_parent(&self.layout.workspaces_root(), source_dir.parent());
         cleanup_empty_parent(
             &self.layout.workspaces_root(),

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -1,6 +1,6 @@
 //! Persists the installed source catalog in top-level `config.toml`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use coral_engine::{DependentJoinConfig, DependentJoinSourceConfig, MemorySize, QueryMemoryConfig};
 use serde::{Deserialize, Serialize};
@@ -13,12 +13,13 @@ use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
 use crate::storage::fs::{self as storage_fs, FileLock};
-use crate::workspaces::WorkspaceName;
+use crate::workspaces::{DeletedWorkspace, WorkspaceName, WorkspaceRecord, WorkspaceStore};
 
 #[derive(Debug, Clone)]
 pub(crate) struct AppConfig {
     version: u32,
     engine: PersistedEngineConfig,
+    workspaces: WorkspaceCatalog,
     catalog: SourceCatalog,
 }
 
@@ -27,12 +28,29 @@ impl Default for AppConfig {
         Self {
             version: default_config_version(),
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
         }
     }
 }
 
 impl AppConfig {
+    pub(crate) fn workspaces(&self) -> Vec<WorkspaceRecord> {
+        self.workspaces.list()
+    }
+
+    pub(crate) fn has_workspace(&self, workspace_name: &WorkspaceName) -> bool {
+        self.workspaces.contains(workspace_name)
+    }
+
+    pub(crate) fn require_workspace(&self, workspace_name: &WorkspaceName) -> Result<(), AppError> {
+        if self.has_workspace(workspace_name) {
+            Ok(())
+        } else {
+            Err(AppError::WorkspaceNotFound(workspace_name.to_string()))
+        }
+    }
+
     pub(crate) fn workspace_sources(&self, workspace_name: &WorkspaceName) -> Vec<InstalledSource> {
         self.catalog.workspace_sources(workspace_name)
     }
@@ -215,6 +233,37 @@ impl From<&InstalledSource> for PersistedInstalledSource {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceCatalog(BTreeSet<WorkspaceName>);
+
+impl Default for WorkspaceCatalog {
+    fn default() -> Self {
+        Self(BTreeSet::from([WorkspaceName::default()]))
+    }
+}
+
+impl WorkspaceCatalog {
+    pub(crate) fn list(&self) -> Vec<WorkspaceRecord> {
+        self.0
+            .iter()
+            .cloned()
+            .map(|name| WorkspaceRecord { name })
+            .collect()
+    }
+
+    pub(crate) fn contains(&self, workspace_name: &WorkspaceName) -> bool {
+        self.0.contains(workspace_name)
+    }
+
+    pub(crate) fn insert(&mut self, workspace_name: WorkspaceName) -> bool {
+        self.0.insert(workspace_name)
+    }
+
+    pub(crate) fn remove(&mut self, workspace_name: &WorkspaceName) -> bool {
+        self.0.remove(workspace_name)
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SourceCatalog(BTreeMap<WorkspaceName, BTreeMap<SourceName, InstalledSource>>);
 
@@ -289,6 +338,13 @@ impl SourceCatalog {
         }
 
         removed
+    }
+
+    pub(crate) fn remove_workspace(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Option<BTreeMap<SourceName, InstalledSource>> {
+        self.0.remove(workspace_name)
     }
 }
 
@@ -425,6 +481,11 @@ impl ConfigStore {
         self.load_unlocked()
     }
 
+    pub(crate) fn load_config(&self) -> Result<AppConfig, AppError> {
+        let _lock = self.state_lock_shared()?;
+        self.load_config_unlocked()
+    }
+
     /// Loads the source catalog without taking the app state lock.
     ///
     /// Callers must already hold the state lock in shared or exclusive mode
@@ -441,39 +502,95 @@ impl ConfigStore {
         self.load_catalog_unlocked()
     }
 
-    fn update_catalog_unlocked<T>(
+    fn update_config_unlocked<T>(
         &self,
-        update: impl FnOnce(&mut SourceCatalog) -> T,
+        update: impl FnOnce(&mut AppConfig) -> Result<T, AppError>,
     ) -> Result<T, AppError> {
         let mut config = self.load_unlocked()?;
-        let result = update(&mut config.catalog);
+        let result = update(&mut config)?;
         self.save_unlocked(&config)?;
         Ok(result)
     }
 
-    #[cfg(test)]
-    fn update_catalog<T>(
+    fn update_config<T>(
+        &self,
+        update: impl FnOnce(&mut AppConfig) -> Result<T, AppError>,
+    ) -> Result<T, AppError> {
+        let _lock = self.state_lock_exclusive()?;
+        self.update_config_unlocked(update)
+    }
+
+    fn update_catalog_unlocked<T>(
         &self,
         update: impl FnOnce(&mut SourceCatalog) -> T,
     ) -> Result<T, AppError> {
-        let _lock = self.state_lock_exclusive()?;
-        self.update_catalog_unlocked(update)
+        self.update_config_unlocked(|config| Ok(update(&mut config.catalog)))
+    }
+
+    pub(crate) fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, AppError> {
+        self.load_config().map(|config| config.workspaces())
+    }
+
+    pub(crate) fn create_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<WorkspaceRecord, AppError> {
+        self.update_config(|config| {
+            if config.workspaces.insert(workspace_name.clone()) {
+                Ok(WorkspaceRecord {
+                    name: workspace_name.clone(),
+                })
+            } else {
+                Err(AppError::WorkspaceAlreadyExists(workspace_name.to_string()))
+            }
+        })
+    }
+
+    pub(crate) fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<DeletedWorkspace>, AppError> {
+        self.update_config(|config| {
+            if workspace_name.is_default() {
+                return Err(AppError::FailedPrecondition(
+                    "default workspace cannot be removed".to_string(),
+                ));
+            }
+            let removed = config.workspaces.remove(workspace_name);
+            if removed {
+                let sources = config
+                    .catalog
+                    .remove_workspace(workspace_name)
+                    .map(BTreeMap::into_values)
+                    .map(Iterator::collect)
+                    .unwrap_or_default();
+                return Ok(Some(DeletedWorkspace {
+                    workspace: WorkspaceRecord {
+                        name: workspace_name.clone(),
+                    },
+                    sources,
+                }));
+            }
+            Ok(None)
+        })
     }
 
     pub(crate) fn list_workspace_sources(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<InstalledSource>, AppError> {
-        self.load_catalog()
-            .map(|catalog| catalog.workspace_sources(workspace_name))
+        let config = self.load_config()?;
+        config.require_workspace(workspace_name)?;
+        Ok(config.workspace_sources(workspace_name))
     }
 
     pub(crate) fn list_workspace_source_names(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<String>, AppError> {
-        self.load_catalog()
-            .map(|catalog| catalog.workspace_source_names(workspace_name))
+        let config = self.load_config()?;
+        config.require_workspace(workspace_name)?;
+        Ok(config.catalog.workspace_source_names(workspace_name))
     }
 
     /// Loads one installed source without taking the app state lock.
@@ -495,8 +612,11 @@ impl ConfigStore {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
-        let _lock = self.state_lock_shared()?;
-        self.get_source_unlocked(workspace_name, source_name)
+        let config = self.load_config()?;
+        config.require_workspace(workspace_name)?;
+        config
+            .get_source(workspace_name, source_name)
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }
 
     /// Upserts one installed source without taking the app state lock.
@@ -516,7 +636,11 @@ impl ConfigStore {
         workspace_name: &WorkspaceName,
         source: InstalledSource,
     ) -> Result<(), AppError> {
-        self.update_catalog(|catalog| catalog.upsert_source(workspace_name, source))
+        self.update_config(|config| {
+            config.require_workspace(workspace_name)?;
+            config.catalog.upsert_source(workspace_name, source);
+            Ok(())
+        })
     }
 
     /// Removes one installed source without taking the app state lock.
@@ -530,6 +654,39 @@ impl ConfigStore {
         self.update_catalog_unlocked(|catalog| {
             catalog.remove_source(workspace_name, source_name);
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn remove_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), AppError> {
+        self.update_config(|config| {
+            config.require_workspace(workspace_name)?;
+            config.catalog.remove_source(workspace_name, source_name);
+            Ok(())
+        })
+    }
+}
+
+impl WorkspaceStore for ConfigStore {
+    fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, AppError> {
+        ConfigStore::list_workspaces(self)
+    }
+
+    fn create_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<WorkspaceRecord, AppError> {
+        ConfigStore::create_workspace(self, workspace_name)
+    }
+
+    fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<DeletedWorkspace>, AppError> {
+        ConfigStore::delete_workspace(self, workspace_name)
     }
 }
 
@@ -545,13 +702,19 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
     doc["version"] = value(i64::from(config.version));
     render_engine_config(&mut doc, &config.engine);
 
-    // Remove and fully rebuild the workspaces section so removed sources don't linger.
+    // Remove and fully rebuild the workspaces section so removed sources and
+    // removed empty workspaces don't linger.
     doc.remove("workspaces");
+
+    for workspace_name in config.workspaces.keys() {
+        ensure_implicit_table(&mut doc["workspaces"]);
+        ensure_explicit_table(&mut doc["workspaces"][workspace_name]);
+    }
 
     for (workspace_name, workspace) in &config.workspaces {
         for (source_name, source) in &workspace.sources {
             ensure_implicit_table(&mut doc["workspaces"]);
-            ensure_implicit_table(&mut doc["workspaces"][workspace_name]);
+            ensure_explicit_table(&mut doc["workspaces"][workspace_name]);
             ensure_implicit_table(&mut doc["workspaces"][workspace_name]["sources"]);
 
             let source_item = &mut doc["workspaces"][workspace_name]["sources"][source_name];
@@ -648,13 +811,24 @@ fn ensure_implicit_table(item: &mut Item) {
         .set_implicit(true);
 }
 
+fn ensure_explicit_table(item: &mut Item) {
+    if !item.is_table() {
+        *item = toml_edit::table();
+    }
+    item.as_table_mut()
+        .expect("table item must be available")
+        .set_implicit(false);
+}
+
 impl TryFrom<PersistedAppConfig> for AppConfig {
     type Error = AppError;
 
     fn try_from(value: PersistedAppConfig) -> Result<Self, Self::Error> {
+        let mut workspaces = WorkspaceCatalog::default();
         let mut catalog = SourceCatalog::default();
         for (workspace_name, workspace_config) in value.workspaces {
             let workspace_name = WorkspaceName::parse(&workspace_name)?;
+            workspaces.insert(workspace_name.clone());
             for (source_name, source) in workspace_config.sources {
                 let source_name = SourceName::parse(&source_name)?;
                 catalog.upsert_source(&workspace_name, source.into_installed_source(source_name));
@@ -663,6 +837,7 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
         Ok(Self {
             version: value.version,
             engine: value.engine,
+            workspaces,
             catalog,
         })
     }
@@ -671,6 +846,11 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
 impl From<&AppConfig> for PersistedAppConfig {
     fn from(value: &AppConfig) -> Self {
         let mut workspaces = BTreeMap::new();
+        for workspace in value.workspaces.list() {
+            workspaces
+                .entry(workspace.name.as_str().to_string())
+                .or_insert_with(PersistedWorkspaceConfig::default);
+        }
         for (workspace_name, sources) in &value.catalog.0 {
             let workspace_config = workspaces
                 .entry(workspace_name.as_str().to_string())
@@ -857,9 +1037,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        AppConfig, PersistedAppConfig, PersistedEngineConfig, PersistedMemoryConfig,
-        RawFeatureContainerState, RawFeatureValue, SourceCatalog, load_raw_feature_overrides,
-        render_config, set_raw_feature_override,
+        AppConfig, AppError, ConfigStore, PersistedAppConfig, PersistedEngineConfig,
+        PersistedMemoryConfig, RawFeatureContainerState, RawFeatureValue, SourceCatalog,
+        WorkspaceCatalog, load_raw_feature_overrides, render_config, set_raw_feature_override,
     };
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
@@ -918,9 +1098,33 @@ mod tests {
         names.iter().map(|name| (*name).to_string()).collect()
     }
 
+    fn assert_workspace_not_found<T>(result: Result<T, AppError>, workspace_name: &WorkspaceName) {
+        match result {
+            Err(AppError::WorkspaceNotFound(actual)) => {
+                assert_eq!(actual, workspace_name.as_str());
+            }
+            Ok(_) => panic!("expected WorkspaceNotFound for '{workspace_name}'"),
+            Err(error) => panic!("expected WorkspaceNotFound for '{workspace_name}', got {error}"),
+        }
+    }
+
     #[test]
     fn default_config_uses_canonical_version() {
         assert_eq!(AppConfig::default().version, 1);
+    }
+
+    #[test]
+    fn require_workspace_rejects_missing_workspace() {
+        let config = AppConfig::default();
+        let missing_workspace = WorkspaceName::parse("missing").expect("workspace");
+
+        config
+            .require_workspace(&default_workspace())
+            .expect("default workspace should exist");
+        assert_workspace_not_found(
+            config.require_workspace(&missing_workspace),
+            &missing_workspace,
+        );
     }
 
     #[test]
@@ -931,6 +1135,7 @@ mod tests {
         let config = AppConfig {
             version: 1,
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog,
         };
 
@@ -945,6 +1150,46 @@ mod tests {
     }
 
     #[test]
+    fn renders_empty_workspaces_as_explicit_tables() {
+        let mut workspaces = WorkspaceCatalog::default();
+        workspaces.insert(WorkspaceName::parse("work").expect("workspace"));
+        let config = AppConfig {
+            version: 1,
+            engine: PersistedEngineConfig::default(),
+            workspaces,
+            catalog: SourceCatalog::default(),
+        };
+
+        let raw = render_config(&PersistedAppConfig::from(&config), None);
+
+        assert!(raw.contains("[workspaces.default]"));
+        assert!(raw.contains("[workspaces.work]"));
+    }
+
+    #[test]
+    fn loads_empty_workspace_tables() {
+        let raw = r"
+version = 1
+
+[workspaces.default]
+
+[workspaces.work]
+";
+
+        let config = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(raw).expect("workspace config should parse"),
+        )
+        .expect("config");
+        let names = config
+            .workspaces()
+            .into_iter()
+            .map(|workspace| workspace.name.as_str().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["default", "work"]);
+    }
+
+    #[test]
     fn omits_empty_versions_from_rendered_source_entries() {
         let workspace_name = default_workspace();
         let mut source = installed_source("github");
@@ -955,6 +1200,7 @@ mod tests {
         let config = AppConfig {
             version: 1,
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog,
         };
 
@@ -1010,6 +1256,62 @@ origin = "bundled"
                 "linear".to_string(),
                 "slack".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn scoped_config_store_methods_reject_missing_workspace() {
+        let temp = TempDir::new().expect("temp dir");
+        let store = ConfigStore::new(test_layout(&temp));
+        let missing_workspace = WorkspaceName::parse("missing").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source");
+
+        assert_workspace_not_found(
+            store.list_workspace_sources(&missing_workspace),
+            &missing_workspace,
+        );
+        assert_workspace_not_found(
+            store.list_workspace_source_names(&missing_workspace),
+            &missing_workspace,
+        );
+        assert_workspace_not_found(
+            store.get_source(&missing_workspace, &source_name),
+            &missing_workspace,
+        );
+        assert_workspace_not_found(
+            store.upsert_source(&missing_workspace, installed_source("github")),
+            &missing_workspace,
+        );
+        assert_workspace_not_found(
+            store.remove_source(&missing_workspace, &source_name),
+            &missing_workspace,
+        );
+    }
+
+    #[test]
+    fn delete_workspace_returns_removed_sources() {
+        let temp = TempDir::new().expect("temp dir");
+        let store = ConfigStore::new(test_layout(&temp));
+        let workspace_name = WorkspaceName::parse("work").expect("workspace");
+
+        store
+            .create_workspace(&workspace_name)
+            .expect("create workspace");
+        store
+            .upsert_source(&workspace_name, installed_source("github"))
+            .expect("upsert source");
+
+        let deleted = store
+            .delete_workspace(&workspace_name)
+            .expect("delete workspace")
+            .expect("workspace should be deleted");
+
+        assert_eq!(deleted.workspace.name, workspace_name);
+        assert_eq!(deleted.sources.len(), 1);
+        assert_eq!(deleted.sources[0].name.as_str(), "github");
+        assert_workspace_not_found(
+            store.list_workspace_sources(&deleted.workspace.name),
+            &deleted.workspace.name,
         );
     }
 
@@ -1140,6 +1442,7 @@ limit = 2147483648
                 },
                 ..PersistedEngineConfig::default()
             },
+            workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
         };
 
@@ -1165,6 +1468,7 @@ flag = true
                 },
                 ..PersistedEngineConfig::default()
             },
+            workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
         };
 
@@ -1190,6 +1494,7 @@ flag = true
         let config = AppConfig {
             version: 1,
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
         };
 
@@ -1324,6 +1629,7 @@ max_concurrency = 0
         let config = AppConfig {
             version: 1,
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog,
         };
 
@@ -1429,6 +1735,7 @@ origin = "bundled"
         let config = AppConfig {
             version: 1,
             engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
             catalog,
         };
 

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -1,10 +1,12 @@
 //! Filesystem helpers for private directories, atomic writes, and file locks.
 
+use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 
 use fs2::FileExt;
+use uuid::Uuid;
 
 pub(crate) fn ensure_dir(path: &Path) -> io::Result<()> {
     if path.as_os_str().is_empty() || path == Path::new(".") {
@@ -73,6 +75,56 @@ pub(crate) fn replace_atomic(from: &Path, to: &Path) -> io::Result<()> {
     }
 
     Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) struct DirectoryBackup {
+    original: PathBuf,
+    backup: PathBuf,
+    moved: bool,
+}
+
+impl DirectoryBackup {
+    pub(crate) fn move_for_delete(path: &Path, name: impl fmt::Display) -> io::Result<Self> {
+        let backup = path.with_file_name(format!("{name}.delete.rollback.{}", Uuid::new_v4()));
+        if !path.try_exists()? {
+            return Ok(Self {
+                original: path.to_path_buf(),
+                backup,
+                moved: false,
+            });
+        }
+        if backup.try_exists()? {
+            fs::remove_dir_all(&backup)?;
+        }
+        fs::rename(path, &backup)?;
+        Ok(Self {
+            original: path.to_path_buf(),
+            backup,
+            moved: true,
+        })
+    }
+
+    pub(crate) fn backup_path(&self) -> &Path {
+        &self.backup
+    }
+
+    pub(crate) fn restore(&self) -> io::Result<()> {
+        if self.moved && self.backup.try_exists()? {
+            if self.original.try_exists()? {
+                fs::remove_dir_all(&self.original)?;
+            }
+            fs::rename(&self.backup, &self.original)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn commit(&self) -> io::Result<()> {
+        if self.moved && self.backup.try_exists()? {
+            fs::remove_dir_all(&self.backup)?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -209,4 +261,63 @@ fn set_file_permissions_private(path: &Path) -> io::Result<()> {
 #[cfg(not(unix))]
 fn set_file_permissions_private(_path: &Path) -> io::Result<()> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DirectoryBackup;
+
+    #[test]
+    fn directory_backup_moves_and_restores_delete_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source_dir = temp.path().join("github");
+        std::fs::create_dir(&source_dir).expect("create source dir");
+        std::fs::write(source_dir.join("manifest.yaml"), "name: github\n").expect("write file");
+
+        let backup = DirectoryBackup::move_for_delete(&source_dir, "github").expect("move backup");
+
+        assert!(!source_dir.exists());
+        assert!(backup.backup_path().exists());
+        assert!(
+            backup
+                .backup_path()
+                .file_name()
+                .expect("backup filename")
+                .to_string_lossy()
+                .starts_with("github.delete.rollback.")
+        );
+
+        backup.restore().expect("restore backup");
+
+        assert!(source_dir.join("manifest.yaml").exists());
+        assert!(!backup.backup_path().exists());
+    }
+
+    #[test]
+    fn directory_backup_commits_delete_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir(&workspace_dir).expect("create workspace dir");
+
+        let backup =
+            DirectoryBackup::move_for_delete(&workspace_dir, "workspace").expect("move backup");
+        backup.commit().expect("commit backup");
+
+        assert!(!workspace_dir.exists());
+        assert!(!backup.backup_path().exists());
+    }
+
+    #[test]
+    fn directory_backup_noops_for_missing_delete_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let missing_dir = temp.path().join("missing");
+
+        let backup =
+            DirectoryBackup::move_for_delete(&missing_dir, "missing").expect("prepare backup");
+        backup.restore().expect("restore missing");
+        backup.commit().expect("commit missing");
+
+        assert!(!missing_dir.exists());
+        assert!(!backup.backup_path().exists());
+    }
 }

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -1,0 +1,212 @@
+#![expect(dead_code, reason = "used in next stack PR")]
+
+use std::sync::Arc;
+
+use tracing::warn;
+
+use crate::bootstrap::AppError;
+use crate::credentials::{CredentialManager, CredentialSetId};
+use crate::state::AppStateLayout;
+use crate::storage::fs::DirectoryBackup;
+use crate::workspaces::{DeletedWorkspace, WorkspaceName, WorkspaceRecord, WorkspaceStore};
+
+/// App-owned workspace lifecycle behavior.
+#[derive(Clone)]
+pub(crate) struct WorkspaceManager {
+    store: Arc<dyn WorkspaceStore>,
+    credential_manager: CredentialManager,
+    layout: AppStateLayout,
+}
+
+impl WorkspaceManager {
+    pub(crate) fn new(
+        store: impl WorkspaceStore,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+    ) -> Self {
+        Self {
+            store: Arc::new(store),
+            credential_manager,
+            layout,
+        }
+    }
+
+    pub(crate) fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, AppError> {
+        self.store.list_workspaces()
+    }
+
+    pub(crate) fn create_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<WorkspaceRecord, AppError> {
+        self.store.create_workspace(workspace_name)
+    }
+
+    pub(crate) fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<WorkspaceRecord, AppError> {
+        if workspace_name.is_default() {
+            return Err(AppError::FailedPrecondition(
+                "default workspace cannot be removed".to_string(),
+            ));
+        }
+
+        let deleted = self
+            .store
+            .delete_workspace(workspace_name)?
+            .ok_or_else(|| AppError::WorkspaceNotFound(workspace_name.to_string()))?;
+        self.cleanup_deleted_workspace_artifacts(&deleted);
+        Ok(deleted.workspace)
+    }
+
+    fn cleanup_deleted_workspace_artifacts(&self, deleted: &DeletedWorkspace) {
+        self.remove_deleted_workspace_credentials(deleted);
+        self.remove_deleted_workspace_dir(&deleted.workspace.name);
+    }
+
+    fn remove_deleted_workspace_credentials(&self, deleted: &DeletedWorkspace) {
+        let workspace_name = &deleted.workspace.name;
+        for source in &deleted.sources {
+            let Some(storage) = source.credential_storage_for_material() else {
+                continue;
+            };
+            let credential_set_id = CredentialSetId::for_source(&source.name);
+            let guard = match self
+                .credential_manager
+                .material_guard(workspace_name, &credential_set_id)
+            {
+                Ok(guard) => guard,
+                Err(error) => {
+                    warn!(
+                        workspace = %workspace_name,
+                        source = %source.name,
+                        credential_set_id = %credential_set_id,
+                        "workspace deleted, but failed to access credential material for cleanup: {error}"
+                    );
+                    continue;
+                }
+            };
+            if let Err(error) = guard.remove_material(storage) {
+                warn!(
+                    workspace = %workspace_name,
+                    source = %source.name,
+                    credential_set_id = %credential_set_id,
+                    %storage,
+                    "workspace deleted, but failed to remove credential material: {error}"
+                );
+            }
+        }
+    }
+
+    fn remove_deleted_workspace_dir(&self, workspace_name: &WorkspaceName) {
+        let workspace_dir = self.layout.workspace_dir(workspace_name);
+        let backup = match DirectoryBackup::move_for_delete(&workspace_dir, workspace_name) {
+            Ok(backup) => backup,
+            Err(error) => {
+                warn!(
+                    workspace = %workspace_name,
+                    workspace_dir = %workspace_dir.display(),
+                    "workspace deleted, but failed to stage workspace directory cleanup: {error}"
+                );
+                return;
+            }
+        };
+        if let Err(error) = backup.commit() {
+            warn!(
+                workspace = %workspace_name,
+                backup_path = %backup.backup_path().display(),
+                "workspace deleted, but failed to remove workspace artifact backup: {error}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use tempfile::TempDir;
+
+    use super::WorkspaceManager;
+    use crate::credentials::{CredentialManager, CredentialSetId, CredentialStore};
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::{AppStateLayout, ConfigStore};
+    use crate::workspaces::WorkspaceName;
+
+    fn test_layout(temp: &TempDir) -> AppStateLayout {
+        AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout")
+    }
+
+    fn installed_source(name: &str) -> InstalledSource {
+        InstalledSource {
+            name: SourceName::parse(name).expect("source"),
+            version: Some("1.0.0".to_string()),
+            variables: BTreeMap::new(),
+            secrets: vec!["TOKEN".to_string()],
+            credential_storage: None,
+            origin: SourceOrigin::Imported,
+        }
+    }
+
+    #[test]
+    fn delete_workspace_commits_config_then_cleans_artifacts() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager =
+            WorkspaceManager::new(store.clone(), credential_manager.clone(), layout.clone());
+        let workspace_name = WorkspaceName::parse("work").expect("workspace");
+        let source = installed_source("github");
+        let credential_set_id = CredentialSetId::for_source(&source.name);
+
+        store
+            .create_workspace(&workspace_name)
+            .expect("create workspace");
+        store
+            .upsert_source(&workspace_name, source)
+            .expect("upsert source");
+        credential_manager
+            .replace_material(
+                &workspace_name,
+                &credential_set_id,
+                crate::credentials::CredentialStorageKind::File,
+                &BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+            )
+            .expect("write credential material");
+        std::fs::create_dir_all(layout.feedback_dir(&workspace_name)).expect("create feedback dir");
+        std::fs::write(
+            layout.feedback_reports_file(&workspace_name),
+            b"{\"message\":\"report\"}\n",
+        )
+        .expect("write workspace artifact");
+
+        let deleted = manager
+            .delete_workspace(&workspace_name)
+            .expect("delete workspace");
+
+        assert_eq!(deleted.name, workspace_name);
+        assert!(matches!(
+            store.list_workspace_sources(&workspace_name),
+            Err(crate::bootstrap::AppError::WorkspaceNotFound(_))
+        ));
+        assert!(
+            !layout.workspace_dir(&workspace_name).exists(),
+            "workspace artifact directory should be removed after config commit"
+        );
+        let material = credential_manager
+            .read_material(
+                &workspace_name,
+                &credential_set_id,
+                crate::credentials::CredentialStorageKind::File,
+            )
+            .expect("read credential material");
+        assert!(
+            material.is_empty(),
+            "credential material should be removed during best-effort cleanup"
+        );
+    }
+}

--- a/crates/coral-app/src/workspaces/mod.rs
+++ b/crates/coral-app/src/workspaces/mod.rs
@@ -1,4 +1,11 @@
+pub(crate) mod manager;
+pub(crate) mod model;
 pub(crate) mod name;
+pub(crate) mod store;
 
+#[expect(unused_imports, reason = "used in next stack PR")]
+pub(crate) use manager::WorkspaceManager;
+pub(crate) use model::{DeletedWorkspace, WorkspaceRecord};
 pub use name::DEFAULT_WORKSPACE_ID;
 pub(crate) use name::WorkspaceName;
+pub(crate) use store::WorkspaceStore;

--- a/crates/coral-app/src/workspaces/model.rs
+++ b/crates/coral-app/src/workspaces/model.rs
@@ -1,0 +1,15 @@
+use crate::workspaces::WorkspaceName;
+
+/// App-owned workspace metadata record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceRecord {
+    pub(crate) name: WorkspaceName,
+}
+
+/// Workspace metadata and scoped source state captured at the config deletion
+/// commit point for post-commit artifact cleanup.
+#[derive(Debug, Clone)]
+pub(crate) struct DeletedWorkspace {
+    pub(crate) workspace: WorkspaceRecord,
+    pub(crate) sources: Vec<crate::sources::model::InstalledSource>,
+}

--- a/crates/coral-app/src/workspaces/name.rs
+++ b/crates/coral-app/src/workspaces/name.rs
@@ -26,6 +26,11 @@ impl WorkspaceName {
     pub(crate) fn as_str(&self) -> &str {
         &self.0
     }
+
+    #[must_use]
+    pub(crate) fn is_default(&self) -> bool {
+        self.0 == DEFAULT_WORKSPACE_ID
+    }
 }
 
 impl fmt::Display for WorkspaceName {

--- a/crates/coral-app/src/workspaces/store.rs
+++ b/crates/coral-app/src/workspaces/store.rs
@@ -1,0 +1,15 @@
+use crate::bootstrap::AppError;
+use crate::workspaces::{DeletedWorkspace, WorkspaceName, WorkspaceRecord};
+
+/// Repository boundary for workspace metadata and workspace-owned source state.
+pub(crate) trait WorkspaceStore: Send + Sync + 'static {
+    fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, AppError>;
+
+    fn create_workspace(&self, workspace_name: &WorkspaceName)
+    -> Result<WorkspaceRecord, AppError>;
+
+    fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<DeletedWorkspace>, AppError>;
+}


### PR DESCRIPTION
## Intent

Resubmit the workspace state persistence change from PR #1403 on a real branch targeting `main`. The previously merged PR landed on a generated Graphite base branch instead of `main`, which left later stack PRs depending on `graphite-base/1404` without the changes actually being present on `main`.

## What it enables

- Persists workspace records and workspace-scoped installed sources in app config.
- Adds app-owned workspace lifecycle orchestration for list/create/delete.
- Keeps source and workspace deletion cleanup behind explicit state-lock and rollback/backup helpers.
- Allows the remaining workspace stack to target a meaningful base branch instead of `graphite-base/1404`.

## Usage examples

- Create a workspace through the app workspace manager and it is recorded durably in `config.toml`.
- Install sources in a workspace and subsequent catalog/query operations reject missing workspaces instead of silently treating them as empty.
- Delete a workspace and the config commit happens before best-effort credential and artifact cleanup.

## Validation

- `make rust-checks`