### PR TITLE
fix(mcp): surface SQL errors in tool content

### DIFF
--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -25,7 +25,7 @@ use harness::{MockServer, MockServerConfig};
 use jsonschema::JSONSchema;
 use rmcp::{
     RoleClient, ServiceExt,
-    model::{CallToolRequestParams, ReadResourceRequestParams},
+    model::{CallToolRequestParams, CallToolResult, ReadResourceRequestParams},
     service::RunningService,
     transport::{ConfigureCommandExt, TokioChildProcess},
 };
@@ -212,6 +212,15 @@ async fn structured_tool_content(
         "tool results should not duplicate structured payloads as text content"
     );
     Ok(result.structured_content.expect("structured content"))
+}
+
+fn tool_error_text(result: &CallToolResult) -> &str {
+    result
+        .content
+        .first()
+        .and_then(|content| content.as_text())
+        .map(|text| text.text.as_str())
+        .expect("tool error text content")
 }
 
 async fn write_jsonrpc_message(
@@ -1249,10 +1258,18 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
         )
         .await?;
     assert_eq!(mixed_sql.is_error, Some(true));
-    assert!(
-        mixed_sql.content.is_empty(),
-        "tool errors should not include text fallback content"
-    );
+    let mixed_sql_detail = mixed_sql
+        .structured_content
+        .as_ref()
+        .expect("structured content")["data"]["results"][1]["error"]["detail"]
+        .as_str()
+        .expect("structured query error detail")
+        .to_string();
+    {
+        let mixed_sql_text = tool_error_text(&mixed_sql);
+        assert!(mixed_sql_text.contains("Query [1]: Query request is invalid"));
+        assert!(mixed_sql_text.contains(&mixed_sql_detail));
+    }
     let mixed_sql = mixed_sql.structured_content.expect("structured content");
     assert_eq!(mixed_sql["error"]["reason"], "SQL_BATCH_PARTIAL_FAILURE");
     let mixed_sql_batch = &mixed_sql["data"];

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -1,5 +1,8 @@
 use coral_client::{DecodedStatusError, decode_status_error};
-use rmcp::{ErrorData, model::CallToolResult};
+use rmcp::{
+    ErrorData,
+    model::{CallToolResult, Content},
+};
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::Value;
@@ -20,6 +23,7 @@ pub(crate) struct ToolError {
 }
 
 pub(crate) fn tool_error_result(error: ToolError, data: Option<Value>) -> CallToolResult {
+    let content = vec![Content::text(tool_error_text(&error, data.as_ref()))];
     let structured = match data {
         Some(data) => serde_json::to_value(ToolErrorWithData { error, data })
             .expect("tool error value with data serializes"),
@@ -28,8 +32,60 @@ pub(crate) fn tool_error_result(error: ToolError, data: Option<Value>) -> CallTo
         }
     };
     let mut result = CallToolResult::structured_error(structured);
-    result.content = Vec::new();
+    result.content = content;
     result
+}
+
+fn tool_error_text(error: &ToolError, data: Option<&Value>) -> String {
+    let mut lines = vec![format!("Error: {}", error.summary)];
+    if !error.detail.trim().is_empty() && error.detail != error.summary {
+        lines.push(format!("Detail: {}", error.detail));
+    }
+    if let Some(hint) = error.hint.as_deref() {
+        lines.push(format!("Hint: {hint}"));
+    }
+    if error.reason.as_deref() == Some("SQL_BATCH_PARTIAL_FAILURE") {
+        lines.extend(query_error_text(data));
+    }
+    lines.join("\n")
+}
+
+fn query_error_text(data: Option<&Value>) -> Vec<String> {
+    let Some(results) = data
+        .and_then(|data| data.get("results"))
+        .and_then(Value::as_array)
+    else {
+        return Vec::new();
+    };
+
+    results
+        .iter()
+        .filter(|result| result.get("status").and_then(Value::as_str) == Some("error"))
+        .filter_map(|result| {
+            let error = result.get("error")?;
+            let summary = error
+                .get("summary")
+                .and_then(Value::as_str)
+                .unwrap_or("Query failed");
+            let detail = error.get("detail").and_then(Value::as_str).unwrap_or("");
+            let label = result
+                .get("index")
+                .and_then(Value::as_u64)
+                .map_or_else(|| "Query".to_string(), |index| format!("Query [{index}]"));
+            let mut lines = vec![format!("{label}: {summary}")];
+            if !detail.trim().is_empty() && detail != summary {
+                lines.push(format!("  Detail: {detail}"));
+            }
+            if let Some(hint) = error
+                .get("hint")
+                .and_then(Value::as_str)
+                .filter(|hint| !hint.trim().is_empty())
+            {
+                lines.push(format!("  Hint: {hint}"));
+            }
+            Some(lines.join("\n"))
+        })
+        .collect()
 }
 
 pub(crate) fn tool_error_from_status(operation: &str, status: &tonic::Status) -> ToolError {
@@ -150,13 +206,22 @@ mod tests {
 
     use std::collections::HashMap;
 
-    use rmcp::model::ErrorCode;
+    use rmcp::model::{CallToolResult, ErrorCode};
     use tonic::{Code, Status};
     use tonic_types::{ErrorDetail, StatusExt as _};
 
     use coral_client::CORAL_ERROR_DOMAIN;
 
     use super::{ToolError, status_to_error_data, tool_error_from_status, tool_error_result};
+
+    fn first_text_content(result: &CallToolResult) -> &str {
+        result
+            .content
+            .first()
+            .and_then(|content| content.as_text())
+            .map(|text| text.text.as_str())
+            .expect("tool error text content")
+    }
 
     #[test]
     fn tool_error_result_includes_structured_error_payload() {
@@ -173,7 +238,9 @@ mod tests {
             None,
         );
         assert_eq!(result.is_error, Some(true));
-        assert!(result.content.is_empty());
+        let text = first_text_content(&result);
+        assert!(text.contains("Error: Query failed"));
+        assert!(text.contains("Detail: planner error"));
         let json = result.structured_content.expect("structured content");
         assert_eq!(json["error"]["grpc_code"], "InvalidArgument");
         assert_eq!(json["error"]["retryable"], false);
@@ -201,10 +268,52 @@ mod tests {
         );
 
         assert_eq!(result.is_error, Some(true));
-        assert!(result.content.is_empty());
         let json = result.structured_content.expect("structured content");
         assert_eq!(json["error"]["reason"], "SQL_BATCH_PARTIAL_FAILURE");
         assert_eq!(json["data"]["total_count"], 2);
+    }
+
+    #[test]
+    fn tool_error_result_surfaces_per_query_detail_in_content() {
+        let result = tool_error_result(
+            ToolError {
+                summary: "One or more SQL queries failed".to_string(),
+                detail: "Inspect `data.results` for per-query successes and errors.".to_string(),
+                hint: None,
+                grpc_code: "Unknown".to_string(),
+                reason: Some("SQL_BATCH_PARTIAL_FAILURE".to_string()),
+                retryable: false,
+                metadata: HashMap::new(),
+            },
+            Some(serde_json::json!({
+                "total_count": 2,
+                "results": [
+                    {
+                        "index": 0,
+                        "status": "success",
+                        "rows": []
+                    },
+                    {
+                        "index": 1,
+                        "status": "error",
+                        "error": {
+                            "summary": "Query request is invalid",
+                            "detail": "table 'nope' not found",
+                            "hint": "Check the SQL and retry.",
+                            "grpc_code": "InvalidArgument",
+                            "retryable": false,
+                            "metadata": {}
+                        }
+                    }
+                ]
+            })),
+        );
+
+        let text = first_text_content(&result);
+        assert!(text.contains("Query [1]: Query request is invalid"));
+        assert!(text.contains("  Detail: table 'nope' not found"));
+        assert!(text.contains("  Hint: Check the SQL and retry."));
+        assert!(!text.contains("Query [0]"));
     }
 
     #[test]

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -381,6 +381,19 @@ fn assert_structured_content_only(result: &CallToolResult) {
     );
 }
 
+fn assert_tool_error_text_contains(result: &CallToolResult, expected: &str) {
+    let text = result
+        .content
+        .first()
+        .and_then(|content| content.as_text())
+        .map(|text| text.text.as_str())
+        .expect("tool error text content");
+    assert!(
+        text.contains(expected),
+        "tool error text should contain {expected:?}, got {text:?}"
+    );
+}
+
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,
@@ -1600,7 +1613,15 @@ async fn mcp_tool_error_does_not_end_session() {
         .await
         .expect("mixed sql still returns tool result");
     assert_eq!(mixed_sql.is_error, Some(true));
-    assert_structured_content_only(&mixed_sql);
+    let mixed_sql_detail = mixed_sql
+        .structured_content
+        .as_ref()
+        .expect("structured content")["data"]["results"][1]["error"]["detail"]
+        .as_str()
+        .expect("structured query error detail")
+        .to_string();
+    assert_tool_error_text_contains(&mixed_sql, "Query [1]: Query request is invalid");
+    assert_tool_error_text_contains(&mixed_sql, &mixed_sql_detail);
     let mixed_sql = mixed_sql.structured_content.expect("structured content");
     assert_matches_output_schema(sql_tool, &mixed_sql);
     assert_eq!(mixed_sql["error"]["reason"], "SQL_BATCH_PARTIAL_FAILURE");

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -180,114 +180,56 @@ Coral uses stdio transport. If a client supports a command-based install flow, p
 
 ### Verify the connection
 
-Once your client is connected, ask the agent to list available tables or run a simple database query. Examples:
+Once your client is connected, ask the agent to list available Coral tables or run a small query.
 
-> "List the tables available in Coral."
+> "Use Coral to show what sources and tables you can query."
 
 > "Run a small Coral query against `coral.tables`."
 
-The agent should call `list_catalog`, `search_catalog`, or query `coral.tables` and `coral.table_functions` to return SQL schemas and catalog items, and use `describe_table` or `list_columns` for table-specific metadata. Large catalogs should be paged with `limit` and `offset`.
+If it works, the agent should return installed schemas and tables. You do not need to know the MCP tool names; the agent gets discovery helpers and a read-only SQL interface to the same sources you use from `coral sql`.
 
-## Available tools and resources
+## What your agent can do
 
-| Type     | Name             | Description                                             |
-| -------- | ---------------- | ------------------------------------------------------- |
-| Tool     | `sql`            | Execute 1 to 10 independent read-only SQL queries against the Coral database |
-| Tool     | `list_catalog`   | List database tables and table functions with pagination |
-| Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
-| Tool     | `describe_table` | Show compact metadata for one database table            |
-| Tool     | `list_columns`   | List columns for one database table with pagination     |
-| Resource | `coral://guide`  | Database workflow guide for agents                     |
-| Resource | `coral://tables` | JSON summaries of query-visible database tables, including Coral catalog tables and required filters |
+Coral gives your agent a read-only SQL view over the sources you have installed locally. That means your agent can:
 
-Clients see the same database catalog and query results as `coral sql`. You set up sources with the CLI, then agents query Coral over MCP as SQL schemas and tables.
+- inspect the available sources, tables, columns, filters, and table functions
+- query connected sources without configuring a separate MCP server for each provider
+- join and aggregate across sources when the question needs more than one API call
+- use the same local credentials and workspace state as the Coral CLI
 
-The `coral` system schema is part of that catalog. No-schema `list_catalog` and `coral://tables` include both configured source tables and Coral catalog tables: `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs`. Agents can also call `describe_table` and `list_columns` on those system tables.
+Set up and update sources with the CLI. The MCP server is the agent-facing query surface, not a source installer.
 
-Agents should treat the discovery tools as catalog helpers, not as replacement provider APIs. Tool descriptions include connected source/schema names, such as `github` or `slack`, to help clients route provider-specific prompts to Coral. For dependent data questions, prefer one SQL statement using `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions. For several independent questions, use one `sql` tool call with multiple `queries[]` entries.
+Only connect Coral to agents you trust. A connected agent can query any source installed in that Coral workspace. See [Security](/project/security) for more detail.
 
-### Discovery tools
+## How to ask for Coral
 
-**`list_catalog`**: paginated list of database tables and parameterized table functions.
+When your agent has many tools available, name Coral explicitly:
 
-- Arguments: optional `schema`, `kind`, `limit`, `offset`. Omit `kind` (or pass `null`) to include both `"table"` and `"table_function"` items.
-- For tables, use `sql_reference` in `FROM` and `JOIN` clauses.
-- For table functions, use `sql_call_example` and fill in the required arguments.
-- Do not quote the whole `schema.item` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
+> "Use Coral to find the latest open GitHub issues assigned to me."
 
-**`search_catalog`**: deterministic regex matching over database catalog metadata.
+> "Use Coral to compare recent deploy errors in Datadog with related Slack messages."
 
-- Arguments: required `pattern` plus optional `schema`, `kind`, `ignore_case`, `limit`, `offset`.
+> "Use Coral. First inspect the catalog, then query the right tables."
 
-**`describe_table`**: compact metadata for one table.
+Good agents will inspect Coral's catalog before writing SQL, then answer from query results. If an answer needs data from multiple connected sources, ask the agent to combine the data in Coral when possible.
 
-- Arguments: exact `schema` and `table`.
-- Returns guide text, required filters, and a column count without dumping full columns.
+## Workspaces
 
-**`list_columns`**: paginated columns for one table.
-
-- Arguments: exact `schema` and `table`, plus optional `pattern`, `ignore_case`, `required_only`, `limit`, `offset`.
-- For existing tables, returns a `columns` page with `total`, `has_more`, and optional `next_offset`. When `pattern` is set, matching rows include `matched_fields` so clients can explain why a column matched.
-- When the requested table does not exist, returns `found: false` with recovery hints instead of an empty page. Clients should branch to `search_catalog` or `list_catalog` rather than pretending the table has zero columns.
-
-### Richer metadata when using SQL tool
-
-When the agent needs metadata it can filter, join, sort, or aggregate before writing the final SQL, query `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` through the `sql` tool instead of relying only on `list_catalog` or `coral://tables`. Use `coral.filters` as the normalized filter surface, with `coral.columns.filter_mode` available when inspecting filter-only virtual columns.
-
-### SQL tool input
-
-The `sql` tool accepts a required `queries` array, not a top-level `sql` string:
+By default, `coral mcp-stdio` uses your default Coral workspace. If you use a named workspace, add `--workspace <name>` to the server args in your MCP config. For JSON-style clients, that looks like:
 
 ```json
 {
-  "queries": [
-    "SELECT table_name FROM coral.tables WHERE schema_name = 'github' ORDER BY table_name",
-    "SELECT column_name, data_type FROM coral.columns WHERE schema_name = 'github' AND table_name = 'pulls' ORDER BY ordinal_position"
-  ]
-}
-```
-
-Each entry must be one independent read-only SQL statement. Coral starts entries concurrently, so a later entry must not depend on rows, errors, or side effects from an earlier entry. If the work is dependent, combine it into one SQL statement or make separate tool calls after inspecting each result.
-
-`queries` must contain 1 to 10 non-blank strings. Missing `queries`, an empty array, more than 10 entries, non-string entries, and blank strings are MCP argument errors and do not dispatch any SQL.
-
-### Searching a provider's data
-
-Some sources expose native search endpoints (for example, GitHub issue search) as table functions with `kind = 'search'`. Prefer these over scanning a regular table when the agent needs ranked, query-driven results. They return provider-ranked candidates, so agents should preserve any returned rank columns and use the returned ids plus catalog-described tables to fetch full detail rows when the search result itself is incomplete.
-
-## Query result format
-
-MCP tool results use `structuredContent` for rows and errors. The `content` array is empty for successful tool results and structured tool errors, so clients should not parse text content.
-
-When every query succeeds, the `sql` tool returns one ordered batch:
-
-```json
-{
-  "total_count": 2,
-  "success_count": 2,
-  "error_count": 0,
-  "results": [
-    {
-      "index": 0,
-      "status": "success",
-      "rows": [{ "table_name": "pulls" }]
-    },
-    {
-      "index": 1,
-      "status": "success",
-      "rows": [{ "column_name": "title", "data_type": "Utf8" }]
+  "mcpServers": {
+    "coral": {
+      "command": "coral",
+      "args": ["mcp-stdio", "--workspace", "work"]
     }
-  ]
+  }
 }
 ```
-
-`results` is ordered to match `queries`, and each item includes its zero-based `index`.
-
-If any query fails, the MCP tool result is marked as an error. The top-level `error` describes the batch failure, and `data` contains the same ordered batch with successful items and per-query error items.
-
-Successful SQL rows are JSON objects. In MCP results, precision-sensitive numeric values such as `Int64`, `UInt64`, and decimals are encoded as JSON strings to avoid precision loss in JSON clients. The CLI is unaffected: `coral sql --format json` keeps emitting these types as JSON numbers.
 
 ## Troubleshooting
 
 - **`coral` not found:** Make sure `coral` is on your `PATH`, or use the full path from `which coral` on macOS or Linux or `(Get-Command coral).Source` in PowerShell.
 - **No tables visible:** Run `coral source list` in your terminal to confirm you have sources installed. If empty, add one with `coral source add`. See the [CLI reference](/reference/cli-reference#coral-source).
+- **The agent ignores Coral:** Ask it to use Coral by name. For stronger routing, install the Coral agent skills from [Installation](/getting-started/installation#skills).

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -315,7 +315,7 @@ Catalog helpers include the `coral` system schema, so `list_catalog`,
 `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and
 `coral.inputs`.
 
-For client setup and MCP result-format details, see [Use Coral over MCP](/guides/use-coral-over-mcp).
+For client setup, see [Use Coral over MCP](/guides/use-coral-over-mcp).
 
 ## `coral completion <SHELL>`
 


### PR DESCRIPTION
## Summary

MCP clients that only surface text content were losing SQL failure details when tool errors moved into a structuredContent-first envelope. This keeps the structured error envelope canonical while adding a readable text mirror for tool errors, including per-query SQL error details for partial batch failures.

The MCP setup guide now stays focused on humans configuring agents, instead of reading like a protocol contract for MCP client implementers.

## Changes

- Add text content to MCP tool error results while preserving the structured error payload.
- Render failed SQL query summaries, details, and hints into the text mirror.
- Cover the behavior in MCP unit/integration tests and the CLI stdio MCP regression.
- Prune the Use Coral over MCP guide to setup, verification, agent prompts, workspaces, and troubleshooting.

## Verification

- cargo fmt --check
- cargo test -p coral-mcp tool_error --all-features
- cargo test -p coral-cli --features cli-test-server --test mcp mcp_stdio_tool_errors_do_not_end_the_session
- make docs-check
- make rust-checks
- git diff --check
- autoreview --mode local
