### PR TITLE
feat(engine): support named query parameters

### DIFF
--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -12,10 +12,10 @@ pub use catalog::{
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
     DependentJoinConfig, DependentJoinSourceConfig, EffectiveDependentJoinConfig, MemorySize,
-    QueryExecution, QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue,
-    QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure, QueryTestResult, QueryTestSuccess,
-    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
+    QueryExecution, QueryExecutionProvenance, QueryMemoryConfig, QueryParameterType,
+    QueryParameterValue, QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
+    QuerySource, QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure, QueryTestResult,
+    QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -12,10 +12,10 @@ pub use catalog::{
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
     DependentJoinConfig, DependentJoinSourceConfig, EffectiveDependentJoinConfig, MemorySize,
-    QueryExecution, QueryExecutionProvenance, QueryMemoryConfig, QueryPlan, QueryRuntimeConfig,
-    QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure,
-    QueryTestResult, QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage,
-    SourceValidationReport,
+    QueryExecution, QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue,
+    QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure, QueryTestResult, QueryTestSuccess,
+    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -371,26 +371,145 @@ impl QueryRuntimeContext {
 
 /// Named SQL query parameters, keyed by parameter name without the `$`
 /// prefix: binding `owner` supplies `$owner` in the statement.
-pub type QueryParameters = BTreeMap<String, QueryParameterValue>;
-
-/// Value bound to one named SQL query parameter (`$name`).
 ///
-/// Values are data, never SQL text: they bind into the planned statement
-/// through `DataFusion` parameter substitution, so no quoting or escaping
-/// rules apply anywhere in the request path.
+/// Values are typed Coral scalar values. Callers should treat values as data,
+/// never SQL text.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct QueryParameters {
+    values: BTreeMap<String, QueryParameterValue>,
+}
+
+impl QueryParameters {
+    /// Builds an empty parameter set.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns true when no parameters are present.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Inserts one named parameter value and returns the previous value.
+    pub fn insert(
+        &mut self,
+        name: impl Into<String>,
+        value: QueryParameterValue,
+    ) -> Option<QueryParameterValue> {
+        self.values.insert(name.into(), value)
+    }
+
+    /// Iterates over parameter names and values in deterministic order.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &QueryParameterValue)> {
+        self.values.iter()
+    }
+
+    /// Iterates over parameter names in deterministic order.
+    pub fn keys(&self) -> impl Iterator<Item = &String> {
+        self.values.keys()
+    }
+}
+
+impl From<BTreeMap<String, QueryParameterValue>> for QueryParameters {
+    fn from(values: BTreeMap<String, QueryParameterValue>) -> Self {
+        Self { values }
+    }
+}
+
+impl<const N: usize> From<[(String, QueryParameterValue); N]> for QueryParameters {
+    fn from(values: [(String, QueryParameterValue); N]) -> Self {
+        Self {
+            values: BTreeMap::from(values),
+        }
+    }
+}
+
+impl FromIterator<(String, QueryParameterValue)> for QueryParameters {
+    fn from_iter<T: IntoIterator<Item = (String, QueryParameterValue)>>(iter: T) -> Self {
+        Self {
+            values: iter.into_iter().collect(),
+        }
+    }
+}
+
+/// Scalar types supported by named SQL query parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum QueryParameterType {
+    /// UTF-8 string.
+    String,
+    /// 64-bit signed integer.
+    Integer,
+    /// 64-bit floating point value.
+    Float,
+    /// Boolean.
+    Boolean,
+}
+
+/// One typed SQL query parameter value.
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum QueryParameterValue {
-    /// UTF-8 string value.
-    String(String),
-    /// 64-bit signed integer value.
-    Integer(i64),
-    /// 64-bit floating point value.
-    Float(f64),
-    /// Boolean value.
-    Boolean(bool),
-    /// SQL NULL.
-    Null,
+    /// UTF-8 string value, or a typed string NULL.
+    String(Option<String>),
+    /// 64-bit signed integer value, or a typed integer NULL.
+    Integer(Option<i64>),
+    /// 64-bit floating point value, or a typed float NULL.
+    Float(Option<f64>),
+    /// Boolean value, or a typed boolean NULL.
+    Boolean(Option<bool>),
+}
+
+impl QueryParameterValue {
+    /// Builds a non-null string parameter.
+    #[must_use]
+    pub fn string(value: impl Into<String>) -> Self {
+        Self::String(Some(value.into()))
+    }
+
+    /// Builds a typed string NULL parameter.
+    #[must_use]
+    pub fn null_string() -> Self {
+        Self::String(None)
+    }
+
+    /// Builds a non-null integer parameter.
+    #[must_use]
+    pub fn integer(value: i64) -> Self {
+        Self::Integer(Some(value))
+    }
+
+    /// Builds a typed integer NULL parameter.
+    #[must_use]
+    pub fn null_integer() -> Self {
+        Self::Integer(None)
+    }
+
+    /// Builds a non-null float parameter.
+    #[must_use]
+    pub fn float(value: f64) -> Self {
+        Self::Float(Some(value))
+    }
+
+    /// Builds a typed float NULL parameter.
+    #[must_use]
+    pub fn null_float() -> Self {
+        Self::Float(None)
+    }
+
+    /// Builds a non-null boolean parameter.
+    #[must_use]
+    pub fn boolean(value: bool) -> Self {
+        Self::Boolean(Some(value))
+    }
+
+    /// Builds a typed boolean NULL parameter.
+    #[must_use]
+    pub fn null_boolean() -> Self {
+        Self::Boolean(None)
+    }
 }
 
 /// Owned runtime-build inputs needed while compiling and registering sources.

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -379,6 +379,7 @@ pub type QueryParameters = BTreeMap<String, QueryParameterValue>;
 /// through `DataFusion` parameter substitution, so no quoting or escaping
 /// rules apply anywhere in the request path.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum QueryParameterValue {
     /// UTF-8 string value.
     String(String),

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -369,6 +369,29 @@ impl QueryRuntimeContext {
     }
 }
 
+/// Named SQL query parameters, keyed by parameter name without the `$`
+/// prefix: binding `owner` supplies `$owner` in the statement.
+pub type QueryParameters = BTreeMap<String, QueryParameterValue>;
+
+/// Value bound to one named SQL query parameter (`$name`).
+///
+/// Values are data, never SQL text: they bind into the planned statement
+/// through `DataFusion` parameter substitution, so no quoting or escaping
+/// rules apply anywhere in the request path.
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryParameterValue {
+    /// UTF-8 string value.
+    String(String),
+    /// 64-bit signed integer value.
+    Integer(i64),
+    /// 64-bit floating point value.
+    Float(f64),
+    /// Boolean value.
+    Boolean(bool),
+    /// SQL NULL.
+    Null,
+}
+
 /// Owned runtime-build inputs needed while compiling and registering sources.
 #[derive(Default)]
 pub struct QueryRuntimeConfig {

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -69,11 +69,12 @@ pub use composition::{
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
     DescribeTableInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution,
-    QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage,
-    QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
-    RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
-    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
+    QueryExecutionProvenance, QueryMemoryConfig, QueryParameterType, QueryParameterValue,
+    QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure, QueryTestResult, QueryTestSuccess,
+    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport, StatusCode,
+    StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
+    TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// High-level query operations for the local query engine.

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -69,11 +69,11 @@ pub use composition::{
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
     DescribeTableInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution,
-    QueryExecutionProvenance, QueryMemoryConfig, QueryPlan, QueryRuntimeConfig,
-    QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure,
-    QueryTestResult, QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage,
-    SourceValidationReport, StatusCode, StructuredQueryError, TableFunctionArgumentInfo,
-    TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
+    QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage,
+    QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
+    RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
+    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// High-level query operations for the local query engine.
@@ -155,13 +155,30 @@ impl CoralQuery {
         runtime: QueryRuntimeConfig,
         sql: &str,
     ) -> Result<QueryExecution, CoreError> {
+        Self::execute_sql_with_params(sources, runtime, sql, QueryParameters::new()).await
+    }
+
+    /// Executes one `SQL` statement with named query parameter values bound
+    /// into its `$name` placeholders.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the SQL is empty, if source compilation fails,
+    /// if a supplied parameter is not referenced by the statement, or if the
+    /// runtime cannot execute the statement.
+    pub async fn execute_sql_with_params(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        sql: &str,
+        params: QueryParameters,
+    ) -> Result<QueryExecution, CoreError> {
         if sql.trim().is_empty() {
             return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
         }
 
         runtime::query::build_runtime(sources, runtime)
             .await?
-            .execute_sql(sql)
+            .execute_sql(sql, &params)
             .await
     }
 
@@ -179,13 +196,30 @@ impl CoralQuery {
         runtime: QueryRuntimeConfig,
         sql: &str,
     ) -> Result<QueryPlan, CoreError> {
+        Self::explain_sql_with_params(sources, runtime, sql, QueryParameters::new()).await
+    }
+
+    /// Explains one `SQL` statement with named query parameter values bound
+    /// into its `$name` placeholders before planning output is rendered.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the SQL is empty, if source compilation fails,
+    /// if a supplied parameter is not referenced by the statement, or if the
+    /// query engine cannot explain the statement.
+    pub async fn explain_sql_with_params(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        sql: &str,
+        params: QueryParameters,
+    ) -> Result<QueryPlan, CoreError> {
         if sql.trim().is_empty() {
             return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
         }
 
         runtime::query::build_runtime(sources, runtime)
             .await?
-            .explain_sql(sql)
+            .explain_sql(sql, &params)
             .await
     }
 
@@ -235,7 +269,10 @@ impl CoralQuery {
 
         let mut query_tests = Vec::with_capacity(test_queries.len());
         for sql in test_queries {
-            match query_runtime.execute_sql(sql).await {
+            match query_runtime
+                .execute_sql(sql, &QueryParameters::new())
+                .await
+            {
                 Ok(execution) => query_tests.push(QueryTestResult::success(
                     sql.clone(),
                     execution.row_count() as u64,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -3,13 +3,13 @@
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
-use datafusion::common::tree_node::TreeNodeRecursion;
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::common::{ScalarValue, TableReference};
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
-use datafusion::logical_expr::LogicalPlan;
+use datafusion::logical_expr::{Expr, LogicalPlan};
 use datafusion::physical_plan::displayable;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
 use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
@@ -32,7 +32,9 @@ use crate::runtime::query_planner::CoralQueryPlanner;
 use crate::runtime::registry::{
     CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationFailure, register_sources,
 };
-use crate::runtime::source_functions::{SourceFunctionNode, SourceFunctionRegistry};
+use crate::runtime::source_functions::{
+    SOURCE_FUNCTION_NODE_NAME, SourceFunctionNode, SourceFunctionRegistry,
+};
 use crate::{
     CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, MemorySize, QueryExecution,
     QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
@@ -642,14 +644,63 @@ fn apply_query_parameters(
     params: &QueryParameters,
 ) -> Result<DataFrame, DataFusionError> {
     if params.is_empty() {
+        reject_unbound_sql_parameters(df.logical_plan())?;
         return Ok(df);
     }
     reject_unknown_parameters(df.logical_plan(), params)?;
     let values: Vec<(String, ScalarValue)> = params
         .iter()
-        .map(|(name, value)| (name.clone(), parameter_scalar_value(value)))
+        .map(|(name, value)| (name.clone(), query_parameter_scalar_value(value)))
         .collect();
     df.with_param_values(values)
+}
+
+fn reject_unbound_sql_parameters(plan: &LogicalPlan) -> Result<(), DataFusionError> {
+    let mut placeholders = ordinary_sql_placeholders(plan)?;
+    if placeholders.is_empty() {
+        return Ok(());
+    }
+    let placeholder = placeholders
+        .pop_first()
+        .expect("empty placeholder set returned above");
+    Err(DataFusionError::Plan(format!(
+        "SQL parameter {placeholder} has no value; pass query parameters or remove the placeholder"
+    )))
+}
+
+fn ordinary_sql_placeholders(plan: &LogicalPlan) -> Result<BTreeSet<String>, DataFusionError> {
+    let mut placeholders = BTreeSet::new();
+    plan.apply_with_subqueries(|node| {
+        if is_parameterized_source_function_call(node) {
+            return Ok(TreeNodeRecursion::Jump);
+        }
+        node.apply_expressions(|expr| {
+            expr.apply(|expr| {
+                if let Expr::Placeholder(placeholder) = expr {
+                    placeholders.insert(placeholder.id.clone());
+                }
+                Ok(TreeNodeRecursion::Continue)
+            })
+        })?;
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(placeholders)
+}
+
+fn is_parameterized_source_function_call(plan: &LogicalPlan) -> bool {
+    let LogicalPlan::Extension(extension) = plan else {
+        return false;
+    };
+    extension.node.name() == SOURCE_FUNCTION_NODE_NAME
+}
+
+fn query_parameter_scalar_value(value: &QueryParameterValue) -> ScalarValue {
+    match value {
+        QueryParameterValue::String(value) => ScalarValue::Utf8(value.clone()),
+        QueryParameterValue::Integer(value) => ScalarValue::Int64(*value),
+        QueryParameterValue::Float(value) => ScalarValue::Float64(*value),
+        QueryParameterValue::Boolean(value) => ScalarValue::Boolean(*value),
+    }
 }
 
 fn reject_unknown_parameters(
@@ -679,16 +730,6 @@ fn reject_unknown_parameters(
         "unknown query parameter(s): {}; {placeholder_hint}",
         unknown.join(", ")
     )))
-}
-
-fn parameter_scalar_value(value: &QueryParameterValue) -> ScalarValue {
-    match value {
-        QueryParameterValue::String(value) => ScalarValue::Utf8(Some(value.clone())),
-        QueryParameterValue::Integer(value) => ScalarValue::Int64(Some(*value)),
-        QueryParameterValue::Float(value) => ScalarValue::Float64(Some(*value)),
-        QueryParameterValue::Boolean(value) => ScalarValue::Boolean(Some(*value)),
-        QueryParameterValue::Null => ScalarValue::Null,
-    }
 }
 
 fn is_missing_required_filter_failure(error: &SqlExecutionFailure) -> bool {

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -3,8 +3,8 @@
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
-use datafusion::common::TableReference;
 use datafusion::common::tree_node::TreeNodeRecursion;
+use datafusion::common::{ScalarValue, TableReference};
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
@@ -35,9 +35,9 @@ use crate::runtime::registry::{
 use crate::runtime::source_functions::{SourceFunctionNode, SourceFunctionRegistry};
 use crate::{
     CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, MemorySize, QueryExecution,
-    QueryExecutionProvenance, QueryMemoryConfig, QueryPlan, QueryResultObserver,
-    QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    QueryTableFunctionUsage, QueryTableUsage, RequestAuthenticator, SourceDecorator,
+    QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
+    QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext,
+    QuerySource, QueryTableFunctionUsage, QueryTableUsage, RequestAuthenticator, SourceDecorator,
     SourceInputResolver, TableFunctionInfo, TableInfo,
 };
 
@@ -364,8 +364,12 @@ impl QueryRuntimeAdapter {
             .find(|failure| failure.schema_name == source_name)
     }
 
-    pub(crate) async fn execute_sql(&self, sql: &str) -> Result<QueryExecution, CoreError> {
-        match self.execute_sql_once(&self.ctx, sql).await {
+    pub(crate) async fn execute_sql(
+        &self,
+        sql: &str,
+        params: &QueryParameters,
+    ) -> Result<QueryExecution, CoreError> {
+        match self.execute_sql_once(&self.ctx, sql, params).await {
             Ok(execution) => Ok(execution),
             Err(SqlExecutionFailure::Collection(error)) => {
                 // Resolver-row overflow is a dependent-join buffering limit, not
@@ -394,7 +398,7 @@ impl QueryRuntimeAdapter {
                     .get_or_build_without_dependent_join()
                     .await?;
 
-                match self.execute_sql_once(&fallback.ctx, sql).await {
+                match self.execute_sql_once(&fallback.ctx, sql, params).await {
                     Ok(execution) => Ok(execution),
                     Err(error) => {
                         if is_missing_required_filter_failure(&error) {
@@ -413,11 +417,13 @@ impl QueryRuntimeAdapter {
         &self,
         ctx: &SessionContext,
         sql: &str,
+        params: &QueryParameters,
     ) -> Result<QueryExecution, SqlExecutionFailure> {
         let df = ctx
             .sql_with_options(sql, read_only_sql_options())
             .await
             .map_err(SqlExecutionFailure::Planning)?;
+        let df = apply_query_parameters(df, params).map_err(SqlExecutionFailure::Planning)?;
         let arrow_schema = Arc::new(df.schema().as_arrow().clone());
         let provenance = self
             .query_provenance(sql, df.logical_plan())
@@ -568,8 +574,12 @@ impl QueryRuntimeAdapter {
             .unwrap_or_else(|| schema_name.to_string())
     }
 
-    pub(crate) async fn explain_sql(&self, sql: &str) -> Result<QueryPlan, CoreError> {
-        let df = self.sql_dataframe(sql).await?;
+    pub(crate) async fn explain_sql(
+        &self,
+        sql: &str,
+        params: &QueryParameters,
+    ) -> Result<QueryPlan, CoreError> {
+        let df = self.sql_dataframe(sql, params).await?;
         let unoptimized_logical_plan = df.logical_plan().display_indent_schema().to_string();
         let (session_state, logical_plan) = df.into_parts();
         let optimized_logical_plan = session_state
@@ -594,8 +604,13 @@ impl QueryRuntimeAdapter {
         ))
     }
 
-    async fn sql_dataframe(&self, sql: &str) -> Result<DataFrame, CoreError> {
-        self.ctx
+    async fn sql_dataframe(
+        &self,
+        sql: &str,
+        params: &QueryParameters,
+    ) -> Result<DataFrame, CoreError> {
+        let df = self
+            .ctx
             .sql_with_options(sql, read_only_sql_options())
             .await
             .map_err(|err| {
@@ -605,7 +620,74 @@ impl QueryRuntimeAdapter {
                     &self.table_functions,
                     Some(sql),
                 )
-            })
+            })?;
+        apply_query_parameters(df, params).map_err(|err| {
+            datafusion_to_core_with_sql_and_table_functions(
+                &err,
+                &self.tables,
+                &self.table_functions,
+                Some(sql),
+            )
+        })
+    }
+}
+
+/// Binds named query parameter values into a planned statement.
+///
+/// Rejects parameters the statement never references, then substitutes the
+/// values into the logical plan via `DataFusion` parameter binding — values
+/// stay data and are never rendered into SQL text.
+fn apply_query_parameters(
+    df: DataFrame,
+    params: &QueryParameters,
+) -> Result<DataFrame, DataFusionError> {
+    if params.is_empty() {
+        return Ok(df);
+    }
+    reject_unknown_parameters(df.logical_plan(), params)?;
+    let values: Vec<(String, ScalarValue)> = params
+        .iter()
+        .map(|(name, value)| (name.clone(), parameter_scalar_value(value)))
+        .collect();
+    df.with_param_values(values)
+}
+
+fn reject_unknown_parameters(
+    plan: &LogicalPlan,
+    params: &QueryParameters,
+) -> Result<(), DataFusionError> {
+    let referenced = plan.get_parameter_names()?;
+    let mut unknown: Vec<&str> = params
+        .keys()
+        .map(String::as_str)
+        .filter(|name| !referenced.contains(&format!("${name}")))
+        .collect();
+    if unknown.is_empty() {
+        return Ok(());
+    }
+    unknown.sort_unstable();
+
+    let mut placeholders: Vec<&str> = referenced.iter().map(String::as_str).collect();
+    placeholders.sort_unstable();
+    let placeholder_hint = if placeholders.is_empty() {
+        "the statement has no parameter placeholders".to_string()
+    } else {
+        format!("the statement references: {}", placeholders.join(", "))
+    };
+
+    Err(DataFusionError::Plan(format!(
+        "unknown query parameter(s): {}; {placeholder_hint}",
+        unknown.join(", ")
+    )))
+}
+
+fn parameter_scalar_value(value: &QueryParameterValue) -> ScalarValue {
+    match value {
+        QueryParameterValue::String(value) => ScalarValue::Utf8(Some(value.clone())),
+        QueryParameterValue::Integer(value) => ScalarValue::Int64(Some(*value)),
+        QueryParameterValue::Float(value) => ScalarValue::Float64(Some(*value)),
+        QueryParameterValue::Boolean(value) => ScalarValue::Boolean(Some(*value)),
+        QueryParameterValue::Null => ScalarValue::Null,
     }
 }
 

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -38,6 +38,8 @@ use crate::runtime::scoped_table_functions::{
     reject_settings, reject_unsupported_modifiers,
 };
 
+pub(crate) const SOURCE_FUNCTION_NODE_NAME: &str = "CoralSourceFunction";
+
 #[derive(Debug)]
 pub(crate) struct SourceFunctionRegistry {
     functions: HashMap<ScopedTableFunctionName, SourceFunction>,
@@ -291,7 +293,7 @@ impl PartialOrd for SourceFunctionNode {
 
 impl UserDefinedLogicalNodeCore for SourceFunctionNode {
     fn name(&self) -> &'static str {
-        "CoralSourceFunction"
+        SOURCE_FUNCTION_NODE_NAME
     }
 
     fn inputs(&self) -> Vec<&LogicalPlan> {

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -9,8 +9,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use coral_engine::{
-    CoralQuery, CoreError, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext,
-    RequestAuthenticator, RequestAuthenticatorError, StatusCode,
+    CoralQuery, CoreError, EngineExtensions, QueryParameterValue, QueryParameters,
+    QueryRuntimeConfig, QueryRuntimeContext, RequestAuthenticator, RequestAuthenticatorError,
+    StatusCode,
 };
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use serde_json::{Value, json};
@@ -3156,4 +3157,204 @@ async fn legacy_json_body_array_form_still_works() {
     );
 
     assert_eq!(rows, users_rows());
+}
+
+fn string_param(name: &str, value: &str) -> (String, QueryParameterValue) {
+    (
+        name.to_string(),
+        QueryParameterValue::String(value.to_string()),
+    )
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_binds_query_parameters() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param("search_type", "hybrid"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("param_search", &server.uri()));
+    let params = QueryParameters::from([
+        string_param("q", "flaky cleanup repo:withcoral/coral"),
+        string_param("mode", "hybrid"),
+    ]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[source],
+            test_runtime(),
+            "SELECT title, score FROM param_search.search_issues(q => $q, mode => $mode)",
+            params,
+        )
+        .await
+        .expect("parameterized source function call should bind and execute"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_rejects_unbound_parameter() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("unbound_search", &server.uri()));
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM unbound_search.search_issues(q => $q)",
+    )
+    .await
+    .expect_err("an unbound parameter in a source function call should fail");
+
+    assert!(
+        error.to_string().contains(
+            "unbound_search.search_issues argument 'q' is bound to parameter $q, \
+             but no value was provided for it"
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn query_parameters_reject_unknown_names() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("strict_params", &server.uri()));
+    let params = QueryParameters::from([string_param("typo", "hybrid")]);
+
+    let error = CoralQuery::execute_sql_with_params(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM strict_params.search_issues(q => $q)",
+        params,
+    )
+    .await
+    .expect_err("parameters the statement never references should fail");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("unknown query parameter(s): typo"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        message.contains("the statement references: $q"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn null_query_parameter_is_treated_as_omitted_optional_argument() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param_is_missing("search_type"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("null_param_search", &server.uri()));
+    let params = QueryParameters::from([
+        string_param("q", "flaky cleanup repo:withcoral/coral"),
+        ("mode".to_string(), QueryParameterValue::Null),
+    ]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[source],
+            test_runtime(),
+            "SELECT title, score FROM null_param_search.search_issues(q => $q, mode => $mode)",
+            params,
+        )
+        .await
+        .expect("null parameter for an optional argument should be omitted"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn null_query_parameter_for_required_argument_fails() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("null_required", &server.uri()));
+    let params = QueryParameters::from([("q".to_string(), QueryParameterValue::Null)]);
+
+    let error = CoralQuery::execute_sql_with_params(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM null_required.search_issues(q => $q)",
+        params,
+    )
+    .await
+    .expect_err("null parameter for a required argument should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("null_required.search_issues missing required argument(s): q"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn query_parameters_bind_in_where_clauses() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "cleanup"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [
+                { "title": "Flaky workspace cleanup", "score": 9.5 },
+                { "title": "Unrelated issue", "score": 1.0 }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("where_params", &server.uri()));
+    let params = QueryParameters::from([
+        string_param("q", "cleanup"),
+        string_param("title", "Flaky workspace cleanup"),
+    ]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[source],
+            test_runtime(),
+            "SELECT title FROM where_params.search_issues(q => $q) WHERE title = $title",
+            params,
+        )
+        .await
+        .expect("parameters should bind in both call arguments and WHERE clauses"),
+    );
+
+    assert_eq!(rows, vec![json!({ "title": "Flaky workspace cleanup" })]);
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -3160,10 +3160,7 @@ async fn legacy_json_body_array_form_still_works() {
 }
 
 fn string_param(name: &str, value: &str) -> (String, QueryParameterValue) {
-    (
-        name.to_string(),
-        QueryParameterValue::String(value.to_string()),
-    )
+    (name.to_string(), QueryParameterValue::string(value))
 }
 
 #[tokio::test]
@@ -3266,6 +3263,25 @@ async fn source_scoped_table_function_rejects_unbound_parameter() {
 }
 
 #[tokio::test]
+async fn query_parameters_reject_unbound_sql_placeholder() {
+    let error = CoralQuery::execute_sql_with_params(
+        &[],
+        test_runtime(),
+        "SELECT $author AS author",
+        QueryParameters::new(),
+    )
+    .await
+    .expect_err("an ordinary unbound SQL placeholder should fail before physical planning");
+
+    assert!(
+        error
+            .to_string()
+            .contains("SQL parameter $author has no value"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
 async fn query_parameters_reject_unknown_names() {
     let server = MockServer::start().await;
     let source = build_source(search_function_manifest("strict_params", &server.uri()));
@@ -3311,7 +3327,7 @@ async fn null_query_parameter_is_treated_as_omitted_optional_argument() {
     let source = build_source(search_function_manifest("null_param_search", &server.uri()));
     let params = QueryParameters::from([
         string_param("q", "flaky cleanup repo:withcoral/coral"),
-        ("mode".to_string(), QueryParameterValue::Null),
+        ("mode".to_string(), QueryParameterValue::null_string()),
     ]);
 
     let rows = execution_to_rows(
@@ -3338,7 +3354,7 @@ async fn null_query_parameter_is_treated_as_omitted_optional_argument() {
 async fn null_query_parameter_for_required_argument_fails() {
     let server = MockServer::start().await;
     let source = build_source(search_function_manifest("null_required", &server.uri()));
-    let params = QueryParameters::from([("q".to_string(), QueryParameterValue::Null)]);
+    let params = QueryParameters::from([("q".to_string(), QueryParameterValue::null_string())]);
 
     let error = CoralQuery::execute_sql_with_params(
         &[source],
@@ -3360,9 +3376,9 @@ async fn null_query_parameter_for_required_argument_fails() {
 #[tokio::test]
 async fn query_parameters_bind_typed_scalar_values() {
     let params = QueryParameters::from([
-        ("count".to_string(), QueryParameterValue::Integer(7)),
-        ("score".to_string(), QueryParameterValue::Float(9.5)),
-        ("enabled".to_string(), QueryParameterValue::Boolean(true)),
+        ("count".to_string(), QueryParameterValue::integer(7)),
+        ("score".to_string(), QueryParameterValue::float(9.5)),
+        ("enabled".to_string(), QueryParameterValue::boolean(true)),
     ]);
 
     let rows = execution_to_rows(
@@ -3385,6 +3401,24 @@ async fn query_parameters_bind_typed_scalar_values() {
             "enabled": true
         })]
     );
+}
+
+#[tokio::test]
+async fn query_parameters_bind_typed_null_values() {
+    let params = QueryParameters::from([("value".to_string(), QueryParameterValue::null_string())]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[],
+            test_runtime(),
+            "SELECT $value IS NULL AS is_null",
+            params,
+        )
+        .await
+        .expect("typed null parameters should bind"),
+    );
+
+    assert_eq!(rows, vec![json!({ "is_null": true })]);
 }
 
 #[tokio::test]

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -3210,6 +3210,40 @@ async fn source_scoped_table_function_binds_query_parameters() {
 }
 
 #[tokio::test]
+async fn explain_sql_binds_query_parameters() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest(
+        "explain_param_search",
+        &server.uri(),
+    ));
+    let params = QueryParameters::from([
+        string_param("q", "flaky cleanup repo:withcoral/coral"),
+        string_param("mode", "hybrid"),
+    ]);
+
+    let plan = CoralQuery::explain_sql_with_params(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM explain_param_search.search_issues(q => $q, mode => $mode)",
+        params,
+    )
+    .await
+    .expect("parameterized source function call should explain after binding");
+
+    assert!(
+        plan.unoptimized_logical_plan()
+            .contains("explain_param_search.search_issues"),
+        "unexpected unoptimized plan: {}",
+        plan.unoptimized_logical_plan()
+    );
+    assert!(
+        plan.physical_plan().contains("Exec"),
+        "unexpected physical plan: {}",
+        plan.physical_plan()
+    );
+}
+
+#[tokio::test]
 async fn source_scoped_table_function_rejects_unbound_parameter() {
     let server = MockServer::start().await;
     let source = build_source(search_function_manifest("unbound_search", &server.uri()));
@@ -3320,6 +3354,36 @@ async fn null_query_parameter_for_required_argument_fails() {
             .to_string()
             .contains("null_required.search_issues missing required argument(s): q"),
         "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn query_parameters_bind_typed_scalar_values() {
+    let params = QueryParameters::from([
+        ("count".to_string(), QueryParameterValue::Integer(7)),
+        ("score".to_string(), QueryParameterValue::Float(9.5)),
+        ("enabled".to_string(), QueryParameterValue::Boolean(true)),
+    ]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[],
+            test_runtime(),
+            "SELECT $count AS count, $score AS score, $enabled AS enabled \
+             WHERE $count = 7 AND $score > 9.0 AND $enabled",
+            params,
+        )
+        .await
+        .expect("integer, float, and boolean parameters should bind"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "count": 7,
+            "score": 9.5,
+            "enabled": true
+        })]
     );
 }
 


### PR DESCRIPTION
## Summary
- Add engine support for named SQL parameters such as `$author`.
- Introduce `QueryParameters` plus Coral-owned `QueryParameterValue` values.
- Convert Coral parameter values to DataFusion values inside `coral-engine`, during planning, explain, and execution.
- Extend source-scoped table-function argument binding so table-function calls can receive parameter-backed values.

## Why
Saved functions need stable parameter binding before the higher-level function lifecycle lands. This PR adds the lower-level engine capability first: callers provide typed Coral parameter values, and the engine binds those values through DataFusion.

## Behavior
Existing SQL without parameters should behave the same.

New supported shape:

```sql
select *
from github.pulls
where user__login = $author
```

The caller supplies `$author` separately through `QueryParameters`.

Coral accepts the v1 scalar subset we support end to end: strings, integers, floats, booleans, and typed NULLs for those families. Unsupported DataFusion scalar variants are not part of the public app-to-engine contract.

## Assumptions
- Parameters are value parameters only. They do not replace identifiers, table names, schemas, SQL fragments, or operators.
- `QueryParameterValue` is Coral-owned. DataFusion conversion stays behind the engine boundary.
- This PR only adds engine support. It does not add saved functions, app lifecycle APIs, CLI commands, or MCP presentation.

## Validation
- `cargo test -p coral-engine --test engine query_parameters --all-features --locked`
- From the top of the stack: `cargo test -p coral-engine --test engine udf --all-features --locked`
- From the top of the stack: `cargo test -p coral-app functions --all-features --locked`
- From the top of the stack: installed `coral`, added a SQL function, listed it, and queried live GitHub data through `functions.open_coral_prs_by_author(author => 'Bradley-Butcher')`.