### PR TITLE
feat(spec): move pagination metadata out of projections

### DIFF
--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use coral_spec::v4::{
     Diagnostic, DiagnosticSeverity, Fingerprint, FingerprintSurface, MCP_IMPORTER_VERSION,
     MaterializedSurface, McpToolCatalog, OPENAPI_IMPORTER_VERSION, PROJECTION_GENERATOR_VERSION,
-    ProjectionCatalog, SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceType,
+    ParameterMetadata, ProjectionCatalog, SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceType,
     V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest,
     generate_projection_catalog, import_mcp_surface, import_openapi_surface,
     normalize_mcp_tool_catalog, normalize_source_document, openapi_document_metadata,
@@ -35,6 +35,7 @@ const DESCRIPTOR_USER_AGENT: &str = "coral-dsl-v4-materializer";
 pub(crate) const PROJECTIONS_FILENAME: &str = "projections.yaml";
 pub(crate) const FINGERPRINT_FILENAME: &str = "fingerprint.yaml";
 pub(crate) const DIAGNOSTICS_FILENAME: &str = "diagnostics.yaml";
+pub(crate) const PARAMETER_METADATA_FILENAME: &str = "parameter_metadata.yaml";
 
 #[derive(Debug)]
 pub(crate) struct MaterializationBuild {
@@ -156,6 +157,7 @@ pub(crate) fn load_v4_materialization(
     let fingerprint_path = layout.v4_fingerprint_file(workspace_name, source_name);
     let projections_path = layout.v4_projections_file(workspace_name, source_name);
     let diagnostics_path = layout.v4_diagnostics_file(workspace_name, source_name);
+    let parameter_metadata_path = layout.v4_parameter_metadata_file(workspace_name, source_name);
     if !fingerprint_path.exists() || !projections_path.exists() || !diagnostics_path.exists() {
         return Err(incompatible_materialization_error(
             source_name,
@@ -177,6 +179,7 @@ pub(crate) fn load_v4_materialization(
     validate_projection_catalog_header(source_name, manifest, &projections)?;
     let diagnostics: Vec<Diagnostic> =
         read_artifact_yaml(source_name, "diagnostics", &diagnostics_path)?;
+    let parameter_metadata = read_parameter_metadata(source_name, &parameter_metadata_path)?;
     let mut surfaces = Vec::new();
     for fingerprint_surface in &fingerprint.surfaces {
         let surface = manifest
@@ -211,10 +214,21 @@ pub(crate) fn load_v4_materialization(
         fingerprint,
         surfaces,
         projections,
+        parameter_metadata,
         diagnostics,
     };
     validate_loaded_materialization(source_name, manifest, &materialized, &fingerprint_surfaces)?;
     Ok(materialized)
+}
+
+fn read_parameter_metadata(
+    source_name: &SourceName,
+    path: &Path,
+) -> Result<ParameterMetadata, AppError> {
+    if !path.exists() {
+        return Ok(ParameterMetadata::default());
+    }
+    read_artifact_yaml(source_name, "parameter metadata override", path)
 }
 
 fn validate_fingerprint_header(
@@ -438,6 +452,20 @@ fn validate_loaded_materialization(
                 .collect(),
         );
     }
+    materialized
+        .parameter_metadata
+        .validate_for_surfaces(
+            materialized
+                .surfaces
+                .iter()
+                .map(|surface| &surface.semantic_ir),
+        )
+        .map_err(|error| {
+            incompatible_materialization_error(
+                source_name,
+                format!("parameter metadata validation failed: {error}"),
+            )
+        })?;
     validate_projection_references(source_name, manifest, materialized, &operations_by_surface)
 }
 
@@ -645,18 +673,33 @@ fn write_materialization(
         importer_version: SURFACE_IMPORTER_VERSION.to_string(),
         projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
     };
-    let materialized = V4MaterializedSource {
-        fingerprint: fingerprint.clone(),
-        surfaces: materialized_surfaces,
-        projections: projections.clone(),
-        diagnostics: diagnostics.clone(),
-    };
+    let materialized = materialized_source(
+        fingerprint.clone(),
+        materialized_surfaces,
+        projections.clone(),
+        diagnostics.clone(),
+    );
     validate_materialized_source(manifest, &materialized)
         .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
     write_yaml(&temp_dir.join(FINGERPRINT_FILENAME), &fingerprint)?;
     write_yaml(&temp_dir.join(PROJECTIONS_FILENAME), &projections)?;
     write_yaml(&temp_dir.join(DIAGNOSTICS_FILENAME), &diagnostics)?;
     Ok(())
+}
+
+fn materialized_source(
+    fingerprint: Fingerprint,
+    surfaces: Vec<MaterializedSurface>,
+    projections: ProjectionCatalog,
+    diagnostics: Vec<Diagnostic>,
+) -> V4MaterializedSource {
+    V4MaterializedSource {
+        fingerprint,
+        surfaces,
+        projections,
+        parameter_metadata: ParameterMetadata::default(),
+        diagnostics,
+    }
 }
 
 struct MaterializedSurfaceBuild {
@@ -1279,6 +1322,41 @@ surfaces:
         replace_v4_materialization(&layout, &workspace_name(), &source_name(), &build.temp_dir)
             .expect("install materialization");
         (state_temp, descriptor_temp, layout, manifest_yaml, manifest)
+    }
+
+    #[test]
+    fn load_v4_materialization_reads_parameter_metadata_override() {
+        let (_state_temp, _descriptor_temp, layout, manifest_yaml, manifest) =
+            setup_materialization();
+        let metadata_path = layout.v4_parameter_metadata_file(&workspace_name(), &source_name());
+        std::fs::create_dir_all(metadata_path.parent().expect("metadata parent"))
+            .expect("create override dir");
+        std::fs::write(
+            &metadata_path,
+            r"
+operation_overrides:
+  issues_list:
+    pagination:
+      mode: none
+",
+        )
+        .expect("write metadata");
+
+        let materialized = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect("load materialization");
+
+        assert!(
+            materialized
+                .parameter_metadata
+                .operation_overrides
+                .contains_key("issues_list")
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -8,10 +8,12 @@ use coral_spec::backends::mcp::{
     McpSourceManifest, McpTableFilterBinding, McpTableFunctionSpec, McpTableSpec,
 };
 use coral_spec::v4::{
-    IrExecutionAttachment, Projection, ProjectionKind, ProjectionVisibility, SqlInputExposure,
-    SurfaceType, V4MaterializedSource, V4SourceManifest, mcp_projection_arg_specs,
-    openapi_document_metadata, projection_arg_specs, projection_column_specs,
-    projection_filter_specs, request_spec_for_projection, validate_openapi_base_url_template,
+    IrExecutionAttachment, ParameterMetadata, Projection, ProjectionKind, ProjectionVisibility,
+    SqlInputExposure, SurfaceType, V4MaterializedSource, V4SourceManifest,
+    mcp_projection_arg_specs, openapi_document_metadata, projection_arg_specs_with_pagination,
+    projection_column_specs, projection_column_specs_with_pagination, projection_filter_specs,
+    projection_filter_specs_with_pagination, request_spec_for_projection_with_pagination,
+    validate_openapi_base_url_template,
 };
 use coral_spec::{
     PaginationSpec, ParsedTemplate, RequestSpec, ResponseSpec, SourceManifestCommon,
@@ -107,44 +109,13 @@ fn http_manifest_for_surface(
                     projection.name, projection.operation_id
                 ))
             })?;
-        let request = request_spec_for_projection(projection, operation)
-            .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
-        let columns = projection_column_specs(projection);
-        match &projection.kind {
-            ProjectionKind::Table => {
-                tables.push(HttpTableSpec {
-                    common: TableCommon {
-                        name: projection.name.clone(),
-                        description: projection.description.clone(),
-                        guide: projection.guide.clone(),
-                        filters: projection_filter_specs(projection),
-                        fetch_limit_default: None,
-                        search_limits: projection.search_limits.clone(),
-                        detail_hints: projection.detail_hints.clone(),
-                        columns,
-                    },
-                    request,
-                    requests: Vec::new(),
-                    response: rest_response_for_operation(operation)?,
-                    pagination: projection.pagination.clone(),
-                });
-            }
-            ProjectionKind::TableFunction { function_kind } => {
-                functions.push(SourceTableFunctionSpec {
-                    name: projection.name.clone(),
-                    kind: *function_kind,
-                    description: projection.description.clone(),
-                    fetch_limit_default: None,
-                    search_limits: projection.search_limits.clone(),
-                    detail_hints: projection.detail_hints.clone(),
-                    args: projection_arg_specs(projection),
-                    request,
-                    response: rest_response_for_operation(operation)?,
-                    pagination: projection.pagination.clone(),
-                    columns,
-                });
-            }
-        }
+        push_http_projection(
+            &mut tables,
+            &mut functions,
+            projection,
+            operation,
+            &materialized.parameter_metadata,
+        )?;
     }
     Ok(HttpSourceManifest {
         common: SourceManifestCommon {
@@ -162,6 +133,56 @@ fn http_manifest_for_surface(
         functions,
         declared_inputs: manifest.declared_inputs.clone(),
     })
+}
+
+fn push_http_projection(
+    tables: &mut Vec<HttpTableSpec>,
+    functions: &mut Vec<SourceTableFunctionSpec>,
+    projection: &Projection,
+    operation: &coral_spec::v4::IrOperation,
+    parameter_metadata: &ParameterMetadata,
+) -> Result<(), AppError> {
+    let pagination = parameter_metadata.effective_pagination_for_operation(operation);
+    let request =
+        request_spec_for_projection_with_pagination(projection, operation, Some(&pagination))
+            .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
+    let columns = projection_column_specs_with_pagination(projection, Some(&pagination));
+    match &projection.kind {
+        ProjectionKind::Table => {
+            tables.push(HttpTableSpec {
+                common: TableCommon {
+                    name: projection.name.clone(),
+                    description: projection.description.clone(),
+                    guide: projection.guide.clone(),
+                    filters: projection_filter_specs_with_pagination(projection, Some(&pagination)),
+                    fetch_limit_default: None,
+                    search_limits: projection.search_limits.clone(),
+                    detail_hints: projection.detail_hints.clone(),
+                    columns,
+                },
+                request,
+                requests: Vec::new(),
+                response: rest_response_for_operation(operation)?,
+                pagination,
+            });
+        }
+        ProjectionKind::TableFunction { function_kind } => {
+            functions.push(SourceTableFunctionSpec {
+                name: projection.name.clone(),
+                kind: *function_kind,
+                description: projection.description.clone(),
+                fetch_limit_default: None,
+                search_limits: projection.search_limits.clone(),
+                detail_hints: projection.detail_hints.clone(),
+                args: projection_arg_specs_with_pagination(projection, Some(&pagination)),
+                request,
+                response: rest_response_for_operation(operation)?,
+                pagination,
+                columns,
+            });
+        }
+    }
+    Ok(())
 }
 
 fn rest_response_for_operation(
@@ -401,11 +422,13 @@ mod tests {
     use coral_spec::v4::{
         Fingerprint, IrExecutionAttachment, IrOperation, IrOperationOutput, MCP_IMPORTER_VERSION,
         MaterializedSurface, McpExecutionAttachment, McpRuntimeConfig, OPENAPI_IMPORTER_VERSION,
-        OpenApiRuntimeConfig, PROJECTION_GENERATOR_VERSION, Projection, ProjectionCatalog,
-        ProjectionKind, ProjectionVisibility, SURFACE_IMPORTER_VERSION, SemanticIr,
-        SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION,
-        V4MaterializedSource, V4SourceCommon, V4SourceManifest, V4Surface,
+        OpenApiRuntimeConfig, PROJECTION_GENERATOR_VERSION, ParameterMetadata, Projection,
+        ProjectionCatalog, ProjectionKind, ProjectionVisibility, SURFACE_IMPORTER_VERSION,
+        SemanticIr, SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType,
+        V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceCommon, V4SourceManifest,
+        V4Surface, generate_projection_catalog, import_openapi_surface,
     };
+    use coral_spec::{PaginationMode, parse_source_manifest_yaml};
 
     use super::{runtime_components_for_v4_source, surface_base_url};
 
@@ -550,7 +573,6 @@ mod tests {
             visibility: ProjectionVisibility::Published,
             inputs: Vec::new(),
             columns: Vec::new(),
-            pagination: coral_spec::PaginationSpec::default(),
             search_limits: None,
             detail_hints: Vec::new(),
             diagnostics: Vec::new(),
@@ -595,6 +617,7 @@ mod tests {
                 ],
                 diagnostics: Vec::new(),
             },
+            parameter_metadata: ParameterMetadata::default(),
             diagnostics: Vec::new(),
         };
 
@@ -651,6 +674,7 @@ mod tests {
                 )],
                 diagnostics: Vec::new(),
             },
+            parameter_metadata: ParameterMetadata::default(),
             diagnostics: Vec::new(),
         };
 
@@ -715,6 +739,7 @@ mod tests {
                 )],
                 diagnostics: Vec::new(),
             },
+            parameter_metadata: ParameterMetadata::default(),
             diagnostics: Vec::new(),
         };
 
@@ -733,6 +758,128 @@ mod tests {
                 .offset_pagination
                 .as_ref(),
             Some(&offset_pagination)
+        );
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "The fixture keeps OpenAPI import and runtime override assertions together."
+    )]
+    fn http_runtime_component_applies_parameter_metadata_pagination() {
+        let manifest = parse_source_manifest_yaml(
+            r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+        )
+        .expect("manifest");
+        let v4 = manifest.as_v4().expect("v4");
+        let surface = v4.surfaces.first().expect("surface");
+        let ir = import_openapi_surface(
+            v4,
+            surface,
+            r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: list-items
+      parameters:
+        - {name: category, in: query, schema: {type: string}}
+        - {name: page_number, in: query, schema: {type: integer}}
+        - {name: per_page, in: query, schema: {type: integer}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: integer}
+"
+            .as_bytes(),
+        )
+        .expect("import");
+        let projections =
+            generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("projections");
+        let parameter_metadata: ParameterMetadata = serde_yaml::from_str(
+            r"
+pagination:
+  - name: custom_page
+    mode: page
+    page_param: page_number
+    page_size:
+      default: 50
+      max: 100
+      query_param: per_page
+",
+        )
+        .expect("metadata");
+        let materialized = V4MaterializedSource {
+            fingerprint: Fingerprint {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "demo".to_string(),
+                manifest_sha256: String::new(),
+                surfaces: Vec::new(),
+                importer_version: SURFACE_IMPORTER_VERSION.to_string(),
+                projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+            },
+            surfaces: vec![MaterializedSurface {
+                surface_id: "rest".to_string(),
+                semantic_ir: ir,
+                source_document_sha256: String::new(),
+                normalized_source_document_path: PathBuf::from("/tmp/source-document.yaml"),
+                raw_source_document_path: PathBuf::from("/tmp/source-document.raw"),
+            }],
+            projections,
+            parameter_metadata,
+            diagnostics: Vec::new(),
+        };
+
+        let components =
+            runtime_components_for_v4_source(v4, &materialized).expect("runtime components");
+        let coral_engine::RuntimeSourceComponent::Http(http) =
+            components.first().expect("http component")
+        else {
+            panic!("expected HTTP component");
+        };
+        let table = http.tables.first().expect("table");
+
+        assert_eq!(table.pagination.mode, PaginationMode::Page);
+        assert_eq!(table.pagination.page_param.as_deref(), Some("page_number"));
+        assert_eq!(
+            table
+                .pagination
+                .page_size
+                .as_ref()
+                .map(|page_size| page_size.default),
+            Some(50)
+        );
+        assert_eq!(
+            table
+                .common
+                .filters
+                .iter()
+                .map(|filter| filter.name.as_str())
+                .collect::<Vec<_>>(),
+            ["category"]
+        );
+        assert_eq!(
+            table
+                .request
+                .query
+                .iter()
+                .map(|query| query.name.as_str())
+                .collect::<Vec<_>>(),
+            ["category"]
         );
     }
 

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -7,7 +7,7 @@ use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_native_strateg
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
 use crate::sources::materialization::{
-    DIAGNOSTICS_FILENAME, FINGERPRINT_FILENAME, PROJECTIONS_FILENAME,
+    DIAGNOSTICS_FILENAME, FINGERPRINT_FILENAME, PARAMETER_METADATA_FILENAME, PROJECTIONS_FILENAME,
 };
 use crate::storage::fs::ensure_dir;
 use crate::workspaces::{WorkspaceName, WorkspacePaths};
@@ -207,6 +207,15 @@ impl AppStateLayout {
             .join(DIAGNOSTICS_FILENAME)
     }
 
+    pub(crate) fn v4_parameter_metadata_file(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> PathBuf {
+        self.v4_override_dir(workspace_name, source_name)
+            .join(PARAMETER_METADATA_FILENAME)
+    }
+
     pub(crate) fn v4_surface_dir(
         &self,
         workspace_name: &WorkspaceName,
@@ -231,7 +240,7 @@ mod tests {
 
     use super::AppStateLayout;
     use crate::sources::SourceName;
-    use crate::sources::materialization::PROJECTIONS_FILENAME;
+    use crate::sources::materialization::{PARAMETER_METADATA_FILENAME, PROJECTIONS_FILENAME};
     use crate::workspaces::WorkspaceName;
     use tempfile::tempdir;
 
@@ -305,6 +314,22 @@ mod tests {
         assert_eq!(
             layout.v4_projections_file(&workspace_name, &source_name),
             override_file
+        );
+    }
+
+    #[test]
+    fn v4_parameter_metadata_file_lives_under_override_dir() {
+        let temp = tempdir().expect("tempdir");
+        let config_dir = temp.path().join("coral-config");
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source");
+
+        assert_eq!(
+            layout.v4_parameter_metadata_file(&workspace_name, &source_name),
+            config_dir
+                .join("workspaces/default/sources/github/overrides")
+                .join(PARAMETER_METADATA_FILENAME)
         );
     }
 }

--- a/crates/coral-spec/src/v4/artifacts.rs
+++ b/crates/coral-spec/src/v4/artifacts.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::SemanticIr;
 use crate::v4::manifest::{SurfaceType, V4SourceManifest};
+use crate::v4::parameter_metadata::ParameterMetadata;
 use crate::v4::projections::ProjectionCatalog;
 use crate::v4::{
     PROJECTION_GENERATOR_VERSION, SURFACE_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION,
@@ -17,6 +18,8 @@ pub struct V4MaterializedSource {
     pub fingerprint: Fingerprint,
     pub surfaces: Vec<MaterializedSurface>,
     pub projections: ProjectionCatalog,
+    #[serde(default)]
+    pub parameter_metadata: ParameterMetadata,
     pub diagnostics: Vec<Diagnostic>,
 }
 
@@ -134,7 +137,8 @@ mod tests {
     use crate::v4::projections::ProjectionCatalog;
     use crate::v4::{
         MCP_IMPORTER_VERSION, OPENAPI_IMPORTER_VERSION, PROJECTION_GENERATOR_VERSION,
-        SURFACE_IMPORTER_VERSION, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4SourceManifest,
+        ParameterMetadata, SURFACE_IMPORTER_VERSION, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION,
+        V4SourceManifest,
     };
 
     use super::{
@@ -189,6 +193,7 @@ surfaces:
                 projections: Vec::new(),
                 diagnostics: Vec::new(),
             },
+            parameter_metadata: ParameterMetadata::default(),
             diagnostics: Vec::new(),
         }
     }

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -179,6 +179,7 @@ mod tests {
                         status_code: 200,
                         media_type: "application/json".to_string(),
                         response: crate::ResponseSpec::default(),
+                        headers: Vec::new(),
                     },
                     pagination: PaginationSpec::default(),
                 })),

--- a/crates/coral-spec/src/v4/ir/rest.rs
+++ b/crates/coral-spec/src/v4/ir/rest.rs
@@ -34,4 +34,6 @@ pub struct RestResponseAttachment {
     pub status_code: u16,
     pub media_type: String,
     pub response: ResponseSpec,
+    #[serde(default)]
+    pub headers: Vec<String>,
 }

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -5,15 +5,16 @@
 
 pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 2;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v1";
-pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v3";
+pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v4";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v1";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v6";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v7";
 
 mod artifacts;
 mod diagnostics;
 mod ir;
 mod manifest;
 mod naming;
+mod parameter_metadata;
 mod projections;
 mod schema;
 mod surfaces;
@@ -43,11 +44,16 @@ pub use manifest::{
     V4SourceCommon, V4SourceManifest, V4Surface, validate_openapi_base_url_template,
 };
 pub use naming::normalize_identifier;
+pub use parameter_metadata::{
+    NamedPaginationSpec, OperationParameterMetadata, PaginationMatch, ParameterMetadata,
+};
 pub use projections::{
     Projection, ProjectionCatalog, ProjectionColumn, ProjectionInput, ProjectionKind,
     ProjectionVisibility, SqlInputExposure, generate_projection_catalog, manifest_data_type_name,
-    mcp_projection_arg_specs, projection_arg_specs, projection_column_specs,
-    projection_filter_specs, request_spec_for_projection,
+    mcp_projection_arg_specs, projection_arg_specs, projection_arg_specs_with_pagination,
+    projection_column_specs, projection_column_specs_with_pagination, projection_filter_specs,
+    projection_filter_specs_with_pagination, request_spec_for_projection,
+    request_spec_for_projection_with_pagination,
 };
 pub use schema::generated_v4_source_manifest_schema;
 pub use surfaces::{

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -1,0 +1,575 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrOperation, SemanticIr};
+use crate::v4::manifest::SurfaceType;
+use crate::{ManifestError, PaginationMode, PaginationSpec, Result};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ParameterMetadata {
+    #[serde(default)]
+    pub pagination: Vec<NamedPaginationSpec>,
+    #[serde(default)]
+    pub operation_overrides: BTreeMap<String, OperationParameterMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedPaginationSpec {
+    pub name: String,
+    #[serde(default, rename = "match")]
+    pub match_rule: PaginationMatch,
+    #[serde(flatten)]
+    pub pagination: PaginationSpec,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OperationParameterMetadata {
+    #[serde(default)]
+    pub pagination: Option<PaginationSpec>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PaginationMatch {
+    #[serde(default)]
+    pub query_params: Vec<String>,
+    #[serde(default)]
+    pub body_paths: Vec<Vec<String>>,
+    #[serde(default)]
+    pub response_headers: Vec<String>,
+}
+
+impl ParameterMetadata {
+    pub fn validate_for_surfaces<'a>(
+        &self,
+        surfaces: impl IntoIterator<Item = &'a SemanticIr>,
+    ) -> Result<()> {
+        let mut names = BTreeSet::new();
+        for strategy in &self.pagination {
+            if strategy.name.trim().is_empty() {
+                return Err(ManifestError::validation(
+                    "parameter metadata pagination strategy name must not be empty",
+                ));
+            }
+            if !names.insert(strategy.name.as_str()) {
+                return Err(ManifestError::validation(format!(
+                    "parameter metadata pagination strategy '{}' is duplicated",
+                    strategy.name
+                )));
+            }
+            strategy
+                .pagination
+                .validated("parameter_metadata.pagination", &strategy.name)?;
+            if strategy.pagination.mode == PaginationMode::LinkHeader
+                && strategy.match_rule.response_headers.is_empty()
+            {
+                return Err(ManifestError::validation(format!(
+                    "parameter metadata pagination strategy '{}' uses mode=link_header and must define match.response_headers",
+                    strategy.name
+                )));
+            }
+            if strategy.effective_match().is_empty() {
+                return Err(ManifestError::validation(format!(
+                    "parameter metadata pagination strategy '{}' must not match every operation",
+                    strategy.name
+                )));
+            }
+        }
+
+        let operation_ids = openapi_operation_ids(surfaces);
+        for (operation_id, override_metadata) in &self.operation_overrides {
+            match operation_ids.get(operation_id).copied().unwrap_or_default() {
+                0 => {
+                    return Err(ManifestError::validation(format!(
+                        "parameter metadata operation override '{operation_id}' does not match any OpenAPI operation"
+                    )));
+                }
+                1 => {}
+                count => {
+                    return Err(ManifestError::validation(format!(
+                        "parameter metadata operation override '{operation_id}' is ambiguous across {count} OpenAPI operations"
+                    )));
+                }
+            }
+            if let Some(pagination) = &override_metadata.pagination {
+                pagination.validated("parameter_metadata.operation_overrides", operation_id)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn effective_pagination_for_operation(&self, operation: &IrOperation) -> PaginationSpec {
+        if let Some(pagination) = self
+            .operation_overrides
+            .get(&operation.id)
+            .and_then(|override_metadata| override_metadata.pagination.clone())
+        {
+            return pagination;
+        }
+
+        self.pagination
+            .iter()
+            .find(|strategy| strategy.matches_operation(operation))
+            .map_or_else(
+                || inferred_pagination(operation),
+                |strategy| strategy.pagination.clone(),
+            )
+    }
+}
+
+impl NamedPaginationSpec {
+    fn effective_match(&self) -> PaginationMatch {
+        if !self.match_rule.is_empty() {
+            return self.match_rule.clone();
+        }
+
+        let mut match_rule = PaginationMatch::default();
+        if let Some(param) = &self.pagination.page_param {
+            match_rule.query_params.push(param.clone());
+        }
+        if let Some(param) = &self.pagination.offset_param {
+            match_rule.query_params.push(param.clone());
+        }
+        if let Some(param) = &self.pagination.cursor_param {
+            match_rule.query_params.push(param.clone());
+        }
+        if !self.pagination.cursor_body_path.is_empty() {
+            match_rule
+                .body_paths
+                .push(self.pagination.cursor_body_path.clone());
+        }
+        if let Some(page_size) = &self.pagination.page_size {
+            if let Some(param) = &page_size.query_param {
+                match_rule.query_params.push(param.clone());
+            }
+            if !page_size.body_path.is_empty() {
+                match_rule.body_paths.push(page_size.body_path.clone());
+            }
+        }
+        match_rule
+    }
+
+    fn matches_operation(&self, operation: &IrOperation) -> bool {
+        self.effective_match().matches_operation(operation)
+    }
+}
+
+impl PaginationMatch {
+    fn is_empty(&self) -> bool {
+        self.query_params.is_empty()
+            && self.body_paths.is_empty()
+            && self.response_headers.is_empty()
+    }
+
+    fn matches_operation(&self, operation: &IrOperation) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+
+        let query_params = operation
+            .inputs
+            .iter()
+            .filter(|input| input.location == IrInputLocation::Query)
+            .map(|input| input.name.as_str())
+            .collect::<BTreeSet<_>>();
+        let body_paths = operation
+            .inputs
+            .iter()
+            .filter(|input| input.location == IrInputLocation::Body)
+            .map(|input| vec![input.name.as_str()])
+            .collect::<BTreeSet<_>>();
+        let response_headers = match &operation.execution {
+            IrExecutionAttachment::Rest(rest) => rest
+                .response
+                .headers
+                .iter()
+                .map(|header| header.to_ascii_lowercase())
+                .collect::<BTreeSet<_>>(),
+            IrExecutionAttachment::Mcp(_) => BTreeSet::new(),
+        };
+
+        self.query_params
+            .iter()
+            .all(|param| query_params.contains(param.as_str()))
+            && self.body_paths.iter().all(|path| {
+                let candidate = path.iter().map(String::as_str).collect::<Vec<_>>();
+                body_paths.contains(&candidate)
+            })
+            && self
+                .response_headers
+                .iter()
+                .all(|header| response_headers.contains(header.to_ascii_lowercase().as_str()))
+    }
+}
+
+fn openapi_operation_ids<'a>(
+    surfaces: impl IntoIterator<Item = &'a SemanticIr>,
+) -> BTreeMap<String, usize> {
+    let mut operation_ids = BTreeMap::new();
+    for surface in surfaces
+        .into_iter()
+        .filter(|surface| surface.surface_type == SurfaceType::OpenApi)
+    {
+        for operation in &surface.operations {
+            *operation_ids.entry(operation.id.clone()).or_default() += 1;
+        }
+    }
+    operation_ids
+}
+
+fn inferred_pagination(operation: &IrOperation) -> PaginationSpec {
+    match &operation.execution {
+        IrExecutionAttachment::Rest(rest) => rest.pagination.clone(),
+        IrExecutionAttachment::Mcp(_) => PaginationSpec::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ParameterMetadata;
+    use crate::v4::ir::{
+        HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
+        IrOperationOutput, IrScalarType, OutputCardinality, RestExecutionAttachment,
+        RestResponseAttachment, SemanticIr,
+    };
+    use crate::v4::manifest::SurfaceType;
+    use crate::{PageSizeSpec, PaginationMode, PaginationSpec, ResponseSpec};
+
+    #[test]
+    fn per_operation_pagination_override_wins_over_global_strategy() {
+        let metadata: ParameterMetadata = serde_yaml::from_str(
+            r"
+pagination:
+  - name: global_page
+    mode: page
+    page_param: page
+    page_size:
+      default: 50
+      max: 100
+      query_param: per_page
+operation_overrides:
+  list_items:
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_step: 50
+",
+        )
+        .expect("metadata");
+        let operation = operation_with_query_params("list_items", &["page", "per_page"]);
+        metadata
+            .validate_for_surfaces(&[surface_with_operation(operation.clone())])
+            .expect("valid metadata");
+
+        let pagination = metadata.effective_pagination_for_operation(&operation);
+
+        assert_eq!(pagination.mode, PaginationMode::Offset);
+        assert_eq!(pagination.offset_param.as_deref(), Some("offset"));
+    }
+
+    #[test]
+    fn global_strategies_match_in_file_order() {
+        let metadata: ParameterMetadata = serde_yaml::from_str(
+            r"
+pagination:
+  - name: first
+    mode: page
+    page_param: page
+    page_size:
+      default: 25
+      max: 100
+      query_param: per_page
+  - name: second
+    mode: page
+    page_param: page
+    page_size:
+      default: 50
+      max: 100
+      query_param: per_page
+",
+        )
+        .expect("metadata");
+        let operation = operation_with_query_params("list_items", &["page", "per_page"]);
+        metadata
+            .validate_for_surfaces(&[surface_with_operation(operation.clone())])
+            .expect("valid metadata");
+
+        let pagination = metadata.effective_pagination_for_operation(&operation);
+
+        assert_eq!(
+            pagination
+                .page_size
+                .as_ref()
+                .map(|page_size| page_size.default),
+            Some(25)
+        );
+    }
+
+    #[test]
+    fn link_header_strategy_matches_response_headers() {
+        let metadata: ParameterMetadata = serde_yaml::from_str(
+            r"
+pagination:
+  - name: link_header
+    mode: link_header
+    match:
+      response_headers: [Link]
+",
+        )
+        .expect("metadata");
+        let mut operation = operation_with_query_params("list_items", &[]);
+        if let IrExecutionAttachment::Rest(rest) = &mut operation.execution {
+            rest.response.headers.push("link".to_string());
+        }
+        metadata
+            .validate_for_surfaces(&[surface_with_operation(operation.clone())])
+            .expect("valid metadata");
+
+        let pagination = metadata.effective_pagination_for_operation(&operation);
+
+        assert_eq!(pagination.mode, PaginationMode::LinkHeader);
+    }
+
+    #[test]
+    fn body_path_strategy_matches_body_inputs() {
+        let metadata: ParameterMetadata = serde_yaml::from_str(
+            r"
+pagination:
+  - name: body_cursor
+    mode: cursor_body
+    cursor_body_path: [page_token]
+    response_cursor_path: [next_page_token]
+",
+        )
+        .expect("metadata");
+        let mut operation = operation_with_query_params("list_items", &[]);
+        operation.inputs.push(IrOperationInput {
+            name: "page_token".to_string(),
+            location: IrInputLocation::Body,
+            required: false,
+            data_type: IrScalarType::String,
+            default_value: None,
+            description: String::new(),
+        });
+        metadata
+            .validate_for_surfaces(&[surface_with_operation(operation.clone())])
+            .expect("valid metadata");
+
+        let pagination = metadata.effective_pagination_for_operation(&operation);
+
+        assert_eq!(pagination.mode, PaginationMode::CursorBody);
+    }
+
+    #[test]
+    fn unmatched_strategy_falls_back_to_inferred_pagination() {
+        let metadata: ParameterMetadata = serde_yaml::from_str(
+            r"
+pagination:
+  - name: custom_page
+    mode: page
+    page_param: page_number
+",
+        )
+        .expect("metadata");
+        let operation = operation_with_inferred_pagination();
+        metadata
+            .validate_for_surfaces(&[surface_with_operation(operation.clone())])
+            .expect("valid metadata");
+
+        let pagination = metadata.effective_pagination_for_operation(&operation);
+
+        assert_eq!(pagination.mode, PaginationMode::Page);
+        assert_eq!(pagination.page_param.as_deref(), Some("page"));
+    }
+
+    #[test]
+    fn rejects_duplicate_strategy_names() {
+        let metadata: ParameterMetadata = serde_yaml::from_str(
+            r"
+pagination:
+  - name: page
+    mode: page
+    page_param: page
+  - name: page
+    mode: page
+    page_param: page_number
+",
+        )
+        .expect("metadata");
+
+        let error = metadata
+            .validate_for_surfaces(&[surface_with_operation(operation_with_query_params(
+                "list_items",
+                &[],
+            ))])
+            .expect_err("duplicate names should be rejected");
+
+        assert!(error.to_string().contains("duplicated"));
+    }
+
+    #[test]
+    fn rejects_global_match_all_strategy() {
+        let metadata: ParameterMetadata = serde_yaml::from_str(
+            r"
+pagination:
+  - name: none
+    mode: none
+",
+        )
+        .expect("metadata");
+
+        let error = metadata
+            .validate_for_surfaces(&[surface_with_operation(operation_with_query_params(
+                "list_items",
+                &[],
+            ))])
+            .expect_err("match-all strategy should be rejected");
+
+        assert!(error.to_string().contains("must not match every operation"));
+    }
+
+    #[test]
+    fn rejects_unknown_operation_override() {
+        let metadata: ParameterMetadata = serde_yaml::from_str(
+            r"
+operation_overrides:
+  missing:
+    pagination:
+      mode: none
+",
+        )
+        .expect("metadata");
+
+        let error = metadata
+            .validate_for_surfaces(&[surface_with_operation(operation_with_query_params(
+                "list_items",
+                &[],
+            ))])
+            .expect_err("unknown operation should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not match any OpenAPI operation")
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_operation_override() {
+        let metadata: ParameterMetadata = serde_yaml::from_str(
+            r"
+operation_overrides:
+  list_items:
+    pagination:
+      mode: none
+",
+        )
+        .expect("metadata");
+
+        let error = metadata
+            .validate_for_surfaces(&[
+                surface_with_operation(operation_with_query_params("list_items", &[])),
+                surface_with_operation(operation_with_query_params("list_items", &[])),
+            ])
+            .expect_err("ambiguous operation should be rejected");
+
+        assert!(error.to_string().contains("is ambiguous"));
+    }
+
+    #[test]
+    fn rejects_invalid_pagination_spec() {
+        let metadata: ParameterMetadata = serde_yaml::from_str(
+            r"
+pagination:
+  - name: page
+    mode: page
+",
+        )
+        .expect("metadata");
+
+        let error = metadata
+            .validate_for_surfaces(&[surface_with_operation(operation_with_query_params(
+                "list_items",
+                &[],
+            ))])
+            .expect_err("invalid pagination should be rejected");
+
+        assert!(error.to_string().contains("requires page_param"));
+    }
+
+    fn operation_with_inferred_pagination() -> IrOperation {
+        let mut operation = operation_with_query_params("list_items", &["page", "per_page"]);
+        if let IrExecutionAttachment::Rest(rest) = &mut operation.execution {
+            rest.pagination = PaginationSpec {
+                mode: PaginationMode::Page,
+                page_param: Some("page".to_string()),
+                page_size: Some(PageSizeSpec {
+                    default: 30,
+                    max: 100,
+                    query_param: Some("per_page".to_string()),
+                    body_path: Vec::new(),
+                }),
+                ..PaginationSpec::default()
+            };
+        }
+        operation
+    }
+
+    fn operation_with_query_params(operation_id: &str, query_params: &[&str]) -> IrOperation {
+        IrOperation {
+            id: operation_id.to_string(),
+            method_name: "GET".to_string(),
+            description: String::new(),
+            deprecated: false,
+            read_only: true,
+            inputs: query_params
+                .iter()
+                .map(|name| IrOperationInput {
+                    name: (*name).to_string(),
+                    location: IrInputLocation::Query,
+                    required: false,
+                    data_type: IrScalarType::String,
+                    default_value: None,
+                    description: String::new(),
+                })
+                .collect(),
+            output: IrOperationOutput {
+                cardinality: OutputCardinality::List,
+                type_ref: "item".to_string(),
+                row_path: Vec::new(),
+            },
+            entity: None,
+            execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
+                method: HttpMethod::Get,
+                path_template: "/items".to_string(),
+                parameters: Vec::new(),
+                request_body: None,
+                response: RestResponseAttachment {
+                    status_code: 200,
+                    media_type: "application/json".to_string(),
+                    response: ResponseSpec::default(),
+                    headers: Vec::new(),
+                },
+                pagination: PaginationSpec::default(),
+            })),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn surface_with_operation(operation: IrOperation) -> SemanticIr {
+        SemanticIr {
+            artifact_schema_version: crate::v4::V4_ARTIFACT_SCHEMA_VERSION,
+            source_name: "demo".to_string(),
+            surface_id: "rest".to_string(),
+            surface_type: SurfaceType::OpenApi,
+            importer_version: crate::v4::OPENAPI_IMPORTER_VERSION.to_string(),
+            operations: vec![operation],
+            types: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+}

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -6,8 +6,16 @@ use super::naming::{pluralize, singularize};
 use super::test_support::github_openapi;
 use super::*;
 use crate::{
-    ManifestDataType, PaginationMode, SourceTableFunctionKind, parse_source_manifest_yaml,
+    ManifestDataType, PaginationMode, PaginationSpec, SourceTableFunctionKind,
+    parse_source_manifest_yaml,
 };
+
+fn rest_pagination(operation: &IrOperation) -> &PaginationSpec {
+    let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+        panic!("expected REST operation");
+    };
+    &rest.pagination
+}
 
 #[test]
 fn imports_and_generates_github_issue_slice() {
@@ -43,7 +51,11 @@ surfaces:
 }
 
 #[test]
-fn projection_generation_keeps_pagination_inputs_internal() {
+#[expect(
+    clippy::too_many_lines,
+    reason = "The fixture keeps projection and runtime pagination assertions together."
+)]
+fn runtime_spec_generation_keeps_pagination_inputs_out_of_sql_surface() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: github
@@ -71,11 +83,11 @@ surfaces:
         .find(|operation| operation.id == projection.operation_id)
         .expect("repo issues operation");
 
-    assert_eq!(projection.pagination.mode, PaginationMode::Page);
-    assert_eq!(projection.pagination.page_param.as_deref(), Some("page"));
+    let pagination = rest_pagination(operation);
+    assert_eq!(pagination.mode, PaginationMode::Page);
+    assert_eq!(pagination.page_param.as_deref(), Some("page"));
     assert_eq!(
-        projection
-            .pagination
+        pagination
             .page_size
             .as_ref()
             .and_then(|page_size| page_size.query_param.as_deref()),
@@ -90,10 +102,10 @@ surfaces:
     assert_eq!(exposures.get("owner"), Some(&SqlInputExposure::Filter));
     assert_eq!(exposures.get("repo"), Some(&SqlInputExposure::Filter));
     assert_eq!(exposures.get("state"), Some(&SqlInputExposure::Filter));
-    assert_eq!(exposures.get("page"), Some(&SqlInputExposure::Internal));
-    assert_eq!(exposures.get("per_page"), Some(&SqlInputExposure::Internal));
+    assert_eq!(exposures.get("page"), Some(&SqlInputExposure::Filter));
+    assert_eq!(exposures.get("per_page"), Some(&SqlInputExposure::Filter));
 
-    let filter_names = projection_filter_specs(projection)
+    let filter_names = projection_filter_specs_with_pagination(projection, Some(pagination))
         .into_iter()
         .map(|filter| filter.name)
         .collect::<BTreeSet<_>>();
@@ -102,7 +114,7 @@ surfaces:
         BTreeSet::from(["owner".to_string(), "repo".to_string(), "state".to_string()])
     );
 
-    let column_names = projection_column_specs(projection)
+    let column_names = projection_column_specs_with_pagination(projection, Some(pagination))
         .into_iter()
         .map(|column| column.name)
         .collect::<BTreeSet<_>>();
@@ -112,7 +124,9 @@ surfaces:
     assert!(!column_names.contains("page"));
     assert!(!column_names.contains("per_page"));
 
-    let request = request_spec_for_projection(projection, operation).expect("request");
+    let request =
+        request_spec_for_projection_with_pagination(projection, operation, Some(pagination))
+            .expect("request");
     let query_names = request
         .query
         .iter()
@@ -126,14 +140,16 @@ surfaces:
             input.sql_exposure = SqlInputExposure::Filter;
         }
     }
-    let stale_filter_names = projection_filter_specs(&stale_projection)
-        .into_iter()
-        .map(|filter| filter.name)
-        .collect::<BTreeSet<_>>();
+    let stale_filter_names =
+        projection_filter_specs_with_pagination(&stale_projection, Some(pagination))
+            .into_iter()
+            .map(|filter| filter.name)
+            .collect::<BTreeSet<_>>();
     assert_eq!(stale_filter_names, filter_names);
 
     let stale_request =
-        request_spec_for_projection(&stale_projection, operation).expect("stale request");
+        request_spec_for_projection_with_pagination(&stale_projection, operation, Some(pagination))
+            .expect("stale request");
     let stale_query_names = stale_request
         .query
         .iter()
@@ -146,7 +162,7 @@ surfaces:
             input.sql_exposure = SqlInputExposure::FunctionArg;
         }
     }
-    let stale_arg_names = projection_arg_specs(&stale_projection)
+    let stale_arg_names = projection_arg_specs_with_pagination(&stale_projection, Some(pagination))
         .into_iter()
         .map(|arg| arg.name)
         .collect::<BTreeSet<_>>();

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -20,7 +20,6 @@ use super::model::{
 use super::names::{
     is_search_operation, projection_guide, projection_name, resolve_projection_name_collisions,
 };
-use super::pagination::pagination_query_param_names;
 
 pub fn generate_projection_catalog(
     manifest: &V4SourceManifest,
@@ -75,7 +74,6 @@ fn generate_projection(
         SqlInputExposure::FunctionArg
     };
     let pagination = rest.map_or_else(PaginationSpec::default, |rest| rest.pagination.clone());
-    let pagination_query_params = pagination_query_param_names(&pagination);
     let mut used_input_names = HashSet::new();
     let use_sql_input_normalization = matches!(operation.execution, IrExecutionAttachment::Mcp(_));
     let inputs = operation
@@ -84,7 +82,7 @@ fn generate_projection(
         .map(|input| {
             let (exposure, pagination_owned_input) = match &operation.execution {
                 IrExecutionAttachment::Rest(_) => {
-                    projection_input_sql_exposure(input, sql_exposure, &pagination_query_params)
+                    (projection_input_sql_exposure(input, sql_exposure), false)
                 }
                 IrExecutionAttachment::Mcp(mcp) if mcp_pagination_owns_input(mcp, input) => {
                     (SqlInputExposure::Internal, true)
@@ -133,7 +131,6 @@ fn generate_projection(
         visibility,
         inputs,
         columns,
-        pagination,
         search_limits: is_search.then_some(SearchLimitsSpec {
             default_top_k: 30,
             max_top_k: 100,
@@ -221,20 +218,15 @@ fn projection_input_required(input: &IrOperationInput) -> bool {
 fn projection_input_sql_exposure(
     input: &IrOperationInput,
     default_exposure: SqlInputExposure,
-    pagination_query_params: &HashSet<&str>,
-) -> (SqlInputExposure, bool) {
-    let pagination_owned_query_input = input.location == IrInputLocation::Query
-        && pagination_query_params.contains(input.name.as_str());
-    let exposure = match input.location {
-        IrInputLocation::Query if pagination_owned_query_input => SqlInputExposure::Internal,
+) -> SqlInputExposure {
+    match input.location {
         IrInputLocation::Path | IrInputLocation::Query | IrInputLocation::ToolArg => {
             default_exposure
         }
         IrInputLocation::Header | IrInputLocation::Cookie | IrInputLocation::Body => {
             SqlInputExposure::Internal
         }
-    };
-    (exposure, pagination_owned_query_input)
+    }
 }
 
 fn mcp_pagination_owns_input(

--- a/crates/coral-spec/src/v4/projections/mod.rs
+++ b/crates/coral-spec/src/v4/projections/mod.rs
@@ -8,5 +8,8 @@ pub use derive::generate_projection_catalog;
 pub use model::*;
 pub use runtime::{
     manifest_data_type_name, mcp_projection_arg_specs, projection_arg_specs,
-    projection_column_specs, projection_filter_specs, request_spec_for_projection,
+    projection_arg_specs_with_pagination, projection_column_specs,
+    projection_column_specs_with_pagination, projection_filter_specs,
+    projection_filter_specs_with_pagination, request_spec_for_projection,
+    request_spec_for_projection_with_pagination,
 };

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -2,9 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::IrInputLocation;
-use crate::{
-    DetailHintSpec, ManifestDataType, PaginationSpec, SearchLimitsSpec, SourceTableFunctionKind,
-};
+use crate::{DetailHintSpec, ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectionCatalog {
@@ -28,7 +26,6 @@ pub struct Projection {
     pub visibility: ProjectionVisibility,
     pub inputs: Vec<ProjectionInput>,
     pub columns: Vec<ProjectionColumn>,
-    pub pagination: PaginationSpec,
     pub search_limits: Option<SearchLimitsSpec>,
     pub detail_hints: Vec<DetailHintSpec>,
     pub diagnostics: Vec<Diagnostic>,
@@ -85,7 +82,7 @@ mod tests {
         Projection, ProjectionCatalog, ProjectionKind, ProjectionVisibility, SqlInputExposure,
     };
     use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
-    use crate::{ManifestDataType, PaginationSpec, SearchLimitsSpec, SourceTableFunctionKind};
+    use crate::{ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
 
     #[test]
     fn projection_catalog_yaml_uses_editor_friendly_enum_shapes() {
@@ -106,7 +103,6 @@ mod tests {
                 visibility: ProjectionVisibility::Published,
                 inputs: Vec::new(),
                 columns: Vec::new(),
-                pagination: PaginationSpec::default(),
                 search_limits: Some(SearchLimitsSpec {
                     default_top_k: 30,
                     max_top_k: 100,
@@ -131,13 +127,17 @@ mod tests {
             yaml.contains("function_kind: search"),
             "missing function kind: {yaml}"
         );
+        assert!(
+            !yaml.contains("pagination:"),
+            "projection catalog should not serialize projection pagination: {yaml}"
+        );
 
         serde_yaml::from_str::<ProjectionCatalog>(&yaml)
             .expect("projection catalog should round-trip");
     }
 
     #[test]
-    fn projection_deserializes_legacy_catalogs_without_namespace() {
+    fn projection_deserializes_legacy_catalogs_without_namespace_and_with_pagination() {
         let raw = format!(
             r"
 artifact_schema_version: {V4_ARTIFACT_SCHEMA_VERSION}

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -5,14 +5,21 @@ use serde_json::Value;
 use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrOperation};
 use crate::{
     ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, ManifestDataType,
-    ParsedTemplate, RequestSpec, Result, TableFunctionArgSpec,
+    PaginationSpec, ParsedTemplate, RequestSpec, Result, TableFunctionArgSpec,
 };
 
 use super::model::{Projection, SqlInputExposure};
 use super::pagination::{pagination_owns_input, pagination_query_param_names};
 
 pub fn projection_filter_specs(projection: &Projection) -> Vec<FilterSpec> {
-    let pagination_query_params = pagination_query_param_names(&projection.pagination);
+    projection_filter_specs_with_pagination(projection, None)
+}
+
+pub fn projection_filter_specs_with_pagination(
+    projection: &Projection,
+    pagination: Option<&PaginationSpec>,
+) -> Vec<FilterSpec> {
+    let pagination_query_params = pagination_query_params(pagination);
     projection
         .inputs
         .iter()
@@ -30,7 +37,14 @@ pub fn projection_filter_specs(projection: &Projection) -> Vec<FilterSpec> {
 }
 
 pub fn projection_arg_specs(projection: &Projection) -> Vec<TableFunctionArgSpec> {
-    let pagination_query_params = pagination_query_param_names(&projection.pagination);
+    projection_arg_specs_with_pagination(projection, None)
+}
+
+pub fn projection_arg_specs_with_pagination(
+    projection: &Projection,
+    pagination: Option<&PaginationSpec>,
+) -> Vec<TableFunctionArgSpec> {
+    let pagination_query_params = pagination_query_params(pagination);
     projection
         .inputs
         .iter()
@@ -64,7 +78,14 @@ pub fn mcp_projection_arg_specs(projection: &Projection) -> Vec<TableFunctionArg
 }
 
 pub fn projection_column_specs(projection: &Projection) -> Vec<ColumnSpec> {
-    let pagination_query_params = pagination_query_param_names(&projection.pagination);
+    projection_column_specs_with_pagination(projection, None)
+}
+
+pub fn projection_column_specs_with_pagination(
+    projection: &Projection,
+    pagination: Option<&PaginationSpec>,
+) -> Vec<ColumnSpec> {
+    let pagination_query_params = pagination_query_params(pagination);
     let mut columns = projection
         .columns
         .iter()
@@ -119,13 +140,21 @@ pub fn request_spec_for_projection(
     projection: &Projection,
     operation: &IrOperation,
 ) -> Result<RequestSpec> {
+    request_spec_for_projection_with_pagination(projection, operation, None)
+}
+
+pub fn request_spec_for_projection_with_pagination(
+    projection: &Projection,
+    operation: &IrOperation,
+    pagination: Option<&PaginationSpec>,
+) -> Result<RequestSpec> {
     let IrExecutionAttachment::Rest(rest) = &operation.execution else {
         return Err(crate::ManifestError::validation(format!(
             "projection '{}' is not backed by a REST operation",
             projection.name
         )));
     };
-    let pagination_query_params = pagination_query_param_names(&projection.pagination);
+    let pagination_query_params = pagination_query_params(pagination);
     let mut path = rest.path_template.clone();
     for input in &projection.inputs {
         if input.source_location == IrInputLocation::Path {
@@ -177,6 +206,10 @@ pub fn request_spec_for_projection(
         body: crate::BodySpec::default(),
         headers: Vec::new(),
     })
+}
+
+fn pagination_query_params(pagination: Option<&PaginationSpec>) -> HashSet<&str> {
+    pagination.map_or_else(HashSet::new, pagination_query_param_names)
 }
 
 fn path_template_token(namespace: &str, key: &str, default: Option<&str>) -> String {

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -20,7 +20,7 @@ impl OpenApiImporter<'_> {
         RestResponseAttachment,
         Option<IrEntityCandidate>,
     ) {
-        let Some((status_code, media_type, schema)) = self.select_json_response(
+        let Some((status_code, media_type, schema, headers)) = self.select_json_response(
             operation.get("responses").and_then(Value::as_object),
             operation_id,
             diagnostics,
@@ -36,6 +36,7 @@ impl OpenApiImporter<'_> {
                     status_code: 204,
                     media_type: "application/json".to_string(),
                     response,
+                    headers: Vec::new(),
                 },
                 None,
             );
@@ -58,6 +59,7 @@ impl OpenApiImporter<'_> {
                     status_code,
                     media_type,
                     response: ResponseSpec::default(),
+                    headers,
                 },
                 None,
             );
@@ -93,6 +95,7 @@ impl OpenApiImporter<'_> {
                 status_code,
                 media_type,
                 response,
+                headers,
             },
             entity,
         )
@@ -102,7 +105,7 @@ impl OpenApiImporter<'_> {
         responses: Option<&Map<String, Value>>,
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
-    ) -> Option<(u16, String, Value)> {
+    ) -> Option<(u16, String, Value, Vec<String>)> {
         let responses = responses?;
         let mut numeric_candidates = Vec::new();
         let mut range_candidates = Vec::new();
@@ -113,6 +116,7 @@ impl OpenApiImporter<'_> {
             let Some(response) = self.resolve_ref(response, operation_id, diagnostics) else {
                 continue;
             };
+            let headers = response_header_names(&response);
             let Some(content) = response.get("content").and_then(Value::as_object) else {
                 continue;
             };
@@ -124,6 +128,7 @@ impl OpenApiImporter<'_> {
                 status.representative_status_code(),
                 "application/json".to_string(),
                 schema,
+                headers,
             );
             if status.is_range() {
                 range_candidates.push(candidate);
@@ -134,6 +139,16 @@ impl OpenApiImporter<'_> {
         preferred_numeric_response(numeric_candidates)
             .or_else(|| range_candidates.into_iter().next())
     }
+}
+
+fn response_header_names(response: &Value) -> Vec<String> {
+    let mut names = response
+        .get("headers")
+        .and_then(Value::as_object)
+        .map(|headers| headers.keys().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
+    names.sort();
+    names
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -167,13 +182,17 @@ fn success_response_status(status: &str) -> Option<SuccessResponseStatus> {
 }
 
 fn preferred_numeric_response(
-    candidates: Vec<(u16, String, Value)>,
-) -> Option<(u16, String, Value)> {
+    candidates: Vec<(u16, String, Value, Vec<String>)>,
+) -> Option<(u16, String, Value, Vec<String>)> {
     candidates
         .iter()
-        .position(|(status, _, _)| *status == 200)
+        .position(|(status, _, _, _)| *status == 200)
         .and_then(|index| candidates.get(index).cloned())
-        .or_else(|| candidates.into_iter().min_by_key(|(status, _, _)| *status))
+        .or_else(|| {
+            candidates
+                .into_iter()
+                .min_by_key(|(status, _, _, _)| *status)
+        })
 }
 
 fn classify_response_schema(


### PR DESCRIPTION
## Summary

- Remove pagination from v4 projection catalog entries while keeping legacy projection catalogs readable.
- Add `overrides/parameter_metadata.yaml` support for source-wide and per-operation pagination metadata overrides.
- Apply effective pagination metadata during HTTP runtime package assembly so pagination-owned parameters stay behind the scenes.

## Validation

- `make rust-checks`
- `autoreview --mode local`