### PR TITLE
feat(search): add source scan observation hook

### DIFF
--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -15,6 +15,9 @@ use crate::state::{
 pub enum Feature {
     /// Expose the optional MCP `feedback` tool.
     Feedback,
+    /// Enable observed-value collection, storage, retrieval, and maintenance
+    /// for Universal Search.
+    ObservedValuesSearch,
     /// Expose MCP task lifecycle tools and task attribution for follow-up Coral
     /// MCP tool calls via the `coral-task-id` metadata key.
     Tasks,
@@ -76,6 +79,14 @@ const FEATURE_SPECS: &[FeatureSpec] = &[
         description: "Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral.",
         enable_flag: "enable-feedback",
         disable_flag: "disable-feedback",
+    },
+    FeatureSpec {
+        feature: Feature::ObservedValuesSearch,
+        key: "observed_values_search",
+        default_enabled: false,
+        description: "Enables observed-value collection, storage, retrieval, and maintenance for Universal Search. Off by default.",
+        enable_flag: "enable-observed-values-search",
+        disable_flag: "disable-observed-values-search",
     },
     FeatureSpec {
         feature: Feature::Tasks,
@@ -330,6 +341,8 @@ fn spec_for_key(key: &str) -> Option<&'static FeatureSpec> {
 
 #[cfg(test)]
 mod tests {
+    use tempfile::TempDir;
+
     use super::*;
 
     fn raw(
@@ -343,6 +356,45 @@ mod tests {
         let features = Features::default();
 
         assert!(!features.enabled(Feature::Feedback));
+    }
+
+    #[test]
+    fn observed_values_search_has_stable_default_off_surface() {
+        let feature = Feature::ObservedValuesSearch;
+        let features = Features::default();
+
+        assert!(!features.enabled(feature));
+        assert_eq!(feature.key(), "observed_values_search");
+        assert_eq!(feature.enable_flag(), "enable-observed-values-search");
+        assert_eq!(feature.disable_flag(), "disable-observed-values-search");
+    }
+
+    #[test]
+    fn feature_store_applies_observed_values_config_and_process_overrides() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            r"
+[features]
+observed_values_search = true
+",
+        )
+        .expect("write config");
+        let store = FeatureStore::discover(Some(config_dir)).expect("feature store");
+
+        let configured = store
+            .load_with_overrides(&FeatureOverrides::default())
+            .expect("load configured features");
+        assert!(configured.enabled(Feature::ObservedValuesSearch));
+
+        let mut process_overrides = FeatureOverrides::default();
+        process_overrides.set(Feature::ObservedValuesSearch, false);
+        let overridden = store
+            .load_with_overrides(&process_overrides)
+            .expect("load process-overridden features");
+        assert!(!overridden.enabled(Feature::ObservedValuesSearch));
     }
 
     #[test]
@@ -422,5 +474,6 @@ mod tests {
 
         assert!(error.to_string().contains("unknown feature 'nope'"));
         assert!(error.to_string().contains("feedback"));
+        assert!(error.to_string().contains("observed_values_search"));
     }
 }

--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -50,11 +50,15 @@ pub(crate) fn engine_extensions_for_providers(
         let EngineExtensions {
             source_decorators,
             query_result_observers,
+            source_observation_publishers,
             request_authenticators,
             source_input_resolver,
         } = extra;
         merged.source_decorators.extend(source_decorators);
         merged.query_result_observers.extend(query_result_observers);
+        merged
+            .source_observation_publishers
+            .extend(source_observation_publishers);
         merged.request_authenticators.extend(request_authenticators);
         if source_input_resolver.is_some() {
             merged.source_input_resolver = source_input_resolver;
@@ -71,7 +75,8 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use coral_engine::{
         QueryExecutionProvenance, QueryResultObserver, QueryResultObserverError,
-        RequestAuthenticator, RequestAuthenticatorError,
+        RequestAuthenticator, RequestAuthenticatorError, SourceObservationPublisher,
+        SourceScanObservation,
     };
     use reqwest::header::{HeaderName, HeaderValue};
 
@@ -117,6 +122,12 @@ mod tests {
         }
     }
 
+    struct TestSourceObservationPublisher;
+
+    impl SourceObservationPublisher for TestSourceObservationPublisher {
+        fn publish_source_scan(&self, _observation: SourceScanObservation<'_>) {}
+    }
+
     struct TestEngineExtensionsProvider {
         key: &'static str,
         name: &'static str,
@@ -147,12 +158,27 @@ mod tests {
         }
     }
 
+    struct TestSourceObservationPublisherProvider {
+        publisher: Arc<dyn SourceObservationPublisher>,
+    }
+
+    impl EngineExtensionsProvider for TestSourceObservationPublisherProvider {
+        fn extensions_for(&self, _selected_sources: &[QuerySource]) -> EngineExtensions {
+            let mut extensions = EngineExtensions::default();
+            extensions
+                .source_observation_publishers
+                .push(Arc::clone(&self.publisher));
+            extensions
+        }
+    }
+
     #[test]
     fn noop_provider_installs_no_extensions() {
         let extensions = NoopEngineExtensionsProvider.extensions_for(&[]);
 
         assert!(extensions.source_decorators.is_empty());
         assert!(extensions.query_result_observers.is_empty());
+        assert!(extensions.source_observation_publishers.is_empty());
         assert!(extensions.request_authenticators.is_empty());
     }
 
@@ -210,5 +236,37 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(observer_names, ["base", "extra"]);
+    }
+
+    #[test]
+    fn provider_lists_merge_source_observation_publishers_in_call_order() {
+        let base = Arc::new(TestSourceObservationPublisher) as Arc<dyn SourceObservationPublisher>;
+        let extra = Arc::new(TestSourceObservationPublisher) as Arc<dyn SourceObservationPublisher>;
+        let providers = vec![
+            Arc::new(TestSourceObservationPublisherProvider {
+                publisher: Arc::clone(&base),
+            }) as Arc<dyn EngineExtensionsProvider>,
+            Arc::new(TestSourceObservationPublisherProvider {
+                publisher: Arc::clone(&extra),
+            }),
+        ];
+
+        let extensions = engine_extensions_for_providers(&providers, &[]);
+
+        assert_eq!(extensions.source_observation_publishers.len(), 2);
+        assert!(Arc::ptr_eq(
+            extensions
+                .source_observation_publishers
+                .first()
+                .expect("first publisher"),
+            &base
+        ));
+        assert!(Arc::ptr_eq(
+            extensions
+                .source_observation_publishers
+                .get(1)
+                .expect("second publisher"),
+            &extra
+        ));
     }
 }

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -3,7 +3,10 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, OnceLock};
 
-use crate::{QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceInputResolver};
+use crate::{
+    QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceInputResolver,
+    SourceObservationPublisher,
+};
 use async_trait::async_trait;
 use coral_spec::{
     ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
@@ -127,6 +130,7 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) source_variables: BTreeMap<String, String>,
     pub(crate) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
     pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    pub(crate) source_observation_publishers: &'a [Arc<dyn SourceObservationPublisher>],
 }
 
 /// Shared resources available while registering one batch of compiled sources.

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -25,6 +25,7 @@ use crate::backends::http::provider::{HttpJsonExecRequest, http_json_exec};
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::filter_expr::literal_to_string;
+use crate::{SourceObservationPublisher, SourceObservationSurfaceKind};
 
 struct FunctionCallContext<'a> {
     source_schema: &'a str,
@@ -39,6 +40,7 @@ struct HttpSourceFunctionState {
     function_name: String,
     target: Arc<HttpFetchTarget>,
     schema: SchemaRef,
+    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
 }
 
 /// Table-valued function that turns manifest-declared function args into an
@@ -62,6 +64,7 @@ impl HttpSourceTableFunction {
         backend: HttpSourceClient,
         source_schema: String,
         function: SourceTableFunctionSpec,
+        source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
     ) -> Result<Self> {
         let schema = schema_from_columns(&function.columns, &source_schema, &function.name)?;
         let target = HttpFetchTarget::from_function(&function);
@@ -74,6 +77,7 @@ impl HttpSourceTableFunction {
                 function_name,
                 target: Arc::new(target),
                 schema,
+                source_observation_publishers,
             }),
         })
     }
@@ -155,6 +159,8 @@ impl TableProvider for HttpSourceFunctionCallTableProvider {
             arg_values: self.arg_values.clone(),
             projection,
             limit,
+            surface_kind: SourceObservationSurfaceKind::Function,
+            source_observation_publishers: self.state.source_observation_publishers.clone(),
         })
     }
 }

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -19,13 +19,14 @@ use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 
+use crate::SourceObservationSurfaceKind;
 use crate::backends::SourceFunctionProviderFactory;
 use crate::backends::http::HttpSourceClient;
 use crate::backends::http::provider::{HttpJsonExecRequest, http_json_exec};
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::filter_expr::literal_to_string;
-use crate::{SourceObservationPublisher, SourceObservationSurfaceKind};
+use crate::backends::shared::source_observation::SourceObservationPublishers;
 
 struct FunctionCallContext<'a> {
     source_schema: &'a str,
@@ -40,7 +41,7 @@ struct HttpSourceFunctionState {
     function_name: String,
     target: Arc<HttpFetchTarget>,
     schema: SchemaRef,
-    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+    source_observation_publishers: SourceObservationPublishers,
 }
 
 /// Table-valued function that turns manifest-declared function args into an
@@ -64,7 +65,7 @@ impl HttpSourceTableFunction {
         backend: HttpSourceClient,
         source_schema: String,
         function: SourceTableFunctionSpec,
-        source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+        source_observation_publishers: SourceObservationPublishers,
     ) -> Result<Self> {
         let schema = schema_from_columns(&function.columns, &source_schema, &function.name)?;
         let target = HttpFetchTarget::from_function(&function);
@@ -160,7 +161,7 @@ impl TableProvider for HttpSourceFunctionCallTableProvider {
             projection,
             limit,
             surface_kind: SourceObservationSurfaceKind::Function,
-            source_observation_publishers: self.state.source_observation_publishers.clone(),
+            source_observation_publishers: Arc::clone(&self.state.source_observation_publishers),
         })
     }
 }

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -366,6 +366,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn source_scan_observation_includes_local_filter_values() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/people"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "people": [
+                    { "id": "1", "name": "Ada" },
+                    { "id": "2", "name": "Grace" }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        let manifest = parse_source_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "people_api",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "people",
+                "description": "People",
+                "filters": [{ "name": "tenant" }],
+                "request": { "path": "/people" },
+                "response": { "rows_path": ["people"] },
+                "columns": [
+                    { "name": "id", "type": "Utf8" },
+                    { "name": "name", "type": "Utf8" },
+                    {
+                        "name": "tenant",
+                        "type": "Utf8",
+                        "virtual": true,
+                        "expr": { "kind": "from_filter", "key": "tenant" }
+                    }
+                ]
+            }]
+        }))
+        .expect("manifest should deserialize");
+        let source = QuerySource::new(manifest, BTreeMap::new(), BTreeMap::new());
+        let publisher = Arc::new(RecordingSourceObservationPublisher::default());
+        let mut extensions = EngineExtensions::default();
+        extensions
+            .source_observation_publishers
+            .push(publisher.clone() as Arc<dyn SourceObservationPublisher>);
+
+        let execution = CoralQuery::execute_sql(
+            &[source],
+            QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions),
+            "SELECT name FROM people_api.people WHERE tenant = 'acme'",
+        )
+        .await
+        .expect("query should execute");
+
+        let rendered = pretty_format_batches(execution.batches())
+            .expect("batches should render")
+            .to_string();
+        assert!(rendered.contains("| Ada"));
+        assert!(rendered.contains("| Grace"));
+
+        let observations = publisher.observations();
+        let people_scan = observations
+            .iter()
+            .find(|observation| {
+                observation.source_name == "people_api" && observation.surface_name == "people"
+            })
+            .expect("people scan should be observed");
+
+        let observed_tenants = people_scan
+            .batch
+            .column_by_name("tenant")
+            .expect("tenant column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("tenant string array")
+            .iter()
+            .collect::<Vec<_>>();
+        assert_eq!(observed_tenants, [Some("acme"), Some("acme")]);
+    }
+
+    #[tokio::test]
     async fn source_scan_observation_covers_dependent_join_fetches() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -9,6 +9,9 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 use datafusion::prelude::SessionContext;
 
+use crate::backends::shared::source_observation::{
+    SourceObservationPublishers, source_observation_publishers,
+};
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
     BackendSchemaRegistration, CompiledBackendSource, RegisteredSource, RegisteredTable,
@@ -16,10 +19,7 @@ use crate::backends::{
     build_registered_table_function, registered_columns_from_specs, required_filter_names,
     validate_lookup_key_filter_backend_support,
 };
-use crate::{
-    RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver,
-    SourceObservationPublisher,
-};
+use crate::{RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver};
 use coral_spec::SourceBackend;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod auth;
@@ -53,7 +53,7 @@ struct HttpCompiledSource {
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<opentelemetry::Context>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+    source_observation_publishers: SourceObservationPublishers,
 }
 
 pub(crate) fn compile_source(
@@ -63,7 +63,7 @@ pub(crate) fn compile_source(
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<opentelemetry::Context>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+    source_observation_publishers: SourceObservationPublishers,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(HttpCompiledSource {
         manifest,
@@ -87,7 +87,7 @@ pub(crate) fn compile_manifest(
         request.runtime_context.body_capture_max_bytes,
         request.runtime_context.trace_context.clone(),
         request.source_input_resolver.clone(),
-        request.source_observation_publishers.to_vec(),
+        source_observation_publishers(request.source_observation_publishers),
     )
 }
 
@@ -141,7 +141,7 @@ impl CompiledBackendSource for HttpCompiledSource {
                 backend.clone(),
                 self.manifest.common.name.clone(),
                 table.clone(),
-                self.source_observation_publishers.clone(),
+                Arc::clone(&self.source_observation_publishers),
             )?);
             tables.insert(table.name().to_string(), provider);
             table_infos.push(registered_table(table));
@@ -153,7 +153,7 @@ impl CompiledBackendSource for HttpCompiledSource {
                     backend.clone(),
                     self.manifest.common.name.clone(),
                     function.clone(),
-                    self.source_observation_publishers.clone(),
+                    Arc::clone(&self.source_observation_publishers),
                 )?);
             table_function_infos.push(build_registered_table_function(
                 &self.manifest.common.name,
@@ -198,55 +198,20 @@ fn registered_table(table: &HttpTableSpec) -> RegisteredTable {
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     use coral_spec::parse_source_manifest_value;
-    use datafusion::arrow::array::{RecordBatch, StringArray};
+    use datafusion::arrow::array::StringArray;
     use datafusion::arrow::util::pretty::pretty_format_batches;
     use serde_json::json;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    use crate::backends::shared::source_observation::test_support::RecordingSourceObservationPublisher;
     use crate::{
         CoralQuery, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-        SourceObservationPublisher, SourceObservationSurfaceKind, SourceScanObservation,
+        SourceObservationPublisher, SourceObservationSurfaceKind,
     };
-
-    #[derive(Default)]
-    struct RecordingSourceObservationPublisher {
-        observations: Mutex<Vec<RecordedSourceObservation>>,
-    }
-
-    struct RecordedSourceObservation {
-        source_name: String,
-        surface_kind: SourceObservationSurfaceKind,
-        surface_name: String,
-        column_names: Vec<String>,
-        row_count: usize,
-        batch: RecordBatch,
-    }
-
-    impl SourceObservationPublisher for RecordingSourceObservationPublisher {
-        fn publish_source_scan(&self, observation: SourceScanObservation<'_>) {
-            self.observations
-                .lock()
-                .expect("observations lock")
-                .push(RecordedSourceObservation {
-                    source_name: observation.source_name.to_string(),
-                    surface_kind: observation.surface_kind,
-                    surface_name: observation.surface_name.to_string(),
-                    column_names: observation
-                        .batch
-                        .schema()
-                        .fields()
-                        .iter()
-                        .map(|field| field.name().clone())
-                        .collect(),
-                    row_count: observation.batch.num_rows(),
-                    batch: observation.batch.clone(),
-                });
-        }
-    }
 
     #[test]
     fn required_secret_names_come_from_declared_secret_inputs() {
@@ -329,6 +294,7 @@ mod tests {
             "tables": [{
                 "name": "people",
                 "description": "People",
+                "filters": [{ "name": "id" }],
                 "request": { "path": "/people" },
                 "response": { "rows_path": ["people"] },
                 "columns": [
@@ -369,7 +335,7 @@ mod tests {
             ["name"]
         );
 
-        let observations = publisher.observations.lock().expect("observations lock");
+        let observations = publisher.observations();
         let people_scan = observations
             .iter()
             .find(|observation| {
@@ -397,5 +363,91 @@ mod tests {
             observed_names,
             [Some("Ada"), Some("Grace"), Some("Katherine")]
         );
+    }
+
+    #[tokio::test]
+    async fn source_scan_observation_covers_dependent_join_fetches() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/people"))
+            .and(query_param("id", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "people": [
+                    { "id": "2", "name": "Grace", "role": "maintainer" }
+                ]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let manifest = parse_source_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "people_api",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "people",
+                "description": "People",
+                "filters": [{ "name": "id", "required": true, "lookup_key": true }],
+                "request": {
+                    "path": "/people",
+                    "query": [{ "name": "id", "from": "filter", "key": "id" }]
+                },
+                "response": { "rows_path": ["people"] },
+                "columns": [
+                    { "name": "id", "type": "Utf8" },
+                    { "name": "name", "type": "Utf8" },
+                    { "name": "role", "type": "Utf8" }
+                ]
+            }]
+        }))
+        .expect("manifest should deserialize");
+        let source = QuerySource::new(manifest, BTreeMap::new(), BTreeMap::new());
+        let publisher = Arc::new(RecordingSourceObservationPublisher::default());
+        let mut extensions = EngineExtensions::default();
+        extensions
+            .source_observation_publishers
+            .push(publisher.clone() as Arc<dyn SourceObservationPublisher>);
+
+        let execution = CoralQuery::execute_sql(
+            &[source],
+            QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions),
+            "SELECT p.name \
+             FROM (VALUES ('2')) AS ids(id) \
+             JOIN people_api.people AS p ON p.id = ids.id",
+        )
+        .await
+        .expect("query should execute");
+
+        let rendered = pretty_format_batches(execution.batches())
+            .expect("batches should render")
+            .to_string();
+        assert!(rendered.contains("| Grace"));
+
+        let observations = publisher.observations();
+        let people_scan = observations
+            .iter()
+            .find(|observation| {
+                observation.source_name == "people_api" && observation.surface_name == "people"
+            })
+            .expect("dependent people scan should be observed");
+
+        assert_eq!(
+            people_scan.surface_kind,
+            SourceObservationSurfaceKind::Table
+        );
+        assert_eq!(people_scan.column_names, ["id", "name", "role"]);
+        assert_eq!(people_scan.row_count, 1);
+
+        let observed_names = people_scan
+            .batch
+            .column_by_name("name")
+            .expect("name column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("name string array")
+            .iter()
+            .collect::<Vec<_>>();
+        assert_eq!(observed_names, [Some("Grace")]);
     }
 }

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -16,7 +16,10 @@ use crate::backends::{
     build_registered_table_function, registered_columns_from_specs, required_filter_names,
     validate_lookup_key_filter_backend_support,
 };
-use crate::{RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver};
+use crate::{
+    RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver,
+    SourceObservationPublisher,
+};
 use coral_spec::SourceBackend;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod auth;
@@ -42,7 +45,7 @@ pub(crate) use client::{HttpSourceClient, HttpSourceClientRuntime};
 pub(crate) use error::ProviderQueryError;
 pub(crate) use provider::HttpSourceTableProvider;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct HttpCompiledSource {
     manifest: HttpSourceManifest,
     source_input_resolution: SourceInputResolutionContext,
@@ -50,6 +53,7 @@ struct HttpCompiledSource {
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<opentelemetry::Context>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
 }
 
 pub(crate) fn compile_source(
@@ -59,6 +63,7 @@ pub(crate) fn compile_source(
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<opentelemetry::Context>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(HttpCompiledSource {
         manifest,
@@ -67,6 +72,7 @@ pub(crate) fn compile_source(
         body_capture_max_bytes,
         trace_context,
         source_input_resolver,
+        source_observation_publishers,
     })
 }
 
@@ -81,6 +87,7 @@ pub(crate) fn compile_manifest(
         request.runtime_context.body_capture_max_bytes,
         request.runtime_context.trace_context.clone(),
         request.source_input_resolver.clone(),
+        request.source_observation_publishers.to_vec(),
     )
 }
 
@@ -134,6 +141,7 @@ impl CompiledBackendSource for HttpCompiledSource {
                 backend.clone(),
                 self.manifest.common.name.clone(),
                 table.clone(),
+                self.source_observation_publishers.clone(),
             )?);
             tables.insert(table.name().to_string(), provider);
             table_infos.push(registered_table(table));
@@ -145,6 +153,7 @@ impl CompiledBackendSource for HttpCompiledSource {
                     backend.clone(),
                     self.manifest.common.name.clone(),
                     function.clone(),
+                    self.source_observation_publishers.clone(),
                 )?);
             table_function_infos.push(build_registered_table_function(
                 &self.manifest.common.name,
@@ -188,10 +197,56 @@ fn registered_table(table: &HttpTableSpec) -> RegisteredTable {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::{Arc, Mutex};
 
     use coral_spec::parse_source_manifest_value;
+    use datafusion::arrow::array::{RecordBatch, StringArray};
+    use datafusion::arrow::util::pretty::pretty_format_batches;
     use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::{
+        CoralQuery, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+        SourceObservationPublisher, SourceObservationSurfaceKind, SourceScanObservation,
+    };
+
+    #[derive(Default)]
+    struct RecordingSourceObservationPublisher {
+        observations: Mutex<Vec<RecordedSourceObservation>>,
+    }
+
+    struct RecordedSourceObservation {
+        source_name: String,
+        surface_kind: SourceObservationSurfaceKind,
+        surface_name: String,
+        column_names: Vec<String>,
+        row_count: usize,
+        batch: RecordBatch,
+    }
+
+    impl SourceObservationPublisher for RecordingSourceObservationPublisher {
+        fn publish_source_scan(&self, observation: SourceScanObservation<'_>) {
+            self.observations
+                .lock()
+                .expect("observations lock")
+                .push(RecordedSourceObservation {
+                    source_name: observation.source_name.to_string(),
+                    surface_kind: observation.surface_kind,
+                    surface_name: observation.surface_name.to_string(),
+                    column_names: observation
+                        .batch
+                        .schema()
+                        .fields()
+                        .iter()
+                        .map(|field| field.name().clone())
+                        .collect(),
+                    row_count: observation.batch.num_rows(),
+                    batch: observation.batch.clone(),
+                });
+        }
+    }
 
     #[test]
     fn required_secret_names_come_from_declared_secret_inputs() {
@@ -249,5 +304,98 @@ mod tests {
         .expect("manifest should deserialize");
 
         assert!(manifest.required_secret_names().is_empty());
+    }
+
+    #[tokio::test]
+    async fn source_scan_observation_sees_full_http_batch_before_projection() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/people"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "people": [
+                    { "id": "1", "name": "Ada", "role": "admin" },
+                    { "id": "2", "name": "Grace", "role": "maintainer" },
+                    { "id": "3", "name": "Katherine", "role": "viewer" }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        let manifest = parse_source_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "people_api",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "people",
+                "description": "People",
+                "request": { "path": "/people" },
+                "response": { "rows_path": ["people"] },
+                "columns": [
+                    { "name": "id", "type": "Utf8" },
+                    { "name": "name", "type": "Utf8" },
+                    { "name": "role", "type": "Utf8" }
+                ]
+            }]
+        }))
+        .expect("manifest should deserialize");
+        let source = QuerySource::new(manifest, BTreeMap::new(), BTreeMap::new());
+        let publisher = Arc::new(RecordingSourceObservationPublisher::default());
+        let mut extensions = EngineExtensions::default();
+        extensions
+            .source_observation_publishers
+            .push(publisher.clone() as Arc<dyn SourceObservationPublisher>);
+
+        let execution = CoralQuery::execute_sql(
+            &[source],
+            QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions),
+            "SELECT name FROM people_api.people WHERE id = '2'",
+        )
+        .await
+        .expect("query should execute");
+
+        let rendered = pretty_format_batches(execution.batches())
+            .expect("batches should render")
+            .to_string();
+        assert!(rendered.contains("| Grace"));
+        assert!(!rendered.contains("| Ada"));
+        assert!(!rendered.contains("| Katherine"));
+        assert_eq!(
+            execution
+                .schema()
+                .iter()
+                .map(|column| column.name.as_str())
+                .collect::<Vec<_>>(),
+            ["name"]
+        );
+
+        let observations = publisher.observations.lock().expect("observations lock");
+        let people_scan = observations
+            .iter()
+            .find(|observation| {
+                observation.source_name == "people_api" && observation.surface_name == "people"
+            })
+            .expect("people scan should be observed");
+
+        assert_eq!(
+            people_scan.surface_kind,
+            SourceObservationSurfaceKind::Table
+        );
+        assert_eq!(people_scan.column_names, ["id", "name", "role"]);
+        assert_eq!(people_scan.row_count, 3);
+
+        let observed_names = people_scan
+            .batch
+            .column_by_name("name")
+            .expect("name column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("name string array")
+            .iter()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            observed_names,
+            [Some("Ada"), Some("Grace"), Some("Katherine")]
+        );
     }
 }

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -14,6 +14,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::empty::EmptyExec;
 use serde_json::Value;
 
+use crate::SourceObservationSurfaceKind;
 use crate::backends::http::HttpSourceClient;
 use crate::backends::http::ProviderQueryError;
 use crate::backends::http::target::HttpFetchTarget;
@@ -24,7 +25,7 @@ use crate::backends::shared::filter_expr::{
 };
 use crate::backends::shared::json_exec::{JsonExec, RowFetcher};
 use crate::backends::shared::mapping::{convert_items, filter_items_by_column_values};
-use crate::{SourceObservationPublisher, SourceObservationSurfaceKind};
+use crate::backends::shared::source_observation::SourceObservationPublishers;
 use coral_spec::backends::http::HttpTableSpec;
 
 /// Table provider that exposes one manifest-defined HTTP table to `DataFusion`.
@@ -34,7 +35,7 @@ pub(crate) struct HttpSourceTableProvider {
     table: Arc<HttpTableSpec>,
     target: HttpFetchTarget,
     schema: SchemaRef,
-    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+    source_observation_publishers: SourceObservationPublishers,
 }
 
 impl std::fmt::Debug for HttpSourceTableProvider {
@@ -57,7 +58,7 @@ impl HttpSourceTableProvider {
         backend: HttpSourceClient,
         source_schema: String,
         table: HttpTableSpec,
-        source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+        source_observation_publishers: SourceObservationPublishers,
     ) -> Result<Self> {
         let schema = schema_from_columns(table.columns(), &source_schema, table.name())?;
         let target = HttpFetchTarget::from_resolved_table_request(&table, table.request.clone());
@@ -81,6 +82,10 @@ impl HttpSourceTableProvider {
 
     pub(crate) fn table_spec(&self) -> &Arc<HttpTableSpec> {
         &self.table
+    }
+
+    pub(crate) fn source_observation_publishers(&self) -> &SourceObservationPublishers {
+        &self.source_observation_publishers
     }
 }
 
@@ -107,7 +112,7 @@ pub(crate) struct HttpJsonExecRequest<'a> {
     pub(crate) projection: Option<&'a Vec<usize>>,
     pub(crate) limit: Option<usize>,
     pub(crate) surface_kind: SourceObservationSurfaceKind,
-    pub(crate) source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+    pub(crate) source_observation_publishers: SourceObservationPublishers,
 }
 
 #[async_trait]
@@ -155,6 +160,7 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
     } = request;
     let target = Arc::new(target);
     let mut conversion_filter_values = request_filter_values.clone();
+    let observation_filter_values = Arc::new(request_filter_values.clone());
     conversion_filter_values.extend(
         local_filter_values
             .iter()
@@ -211,6 +217,15 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
             )
         })
     };
+    let observation_converter = {
+        let target = target.clone();
+        let schema = schema.clone();
+        let filters = Arc::clone(&observation_filter_values);
+        let args = Arc::clone(&arg_values);
+        Arc::new(move |items: &[Value]| {
+            convert_items(target.columns(), schema.clone(), &filters, &args, items)
+        })
+    };
 
     let exec = JsonExec::new(
         source_schema,
@@ -220,7 +235,11 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         converter,
         projection.cloned(),
     )?
-    .with_source_observation(surface_kind, source_observation_publishers);
+    .with_source_observation_converter(
+        surface_kind,
+        source_observation_publishers,
+        observation_converter,
+    );
 
     Ok(Arc::new(exec))
 }
@@ -325,7 +344,7 @@ impl TableProvider for HttpSourceTableProvider {
             projection,
             limit,
             surface_kind: SourceObservationSurfaceKind::Table,
-            source_observation_publishers: self.source_observation_publishers.clone(),
+            source_observation_publishers: Arc::clone(&self.source_observation_publishers),
         })
     }
 }

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -142,6 +142,18 @@ impl RowFetcher for HttpFetchPlan {
     }
 }
 
+fn merge_filter_values(
+    mut values: HashMap<String, String>,
+    extra_values: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    values.extend(
+        extra_values
+            .iter()
+            .map(|(filter, value)| (filter.clone(), value.clone())),
+    );
+    values
+}
+
 pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn ExecutionPlan>> {
     let HttpJsonExecRequest {
         backend,
@@ -159,13 +171,12 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         source_observation_publishers,
     } = request;
     let target = Arc::new(target);
-    let mut conversion_filter_values = request_filter_values.clone();
-    let observation_filter_values = Arc::new(request_filter_values.clone());
-    conversion_filter_values.extend(
-        local_filter_values
-            .iter()
-            .map(|(filter, value)| (filter.clone(), value.clone())),
-    );
+    let conversion_filter_values =
+        merge_filter_values(request_filter_values.clone(), &local_filter_values);
+    let observation_filter_values = Arc::new(merge_filter_values(
+        request_filter_values.clone(),
+        &local_filter_values,
+    ));
     let request_filter_values = Arc::new(request_filter_values);
     let local_filter_values = Arc::new(local_filter_values);
     let active_filter_values = Arc::new(active_filter_values);

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -24,6 +24,7 @@ use crate::backends::shared::filter_expr::{
 };
 use crate::backends::shared::json_exec::{JsonExec, RowFetcher};
 use crate::backends::shared::mapping::{convert_items, filter_items_by_column_values};
+use crate::{SourceObservationPublisher, SourceObservationSurfaceKind};
 use coral_spec::backends::http::HttpTableSpec;
 
 /// Table provider that exposes one manifest-defined HTTP table to `DataFusion`.
@@ -33,6 +34,7 @@ pub(crate) struct HttpSourceTableProvider {
     table: Arc<HttpTableSpec>,
     target: HttpFetchTarget,
     schema: SchemaRef,
+    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
 }
 
 impl std::fmt::Debug for HttpSourceTableProvider {
@@ -55,6 +57,7 @@ impl HttpSourceTableProvider {
         backend: HttpSourceClient,
         source_schema: String,
         table: HttpTableSpec,
+        source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
     ) -> Result<Self> {
         let schema = schema_from_columns(table.columns(), &source_schema, table.name())?;
         let target = HttpFetchTarget::from_resolved_table_request(&table, table.request.clone());
@@ -64,6 +67,7 @@ impl HttpSourceTableProvider {
             table: Arc::new(table),
             target,
             schema,
+            source_observation_publishers,
         })
     }
 
@@ -102,6 +106,8 @@ pub(crate) struct HttpJsonExecRequest<'a> {
     pub(crate) arg_values: HashMap<String, String>,
     pub(crate) projection: Option<&'a Vec<usize>>,
     pub(crate) limit: Option<usize>,
+    pub(crate) surface_kind: SourceObservationSurfaceKind,
+    pub(crate) source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
 }
 
 #[async_trait]
@@ -144,6 +150,8 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         arg_values,
         projection,
         limit,
+        surface_kind,
+        source_observation_publishers,
     } = request;
     let target = Arc::new(target);
     let mut conversion_filter_values = request_filter_values.clone();
@@ -211,7 +219,8 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         fetcher,
         converter,
         projection.cloned(),
-    )?;
+    )?
+    .with_source_observation(surface_kind, source_observation_publishers);
 
     Ok(Arc::new(exec))
 }
@@ -315,6 +324,8 @@ impl TableProvider for HttpSourceTableProvider {
             arg_values: HashMap::new(),
             projection,
             limit,
+            surface_kind: SourceObservationSurfaceKind::Table,
+            source_observation_publishers: self.source_observation_publishers.clone(),
         })
     }
 }

--- a/crates/coral-engine/src/backends/mcp/function.rs
+++ b/crates/coral-engine/src/backends/mcp/function.rs
@@ -21,6 +21,7 @@ use crate::backends::schema_from_columns;
 use crate::backends::shared::json_exec::JsonExec;
 use crate::backends::shared::mapping::convert_items;
 use crate::backends::shared::scalar::timestamp_to_rfc3339;
+use crate::{SourceObservationPublisher, SourceObservationSurfaceKind};
 
 #[derive(Clone)]
 pub(super) struct McpSourceTableFunction {
@@ -39,6 +40,7 @@ struct McpFunctionState {
     offset_pagination: Option<McpOffsetPaginationSpec>,
     columns: Arc<[coral_spec::ColumnSpec]>,
     fetch_limit_default: Option<usize>,
+    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
 }
 
 impl std::fmt::Debug for McpSourceTableFunction {
@@ -66,6 +68,7 @@ impl McpSourceTableFunction {
         backend: McpSourceClient,
         source_schema: String,
         function: McpTableFunctionSpec,
+        source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
     ) -> Result<Self> {
         let schema = schema_from_columns(function.columns(), &source_schema, function.name())?;
         let function_name = function.name().to_string();
@@ -88,6 +91,7 @@ impl McpSourceTableFunction {
                 offset_pagination,
                 columns: Arc::from(columns),
                 fetch_limit_default,
+                source_observation_publishers,
             }),
         })
     }
@@ -188,7 +192,11 @@ impl TableProvider for McpFunctionCallTableProvider {
             fetcher,
             converter,
             projection.cloned(),
-        )?;
+        )?
+        .with_source_observation(
+            SourceObservationSurfaceKind::Function,
+            self.state.source_observation_publishers.clone(),
+        );
         Ok(Arc::new(exec))
     }
 }

--- a/crates/coral-engine/src/backends/mcp/function.rs
+++ b/crates/coral-engine/src/backends/mcp/function.rs
@@ -16,12 +16,13 @@ use serde_json::Value;
 use super::client::McpSourceClient;
 use super::error::McpProviderQueryError;
 use super::fetch::McpFetchPlan;
+use crate::SourceObservationSurfaceKind;
 use crate::backends::SourceFunctionProviderFactory;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::json_exec::JsonExec;
 use crate::backends::shared::mapping::convert_items;
 use crate::backends::shared::scalar::timestamp_to_rfc3339;
-use crate::{SourceObservationPublisher, SourceObservationSurfaceKind};
+use crate::backends::shared::source_observation::SourceObservationPublishers;
 
 #[derive(Clone)]
 pub(super) struct McpSourceTableFunction {
@@ -40,7 +41,7 @@ struct McpFunctionState {
     offset_pagination: Option<McpOffsetPaginationSpec>,
     columns: Arc<[coral_spec::ColumnSpec]>,
     fetch_limit_default: Option<usize>,
-    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+    source_observation_publishers: SourceObservationPublishers,
 }
 
 impl std::fmt::Debug for McpSourceTableFunction {
@@ -68,7 +69,7 @@ impl McpSourceTableFunction {
         backend: McpSourceClient,
         source_schema: String,
         function: McpTableFunctionSpec,
-        source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+        source_observation_publishers: SourceObservationPublishers,
     ) -> Result<Self> {
         let schema = schema_from_columns(function.columns(), &source_schema, function.name())?;
         let function_name = function.name().to_string();
@@ -195,7 +196,7 @@ impl TableProvider for McpFunctionCallTableProvider {
         )?
         .with_source_observation(
             SourceObservationSurfaceKind::Function,
-            self.state.source_observation_publishers.clone(),
+            Arc::clone(&self.state.source_observation_publishers),
         );
         Ok(Arc::new(exec))
     }

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -26,6 +26,9 @@ use self::client::{McpSourceClient, McpToolCaller};
 use self::function::McpSourceTableFunction;
 use self::provider::McpTableProvider;
 use self::transport::{StdioMcpToolCaller, StreamableHttpMcpToolCaller};
+use crate::backends::shared::source_observation::{
+    SourceObservationPublishers, source_observation_publishers,
+};
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
     BackendSchemaRegistration, CompiledBackendSource, RegisteredSource,
@@ -36,7 +39,6 @@ use crate::backends::{
 use crate::runtime::error::datafusion_to_core;
 use crate::{
     CoreError, SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
-    SourceObservationPublisher,
 };
 
 #[derive(Clone)]
@@ -45,7 +47,7 @@ struct McpCompiledSource {
     source_input_resolution: SourceInputResolutionContext,
     source_inputs: Arc<McpSourceInputs>,
     caller: McpSourceClient,
-    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+    source_observation_publishers: SourceObservationPublishers,
 }
 
 #[derive(Debug, Clone)]
@@ -127,7 +129,7 @@ pub(crate) fn compile_manifest(
         source_input_resolution,
         source_inputs,
         caller,
-        request.source_observation_publishers.to_vec(),
+        source_observation_publishers(request.source_observation_publishers),
     )
 }
 
@@ -163,7 +165,7 @@ fn compile_source_with_caller(
     source_input_resolution: SourceInputResolutionContext,
     source_inputs: Arc<McpSourceInputs>,
     caller: Arc<dyn McpToolCaller>,
-    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+    source_observation_publishers: SourceObservationPublishers,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(McpCompiledSource {
         manifest,
@@ -209,7 +211,7 @@ impl CompiledBackendSource for McpCompiledSource {
                     self.caller.clone(),
                     self.manifest.common.name.clone(),
                     function.clone(),
-                    self.source_observation_publishers.clone(),
+                    Arc::clone(&self.source_observation_publishers),
                 )?);
             table_function_infos.push(build_registered_table_function(
                 &self.manifest.common.name,
@@ -226,7 +228,7 @@ impl CompiledBackendSource for McpCompiledSource {
                 self.manifest.common.name.clone(),
                 Arc::clone(&self.source_inputs),
                 table.clone(),
-                self.source_observation_publishers.clone(),
+                Arc::clone(&self.source_observation_publishers),
             )?);
             tables.insert(table.name().to_string(), provider);
             let required_filters = required_filter_names(table.filters());

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -36,14 +36,16 @@ use crate::backends::{
 use crate::runtime::error::datafusion_to_core;
 use crate::{
     CoreError, SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
+    SourceObservationPublisher,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct McpCompiledSource {
     manifest: McpSourceManifest,
     source_input_resolution: SourceInputResolutionContext,
     source_inputs: Arc<McpSourceInputs>,
     caller: McpSourceClient,
+    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
 }
 
 #[derive(Debug, Clone)]
@@ -125,6 +127,7 @@ pub(crate) fn compile_manifest(
         source_input_resolution,
         source_inputs,
         caller,
+        request.source_observation_publishers.to_vec(),
     )
 }
 
@@ -160,12 +163,14 @@ fn compile_source_with_caller(
     source_input_resolution: SourceInputResolutionContext,
     source_inputs: Arc<McpSourceInputs>,
     caller: Arc<dyn McpToolCaller>,
+    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(McpCompiledSource {
         manifest,
         source_input_resolution,
         source_inputs,
         caller: McpSourceClient::new(caller),
+        source_observation_publishers,
     })
 }
 
@@ -204,6 +209,7 @@ impl CompiledBackendSource for McpCompiledSource {
                     self.caller.clone(),
                     self.manifest.common.name.clone(),
                     function.clone(),
+                    self.source_observation_publishers.clone(),
                 )?);
             table_function_infos.push(build_registered_table_function(
                 &self.manifest.common.name,
@@ -220,6 +226,7 @@ impl CompiledBackendSource for McpCompiledSource {
                 self.manifest.common.name.clone(),
                 Arc::clone(&self.source_inputs),
                 table.clone(),
+                self.source_observation_publishers.clone(),
             )?);
             tables.insert(table.name().to_string(), provider);
             let required_filters = required_filter_names(table.filters());

--- a/crates/coral-engine/src/backends/mcp/provider.rs
+++ b/crates/coral-engine/src/backends/mcp/provider.rs
@@ -21,6 +21,7 @@ use crate::backends::schema_from_columns;
 use crate::backends::shared::filter_expr::{classify_filter_pushdown, extract_filter_values};
 use crate::backends::shared::json_exec::JsonExec;
 use crate::backends::shared::mapping::convert_items;
+use crate::{SourceObservationPublisher, SourceObservationSurfaceKind};
 
 pub(super) struct McpTableProvider {
     backend: McpSourceClient,
@@ -28,6 +29,7 @@ pub(super) struct McpTableProvider {
     source_inputs: Arc<McpSourceInputs>,
     table: Arc<McpTableSpec>,
     schema: SchemaRef,
+    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
 }
 
 impl std::fmt::Debug for McpTableProvider {
@@ -46,6 +48,7 @@ impl McpTableProvider {
         source_schema: String,
         source_inputs: Arc<McpSourceInputs>,
         table: McpTableSpec,
+        source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
     ) -> Result<Self> {
         let schema = schema_from_columns(table.columns(), &source_schema, table.name())?;
         Ok(Self {
@@ -54,6 +57,7 @@ impl McpTableProvider {
             source_inputs,
             table: Arc::new(table),
             schema,
+            source_observation_publishers,
         })
     }
 }
@@ -170,7 +174,11 @@ impl TableProvider for McpTableProvider {
             fetcher,
             converter,
             projection.cloned(),
-        )?;
+        )?
+        .with_source_observation(
+            SourceObservationSurfaceKind::Table,
+            self.source_observation_publishers.clone(),
+        );
         Ok(Arc::new(exec))
     }
 }

--- a/crates/coral-engine/src/backends/mcp/provider.rs
+++ b/crates/coral-engine/src/backends/mcp/provider.rs
@@ -17,11 +17,12 @@ use super::McpSourceInputs;
 use super::client::McpSourceClient;
 use super::error::McpProviderQueryError;
 use super::fetch::McpFetchPlan;
+use crate::SourceObservationSurfaceKind;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::filter_expr::{classify_filter_pushdown, extract_filter_values};
 use crate::backends::shared::json_exec::JsonExec;
 use crate::backends::shared::mapping::convert_items;
-use crate::{SourceObservationPublisher, SourceObservationSurfaceKind};
+use crate::backends::shared::source_observation::SourceObservationPublishers;
 
 pub(super) struct McpTableProvider {
     backend: McpSourceClient,
@@ -29,7 +30,7 @@ pub(super) struct McpTableProvider {
     source_inputs: Arc<McpSourceInputs>,
     table: Arc<McpTableSpec>,
     schema: SchemaRef,
-    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+    source_observation_publishers: SourceObservationPublishers,
 }
 
 impl std::fmt::Debug for McpTableProvider {
@@ -48,7 +49,7 @@ impl McpTableProvider {
         source_schema: String,
         source_inputs: Arc<McpSourceInputs>,
         table: McpTableSpec,
-        source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+        source_observation_publishers: SourceObservationPublishers,
     ) -> Result<Self> {
         let schema = schema_from_columns(table.columns(), &source_schema, table.name())?;
         Ok(Self {
@@ -177,7 +178,7 @@ impl TableProvider for McpTableProvider {
         )?
         .with_source_observation(
             SourceObservationSurfaceKind::Table,
-            self.source_observation_publishers.clone(),
+            Arc::clone(&self.source_observation_publishers),
         );
         Ok(Arc::new(exec))
     }

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -1,12 +1,15 @@
 use super::*;
+use crate::backends::shared::source_observation::{
+    source_observation_publishers, test_support::RecordingSourceObservationPublisher,
+};
 use crate::runtime::catalog;
 use crate::runtime::registry::{CompiledQuerySource, register_sources_blocking};
 use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
     QuerySource, SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
-    SourceObservationPublisher, SourceObservationSurfaceKind, SourceScanObservation,
+    SourceObservationPublisher, SourceObservationSurfaceKind,
 };
-use datafusion::arrow::array::{RecordBatch, StringArray};
+use datafusion::arrow::array::StringArray;
 use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::error::DataFusionError;
 use datafusion::prelude::SessionContext;
@@ -71,42 +74,6 @@ impl McpToolCaller for FakeMcpTableCaller {
                 { "id": "3", "title": "Bug C", "state": "closed" }
             ]
         }))
-    }
-}
-
-#[derive(Default)]
-struct RecordingSourceObservationPublisher {
-    observations: Mutex<Vec<RecordedSourceObservation>>,
-}
-
-struct RecordedSourceObservation {
-    source_name: String,
-    surface_kind: SourceObservationSurfaceKind,
-    surface_name: String,
-    column_names: Vec<String>,
-    row_count: usize,
-    batch: RecordBatch,
-}
-
-impl SourceObservationPublisher for RecordingSourceObservationPublisher {
-    fn publish_source_scan(&self, observation: SourceScanObservation<'_>) {
-        self.observations
-            .lock()
-            .expect("observations lock")
-            .push(RecordedSourceObservation {
-                source_name: observation.source_name.to_string(),
-                surface_kind: observation.surface_kind,
-                surface_name: observation.surface_name.to_string(),
-                column_names: observation
-                    .batch
-                    .schema()
-                    .fields()
-                    .iter()
-                    .map(|field| field.name().clone())
-                    .collect(),
-                row_count: observation.batch.num_rows(),
-                batch: observation.batch.clone(),
-            });
     }
 }
 
@@ -343,7 +310,7 @@ fn compile_sources_with_mcp_manifest(
         source_input_resolution,
         source_inputs,
         caller,
-        Vec::new(),
+        source_observation_publishers(&[]),
     );
     vec![CompiledQuerySource { source, compiled }]
 }
@@ -351,26 +318,15 @@ fn compile_sources_with_mcp_manifest(
 fn compile_sources_with_observation_publishers(
     manifest: coral_spec::ValidatedSourceManifest,
     caller: Arc<dyn McpToolCaller>,
-    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+    publishers: &[Arc<dyn SourceObservationPublisher>],
 ) -> Vec<CompiledQuerySource> {
-    let mcp_manifest = manifest.as_mcp().expect("mcp manifest").clone();
-    let variables = BTreeMap::new();
-    let source = QuerySource::new(manifest, variables.clone(), BTreeMap::new());
-    let source_input_resolution = SourceInputResolutionContext::from_query_source(&source);
-    let resolved_inputs = Arc::new(coral_spec::resolve_inputs(
-        &mcp_manifest.declared_inputs,
-        source_input_resolution.secrets(),
-        source_input_resolution.variables(),
-    ));
-    let source_inputs = Arc::new(McpSourceInputs::static_inputs(resolved_inputs));
-    let compiled = compile_source_with_caller(
-        mcp_manifest,
-        source_input_resolution,
-        source_inputs,
+    compile_sources_with_inputs_and_observation_publishers(
+        manifest,
         caller,
-        source_observation_publishers,
-    );
-    vec![CompiledQuerySource { source, compiled }]
+        BTreeMap::new(),
+        None,
+        publishers,
+    )
 }
 
 fn compile_sources_with_inputs(
@@ -378,6 +334,22 @@ fn compile_sources_with_inputs(
     caller: Arc<dyn McpToolCaller>,
     secrets: BTreeMap<String, String>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+) -> Vec<CompiledQuerySource> {
+    compile_sources_with_inputs_and_observation_publishers(
+        manifest,
+        caller,
+        secrets,
+        source_input_resolver,
+        &[],
+    )
+}
+
+fn compile_sources_with_inputs_and_observation_publishers(
+    manifest: coral_spec::ValidatedSourceManifest,
+    caller: Arc<dyn McpToolCaller>,
+    secrets: BTreeMap<String, String>,
+    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    publishers: &[Arc<dyn SourceObservationPublisher>],
 ) -> Vec<CompiledQuerySource> {
     let mcp_manifest = manifest.as_mcp().expect("mcp manifest").clone();
     let variables = BTreeMap::new();
@@ -401,7 +373,7 @@ fn compile_sources_with_inputs(
         source_input_resolution,
         source_inputs,
         caller,
-        Vec::new(),
+        source_observation_publishers(publishers),
     );
     vec![CompiledQuerySource { source, compiled }]
 }
@@ -835,7 +807,7 @@ async fn source_scan_observation_sees_full_mcp_batch_before_projection() {
         compile_sources_with_observation_publishers(
             mcp_table_manifest(),
             caller,
-            vec![publisher.clone() as Arc<dyn SourceObservationPublisher>],
+            &[publisher.clone() as Arc<dyn SourceObservationPublisher>],
         ),
     );
 
@@ -865,7 +837,7 @@ async fn source_scan_observation_sees_full_mcp_batch_before_projection() {
         ["title"]
     );
 
-    let observations = publisher.observations.lock().expect("observations lock");
+    let observations = publisher.observations();
     let issue_scan = observations
         .iter()
         .find(|observation| {

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -4,7 +4,9 @@ use crate::runtime::registry::{CompiledQuerySource, register_sources_blocking};
 use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
     QuerySource, SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
+    SourceObservationPublisher, SourceObservationSurfaceKind, SourceScanObservation,
 };
+use datafusion::arrow::array::{RecordBatch, StringArray};
 use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::error::DataFusionError;
 use datafusion::prelude::SessionContext;
@@ -69,6 +71,42 @@ impl McpToolCaller for FakeMcpTableCaller {
                 { "id": "3", "title": "Bug C", "state": "closed" }
             ]
         }))
+    }
+}
+
+#[derive(Default)]
+struct RecordingSourceObservationPublisher {
+    observations: Mutex<Vec<RecordedSourceObservation>>,
+}
+
+struct RecordedSourceObservation {
+    source_name: String,
+    surface_kind: SourceObservationSurfaceKind,
+    surface_name: String,
+    column_names: Vec<String>,
+    row_count: usize,
+    batch: RecordBatch,
+}
+
+impl SourceObservationPublisher for RecordingSourceObservationPublisher {
+    fn publish_source_scan(&self, observation: SourceScanObservation<'_>) {
+        self.observations
+            .lock()
+            .expect("observations lock")
+            .push(RecordedSourceObservation {
+                source_name: observation.source_name.to_string(),
+                surface_kind: observation.surface_kind,
+                surface_name: observation.surface_name.to_string(),
+                column_names: observation
+                    .batch
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|field| field.name().clone())
+                    .collect(),
+                row_count: observation.batch.num_rows(),
+                batch: observation.batch.clone(),
+            });
     }
 }
 
@@ -300,8 +338,38 @@ fn compile_sources_with_mcp_manifest(
         source_input_resolution.variables(),
     ));
     let source_inputs = Arc::new(McpSourceInputs::static_inputs(resolved_inputs));
-    let compiled =
-        compile_source_with_caller(mcp_manifest, source_input_resolution, source_inputs, caller);
+    let compiled = compile_source_with_caller(
+        mcp_manifest,
+        source_input_resolution,
+        source_inputs,
+        caller,
+        Vec::new(),
+    );
+    vec![CompiledQuerySource { source, compiled }]
+}
+
+fn compile_sources_with_observation_publishers(
+    manifest: coral_spec::ValidatedSourceManifest,
+    caller: Arc<dyn McpToolCaller>,
+    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+) -> Vec<CompiledQuerySource> {
+    let mcp_manifest = manifest.as_mcp().expect("mcp manifest").clone();
+    let variables = BTreeMap::new();
+    let source = QuerySource::new(manifest, variables.clone(), BTreeMap::new());
+    let source_input_resolution = SourceInputResolutionContext::from_query_source(&source);
+    let resolved_inputs = Arc::new(coral_spec::resolve_inputs(
+        &mcp_manifest.declared_inputs,
+        source_input_resolution.secrets(),
+        source_input_resolution.variables(),
+    ));
+    let source_inputs = Arc::new(McpSourceInputs::static_inputs(resolved_inputs));
+    let compiled = compile_source_with_caller(
+        mcp_manifest,
+        source_input_resolution,
+        source_inputs,
+        caller,
+        source_observation_publishers,
+    );
     vec![CompiledQuerySource { source, compiled }]
 }
 
@@ -328,8 +396,13 @@ fn compile_sources_with_inputs(
         )),
         None => Arc::new(McpSourceInputs::static_inputs(resolved_inputs)),
     };
-    let compiled =
-        compile_source_with_caller(mcp_manifest, source_input_resolution, source_inputs, caller);
+    let compiled = compile_source_with_caller(
+        mcp_manifest,
+        source_input_resolution,
+        source_inputs,
+        caller,
+        Vec::new(),
+    );
     vec![CompiledQuerySource { source, compiled }]
 }
 
@@ -748,6 +821,72 @@ async fn applies_projection_and_limit_to_mcp_table_scan() {
     let schema = batches.first().expect("at least one batch").schema();
     assert_eq!(schema.fields().len(), 1);
     assert_eq!(schema.field(0).name(), "title");
+}
+
+#[tokio::test]
+async fn source_scan_observation_sees_full_mcp_batch_before_projection() {
+    let ctx = SessionContext::new();
+    let caller = Arc::new(FakeMcpTableCaller {
+        calls: Mutex::new(Vec::new()),
+    });
+    let publisher = Arc::new(RecordingSourceObservationPublisher::default());
+    register_test_sources(
+        &ctx,
+        compile_sources_with_observation_publishers(
+            mcp_table_manifest(),
+            caller,
+            vec![publisher.clone() as Arc<dyn SourceObservationPublisher>],
+        ),
+    );
+
+    let batches = ctx
+        .sql("SELECT title FROM test_mcp.issues WHERE id = '2'")
+        .await
+        .expect("query should plan")
+        .collect()
+        .await
+        .expect("query should execute");
+
+    let rendered = pretty_format_batches(&batches)
+        .expect("batches should render")
+        .to_string();
+    assert!(rendered.contains("| Bug B"));
+    assert!(!rendered.contains("| Bug A"));
+    assert!(!rendered.contains("| Bug C"));
+    assert_eq!(
+        batches
+            .first()
+            .expect("projected result batch")
+            .schema()
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect::<Vec<_>>(),
+        ["title"]
+    );
+
+    let observations = publisher.observations.lock().expect("observations lock");
+    let issue_scan = observations
+        .iter()
+        .find(|observation| {
+            observation.source_name == "test_mcp" && observation.surface_name == "issues"
+        })
+        .expect("issues scan should be observed");
+
+    assert_eq!(issue_scan.surface_kind, SourceObservationSurfaceKind::Table);
+    assert_eq!(issue_scan.column_names, ["id", "title", "state"]);
+    assert_eq!(issue_scan.row_count, 3);
+
+    let observed_ids = issue_scan
+        .batch
+        .column_by_name("id")
+        .expect("id column")
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("id string array")
+        .iter()
+        .collect::<Vec<_>>();
+    assert_eq!(observed_ids, [Some("1"), Some("2"), Some("3")]);
 }
 
 /// Returns the ClickHouse-style success/error union and records each MCP

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -72,6 +72,7 @@ use std::sync::Arc;
 
 use crate::{
     CoreError, QuerySource, RequestAuthenticator, RuntimeSourceComponent, SourceInputResolver,
+    SourceObservationPublisher,
 };
 #[cfg(test)]
 use coral_spec::ValidatedSourceManifest;
@@ -97,6 +98,7 @@ pub(crate) fn compile_query_source(
     runtime_context: &crate::QueryRuntimeContext,
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    source_observation_publishers: &[Arc<dyn SourceObservationPublisher>],
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     if source.components().is_empty() {
         return Err(CoreError::FailedPrecondition(format!(
@@ -111,6 +113,7 @@ pub(crate) fn compile_query_source(
         source_variables: source.variables().clone(),
         request_authenticators,
         source_input_resolver,
+        source_observation_publishers,
     };
     let compiled_components = source
         .components()
@@ -156,6 +159,7 @@ pub(crate) fn compile_source_manifest(
             source_variables,
             request_authenticators: &request_authenticators,
             source_input_resolver: None,
+            source_observation_publishers: &[],
         },
     )
 }

--- a/crates/coral-engine/src/backends/shared/json_exec.rs
+++ b/crates/coral-engine/src/backends/shared/json_exec.rs
@@ -45,14 +45,39 @@ fn observe_source_scan_batch(
     output_converter: Converter,
 ) -> Converter {
     Arc::new(move |items| {
-        let observation_batch = observation_converter(items)?;
-        publish_source_scan_batch(
-            &source_name,
-            &surface_name,
-            &observation,
-            &observation_batch,
-        );
-        output_converter(items)
+        let output_batch = output_converter(items)?;
+        match observation_converter(items) {
+            Ok(observation_batch) => {
+                publish_source_scan_batch(
+                    &source_name,
+                    &surface_name,
+                    &observation,
+                    &observation_batch,
+                );
+            }
+            Err(error) => {
+                tracing::debug!(
+                    source = source_name,
+                    surface = surface_name,
+                    error = %error,
+                    "failed to convert source-scan observation batch; dropping observation"
+                );
+            }
+        }
+        Ok(output_batch)
+    })
+}
+
+fn observe_output_batch(
+    source_name: String,
+    surface_name: String,
+    observation: SourceObservationConfig,
+    output_converter: Converter,
+) -> Converter {
+    Arc::new(move |items| {
+        let output_batch = output_converter(items)?;
+        publish_source_scan_batch(&source_name, &surface_name, &observation, &output_batch);
+        Ok(output_batch)
     })
 }
 
@@ -122,12 +147,20 @@ impl JsonExec {
     /// metadata and publishers.
     #[must_use]
     pub(crate) fn with_source_observation(
-        self,
+        mut self,
         surface_kind: SourceObservationSurfaceKind,
         publishers: SourceObservationPublishers,
     ) -> Self {
-        let observation_converter = self.converter.clone();
-        self.with_source_observation_converter(surface_kind, publishers, observation_converter)
+        let Some(observation) = SourceObservationConfig::new(surface_kind, publishers) else {
+            return self;
+        };
+        self.converter = observe_output_batch(
+            self.source_name.clone(),
+            self.table_name.clone(),
+            observation,
+            self.converter.clone(),
+        );
+        self
     }
 
     /// Publishes typed source-scan observations using a converter that may see
@@ -269,6 +302,7 @@ async fn next_projected_batch(mut state: ChunkState) -> Result<Option<(RecordBat
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use async_trait::async_trait;
     use datafusion::arrow::array::Array;
@@ -427,6 +461,140 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![2, 2, 1]
         );
+    }
+
+    #[tokio::test]
+    async fn source_observation_reuses_output_conversion_when_shapes_match() {
+        let schema = int_schema();
+        let conversion_count = Arc::new(AtomicUsize::new(0));
+        let converter = {
+            let schema = schema.clone();
+            let conversion_count = conversion_count.clone();
+            Arc::new(move |items: &[Value]| {
+                conversion_count.fetch_add(1, Ordering::SeqCst);
+                int_converter(schema.clone())(items)
+            })
+        };
+        let publisher = Arc::new(RecordingSourceObservationPublisher::default());
+        let exec = JsonExec::new(
+            "demo",
+            "numbers",
+            schema,
+            Arc::new(StaticFetcher {
+                rows: vec![Value::from(1), Value::from(2)],
+            }),
+            converter,
+            None,
+        )
+        .expect("exec should build")
+        .with_source_observation(
+            SourceObservationSurfaceKind::Table,
+            source_observation_publishers(&[
+                publisher.clone() as Arc<dyn SourceObservationPublisher>
+            ]),
+        );
+        let ctx = SessionContext::new_with_config(SessionConfig::new().with_batch_size(10));
+
+        let batches = exec
+            .execute(0, ctx.task_ctx())
+            .expect("execute should create stream")
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("stream should collect");
+
+        assert_eq!(conversion_count.load(Ordering::SeqCst), 1);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(publisher.observations().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn source_observation_waits_for_successful_output_conversion() {
+        let schema = int_schema();
+        let observation_conversion_count = Arc::new(AtomicUsize::new(0));
+        let observation_converter = {
+            let schema = schema.clone();
+            let observation_conversion_count = observation_conversion_count.clone();
+            Arc::new(move |items: &[Value]| {
+                observation_conversion_count.fetch_add(1, Ordering::SeqCst);
+                int_converter(schema.clone())(items)
+            })
+        };
+        let output_converter: Converter = Arc::new(|_| {
+            Err(datafusion::error::DataFusionError::Execution(
+                "output conversion failed".to_string(),
+            ))
+        });
+        let publisher = Arc::new(RecordingSourceObservationPublisher::default());
+        let exec = JsonExec::new(
+            "demo",
+            "numbers",
+            schema,
+            Arc::new(StaticFetcher {
+                rows: vec![Value::from(1)],
+            }),
+            output_converter,
+            None,
+        )
+        .expect("exec should build")
+        .with_source_observation_converter(
+            SourceObservationSurfaceKind::Table,
+            source_observation_publishers(&[
+                publisher.clone() as Arc<dyn SourceObservationPublisher>
+            ]),
+            observation_converter,
+        );
+        let ctx = SessionContext::new();
+
+        let error = exec
+            .execute(0, ctx.task_ctx())
+            .expect("execute should create stream")
+            .try_collect::<Vec<_>>()
+            .await
+            .expect_err("output conversion should fail");
+
+        assert!(error.to_string().contains("output conversion failed"));
+        assert_eq!(observation_conversion_count.load(Ordering::SeqCst), 0);
+        assert!(publisher.observations().is_empty());
+    }
+
+    #[tokio::test]
+    async fn source_observation_conversion_failure_is_best_effort() {
+        let schema = int_schema();
+        let observation_converter: Converter = Arc::new(|_| {
+            Err(datafusion::error::DataFusionError::Execution(
+                "observation conversion failed".to_string(),
+            ))
+        });
+        let publisher = Arc::new(RecordingSourceObservationPublisher::default());
+        let exec = JsonExec::new(
+            "demo",
+            "numbers",
+            schema.clone(),
+            Arc::new(StaticFetcher {
+                rows: vec![Value::from(1)],
+            }),
+            int_converter(schema),
+            None,
+        )
+        .expect("exec should build")
+        .with_source_observation_converter(
+            SourceObservationSurfaceKind::Table,
+            source_observation_publishers(&[
+                publisher.clone() as Arc<dyn SourceObservationPublisher>
+            ]),
+            observation_converter,
+        );
+        let ctx = SessionContext::new();
+
+        let batches = exec
+            .execute(0, ctx.task_ctx())
+            .expect("execute should create stream")
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("observation conversion should not fail the query");
+
+        assert_eq!(batches.len(), 1);
+        assert!(publisher.observations().is_empty());
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/shared/json_exec.rs
+++ b/crates/coral-engine/src/backends/shared/json_exec.rs
@@ -19,6 +19,8 @@ use datafusion::physical_plan::{
 use futures::{TryStreamExt, stream};
 use serde_json::Value;
 
+use crate::{SourceObservationPublisher, SourceObservationSurfaceKind, SourceScanObservation};
+
 /// Fetches raw JSON rows for one logical table scan.
 #[async_trait]
 pub(crate) trait RowFetcher: fmt::Debug + Send + Sync {
@@ -32,6 +34,52 @@ pub(crate) type Fetcher = Arc<dyn RowFetcher>;
 /// Converts fetched JSON rows into a projected `RecordBatch`.
 pub(crate) type Converter = Arc<dyn Fn(&[Value]) -> Result<RecordBatch> + Send + Sync>;
 
+#[derive(Clone)]
+struct SourceObservationConfig {
+    surface_kind: SourceObservationSurfaceKind,
+    publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+}
+
+fn observe_source_scan_batch(
+    source_name: String,
+    surface_name: String,
+    observation: SourceObservationConfig,
+    converter: Converter,
+) -> Converter {
+    Arc::new(move |items| {
+        let batch = converter(items)?;
+        publish_source_scan_batch(&source_name, &surface_name, &observation, &batch);
+        Ok(batch)
+    })
+}
+
+fn publish_source_scan_batch(
+    source_name: &str,
+    surface_name: &str,
+    observation: &SourceObservationConfig,
+    batch: &RecordBatch,
+) {
+    let event = SourceScanObservation {
+        source_name,
+        surface_kind: observation.surface_kind,
+        surface_name,
+        batch,
+    };
+    for publisher in &observation.publishers {
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            publisher.publish_source_scan(event);
+        }))
+        .is_err()
+        {
+            tracing::warn!(
+                source = source_name,
+                surface = surface_name,
+                "source observation publisher panicked; dropping source-scan observation"
+            );
+        }
+    }
+}
+
 /// Execution-plan node for backends that fetch JSON rows and convert them into
 /// `Arrow` record batches.
 pub(crate) struct JsonExec {
@@ -42,6 +90,7 @@ pub(crate) struct JsonExec {
     fetcher: Fetcher,
     converter: Converter,
     projection: Option<Vec<usize>>,
+    source_observation: Option<SourceObservationConfig>,
 }
 
 impl fmt::Debug for JsonExec {
@@ -89,7 +138,24 @@ impl JsonExec {
             fetcher,
             converter,
             projection,
+            source_observation: None,
         })
+    }
+
+    /// Publishes typed source-scan observations after JSON conversion and
+    /// before `DataFusion` projection. This is a shared execution hook; backend
+    /// adapters should only pass through metadata and publishers.
+    #[must_use]
+    pub(crate) fn with_source_observation(
+        mut self,
+        surface_kind: SourceObservationSurfaceKind,
+        publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+    ) -> Self {
+        self.source_observation = (!publishers.is_empty()).then_some(SourceObservationConfig {
+            surface_kind,
+            publishers,
+        });
+        self
     }
 }
 
@@ -140,7 +206,15 @@ impl ExecutionPlan for JsonExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let fetcher = self.fetcher.clone();
-        let converter = self.converter.clone();
+        let converter = match self.source_observation.clone() {
+            Some(observation) => observe_source_scan_batch(
+                self.source_name.clone(),
+                self.table_name.clone(),
+                observation,
+                self.converter.clone(),
+            ),
+            None => self.converter.clone(),
+        };
         let projected_schema = self.projected_schema.clone();
         let projection = self.projection.clone();
         // Emit the fetched rows in `batch_size`-row chunks rather than a single

--- a/crates/coral-engine/src/backends/shared/json_exec.rs
+++ b/crates/coral-engine/src/backends/shared/json_exec.rs
@@ -19,7 +19,10 @@ use datafusion::physical_plan::{
 use futures::{TryStreamExt, stream};
 use serde_json::Value;
 
-use crate::{SourceObservationPublisher, SourceObservationSurfaceKind, SourceScanObservation};
+use crate::SourceObservationSurfaceKind;
+use crate::backends::shared::source_observation::{
+    SourceObservationConfig, SourceObservationPublishers, publish_source_scan_batch,
+};
 
 /// Fetches raw JSON rows for one logical table scan.
 #[async_trait]
@@ -34,50 +37,23 @@ pub(crate) type Fetcher = Arc<dyn RowFetcher>;
 /// Converts fetched JSON rows into a projected `RecordBatch`.
 pub(crate) type Converter = Arc<dyn Fn(&[Value]) -> Result<RecordBatch> + Send + Sync>;
 
-#[derive(Clone)]
-struct SourceObservationConfig {
-    surface_kind: SourceObservationSurfaceKind,
-    publishers: Vec<Arc<dyn SourceObservationPublisher>>,
-}
-
 fn observe_source_scan_batch(
     source_name: String,
     surface_name: String,
     observation: SourceObservationConfig,
-    converter: Converter,
+    observation_converter: Converter,
+    output_converter: Converter,
 ) -> Converter {
     Arc::new(move |items| {
-        let batch = converter(items)?;
-        publish_source_scan_batch(&source_name, &surface_name, &observation, &batch);
-        Ok(batch)
+        let observation_batch = observation_converter(items)?;
+        publish_source_scan_batch(
+            &source_name,
+            &surface_name,
+            &observation,
+            &observation_batch,
+        );
+        output_converter(items)
     })
-}
-
-fn publish_source_scan_batch(
-    source_name: &str,
-    surface_name: &str,
-    observation: &SourceObservationConfig,
-    batch: &RecordBatch,
-) {
-    let event = SourceScanObservation {
-        source_name,
-        surface_kind: observation.surface_kind,
-        surface_name,
-        batch,
-    };
-    for publisher in &observation.publishers {
-        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            publisher.publish_source_scan(event);
-        }))
-        .is_err()
-        {
-            tracing::warn!(
-                source = source_name,
-                surface = surface_name,
-                "source observation publisher panicked; dropping source-scan observation"
-            );
-        }
-    }
 }
 
 /// Execution-plan node for backends that fetch JSON rows and convert them into
@@ -90,7 +66,6 @@ pub(crate) struct JsonExec {
     fetcher: Fetcher,
     converter: Converter,
     projection: Option<Vec<usize>>,
-    source_observation: Option<SourceObservationConfig>,
 }
 
 impl fmt::Debug for JsonExec {
@@ -138,23 +113,45 @@ impl JsonExec {
             fetcher,
             converter,
             projection,
-            source_observation: None,
         })
     }
 
-    /// Publishes typed source-scan observations after JSON conversion and
-    /// before `DataFusion` projection. This is a shared execution hook; backend
-    /// adapters should only pass through metadata and publishers.
+    /// Publishes typed source-scan observations after JSON conversion, before
+    /// `DataFusion` projection, and once per emitted `batch_size` chunk. This
+    /// is a shared execution hook; backend adapters should only pass through
+    /// metadata and publishers.
     #[must_use]
     pub(crate) fn with_source_observation(
+        self,
+        surface_kind: SourceObservationSurfaceKind,
+        publishers: SourceObservationPublishers,
+    ) -> Self {
+        let observation_converter = self.converter.clone();
+        self.with_source_observation_converter(surface_kind, publishers, observation_converter)
+    }
+
+    /// Publishes typed source-scan observations using a converter that may see
+    /// a less-shaped view of the fetched rows than the query-output converter.
+    ///
+    /// HTTP scans use this to observe upstream rows before Coral-side local
+    /// filters and truncation while still returning the filtered query result.
+    #[must_use]
+    pub(crate) fn with_source_observation_converter(
         mut self,
         surface_kind: SourceObservationSurfaceKind,
-        publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+        publishers: SourceObservationPublishers,
+        observation_converter: Converter,
     ) -> Self {
-        self.source_observation = (!publishers.is_empty()).then_some(SourceObservationConfig {
-            surface_kind,
-            publishers,
-        });
+        let Some(observation) = SourceObservationConfig::new(surface_kind, publishers) else {
+            return self;
+        };
+        self.converter = observe_source_scan_batch(
+            self.source_name.clone(),
+            self.table_name.clone(),
+            observation,
+            observation_converter,
+            self.converter.clone(),
+        );
         self
     }
 }
@@ -206,15 +203,7 @@ impl ExecutionPlan for JsonExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let fetcher = self.fetcher.clone();
-        let converter = match self.source_observation.clone() {
-            Some(observation) => observe_source_scan_batch(
-                self.source_name.clone(),
-                self.table_name.clone(),
-                observation,
-                self.converter.clone(),
-            ),
-            None => self.converter.clone(),
-        };
+        let converter = self.converter.clone();
         let projected_schema = self.projected_schema.clone();
         let projection = self.projection.clone();
         // Emit the fetched rows in `batch_size`-row chunks rather than a single
@@ -287,12 +276,23 @@ mod tests {
     use datafusion::arrow::array::RecordBatch;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::prelude::{SessionConfig, SessionContext};
+    use futures::TryStreamExt;
     use serde_json::Value;
 
     use super::{ChunkState, Converter, Fetcher, JsonExec, RowFetcher, next_projected_batch};
+    use crate::backends::shared::source_observation::{
+        source_observation_publishers, test_support::RecordingSourceObservationPublisher,
+    };
+    use crate::{SourceObservationPublisher, SourceObservationSurfaceKind};
 
     #[derive(Debug)]
     struct NoopFetcher;
+
+    #[derive(Debug)]
+    struct StaticFetcher {
+        rows: Vec<Value>,
+    }
 
     fn noop_fetcher() -> Fetcher {
         Arc::new(NoopFetcher)
@@ -302,6 +302,13 @@ mod tests {
     impl RowFetcher for NoopFetcher {
         async fn fetch(&self) -> datafusion::error::Result<Vec<Value>> {
             Ok(Vec::new())
+        }
+    }
+
+    #[async_trait]
+    impl RowFetcher for StaticFetcher {
+        async fn fetch(&self) -> datafusion::error::Result<Vec<Value>> {
+            Ok(self.rows.clone())
         }
     }
 
@@ -373,6 +380,53 @@ mod tests {
             })
             .collect();
         assert_eq!(observed, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn source_observation_publishes_one_event_per_emitted_chunk() {
+        let schema = int_schema();
+        let publisher = Arc::new(RecordingSourceObservationPublisher::default());
+        let exec = JsonExec::new(
+            "demo",
+            "numbers",
+            schema.clone(),
+            Arc::new(StaticFetcher {
+                rows: (0..5).map(Value::from).collect(),
+            }),
+            int_converter(schema),
+            None,
+        )
+        .expect("exec should build")
+        .with_source_observation(
+            SourceObservationSurfaceKind::Table,
+            source_observation_publishers(&[
+                publisher.clone() as Arc<dyn SourceObservationPublisher>
+            ]),
+        );
+        let ctx = SessionContext::new_with_config(SessionConfig::new().with_batch_size(2));
+
+        let batches = exec
+            .execute(0, ctx.task_ctx())
+            .expect("execute should create stream")
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("stream should collect");
+
+        assert_eq!(
+            batches
+                .iter()
+                .map(RecordBatch::num_rows)
+                .collect::<Vec<_>>(),
+            vec![2, 2, 1]
+        );
+        assert_eq!(
+            publisher
+                .observations()
+                .iter()
+                .map(|observation| observation.row_count)
+                .collect::<Vec<_>>(),
+            vec![2, 2, 1]
+        );
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/shared/mod.rs
+++ b/crates/coral-engine/src/backends/shared/mod.rs
@@ -6,5 +6,6 @@ pub(crate) mod json_path;
 pub(crate) mod mapping;
 pub(crate) mod response_rows;
 pub(crate) mod scalar;
+pub(crate) mod source_observation;
 pub(crate) mod template;
 pub(crate) mod trace;

--- a/crates/coral-engine/src/backends/shared/source_observation.rs
+++ b/crates/coral-engine/src/backends/shared/source_observation.rs
@@ -1,0 +1,124 @@
+//! Shared source-scan observation helpers.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::RecordBatch;
+
+use crate::{SourceObservationPublisher, SourceObservationSurfaceKind, SourceScanObservation};
+
+pub(crate) type SourceObservationPublishers = Arc<[Arc<dyn SourceObservationPublisher>]>;
+
+#[derive(Clone)]
+pub(crate) struct SourceObservationConfig {
+    pub(crate) surface_kind: SourceObservationSurfaceKind,
+    pub(crate) publishers: SourceObservationPublishers,
+}
+
+impl SourceObservationConfig {
+    pub(crate) fn new(
+        surface_kind: SourceObservationSurfaceKind,
+        publishers: SourceObservationPublishers,
+    ) -> Option<Self> {
+        (!publishers.is_empty()).then_some(Self {
+            surface_kind,
+            publishers,
+        })
+    }
+}
+
+pub(crate) fn source_observation_publishers(
+    publishers: &[Arc<dyn SourceObservationPublisher>],
+) -> SourceObservationPublishers {
+    Arc::from(publishers.to_vec())
+}
+
+pub(crate) fn publish_source_scan_batch(
+    source_name: &str,
+    surface_name: &str,
+    observation: &SourceObservationConfig,
+    batch: &RecordBatch,
+) {
+    let event = SourceScanObservation {
+        source_name,
+        surface_kind: observation.surface_kind,
+        surface_name,
+        batch,
+    };
+    for publisher in observation.publishers.iter() {
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            publisher.publish_source_scan(event);
+        }))
+        .is_err()
+        {
+            tracing::warn!(
+                source = source_name,
+                surface = surface_name,
+                "source observation publisher panicked; dropping source-scan observation"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::Mutex;
+
+    use datafusion::arrow::array::RecordBatch;
+
+    use super::*;
+
+    #[derive(Default)]
+    pub(crate) struct RecordingSourceObservationPublisher {
+        observations: Mutex<Vec<RecordedSourceObservation>>,
+    }
+
+    pub(crate) struct RecordedSourceObservation {
+        pub(crate) source_name: String,
+        pub(crate) surface_kind: SourceObservationSurfaceKind,
+        pub(crate) surface_name: String,
+        pub(crate) column_names: Vec<String>,
+        pub(crate) row_count: usize,
+        pub(crate) batch: RecordBatch,
+    }
+
+    impl RecordingSourceObservationPublisher {
+        pub(crate) fn observations(&self) -> Vec<RecordedSourceObservation> {
+            self.observations.lock().expect("observations lock").clone()
+        }
+    }
+
+    impl Clone for RecordedSourceObservation {
+        fn clone(&self) -> Self {
+            Self {
+                source_name: self.source_name.clone(),
+                surface_kind: self.surface_kind,
+                surface_name: self.surface_name.clone(),
+                column_names: self.column_names.clone(),
+                row_count: self.row_count,
+                batch: self.batch.clone(),
+            }
+        }
+    }
+
+    impl SourceObservationPublisher for RecordingSourceObservationPublisher {
+        fn publish_source_scan(&self, observation: SourceScanObservation<'_>) {
+            self.observations
+                .lock()
+                .expect("observations lock")
+                .push(RecordedSourceObservation {
+                    source_name: observation.source_name.to_string(),
+                    surface_kind: observation.surface_kind,
+                    surface_name: observation.surface_name.to_string(),
+                    column_names: observation
+                        .batch
+                        .schema()
+                        .fields()
+                        .iter()
+                        .map(|field| field.name().clone())
+                        .collect(),
+                    row_count: observation.batch.num_rows(),
+                    batch: observation.batch.clone(),
+                });
+        }
+    }
+}

--- a/crates/coral-engine/src/backends/shared/source_observation.rs
+++ b/crates/coral-engine/src/backends/shared/source_observation.rs
@@ -32,6 +32,11 @@ pub(crate) fn source_observation_publishers(
     Arc::from(publishers.to_vec())
 }
 
+/// Publishes through the engine's non-blocking observation contract.
+///
+/// This helper intentionally does not spawn detached tasks. Queueing,
+/// backpressure, dropping, and shutdown drainage belong in the app-side
+/// publisher implementation that owns the corresponding lifecycle.
 pub(crate) fn publish_source_scan_batch(
     source_name: &str,
     surface_name: &str,

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -23,6 +23,10 @@ pub struct EngineExtensions {
     pub source_decorators: Vec<Box<dyn SourceDecorator>>,
     /// Post-query observers invoked after successful SQL result collection.
     pub query_result_observers: Vec<Arc<dyn QueryResultObserver>>,
+    /// Source-scan observers invoked while shared source execution materializes
+    /// typed rows. Publishers must be non-blocking and must not treat delivery
+    /// as durable persistence.
+    pub source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
     /// Request-time custom authenticators keyed by `auth.authenticator`.
     pub request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     /// Request-time resolver for app-managed source inputs.
@@ -72,6 +76,38 @@ pub enum QueryResultObserverError {
     /// The observer could not proceed because a precondition was unmet.
     #[error("{0}")]
     FailedPrecondition(String),
+}
+
+/// Logical surface kind for a source-scan observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceObservationSurfaceKind {
+    /// A manifest-declared table scan.
+    Table,
+    /// A manifest-declared table-function scan.
+    Function,
+}
+
+/// One typed source-scan batch observed during shared source execution.
+#[derive(Debug, Clone, Copy)]
+pub struct SourceScanObservation<'a> {
+    /// Source/schema name.
+    pub source_name: &'a str,
+    /// Kind of source surface.
+    pub surface_kind: SourceObservationSurfaceKind,
+    /// Table or function name within the source.
+    pub surface_name: &'a str,
+    /// Typed, table-shaped batch. Consumers that need to retain data must clone
+    /// or enqueue it themselves.
+    pub batch: &'a RecordBatch,
+}
+
+/// Non-blocking sink for source-scan observations.
+pub trait SourceObservationPublisher: Send + Sync {
+    /// Publishes one typed source-scan batch.
+    ///
+    /// Implementations must return promptly. Dropping observations under load is
+    /// preferable to delaying SQL execution.
+    fn publish_source_scan(&self, observation: SourceScanObservation<'_>);
 }
 
 impl QueryResultObserverError {

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -65,7 +65,8 @@ pub use backends::mcp::discover_tool_catalog as discover_mcp_tool_catalog;
 pub use composition::{
     EngineExtensions, QueryResultObserver, QueryResultObserverError, RequestAuthenticator,
     RequestAuthenticatorError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
-    SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError, SourceTables,
+    SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
+    SourceObservationPublisher, SourceObservationSurfaceKind, SourceScanObservation, SourceTables,
 };
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,

--- a/crates/coral-engine/src/runtime/dependent_join/exec.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/exec.rs
@@ -19,7 +19,11 @@ use datafusion::physical_plan::{
 };
 use futures::{StreamExt, stream};
 
+use crate::SourceObservationSurfaceKind;
 use crate::backends::http::HttpSourceClient;
+use crate::backends::shared::source_observation::{
+    SourceObservationConfig, SourceObservationPublishers,
+};
 use crate::runtime::dependent_join::bindings::BindingProjector;
 use crate::runtime::dependent_join::driver::run_binding_phase;
 use crate::runtime::dependent_join::fetcher::{BindingFetcher, BindingFetcherConfig};
@@ -46,6 +50,7 @@ pub(crate) struct DependentJoinExec {
     max_resolver_rows_per_binding: usize,
     max_concurrency: usize,
     page_hint: Option<usize>,
+    source_observation_publishers: SourceObservationPublishers,
     output_schema: SchemaRef,
     props: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
@@ -67,6 +72,7 @@ pub(crate) struct DependentJoinExecConfig {
     pub(crate) max_resolver_rows_per_binding: usize,
     pub(crate) max_concurrency: usize,
     pub(crate) page_hint: Option<usize>,
+    pub(crate) source_observation_publishers: SourceObservationPublishers,
     pub(crate) output_schema: SchemaRef,
 }
 
@@ -93,6 +99,7 @@ impl DependentJoinExec {
             max_resolver_rows_per_binding: config.max_resolver_rows_per_binding,
             max_concurrency: config.max_concurrency,
             page_hint: config.page_hint,
+            source_observation_publishers: config.source_observation_publishers,
             output_schema: config.output_schema,
             props,
             metrics: ExecutionPlanMetricsSet::new(),
@@ -118,6 +125,7 @@ impl DependentJoinExec {
             max_resolver_rows_per_binding: self.max_resolver_rows_per_binding,
             max_concurrency: self.max_concurrency,
             page_hint: self.page_hint,
+            source_observation_publishers: Arc::clone(&self.source_observation_publishers),
             output_schema: Arc::clone(&self.output_schema),
             props,
             metrics: self.metrics.clone(),
@@ -318,6 +326,7 @@ impl ExecutionPlan for DependentJoinExec {
         let max_concurrency = self.max_concurrency;
         let max_rows_per_binding = self.max_rows_per_binding;
         let page_hint = self.page_hint;
+        let source_observation_publishers = Arc::clone(&self.source_observation_publishers);
         let output_schema = Arc::clone(&self.output_schema);
         let stream_schema = Arc::clone(&self.output_schema);
         let retained_stream_schema = Arc::clone(&self.output_schema);
@@ -345,6 +354,7 @@ impl ExecutionPlan for DependentJoinExec {
                 max_concurrency,
                 max_rows_per_binding,
                 page_hint,
+                source_observation_publishers,
                 metrics,
                 output_schema,
                 memory,
@@ -390,6 +400,7 @@ async fn execute_dependent_join(
     max_concurrency: usize,
     max_rows_per_binding: usize,
     page_hint: Option<usize>,
+    source_observation_publishers: SourceObservationPublishers,
     metrics: DependentJoinMetrics,
     output_schema: SchemaRef,
     memory: RetainedMemory,
@@ -419,6 +430,10 @@ async fn execute_dependent_join(
     metrics.record(&state);
 
     let output_memory = state.memory().new_empty();
+    let source_observation = SourceObservationConfig::new(
+        SourceObservationSurfaceKind::Table,
+        source_observation_publishers,
+    );
     build_joined_batches(
         &BuildJoinedBatchesConfig {
             state: &state,
@@ -430,6 +445,7 @@ async fn execute_dependent_join(
             resolver_projection_len,
             dependent_first,
             output_schema: &output_schema,
+            source_observation: source_observation.as_ref(),
         },
         output_memory,
     )

--- a/crates/coral-engine/src/runtime/dependent_join/output.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/output.rs
@@ -9,6 +9,9 @@ use datafusion::common::{DataFusionError, Result};
 
 use crate::backends::schema_from_columns;
 use crate::backends::shared::mapping::convert_items;
+use crate::backends::shared::source_observation::{
+    SourceObservationConfig, publish_source_scan_batch,
+};
 use crate::runtime::dependent_join::bindings::{
     Tuple, extract_binding_value, filter_values_for_tuple,
 };
@@ -26,6 +29,7 @@ pub(crate) struct BuildJoinedBatchesConfig<'a> {
     pub(crate) resolver_projection_len: usize,
     pub(crate) dependent_first: bool,
     pub(crate) output_schema: &'a SchemaRef,
+    pub(crate) source_observation: Option<&'a SourceObservationConfig>,
 }
 
 pub(crate) fn build_joined_batches(
@@ -57,6 +61,14 @@ pub(crate) fn build_joined_batches(
             &HashMap::new(),
             rows,
         )?;
+        if let Some(source_observation) = config.source_observation {
+            publish_source_scan_batch(
+                config.dependent_source_schema,
+                config.dependent_table.name(),
+                source_observation,
+                &dependent_batch,
+            );
+        }
         // The rewrite replaced the Join node, so nothing downstream re-applies
         // the ON condition. APIs can resolve keyed lookups loosely (rename
         // redirects, case-insensitive identifiers), so enforce the join

--- a/crates/coral-engine/src/runtime/dependent_join/planner.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/planner.rs
@@ -8,6 +8,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 
 use crate::backends::http::HttpSourceTableProvider;
+use crate::backends::shared::source_observation::SourceObservationPublishers;
 use crate::runtime::dependent_join::exec::{DependentJoinExec, DependentJoinExecConfig};
 use crate::runtime::dependent_join::logical::DependentJoinNode;
 
@@ -49,6 +50,7 @@ impl ExtensionPlanner for DependentJoinExtensionPlanner {
             max_resolver_rows_per_binding: node.max_resolver_rows_per_binding,
             max_concurrency: node.max_concurrency,
             page_hint: node.page_hint,
+            source_observation_publishers: provider.source_observation_publishers,
             output_schema: Arc::new(node.schema.as_arrow().clone()),
         });
 
@@ -60,6 +62,7 @@ struct ResolvedHttpDependent {
     client: crate::backends::http::HttpSourceClient,
     source_schema: String,
     table: Arc<coral_spec::backends::http::HttpTableSpec>,
+    source_observation_publishers: SourceObservationPublishers,
 }
 
 async fn resolve_http_provider(
@@ -107,5 +110,6 @@ async fn resolve_http_provider(
         client: provider.client().clone(),
         source_schema: provider.source_schema().to_string(),
         table: Arc::clone(provider.table_spec()),
+        source_observation_publishers: Arc::clone(provider.source_observation_publishers()),
     })
 }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -48,7 +48,8 @@ use crate::{
     QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
     QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext,
     QuerySource, QueryTableFunctionUsage, QueryTableUsage, RequestAuthenticator, SourceDecorator,
-    SourceInputResolver, TableFunctionInfo, TableInfo, UdfRuntimeDefinition,
+    SourceInputResolver, SourceObservationPublisher, TableFunctionInfo, TableInfo,
+    UdfRuntimeDefinition,
 };
 
 pub(crate) struct QueryRuntimeAdapter {
@@ -77,14 +78,20 @@ struct FallbackRuntime {
 }
 
 #[derive(Clone)]
+struct RuntimeExtensionHooks {
+    request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
+    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    source_observation_publishers: Vec<Arc<dyn SourceObservationPublisher>>,
+}
+
+#[derive(Clone)]
 struct FallbackRuntimeConfig {
     sources: Vec<QuerySource>,
     runtime_context: QueryRuntimeContext,
     dependent_join: DependentJoinConfig,
     memory: QueryMemoryConfig,
     udfs: Vec<UdfRuntimeDefinition>,
-    request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
-    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    extension_hooks: RuntimeExtensionHooks,
 }
 
 struct RegisteredRuntime {
@@ -99,8 +106,7 @@ struct RegisteredRuntime {
 struct RuntimeBuildInputs<'a> {
     sources: &'a [QuerySource],
     runtime_context: &'a QueryRuntimeContext,
-    request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
-    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    extension_hooks: &'a RuntimeExtensionHooks,
     source_decorators: &'a mut [Box<dyn SourceDecorator>],
     dependent_join: &'a DependentJoinConfig,
     memory: &'a QueryMemoryConfig,
@@ -132,8 +138,11 @@ async fn build_runtime_inner(
         mut extensions,
         udfs,
     } = runtime;
-    let request_authenticators = extensions.request_authenticators.clone();
-    let source_input_resolver = extensions.source_input_resolver.clone();
+    let extension_hooks = RuntimeExtensionHooks {
+        request_authenticators: extensions.request_authenticators.clone(),
+        source_input_resolver: extensions.source_input_resolver.clone(),
+        source_observation_publishers: extensions.source_observation_publishers.clone(),
+    };
     let udfs_installed = !udfs.is_empty();
     // Resolver-row overflow can retry without the dependent-join optimizer only
     // when runtime registration is replayable. Source decorators are mutable
@@ -149,16 +158,14 @@ async fn build_runtime_inner(
             dependent_join: dependent_join.clone(),
             memory: memory.clone(),
             udfs: udfs.clone(),
-            request_authenticators: request_authenticators.clone(),
-            source_input_resolver: source_input_resolver.clone(),
+            extension_hooks: extension_hooks.clone(),
         })
     });
 
     let primary = build_registered_runtime(RuntimeBuildInputs {
         sources,
         runtime_context: &runtime_context,
-        request_authenticators: &request_authenticators,
-        source_input_resolver,
+        extension_hooks: &extension_hooks,
         source_decorators: extensions.source_decorators.as_mut_slice(),
         dependent_join: &dependent_join,
         memory: &memory,
@@ -189,8 +196,7 @@ async fn build_registered_runtime(
         &ctx,
         config.sources,
         config.runtime_context,
-        config.request_authenticators,
-        config.source_input_resolver,
+        config.extension_hooks,
         config.source_decorators,
     )
     .await?;
@@ -331,8 +337,7 @@ async fn register_runtime_sources(
     ctx: &SessionContext,
     sources: &[QuerySource],
     runtime_context: &QueryRuntimeContext,
-    request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
-    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    extension_hooks: &RuntimeExtensionHooks,
     source_decorators: &mut [Box<dyn SourceDecorator>],
 ) -> Result<crate::runtime::registry::SourceRegistrationResult, CoreError> {
     let mut source_candidates = Vec::new();
@@ -340,8 +345,9 @@ async fn register_runtime_sources(
         match compile_query_source(
             source,
             runtime_context,
-            request_authenticators,
-            source_input_resolver.clone(),
+            &extension_hooks.request_authenticators,
+            extension_hooks.source_input_resolver.clone(),
+            &extension_hooks.source_observation_publishers,
         ) {
             Ok(compiled) => {
                 source_candidates.push(SourceRegistrationCandidate::Compiled(
@@ -1114,8 +1120,7 @@ impl FallbackRuntimeConfig {
         build_registered_runtime(RuntimeBuildInputs {
             sources: &self.sources,
             runtime_context: &self.runtime_context,
-            request_authenticators: &self.request_authenticators,
-            source_input_resolver: self.source_input_resolver.clone(),
+            extension_hooks: &self.extension_hooks,
             source_decorators: source_decorators.as_mut_slice(),
             dependent_join: &dependent_join,
             memory: &self.memory,
@@ -1295,8 +1300,11 @@ mod tests {
                 limit: Some(MemorySize::from_str("1Ki").unwrap()),
             },
             udfs: Vec::new(),
-            request_authenticators: HashMap::new(),
-            source_input_resolver: None,
+            extension_hooks: RuntimeExtensionHooks {
+                request_authenticators: HashMap::new(),
+                source_input_resolver: None,
+                source_observation_publishers: Vec::new(),
+            },
         };
 
         let runtime = fallback

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -267,7 +267,7 @@ mod tests {
     fn initial_instructions_frame_coral_as_sql_database() {
         let instructions = initial_instructions("default", &[], &[]);
         assert!(instructions.contains("read-only SQL database"));
-        assert!(instructions.contains("catalog helpers"));
+        assert!(instructions.contains("catalog helper"));
         assert!(instructions.contains("CROSS JOIN"));
         assert!(instructions.contains("row-by-row tool calls"));
     }


### PR DESCRIPTION
## Summary

- Adds `EngineExtensions.source_observation_publishers` and a minimal `SourceScanObservation` contract for non-blocking source-scan observation.
- Wires HTTP and MCP table/function scans through shared `JsonExec` so publishers see typed, mapped source batches before DataFusion projection.
- Preserves app layering: app code installs publishers through `EngineExtensionsProvider`; MCP/CLI adapters stay thin and only pass through engine metadata.
- Adds regression tests proving projected SQL output can be narrower than the observed source-scan batch for both HTTP and MCP sources.

## Deliberately out of scope

- No observed-value storage, SQLite projection, queue, retrieval, retention, governance, or shutdown drainage.
- No adapter-owned observation logic beyond passing surface identity and publishers into shared execution.
- No observation-stage/scope classification; later ingestion indexes observed positive values rather than treating events as completeness evidence.
- Fallback runtime retries may re-observe a source scan if the primary runtime partially executed first; the later ingestion/indexer PR must be idempotent.

## Verification

- `cargo clippy -p coral-engine --all-targets --all-features --locked -- -D warnings`
- `cargo test -p coral-engine source_scan_observation --lib`
- `cargo test -p coral-app query::extensions::tests::provider_lists_merge_source_observation_publishers_in_call_order --lib`
- `cargo check -p coral-app --lib`


## Feature flag

Defines the canonical default-off `observed_values_search` runtime feature (`coral features enable observed_values_search`, with `--enable-observed-values-search` and `--disable-observed-values-search` process overrides). The generic observation hook remains available, but it is inert until an enabled app lifecycle installs observed-value publishers.
