### PR TITLE
refactor(spec): remove pagination from v4 projections

### DIFF
--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -107,6 +107,7 @@ fn http_manifest_for_surface(
                     projection.name, projection.operation_id
                 ))
             })?;
+        let rest = rest_execution_for_operation(operation)?;
         let request = request_spec_for_projection(projection, operation)
             .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
         let columns = projection_column_specs(projection);
@@ -125,8 +126,8 @@ fn http_manifest_for_surface(
                     },
                     request,
                     requests: Vec::new(),
-                    response: rest_response_for_operation(operation)?,
-                    pagination: projection.pagination.clone(),
+                    response: rest.response.response.clone(),
+                    pagination: rest.pagination.clone(),
                 });
             }
             ProjectionKind::TableFunction { function_kind } => {
@@ -139,8 +140,8 @@ fn http_manifest_for_surface(
                     detail_hints: projection.detail_hints.clone(),
                     args: projection_arg_specs(projection),
                     request,
-                    response: rest_response_for_operation(operation)?,
-                    pagination: projection.pagination.clone(),
+                    response: rest.response.response.clone(),
+                    pagination: rest.pagination.clone(),
                     columns,
                 });
             }
@@ -164,11 +165,11 @@ fn http_manifest_for_surface(
     })
 }
 
-fn rest_response_for_operation(
+fn rest_execution_for_operation(
     operation: &coral_spec::v4::IrOperation,
-) -> Result<ResponseSpec, AppError> {
+) -> Result<&coral_spec::v4::RestExecutionAttachment, AppError> {
     match &operation.execution {
-        IrExecutionAttachment::Rest(rest) => Ok(rest.response.response.clone()),
+        IrExecutionAttachment::Rest(rest) => Ok(rest),
         IrExecutionAttachment::Mcp(_) => Err(AppError::FailedPrecondition(format!(
             "DSL v4 operation '{}' is not a REST operation",
             operation.id
@@ -399,31 +400,94 @@ mod tests {
     use coral_spec::backends::http::{AuthSpec, RateLimitSpec};
     use coral_spec::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec, McpServerSpec};
     use coral_spec::v4::{
-        Fingerprint, IrExecutionAttachment, IrOperation, IrOperationOutput, MCP_IMPORTER_VERSION,
-        MaterializedSurface, McpExecutionAttachment, McpRuntimeConfig, OPENAPI_IMPORTER_VERSION,
-        OpenApiRuntimeConfig, PROJECTION_GENERATOR_VERSION, Projection, ProjectionCatalog,
-        ProjectionKind, ProjectionVisibility, SURFACE_IMPORTER_VERSION, SemanticIr,
-        SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION,
-        V4MaterializedSource, V4SourceCommon, V4SourceManifest, V4Surface,
+        Fingerprint, HttpMethod, IrExecutionAttachment, IrOperation, IrOperationOutput,
+        MCP_IMPORTER_VERSION, MaterializedSurface, McpExecutionAttachment, McpRuntimeConfig,
+        OPENAPI_IMPORTER_VERSION, OpenApiRuntimeConfig, PROJECTION_GENERATOR_VERSION, Projection,
+        ProjectionCatalog, ProjectionKind, ProjectionVisibility, RestExecutionAttachment,
+        RestResponseAttachment, SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceDescriptor,
+        SurfaceRuntimeConfig, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource,
+        V4SourceCommon, V4SourceManifest, V4Surface,
     };
+    use coral_spec::{PageSizeSpec, PaginationMode, PaginationSpec, ResponseSpec};
 
     use super::{runtime_components_for_v4_source, surface_base_url};
 
     fn surface_without_authored_base_url() -> V4Surface {
+        openapi_surface_with_base_url("rest", "demo", "")
+    }
+
+    fn openapi_surface(id: &str, relation_namespace: &str) -> V4Surface {
+        openapi_surface_with_base_url(id, relation_namespace, "https://api.example.com")
+    }
+
+    fn openapi_surface_with_base_url(
+        id: &str,
+        relation_namespace: &str,
+        base_url: &str,
+    ) -> V4Surface {
         V4Surface {
-            id: "rest".to_string(),
-            relation_namespace: "demo".to_string(),
+            id: id.to_string(),
+            relation_namespace: relation_namespace.to_string(),
             surface_type: SurfaceType::OpenApi,
             descriptor: SurfaceDescriptor::File {
                 file: PathBuf::from("/tmp/openapi.yaml"),
             },
             inputs: Vec::new(),
             runtime: SurfaceRuntimeConfig::OpenApi(OpenApiRuntimeConfig {
-                base_url: coral_spec::ParsedTemplate::parse("").expect("empty template"),
+                base_url: coral_spec::ParsedTemplate::parse(base_url).expect("base_url template"),
                 auth: AuthSpec::default(),
                 request_headers: Vec::new(),
                 rate_limit: RateLimitSpec::default(),
             }),
+        }
+    }
+
+    fn rest_materialized_surface_with_pagination(
+        surface_id: &str,
+        operation_id: &str,
+        pagination: PaginationSpec,
+    ) -> MaterializedSurface {
+        MaterializedSurface {
+            surface_id: surface_id.to_string(),
+            semantic_ir: SemanticIr {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "github_v4".to_string(),
+                surface_id: surface_id.to_string(),
+                surface_type: SurfaceType::OpenApi,
+                importer_version: OPENAPI_IMPORTER_VERSION.to_string(),
+                operations: vec![IrOperation {
+                    id: operation_id.to_string(),
+                    method_name: operation_id.to_string(),
+                    description: String::new(),
+                    deprecated: false,
+                    read_only: true,
+                    inputs: Vec::new(),
+                    output: IrOperationOutput {
+                        cardinality: coral_spec::v4::OutputCardinality::List,
+                        type_ref: "item".to_string(),
+                        row_path: Vec::new(),
+                    },
+                    entity: None,
+                    execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
+                        method: HttpMethod::Get,
+                        path_template: "/items".to_string(),
+                        parameters: Vec::new(),
+                        request_body: None,
+                        response: RestResponseAttachment {
+                            status_code: 200,
+                            media_type: "application/json".to_string(),
+                            response: ResponseSpec::default(),
+                        },
+                        pagination,
+                    })),
+                    diagnostics: Vec::new(),
+                }],
+                types: Vec::new(),
+                diagnostics: Vec::new(),
+            },
+            source_document_sha256: String::new(),
+            normalized_source_document_path: PathBuf::from("/tmp/source-document.yaml"),
+            raw_source_document_path: PathBuf::from("/tmp/source-document.raw"),
         }
     }
 
@@ -550,7 +614,6 @@ mod tests {
             visibility: ProjectionVisibility::Published,
             inputs: Vec::new(),
             columns: Vec::new(),
-            pagination: coral_spec::PaginationSpec::default(),
             search_limits: None,
             detail_hints: Vec::new(),
             diagnostics: Vec::new(),
@@ -606,6 +669,82 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(schema_names, ["github_v4_rest", "github_v4_mcp"]);
+    }
+
+    #[test]
+    fn rest_runtime_component_keeps_operation_pagination() {
+        let surface = openapi_surface("rest", "github_v4_rest");
+        let manifest = V4SourceManifest {
+            common: V4SourceCommon {
+                dsl_version: 4,
+                name: "github_v4".to_string(),
+                description: String::new(),
+                test_queries: Vec::new(),
+            },
+            declared_inputs: Vec::new(),
+            surfaces: vec![surface],
+        };
+        let pagination = PaginationSpec {
+            mode: PaginationMode::Page,
+            page_size: Some(PageSizeSpec {
+                default: 30,
+                max: 100,
+                query_param: Some("per_page".to_string()),
+                body_path: Vec::new(),
+            }),
+            page_param: Some("page".to_string()),
+            page_start: 1,
+            max_pages: Some(7),
+            ..PaginationSpec::default()
+        };
+        let materialized = V4MaterializedSource {
+            fingerprint: Fingerprint {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "github_v4".to_string(),
+                manifest_sha256: String::new(),
+                surfaces: Vec::new(),
+                importer_version: SURFACE_IMPORTER_VERSION.to_string(),
+                projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+            },
+            surfaces: vec![rest_materialized_surface_with_pagination(
+                "rest",
+                "rest_list_issues",
+                pagination.clone(),
+            )],
+            projections: ProjectionCatalog {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "github_v4".to_string(),
+                generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+                projections: vec![published_projection(
+                    "rest",
+                    "github_v4_rest",
+                    "rest_list_issues",
+                )],
+                diagnostics: Vec::new(),
+            },
+            diagnostics: Vec::new(),
+        };
+
+        let components =
+            runtime_components_for_v4_source(&manifest, &materialized).expect("runtime components");
+        let coral_engine::RuntimeSourceComponent::Http(http) =
+            components.first().expect("http component")
+        else {
+            panic!("expected HTTP component");
+        };
+        let table_pagination = &http.tables.first().expect("http table").pagination;
+
+        assert_eq!(table_pagination.mode, PaginationMode::Page);
+        assert_eq!(table_pagination.page_param.as_deref(), Some("page"));
+        assert_eq!(table_pagination.page_start, 1);
+        assert_eq!(table_pagination.max_pages, Some(7));
+        assert_eq!(
+            table_pagination
+                .page_size
+                .as_ref()
+                .and_then(|page_size| page_size.query_param.as_deref()),
+            Some("per_page")
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -7,7 +7,7 @@ pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 2;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v1";
 pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v3";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v1";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v6";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v7";
 
 mod artifacts;
 mod diagnostics;

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -71,11 +71,13 @@ surfaces:
         .find(|operation| operation.id == projection.operation_id)
         .expect("repo issues operation");
 
-    assert_eq!(projection.pagination.mode, PaginationMode::Page);
-    assert_eq!(projection.pagination.page_param.as_deref(), Some("page"));
+    let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+        panic!("expected REST execution");
+    };
+    assert_eq!(rest.pagination.mode, PaginationMode::Page);
+    assert_eq!(rest.pagination.page_param.as_deref(), Some("page"));
     assert_eq!(
-        projection
-            .pagination
+        rest.pagination
             .page_size
             .as_ref()
             .and_then(|page_size| page_size.query_param.as_deref()),
@@ -119,39 +121,11 @@ surfaces:
         .map(|param| param.name.as_str())
         .collect::<BTreeSet<_>>();
     assert_eq!(query_names, BTreeSet::from(["state"]));
-
-    let mut stale_projection = projection.clone();
-    for input in &mut stale_projection.inputs {
-        if matches!(input.wire_name.as_str(), "page" | "per_page") {
-            input.sql_exposure = SqlInputExposure::Filter;
-        }
-    }
-    let stale_filter_names = projection_filter_specs(&stale_projection)
-        .into_iter()
-        .map(|filter| filter.name)
-        .collect::<BTreeSet<_>>();
-    assert_eq!(stale_filter_names, filter_names);
-
-    let stale_request =
-        request_spec_for_projection(&stale_projection, operation).expect("stale request");
-    let stale_query_names = stale_request
-        .query
-        .iter()
-        .map(|param| param.name.as_str())
-        .collect::<BTreeSet<_>>();
-    assert_eq!(stale_query_names, query_names);
-
-    for input in &mut stale_projection.inputs {
-        if matches!(input.wire_name.as_str(), "page" | "per_page") {
-            input.sql_exposure = SqlInputExposure::FunctionArg;
-        }
-    }
-    let stale_arg_names = projection_arg_specs(&stale_projection)
-        .into_iter()
-        .map(|arg| arg.name)
-        .collect::<BTreeSet<_>>();
-    assert!(!stale_arg_names.contains("page"));
-    assert!(!stale_arg_names.contains("per_page"));
+    assert!(
+        !projection.guide.contains("paginate"),
+        "projection guide should not describe pagination: {}",
+        projection.guide
+    );
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -121,7 +121,7 @@ fn generate_projection(
         .collect::<Vec<_>>();
     let columns = projection_columns(ir, operation);
     let name = generated_projection_name(operation, is_search);
-    let guide = projection_guide(&kind, &inputs, &pagination, is_search);
+    let guide = projection_guide(&kind, &inputs, is_search);
     let projection = Projection {
         name,
         namespace: namespace.to_string(),
@@ -133,7 +133,6 @@ fn generate_projection(
         visibility,
         inputs,
         columns,
-        pagination,
         search_limits: is_search.then_some(SearchLimitsSpec {
             default_top_k: 30,
             max_top_k: 100,

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -2,9 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::IrInputLocation;
-use crate::{
-    DetailHintSpec, ManifestDataType, PaginationSpec, SearchLimitsSpec, SourceTableFunctionKind,
-};
+use crate::{DetailHintSpec, ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectionCatalog {
@@ -28,7 +26,6 @@ pub struct Projection {
     pub visibility: ProjectionVisibility,
     pub inputs: Vec<ProjectionInput>,
     pub columns: Vec<ProjectionColumn>,
-    pub pagination: PaginationSpec,
     pub search_limits: Option<SearchLimitsSpec>,
     pub detail_hints: Vec<DetailHintSpec>,
     pub diagnostics: Vec<Diagnostic>,
@@ -85,7 +82,7 @@ mod tests {
         Projection, ProjectionCatalog, ProjectionKind, ProjectionVisibility, SqlInputExposure,
     };
     use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
-    use crate::{ManifestDataType, PaginationSpec, SearchLimitsSpec, SourceTableFunctionKind};
+    use crate::{ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
 
     #[test]
     fn projection_catalog_yaml_uses_editor_friendly_enum_shapes() {
@@ -106,7 +103,6 @@ mod tests {
                 visibility: ProjectionVisibility::Published,
                 inputs: Vec::new(),
                 columns: Vec::new(),
-                pagination: PaginationSpec::default(),
                 search_limits: Some(SearchLimitsSpec {
                     default_top_k: 30,
                     max_top_k: 100,
@@ -130,6 +126,10 @@ mod tests {
         assert!(
             yaml.contains("function_kind: search"),
             "missing function kind: {yaml}"
+        );
+        assert!(
+            !yaml.contains("pagination:"),
+            "projection catalog should not serialize pagination: {yaml}"
         );
 
         serde_yaml::from_str::<ProjectionCatalog>(&yaml)
@@ -156,7 +156,6 @@ projections:
     visibility: published
     inputs: []
     columns: []
-    pagination: {{}}
     search_limits: null
     detail_hints: []
     diagnostics: []

--- a/crates/coral-spec/src/v4/projections/names.rs
+++ b/crates/coral-spec/src/v4/projections/names.rs
@@ -4,7 +4,6 @@ use crate::v4::diagnostics::{Diagnostic, DiagnosticSeverity};
 use crate::v4::ir::{IrExecutionAttachment, IrOperation, OutputCardinality, SemanticIr};
 use crate::v4::manifest::V4SourceManifest;
 use crate::v4::naming::{normalize_identifier, pluralize, singularize, stable_suffix};
-use crate::{PaginationMode, PaginationSpec};
 
 use super::model::{
     Projection, ProjectionInput, ProjectionKind, ProjectionVisibility, SqlInputExposure,
@@ -189,7 +188,6 @@ fn normalized_path_literal_segment(segment: &str) -> Option<String> {
 pub(super) fn projection_guide(
     kind: &ProjectionKind,
     inputs: &[ProjectionInput],
-    pagination: &PaginationSpec,
     is_search: bool,
 ) -> String {
     let exposed_inputs = inputs
@@ -234,9 +232,6 @@ pub(super) fn projection_guide(
         sentences.push(
             "Use LIMIT to control result size; search endpoints can be rate-limited.".to_string(),
         );
-    } else if pagination.mode != PaginationMode::None {
-        sentences
-            .push("Use LIMIT for spot checks; large result sets paginate quickly.".to_string());
     }
 
     sentences.join(" ")

--- a/crates/coral-spec/src/v4/projections/pagination.rs
+++ b/crates/coral-spec/src/v4/projections/pagination.rs
@@ -1,9 +1,6 @@
 use std::collections::HashSet;
 
 use crate::PaginationSpec;
-use crate::v4::ir::IrInputLocation;
-
-use super::model::ProjectionInput;
 
 pub(super) fn pagination_query_param_names(pagination: &PaginationSpec) -> HashSet<&str> {
     let mut names = HashSet::new();
@@ -22,12 +19,4 @@ pub(super) fn pagination_query_param_names(pagination: &PaginationSpec) -> HashS
         names.insert(name);
     }
     names
-}
-
-pub(super) fn pagination_owns_input(
-    input: &ProjectionInput,
-    pagination_query_params: &HashSet<&str>,
-) -> bool {
-    input.source_location == IrInputLocation::Query
-        && pagination_query_params.contains(input.wire_name.as_str())
 }

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -9,15 +9,12 @@ use crate::{
 };
 
 use super::model::{Projection, SqlInputExposure};
-use super::pagination::{pagination_owns_input, pagination_query_param_names};
 
 pub fn projection_filter_specs(projection: &Projection) -> Vec<FilterSpec> {
-    let pagination_query_params = pagination_query_param_names(&projection.pagination);
     projection
         .inputs
         .iter()
         .filter(|input| input.sql_exposure == SqlInputExposure::Filter)
-        .filter(|input| !pagination_owns_input(input, &pagination_query_params))
         .map(|input| FilterSpec {
             name: input.name.clone(),
             data_type: manifest_data_type_name(input.data_type).to_string(),
@@ -30,12 +27,10 @@ pub fn projection_filter_specs(projection: &Projection) -> Vec<FilterSpec> {
 }
 
 pub fn projection_arg_specs(projection: &Projection) -> Vec<TableFunctionArgSpec> {
-    let pagination_query_params = pagination_query_param_names(&projection.pagination);
     projection
         .inputs
         .iter()
         .filter(|input| input.sql_exposure == SqlInputExposure::FunctionArg)
-        .filter(|input| !pagination_owns_input(input, &pagination_query_params))
         .map(|input| TableFunctionArgSpec {
             name: input.name.clone(),
             required: input.required,
@@ -64,7 +59,6 @@ pub fn mcp_projection_arg_specs(projection: &Projection) -> Vec<TableFunctionArg
 }
 
 pub fn projection_column_specs(projection: &Projection) -> Vec<ColumnSpec> {
-    let pagination_query_params = pagination_query_param_names(&projection.pagination);
     let mut columns = projection
         .columns
         .iter()
@@ -88,7 +82,6 @@ pub fn projection_column_specs(projection: &Projection) -> Vec<ColumnSpec> {
             .inputs
             .iter()
             .filter(|input| input.sql_exposure == SqlInputExposure::Filter)
-            .filter(|input| !pagination_owns_input(input, &pagination_query_params))
             .filter(|input| !existing.contains(&input.name))
             .map(|input| ColumnSpec {
                 name: input.name.clone(),
@@ -125,7 +118,6 @@ pub fn request_spec_for_projection(
             projection.name
         )));
     };
-    let pagination_query_params = pagination_query_param_names(&projection.pagination);
     let mut path = rest.path_template.clone();
     for input in &projection.inputs {
         if input.source_location == IrInputLocation::Path {
@@ -145,7 +137,6 @@ pub fn request_spec_for_projection(
         .inputs
         .iter()
         .filter(|input| input.source_location == IrInputLocation::Query)
-        .filter(|input| !pagination_owns_input(input, &pagination_query_params))
         .filter_map(|input| {
             let value = match input.sql_exposure {
                 SqlInputExposure::Filter => crate::ValueSourceSpec::Filter {


### PR DESCRIPTION
## Summary

- Remove pagination from the DSL v4 `Projection` model and generated `projections.yaml` artifact shape.
- Keep pagination as an execution detail on semantic IR attachments and copy REST pagination into runtime HTTP specs from the matched operation.
- Bump the projection generator version to invalidate stale materialized projection catalogs.

## Why

Pagination was duplicated into projections even though it is not part of the SQL-facing projection schema. That made the projection catalog carry engine execution details and created two possible sources of truth.

## Impact

Existing materialized DSL v4 sources with old projection catalogs will need to be re-added so `projections.yaml` is regenerated without pagination. Runtime pagination behavior is preserved through semantic IR.

## Validation

- `cargo test -p coral-spec`
- `cargo test -p coral-app sources::runtime_package`
- `make rust-checks`