### PR TITLE
feat(search): enqueue observed values in sqlite

### DIFF
--- a/crates/coral-app/src/hash.rs
+++ b/crates/coral-app/src/hash.rs
@@ -1,0 +1,7 @@
+//! Small hashing helpers shared inside the app crate.
+
+use sha2::{Digest as _, Sha256};
+
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -48,6 +48,7 @@ mod credentials;
 pub mod features;
 mod feedback;
 mod functions;
+mod hash;
 mod identity;
 mod query;
 mod request_context;

--- a/crates/coral-app/src/search/migrations/0002_observed_values.sql
+++ b/crates/coral-app/src/search/migrations/0002_observed_values.sql
@@ -1,0 +1,85 @@
+CREATE TABLE IF NOT EXISTS observed_workspace_generations (
+    workspace TEXT PRIMARY KEY,
+    generation INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS observed_source_generations (
+    workspace TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    generation INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (workspace, source_name)
+);
+
+CREATE TABLE IF NOT EXISTS observed_values (
+    workspace TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    source_scope_id TEXT NOT NULL,
+    surface_kind TEXT NOT NULL,
+    surface_name TEXT NOT NULL,
+    column_name TEXT NOT NULL,
+    value_key TEXT NOT NULL,
+    display_value TEXT NOT NULL,
+    search_text TEXT NOT NULL,
+    first_observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    last_observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    observation_count INTEGER NOT NULL DEFAULT 1,
+    source_generation INTEGER NOT NULL,
+    workspace_generation INTEGER NOT NULL,
+    PRIMARY KEY (
+        workspace,
+        source_name,
+        source_scope_id,
+        surface_kind,
+        surface_name,
+        column_name,
+        value_key
+    )
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS observed_values_fts USING fts5(
+    workspace UNINDEXED,
+    source_name UNINDEXED,
+    source_scope_id UNINDEXED,
+    surface_kind UNINDEXED,
+    surface_name UNINDEXED,
+    column_name UNINDEXED,
+    value_key UNINDEXED,
+    display_value,
+    search_text,
+    tokenize = 'trigram'
+);
+
+CREATE TABLE IF NOT EXISTS observed_queue_jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    workspace TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    source_scope_id TEXT NOT NULL,
+    surface_kind TEXT NOT NULL,
+    surface_name TEXT NOT NULL,
+    workspace_generation INTEGER NOT NULL,
+    source_generation INTEGER NOT NULL,
+    payload_json TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_observed_queue_jobs_workspace_id
+    ON observed_queue_jobs (workspace, id);
+CREATE INDEX IF NOT EXISTS idx_observed_queue_jobs_source
+    ON observed_queue_jobs (workspace, source_name, source_scope_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_observed_queue_jobs_pending_scope
+    ON observed_queue_jobs (
+        workspace,
+        source_name,
+        source_scope_id,
+        surface_kind,
+        surface_name,
+        workspace_generation,
+        source_generation
+    );
+CREATE INDEX IF NOT EXISTS idx_observed_values_source
+    ON observed_values (workspace, source_name, source_scope_id);

--- a/crates/coral-app/src/search/migrations/0002_observed_values.sql
+++ b/crates/coral-app/src/search/migrations/0002_observed_values.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS observed_source_generations (
 
 CREATE TABLE IF NOT EXISTS observed_values (
     workspace TEXT NOT NULL,
+    owner_source_name TEXT NOT NULL,
     source_name TEXT NOT NULL,
     source_scope_id TEXT NOT NULL,
     surface_kind TEXT NOT NULL,
@@ -29,6 +30,7 @@ CREATE TABLE IF NOT EXISTS observed_values (
     workspace_generation INTEGER NOT NULL,
     PRIMARY KEY (
         workspace,
+        owner_source_name,
         source_name,
         source_scope_id,
         surface_kind,
@@ -40,6 +42,7 @@ CREATE TABLE IF NOT EXISTS observed_values (
 
 CREATE VIRTUAL TABLE IF NOT EXISTS observed_values_fts USING fts5(
     workspace UNINDEXED,
+    owner_source_name UNINDEXED,
     source_name UNINDEXED,
     source_scope_id UNINDEXED,
     surface_kind UNINDEXED,
@@ -54,6 +57,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS observed_values_fts USING fts5(
 CREATE TABLE IF NOT EXISTS observed_queue_jobs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     workspace TEXT NOT NULL,
+    owner_source_name TEXT NOT NULL,
     source_name TEXT NOT NULL,
     source_scope_id TEXT NOT NULL,
     surface_kind TEXT NOT NULL,
@@ -70,10 +74,16 @@ CREATE TABLE IF NOT EXISTS observed_queue_jobs (
 CREATE INDEX IF NOT EXISTS idx_observed_queue_jobs_workspace_id
     ON observed_queue_jobs (workspace, id);
 CREATE INDEX IF NOT EXISTS idx_observed_queue_jobs_source
-    ON observed_queue_jobs (workspace, source_name, source_scope_id);
+    ON observed_queue_jobs (
+        workspace,
+        owner_source_name,
+        source_name,
+        source_scope_id
+    );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_observed_queue_jobs_pending_scope
     ON observed_queue_jobs (
         workspace,
+        owner_source_name,
         source_name,
         source_scope_id,
         surface_kind,
@@ -82,4 +92,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_observed_queue_jobs_pending_scope
         source_generation
     );
 CREATE INDEX IF NOT EXISTS idx_observed_values_source
-    ON observed_values (workspace, source_name, source_scope_id);
+    ON observed_values (
+        workspace,
+        owner_source_name,
+        source_name,
+        source_scope_id
+    );

--- a/crates/coral-app/src/search/mod.rs
+++ b/crates/coral-app/src/search/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod catalog;
 pub(crate) mod engine;
 pub(crate) mod maintenance;
 pub(crate) mod manager;
+pub(crate) mod observed;
 pub(crate) mod provider;
 pub(crate) mod result;
 pub(crate) mod service;

--- a/crates/coral-app/src/search/observed/collector.rs
+++ b/crates/coral-app/src/search/observed/collector.rs
@@ -16,9 +16,7 @@ use arrow::record_batch::RecordBatch;
 use arrow::util::display::array_value_to_string;
 
 use crate::hash::sha256_hex;
-use crate::search::observed::sensitive::{
-    exclude_sensitive_json_fields, is_sensitive_column, is_sensitive_value,
-};
+use crate::search::observed::sensitive::{is_sensitive_column, sanitize_observed_value};
 use crate::search::observed::sqlite_queue::{ObservedValueCandidate, ObservedValuesQueuePayload};
 
 #[derive(Debug, Clone, Default)]
@@ -54,12 +52,11 @@ impl ObservedValuesCollector {
                 ) else {
                     continue;
                 };
-                let Some(display_value) = exclude_sensitive_json_fields(display_value) else {
+                let Some(display_value) =
+                    sanitize_observed_value(display_value, self.budget.value_bytes_limit)
+                else {
                     continue;
                 };
-                if is_sensitive_value(&display_value) {
-                    continue;
-                }
                 let search_text = normalize_search_text(&display_value);
                 if search_text.is_empty() {
                     continue;
@@ -251,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn suppresses_embedded_sensitive_values() {
+    fn suppresses_embedded_sensitive_values_and_preserves_safe_url_content() {
         let batch = batch(
             ["note"],
             [vec![
@@ -267,7 +264,10 @@ mod tests {
             .map(|candidate| candidate.display_value.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(values, ["Ticket SK-101 is public"]);
+        assert_eq!(
+            values,
+            ["https://example.test/callback", "Ticket SK-101 is public"]
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/search/observed/collector.rs
+++ b/crates/coral-app/src/search/observed/collector.rs
@@ -12,22 +12,8 @@ use arrow::record_batch::RecordBatch;
 use arrow::util::display::array_value_to_string;
 
 use crate::hash::sha256_hex;
+use crate::search::observed::sensitive::{is_sensitive_column, is_sensitive_value};
 use crate::search::observed::sqlite_queue::{ObservedValueCandidate, ObservedValuesQueuePayload};
-
-const SENSITIVE_COLUMN_NAMES: &[&str] = &[
-    "apikey",
-    "authorization",
-    "authtoken",
-    "cookie",
-    "credential",
-    "password",
-    "passwd",
-    "privatekey",
-    "refreshtoken",
-    "secret",
-    "session",
-    "token",
-];
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ObservedValuesCollector {
@@ -106,13 +92,18 @@ pub(crate) struct ObservedValuesCollectionBudget {
     pub(crate) job_bytes_limit: usize,
 }
 
+const DEFAULT_CANDIDATE_LIMIT: usize = 10_000;
+const DEFAULT_CANDIDATE_BYTES_LIMIT: usize = 8 * 1024 * 1024;
+const DEFAULT_VALUE_BYTES_LIMIT: usize = 4 * 1024;
+const DEFAULT_JOB_BYTES_LIMIT: usize = 1024 * 1024;
+
 impl Default for ObservedValuesCollectionBudget {
     fn default() -> Self {
         Self {
-            candidate_limit: 10_000,
-            candidate_bytes_limit: 8 * 1024 * 1024,
-            value_bytes_limit: 4 * 1024,
-            job_bytes_limit: 1024 * 1024,
+            candidate_limit: DEFAULT_CANDIDATE_LIMIT,
+            candidate_bytes_limit: DEFAULT_CANDIDATE_BYTES_LIMIT,
+            value_bytes_limit: DEFAULT_VALUE_BYTES_LIMIT,
+            job_bytes_limit: DEFAULT_JOB_BYTES_LIMIT,
         }
     }
 }
@@ -146,82 +137,6 @@ fn normalize_search_text(value: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ")
         .to_lowercase()
-}
-
-fn is_sensitive_column(column_name: &str) -> bool {
-    let normalized = column_name
-        .chars()
-        .filter(char::is_ascii_alphanumeric)
-        .collect::<String>()
-        .to_ascii_lowercase();
-    SENSITIVE_COLUMN_NAMES
-        .iter()
-        .any(|name| normalized.contains(name))
-}
-
-fn is_sensitive_value(value: &str) -> bool {
-    let trimmed = value.trim();
-    if trimmed.contains("-----BEGIN ") || trimmed.contains(" PRIVATE KEY-----") {
-        return true;
-    }
-    is_sensitive_token(trimmed)
-        || contains_sensitive_token(trimmed)
-        || contains_sensitive_key_value_pair(trimmed)
-}
-
-fn is_sensitive_token(value: &str) -> bool {
-    let lower = value.to_ascii_lowercase();
-    if (lower.starts_with("sk-") && value.len() >= 20)
-        || lower.starts_with("ghp_")
-        || lower.starts_with("github_pat_")
-        || lower.starts_with("xoxb-")
-        || lower.starts_with("xoxp-")
-        || lower.starts_with("xoxa-")
-        || lower.starts_with("ya29.")
-    {
-        return true;
-    }
-    looks_like_jwt(value)
-}
-
-fn contains_sensitive_token(value: &str) -> bool {
-    value
-        .split(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')))
-        .any(is_sensitive_token)
-}
-
-fn contains_sensitive_key_value_pair(value: &str) -> bool {
-    value
-        .split(|ch: char| {
-            matches!(
-                ch,
-                '?' | '&' | ';' | ',' | '"' | '\'' | '{' | '}' | '[' | ']' | ' ' | '\t' | '\n'
-            )
-        })
-        .filter_map(|segment| segment.split_once('=').or_else(|| segment.split_once(':')))
-        .any(|(key, value)| !value.trim().is_empty() && is_sensitive_column(key))
-}
-
-fn looks_like_jwt(value: &str) -> bool {
-    let mut parts = value.split('.');
-    let Some(header) = parts.next() else {
-        return false;
-    };
-    let Some(payload) = parts.next() else {
-        return false;
-    };
-    let Some(signature) = parts.next() else {
-        return false;
-    };
-    if parts.next().is_some() {
-        return false;
-    }
-    [header, payload, signature].iter().all(|part| {
-        part.len() >= 8
-            && part
-                .chars()
-                .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
-    })
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/search/observed/collector.rs
+++ b/crates/coral-app/src/search/observed/collector.rs
@@ -7,7 +7,11 @@
 
 use std::collections::HashSet;
 
-use arrow::array::Array;
+use arrow::array::{
+    Array, BinaryArray, BinaryViewArray, LargeBinaryArray, LargeStringArray, StringArray,
+    StringViewArray,
+};
+use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 use arrow::util::display::array_value_to_string;
 
@@ -26,6 +30,7 @@ impl ObservedValuesCollector {
     pub(crate) fn collect_batch(&self, batch: &RecordBatch) -> ObservedValuesQueuePayload {
         let mut values = Vec::new();
         let mut observed_bytes = 0_usize;
+        let mut inspected_cells = 0_usize;
         let mut seen = HashSet::new();
         let schema = batch.schema();
         let eligible_column_indices = (0..batch.num_columns())
@@ -33,9 +38,12 @@ impl ObservedValuesCollector {
             .collect::<Vec<_>>();
         for row_index in 0..batch.num_rows() {
             for &column_index in &eligible_column_indices {
-                if values.len() >= self.budget.candidate_limit {
+                if values.len() >= self.budget.candidate_limit
+                    || inspected_cells >= self.budget.inspected_cell_limit
+                {
                     return ObservedValuesQueuePayload { values };
                 }
+                inspected_cells += 1;
                 let field = schema.field(column_index);
                 let column_name = field.name();
                 let column = batch.column(column_index);
@@ -92,12 +100,14 @@ impl ObservedValuesCollector {
 )]
 pub(crate) struct ObservedValuesCollectionBudget {
     pub(crate) candidate_limit: usize,
+    pub(crate) inspected_cell_limit: usize,
     pub(crate) candidate_bytes_limit: usize,
     pub(crate) value_bytes_limit: usize,
     pub(crate) job_bytes_limit: usize,
 }
 
 const DEFAULT_CANDIDATE_LIMIT: usize = 10_000;
+const DEFAULT_INSPECTED_CELL_LIMIT: usize = 10_000;
 const DEFAULT_CANDIDATE_BYTES_LIMIT: usize = 8 * 1024 * 1024;
 const DEFAULT_VALUE_BYTES_LIMIT: usize = 4 * 1024;
 const DEFAULT_JOB_BYTES_LIMIT: usize = 1024 * 1024;
@@ -106,6 +116,7 @@ impl Default for ObservedValuesCollectionBudget {
     fn default() -> Self {
         Self {
             candidate_limit: DEFAULT_CANDIDATE_LIMIT,
+            inspected_cell_limit: DEFAULT_INSPECTED_CELL_LIMIT,
             candidate_bytes_limit: DEFAULT_CANDIDATE_BYTES_LIMIT,
             value_bytes_limit: DEFAULT_VALUE_BYTES_LIMIT,
             job_bytes_limit: DEFAULT_JOB_BYTES_LIMIT,
@@ -128,12 +139,46 @@ fn observed_display_value(
     if column.is_null(row_index) {
         return None;
     }
+    if raw_value_len(column, row_index).is_some_and(|length| length > max_value_bytes) {
+        return None;
+    }
     let value = array_value_to_string(column, row_index).ok()?;
     let trimmed = value.trim();
     if trimmed.is_empty() || trimmed.len() > max_value_bytes {
         return None;
     }
     Some(trimmed.to_string())
+}
+
+fn raw_value_len(column: &dyn Array, row_index: usize) -> Option<usize> {
+    match column.data_type() {
+        DataType::Utf8 => column
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .map(|array| array.value(row_index).len()),
+        DataType::LargeUtf8 => column
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .map(|array| array.value(row_index).len()),
+        DataType::Utf8View => column
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .map(|array| array.value(row_index).len()),
+        DataType::Binary => column
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .map(|array| array.value(row_index).len()),
+        DataType::LargeBinary => column
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .map(|array| array.value(row_index).len()),
+        DataType::BinaryView => column
+            .as_any()
+            .downcast_ref::<BinaryViewArray>()
+            .map(|array| array.value(row_index).len()),
+        DataType::FixedSizeBinary(width) => Some(usize::try_from(*width).unwrap_or(usize::MAX)),
+        _ => None,
+    }
 }
 
 fn normalize_search_text(value: &str) -> String {
@@ -148,11 +193,11 @@ fn normalize_search_text(value: &str) -> String {
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::StringArray;
+    use arrow::array::{BinaryArray, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
 
-    use super::{ObservedValuesCollectionBudget, ObservedValuesCollector};
+    use super::{ObservedValuesCollectionBudget, ObservedValuesCollector, raw_value_len};
     use crate::search::observed::sqlite_queue::ObservedValuesQueuePayload;
     use crate::search::observed::writer::payload_json_with_budget;
 
@@ -246,6 +291,7 @@ mod tests {
     fn collection_budget_caps_candidates() {
         let collector = ObservedValuesCollector::with_budget(ObservedValuesCollectionBudget {
             candidate_limit: 1,
+            inspected_cell_limit: usize::MAX,
             candidate_bytes_limit: usize::MAX,
             value_bytes_limit: usize::MAX,
             job_bytes_limit: usize::MAX,
@@ -267,6 +313,7 @@ mod tests {
     fn deduplicates_batch_values_before_budgeting() {
         let collector = ObservedValuesCollector::with_budget(ObservedValuesCollectionBudget {
             candidate_limit: 2,
+            inspected_cell_limit: usize::MAX,
             candidate_bytes_limit: usize::MAX,
             value_bytes_limit: usize::MAX,
             job_bytes_limit: usize::MAX,
@@ -296,6 +343,7 @@ mod tests {
     fn candidate_budget_uses_row_major_order() {
         let collector = ObservedValuesCollector::with_budget(ObservedValuesCollectionBudget {
             candidate_limit: 4,
+            inspected_cell_limit: usize::MAX,
             candidate_bytes_limit: usize::MAX,
             value_bytes_limit: usize::MAX,
             job_bytes_limit: usize::MAX,
@@ -328,6 +376,46 @@ mod tests {
                 ("first", "first-2"),
             ]
         );
+    }
+
+    #[test]
+    fn inspected_cell_budget_counts_null_and_duplicate_cells() {
+        let collector = ObservedValuesCollector::with_budget(ObservedValuesCollectionBudget {
+            candidate_limit: usize::MAX,
+            inspected_cell_limit: 3,
+            candidate_bytes_limit: usize::MAX,
+            value_bytes_limit: usize::MAX,
+            job_bytes_limit: usize::MAX,
+        });
+        let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, true)]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringArray::from(vec![
+                None,
+                Some("Repeat"),
+                Some("Repeat"),
+                Some("Late"),
+            ]))],
+        )
+        .expect("record batch");
+
+        let payload = collector.collect_batch(&batch);
+        let values = payload
+            .values
+            .iter()
+            .map(|candidate| candidate.display_value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, ["Repeat"]);
+    }
+
+    #[test]
+    fn raw_length_precheck_covers_string_and_binary_cells() {
+        let strings = StringArray::from(vec!["oversized"]);
+        let binaries = BinaryArray::from(vec![b"oversized".as_slice()]);
+
+        assert_eq!(raw_value_len(&strings, 0), Some(9));
+        assert_eq!(raw_value_len(&binaries, 0), Some(9));
     }
 
     #[test]

--- a/crates/coral-app/src/search/observed/collector.rs
+++ b/crates/coral-app/src/search/observed/collector.rs
@@ -12,7 +12,9 @@ use arrow::record_batch::RecordBatch;
 use arrow::util::display::array_value_to_string;
 
 use crate::hash::sha256_hex;
-use crate::search::observed::sensitive::{is_sensitive_column, is_sensitive_value};
+use crate::search::observed::sensitive::{
+    exclude_sensitive_json_fields, is_sensitive_column, is_sensitive_value,
+};
 use crate::search::observed::sqlite_queue::{ObservedValueCandidate, ObservedValuesQueuePayload};
 
 #[derive(Debug, Clone, Default)]
@@ -26,22 +28,25 @@ impl ObservedValuesCollector {
         let mut observed_bytes = 0_usize;
         let mut seen = HashSet::new();
         let schema = batch.schema();
-        for column_index in 0..batch.num_columns() {
-            let field = schema.field(column_index);
-            let column_name = field.name();
-            if is_sensitive_column(column_name) {
-                continue;
-            }
-            let column = batch.column(column_index);
-            for row_index in 0..batch.num_rows() {
+        let eligible_column_indices = (0..batch.num_columns())
+            .filter(|&column_index| !is_sensitive_column(schema.field(column_index).name()))
+            .collect::<Vec<_>>();
+        for row_index in 0..batch.num_rows() {
+            for &column_index in &eligible_column_indices {
                 if values.len() >= self.budget.candidate_limit {
                     return ObservedValuesQueuePayload { values };
                 }
+                let field = schema.field(column_index);
+                let column_name = field.name();
+                let column = batch.column(column_index);
                 let Some(display_value) = observed_display_value(
                     column.as_ref(),
                     row_index,
                     self.budget.value_bytes_limit,
                 ) else {
+                    continue;
+                };
+                let Some(display_value) = exclude_sensitive_json_fields(display_value) else {
                     continue;
                 };
                 if is_sensitive_value(&display_value) {
@@ -148,6 +153,8 @@ mod tests {
     use arrow::record_batch::RecordBatch;
 
     use super::{ObservedValuesCollectionBudget, ObservedValuesCollector};
+    use crate::search::observed::sqlite_queue::ObservedValuesQueuePayload;
+    use crate::search::observed::writer::payload_json_with_budget;
 
     #[test]
     fn suppresses_sensitive_columns_and_values() {
@@ -167,7 +174,7 @@ mod tests {
             .map(|candidate| candidate.display_value.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(values, ["Grace", "Ada", "ok"]);
+        assert_eq!(values, ["Grace", "ok", "Ada"]);
     }
 
     #[test]
@@ -219,6 +226,23 @@ mod tests {
     }
 
     #[test]
+    fn excludes_sensitive_json_fields_while_preserving_benign_siblings() {
+        let payload = ObservedValuesCollector::default().collect_batch(&batch(
+            ["metadata"],
+            [vec![
+                r#"{"name":"Ada","api_key":"literal-secret","nested":{"project":"coral","refresh_token":"other-secret"}}"#,
+            ]],
+        ));
+        let values = payload
+            .values
+            .iter()
+            .map(|candidate| candidate.display_value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, [r#"{"name":"Ada","nested":{"project":"coral"}}"#]);
+    }
+
+    #[test]
     fn collection_budget_caps_candidates() {
         let collector = ObservedValuesCollector::with_budget(ObservedValuesCollectionBudget {
             candidate_limit: 1,
@@ -266,6 +290,110 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(values, [("first", "Repeat"), ("second", "Distinct")]);
+    }
+
+    #[test]
+    fn candidate_budget_uses_row_major_order() {
+        let collector = ObservedValuesCollector::with_budget(ObservedValuesCollectionBudget {
+            candidate_limit: 4,
+            candidate_bytes_limit: usize::MAX,
+            value_bytes_limit: usize::MAX,
+            job_bytes_limit: usize::MAX,
+        });
+        let payload = collector.collect_batch(&batch(
+            ["first", "second", "third"],
+            [
+                vec!["first-1", "first-2", "first-3"],
+                vec!["second-1", "second-2", "second-3"],
+                vec!["third-1", "third-2", "third-3"],
+            ],
+        ));
+        let values = payload
+            .values
+            .iter()
+            .map(|candidate| {
+                (
+                    candidate.column_name.as_str(),
+                    candidate.display_value.as_str(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            values,
+            [
+                ("first", "first-1"),
+                ("second", "second-1"),
+                ("third", "third-1"),
+                ("first", "first-2"),
+            ]
+        );
+    }
+
+    #[test]
+    fn serialized_job_budget_preserves_late_columns_with_row_major_collection() {
+        let payload = ObservedValuesCollector::default().collect_batch(&batch(
+            ["id", "title", "description"],
+            [
+                vec!["id-1", "id-2", "id-3", "id-4", "id-5", "id-6"],
+                vec![
+                    "title-1", "title-2", "title-3", "title-4", "title-5", "title-6",
+                ],
+                vec![
+                    "useful-1", "useful-2", "useful-3", "useful-4", "useful-5", "useful-6",
+                ],
+            ],
+        ));
+        let first_row_values = payload
+            .values
+            .get(..3)
+            .expect("three candidates from the first row")
+            .to_vec();
+        let job_bytes_limit = serde_json::to_string(&ObservedValuesQueuePayload {
+            values: first_row_values,
+        })
+        .expect("first-row payload json")
+        .len();
+        let first_column_payload = ObservedValuesQueuePayload {
+            values: payload
+                .values
+                .iter()
+                .filter(|candidate| candidate.column_name == "id")
+                .cloned()
+                .collect(),
+        };
+        assert!(
+            serde_json::to_string(&first_column_payload)
+                .expect("first-column payload json")
+                .len()
+                > job_bytes_limit,
+            "the first column alone should exceed the serialized job budget"
+        );
+
+        let payload_json = payload_json_with_budget(payload, job_bytes_limit)
+            .expect("serialize row-major payload")
+            .expect("first row should fit the serialized job budget");
+        let payload: ObservedValuesQueuePayload =
+            serde_json::from_str(&payload_json).expect("decode row-major payload");
+        let values = payload
+            .values
+            .iter()
+            .map(|candidate| {
+                (
+                    candidate.column_name.as_str(),
+                    candidate.display_value.as_str(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            values,
+            [
+                ("id", "id-1"),
+                ("title", "title-1"),
+                ("description", "useful-1"),
+            ]
+        );
     }
 
     fn batch<const N: usize>(

--- a/crates/coral-app/src/search/observed/collector.rs
+++ b/crates/coral-app/src/search/observed/collector.rs
@@ -1,0 +1,372 @@
+//! Observed-values batch collection.
+
+#![allow(
+    dead_code,
+    reason = "observed-values provider substrate is staged before app wiring in the next PR"
+)]
+
+use std::collections::HashSet;
+
+use arrow::array::Array;
+use arrow::record_batch::RecordBatch;
+use arrow::util::display::array_value_to_string;
+
+use crate::hash::sha256_hex;
+use crate::search::observed::sqlite_queue::{ObservedValueCandidate, ObservedValuesQueuePayload};
+
+const SENSITIVE_COLUMN_NAMES: &[&str] = &[
+    "apikey",
+    "authorization",
+    "authtoken",
+    "cookie",
+    "credential",
+    "password",
+    "passwd",
+    "privatekey",
+    "refreshtoken",
+    "secret",
+    "session",
+    "token",
+];
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ObservedValuesCollector {
+    budget: ObservedValuesCollectionBudget,
+}
+
+impl ObservedValuesCollector {
+    pub(crate) fn collect_batch(&self, batch: &RecordBatch) -> ObservedValuesQueuePayload {
+        let mut values = Vec::new();
+        let mut observed_bytes = 0_usize;
+        let mut seen = HashSet::new();
+        let schema = batch.schema();
+        for column_index in 0..batch.num_columns() {
+            let field = schema.field(column_index);
+            let column_name = field.name();
+            if is_sensitive_column(column_name) {
+                continue;
+            }
+            let column = batch.column(column_index);
+            for row_index in 0..batch.num_rows() {
+                if values.len() >= self.budget.candidate_limit {
+                    return ObservedValuesQueuePayload { values };
+                }
+                let Some(display_value) = observed_display_value(
+                    column.as_ref(),
+                    row_index,
+                    self.budget.value_bytes_limit,
+                ) else {
+                    continue;
+                };
+                if is_sensitive_value(&display_value) {
+                    continue;
+                }
+                let search_text = normalize_search_text(&display_value);
+                if search_text.is_empty() {
+                    continue;
+                }
+                if !seen.insert((column_name.clone(), search_text.clone())) {
+                    continue;
+                }
+                let candidate_bytes = column_name
+                    .len()
+                    .saturating_add(display_value.len())
+                    .saturating_add(search_text.len());
+                if observed_bytes.saturating_add(candidate_bytes)
+                    > self.budget.candidate_bytes_limit
+                {
+                    return ObservedValuesQueuePayload { values };
+                }
+                observed_bytes = observed_bytes.saturating_add(candidate_bytes);
+                values.push(ObservedValueCandidate {
+                    column_name: column_name.clone(),
+                    display_value,
+                    search_text: search_text.clone(),
+                    value_key: sha256_hex(search_text.as_bytes()),
+                });
+            }
+        }
+        ObservedValuesQueuePayload { values }
+    }
+
+    pub(crate) fn budget(&self) -> &ObservedValuesCollectionBudget {
+        &self.budget
+    }
+}
+
+#[derive(Debug, Clone)]
+#[expect(
+    clippy::struct_field_names,
+    reason = "observed-values collection budgets are byte/count limits with explicit units"
+)]
+pub(crate) struct ObservedValuesCollectionBudget {
+    pub(crate) candidate_limit: usize,
+    pub(crate) candidate_bytes_limit: usize,
+    pub(crate) value_bytes_limit: usize,
+    pub(crate) job_bytes_limit: usize,
+}
+
+impl Default for ObservedValuesCollectionBudget {
+    fn default() -> Self {
+        Self {
+            candidate_limit: 10_000,
+            candidate_bytes_limit: 8 * 1024 * 1024,
+            value_bytes_limit: 4 * 1024,
+            job_bytes_limit: 1024 * 1024,
+        }
+    }
+}
+
+#[cfg(test)]
+impl ObservedValuesCollector {
+    pub(crate) fn with_budget(budget: ObservedValuesCollectionBudget) -> Self {
+        Self { budget }
+    }
+}
+
+fn observed_display_value(
+    column: &dyn Array,
+    row_index: usize,
+    max_value_bytes: usize,
+) -> Option<String> {
+    if column.is_null(row_index) {
+        return None;
+    }
+    let value = array_value_to_string(column, row_index).ok()?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.len() > max_value_bytes {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+fn normalize_search_text(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+fn is_sensitive_column(column_name: &str) -> bool {
+    let normalized = column_name
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect::<String>()
+        .to_ascii_lowercase();
+    SENSITIVE_COLUMN_NAMES
+        .iter()
+        .any(|name| normalized.contains(name))
+}
+
+fn is_sensitive_value(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.contains("-----BEGIN ") || trimmed.contains(" PRIVATE KEY-----") {
+        return true;
+    }
+    is_sensitive_token(trimmed)
+        || contains_sensitive_token(trimmed)
+        || contains_sensitive_key_value_pair(trimmed)
+}
+
+fn is_sensitive_token(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    if (lower.starts_with("sk-") && value.len() >= 20)
+        || lower.starts_with("ghp_")
+        || lower.starts_with("github_pat_")
+        || lower.starts_with("xoxb-")
+        || lower.starts_with("xoxp-")
+        || lower.starts_with("xoxa-")
+        || lower.starts_with("ya29.")
+    {
+        return true;
+    }
+    looks_like_jwt(value)
+}
+
+fn contains_sensitive_token(value: &str) -> bool {
+    value
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')))
+        .any(is_sensitive_token)
+}
+
+fn contains_sensitive_key_value_pair(value: &str) -> bool {
+    value
+        .split(|ch: char| {
+            matches!(
+                ch,
+                '?' | '&' | ';' | ',' | '"' | '\'' | '{' | '}' | '[' | ']' | ' ' | '\t' | '\n'
+            )
+        })
+        .filter_map(|segment| segment.split_once('=').or_else(|| segment.split_once(':')))
+        .any(|(key, value)| !value.trim().is_empty() && is_sensitive_column(key))
+}
+
+fn looks_like_jwt(value: &str) -> bool {
+    let mut parts = value.split('.');
+    let Some(header) = parts.next() else {
+        return false;
+    };
+    let Some(payload) = parts.next() else {
+        return false;
+    };
+    let Some(signature) = parts.next() else {
+        return false;
+    };
+    if parts.next().is_some() {
+        return false;
+    }
+    [header, payload, signature].iter().all(|part| {
+        part.len() >= 8
+            && part
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::StringArray;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+
+    use super::{ObservedValuesCollectionBudget, ObservedValuesCollector};
+
+    #[test]
+    fn suppresses_sensitive_columns_and_values() {
+        let batch = batch(
+            ["name", "api_token", "note", "password_hash"],
+            [
+                vec!["Grace", "Ada"],
+                vec!["ghp_supersecret", "plain-token"],
+                vec!["ok", "sk-super-secret-value"],
+                vec!["hashed", "values"],
+            ],
+        );
+        let payload = ObservedValuesCollector::default().collect_batch(&batch);
+        let values = payload
+            .values
+            .iter()
+            .map(|candidate| candidate.display_value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, ["Grace", "Ada", "ok"]);
+    }
+
+    #[test]
+    fn suppresses_sensitive_column_stems_and_short_sk_prefixes_survive() {
+        let batch = batch(
+            [
+                "ticket_key",
+                "secret_key",
+                "token_id",
+                "api_key_value",
+                "note",
+            ],
+            [
+                vec!["SK-101"],
+                vec!["secret"],
+                vec!["token"],
+                vec!["api-key"],
+                vec!["sk-abcdefghijklmnopqrstuvwxyz"],
+            ],
+        );
+        let payload = ObservedValuesCollector::default().collect_batch(&batch);
+        let values = payload
+            .values
+            .iter()
+            .map(|candidate| candidate.display_value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, ["SK-101"]);
+    }
+
+    #[test]
+    fn suppresses_embedded_sensitive_values() {
+        let batch = batch(
+            ["note"],
+            [vec![
+                "Bearer sk-abcdefghijklmnopqrstuvwxyz",
+                "https://example.test/callback?api_key=literal-secret",
+                "Ticket SK-101 is public",
+            ]],
+        );
+        let payload = ObservedValuesCollector::default().collect_batch(&batch);
+        let values = payload
+            .values
+            .iter()
+            .map(|candidate| candidate.display_value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, ["Ticket SK-101 is public"]);
+    }
+
+    #[test]
+    fn collection_budget_caps_candidates() {
+        let collector = ObservedValuesCollector::with_budget(ObservedValuesCollectionBudget {
+            candidate_limit: 1,
+            candidate_bytes_limit: usize::MAX,
+            value_bytes_limit: usize::MAX,
+            job_bytes_limit: usize::MAX,
+        });
+        let payload = collector.collect_batch(&batch(["name"], [vec!["Grace", "Ada"]]));
+
+        assert_eq!(payload.values.len(), 1);
+        assert_eq!(
+            payload
+                .values
+                .first()
+                .expect("one observed candidate")
+                .display_value,
+            "Grace"
+        );
+    }
+
+    #[test]
+    fn deduplicates_batch_values_before_budgeting() {
+        let collector = ObservedValuesCollector::with_budget(ObservedValuesCollectionBudget {
+            candidate_limit: 2,
+            candidate_bytes_limit: usize::MAX,
+            value_bytes_limit: usize::MAX,
+            job_bytes_limit: usize::MAX,
+        });
+        let payload = collector.collect_batch(&batch(
+            ["first", "second"],
+            [
+                vec!["Repeat", "Repeat", "Repeat"],
+                vec!["Distinct", "Other", "More"],
+            ],
+        ));
+        let values = payload
+            .values
+            .iter()
+            .map(|candidate| {
+                (
+                    candidate.column_name.as_str(),
+                    candidate.display_value.as_str(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, [("first", "Repeat"), ("second", "Distinct")]);
+    }
+
+    fn batch<const N: usize>(
+        columns: [&'static str; N],
+        values: [Vec<&'static str>; N],
+    ) -> RecordBatch {
+        let schema = Arc::new(Schema::new(
+            columns
+                .into_iter()
+                .map(|name| Field::new(name, DataType::Utf8, true))
+                .collect::<Vec<_>>(),
+        ));
+        let arrays = values
+            .into_iter()
+            .map(|values| Arc::new(StringArray::from(values)) as _)
+            .collect();
+        RecordBatch::try_new(schema, arrays).expect("record batch")
+    }
+}

--- a/crates/coral-app/src/search/observed/mod.rs
+++ b/crates/coral-app/src/search/observed/mod.rs
@@ -1,0 +1,8 @@
+//! Observed-values collection and governance for Universal Search.
+
+mod collector;
+mod publisher;
+mod source_scope;
+mod sqlite_queue;
+mod sqlite_store;
+mod writer;

--- a/crates/coral-app/src/search/observed/mod.rs
+++ b/crates/coral-app/src/search/observed/mod.rs
@@ -2,6 +2,7 @@
 
 mod collector;
 mod publisher;
+mod sensitive;
 mod source_scope;
 mod sqlite_queue;
 mod sqlite_store;

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -154,7 +154,8 @@ impl SourceScanObservedValuesPublisher {
         }
         match self.writer.try_enqueue(ObservedValuesWrite {
             workspace_name: self.workspace_name.clone(),
-            source_name: scope.observed_source_name.clone(),
+            owner_source_name: scope.owner_source_name.clone(),
+            source_name: scope.source_name.clone(),
             source_scope_id: scope.source_scope_id.clone(),
             surface_kind,
             surface_name: observation.surface_name.to_string(),
@@ -166,7 +167,8 @@ impl SourceScanObservedValuesPublisher {
             Err(ObservedValuesTryEnqueueError::Full) => {
                 tracing::debug!(
                     workspace = %self.workspace_name.as_str(),
-                    source = %scope.observed_source_name,
+                    source = %scope.source_name,
+                    source_owner = %scope.owner_source_name,
                     surface = %observation.surface_name,
                     "dropping observed-values source-scan observation because writer queue is full"
                 );
@@ -174,7 +176,8 @@ impl SourceScanObservedValuesPublisher {
             Err(ObservedValuesTryEnqueueError::Disconnected) => {
                 tracing::debug!(
                     workspace = %self.workspace_name.as_str(),
-                    source = %scope.observed_source_name,
+                    source = %scope.source_name,
+                    source_owner = %scope.owner_source_name,
                     surface = %observation.surface_name,
                     "dropping observed-values source-scan observation because writer is stopped"
                 );
@@ -200,7 +203,10 @@ mod tests {
     use arrow::array::StringArray;
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
-    use coral_engine::{QuerySource, SourceObservationSurfaceKind, SourceScanObservation};
+    use coral_engine::{
+        QuerySource, RuntimeSourceComponent, RuntimeSourcePackage, SourceObservationSurfaceKind,
+        SourceScanObservation,
+    };
     use coral_spec::parse_source_manifest_yaml;
     use serde_json::json;
     use tempfile::tempdir;
@@ -284,6 +290,67 @@ mod tests {
         assert!(payloads.contains("hello"));
         assert!(!payloads.contains("literal-secret"));
         assert!(!payloads.contains("ghp_supersecret"));
+    }
+
+    #[test]
+    fn publisher_preserves_owner_and_query_schema_for_multi_surface_v4_package() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let handle = SearchObservationHandle::new(layout.clone());
+        let source = multi_surface_v4_query_source();
+        let extensions = handle.extensions_for(&workspace, &[source]);
+        let publisher = extensions
+            .source_observation_publishers
+            .first()
+            .expect("publisher");
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "title",
+                DataType::Utf8,
+                false,
+            )])),
+            vec![Arc::new(StringArray::from(vec!["Fix the bug"]))],
+        )
+        .expect("batch");
+
+        for source_name in ["github_v4_rest", "github_v4_mcp"] {
+            publisher.publish_source_scan(SourceScanObservation {
+                source_name,
+                surface_kind: SourceObservationSurfaceKind::Table,
+                surface_name: "list_issues",
+                batch: &batch,
+            });
+        }
+
+        let identities = wait_for_source_identities(&layout, &workspace, 2);
+        assert_eq!(
+            identities,
+            [
+                (
+                    "github_v4".to_string(),
+                    "github_v4_rest".to_string(),
+                    "list_issues".to_string(),
+                ),
+                (
+                    "github_v4".to_string(),
+                    "github_v4_mcp".to_string(),
+                    "list_issues".to_string(),
+                ),
+            ]
+        );
+
+        let store = SqliteObservedValuesStore::new(layout);
+        store
+            .clear_source(&workspace, "github_v4")
+            .expect("clear logical source owner");
+        assert_eq!(
+            store
+                .pending_queue_job_count(&workspace)
+                .expect("queue count"),
+            0
+        );
     }
 
     #[test]
@@ -424,6 +491,49 @@ tables:
         )
     }
 
+    fn multi_surface_v4_query_source() -> QuerySource {
+        // Multi-surface v4 sources reach the engine through this backend-ready
+        // package shape: one installed owner with one schema per component.
+        QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: "github_v4".to_string(),
+                authored_version: None,
+                description: String::new(),
+                declared_inputs: Vec::new(),
+                test_queries: Vec::new(),
+                components: vec![
+                    http_component("github_v4_rest"),
+                    http_component("github_v4_mcp"),
+                ],
+            },
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect("multi-surface query source")
+    }
+
+    fn http_component(source_name: &str) -> RuntimeSourceComponent {
+        let yaml = format!(
+            r"
+dsl_version: 3
+name: {source_name}
+version: 0.1.0
+backend: http
+base_url: https://api.github.com
+tables:
+  - name: list_issues
+    description: Issues
+    request:
+      path: /issues
+    columns:
+      - name: title
+        type: Utf8
+"
+        );
+        let manifest = parse_source_manifest_yaml(&yaml).expect("component manifest");
+        RuntimeSourceComponent::Http(manifest.as_http().expect("HTTP component").clone())
+    }
+
     fn wait_for_payloads(layout: &AppStateLayout, workspace: &WorkspaceName) -> Vec<String> {
         let store = SqliteObservedValuesStore::new(layout.clone());
         for _ in 0..100 {
@@ -434,6 +544,24 @@ tables:
             thread::sleep(Duration::from_millis(10));
         }
         panic!("observed-values writer did not enqueue payload");
+    }
+
+    fn wait_for_source_identities(
+        layout: &AppStateLayout,
+        workspace: &WorkspaceName,
+        expected_count: usize,
+    ) -> Vec<(String, String, String)> {
+        let store = SqliteObservedValuesStore::new(layout.clone());
+        for _ in 0..100 {
+            let identities = store
+                .queue_source_identities(workspace)
+                .expect("queue source identities");
+            if identities.len() == expected_count {
+                return identities;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("observed-values writer did not enqueue expected source identities");
     }
 
     fn observed_candidate(display_value: &str) -> ObservedValueCandidate {

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -18,10 +18,11 @@ use crate::search::observed::collector::ObservedValuesCollector;
 use crate::search::observed::source_scope::{
     ObservedSourceSurfaceScope, SurfaceKey, source_surface_scopes,
 };
-use crate::search::observed::sqlite_queue::ObservedValuesSurfaceKind;
+use crate::search::observed::sqlite_queue::{ObservedValuesEpoch, ObservedValuesSurfaceKind};
 use crate::search::observed::sqlite_store::SqliteObservedValuesStore;
 use crate::search::observed::writer::{
-    ObservedValuesTryEnqueueError, ObservedValuesWrite, ObservedValuesWriter,
+    ObservedValuesTryReserveError, ObservedValuesWrite, ObservedValuesWriter,
+    payload_json_with_budget,
 };
 use crate::search::sqlite_store::SqliteSearchError;
 use crate::state::AppStateLayout;
@@ -52,11 +53,11 @@ impl SearchObservationHandle {
     ) -> EngineExtensions {
         let mut scopes = HashMap::new();
         for source in selected_sources {
-            let generation = match self
+            let epoch = match self
                 .store
-                .current_generations(workspace_name, source.source_name())
+                .capture_epoch(workspace_name, source.source_name())
             {
-                Ok(generation) => generation,
+                Ok(epoch) => epoch,
                 Err(error) => {
                     tracing::debug!(
                         workspace = %workspace_name.as_str(),
@@ -67,8 +68,8 @@ impl SearchObservationHandle {
                     continue;
                 }
             };
-            for scope in source_surface_scopes(source, generation) {
-                scopes.insert(scope.key(), scope);
+            for scope in source_surface_scopes(source) {
+                scopes.insert(scope.key(), RegisteredSurface { scope, epoch });
             }
         }
         if scopes.is_empty() {
@@ -93,7 +94,7 @@ impl SearchObservationHandle {
     )]
     pub(crate) fn clear_workspace(&self, workspace_name: &WorkspaceName) -> Result<(), AppError> {
         self.store
-            .clear_workspace(workspace_name)
+            .clear_workspace_and_advance_epoch(workspace_name)
             .map_err(|error| observed_values_store_error(&error))
     }
 
@@ -103,7 +104,7 @@ impl SearchObservationHandle {
         source_name: &str,
     ) -> Result<(), AppError> {
         self.store
-            .clear_source(workspace_name, source_name)
+            .clear_source_and_advance_epoch(workspace_name, source_name)
             .map_err(|error| observed_values_store_error(&error))
     }
 }
@@ -121,7 +122,12 @@ struct SourceScanObservedValuesPublisher {
     workspace_name: WorkspaceName,
     writer: ObservedValuesWriter,
     collector: ObservedValuesCollector,
-    scopes: HashMap<SurfaceKey, ObservedSourceSurfaceScope>,
+    scopes: HashMap<SurfaceKey, RegisteredSurface>,
+}
+
+struct RegisteredSurface {
+    scope: ObservedSourceSurfaceScope,
+    epoch: ObservedValuesEpoch,
 }
 
 impl SourceObservationPublisher for SourceScanObservedValuesPublisher {
@@ -138,7 +144,7 @@ impl SourceScanObservedValuesPublisher {
             surface_kind,
             surface_name: observation.surface_name.to_string(),
         };
-        let Some(scope) = self.scopes.get(&key) else {
+        let Some(registered) = self.scopes.get(&key) else {
             tracing::debug!(
                 workspace = %self.workspace_name.as_str(),
                 source = %observation.source_name,
@@ -147,24 +153,11 @@ impl SourceScanObservedValuesPublisher {
             );
             return;
         };
+        let scope = &registered.scope;
 
-        let payload = self.collector.collect_batch(observation.batch);
-        if payload.is_empty() {
-            return;
-        }
-        match self.writer.try_enqueue(ObservedValuesWrite {
-            workspace_name: self.workspace_name.clone(),
-            owner_source_name: scope.owner_source_name.clone(),
-            source_name: scope.source_name.clone(),
-            source_scope_id: scope.source_scope_id.clone(),
-            surface_kind,
-            surface_name: observation.surface_name.to_string(),
-            payload,
-            max_job_bytes: self.collector.budget().job_bytes_limit,
-            generation: scope.generation,
-        }) {
-            Ok(()) => {}
-            Err(ObservedValuesTryEnqueueError::Full) => {
+        let permit = match self.writer.try_reserve() {
+            Ok(permit) => permit,
+            Err(ObservedValuesTryReserveError::Full) => {
                 tracing::debug!(
                     workspace = %self.workspace_name.as_str(),
                     source = %scope.source_name,
@@ -172,8 +165,9 @@ impl SourceScanObservedValuesPublisher {
                     surface = %observation.surface_name,
                     "dropping observed-values source-scan observation because writer queue is full"
                 );
+                return;
             }
-            Err(ObservedValuesTryEnqueueError::Disconnected) => {
+            Err(ObservedValuesTryReserveError::Disconnected) => {
                 tracing::debug!(
                     workspace = %self.workspace_name.as_str(),
                     source = %scope.source_name,
@@ -181,8 +175,49 @@ impl SourceScanObservedValuesPublisher {
                     surface = %observation.surface_name,
                     "dropping observed-values source-scan observation because writer is stopped"
                 );
+                return;
             }
+        };
+
+        let payload = self.collector.collect_batch(observation.batch);
+        if payload.is_empty() {
+            return;
         }
+        let payload_json = match payload_json_with_budget(
+            payload,
+            self.collector.budget().job_bytes_limit,
+        ) {
+            Ok(Some(payload_json)) => payload_json,
+            Ok(None) => {
+                tracing::debug!(
+                    workspace = %self.workspace_name.as_str(),
+                    source = %scope.source_name,
+                    surface = %observation.surface_name,
+                    "dropping observed-values source-scan observation because no candidate fits the serialized job budget"
+                );
+                return;
+            }
+            Err(error) => {
+                tracing::debug!(
+                    workspace = %self.workspace_name.as_str(),
+                    source = %scope.source_name,
+                    surface = %observation.surface_name,
+                    error = %error,
+                    "failed to serialize observed-values source-scan observation"
+                );
+                return;
+            }
+        };
+        permit.send(ObservedValuesWrite {
+            workspace_name: self.workspace_name.clone(),
+            owner_source_name: scope.owner_source_name.clone(),
+            source_name: scope.source_name.clone(),
+            source_scope_id: scope.source_scope_id.clone(),
+            surface_kind,
+            surface_name: observation.surface_name.to_string(),
+            payload_json,
+            epoch: registered.epoch,
+        });
     }
 }
 
@@ -214,7 +249,7 @@ mod tests {
     use super::SearchObservationHandle;
     use crate::search::observed::source_scope::source_surface_scopes;
     use crate::search::observed::sqlite_queue::{
-        ObservedValueCandidate, ObservedValuesGeneration, ObservedValuesQueuePayload,
+        ObservedValueCandidate, ObservedValuesQueuePayload,
     };
     use crate::search::observed::sqlite_store::SqliteObservedValuesStore;
     use crate::search::observed::writer::payload_json_with_budget;
@@ -226,12 +261,8 @@ mod tests {
         let first = http_query_source("/issues");
         let second = http_query_source("/search/issues");
 
-        let first_scope = source_surface_scopes(&first, ObservedValuesGeneration::ZERO)
-            .pop()
-            .expect("first scope");
-        let second_scope = source_surface_scopes(&second, ObservedValuesGeneration::ZERO)
-            .pop()
-            .expect("second scope");
+        let first_scope = source_surface_scopes(&first).pop().expect("first scope");
+        let second_scope = source_surface_scopes(&second).pop().expect("second scope");
 
         assert_ne!(first_scope.source_scope_id, second_scope.source_scope_id);
     }
@@ -241,12 +272,8 @@ mod tests {
         let first = basic_auth_query_source("{{ input.user }}", "{{ input.password }}");
         let second = basic_auth_query_source("{{ input.user }}", "{{ input.alt_password }}");
 
-        let first_scope = source_surface_scopes(&first, ObservedValuesGeneration::ZERO)
-            .pop()
-            .expect("first scope");
-        let second_scope = source_surface_scopes(&second, ObservedValuesGeneration::ZERO)
-            .pop()
-            .expect("second scope");
+        let first_scope = source_surface_scopes(&first).pop().expect("first scope");
+        let second_scope = source_surface_scopes(&second).pop().expect("second scope");
 
         assert_ne!(first_scope.source_scope_id, second_scope.source_scope_id);
     }
@@ -343,7 +370,7 @@ mod tests {
 
         let store = SqliteObservedValuesStore::new(layout);
         store
-            .clear_source(&workspace, "github_v4")
+            .clear_source_and_advance_epoch(&workspace, "github_v4")
             .expect("clear logical source owner");
         assert_eq!(
             store

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -1,0 +1,447 @@
+//! Source-scan observed-values publisher wiring.
+
+#![allow(
+    dead_code,
+    reason = "observed-values provider substrate is staged before app wiring in the next PR"
+)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use coral_engine::{
+    EngineExtensions, QuerySource, SourceObservationPublisher, SourceObservationSurfaceKind,
+    SourceScanObservation,
+};
+
+use crate::bootstrap::AppError;
+use crate::search::observed::collector::ObservedValuesCollector;
+use crate::search::observed::source_scope::{
+    ObservedSourceSurfaceScope, SurfaceKey, source_surface_scopes,
+};
+use crate::search::observed::sqlite_queue::ObservedValuesSurfaceKind;
+use crate::search::observed::sqlite_store::SqliteObservedValuesStore;
+use crate::search::observed::writer::{
+    ObservedValuesTryEnqueueError, ObservedValuesWrite, ObservedValuesWriter,
+};
+use crate::search::sqlite_store::SqliteSearchError;
+use crate::state::AppStateLayout;
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SearchObservationHandle {
+    store: SqliteObservedValuesStore,
+    writer: ObservedValuesWriter,
+    collector: ObservedValuesCollector,
+}
+
+impl SearchObservationHandle {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        let store = SqliteObservedValuesStore::new(layout);
+        let writer = ObservedValuesWriter::start(store.clone());
+        Self {
+            store,
+            writer,
+            collector: ObservedValuesCollector::default(),
+        }
+    }
+
+    pub(crate) fn extensions_for(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[QuerySource],
+    ) -> EngineExtensions {
+        let mut scopes = HashMap::new();
+        for source in selected_sources {
+            let generation = match self
+                .store
+                .current_generations(workspace_name, source.source_name())
+            {
+                Ok(generation) => generation,
+                Err(error) => {
+                    tracing::debug!(
+                        workspace = %workspace_name.as_str(),
+                        source = %source.source_name(),
+                        error = %error,
+                        "skipping observed-values publisher for source"
+                    );
+                    continue;
+                }
+            };
+            for scope in source_surface_scopes(source, generation) {
+                scopes.insert(scope.key(), scope);
+            }
+        }
+        if scopes.is_empty() {
+            return EngineExtensions::default();
+        }
+
+        let mut extensions = EngineExtensions::default();
+        extensions.source_observation_publishers.push(Arc::new(
+            SourceScanObservedValuesPublisher {
+                workspace_name: workspace_name.clone(),
+                writer: self.writer.clone(),
+                collector: self.collector.clone(),
+                scopes,
+            },
+        ));
+        extensions
+    }
+
+    #[expect(
+        dead_code,
+        reason = "clear-all observed-values governance is staged before its transport RPC"
+    )]
+    pub(crate) fn clear_workspace(&self, workspace_name: &WorkspaceName) -> Result<(), AppError> {
+        self.store
+            .clear_workspace(workspace_name)
+            .map_err(|error| observed_values_store_error(&error))
+    }
+
+    pub(crate) fn clear_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &str,
+    ) -> Result<(), AppError> {
+        self.store
+            .clear_source(workspace_name, source_name)
+            .map_err(|error| observed_values_store_error(&error))
+    }
+}
+
+fn observed_values_store_error(error: &SqliteSearchError) -> AppError {
+    let detail = if error.is_lock_contention() {
+        "observed-values SQLite store is locked".to_string()
+    } else {
+        format!("observed-values SQLite store is unavailable: {error}")
+    };
+    AppError::Unavailable(detail)
+}
+
+struct SourceScanObservedValuesPublisher {
+    workspace_name: WorkspaceName,
+    writer: ObservedValuesWriter,
+    collector: ObservedValuesCollector,
+    scopes: HashMap<SurfaceKey, ObservedSourceSurfaceScope>,
+}
+
+impl SourceObservationPublisher for SourceScanObservedValuesPublisher {
+    fn publish_source_scan(&self, observation: SourceScanObservation<'_>) {
+        self.publish(observation);
+    }
+}
+
+impl SourceScanObservedValuesPublisher {
+    fn publish(&self, observation: SourceScanObservation<'_>) {
+        let surface_kind = observed_surface_kind(observation.surface_kind);
+        let key = SurfaceKey {
+            source_name: observation.source_name.to_string(),
+            surface_kind,
+            surface_name: observation.surface_name.to_string(),
+        };
+        let Some(scope) = self.scopes.get(&key) else {
+            tracing::debug!(
+                workspace = %self.workspace_name.as_str(),
+                source = %observation.source_name,
+                surface = %observation.surface_name,
+                "observed-values source-scan observation did not match a known source surface"
+            );
+            return;
+        };
+
+        let payload = self.collector.collect_batch(observation.batch);
+        if payload.is_empty() {
+            return;
+        }
+        match self.writer.try_enqueue(ObservedValuesWrite {
+            workspace_name: self.workspace_name.clone(),
+            source_name: scope.observed_source_name.clone(),
+            source_scope_id: scope.source_scope_id.clone(),
+            surface_kind,
+            surface_name: observation.surface_name.to_string(),
+            payload,
+            max_job_bytes: self.collector.budget().job_bytes_limit,
+            generation: scope.generation,
+        }) {
+            Ok(()) => {}
+            Err(ObservedValuesTryEnqueueError::Full) => {
+                tracing::debug!(
+                    workspace = %self.workspace_name.as_str(),
+                    source = %scope.observed_source_name,
+                    surface = %observation.surface_name,
+                    "dropping observed-values source-scan observation because writer queue is full"
+                );
+            }
+            Err(ObservedValuesTryEnqueueError::Disconnected) => {
+                tracing::debug!(
+                    workspace = %self.workspace_name.as_str(),
+                    source = %scope.observed_source_name,
+                    surface = %observation.surface_name,
+                    "dropping observed-values source-scan observation because writer is stopped"
+                );
+            }
+        }
+    }
+}
+
+fn observed_surface_kind(kind: SourceObservationSurfaceKind) -> ObservedValuesSurfaceKind {
+    match kind {
+        SourceObservationSurfaceKind::Table => ObservedValuesSurfaceKind::Table,
+        SourceObservationSurfaceKind::Function => ObservedValuesSurfaceKind::Function,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    use arrow::array::StringArray;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use coral_engine::{QuerySource, SourceObservationSurfaceKind, SourceScanObservation};
+    use coral_spec::parse_source_manifest_yaml;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::SearchObservationHandle;
+    use crate::search::observed::source_scope::source_surface_scopes;
+    use crate::search::observed::sqlite_queue::{
+        ObservedValueCandidate, ObservedValuesGeneration, ObservedValuesQueuePayload,
+    };
+    use crate::search::observed::sqlite_store::SqliteObservedValuesStore;
+    use crate::search::observed::writer::payload_json_with_budget;
+    use crate::state::AppStateLayout;
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn http_request_shape_changes_source_scope() {
+        let first = http_query_source("/issues");
+        let second = http_query_source("/search/issues");
+
+        let first_scope = source_surface_scopes(&first, ObservedValuesGeneration::ZERO)
+            .pop()
+            .expect("first scope");
+        let second_scope = source_surface_scopes(&second, ObservedValuesGeneration::ZERO)
+            .pop()
+            .expect("second scope");
+
+        assert_ne!(first_scope.source_scope_id, second_scope.source_scope_id);
+    }
+
+    #[test]
+    fn basic_auth_shape_changes_source_scope() {
+        let first = basic_auth_query_source("{{ input.user }}", "{{ input.password }}");
+        let second = basic_auth_query_source("{{ input.user }}", "{{ input.alt_password }}");
+
+        let first_scope = source_surface_scopes(&first, ObservedValuesGeneration::ZERO)
+            .pop()
+            .expect("first scope");
+        let second_scope = source_surface_scopes(&second, ObservedValuesGeneration::ZERO)
+            .pop()
+            .expect("second scope");
+
+        assert_ne!(first_scope.source_scope_id, second_scope.source_scope_id);
+    }
+
+    #[test]
+    fn publisher_does_not_store_source_secrets_or_sensitive_values() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let handle = SearchObservationHandle::new(layout.clone());
+        let source = secret_input_query_source();
+        let extensions = handle.extensions_for(&workspace, &[source]);
+        let publisher = extensions
+            .source_observation_publishers
+            .first()
+            .expect("publisher");
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("name", DataType::Utf8, false),
+                Field::new("api_token", DataType::Utf8, false),
+                Field::new("note", DataType::Utf8, false),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec!["Grace"])),
+                Arc::new(StringArray::from(vec!["ghp_supersecret"])),
+                Arc::new(StringArray::from(vec!["hello"])),
+            ],
+        )
+        .expect("batch");
+
+        publisher.publish_source_scan(SourceScanObservation {
+            source_name: "github",
+            surface_kind: SourceObservationSurfaceKind::Table,
+            surface_name: "issues",
+            batch: &batch,
+        });
+
+        let payloads = wait_for_payloads(&layout, &workspace).join("\n");
+        assert!(payloads.contains("Grace"));
+        assert!(payloads.contains("hello"));
+        assert!(!payloads.contains("literal-secret"));
+        assert!(!payloads.contains("ghp_supersecret"));
+    }
+
+    #[test]
+    fn payload_budget_keeps_largest_serialized_prefix() {
+        let payload = ObservedValuesQueuePayload {
+            values: vec![
+                observed_candidate("Ada"),
+                observed_candidate("Grace"),
+                observed_candidate("Katherine"),
+            ],
+        };
+        let two_value_json = serde_json::to_string(&json!({
+            "values": [
+                {
+                    "column_name": "name",
+                    "display_value": "Ada",
+                    "search_text": "ada",
+                    "value_key": "key"
+                },
+                {
+                    "column_name": "name",
+                    "display_value": "Grace",
+                    "search_text": "grace",
+                    "value_key": "key"
+                }
+            ]
+        }))
+        .expect("json");
+
+        let payload_json =
+            payload_json_with_budget(payload, two_value_json.len()).expect("payload budget");
+        let payload_json = payload_json.expect("budget should keep two values");
+        let decoded: ObservedValuesQueuePayload =
+            serde_json::from_str(&payload_json).expect("payload json");
+        let display_values = decoded
+            .values
+            .iter()
+            .map(|candidate| candidate.display_value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(display_values, ["Ada", "Grace"]);
+    }
+
+    fn http_query_source(path: &str) -> QuerySource {
+        let yaml = format!(
+            r"
+dsl_version: 3
+name: github
+version: 0.1.0
+backend: http
+base_url: https://api.github.com
+tables:
+  - name: issues
+    description: Issues
+    request:
+      path: {path}
+    columns:
+      - name: title
+        type: Utf8
+"
+        );
+        let manifest = parse_source_manifest_yaml(&yaml).expect("manifest");
+        QuerySource::from_manifest(&manifest, BTreeMap::new(), BTreeMap::new())
+    }
+
+    fn basic_auth_query_source(username: &str, password: &str) -> QuerySource {
+        let yaml = format!(
+            r#"
+dsl_version: 3
+name: github
+version: 0.1.0
+backend: http
+base_url: https://api.github.com
+inputs:
+  user:
+    kind: variable
+    required: true
+  password:
+    kind: secret
+    required: true
+  alt_password:
+    kind: secret
+    required: true
+auth:
+  type: BasicAuth
+  username: "{username}"
+  password: "{password}"
+tables:
+  - name: issues
+    description: Issues
+    request:
+      path: /issues
+    columns:
+      - name: title
+        type: Utf8
+"#
+        );
+        let manifest = parse_source_manifest_yaml(&yaml).expect("manifest");
+        QuerySource::from_manifest(
+            &manifest,
+            BTreeMap::from([("user".to_string(), "octocat".to_string())]),
+            BTreeMap::from([
+                ("password".to_string(), "literal-secret".to_string()),
+                ("alt_password".to_string(), "other-secret".to_string()),
+            ]),
+        )
+    }
+
+    fn secret_input_query_source() -> QuerySource {
+        let yaml = r"
+dsl_version: 3
+name: github
+version: 0.1.0
+backend: http
+base_url: https://api.github.com
+inputs:
+  api_key:
+    kind: secret
+    required: true
+tables:
+  - name: issues
+    description: Issues
+    request:
+      path: /issues
+    columns:
+      - name: name
+        type: Utf8
+      - name: api_token
+        type: Utf8
+      - name: note
+        type: Utf8
+";
+        let manifest = parse_source_manifest_yaml(yaml).expect("manifest");
+        QuerySource::from_manifest(
+            &manifest,
+            BTreeMap::new(),
+            BTreeMap::from([("api_key".to_string(), "literal-secret".to_string())]),
+        )
+    }
+
+    fn wait_for_payloads(layout: &AppStateLayout, workspace: &WorkspaceName) -> Vec<String> {
+        let store = SqliteObservedValuesStore::new(layout.clone());
+        for _ in 0..100 {
+            let payloads = store.queue_payloads(workspace).expect("payloads");
+            if !payloads.is_empty() {
+                return payloads;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("observed-values writer did not enqueue payload");
+    }
+
+    fn observed_candidate(display_value: &str) -> ObservedValueCandidate {
+        ObservedValueCandidate {
+            column_name: "name".to_string(),
+            display_value: display_value.to_string(),
+            search_text: display_value.to_ascii_lowercase(),
+            value_key: "key".to_string(),
+        }
+    }
+}

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -296,11 +296,15 @@ mod tests {
                 Field::new("name", DataType::Utf8, false),
                 Field::new("api_token", DataType::Utf8, false),
                 Field::new("note", DataType::Utf8, false),
+                Field::new("metadata", DataType::Utf8, false),
             ])),
             vec![
                 Arc::new(StringArray::from(vec!["Grace"])),
                 Arc::new(StringArray::from(vec!["ghp_supersecret"])),
                 Arc::new(StringArray::from(vec!["hello"])),
+                Arc::new(StringArray::from(vec![
+                    r#"{"project":"coral","api_key":"literal-secret"}"#,
+                ])),
             ],
         )
         .expect("batch");
@@ -315,6 +319,8 @@ mod tests {
         let payloads = wait_for_payloads(&layout, &workspace).join("\n");
         assert!(payloads.contains("Grace"));
         assert!(payloads.contains("hello"));
+        assert!(payloads.contains("project"));
+        assert!(payloads.contains("coral"));
         assert!(!payloads.contains("literal-secret"));
         assert!(!payloads.contains("ghp_supersecret"));
     }

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -16,7 +16,7 @@ use coral_engine::{
 use crate::bootstrap::AppError;
 use crate::search::observed::collector::ObservedValuesCollector;
 use crate::search::observed::source_scope::{
-    ObservedSourceSurfaceScope, SurfaceKey, source_surface_scopes,
+    ObservedSourceSurfaceScope, SourceScopeSeed, SurfaceKey, source_surface_scopes,
 };
 use crate::search::observed::sqlite_queue::{ObservedValuesEpoch, ObservedValuesSurfaceKind};
 use crate::search::observed::sqlite_store::SqliteObservedValuesStore;
@@ -68,7 +68,7 @@ impl SearchObservationHandle {
                     continue;
                 }
             };
-            for scope in source_surface_scopes(source) {
+            for scope in source_surface_scopes(source, SourceScopeSeed::PRE_ACTIVATION) {
                 scopes.insert(scope.key(), RegisteredSurface { scope, epoch });
             }
         }
@@ -245,9 +245,10 @@ mod tests {
     use coral_spec::parse_source_manifest_yaml;
     use serde_json::json;
     use tempfile::tempdir;
+    use uuid::Uuid;
 
     use super::SearchObservationHandle;
-    use crate::search::observed::source_scope::source_surface_scopes;
+    use crate::search::observed::source_scope::{SourceScopeSeed, source_surface_scopes};
     use crate::search::observed::sqlite_queue::{
         ObservedValueCandidate, ObservedValuesQueuePayload,
     };
@@ -257,25 +258,49 @@ mod tests {
     use crate::workspaces::WorkspaceName;
 
     #[test]
-    fn http_request_shape_changes_source_scope() {
-        let first = http_query_source("/issues");
-        let second = http_query_source("/search/issues");
+    fn opaque_scope_seed_is_deterministic() {
+        let source = http_query_source("/issues");
 
-        let first_scope = source_surface_scopes(&first).pop().expect("first scope");
-        let second_scope = source_surface_scopes(&second).pop().expect("second scope");
+        let first_scope = source_surface_scopes(&source, SourceScopeSeed::PRE_ACTIVATION)
+            .pop()
+            .expect("first scope");
+        let second_scope = source_surface_scopes(&source, SourceScopeSeed::PRE_ACTIVATION)
+            .pop()
+            .expect("second scope");
 
-        assert_ne!(first_scope.source_scope_id, second_scope.source_scope_id);
+        assert_eq!(first_scope.source_scope_id, second_scope.source_scope_id);
     }
 
     #[test]
-    fn basic_auth_shape_changes_source_scope() {
-        let first = basic_auth_query_source("{{ input.user }}", "{{ input.password }}");
-        let second = basic_auth_query_source("{{ input.user }}", "{{ input.alt_password }}");
+    fn opaque_runtime_contract_and_credential_inputs_partition_scopes() {
+        let source = http_query_source("/issues");
+        let first_scope = source_surface_scopes(
+            &source,
+            SourceScopeSeed::new("runtime-contract-a", Uuid::from_u128(1)),
+        )
+        .pop()
+        .expect("first scope");
+        let contract_changed = source_surface_scopes(
+            &source,
+            SourceScopeSeed::new("runtime-contract-b", Uuid::from_u128(1)),
+        )
+        .pop()
+        .expect("contract scope");
+        let credential_changed = source_surface_scopes(
+            &source,
+            SourceScopeSeed::new("runtime-contract-a", Uuid::from_u128(2)),
+        )
+        .pop()
+        .expect("credential scope");
 
-        let first_scope = source_surface_scopes(&first).pop().expect("first scope");
-        let second_scope = source_surface_scopes(&second).pop().expect("second scope");
-
-        assert_ne!(first_scope.source_scope_id, second_scope.source_scope_id);
+        assert_ne!(
+            first_scope.source_scope_id,
+            contract_changed.source_scope_id
+        );
+        assert_ne!(
+            first_scope.source_scope_id,
+            credential_changed.source_scope_id
+        );
     }
 
     #[test]
@@ -447,49 +472,6 @@ tables:
         );
         let manifest = parse_source_manifest_yaml(&yaml).expect("manifest");
         QuerySource::from_manifest(&manifest, BTreeMap::new(), BTreeMap::new())
-    }
-
-    fn basic_auth_query_source(username: &str, password: &str) -> QuerySource {
-        let yaml = format!(
-            r#"
-dsl_version: 3
-name: github
-version: 0.1.0
-backend: http
-base_url: https://api.github.com
-inputs:
-  user:
-    kind: variable
-    required: true
-  password:
-    kind: secret
-    required: true
-  alt_password:
-    kind: secret
-    required: true
-auth:
-  type: BasicAuth
-  username: "{username}"
-  password: "{password}"
-tables:
-  - name: issues
-    description: Issues
-    request:
-      path: /issues
-    columns:
-      - name: title
-        type: Utf8
-"#
-        );
-        let manifest = parse_source_manifest_yaml(&yaml).expect("manifest");
-        QuerySource::from_manifest(
-            &manifest,
-            BTreeMap::from([("user".to_string(), "octocat".to_string())]),
-            BTreeMap::from([
-                ("password".to_string(), "literal-secret".to_string()),
-                ("alt_password".to_string(), "other-secret".to_string()),
-            ]),
-        )
     }
 
     fn secret_input_query_source() -> QuerySource {

--- a/crates/coral-app/src/search/observed/sensitive.rs
+++ b/crates/coral-app/src/search/observed/sensitive.rs
@@ -1,0 +1,92 @@
+//! Sensitive observed-value detection.
+
+const SENSITIVE_COLUMN_NAMES: &[&str] = &[
+    "apikey",
+    "authorization",
+    "authtoken",
+    "cookie",
+    "credential",
+    "password",
+    "passwd",
+    "privatekey",
+    "refreshtoken",
+    "secret",
+    "session",
+    "token",
+];
+
+pub(super) fn is_sensitive_column(column_name: &str) -> bool {
+    let normalized = column_name
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect::<String>()
+        .to_ascii_lowercase();
+    SENSITIVE_COLUMN_NAMES
+        .iter()
+        .any(|name| normalized.contains(name))
+}
+
+pub(super) fn is_sensitive_value(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.contains("-----BEGIN ") || trimmed.contains(" PRIVATE KEY-----") {
+        return true;
+    }
+    is_sensitive_token(trimmed)
+        || contains_sensitive_token(trimmed)
+        || contains_sensitive_key_value_pair(trimmed)
+}
+
+fn is_sensitive_token(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    if (lower.starts_with("sk-") && value.len() >= 20)
+        || lower.starts_with("ghp_")
+        || lower.starts_with("github_pat_")
+        || lower.starts_with("xoxb-")
+        || lower.starts_with("xoxp-")
+        || lower.starts_with("xoxa-")
+        || lower.starts_with("ya29.")
+    {
+        return true;
+    }
+    looks_like_jwt(value)
+}
+
+fn contains_sensitive_token(value: &str) -> bool {
+    value
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')))
+        .any(is_sensitive_token)
+}
+
+fn contains_sensitive_key_value_pair(value: &str) -> bool {
+    value
+        .split(|ch: char| {
+            matches!(
+                ch,
+                '?' | '&' | ';' | ',' | '"' | '\'' | '{' | '}' | '[' | ']' | ' ' | '\t' | '\n'
+            )
+        })
+        .filter_map(|segment| segment.split_once('=').or_else(|| segment.split_once(':')))
+        .any(|(key, value)| !value.trim().is_empty() && is_sensitive_column(key))
+}
+
+fn looks_like_jwt(value: &str) -> bool {
+    let mut parts = value.split('.');
+    let Some(header) = parts.next() else {
+        return false;
+    };
+    let Some(payload) = parts.next() else {
+        return false;
+    };
+    let Some(signature) = parts.next() else {
+        return false;
+    };
+    if parts.next().is_some() {
+        return false;
+    }
+    [header, payload, signature].iter().all(|part| {
+        part.len() >= 8
+            && part
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    })
+}

--- a/crates/coral-app/src/search/observed/sensitive.rs
+++ b/crates/coral-app/src/search/observed/sensitive.rs
@@ -1,5 +1,7 @@
 //! Sensitive observed-value detection.
 
+use serde_json::Value;
+
 const SENSITIVE_COLUMN_NAMES: &[&str] = &[
     "apikey",
     "authorization",
@@ -34,6 +36,51 @@ pub(super) fn is_sensitive_value(value: &str) -> bool {
     is_sensitive_token(trimmed)
         || contains_sensitive_token(trimmed)
         || contains_sensitive_key_value_pair(trimmed)
+}
+
+pub(super) fn exclude_sensitive_json_fields(value: String) -> Option<String> {
+    let Ok(mut structured_value) = serde_json::from_str::<Value>(&value) else {
+        return Some(value);
+    };
+    if !remove_sensitive_fields(&mut structured_value) {
+        return Some(value);
+    }
+    if !has_observable_content(&structured_value) {
+        return None;
+    }
+    serde_json::to_string(&structured_value).ok()
+}
+
+fn remove_sensitive_fields(value: &mut Value) -> bool {
+    match value {
+        Value::Object(fields) => {
+            let original_field_count = fields.len();
+            fields.retain(|name, _| !is_sensitive_column(name));
+            let mut removed_field = fields.len() != original_field_count;
+            for value in fields.values_mut() {
+                removed_field |= remove_sensitive_fields(value);
+            }
+            removed_field
+        }
+        Value::Array(values) => {
+            let mut removed_field = false;
+            for value in values {
+                removed_field |= remove_sensitive_fields(value);
+            }
+            removed_field
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => false,
+    }
+}
+
+fn has_observable_content(value: &Value) -> bool {
+    match value {
+        Value::Null => false,
+        Value::String(value) => !value.trim().is_empty(),
+        Value::Array(values) => values.iter().any(has_observable_content),
+        Value::Object(fields) => fields.values().any(has_observable_content),
+        Value::Bool(_) | Value::Number(_) => true,
+    }
 }
 
 fn is_sensitive_token(value: &str) -> bool {

--- a/crates/coral-app/src/search/observed/sensitive.rs
+++ b/crates/coral-app/src/search/observed/sensitive.rs
@@ -1,6 +1,11 @@
-//! Sensitive observed-value detection.
+//! Best-effort suppression of obvious secrets in observed values.
+//!
+//! This module recognizes credential-like field names and a limited set of
+//! obvious secret token shapes. It is defense in depth, not general
+//! sensitive-data detection or a data-loss-prevention boundary.
 
 use serde_json::Value;
+use url::{Url, form_urlencoded};
 
 const SENSITIVE_COLUMN_NAMES: &[&str] = &[
     "apikey",
@@ -17,6 +22,7 @@ const SENSITIVE_COLUMN_NAMES: &[&str] = &[
     "token",
 ];
 
+/// Returns whether a field name resembles a credential-bearing field.
 pub(super) fn is_sensitive_column(column_name: &str) -> bool {
     let normalized = column_name
         .chars()
@@ -28,6 +34,9 @@ pub(super) fn is_sensitive_column(column_name: &str) -> bool {
         .any(|name| normalized.contains(name))
 }
 
+/// Returns whether a value contains one of the obvious secret shapes we know.
+///
+/// A `false` result does not mean the value is generally non-sensitive.
 pub(super) fn is_sensitive_value(value: &str) -> bool {
     let trimmed = value.trim();
     if trimmed.contains("-----BEGIN ") || trimmed.contains(" PRIVATE KEY-----") {
@@ -38,39 +47,213 @@ pub(super) fn is_sensitive_value(value: &str) -> bool {
         || contains_sensitive_key_value_pair(trimmed)
 }
 
-pub(super) fn exclude_sensitive_json_fields(value: String) -> Option<String> {
-    let Ok(mut structured_value) = serde_json::from_str::<Value>(&value) else {
-        return Some(value);
+/// Removes recognized secret-bearing fields while preserving safe structured content.
+///
+/// This is a best-effort heuristic and does not classify arbitrary sensitive data.
+pub(super) fn sanitize_observed_value(value: String, max_value_bytes: usize) -> Option<String> {
+    let sanitized = match sanitize_json(&value)
+        .or_else(|| sanitize_url(&value))
+        .or_else(|| sanitize_form(&value))
+        .unwrap_or(SanitizedValue::Unchanged)
+    {
+        SanitizedValue::Unchanged => value,
+        SanitizedValue::Changed(value) => value,
+        SanitizedValue::Drop => return None,
     };
-    if !remove_sensitive_fields(&mut structured_value) {
-        return Some(value);
-    }
-    if !has_observable_content(&structured_value) {
+
+    if sanitized.len() > max_value_bytes || is_sensitive_value(&sanitized) {
         return None;
     }
-    serde_json::to_string(&structured_value).ok()
+    Some(sanitized)
 }
 
-fn remove_sensitive_fields(value: &mut Value) -> bool {
+enum SanitizedValue {
+    Unchanged,
+    Changed(String),
+    Drop,
+}
+
+fn sanitize_json(value: &str) -> Option<SanitizedValue> {
+    let trimmed = value.trim_start();
+    if !trimmed.starts_with('{') && !trimmed.starts_with('[') {
+        return None;
+    }
+
+    let mut structured_value = serde_json::from_str::<Value>(value).ok()?;
+    match sanitize_json_value(&mut structured_value) {
+        JsonSanitization::Unchanged => Some(SanitizedValue::Unchanged),
+        JsonSanitization::Changed => Some(
+            serde_json::to_string(&structured_value)
+                .map_or(SanitizedValue::Drop, SanitizedValue::Changed),
+        ),
+        JsonSanitization::Drop => Some(SanitizedValue::Drop),
+    }
+}
+
+enum JsonSanitization {
+    Unchanged,
+    Changed,
+    Drop,
+}
+
+fn sanitize_json_value(value: &mut Value) -> JsonSanitization {
     match value {
         Value::Object(fields) => {
-            let original_field_count = fields.len();
-            fields.retain(|name, _| !is_sensitive_column(name));
-            let mut removed_field = fields.len() != original_field_count;
-            for value in fields.values_mut() {
-                removed_field |= remove_sensitive_fields(value);
+            let mut changed = false;
+            fields.retain(|name, value| {
+                if is_sensitive_column(name) {
+                    changed = true;
+                    return false;
+                }
+                match sanitize_json_value(value) {
+                    JsonSanitization::Unchanged => true,
+                    JsonSanitization::Changed => {
+                        changed = true;
+                        true
+                    }
+                    JsonSanitization::Drop => {
+                        changed = true;
+                        false
+                    }
+                }
+            });
+            if !changed {
+                JsonSanitization::Unchanged
+            } else if fields.values().any(has_observable_content) {
+                JsonSanitization::Changed
+            } else {
+                JsonSanitization::Drop
             }
-            removed_field
         }
         Value::Array(values) => {
-            let mut removed_field = false;
-            for value in values {
-                removed_field |= remove_sensitive_fields(value);
+            let mut changed = false;
+            values.retain_mut(|value| match sanitize_json_value(value) {
+                JsonSanitization::Unchanged => true,
+                JsonSanitization::Changed => {
+                    changed = true;
+                    true
+                }
+                JsonSanitization::Drop => {
+                    changed = true;
+                    false
+                }
+            });
+            if !changed {
+                JsonSanitization::Unchanged
+            } else if values.iter().any(has_observable_content) {
+                JsonSanitization::Changed
+            } else {
+                JsonSanitization::Drop
             }
-            removed_field
         }
-        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => false,
+        Value::String(value) if is_sensitive_value(value) => JsonSanitization::Drop,
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+            JsonSanitization::Unchanged
+        }
     }
+}
+
+fn sanitize_url(value: &str) -> Option<SanitizedValue> {
+    let Ok(mut url) = Url::parse(value) else {
+        return sanitize_relative_url(value);
+    };
+    url.query()?;
+
+    let pairs = url.query_pairs().into_owned().collect::<Vec<_>>();
+    let retained_pairs = pairs
+        .iter()
+        .filter(|(key, value)| !is_sensitive_pair(key, value))
+        .cloned()
+        .collect::<Vec<_>>();
+    if retained_pairs.len() == pairs.len() {
+        return Some(SanitizedValue::Unchanged);
+    }
+
+    url.set_query(None);
+    if !retained_pairs.is_empty() {
+        url.query_pairs_mut().extend_pairs(
+            retained_pairs
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        );
+    }
+    Some(SanitizedValue::Changed(url.into()))
+}
+
+fn sanitize_relative_url(value: &str) -> Option<SanitizedValue> {
+    let (path, query_and_fragment) = value.split_once('?')?;
+    let (query, fragment) = query_and_fragment
+        .split_once('#')
+        .map_or((query_and_fragment, None), |(query, fragment)| {
+            (query, Some(fragment))
+        });
+    let pairs = form_urlencoded::parse(query.as_bytes())
+        .into_owned()
+        .collect::<Vec<_>>();
+    let retained_pairs = pairs
+        .iter()
+        .filter(|(key, value)| !is_sensitive_pair(key, value))
+        .cloned()
+        .collect::<Vec<_>>();
+    if retained_pairs.len() == pairs.len() {
+        return Some(SanitizedValue::Unchanged);
+    }
+
+    let mut sanitized = path.to_string();
+    if !retained_pairs.is_empty() {
+        sanitized.push('?');
+        let mut serializer = form_urlencoded::Serializer::new(String::new());
+        serializer.extend_pairs(
+            retained_pairs
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        );
+        sanitized.push_str(&serializer.finish());
+    }
+    if let Some(fragment) = fragment {
+        sanitized.push('#');
+        sanitized.push_str(fragment);
+    }
+    if sanitized.is_empty() {
+        Some(SanitizedValue::Drop)
+    } else {
+        Some(SanitizedValue::Changed(sanitized))
+    }
+}
+
+fn sanitize_form(value: &str) -> Option<SanitizedValue> {
+    if !value.contains('=') {
+        return None;
+    }
+    let pairs = form_urlencoded::parse(value.as_bytes())
+        .into_owned()
+        .collect::<Vec<_>>();
+    if pairs.is_empty() {
+        return None;
+    }
+    let retained_pairs = pairs
+        .iter()
+        .filter(|(key, value)| !is_sensitive_pair(key, value))
+        .cloned()
+        .collect::<Vec<_>>();
+    if retained_pairs.len() == pairs.len() {
+        return Some(SanitizedValue::Unchanged);
+    }
+    if retained_pairs.is_empty() {
+        return Some(SanitizedValue::Drop);
+    }
+
+    let mut serializer = form_urlencoded::Serializer::new(String::new());
+    serializer.extend_pairs(
+        retained_pairs
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    );
+    Some(SanitizedValue::Changed(serializer.finish()))
+}
+
+fn is_sensitive_pair(key: &str, value: &str) -> bool {
+    is_sensitive_column(key) || is_sensitive_value(value)
 }
 
 fn has_observable_content(value: &Value) -> bool {
@@ -106,14 +289,28 @@ fn contains_sensitive_token(value: &str) -> bool {
 
 fn contains_sensitive_key_value_pair(value: &str) -> bool {
     value
-        .split(|ch: char| {
-            matches!(
-                ch,
-                '?' | '&' | ';' | ',' | '"' | '\'' | '{' | '}' | '[' | ']' | ' ' | '\t' | '\n'
-            )
-        })
-        .filter_map(|segment| segment.split_once('=').or_else(|| segment.split_once(':')))
-        .any(|(key, value)| !value.trim().is_empty() && is_sensitive_column(key))
+        .char_indices()
+        .filter(|(_, character)| matches!(character, '=' | ':'))
+        .filter_map(|(separator_index, _)| sensitive_key_before(value, separator_index))
+        .any(is_sensitive_column)
+}
+
+fn sensitive_key_before(value: &str, separator_index: usize) -> Option<&str> {
+    let prefix = value
+        .get(..separator_index)?
+        .trim_end_matches(|character: char| {
+            character.is_whitespace() || matches!(character, '"' | '\'')
+        });
+    let key_start = prefix
+        .char_indices()
+        .rev()
+        .find(|(_, character)| !is_sensitive_key_character(*character))
+        .map_or(0, |(index, character)| index + character.len_utf8());
+    prefix.get(key_start..).filter(|key| !key.is_empty())
+}
+
+fn is_sensitive_key_character(character: char) -> bool {
+    character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
 }
 
 fn looks_like_jwt(value: &str) -> bool {
@@ -136,4 +333,127 @@ fn looks_like_jwt(value: &str) -> bool {
                 .chars()
                 .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+    use url::Url;
+
+    use super::sanitize_observed_value;
+
+    #[test]
+    fn sanitizes_nested_json_and_preserves_benign_siblings() {
+        let value = sanitize_observed_value(
+            r#"{"name":"Ada","api_key":"literal-secret","nested":{"project":"coral","refresh_token":"other-secret"},"items":[{"label":"safe","password":"hidden"},{"token":"hidden"}]}"#
+                .to_string(),
+            usize::MAX,
+        )
+        .expect("safe JSON fields should remain");
+        let value: Value = serde_json::from_str(&value).expect("sanitized JSON");
+
+        assert_eq!(
+            value,
+            json!({
+                "name": "Ada",
+                "nested": { "project": "coral" },
+                "items": [{ "label": "safe" }]
+            })
+        );
+    }
+
+    #[test]
+    fn sanitizes_decoded_url_query_keys_and_preserves_the_url() {
+        let value = sanitize_observed_value(
+            "https://example.test/callback?name=Ada&api%5Fkey=literal-secret&project=coral"
+                .to_string(),
+            usize::MAX,
+        )
+        .expect("URL base and safe pairs should remain");
+        let url = Url::parse(&value).expect("sanitized URL");
+        let pairs = url.query_pairs().into_owned().collect::<Vec<_>>();
+
+        assert_eq!(
+            pairs,
+            [
+                ("name".to_string(), "Ada".to_string()),
+                ("project".to_string(), "coral".to_string()),
+            ]
+        );
+        assert!(!value.contains("literal-secret"));
+    }
+
+    #[test]
+    fn sanitizes_relative_url_query_keys_and_preserves_path_and_fragment() {
+        let value = sanitize_observed_value(
+            "/callback?name=Ada&api_key=literal-secret#details".to_string(),
+            usize::MAX,
+        )
+        .expect("relative URL content should remain");
+
+        assert_eq!(value, "/callback?name=Ada#details");
+    }
+
+    #[test]
+    fn sanitizes_decoded_form_keys_and_preserves_safe_pairs() {
+        let value = sanitize_observed_value(
+            "name=Ada&api%5Fkey=literal-secret&project=coral".to_string(),
+            usize::MAX,
+        )
+        .expect("safe form pairs should remain");
+
+        assert_eq!(value, "name=Ada&project=coral");
+    }
+
+    #[test]
+    fn drops_empty_structures_but_keeps_a_url_without_sensitive_query_pairs() {
+        assert!(
+            sanitize_observed_value(r#"{"api_key":"hidden"}"#.to_string(), usize::MAX).is_none()
+        );
+        assert!(
+            sanitize_observed_value("api_key=hidden&token=hidden".to_string(), usize::MAX)
+                .is_none()
+        );
+        assert_eq!(
+            sanitize_observed_value(
+                "https://example.test/callback?api_key=hidden".to_string(),
+                usize::MAX,
+            )
+            .as_deref(),
+            Some("https://example.test/callback")
+        );
+    }
+
+    #[test]
+    fn leaves_benign_structured_values_byte_for_byte_unchanged() {
+        for value in [
+            r#"{ "name": "Ada" }"#,
+            "https://example.test/callback?name=Ada",
+            "name=Ada&project=coral",
+        ] {
+            assert_eq!(
+                sanitize_observed_value(value.to_string(), usize::MAX).as_deref(),
+                Some(value)
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_recognizable_sensitive_assignments_fail_closed() {
+        assert!(
+            sanitize_observed_value(
+                r#"{"name":"Ada","api_key":"literal-secret""#.to_string(),
+                usize::MAX,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_reconstructed_values_that_exceed_the_value_budget() {
+        let value = "safe=ééé&token=x".to_string();
+        let max_value_bytes = value.len();
+
+        assert!(sanitize_observed_value(value, max_value_bytes).is_none());
+    }
 }

--- a/crates/coral-app/src/search/observed/source_scope.rs
+++ b/crates/coral-app/src/search/observed/source_scope.rs
@@ -29,7 +29,10 @@ pub(super) struct SurfaceKey {
 
 #[derive(Debug, Clone)]
 pub(super) struct ObservedSourceSurfaceScope {
-    pub(super) observed_source_name: String,
+    /// Canonical installed source that owns lifecycle clears and generations.
+    pub(super) owner_source_name: String,
+    /// Runtime component schema used in SQL and search results.
+    pub(super) source_name: String,
     surface_key: SurfaceKey,
     pub(super) source_scope_id: String,
     pub(super) generation: ObservedValuesGeneration,
@@ -182,7 +185,8 @@ fn surface_scope(
     let scope_bytes =
         serde_json::to_vec(&scope).expect("observed-values source scope must serialize");
     ObservedSourceSurfaceScope {
-        observed_source_name: source.source_name().to_string(),
+        owner_source_name: source.source_name().to_string(),
+        source_name: component_source_name.to_string(),
         surface_key: SurfaceKey {
             source_name: component_source_name.to_string(),
             surface_kind,

--- a/crates/coral-app/src/search/observed/source_scope.rs
+++ b/crates/coral-app/src/search/observed/source_scope.rs
@@ -1,30 +1,48 @@
-//! Pure source-surface scope derivation for observed-value invalidation.
-
-use std::collections::BTreeMap;
+//! Source-surface routing and opaque scope derivation for observed values.
 
 use coral_engine::{QuerySource, RuntimeSourceComponent};
-use coral_spec::backends::file::{
-    FileFormatOptions, FileMetadataColumnSpec, FileObjectStoreSpec, FileSourceManifest,
-    FileTableSpec, PartitionColumnSpec, PartitionPathSpec, S3AuthSpec,
-};
-use coral_spec::backends::http::{AuthSpec, HttpSourceManifest, HttpTableSpec};
-use coral_spec::{
-    BodySpec, ColumnSpec, HeaderSpec, ManifestInputKind, ManifestInputSpec, McpEnvSpec,
-    McpHttpAuthSpec, McpLimitBinding, McpServerSpec, McpSourceManifest, McpTableFilterBinding,
-    McpTableFunctionSpec, McpTableSpec, ParsedTemplate, RequestSpec, ResponseSpec,
-    SourceTableFunctionSpec, TableFunctionArgSpec, TemplateNamespace, ValueSourceSpec,
-};
 use serde::Serialize;
-use serde_json::{Value, json};
+use uuid::Uuid;
 
 use crate::hash::sha256_hex;
 use crate::search::observed::sqlite_queue::ObservedValuesSurfaceKind;
+
+const SOURCE_SCOPE_FORMAT_VERSION: u8 = 1;
+const PRE_ACTIVATION_RUNTIME_CONTRACT_FINGERPRINT: &str = "observed-values/pre-activation/v0";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(super) struct SurfaceKey {
     pub(super) source_name: String,
     pub(super) surface_kind: ObservedValuesSurfaceKind,
     pub(super) surface_name: String,
+}
+
+/// Opaque identity supplied by the app-owned runtime-package boundary.
+///
+/// The queue substrate does not interpret either value. The app-wiring PR
+/// replaces the pre-activation seed with a complete runtime-contract
+/// fingerprint and an app-owned credential revision.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct SourceScopeSeed<'a> {
+    runtime_contract_fingerprint: &'a str,
+    credential_revision: Uuid,
+}
+
+impl SourceScopeSeed<'static> {
+    pub(super) const PRE_ACTIVATION: Self =
+        Self::new(PRE_ACTIVATION_RUNTIME_CONTRACT_FINGERPRINT, Uuid::nil());
+}
+
+impl<'a> SourceScopeSeed<'a> {
+    pub(super) const fn new(
+        runtime_contract_fingerprint: &'a str,
+        credential_revision: Uuid,
+    ) -> Self {
+        Self {
+            runtime_contract_fingerprint,
+            credential_revision,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -43,112 +61,65 @@ impl ObservedSourceSurfaceScope {
     }
 }
 
-pub(super) fn source_surface_scopes(source: &QuerySource) -> Vec<ObservedSourceSurfaceScope> {
+pub(super) fn source_surface_scopes(
+    source: &QuerySource,
+    seed: SourceScopeSeed<'_>,
+) -> Vec<ObservedSourceSurfaceScope> {
     let mut scopes = Vec::new();
     for component in source.components() {
         match component {
             RuntimeSourceComponent::Http(manifest) => {
-                scopes.extend(http_surface_scopes(source, manifest));
+                scopes.extend(manifest.tables.iter().map(|table| {
+                    surface_scope(
+                        source,
+                        manifest.common.name.as_str(),
+                        ObservedValuesSurfaceKind::Table,
+                        table.name(),
+                        seed,
+                    )
+                }));
+                scopes.extend(manifest.functions.iter().map(|function| {
+                    surface_scope(
+                        source,
+                        manifest.common.name.as_str(),
+                        ObservedValuesSurfaceKind::Function,
+                        function.name.as_str(),
+                        seed,
+                    )
+                }));
             }
             RuntimeSourceComponent::File(manifest) => {
-                scopes.extend(file_surface_scopes(source, manifest));
+                scopes.extend(manifest.tables.iter().map(|table| {
+                    surface_scope(
+                        source,
+                        manifest.common.name.as_str(),
+                        ObservedValuesSurfaceKind::Table,
+                        table.name(),
+                        seed,
+                    )
+                }));
             }
             RuntimeSourceComponent::Mcp(manifest) => {
-                scopes.extend(mcp_surface_scopes(source, manifest));
+                scopes.extend(manifest.tables.iter().map(|table| {
+                    surface_scope(
+                        source,
+                        manifest.common.name.as_str(),
+                        ObservedValuesSurfaceKind::Table,
+                        table.name(),
+                        seed,
+                    )
+                }));
+                scopes.extend(manifest.functions.iter().map(|function| {
+                    surface_scope(
+                        source,
+                        manifest.common.name.as_str(),
+                        ObservedValuesSurfaceKind::Function,
+                        function.name(),
+                        seed,
+                    )
+                }));
             }
         }
-    }
-    scopes
-}
-
-fn http_surface_scopes(
-    source: &QuerySource,
-    manifest: &HttpSourceManifest,
-) -> Vec<ObservedSourceSurfaceScope> {
-    let component_shape = json!({
-        "backend": "http",
-        "component_source_name": manifest.common.name,
-        "base_url": template_shape(&manifest.base_url),
-        "auth": auth_shape(&manifest.auth),
-        "request_headers": header_shapes(&manifest.request_headers),
-    });
-    let mut scopes = Vec::new();
-    for table in &manifest.tables {
-        scopes.push(surface_scope(
-            source,
-            manifest.common.name.as_str(),
-            ObservedValuesSurfaceKind::Table,
-            table.name(),
-            &component_shape,
-            &http_table_shape(table),
-        ));
-    }
-    for function in &manifest.functions {
-        scopes.push(surface_scope(
-            source,
-            manifest.common.name.as_str(),
-            ObservedValuesSurfaceKind::Function,
-            function.name.as_str(),
-            &component_shape,
-            &source_function_shape(function),
-        ));
-    }
-    scopes
-}
-
-fn file_surface_scopes(
-    source: &QuerySource,
-    manifest: &FileSourceManifest,
-) -> Vec<ObservedSourceSurfaceScope> {
-    let component_shape = json!({
-        "backend": "file",
-        "component_source_name": manifest.common.name,
-    });
-    manifest
-        .tables
-        .iter()
-        .map(|table| {
-            surface_scope(
-                source,
-                manifest.common.name.as_str(),
-                ObservedValuesSurfaceKind::Table,
-                table.name(),
-                &component_shape,
-                &file_table_shape(table),
-            )
-        })
-        .collect()
-}
-
-fn mcp_surface_scopes(
-    source: &QuerySource,
-    manifest: &McpSourceManifest,
-) -> Vec<ObservedSourceSurfaceScope> {
-    let component_shape = json!({
-        "backend": "mcp",
-        "component_source_name": manifest.common.name,
-        "server": mcp_server_shape(&manifest.server),
-    });
-    let mut scopes = Vec::new();
-    for table in &manifest.tables {
-        scopes.push(surface_scope(
-            source,
-            manifest.common.name.as_str(),
-            ObservedValuesSurfaceKind::Table,
-            table.name(),
-            &component_shape,
-            &mcp_table_shape(table),
-        ));
-    }
-    for function in &manifest.functions {
-        scopes.push(surface_scope(
-            source,
-            manifest.common.name.as_str(),
-            ObservedValuesSurfaceKind::Function,
-            function.name(),
-            &component_shape,
-            &mcp_function_shape(function),
-        ));
     }
     scopes
 }
@@ -158,19 +129,17 @@ fn surface_scope(
     component_source_name: &str,
     surface_kind: ObservedValuesSurfaceKind,
     surface_name: &str,
-    component_shape: &Value,
-    surface_shape: &Value,
+    seed: SourceScopeSeed<'_>,
 ) -> ObservedSourceSurfaceScope {
-    let scope = json!({
-        "logical_source_name": source.source_name(),
-        "authored_version": source.version(),
-        "declared_inputs": input_shapes(source.declared_inputs()),
-        "variables": source.variables(),
-        "component": component_shape,
-        "surface": surface_shape,
-    });
-    let scope_bytes =
-        serde_json::to_vec(&scope).expect("observed-values source scope must serialize");
+    let scope_bytes = serde_json::to_vec(&ScopeFingerprint {
+        format_version: SOURCE_SCOPE_FORMAT_VERSION,
+        runtime_contract_fingerprint: seed.runtime_contract_fingerprint,
+        credential_revision: seed.credential_revision,
+        component_source_name,
+        surface_kind: surface_kind.as_str(),
+        surface_name,
+    })
+    .expect("observed-values source scope must serialize");
     ObservedSourceSurfaceScope {
         owner_source_name: source.source_name().to_string(),
         source_name: component_source_name.to_string(),
@@ -183,502 +152,12 @@ fn surface_scope(
     }
 }
 
-fn input_shapes(inputs: &[ManifestInputSpec]) -> Vec<Value> {
-    inputs
-        .iter()
-        .map(|input| {
-            json!({
-                "key": input.key,
-                "kind": input_kind_label(input.kind),
-                "required": input.required,
-                "has_default": !input.default_value.is_empty(),
-                "has_hint": input.hint.is_some(),
-                "has_credential": input.credential.is_some(),
-            })
-        })
-        .collect()
-}
-
-fn input_kind_label(kind: ManifestInputKind) -> &'static str {
-    match kind {
-        ManifestInputKind::Variable => "variable",
-        ManifestInputKind::Secret => "secret",
-    }
-}
-
-fn http_table_shape(table: &HttpTableSpec) -> Value {
-    json!({
-        "kind": "table",
-        "name": table.name(),
-        "filters": to_json(table.filters()),
-        "fetch_limit_default": table.fetch_limit_default(),
-        "request": request_shape(&table.request),
-        "requests": table.requests.iter().map(request_route_shape).collect::<Vec<_>>(),
-        "response": response_shape(&table.response),
-        "pagination": to_json(&table.pagination),
-        "columns": column_shapes(table.columns()),
-    })
-}
-
-fn source_function_shape(function: &SourceTableFunctionSpec) -> Value {
-    json!({
-        "kind": "function",
-        "name": function.name,
-        "function_kind": function.kind.as_str(),
-        "fetch_limit_default": function.fetch_limit_default,
-        "search_limits": to_json(&function.search_limits),
-        "args": function.args.iter().map(function_arg_shape).collect::<Vec<_>>(),
-        "request": request_shape(&function.request),
-        "response": response_shape(&function.response),
-        "pagination": to_json(&function.pagination),
-        "columns": column_shapes(&function.columns),
-    })
-}
-
-fn file_table_shape(table: &FileTableSpec) -> Value {
-    json!({
-        "kind": "table",
-        "name": table.name(),
-        "format": table.format.as_str(),
-        "format_options": file_format_options_shape(&table.format_options),
-        "source": {
-            "location": template_shape(&table.source.location),
-            "glob": table.source.glob_or_default(table.format),
-            "partitions": table.source.partitions.iter().map(partition_shape).collect::<Vec<_>>(),
-            "metadata": table.source.metadata.iter().map(file_metadata_shape).collect::<Vec<_>>(),
-            "object_store": file_object_store_shape(table.source.object_store.as_ref()),
-        },
-        "filters": to_json(table.filters()),
-        "columns": column_shapes(table.columns()),
-    })
-}
-
-fn file_format_options_shape(options: &FileFormatOptions) -> Value {
-    json!({
-        "has_header": options.has_header,
-        "delimiter": options.delimiter,
-    })
-}
-
-fn partition_shape(partition: &PartitionColumnSpec) -> Value {
-    json!({
-        "name": partition.name,
-        "data_type": partition.data_type.as_str(),
-        "path": partition_path_shape(&partition.path),
-    })
-}
-
-fn partition_path_shape(path: &PartitionPathSpec) -> Value {
-    match path {
-        PartitionPathSpec::Hive => json!({ "kind": "hive" }),
-        PartitionPathSpec::Segment { index } => json!({
-            "kind": "segment",
-            "index": index,
-        }),
-    }
-}
-
-fn file_metadata_shape(metadata: &FileMetadataColumnSpec) -> Value {
-    json!({
-        "name": metadata.name,
-        "kind": metadata.kind.as_str(),
-    })
-}
-
-fn file_object_store_shape(object_store: Option<&FileObjectStoreSpec>) -> Value {
-    match object_store {
-        Some(FileObjectStoreSpec::S3 { region, auth }) => json!({
-            "type": "s3",
-            "region": region.as_ref().map(template_shape),
-            "auth": s3_auth_shape(auth),
-        }),
-        None => Value::Null,
-    }
-}
-
-fn s3_auth_shape(auth: &S3AuthSpec) -> Value {
-    match auth {
-        S3AuthSpec::AccessKey {
-            access_key_id,
-            secret_access_key,
-            session_token,
-        } => json!({
-            "type": "access_key",
-            "access_key_id": template_shape(access_key_id),
-            "secret_access_key": template_shape(secret_access_key),
-            "has_session_token": session_token.is_some(),
-        }),
-        S3AuthSpec::InstanceProfile => json!({ "type": "instance_profile" }),
-    }
-}
-
-fn mcp_table_shape(table: &McpTableSpec) -> Value {
-    json!({
-        "kind": "table",
-        "name": table.name(),
-        "tool": table.tool,
-        "tool_args": value_source_map_shape(&table.tool_args),
-        "filter_bindings": table.filter_bindings.iter().map(mcp_filter_binding_shape).collect::<Vec<_>>(),
-        "limit_binding": table.limit_binding.as_ref().map(mcp_limit_binding_shape),
-        "pagination": to_json(&table.pagination),
-        "offset_pagination": to_json(&table.offset_pagination),
-        "response": response_shape(&table.response),
-        "filters": to_json(table.filters()),
-        "columns": column_shapes(table.columns()),
-    })
-}
-
-fn mcp_function_shape(function: &McpTableFunctionSpec) -> Value {
-    json!({
-        "kind": "function",
-        "name": function.name(),
-        "tool": function.tool,
-        "args": function.args().iter().map(function_arg_shape).collect::<Vec<_>>(),
-        "pagination": to_json(&function.pagination),
-        "offset_pagination": to_json(&function.offset_pagination),
-        "response": response_shape(&function.common.response),
-        "columns": column_shapes(function.columns()),
-    })
-}
-
-fn auth_shape(auth: &AuthSpec) -> Value {
-    match auth {
-        AuthSpec::BasicAuth(basic_auth) => json!({
-            "type": "BasicAuth",
-            "username": template_shape(&basic_auth.username),
-            "password": template_shape(&basic_auth.password),
-        }),
-        AuthSpec::HeaderAuth(header_auth) => json!({
-            "type": "HeaderAuth",
-            "headers": header_shapes(&header_auth.headers),
-        }),
-        AuthSpec::CustomAuth(custom_auth) => {
-            let mut config_keys = custom_auth.config.keys().collect::<Vec<_>>();
-            config_keys.sort();
-            json!({
-                "type": "CustomAuth",
-                "authenticator": custom_auth.authenticator,
-                "config_keys": config_keys,
-            })
-        }
-    }
-}
-
-fn request_shape(request: &RequestSpec) -> Value {
-    json!({
-        "method": request.method,
-        "path": template_shape(&request.path),
-        "query": request.query.iter().map(|query| {
-            json!({
-                "name": query.name,
-                "value": value_source_shape(query),
-            })
-        }).collect::<Vec<_>>(),
-        "body": body_shape(&request.body),
-        "headers": header_shapes(&request.headers),
-    })
-}
-
-fn request_route_shape(route: &coral_spec::RequestRouteSpec) -> Value {
-    json!({
-        "when_filters": route.when_filters,
-        "request": request_shape(&route.request),
-    })
-}
-
-fn body_shape(body: &BodySpec) -> Value {
-    match body {
-        BodySpec::Json { fields } => json!({
-            "format": "json",
-            "fields": fields.iter().map(|field| {
-                json!({
-                    "path": field.path,
-                    "when_arg": field.when_arg,
-                    "value": value_source_shape(field),
-                })
-            }).collect::<Vec<_>>(),
-        }),
-        BodySpec::Text { content } => json!({
-            "format": "text",
-            "content": value_source_shape(content),
-        }),
-    }
-}
-
-fn response_shape(response: &ResponseSpec) -> Value {
-    json!({
-        "format": response.format,
-        "rows_path": response.rows_path,
-        "ok_path": response.ok_path,
-        "error_path": response.error_path,
-        "allow_404_empty": response.allow_404_empty,
-        "row_strategy": response.row_strategy,
-    })
-}
-
-fn header_shapes(headers: &[HeaderSpec]) -> Vec<Value> {
-    headers
-        .iter()
-        .map(|header| {
-            json!({
-                "name": header.name,
-                "value": value_source_shape(header),
-            })
-        })
-        .collect()
-}
-
-fn mcp_server_shape(server: &McpServerSpec) -> Value {
-    match server {
-        McpServerSpec::Stdio { command, args, env } => json!({
-            "transport": "stdio",
-            "command": command,
-            "args": args,
-            "env": env.iter().map(mcp_env_shape).collect::<Vec<_>>(),
-        }),
-        McpServerSpec::StreamableHttp { url, auth } => json!({
-            "transport": "streamable_http",
-            "url": url,
-            "auth": auth.as_ref().map(mcp_http_auth_shape),
-        }),
-    }
-}
-
-fn mcp_env_shape(env: &McpEnvSpec) -> Value {
-    json!({
-        "name": env.name,
-        "value": value_source_shape(&env.value),
-    })
-}
-
-fn mcp_http_auth_shape(auth: &McpHttpAuthSpec) -> Value {
-    json!({
-        "type": "bearer",
-        "token": value_source_shape(auth.bearer_token()),
-    })
-}
-
-fn value_source_map_shape(values: &BTreeMap<String, ValueSourceSpec>) -> Value {
-    Value::Object(
-        values
-            .iter()
-            .map(|(key, value)| (key.clone(), value_source_shape(value)))
-            .collect(),
-    )
-}
-
-fn mcp_filter_binding_shape(binding: &McpTableFilterBinding) -> Value {
-    json!({
-        "name": binding.name,
-        "tool_arg": binding.tool_arg,
-    })
-}
-
-fn mcp_limit_binding_shape(binding: &McpLimitBinding) -> Value {
-    json!({
-        "tool_arg": binding.tool_arg,
-        "max": binding.max,
-    })
-}
-
-fn function_arg_shape(arg: &TableFunctionArgSpec) -> Value {
-    json!({
-        "name": arg.name,
-        "required": arg.required,
-        "values": arg.values,
-        "bind": {
-            "arg": arg.bind.arg,
-        },
-    })
-}
-
-fn column_shapes(columns: &[ColumnSpec]) -> Vec<Value> {
-    columns
-        .iter()
-        .map(|column| {
-            json!({
-                "name": column.name,
-                "data_type": column.data_type,
-                "nullable": column.nullable,
-                "virtual": column.r#virtual,
-                "description": column.description,
-                "expr": to_json(&column.expr),
-            })
-        })
-        .collect()
-}
-
-fn value_source_shape<T>(value: &T) -> Value
-where
-    T: ValueSourceLike + ?Sized,
-{
-    value.value_source_shape()
-}
-
-trait ValueSourceLike {
-    fn value_source_shape(&self) -> Value;
-}
-
-impl ValueSourceLike for ValueSourceSpec {
-    fn value_source_shape(&self) -> Value {
-        match self {
-            ValueSourceSpec::Template { template } => json!({
-                "from": "template",
-                "template": template_shape(template),
-            }),
-            ValueSourceSpec::OneOf { values } => json!({
-                "from": "one_of",
-                "values": values.iter().map(value_source_shape).collect::<Vec<_>>(),
-            }),
-            ValueSourceSpec::Literal { value } => json!({
-                "from": "literal",
-                "value_type": json_value_type(value),
-            }),
-            ValueSourceSpec::Filter { key, default } => {
-                keyed_default_source_shape("filter", key, default.is_some())
-            }
-            ValueSourceSpec::FilterInt { key, default } => {
-                keyed_default_source_shape("filter_int", key, default.is_some())
-            }
-            ValueSourceSpec::FilterBool { key, default } => {
-                keyed_default_source_shape("filter_bool", key, default.is_some())
-            }
-            ValueSourceSpec::FilterStringArray { key, default } => {
-                keyed_default_source_shape("filter_string_array", key, default.is_some())
-            }
-            ValueSourceSpec::FilterSplit {
-                key,
-                separator,
-                part,
-            } => json!({
-                "from": "filter_split",
-                "key": key,
-                "separator": separator,
-                "part": part,
-            }),
-            ValueSourceSpec::FilterSplitInt {
-                key,
-                separator,
-                part,
-            } => json!({
-                "from": "filter_split_int",
-                "key": key,
-                "separator": separator,
-                "part": part,
-            }),
-            ValueSourceSpec::Arg { key, default } => {
-                keyed_default_source_shape("arg", key, default.is_some())
-            }
-            ValueSourceSpec::ArgInt { key, default } => {
-                keyed_default_source_shape("arg_int", key, default.is_some())
-            }
-            ValueSourceSpec::ArgBool { key, default } => {
-                keyed_default_source_shape("arg_bool", key, default.is_some())
-            }
-            ValueSourceSpec::ArgSplit {
-                key,
-                separator,
-                part,
-            } => json!({
-                "from": "arg_split",
-                "key": key,
-                "separator": separator,
-                "part": part,
-            }),
-            ValueSourceSpec::ArgSplitInt {
-                key,
-                separator,
-                part,
-            } => json!({
-                "from": "arg_split_int",
-                "key": key,
-                "separator": separator,
-                "part": part,
-            }),
-            ValueSourceSpec::Input { key } => json!({
-                "from": "input",
-                "key": key,
-            }),
-            ValueSourceSpec::Bearer { key } => json!({
-                "from": "bearer",
-                "key": key,
-            }),
-            ValueSourceSpec::State { key } => json!({
-                "from": "state",
-                "key": key,
-            }),
-            ValueSourceSpec::NowEpochMinusSeconds { seconds } => json!({
-                "from": "now_epoch_minus_seconds",
-                "seconds": seconds,
-            }),
-        }
-    }
-}
-
-fn keyed_default_source_shape(from: &str, key: &str, has_default: bool) -> Value {
-    json!({
-        "from": from,
-        "key": key,
-        "has_default": has_default,
-    })
-}
-
-impl ValueSourceLike for HeaderSpec {
-    fn value_source_shape(&self) -> Value {
-        value_source_shape(&self.value)
-    }
-}
-
-impl ValueSourceLike for coral_spec::QueryParamSpec {
-    fn value_source_shape(&self) -> Value {
-        value_source_shape(&self.value)
-    }
-}
-
-impl ValueSourceLike for coral_spec::BodyFieldSpec {
-    fn value_source_shape(&self) -> Value {
-        value_source_shape(&self.value)
-    }
-}
-
-fn json_value_type(value: &Value) -> &'static str {
-    match value {
-        Value::Null => "null",
-        Value::Bool(_) => "bool",
-        Value::Number(_) => "number",
-        Value::String(_) => "string",
-        Value::Array(_) => "array",
-        Value::Object(_) => "object",
-    }
-}
-
-fn template_shape(template: &ParsedTemplate) -> Value {
-    json!({
-        "raw": template.raw(),
-        "tokens": template.tokens().map(|token| {
-            json!({
-                "namespace": template_namespace_shape(token.namespace()),
-                "key": token.key(),
-                "has_default": token.default_value().is_some(),
-            })
-        }).collect::<Vec<_>>(),
-    })
-}
-
-fn template_namespace_shape(namespace: &TemplateNamespace) -> Value {
-    match namespace {
-        TemplateNamespace::Input => json!("input"),
-        TemplateNamespace::Filter => json!("filter"),
-        TemplateNamespace::Arg => json!("arg"),
-        TemplateNamespace::Expr => json!("expr"),
-        TemplateNamespace::State => json!("state"),
-        TemplateNamespace::Other(value) => json!({ "other": value }),
-    }
-}
-
-fn to_json<T>(value: &T) -> Value
-where
-    T: Serialize + ?Sized,
-{
-    serde_json::to_value(value).expect("observed-values source shape must serialize")
+#[derive(Serialize)]
+struct ScopeFingerprint<'a> {
+    format_version: u8,
+    runtime_contract_fingerprint: &'a str,
+    credential_revision: Uuid,
+    component_source_name: &'a str,
+    surface_kind: &'static str,
+    surface_name: &'a str,
 }

--- a/crates/coral-app/src/search/observed/source_scope.rs
+++ b/crates/coral-app/src/search/observed/source_scope.rs
@@ -18,7 +18,7 @@ use serde::Serialize;
 use serde_json::{Value, json};
 
 use crate::hash::sha256_hex;
-use crate::search::observed::sqlite_queue::{ObservedValuesGeneration, ObservedValuesSurfaceKind};
+use crate::search::observed::sqlite_queue::ObservedValuesSurfaceKind;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(super) struct SurfaceKey {
@@ -29,13 +29,12 @@ pub(super) struct SurfaceKey {
 
 #[derive(Debug, Clone)]
 pub(super) struct ObservedSourceSurfaceScope {
-    /// Canonical installed source that owns lifecycle clears and generations.
+    /// Canonical installed source that owns lifecycle clears and invalidation epochs.
     pub(super) owner_source_name: String,
     /// Runtime component schema used in SQL and search results.
     pub(super) source_name: String,
     surface_key: SurfaceKey,
     pub(super) source_scope_id: String,
-    pub(super) generation: ObservedValuesGeneration,
 }
 
 impl ObservedSourceSurfaceScope {
@@ -44,21 +43,18 @@ impl ObservedSourceSurfaceScope {
     }
 }
 
-pub(super) fn source_surface_scopes(
-    source: &QuerySource,
-    generation: ObservedValuesGeneration,
-) -> Vec<ObservedSourceSurfaceScope> {
+pub(super) fn source_surface_scopes(source: &QuerySource) -> Vec<ObservedSourceSurfaceScope> {
     let mut scopes = Vec::new();
     for component in source.components() {
         match component {
             RuntimeSourceComponent::Http(manifest) => {
-                scopes.extend(http_surface_scopes(source, manifest, generation));
+                scopes.extend(http_surface_scopes(source, manifest));
             }
             RuntimeSourceComponent::File(manifest) => {
-                scopes.extend(file_surface_scopes(source, manifest, generation));
+                scopes.extend(file_surface_scopes(source, manifest));
             }
             RuntimeSourceComponent::Mcp(manifest) => {
-                scopes.extend(mcp_surface_scopes(source, manifest, generation));
+                scopes.extend(mcp_surface_scopes(source, manifest));
             }
         }
     }
@@ -68,7 +64,6 @@ pub(super) fn source_surface_scopes(
 fn http_surface_scopes(
     source: &QuerySource,
     manifest: &HttpSourceManifest,
-    generation: ObservedValuesGeneration,
 ) -> Vec<ObservedSourceSurfaceScope> {
     let component_shape = json!({
         "backend": "http",
@@ -86,7 +81,6 @@ fn http_surface_scopes(
             table.name(),
             &component_shape,
             &http_table_shape(table),
-            generation,
         ));
     }
     for function in &manifest.functions {
@@ -97,7 +91,6 @@ fn http_surface_scopes(
             function.name.as_str(),
             &component_shape,
             &source_function_shape(function),
-            generation,
         ));
     }
     scopes
@@ -106,7 +99,6 @@ fn http_surface_scopes(
 fn file_surface_scopes(
     source: &QuerySource,
     manifest: &FileSourceManifest,
-    generation: ObservedValuesGeneration,
 ) -> Vec<ObservedSourceSurfaceScope> {
     let component_shape = json!({
         "backend": "file",
@@ -123,7 +115,6 @@ fn file_surface_scopes(
                 table.name(),
                 &component_shape,
                 &file_table_shape(table),
-                generation,
             )
         })
         .collect()
@@ -132,7 +123,6 @@ fn file_surface_scopes(
 fn mcp_surface_scopes(
     source: &QuerySource,
     manifest: &McpSourceManifest,
-    generation: ObservedValuesGeneration,
 ) -> Vec<ObservedSourceSurfaceScope> {
     let component_shape = json!({
         "backend": "mcp",
@@ -148,7 +138,6 @@ fn mcp_surface_scopes(
             table.name(),
             &component_shape,
             &mcp_table_shape(table),
-            generation,
         ));
     }
     for function in &manifest.functions {
@@ -159,7 +148,6 @@ fn mcp_surface_scopes(
             function.name(),
             &component_shape,
             &mcp_function_shape(function),
-            generation,
         ));
     }
     scopes
@@ -172,7 +160,6 @@ fn surface_scope(
     surface_name: &str,
     component_shape: &Value,
     surface_shape: &Value,
-    generation: ObservedValuesGeneration,
 ) -> ObservedSourceSurfaceScope {
     let scope = json!({
         "logical_source_name": source.source_name(),
@@ -193,7 +180,6 @@ fn surface_scope(
             surface_name: surface_name.to_string(),
         },
         source_scope_id: sha256_hex(&scope_bytes),
-        generation,
     }
 }
 

--- a/crates/coral-app/src/search/observed/source_scope.rs
+++ b/crates/coral-app/src/search/observed/source_scope.rs
@@ -1,0 +1,694 @@
+//! Pure source-surface scope derivation for observed-value invalidation.
+
+use std::collections::BTreeMap;
+
+use coral_engine::{QuerySource, RuntimeSourceComponent};
+use coral_spec::backends::file::{
+    FileFormatOptions, FileMetadataColumnSpec, FileObjectStoreSpec, FileSourceManifest,
+    FileTableSpec, PartitionColumnSpec, PartitionPathSpec, S3AuthSpec,
+};
+use coral_spec::backends::http::{AuthSpec, HttpSourceManifest, HttpTableSpec};
+use coral_spec::{
+    BodySpec, ColumnSpec, HeaderSpec, ManifestInputKind, ManifestInputSpec, McpEnvSpec,
+    McpHttpAuthSpec, McpLimitBinding, McpServerSpec, McpSourceManifest, McpTableFilterBinding,
+    McpTableFunctionSpec, McpTableSpec, ParsedTemplate, RequestSpec, ResponseSpec,
+    SourceTableFunctionSpec, TableFunctionArgSpec, TemplateNamespace, ValueSourceSpec,
+};
+use serde::Serialize;
+use serde_json::{Value, json};
+
+use crate::hash::sha256_hex;
+use crate::search::observed::sqlite_queue::{ObservedValuesGeneration, ObservedValuesSurfaceKind};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct SurfaceKey {
+    pub(super) source_name: String,
+    pub(super) surface_kind: ObservedValuesSurfaceKind,
+    pub(super) surface_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ObservedSourceSurfaceScope {
+    pub(super) observed_source_name: String,
+    surface_key: SurfaceKey,
+    pub(super) source_scope_id: String,
+    pub(super) generation: ObservedValuesGeneration,
+}
+
+impl ObservedSourceSurfaceScope {
+    pub(super) fn key(&self) -> SurfaceKey {
+        self.surface_key.clone()
+    }
+}
+
+pub(super) fn source_surface_scopes(
+    source: &QuerySource,
+    generation: ObservedValuesGeneration,
+) -> Vec<ObservedSourceSurfaceScope> {
+    let mut scopes = Vec::new();
+    for component in source.components() {
+        match component {
+            RuntimeSourceComponent::Http(manifest) => {
+                scopes.extend(http_surface_scopes(source, manifest, generation));
+            }
+            RuntimeSourceComponent::File(manifest) => {
+                scopes.extend(file_surface_scopes(source, manifest, generation));
+            }
+            RuntimeSourceComponent::Mcp(manifest) => {
+                scopes.extend(mcp_surface_scopes(source, manifest, generation));
+            }
+        }
+    }
+    scopes
+}
+
+fn http_surface_scopes(
+    source: &QuerySource,
+    manifest: &HttpSourceManifest,
+    generation: ObservedValuesGeneration,
+) -> Vec<ObservedSourceSurfaceScope> {
+    let component_shape = json!({
+        "backend": "http",
+        "component_source_name": manifest.common.name,
+        "base_url": template_shape(&manifest.base_url),
+        "auth": auth_shape(&manifest.auth),
+        "request_headers": header_shapes(&manifest.request_headers),
+    });
+    let mut scopes = Vec::new();
+    for table in &manifest.tables {
+        scopes.push(surface_scope(
+            source,
+            manifest.common.name.as_str(),
+            ObservedValuesSurfaceKind::Table,
+            table.name(),
+            &component_shape,
+            &http_table_shape(table),
+            generation,
+        ));
+    }
+    for function in &manifest.functions {
+        scopes.push(surface_scope(
+            source,
+            manifest.common.name.as_str(),
+            ObservedValuesSurfaceKind::Function,
+            function.name.as_str(),
+            &component_shape,
+            &source_function_shape(function),
+            generation,
+        ));
+    }
+    scopes
+}
+
+fn file_surface_scopes(
+    source: &QuerySource,
+    manifest: &FileSourceManifest,
+    generation: ObservedValuesGeneration,
+) -> Vec<ObservedSourceSurfaceScope> {
+    let component_shape = json!({
+        "backend": "file",
+        "component_source_name": manifest.common.name,
+    });
+    manifest
+        .tables
+        .iter()
+        .map(|table| {
+            surface_scope(
+                source,
+                manifest.common.name.as_str(),
+                ObservedValuesSurfaceKind::Table,
+                table.name(),
+                &component_shape,
+                &file_table_shape(table),
+                generation,
+            )
+        })
+        .collect()
+}
+
+fn mcp_surface_scopes(
+    source: &QuerySource,
+    manifest: &McpSourceManifest,
+    generation: ObservedValuesGeneration,
+) -> Vec<ObservedSourceSurfaceScope> {
+    let component_shape = json!({
+        "backend": "mcp",
+        "component_source_name": manifest.common.name,
+        "server": mcp_server_shape(&manifest.server),
+    });
+    let mut scopes = Vec::new();
+    for table in &manifest.tables {
+        scopes.push(surface_scope(
+            source,
+            manifest.common.name.as_str(),
+            ObservedValuesSurfaceKind::Table,
+            table.name(),
+            &component_shape,
+            &mcp_table_shape(table),
+            generation,
+        ));
+    }
+    for function in &manifest.functions {
+        scopes.push(surface_scope(
+            source,
+            manifest.common.name.as_str(),
+            ObservedValuesSurfaceKind::Function,
+            function.name(),
+            &component_shape,
+            &mcp_function_shape(function),
+            generation,
+        ));
+    }
+    scopes
+}
+
+fn surface_scope(
+    source: &QuerySource,
+    component_source_name: &str,
+    surface_kind: ObservedValuesSurfaceKind,
+    surface_name: &str,
+    component_shape: &Value,
+    surface_shape: &Value,
+    generation: ObservedValuesGeneration,
+) -> ObservedSourceSurfaceScope {
+    let scope = json!({
+        "logical_source_name": source.source_name(),
+        "authored_version": source.version(),
+        "declared_inputs": input_shapes(source.declared_inputs()),
+        "variables": source.variables(),
+        "component": component_shape,
+        "surface": surface_shape,
+    });
+    let scope_bytes =
+        serde_json::to_vec(&scope).expect("observed-values source scope must serialize");
+    ObservedSourceSurfaceScope {
+        observed_source_name: source.source_name().to_string(),
+        surface_key: SurfaceKey {
+            source_name: component_source_name.to_string(),
+            surface_kind,
+            surface_name: surface_name.to_string(),
+        },
+        source_scope_id: sha256_hex(&scope_bytes),
+        generation,
+    }
+}
+
+fn input_shapes(inputs: &[ManifestInputSpec]) -> Vec<Value> {
+    inputs
+        .iter()
+        .map(|input| {
+            json!({
+                "key": input.key,
+                "kind": input_kind_label(input.kind),
+                "required": input.required,
+                "has_default": !input.default_value.is_empty(),
+                "has_hint": input.hint.is_some(),
+                "has_credential": input.credential.is_some(),
+            })
+        })
+        .collect()
+}
+
+fn input_kind_label(kind: ManifestInputKind) -> &'static str {
+    match kind {
+        ManifestInputKind::Variable => "variable",
+        ManifestInputKind::Secret => "secret",
+    }
+}
+
+fn http_table_shape(table: &HttpTableSpec) -> Value {
+    json!({
+        "kind": "table",
+        "name": table.name(),
+        "filters": to_json(table.filters()),
+        "fetch_limit_default": table.fetch_limit_default(),
+        "request": request_shape(&table.request),
+        "requests": table.requests.iter().map(request_route_shape).collect::<Vec<_>>(),
+        "response": response_shape(&table.response),
+        "pagination": to_json(&table.pagination),
+        "columns": column_shapes(table.columns()),
+    })
+}
+
+fn source_function_shape(function: &SourceTableFunctionSpec) -> Value {
+    json!({
+        "kind": "function",
+        "name": function.name,
+        "function_kind": function.kind.as_str(),
+        "fetch_limit_default": function.fetch_limit_default,
+        "search_limits": to_json(&function.search_limits),
+        "args": function.args.iter().map(function_arg_shape).collect::<Vec<_>>(),
+        "request": request_shape(&function.request),
+        "response": response_shape(&function.response),
+        "pagination": to_json(&function.pagination),
+        "columns": column_shapes(&function.columns),
+    })
+}
+
+fn file_table_shape(table: &FileTableSpec) -> Value {
+    json!({
+        "kind": "table",
+        "name": table.name(),
+        "format": table.format.as_str(),
+        "format_options": file_format_options_shape(&table.format_options),
+        "source": {
+            "location": template_shape(&table.source.location),
+            "glob": table.source.glob_or_default(table.format),
+            "partitions": table.source.partitions.iter().map(partition_shape).collect::<Vec<_>>(),
+            "metadata": table.source.metadata.iter().map(file_metadata_shape).collect::<Vec<_>>(),
+            "object_store": file_object_store_shape(table.source.object_store.as_ref()),
+        },
+        "filters": to_json(table.filters()),
+        "columns": column_shapes(table.columns()),
+    })
+}
+
+fn file_format_options_shape(options: &FileFormatOptions) -> Value {
+    json!({
+        "has_header": options.has_header,
+        "delimiter": options.delimiter,
+    })
+}
+
+fn partition_shape(partition: &PartitionColumnSpec) -> Value {
+    json!({
+        "name": partition.name,
+        "data_type": partition.data_type.as_str(),
+        "path": partition_path_shape(&partition.path),
+    })
+}
+
+fn partition_path_shape(path: &PartitionPathSpec) -> Value {
+    match path {
+        PartitionPathSpec::Hive => json!({ "kind": "hive" }),
+        PartitionPathSpec::Segment { index } => json!({
+            "kind": "segment",
+            "index": index,
+        }),
+    }
+}
+
+fn file_metadata_shape(metadata: &FileMetadataColumnSpec) -> Value {
+    json!({
+        "name": metadata.name,
+        "kind": metadata.kind.as_str(),
+    })
+}
+
+fn file_object_store_shape(object_store: Option<&FileObjectStoreSpec>) -> Value {
+    match object_store {
+        Some(FileObjectStoreSpec::S3 { region, auth }) => json!({
+            "type": "s3",
+            "region": region.as_ref().map(template_shape),
+            "auth": s3_auth_shape(auth),
+        }),
+        None => Value::Null,
+    }
+}
+
+fn s3_auth_shape(auth: &S3AuthSpec) -> Value {
+    match auth {
+        S3AuthSpec::AccessKey {
+            access_key_id,
+            secret_access_key,
+            session_token,
+        } => json!({
+            "type": "access_key",
+            "access_key_id": template_shape(access_key_id),
+            "secret_access_key": template_shape(secret_access_key),
+            "has_session_token": session_token.is_some(),
+        }),
+        S3AuthSpec::InstanceProfile => json!({ "type": "instance_profile" }),
+    }
+}
+
+fn mcp_table_shape(table: &McpTableSpec) -> Value {
+    json!({
+        "kind": "table",
+        "name": table.name(),
+        "tool": table.tool,
+        "tool_args": value_source_map_shape(&table.tool_args),
+        "filter_bindings": table.filter_bindings.iter().map(mcp_filter_binding_shape).collect::<Vec<_>>(),
+        "limit_binding": table.limit_binding.as_ref().map(mcp_limit_binding_shape),
+        "pagination": to_json(&table.pagination),
+        "offset_pagination": to_json(&table.offset_pagination),
+        "response": response_shape(&table.response),
+        "filters": to_json(table.filters()),
+        "columns": column_shapes(table.columns()),
+    })
+}
+
+fn mcp_function_shape(function: &McpTableFunctionSpec) -> Value {
+    json!({
+        "kind": "function",
+        "name": function.name(),
+        "tool": function.tool,
+        "args": function.args().iter().map(function_arg_shape).collect::<Vec<_>>(),
+        "pagination": to_json(&function.pagination),
+        "offset_pagination": to_json(&function.offset_pagination),
+        "response": response_shape(&function.common.response),
+        "columns": column_shapes(function.columns()),
+    })
+}
+
+fn auth_shape(auth: &AuthSpec) -> Value {
+    match auth {
+        AuthSpec::BasicAuth(basic_auth) => json!({
+            "type": "BasicAuth",
+            "username": template_shape(&basic_auth.username),
+            "password": template_shape(&basic_auth.password),
+        }),
+        AuthSpec::HeaderAuth(header_auth) => json!({
+            "type": "HeaderAuth",
+            "headers": header_shapes(&header_auth.headers),
+        }),
+        AuthSpec::CustomAuth(custom_auth) => {
+            let mut config_keys = custom_auth.config.keys().collect::<Vec<_>>();
+            config_keys.sort();
+            json!({
+                "type": "CustomAuth",
+                "authenticator": custom_auth.authenticator,
+                "config_keys": config_keys,
+            })
+        }
+    }
+}
+
+fn request_shape(request: &RequestSpec) -> Value {
+    json!({
+        "method": request.method,
+        "path": template_shape(&request.path),
+        "query": request.query.iter().map(|query| {
+            json!({
+                "name": query.name,
+                "value": value_source_shape(query),
+            })
+        }).collect::<Vec<_>>(),
+        "body": body_shape(&request.body),
+        "headers": header_shapes(&request.headers),
+    })
+}
+
+fn request_route_shape(route: &coral_spec::RequestRouteSpec) -> Value {
+    json!({
+        "when_filters": route.when_filters,
+        "request": request_shape(&route.request),
+    })
+}
+
+fn body_shape(body: &BodySpec) -> Value {
+    match body {
+        BodySpec::Json { fields } => json!({
+            "format": "json",
+            "fields": fields.iter().map(|field| {
+                json!({
+                    "path": field.path,
+                    "when_arg": field.when_arg,
+                    "value": value_source_shape(field),
+                })
+            }).collect::<Vec<_>>(),
+        }),
+        BodySpec::Text { content } => json!({
+            "format": "text",
+            "content": value_source_shape(content),
+        }),
+    }
+}
+
+fn response_shape(response: &ResponseSpec) -> Value {
+    json!({
+        "format": response.format,
+        "rows_path": response.rows_path,
+        "ok_path": response.ok_path,
+        "error_path": response.error_path,
+        "allow_404_empty": response.allow_404_empty,
+        "row_strategy": response.row_strategy,
+    })
+}
+
+fn header_shapes(headers: &[HeaderSpec]) -> Vec<Value> {
+    headers
+        .iter()
+        .map(|header| {
+            json!({
+                "name": header.name,
+                "value": value_source_shape(header),
+            })
+        })
+        .collect()
+}
+
+fn mcp_server_shape(server: &McpServerSpec) -> Value {
+    match server {
+        McpServerSpec::Stdio { command, args, env } => json!({
+            "transport": "stdio",
+            "command": command,
+            "args": args,
+            "env": env.iter().map(mcp_env_shape).collect::<Vec<_>>(),
+        }),
+        McpServerSpec::StreamableHttp { url, auth } => json!({
+            "transport": "streamable_http",
+            "url": url,
+            "auth": auth.as_ref().map(mcp_http_auth_shape),
+        }),
+    }
+}
+
+fn mcp_env_shape(env: &McpEnvSpec) -> Value {
+    json!({
+        "name": env.name,
+        "value": value_source_shape(&env.value),
+    })
+}
+
+fn mcp_http_auth_shape(auth: &McpHttpAuthSpec) -> Value {
+    json!({
+        "type": "bearer",
+        "token": value_source_shape(auth.bearer_token()),
+    })
+}
+
+fn value_source_map_shape(values: &BTreeMap<String, ValueSourceSpec>) -> Value {
+    Value::Object(
+        values
+            .iter()
+            .map(|(key, value)| (key.clone(), value_source_shape(value)))
+            .collect(),
+    )
+}
+
+fn mcp_filter_binding_shape(binding: &McpTableFilterBinding) -> Value {
+    json!({
+        "name": binding.name,
+        "tool_arg": binding.tool_arg,
+    })
+}
+
+fn mcp_limit_binding_shape(binding: &McpLimitBinding) -> Value {
+    json!({
+        "tool_arg": binding.tool_arg,
+        "max": binding.max,
+    })
+}
+
+fn function_arg_shape(arg: &TableFunctionArgSpec) -> Value {
+    json!({
+        "name": arg.name,
+        "required": arg.required,
+        "values": arg.values,
+        "bind": {
+            "arg": arg.bind.arg,
+        },
+    })
+}
+
+fn column_shapes(columns: &[ColumnSpec]) -> Vec<Value> {
+    columns
+        .iter()
+        .map(|column| {
+            json!({
+                "name": column.name,
+                "data_type": column.data_type,
+                "nullable": column.nullable,
+                "virtual": column.r#virtual,
+                "description": column.description,
+                "expr": to_json(&column.expr),
+            })
+        })
+        .collect()
+}
+
+fn value_source_shape<T>(value: &T) -> Value
+where
+    T: ValueSourceLike + ?Sized,
+{
+    value.value_source_shape()
+}
+
+trait ValueSourceLike {
+    fn value_source_shape(&self) -> Value;
+}
+
+impl ValueSourceLike for ValueSourceSpec {
+    fn value_source_shape(&self) -> Value {
+        match self {
+            ValueSourceSpec::Template { template } => json!({
+                "from": "template",
+                "template": template_shape(template),
+            }),
+            ValueSourceSpec::OneOf { values } => json!({
+                "from": "one_of",
+                "values": values.iter().map(value_source_shape).collect::<Vec<_>>(),
+            }),
+            ValueSourceSpec::Literal { value } => json!({
+                "from": "literal",
+                "value_type": json_value_type(value),
+            }),
+            ValueSourceSpec::Filter { key, default } => {
+                keyed_default_source_shape("filter", key, default.is_some())
+            }
+            ValueSourceSpec::FilterInt { key, default } => {
+                keyed_default_source_shape("filter_int", key, default.is_some())
+            }
+            ValueSourceSpec::FilterBool { key, default } => {
+                keyed_default_source_shape("filter_bool", key, default.is_some())
+            }
+            ValueSourceSpec::FilterStringArray { key, default } => {
+                keyed_default_source_shape("filter_string_array", key, default.is_some())
+            }
+            ValueSourceSpec::FilterSplit {
+                key,
+                separator,
+                part,
+            } => json!({
+                "from": "filter_split",
+                "key": key,
+                "separator": separator,
+                "part": part,
+            }),
+            ValueSourceSpec::FilterSplitInt {
+                key,
+                separator,
+                part,
+            } => json!({
+                "from": "filter_split_int",
+                "key": key,
+                "separator": separator,
+                "part": part,
+            }),
+            ValueSourceSpec::Arg { key, default } => {
+                keyed_default_source_shape("arg", key, default.is_some())
+            }
+            ValueSourceSpec::ArgInt { key, default } => {
+                keyed_default_source_shape("arg_int", key, default.is_some())
+            }
+            ValueSourceSpec::ArgBool { key, default } => {
+                keyed_default_source_shape("arg_bool", key, default.is_some())
+            }
+            ValueSourceSpec::ArgSplit {
+                key,
+                separator,
+                part,
+            } => json!({
+                "from": "arg_split",
+                "key": key,
+                "separator": separator,
+                "part": part,
+            }),
+            ValueSourceSpec::ArgSplitInt {
+                key,
+                separator,
+                part,
+            } => json!({
+                "from": "arg_split_int",
+                "key": key,
+                "separator": separator,
+                "part": part,
+            }),
+            ValueSourceSpec::Input { key } => json!({
+                "from": "input",
+                "key": key,
+            }),
+            ValueSourceSpec::Bearer { key } => json!({
+                "from": "bearer",
+                "key": key,
+            }),
+            ValueSourceSpec::State { key } => json!({
+                "from": "state",
+                "key": key,
+            }),
+            ValueSourceSpec::NowEpochMinusSeconds { seconds } => json!({
+                "from": "now_epoch_minus_seconds",
+                "seconds": seconds,
+            }),
+        }
+    }
+}
+
+fn keyed_default_source_shape(from: &str, key: &str, has_default: bool) -> Value {
+    json!({
+        "from": from,
+        "key": key,
+        "has_default": has_default,
+    })
+}
+
+impl ValueSourceLike for HeaderSpec {
+    fn value_source_shape(&self) -> Value {
+        value_source_shape(&self.value)
+    }
+}
+
+impl ValueSourceLike for coral_spec::QueryParamSpec {
+    fn value_source_shape(&self) -> Value {
+        value_source_shape(&self.value)
+    }
+}
+
+impl ValueSourceLike for coral_spec::BodyFieldSpec {
+    fn value_source_shape(&self) -> Value {
+        value_source_shape(&self.value)
+    }
+}
+
+fn json_value_type(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn template_shape(template: &ParsedTemplate) -> Value {
+    json!({
+        "raw": template.raw(),
+        "tokens": template.tokens().map(|token| {
+            json!({
+                "namespace": template_namespace_shape(token.namespace()),
+                "key": token.key(),
+                "has_default": token.default_value().is_some(),
+            })
+        }).collect::<Vec<_>>(),
+    })
+}
+
+fn template_namespace_shape(namespace: &TemplateNamespace) -> Value {
+    match namespace {
+        TemplateNamespace::Input => json!("input"),
+        TemplateNamespace::Filter => json!("filter"),
+        TemplateNamespace::Arg => json!("arg"),
+        TemplateNamespace::Expr => json!("expr"),
+        TemplateNamespace::State => json!("state"),
+        TemplateNamespace::Other(value) => json!({ "other": value }),
+    }
+}
+
+fn to_json<T>(value: &T) -> Value
+where
+    T: Serialize + ?Sized,
+{
+    serde_json::to_value(value).expect("observed-values source shape must serialize")
+}

--- a/crates/coral-app/src/search/observed/sqlite_queue.rs
+++ b/crates/coral-app/src/search/observed/sqlite_queue.rs
@@ -1,0 +1,71 @@
+//! Durable observed-values queue records.
+
+#![allow(
+    dead_code,
+    reason = "observed-values provider substrate is staged before app wiring in the next PR"
+)]
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ObservedValuesGeneration {
+    pub(crate) workspace_generation: i64,
+    pub(crate) source_generation: i64,
+}
+
+impl ObservedValuesGeneration {
+    pub(crate) const ZERO: Self = Self {
+        workspace_generation: 0,
+        source_generation: 0,
+    };
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ObservedValuesSurfaceKind {
+    Table,
+    Function,
+}
+
+impl ObservedValuesSurfaceKind {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Table => "table",
+            Self::Function => "function",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ObservedValuesQueuePayload {
+    pub(crate) values: Vec<ObservedValueCandidate>,
+}
+
+impl ObservedValuesQueuePayload {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ObservedValueCandidate {
+    pub(crate) column_name: String,
+    pub(crate) display_value: String,
+    pub(crate) search_text: String,
+    pub(crate) value_key: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ObservedValuesQueueJob {
+    pub(crate) source_name: String,
+    pub(crate) source_scope_id: String,
+    pub(crate) surface_kind: ObservedValuesSurfaceKind,
+    pub(crate) surface_name: String,
+    pub(crate) payload_json: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ObservedValuesEnqueueResult {
+    Enqueued { job_id: i64 },
+    StaleGeneration,
+    QueueFull,
+}

--- a/crates/coral-app/src/search/observed/sqlite_queue.rs
+++ b/crates/coral-app/src/search/observed/sqlite_queue.rs
@@ -56,6 +56,9 @@ pub(crate) struct ObservedValueCandidate {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ObservedValuesQueueJob {
+    /// Canonical installed source that owns lifecycle clears and generations.
+    pub(crate) owner_source_name: String,
+    /// Runtime component schema used in SQL and search results.
     pub(crate) source_name: String,
     pub(crate) source_scope_id: String,
     pub(crate) surface_kind: ObservedValuesSurfaceKind,

--- a/crates/coral-app/src/search/observed/sqlite_queue.rs
+++ b/crates/coral-app/src/search/observed/sqlite_queue.rs
@@ -7,13 +7,16 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Snapshot of the workspace-wide and source-local invalidation counters.
+///
+/// A queued observation is accepted only while both counters still match.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ObservedValuesGeneration {
+pub(crate) struct ObservedValuesEpoch {
     pub(crate) workspace_generation: i64,
     pub(crate) source_generation: i64,
 }
 
-impl ObservedValuesGeneration {
+impl ObservedValuesEpoch {
     pub(crate) const ZERO: Self = Self {
         workspace_generation: 0,
         source_generation: 0,
@@ -69,6 +72,6 @@ pub(crate) struct ObservedValuesQueueJob {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ObservedValuesEnqueueResult {
     Enqueued { job_id: i64 },
-    StaleGeneration,
+    StaleEpoch,
     QueueFull,
 }

--- a/crates/coral-app/src/search/observed/sqlite_store.rs
+++ b/crates/coral-app/src/search/observed/sqlite_store.rs
@@ -1,0 +1,526 @@
+//! `SQLite` observed-values queue and governance operations.
+
+#![allow(
+    dead_code,
+    reason = "observed-values provider substrate is staged before app wiring in the next PR"
+)]
+
+use rusqlite::{Connection, OptionalExtension as _, TransactionBehavior, params};
+
+use crate::search::observed::sqlite_queue::{
+    ObservedValuesEnqueueResult, ObservedValuesGeneration, ObservedValuesQueueJob,
+};
+use crate::search::sqlite_store::{SqliteSearchError, SqliteSearchStore};
+use crate::state::AppStateLayout;
+use crate::workspaces::WorkspaceName;
+
+#[cfg(not(test))]
+const MAX_PENDING_QUEUE_JOBS_PER_WORKSPACE: i64 = 1024;
+#[cfg(test)]
+const MAX_PENDING_QUEUE_JOBS_PER_WORKSPACE: i64 = 2;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SqliteObservedValuesStore {
+    layout: AppStateLayout,
+}
+
+impl SqliteObservedValuesStore {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
+    pub(crate) fn current_generations(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &str,
+    ) -> Result<ObservedValuesGeneration, SqliteSearchError> {
+        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
+        let connection = store.connect()?;
+        observed_generations(&connection, workspace_name, source_name)
+    }
+
+    pub(crate) fn enqueue_source_scan(
+        &self,
+        workspace_name: &WorkspaceName,
+        job: &ObservedValuesQueueJob,
+        expected_generation: ObservedValuesGeneration,
+    ) -> Result<ObservedValuesEnqueueResult, SqliteSearchError> {
+        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
+        let mut connection = store.connect()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let current_generation =
+            observed_generations(&transaction, workspace_name, &job.source_name)?;
+        if current_generation != expected_generation {
+            transaction.commit()?;
+            return Ok(ObservedValuesEnqueueResult::StaleGeneration);
+        }
+        if pending_queue_job_id(&transaction, workspace_name, job, expected_generation)?.is_none()
+            && pending_queue_job_count(&transaction, workspace_name)?
+                >= MAX_PENDING_QUEUE_JOBS_PER_WORKSPACE
+        {
+            transaction.commit()?;
+            return Ok(ObservedValuesEnqueueResult::QueueFull);
+        }
+
+        transaction.execute(
+            "
+            INSERT INTO observed_queue_jobs (
+                workspace,
+                source_name,
+                source_scope_id,
+                surface_kind,
+                surface_name,
+                workspace_generation,
+                source_generation,
+                payload_json,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                ?1,
+                ?2,
+                ?3,
+                ?4,
+                ?5,
+                ?6,
+                ?7,
+                ?8,
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+            ON CONFLICT(
+                workspace,
+                source_name,
+                source_scope_id,
+                surface_kind,
+                surface_name,
+                workspace_generation,
+                source_generation
+            ) DO UPDATE SET
+                payload_json = excluded.payload_json,
+                attempts = 0,
+                last_error = '',
+                updated_at = excluded.updated_at
+            ",
+            params![
+                workspace_name.as_str(),
+                &job.source_name,
+                &job.source_scope_id,
+                job.surface_kind.as_str(),
+                &job.surface_name,
+                expected_generation.workspace_generation,
+                expected_generation.source_generation,
+                &job.payload_json,
+            ],
+        )?;
+        let job_id = pending_queue_job_id(&transaction, workspace_name, job, expected_generation)?
+            .expect("pending observed-values queue job should exist after upsert");
+        transaction.commit()?;
+        Ok(ObservedValuesEnqueueResult::Enqueued { job_id })
+    }
+
+    pub(crate) fn clear_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<(), SqliteSearchError> {
+        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
+        let mut connection = store.connect()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        transaction.execute(
+            "DELETE FROM observed_values_fts WHERE workspace = ?1",
+            params![workspace_name.as_str()],
+        )?;
+        transaction.execute(
+            "DELETE FROM observed_values WHERE workspace = ?1",
+            params![workspace_name.as_str()],
+        )?;
+        transaction.execute(
+            "DELETE FROM observed_queue_jobs WHERE workspace = ?1",
+            params![workspace_name.as_str()],
+        )?;
+        increment_workspace_generation(&transaction, workspace_name)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    pub(crate) fn clear_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &str,
+    ) -> Result<(), SqliteSearchError> {
+        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
+        let mut connection = store.connect()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        transaction.execute(
+            "DELETE FROM observed_values_fts WHERE workspace = ?1 AND source_name = ?2",
+            params![workspace_name.as_str(), source_name],
+        )?;
+        transaction.execute(
+            "DELETE FROM observed_values WHERE workspace = ?1 AND source_name = ?2",
+            params![workspace_name.as_str(), source_name],
+        )?;
+        transaction.execute(
+            "DELETE FROM observed_queue_jobs WHERE workspace = ?1 AND source_name = ?2",
+            params![workspace_name.as_str(), source_name],
+        )?;
+        increment_source_generation(&transaction, workspace_name, source_name)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_queue_job_count(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<usize, SqliteSearchError> {
+        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
+        let connection = store.connect()?;
+        let count: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM observed_queue_jobs WHERE workspace = ?1",
+            params![workspace_name.as_str()],
+            |row| row.get(0),
+        )?;
+        Ok(usize::try_from(count).unwrap_or(usize::MAX))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn queue_payloads(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<String>, SqliteSearchError> {
+        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
+        let connection = store.connect()?;
+        let mut statement = connection.prepare(
+            "
+            SELECT payload_json
+            FROM observed_queue_jobs
+            WHERE workspace = ?1
+            ORDER BY id
+            ",
+        )?;
+        let rows = statement.query_map(params![workspace_name.as_str()], |row| row.get(0))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(SqliteSearchError::from)
+    }
+}
+
+fn pending_queue_job_count(
+    connection: &Connection,
+    workspace_name: &WorkspaceName,
+) -> Result<i64, SqliteSearchError> {
+    connection
+        .query_row(
+            "SELECT COUNT(*) FROM observed_queue_jobs WHERE workspace = ?1",
+            params![workspace_name.as_str()],
+            |row| row.get(0),
+        )
+        .map_err(SqliteSearchError::from)
+}
+
+fn pending_queue_job_id(
+    connection: &Connection,
+    workspace_name: &WorkspaceName,
+    job: &ObservedValuesQueueJob,
+    generation: ObservedValuesGeneration,
+) -> Result<Option<i64>, SqliteSearchError> {
+    connection
+        .query_row(
+            "
+            SELECT id
+            FROM observed_queue_jobs
+            WHERE workspace = ?1
+              AND source_name = ?2
+              AND source_scope_id = ?3
+              AND surface_kind = ?4
+              AND surface_name = ?5
+              AND workspace_generation = ?6
+              AND source_generation = ?7
+            ",
+            params![
+                workspace_name.as_str(),
+                &job.source_name,
+                &job.source_scope_id,
+                job.surface_kind.as_str(),
+                &job.surface_name,
+                generation.workspace_generation,
+                generation.source_generation,
+            ],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(SqliteSearchError::from)
+}
+
+fn observed_generations(
+    connection: &Connection,
+    workspace_name: &WorkspaceName,
+    source_name: &str,
+) -> Result<ObservedValuesGeneration, SqliteSearchError> {
+    let workspace_generation = connection
+        .query_row(
+            "
+            SELECT generation
+            FROM observed_workspace_generations
+            WHERE workspace = ?1
+            ",
+            params![workspace_name.as_str()],
+            |row| row.get(0),
+        )
+        .optional()?
+        .unwrap_or(ObservedValuesGeneration::ZERO.workspace_generation);
+    let source_generation = connection
+        .query_row(
+            "
+            SELECT generation
+            FROM observed_source_generations
+            WHERE workspace = ?1 AND source_name = ?2
+            ",
+            params![workspace_name.as_str(), source_name],
+            |row| row.get(0),
+        )
+        .optional()?
+        .unwrap_or(ObservedValuesGeneration::ZERO.source_generation);
+    Ok(ObservedValuesGeneration {
+        workspace_generation,
+        source_generation,
+    })
+}
+
+fn increment_workspace_generation(
+    connection: &Connection,
+    workspace_name: &WorkspaceName,
+) -> Result<(), SqliteSearchError> {
+    connection.execute(
+        "
+        INSERT INTO observed_workspace_generations (workspace, generation, updated_at)
+        VALUES (?1, 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        ON CONFLICT(workspace) DO UPDATE SET
+            generation = generation + 1,
+            updated_at = excluded.updated_at
+        ",
+        params![workspace_name.as_str()],
+    )?;
+    Ok(())
+}
+
+fn increment_source_generation(
+    connection: &Connection,
+    workspace_name: &WorkspaceName,
+    source_name: &str,
+) -> Result<(), SqliteSearchError> {
+    connection.execute(
+        "
+        INSERT INTO observed_source_generations (
+            workspace,
+            source_name,
+            generation,
+            updated_at
+        )
+        VALUES (?1, ?2, 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        ON CONFLICT(workspace, source_name) DO UPDATE SET
+            generation = generation + 1,
+            updated_at = excluded.updated_at
+        ",
+        params![workspace_name.as_str(), source_name],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SqliteObservedValuesStore;
+    use crate::search::observed::sqlite_queue::{
+        ObservedValuesEnqueueResult, ObservedValuesQueueJob, ObservedValuesSurfaceKind,
+    };
+    use crate::state::AppStateLayout;
+    use crate::workspaces::WorkspaceName;
+    use tempfile::tempdir;
+
+    #[test]
+    fn queue_job_is_durable_across_store_reopen() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let store = SqliteObservedValuesStore::new(layout.clone());
+        let generation = store
+            .current_generations(&workspace, "github")
+            .expect("generation");
+        let result = store
+            .enqueue_source_scan(&workspace, &test_job(), generation)
+            .expect("enqueue");
+
+        assert!(matches!(
+            result,
+            ObservedValuesEnqueueResult::Enqueued { .. }
+        ));
+        let reopened = SqliteObservedValuesStore::new(layout);
+        assert_eq!(
+            reopened
+                .pending_queue_job_count(&workspace)
+                .expect("queue count"),
+            1
+        );
+    }
+
+    #[test]
+    fn clear_workspace_does_not_need_source_manifests() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let store = SqliteObservedValuesStore::new(layout);
+        let generation = store
+            .current_generations(&workspace, "github")
+            .expect("generation");
+        store
+            .enqueue_source_scan(&workspace, &test_job(), generation)
+            .expect("enqueue");
+
+        store.clear_workspace(&workspace).expect("clear workspace");
+
+        assert_eq!(
+            store
+                .pending_queue_job_count(&workspace)
+                .expect("queue count"),
+            0
+        );
+        assert_eq!(
+            store
+                .current_generations(&workspace, "github")
+                .expect("generation")
+                .workspace_generation,
+            1
+        );
+    }
+
+    #[test]
+    fn stale_source_generation_is_not_enqueued() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let store = SqliteObservedValuesStore::new(layout);
+        let stale_generation = store
+            .current_generations(&workspace, "github")
+            .expect("generation");
+
+        store
+            .clear_source(&workspace, "github")
+            .expect("clear source");
+        let result = store
+            .enqueue_source_scan(&workspace, &test_job(), stale_generation)
+            .expect("enqueue");
+
+        assert_eq!(result, ObservedValuesEnqueueResult::StaleGeneration);
+        assert_eq!(
+            store
+                .pending_queue_job_count(&workspace)
+                .expect("queue count"),
+            0
+        );
+    }
+
+    #[test]
+    fn pending_queue_jobs_are_deduplicated_by_scope() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let store = SqliteObservedValuesStore::new(layout);
+        let generation = store
+            .current_generations(&workspace, "github")
+            .expect("generation");
+        store
+            .enqueue_source_scan(
+                &workspace,
+                &test_job_with("scope", "issues", "Bug"),
+                generation,
+            )
+            .expect("first enqueue");
+        store
+            .enqueue_source_scan(
+                &workspace,
+                &test_job_with("scope", "issues", "Fix"),
+                generation,
+            )
+            .expect("second enqueue");
+
+        assert_eq!(
+            store
+                .pending_queue_job_count(&workspace)
+                .expect("queue count"),
+            1
+        );
+        assert_eq!(
+            store.queue_payloads(&workspace).expect("payloads"),
+            [payload_json("Fix")]
+        );
+    }
+
+    #[test]
+    fn enqueue_respects_workspace_pending_queue_cap() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let store = SqliteObservedValuesStore::new(layout);
+        let generation = store
+            .current_generations(&workspace, "github")
+            .expect("generation");
+        store
+            .enqueue_source_scan(
+                &workspace,
+                &test_job_with("scope-1", "issues", "One"),
+                generation,
+            )
+            .expect("first enqueue");
+        store
+            .enqueue_source_scan(
+                &workspace,
+                &test_job_with("scope-2", "issues", "Two"),
+                generation,
+            )
+            .expect("second enqueue");
+        let result = store
+            .enqueue_source_scan(
+                &workspace,
+                &test_job_with("scope-3", "issues", "Three"),
+                generation,
+            )
+            .expect("third enqueue");
+
+        assert_eq!(result, ObservedValuesEnqueueResult::QueueFull);
+        assert_eq!(
+            store
+                .pending_queue_job_count(&workspace)
+                .expect("queue count"),
+            2
+        );
+    }
+
+    fn test_job() -> ObservedValuesQueueJob {
+        test_job_with("scope", "issues", "Bug")
+    }
+
+    fn test_job_with(
+        source_scope_id: &str,
+        surface_name: &str,
+        display_value: &str,
+    ) -> ObservedValuesQueueJob {
+        ObservedValuesQueueJob {
+            source_name: "github".to_string(),
+            source_scope_id: source_scope_id.to_string(),
+            surface_kind: ObservedValuesSurfaceKind::Table,
+            surface_name: surface_name.to_string(),
+            payload_json: payload_json(display_value),
+        }
+    }
+
+    fn payload_json(display_value: &str) -> String {
+        format!(
+            r#"{{"values":[{{"column_name":"title","display_value":"{display_value}","search_text":"{}","value_key":"key"}}]}}"#,
+            display_value.to_ascii_lowercase()
+        )
+    }
+}

--- a/crates/coral-app/src/search/observed/sqlite_store.rs
+++ b/crates/coral-app/src/search/observed/sqlite_store.rs
@@ -32,11 +32,11 @@ impl SqliteObservedValuesStore {
     pub(crate) fn current_generations(
         &self,
         workspace_name: &WorkspaceName,
-        source_name: &str,
+        owner_source_name: &str,
     ) -> Result<ObservedValuesGeneration, SqliteSearchError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let connection = store.connect()?;
-        observed_generations(&connection, workspace_name, source_name)
+        observed_generations(&connection, workspace_name, owner_source_name)
     }
 
     pub(crate) fn enqueue_source_scan(
@@ -49,7 +49,7 @@ impl SqliteObservedValuesStore {
         let mut connection = store.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let current_generation =
-            observed_generations(&transaction, workspace_name, &job.source_name)?;
+            observed_generations(&transaction, workspace_name, &job.owner_source_name)?;
         if current_generation != expected_generation {
             transaction.commit()?;
             return Ok(ObservedValuesEnqueueResult::StaleGeneration);
@@ -66,6 +66,7 @@ impl SqliteObservedValuesStore {
             "
             INSERT INTO observed_queue_jobs (
                 workspace,
+                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -85,11 +86,13 @@ impl SqliteObservedValuesStore {
                 ?6,
                 ?7,
                 ?8,
+                ?9,
                 strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
                 strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
             )
             ON CONFLICT(
                 workspace,
+                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -104,6 +107,7 @@ impl SqliteObservedValuesStore {
             ",
             params![
                 workspace_name.as_str(),
+                &job.owner_source_name,
                 &job.source_name,
                 &job.source_scope_id,
                 job.surface_kind.as_str(),
@@ -146,24 +150,24 @@ impl SqliteObservedValuesStore {
     pub(crate) fn clear_source(
         &self,
         workspace_name: &WorkspaceName,
-        source_name: &str,
+        owner_source_name: &str,
     ) -> Result<(), SqliteSearchError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let mut connection = store.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         transaction.execute(
-            "DELETE FROM observed_values_fts WHERE workspace = ?1 AND source_name = ?2",
-            params![workspace_name.as_str(), source_name],
+            "DELETE FROM observed_values_fts WHERE workspace = ?1 AND owner_source_name = ?2",
+            params![workspace_name.as_str(), owner_source_name],
         )?;
         transaction.execute(
-            "DELETE FROM observed_values WHERE workspace = ?1 AND source_name = ?2",
-            params![workspace_name.as_str(), source_name],
+            "DELETE FROM observed_values WHERE workspace = ?1 AND owner_source_name = ?2",
+            params![workspace_name.as_str(), owner_source_name],
         )?;
         transaction.execute(
-            "DELETE FROM observed_queue_jobs WHERE workspace = ?1 AND source_name = ?2",
-            params![workspace_name.as_str(), source_name],
+            "DELETE FROM observed_queue_jobs WHERE workspace = ?1 AND owner_source_name = ?2",
+            params![workspace_name.as_str(), owner_source_name],
         )?;
-        increment_source_generation(&transaction, workspace_name, source_name)?;
+        increment_source_generation(&transaction, workspace_name, owner_source_name)?;
         transaction.commit()?;
         Ok(())
     }
@@ -202,6 +206,28 @@ impl SqliteObservedValuesStore {
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(SqliteSearchError::from)
     }
+
+    #[cfg(test)]
+    pub(crate) fn queue_source_identities(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<(String, String, String)>, SqliteSearchError> {
+        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
+        let connection = store.connect()?;
+        let mut statement = connection.prepare(
+            "
+            SELECT owner_source_name, source_name, surface_name
+            FROM observed_queue_jobs
+            WHERE workspace = ?1
+            ORDER BY id
+            ",
+        )?;
+        let rows = statement.query_map(params![workspace_name.as_str()], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(SqliteSearchError::from)
+    }
 }
 
 fn pending_queue_job_count(
@@ -229,15 +255,17 @@ fn pending_queue_job_id(
             SELECT id
             FROM observed_queue_jobs
             WHERE workspace = ?1
-              AND source_name = ?2
-              AND source_scope_id = ?3
-              AND surface_kind = ?4
-              AND surface_name = ?5
-              AND workspace_generation = ?6
-              AND source_generation = ?7
+              AND owner_source_name = ?2
+              AND source_name = ?3
+              AND source_scope_id = ?4
+              AND surface_kind = ?5
+              AND surface_name = ?6
+              AND workspace_generation = ?7
+              AND source_generation = ?8
             ",
             params![
                 workspace_name.as_str(),
+                &job.owner_source_name,
                 &job.source_name,
                 &job.source_scope_id,
                 job.surface_kind.as_str(),
@@ -254,7 +282,7 @@ fn pending_queue_job_id(
 fn observed_generations(
     connection: &Connection,
     workspace_name: &WorkspaceName,
-    source_name: &str,
+    owner_source_name: &str,
 ) -> Result<ObservedValuesGeneration, SqliteSearchError> {
     let workspace_generation = connection
         .query_row(
@@ -275,7 +303,7 @@ fn observed_generations(
             FROM observed_source_generations
             WHERE workspace = ?1 AND source_name = ?2
             ",
-            params![workspace_name.as_str(), source_name],
+            params![workspace_name.as_str(), owner_source_name],
             |row| row.get(0),
         )
         .optional()?
@@ -306,7 +334,7 @@ fn increment_workspace_generation(
 fn increment_source_generation(
     connection: &Connection,
     workspace_name: &WorkspaceName,
-    source_name: &str,
+    owner_source_name: &str,
 ) -> Result<(), SqliteSearchError> {
     connection.execute(
         "
@@ -321,7 +349,7 @@ fn increment_source_generation(
             generation = generation + 1,
             updated_at = excluded.updated_at
         ",
-        params![workspace_name.as_str(), source_name],
+        params![workspace_name.as_str(), owner_source_name],
     )?;
     Ok(())
 }
@@ -509,6 +537,7 @@ mod tests {
         display_value: &str,
     ) -> ObservedValuesQueueJob {
         ObservedValuesQueueJob {
+            owner_source_name: "github".to_string(),
             source_name: "github".to_string(),
             source_scope_id: source_scope_id.to_string(),
             surface_kind: ObservedValuesSurfaceKind::Table,

--- a/crates/coral-app/src/search/observed/sqlite_store.rs
+++ b/crates/coral-app/src/search/observed/sqlite_store.rs
@@ -5,10 +5,10 @@
     reason = "observed-values provider substrate is staged before app wiring in the next PR"
 )]
 
-use rusqlite::{Connection, OptionalExtension as _, TransactionBehavior, params};
+use rusqlite::{Connection, OptionalExtension as _, Transaction, TransactionBehavior, params};
 
 use crate::search::observed::sqlite_queue::{
-    ObservedValuesEnqueueResult, ObservedValuesGeneration, ObservedValuesQueueJob,
+    ObservedValuesEnqueueResult, ObservedValuesEpoch, ObservedValuesQueueJob,
 };
 use crate::search::sqlite_store::{SqliteSearchError, SqliteSearchStore};
 use crate::state::AppStateLayout;
@@ -29,125 +29,44 @@ impl SqliteObservedValuesStore {
         Self { layout }
     }
 
-    pub(crate) fn current_generations(
+    pub(crate) fn capture_epoch(
         &self,
         workspace_name: &WorkspaceName,
         owner_source_name: &str,
-    ) -> Result<ObservedValuesGeneration, SqliteSearchError> {
+    ) -> Result<ObservedValuesEpoch, SqliteSearchError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let connection = store.connect()?;
-        observed_generations(&connection, workspace_name, owner_source_name)
+        read_epoch(&connection, workspace_name, owner_source_name)
     }
 
-    pub(crate) fn enqueue_source_scan(
+    pub(crate) fn enqueue_if_current(
         &self,
         workspace_name: &WorkspaceName,
         job: &ObservedValuesQueueJob,
-        expected_generation: ObservedValuesGeneration,
+        captured_epoch: ObservedValuesEpoch,
     ) -> Result<ObservedValuesEnqueueResult, SqliteSearchError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let mut connection = store.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let current_generation =
-            observed_generations(&transaction, workspace_name, &job.owner_source_name)?;
-        if current_generation != expected_generation {
-            transaction.commit()?;
-            return Ok(ObservedValuesEnqueueResult::StaleGeneration);
-        }
-        if pending_queue_job_id(&transaction, workspace_name, job, expected_generation)?.is_none()
-            && pending_queue_job_count(&transaction, workspace_name)?
-                >= MAX_PENDING_QUEUE_JOBS_PER_WORKSPACE
-        {
-            transaction.commit()?;
-            return Ok(ObservedValuesEnqueueResult::QueueFull);
-        }
-
-        transaction.execute(
-            "
-            INSERT INTO observed_queue_jobs (
-                workspace,
-                owner_source_name,
-                source_name,
-                source_scope_id,
-                surface_kind,
-                surface_name,
-                workspace_generation,
-                source_generation,
-                payload_json,
-                created_at,
-                updated_at
-            )
-            VALUES (
-                ?1,
-                ?2,
-                ?3,
-                ?4,
-                ?5,
-                ?6,
-                ?7,
-                ?8,
-                ?9,
-                strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
-                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-            )
-            ON CONFLICT(
-                workspace,
-                owner_source_name,
-                source_name,
-                source_scope_id,
-                surface_kind,
-                surface_name,
-                workspace_generation,
-                source_generation
-            ) DO UPDATE SET
-                payload_json = excluded.payload_json,
-                attempts = 0,
-                last_error = '',
-                updated_at = excluded.updated_at
-            ",
-            params![
-                workspace_name.as_str(),
-                &job.owner_source_name,
-                &job.source_name,
-                &job.source_scope_id,
-                job.surface_kind.as_str(),
-                &job.surface_name,
-                expected_generation.workspace_generation,
-                expected_generation.source_generation,
-                &job.payload_json,
-            ],
-        )?;
-        let job_id = pending_queue_job_id(&transaction, workspace_name, job, expected_generation)?
-            .expect("pending observed-values queue job should exist after upsert");
+        let result =
+            enqueue_if_current_in_transaction(&transaction, workspace_name, job, captured_epoch)?;
         transaction.commit()?;
-        Ok(ObservedValuesEnqueueResult::Enqueued { job_id })
+        Ok(result)
     }
 
-    pub(crate) fn clear_workspace(
+    pub(crate) fn clear_workspace_and_advance_epoch(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<(), SqliteSearchError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let mut connection = store.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        transaction.execute(
-            "DELETE FROM observed_values_fts WHERE workspace = ?1",
-            params![workspace_name.as_str()],
-        )?;
-        transaction.execute(
-            "DELETE FROM observed_values WHERE workspace = ?1",
-            params![workspace_name.as_str()],
-        )?;
-        transaction.execute(
-            "DELETE FROM observed_queue_jobs WHERE workspace = ?1",
-            params![workspace_name.as_str()],
-        )?;
-        increment_workspace_generation(&transaction, workspace_name)?;
+        clear_workspace_in_transaction(&transaction, workspace_name)?;
         transaction.commit()?;
         Ok(())
     }
 
-    pub(crate) fn clear_source(
+    pub(crate) fn clear_source_and_advance_epoch(
         &self,
         workspace_name: &WorkspaceName,
         owner_source_name: &str,
@@ -155,19 +74,7 @@ impl SqliteObservedValuesStore {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let mut connection = store.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        transaction.execute(
-            "DELETE FROM observed_values_fts WHERE workspace = ?1 AND owner_source_name = ?2",
-            params![workspace_name.as_str(), owner_source_name],
-        )?;
-        transaction.execute(
-            "DELETE FROM observed_values WHERE workspace = ?1 AND owner_source_name = ?2",
-            params![workspace_name.as_str(), owner_source_name],
-        )?;
-        transaction.execute(
-            "DELETE FROM observed_queue_jobs WHERE workspace = ?1 AND owner_source_name = ?2",
-            params![workspace_name.as_str(), owner_source_name],
-        )?;
-        increment_source_generation(&transaction, workspace_name, owner_source_name)?;
+        clear_source_in_transaction(&transaction, workspace_name, owner_source_name)?;
         transaction.commit()?;
         Ok(())
     }
@@ -230,6 +137,124 @@ impl SqliteObservedValuesStore {
     }
 }
 
+fn enqueue_if_current_in_transaction(
+    transaction: &Transaction<'_>,
+    workspace_name: &WorkspaceName,
+    job: &ObservedValuesQueueJob,
+    captured_epoch: ObservedValuesEpoch,
+) -> Result<ObservedValuesEnqueueResult, SqliteSearchError> {
+    let current_epoch = read_epoch(transaction, workspace_name, &job.owner_source_name)?;
+    if current_epoch != captured_epoch {
+        return Ok(ObservedValuesEnqueueResult::StaleEpoch);
+    }
+    if pending_queue_job_id(transaction, workspace_name, job, captured_epoch)?.is_none()
+        && pending_queue_job_count(transaction, workspace_name)?
+            >= MAX_PENDING_QUEUE_JOBS_PER_WORKSPACE
+    {
+        return Ok(ObservedValuesEnqueueResult::QueueFull);
+    }
+
+    transaction.execute(
+        "
+            INSERT INTO observed_queue_jobs (
+                workspace,
+                owner_source_name,
+                source_name,
+                source_scope_id,
+                surface_kind,
+                surface_name,
+                workspace_generation,
+                source_generation,
+                payload_json,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                ?1,
+                ?2,
+                ?3,
+                ?4,
+                ?5,
+                ?6,
+                ?7,
+                ?8,
+                ?9,
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+            ON CONFLICT(
+                workspace,
+                owner_source_name,
+                source_name,
+                source_scope_id,
+                surface_kind,
+                surface_name,
+                workspace_generation,
+                source_generation
+            ) DO UPDATE SET
+                payload_json = excluded.payload_json,
+                attempts = 0,
+                last_error = '',
+                updated_at = excluded.updated_at
+            ",
+        params![
+            workspace_name.as_str(),
+            &job.owner_source_name,
+            &job.source_name,
+            &job.source_scope_id,
+            job.surface_kind.as_str(),
+            &job.surface_name,
+            captured_epoch.workspace_generation,
+            captured_epoch.source_generation,
+            &job.payload_json,
+        ],
+    )?;
+    let job_id = pending_queue_job_id(transaction, workspace_name, job, captured_epoch)?
+        .expect("pending observed-values queue job should exist after upsert");
+    Ok(ObservedValuesEnqueueResult::Enqueued { job_id })
+}
+
+fn clear_workspace_in_transaction(
+    transaction: &Transaction<'_>,
+    workspace_name: &WorkspaceName,
+) -> Result<(), SqliteSearchError> {
+    transaction.execute(
+        "DELETE FROM observed_values_fts WHERE workspace = ?1",
+        params![workspace_name.as_str()],
+    )?;
+    transaction.execute(
+        "DELETE FROM observed_values WHERE workspace = ?1",
+        params![workspace_name.as_str()],
+    )?;
+    transaction.execute(
+        "DELETE FROM observed_queue_jobs WHERE workspace = ?1",
+        params![workspace_name.as_str()],
+    )?;
+    advance_workspace_epoch(transaction, workspace_name)?;
+    Ok(())
+}
+
+fn clear_source_in_transaction(
+    transaction: &Transaction<'_>,
+    workspace_name: &WorkspaceName,
+    owner_source_name: &str,
+) -> Result<(), SqliteSearchError> {
+    transaction.execute(
+        "DELETE FROM observed_values_fts WHERE workspace = ?1 AND owner_source_name = ?2",
+        params![workspace_name.as_str(), owner_source_name],
+    )?;
+    transaction.execute(
+        "DELETE FROM observed_values WHERE workspace = ?1 AND owner_source_name = ?2",
+        params![workspace_name.as_str(), owner_source_name],
+    )?;
+    transaction.execute(
+        "DELETE FROM observed_queue_jobs WHERE workspace = ?1 AND owner_source_name = ?2",
+        params![workspace_name.as_str(), owner_source_name],
+    )?;
+    advance_source_epoch(transaction, workspace_name, owner_source_name)?;
+    Ok(())
+}
+
 fn pending_queue_job_count(
     connection: &Connection,
     workspace_name: &WorkspaceName,
@@ -247,7 +272,7 @@ fn pending_queue_job_id(
     connection: &Connection,
     workspace_name: &WorkspaceName,
     job: &ObservedValuesQueueJob,
-    generation: ObservedValuesGeneration,
+    epoch: ObservedValuesEpoch,
 ) -> Result<Option<i64>, SqliteSearchError> {
     connection
         .query_row(
@@ -270,8 +295,8 @@ fn pending_queue_job_id(
                 &job.source_scope_id,
                 job.surface_kind.as_str(),
                 &job.surface_name,
-                generation.workspace_generation,
-                generation.source_generation,
+                epoch.workspace_generation,
+                epoch.source_generation,
             ],
             |row| row.get(0),
         )
@@ -279,11 +304,11 @@ fn pending_queue_job_id(
         .map_err(SqliteSearchError::from)
 }
 
-fn observed_generations(
+fn read_epoch(
     connection: &Connection,
     workspace_name: &WorkspaceName,
     owner_source_name: &str,
-) -> Result<ObservedValuesGeneration, SqliteSearchError> {
+) -> Result<ObservedValuesEpoch, SqliteSearchError> {
     let workspace_generation = connection
         .query_row(
             "
@@ -295,7 +320,7 @@ fn observed_generations(
             |row| row.get(0),
         )
         .optional()?
-        .unwrap_or(ObservedValuesGeneration::ZERO.workspace_generation);
+        .unwrap_or(ObservedValuesEpoch::ZERO.workspace_generation);
     let source_generation = connection
         .query_row(
             "
@@ -307,14 +332,14 @@ fn observed_generations(
             |row| row.get(0),
         )
         .optional()?
-        .unwrap_or(ObservedValuesGeneration::ZERO.source_generation);
-    Ok(ObservedValuesGeneration {
+        .unwrap_or(ObservedValuesEpoch::ZERO.source_generation);
+    Ok(ObservedValuesEpoch {
         workspace_generation,
         source_generation,
     })
 }
 
-fn increment_workspace_generation(
+fn advance_workspace_epoch(
     connection: &Connection,
     workspace_name: &WorkspaceName,
 ) -> Result<(), SqliteSearchError> {
@@ -331,7 +356,7 @@ fn increment_workspace_generation(
     Ok(())
 }
 
-fn increment_source_generation(
+fn advance_source_epoch(
     connection: &Connection,
     workspace_name: &WorkspaceName,
     owner_source_name: &str,
@@ -356,10 +381,19 @@ fn increment_source_generation(
 
 #[cfg(test)]
 mod tests {
-    use super::SqliteObservedValuesStore;
+    use std::sync::mpsc::sync_channel;
+    use std::thread;
+    use std::time::Duration;
+
+    use rusqlite::TransactionBehavior;
+
+    use super::{
+        SqliteObservedValuesStore, clear_source_in_transaction, enqueue_if_current_in_transaction,
+    };
     use crate::search::observed::sqlite_queue::{
         ObservedValuesEnqueueResult, ObservedValuesQueueJob, ObservedValuesSurfaceKind,
     };
+    use crate::search::sqlite_store::{SqliteSearchError, SqliteSearchStore};
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
     use tempfile::tempdir;
@@ -371,11 +405,9 @@ mod tests {
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let workspace = WorkspaceName::default();
         let store = SqliteObservedValuesStore::new(layout.clone());
-        let generation = store
-            .current_generations(&workspace, "github")
-            .expect("generation");
+        let epoch = store.capture_epoch(&workspace, "github").expect("epoch");
         let result = store
-            .enqueue_source_scan(&workspace, &test_job(), generation)
+            .enqueue_if_current(&workspace, &test_job(), epoch)
             .expect("enqueue");
 
         assert!(matches!(
@@ -398,14 +430,14 @@ mod tests {
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let workspace = WorkspaceName::default();
         let store = SqliteObservedValuesStore::new(layout);
-        let generation = store
-            .current_generations(&workspace, "github")
-            .expect("generation");
+        let epoch = store.capture_epoch(&workspace, "github").expect("epoch");
         store
-            .enqueue_source_scan(&workspace, &test_job(), generation)
+            .enqueue_if_current(&workspace, &test_job(), epoch)
             .expect("enqueue");
 
-        store.clear_workspace(&workspace).expect("clear workspace");
+        store
+            .clear_workspace_and_advance_epoch(&workspace)
+            .expect("clear workspace");
 
         assert_eq!(
             store
@@ -415,38 +447,183 @@ mod tests {
         );
         assert_eq!(
             store
-                .current_generations(&workspace, "github")
-                .expect("generation")
+                .capture_epoch(&workspace, "github")
+                .expect("epoch")
                 .workspace_generation,
             1
         );
     }
 
     #[test]
-    fn stale_source_generation_is_not_enqueued() {
+    fn stale_source_epoch_is_not_enqueued() {
         let temp = tempdir().expect("tempdir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let workspace = WorkspaceName::default();
         let store = SqliteObservedValuesStore::new(layout);
-        let stale_generation = store
-            .current_generations(&workspace, "github")
-            .expect("generation");
+        let stale_epoch = store.capture_epoch(&workspace, "github").expect("epoch");
 
         store
-            .clear_source(&workspace, "github")
+            .clear_source_and_advance_epoch(&workspace, "github")
             .expect("clear source");
         let result = store
-            .enqueue_source_scan(&workspace, &test_job(), stale_generation)
+            .enqueue_if_current(&workspace, &test_job(), stale_epoch)
             .expect("enqueue");
 
-        assert_eq!(result, ObservedValuesEnqueueResult::StaleGeneration);
+        assert_eq!(result, ObservedValuesEnqueueResult::StaleEpoch);
         assert_eq!(
             store
                 .pending_queue_job_count(&workspace)
                 .expect("queue count"),
             0
         );
+    }
+
+    #[test]
+    fn clear_transaction_committing_first_rejects_in_flight_observation() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let store = SqliteObservedValuesStore::new(layout.clone());
+        let captured_epoch = store
+            .capture_epoch(&workspace, "github")
+            .expect("captured epoch");
+
+        let search_store =
+            SqliteSearchStore::open_workspace(&layout, &workspace).expect("search store");
+        let mut connection = search_store.connect_for_test().expect("connection");
+        let mut contending_connection = search_store.connect_for_test().expect("contender");
+        contending_connection
+            .busy_timeout(Duration::ZERO)
+            .expect("disable contender wait");
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .expect("clear transaction");
+        clear_source_in_transaction(&transaction, &workspace, "github")
+            .expect("clear source in transaction");
+
+        let (contended_tx, contended_rx) = sync_channel(0);
+        let (retry_tx, retry_rx) = sync_channel(0);
+        let worker = thread::spawn({
+            let store = store.clone();
+            let workspace = workspace.clone();
+            move || {
+                contended_tx
+                    .send(immediate_transaction_is_locked(&mut contending_connection))
+                    .expect("report lock contention");
+                retry_rx.recv().expect("retry after clear commit");
+                store.enqueue_if_current(&workspace, &test_job(), captured_epoch)
+            }
+        });
+        assert!(
+            contended_rx.recv().expect("lock contention result"),
+            "enqueue must contend with the open clear transaction"
+        );
+        transaction.commit().expect("commit clear");
+        retry_tx.send(()).expect("resume enqueue");
+
+        let result = worker.join().expect("enqueue worker").expect("enqueue");
+        assert_eq!(result, ObservedValuesEnqueueResult::StaleEpoch);
+        assert_eq!(
+            store
+                .pending_queue_job_count(&workspace)
+                .expect("queue count"),
+            0
+        );
+    }
+
+    #[test]
+    fn enqueue_transaction_committing_first_is_removed_by_clear() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let store = SqliteObservedValuesStore::new(layout.clone());
+        let captured_epoch = store
+            .capture_epoch(&workspace, "github")
+            .expect("captured epoch");
+
+        let search_store =
+            SqliteSearchStore::open_workspace(&layout, &workspace).expect("search store");
+        let mut connection = search_store.connect_for_test().expect("connection");
+        let mut contending_connection = search_store.connect_for_test().expect("contender");
+        contending_connection
+            .busy_timeout(Duration::ZERO)
+            .expect("disable contender wait");
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .expect("enqueue transaction");
+        let result = enqueue_if_current_in_transaction(
+            &transaction,
+            &workspace,
+            &test_job(),
+            captured_epoch,
+        )
+        .expect("enqueue in transaction");
+        assert!(matches!(
+            result,
+            ObservedValuesEnqueueResult::Enqueued { .. }
+        ));
+
+        let (contended_tx, contended_rx) = sync_channel(0);
+        let (retry_tx, retry_rx) = sync_channel(0);
+        let worker = thread::spawn({
+            let store = store.clone();
+            let workspace = workspace.clone();
+            move || {
+                contended_tx
+                    .send(immediate_transaction_is_locked(&mut contending_connection))
+                    .expect("report lock contention");
+                retry_rx.recv().expect("retry after enqueue commit");
+                store.clear_source_and_advance_epoch(&workspace, "github")
+            }
+        });
+        assert!(
+            contended_rx.recv().expect("lock contention result"),
+            "clear must contend with the open enqueue transaction"
+        );
+        transaction.commit().expect("commit enqueue");
+        retry_tx.send(()).expect("resume clear");
+        worker.join().expect("clear worker").expect("clear source");
+
+        assert_eq!(
+            store
+                .pending_queue_job_count(&workspace)
+                .expect("queue count"),
+            0
+        );
+    }
+
+    #[test]
+    fn workspace_clear_invalidates_captured_source_epoch() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let store = SqliteObservedValuesStore::new(layout);
+        let captured_epoch = store
+            .capture_epoch(&workspace, "github")
+            .expect("captured epoch");
+
+        store
+            .clear_workspace_and_advance_epoch(&workspace)
+            .expect("clear workspace");
+        let result = store
+            .enqueue_if_current(&workspace, &test_job(), captured_epoch)
+            .expect("enqueue");
+
+        assert_eq!(result, ObservedValuesEnqueueResult::StaleEpoch);
+    }
+
+    fn immediate_transaction_is_locked(connection: &mut rusqlite::Connection) -> bool {
+        match connection.transaction_with_behavior(TransactionBehavior::Immediate) {
+            Ok(transaction) => {
+                drop(transaction);
+                false
+            }
+            Err(error) => SqliteSearchError::from(error).is_lock_contention(),
+        }
     }
 
     #[test]
@@ -456,22 +633,12 @@ mod tests {
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let workspace = WorkspaceName::default();
         let store = SqliteObservedValuesStore::new(layout);
-        let generation = store
-            .current_generations(&workspace, "github")
-            .expect("generation");
+        let epoch = store.capture_epoch(&workspace, "github").expect("epoch");
         store
-            .enqueue_source_scan(
-                &workspace,
-                &test_job_with("scope", "issues", "Bug"),
-                generation,
-            )
+            .enqueue_if_current(&workspace, &test_job_with("scope", "issues", "Bug"), epoch)
             .expect("first enqueue");
         store
-            .enqueue_source_scan(
-                &workspace,
-                &test_job_with("scope", "issues", "Fix"),
-                generation,
-            )
+            .enqueue_if_current(&workspace, &test_job_with("scope", "issues", "Fix"), epoch)
             .expect("second enqueue");
 
         assert_eq!(
@@ -493,28 +660,26 @@ mod tests {
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let workspace = WorkspaceName::default();
         let store = SqliteObservedValuesStore::new(layout);
-        let generation = store
-            .current_generations(&workspace, "github")
-            .expect("generation");
+        let epoch = store.capture_epoch(&workspace, "github").expect("epoch");
         store
-            .enqueue_source_scan(
+            .enqueue_if_current(
                 &workspace,
                 &test_job_with("scope-1", "issues", "One"),
-                generation,
+                epoch,
             )
             .expect("first enqueue");
         store
-            .enqueue_source_scan(
+            .enqueue_if_current(
                 &workspace,
                 &test_job_with("scope-2", "issues", "Two"),
-                generation,
+                epoch,
             )
             .expect("second enqueue");
         let result = store
-            .enqueue_source_scan(
+            .enqueue_if_current(
                 &workspace,
                 &test_job_with("scope-3", "issues", "Three"),
-                generation,
+                epoch,
             )
             .expect("third enqueue");
 

--- a/crates/coral-app/src/search/observed/writer.rs
+++ b/crates/coral-app/src/search/observed/writer.rs
@@ -1,0 +1,170 @@
+//! Bounded observed-values writer lifecycle and durable queue handoff.
+
+use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
+
+use serde::Serialize;
+
+use crate::search::observed::sqlite_queue::{
+    ObservedValueCandidate, ObservedValuesEnqueueResult, ObservedValuesGeneration,
+    ObservedValuesQueueJob, ObservedValuesQueuePayload, ObservedValuesSurfaceKind,
+};
+use crate::search::observed::sqlite_store::SqliteObservedValuesStore;
+use crate::workspaces::WorkspaceName;
+
+const OBSERVED_VALUES_WRITE_QUEUE_CAPACITY: usize = 128;
+
+#[derive(Debug, Clone)]
+pub(super) struct ObservedValuesWriter {
+    sender: SyncSender<ObservedValuesWrite>,
+}
+
+#[derive(Debug)]
+pub(super) struct ObservedValuesWrite {
+    pub(super) workspace_name: WorkspaceName,
+    pub(super) source_name: String,
+    pub(super) source_scope_id: String,
+    pub(super) surface_kind: ObservedValuesSurfaceKind,
+    pub(super) surface_name: String,
+    pub(super) payload: ObservedValuesQueuePayload,
+    pub(super) max_job_bytes: usize,
+    pub(super) generation: ObservedValuesGeneration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ObservedValuesTryEnqueueError {
+    Full,
+    Disconnected,
+}
+
+impl ObservedValuesWriter {
+    pub(super) fn start(store: SqliteObservedValuesStore) -> Self {
+        let (sender, receiver) = sync_channel(OBSERVED_VALUES_WRITE_QUEUE_CAPACITY);
+        if let Err(error) = std::thread::Builder::new()
+            .name("coral-observed-values-writer".to_string())
+            .spawn(move || run_observed_values_writer(&store, receiver))
+        {
+            tracing::warn!(
+                error = %error,
+                "failed to start observed-values background writer"
+            );
+        }
+        Self { sender }
+    }
+
+    pub(super) fn try_enqueue(
+        &self,
+        write: ObservedValuesWrite,
+    ) -> Result<(), ObservedValuesTryEnqueueError> {
+        self.sender.try_send(write).map_err(|error| match error {
+            TrySendError::Full(_) => ObservedValuesTryEnqueueError::Full,
+            TrySendError::Disconnected(_) => ObservedValuesTryEnqueueError::Disconnected,
+        })
+    }
+}
+
+fn run_observed_values_writer(
+    store: &SqliteObservedValuesStore,
+    receiver: Receiver<ObservedValuesWrite>,
+) {
+    for write in receiver {
+        let payload_json = match payload_json_with_budget(write.payload, write.max_job_bytes) {
+            Ok(Some(payload_json)) => payload_json,
+            Ok(None) => {
+                tracing::debug!(
+                    workspace = %write.workspace_name.as_str(),
+                    source = %write.source_name,
+                    surface = %write.surface_name,
+                    "dropping observed-values source-scan observation because serialized payload exceeds job budget"
+                );
+                continue;
+            }
+            Err(error) => {
+                tracing::debug!(
+                    workspace = %write.workspace_name.as_str(),
+                    source = %write.source_name,
+                    surface = %write.surface_name,
+                    error = %error,
+                    "failed to serialize observed-values source-scan observation"
+                );
+                continue;
+            }
+        };
+        let job = ObservedValuesQueueJob {
+            source_name: write.source_name,
+            source_scope_id: write.source_scope_id,
+            surface_kind: write.surface_kind,
+            surface_name: write.surface_name,
+            payload_json,
+        };
+        match store.enqueue_source_scan(&write.workspace_name, &job, write.generation) {
+            Ok(ObservedValuesEnqueueResult::Enqueued { .. }) => {}
+            Ok(ObservedValuesEnqueueResult::StaleGeneration) => {
+                tracing::debug!(
+                    workspace = %write.workspace_name.as_str(),
+                    source = %job.source_name,
+                    surface = %job.surface_name,
+                    "dropping stale observed-values source-scan observation"
+                );
+            }
+            Ok(ObservedValuesEnqueueResult::QueueFull) => {
+                tracing::debug!(
+                    workspace = %write.workspace_name.as_str(),
+                    source = %job.source_name,
+                    surface = %job.surface_name,
+                    "dropping observed-values source-scan observation because durable queue is full"
+                );
+            }
+            Err(error) => {
+                tracing::debug!(
+                    workspace = %write.workspace_name.as_str(),
+                    source = %job.source_name,
+                    surface = %job.surface_name,
+                    error = %error,
+                    "failed to enqueue observed-values source-scan observation"
+                );
+            }
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ObservedValuesQueuePayloadRef<'a> {
+    values: &'a [ObservedValueCandidate],
+}
+
+pub(super) fn payload_json_with_budget(
+    payload: ObservedValuesQueuePayload,
+    max_job_bytes: usize,
+) -> Result<Option<String>, String> {
+    if payload.is_empty() {
+        return Ok(None);
+    }
+    let values = payload.values;
+    let payload_json = payload_json_for_values(&values)?;
+    if payload_json.len() <= max_job_bytes {
+        return Ok(Some(payload_json));
+    }
+
+    let mut best = None;
+    let mut low = 0_usize;
+    let mut high = values.len();
+    while low < high {
+        let candidate_len = (low + high).div_ceil(2);
+        let candidate_values = values
+            .get(..candidate_len)
+            .expect("binary-search prefix length stays within observed-values payload bounds");
+        let candidate_json = payload_json_for_values(candidate_values)?;
+        if candidate_json.len() <= max_job_bytes {
+            best = Some(candidate_json);
+            low = candidate_len;
+        } else {
+            high = candidate_len.saturating_sub(1);
+        }
+    }
+    Ok(best)
+}
+
+fn payload_json_for_values(values: &[ObservedValueCandidate]) -> Result<String, String> {
+    serde_json::to_string(&ObservedValuesQueuePayloadRef { values })
+        .map_err(|error| error.to_string())
+}

--- a/crates/coral-app/src/search/observed/writer.rs
+++ b/crates/coral-app/src/search/observed/writer.rs
@@ -21,6 +21,7 @@ pub(super) struct ObservedValuesWriter {
 #[derive(Debug)]
 pub(super) struct ObservedValuesWrite {
     pub(super) workspace_name: WorkspaceName,
+    pub(super) owner_source_name: String,
     pub(super) source_name: String,
     pub(super) source_scope_id: String,
     pub(super) surface_kind: ObservedValuesSurfaceKind,
@@ -90,6 +91,7 @@ fn run_observed_values_writer(
             }
         };
         let job = ObservedValuesQueueJob {
+            owner_source_name: write.owner_source_name,
             source_name: write.source_name,
             source_scope_id: write.source_scope_id,
             surface_kind: write.surface_kind,

--- a/crates/coral-app/src/search/observed/writer.rs
+++ b/crates/coral-app/src/search/observed/writer.rs
@@ -1,11 +1,10 @@
 //! Bounded observed-values writer lifecycle and durable queue handoff.
 
-use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
-
 use serde::Serialize;
+use tokio::sync::mpsc::{self, Receiver, Sender, error::TrySendError};
 
 use crate::search::observed::sqlite_queue::{
-    ObservedValueCandidate, ObservedValuesEnqueueResult, ObservedValuesGeneration,
+    ObservedValueCandidate, ObservedValuesEnqueueResult, ObservedValuesEpoch,
     ObservedValuesQueueJob, ObservedValuesQueuePayload, ObservedValuesSurfaceKind,
 };
 use crate::search::observed::sqlite_store::SqliteObservedValuesStore;
@@ -15,7 +14,7 @@ const OBSERVED_VALUES_WRITE_QUEUE_CAPACITY: usize = 128;
 
 #[derive(Debug, Clone)]
 pub(super) struct ObservedValuesWriter {
-    sender: SyncSender<ObservedValuesWrite>,
+    sender: Sender<ObservedValuesWrite>,
 }
 
 #[derive(Debug)]
@@ -26,20 +25,29 @@ pub(super) struct ObservedValuesWrite {
     pub(super) source_scope_id: String,
     pub(super) surface_kind: ObservedValuesSurfaceKind,
     pub(super) surface_name: String,
-    pub(super) payload: ObservedValuesQueuePayload,
-    pub(super) max_job_bytes: usize,
-    pub(super) generation: ObservedValuesGeneration,
+    pub(super) payload_json: String,
+    pub(super) epoch: ObservedValuesEpoch,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum ObservedValuesTryEnqueueError {
+pub(super) enum ObservedValuesTryReserveError {
     Full,
     Disconnected,
 }
 
+pub(super) struct ObservedValuesWritePermit<'a> {
+    permit: mpsc::Permit<'a, ObservedValuesWrite>,
+}
+
+impl ObservedValuesWritePermit<'_> {
+    pub(super) fn send(self, write: ObservedValuesWrite) {
+        self.permit.send(write);
+    }
+}
+
 impl ObservedValuesWriter {
     pub(super) fn start(store: SqliteObservedValuesStore) -> Self {
-        let (sender, receiver) = sync_channel(OBSERVED_VALUES_WRITE_QUEUE_CAPACITY);
+        let (sender, receiver) = mpsc::channel(OBSERVED_VALUES_WRITE_QUEUE_CAPACITY);
         if let Err(error) = std::thread::Builder::new()
             .name("coral-observed-values-writer".to_string())
             .spawn(move || run_observed_values_writer(&store, receiver))
@@ -52,55 +60,35 @@ impl ObservedValuesWriter {
         Self { sender }
     }
 
-    pub(super) fn try_enqueue(
+    pub(super) fn try_reserve(
         &self,
-        write: ObservedValuesWrite,
-    ) -> Result<(), ObservedValuesTryEnqueueError> {
-        self.sender.try_send(write).map_err(|error| match error {
-            TrySendError::Full(_) => ObservedValuesTryEnqueueError::Full,
-            TrySendError::Disconnected(_) => ObservedValuesTryEnqueueError::Disconnected,
-        })
+    ) -> Result<ObservedValuesWritePermit<'_>, ObservedValuesTryReserveError> {
+        self.sender
+            .try_reserve()
+            .map(|permit| ObservedValuesWritePermit { permit })
+            .map_err(|error| match error {
+                TrySendError::Full(()) => ObservedValuesTryReserveError::Full,
+                TrySendError::Closed(()) => ObservedValuesTryReserveError::Disconnected,
+            })
     }
 }
 
 fn run_observed_values_writer(
     store: &SqliteObservedValuesStore,
-    receiver: Receiver<ObservedValuesWrite>,
+    mut receiver: Receiver<ObservedValuesWrite>,
 ) {
-    for write in receiver {
-        let payload_json = match payload_json_with_budget(write.payload, write.max_job_bytes) {
-            Ok(Some(payload_json)) => payload_json,
-            Ok(None) => {
-                tracing::debug!(
-                    workspace = %write.workspace_name.as_str(),
-                    source = %write.source_name,
-                    surface = %write.surface_name,
-                    "dropping observed-values source-scan observation because serialized payload exceeds job budget"
-                );
-                continue;
-            }
-            Err(error) => {
-                tracing::debug!(
-                    workspace = %write.workspace_name.as_str(),
-                    source = %write.source_name,
-                    surface = %write.surface_name,
-                    error = %error,
-                    "failed to serialize observed-values source-scan observation"
-                );
-                continue;
-            }
-        };
+    while let Some(write) = receiver.blocking_recv() {
         let job = ObservedValuesQueueJob {
             owner_source_name: write.owner_source_name,
             source_name: write.source_name,
             source_scope_id: write.source_scope_id,
             surface_kind: write.surface_kind,
             surface_name: write.surface_name,
-            payload_json,
+            payload_json: write.payload_json,
         };
-        match store.enqueue_source_scan(&write.workspace_name, &job, write.generation) {
+        match store.enqueue_if_current(&write.workspace_name, &job, write.epoch) {
             Ok(ObservedValuesEnqueueResult::Enqueued { .. }) => {}
-            Ok(ObservedValuesEnqueueResult::StaleGeneration) => {
+            Ok(ObservedValuesEnqueueResult::StaleEpoch) => {
                 tracing::debug!(
                     workspace = %write.workspace_name.as_str(),
                     source = %job.source_name,
@@ -169,4 +157,46 @@ pub(super) fn payload_json_with_budget(
 fn payload_json_for_values(values: &[ObservedValueCandidate]) -> Result<String, String> {
     serde_json::to_string(&ObservedValuesQueuePayloadRef { values })
         .map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ObservedValuesTryReserveError, ObservedValuesWrite, ObservedValuesWriter};
+    use crate::search::observed::sqlite_queue::{ObservedValuesEpoch, ObservedValuesSurfaceKind};
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn writer_capacity_is_reserved_before_a_write_is_built() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let writer = ObservedValuesWriter { sender };
+
+        let permit = writer.try_reserve().expect("first reservation");
+        assert!(matches!(
+            writer.try_reserve(),
+            Err(ObservedValuesTryReserveError::Full)
+        ));
+
+        permit.send(test_write());
+        assert!(matches!(
+            writer.try_reserve(),
+            Err(ObservedValuesTryReserveError::Full)
+        ));
+        receiver.try_recv().expect("reserved write");
+        writer
+            .try_reserve()
+            .expect("capacity should return after dequeue");
+    }
+
+    fn test_write() -> ObservedValuesWrite {
+        ObservedValuesWrite {
+            workspace_name: WorkspaceName::default(),
+            owner_source_name: "github".to_string(),
+            source_name: "github".to_string(),
+            source_scope_id: "scope".to_string(),
+            surface_kind: ObservedValuesSurfaceKind::Table,
+            surface_name: "issues".to_string(),
+            payload_json: r#"{"values":[]}"#.to_string(),
+            epoch: ObservedValuesEpoch::ZERO,
+        }
+    }
 }

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -248,6 +248,8 @@ pub(crate) enum SqliteSearchError {
         database_version: u32,
         supported_version: u32,
     },
+    #[error("SQLite search schema is incomplete after rebuilding version {schema_version}")]
+    IncompleteSchemaAfterRebuild { schema_version: u32 },
 }
 
 impl SqliteSearchError {
@@ -275,7 +277,9 @@ impl SqliteSearchError {
                 error.sqlite_error_code(),
                 Some(ErrorCode::DiskFull | ErrorCode::OutOfMemory | ErrorCode::TooBig)
             ),
-            Self::UnsupportedCapability { .. } | Self::UnsupportedSchemaVersion { .. } => false,
+            Self::UnsupportedCapability { .. }
+            | Self::UnsupportedSchemaVersion { .. }
+            | Self::IncompleteSchemaAfterRebuild { .. } => false,
         }
     }
 }
@@ -403,17 +407,91 @@ fn migrate_if_needed(connection: &mut Connection) -> Result<(), SqliteSearchErro
         });
     }
 
-    // Repair mode deliberately reruns every current migration when the version
-    // stamp says "current" but required schema objects are missing. Keep every
-    // migration idempotent: use IF NOT EXISTS and conflict-safe metadata writes.
-    let repair_current_version = user_version == SEARCH_SQLITE_SCHEMA_VERSION;
-    for migration in SEARCH_SQLITE_MIGRATIONS {
-        let should_apply = migration.version > user_version || repair_current_version;
-        if !should_apply {
-            continue;
+    // Replay the full idempotent history before upgrading so a damaged older
+    // schema cannot carry missing objects into the current version.
+    match apply_all_migrations(connection) {
+        Ok(()) if schema_is_current(connection)? => return Ok(()),
+        Ok(()) => {
+            tracing::warn!(
+                "SQLite search schema remained incomplete after repair; rebuilding the disposable search index"
+            );
         }
+        Err(error) if schema_rebuild_can_recover(&error) => {
+            tracing::warn!(
+                error = %error,
+                "SQLite search schema repair failed; rebuilding the disposable search index"
+            );
+        }
+        Err(error) => return Err(error),
+    }
+
+    discard_search_index_schema(connection)?;
+    apply_all_migrations(connection)?;
+    if !schema_is_current(connection)? {
+        return Err(SqliteSearchError::IncompleteSchemaAfterRebuild {
+            schema_version: SEARCH_SQLITE_SCHEMA_VERSION,
+        });
+    }
+    Ok(())
+}
+
+fn schema_rebuild_can_recover(error: &SqliteSearchError) -> bool {
+    matches!(
+        error,
+        SqliteSearchError::Sqlite(error)
+            if matches!(
+                error.sqlite_error_code(),
+                Some(ErrorCode::Unknown | ErrorCode::SchemaChanged)
+            )
+    )
+}
+
+fn apply_all_migrations(connection: &mut Connection) -> Result<(), SqliteSearchError> {
+    for migration in SEARCH_SQLITE_MIGRATIONS {
         apply_migration(connection, migration)?;
     }
+    Ok(())
+}
+
+fn discard_search_index_schema(connection: &mut Connection) -> Result<(), SqliteSearchError> {
+    let objects = {
+        let mut statement = connection.prepare(
+            "
+            SELECT type, name
+            FROM sqlite_schema
+            WHERE type IN ('trigger', 'view', 'index', 'table')
+              AND name NOT GLOB 'sqlite_*'
+            ORDER BY CASE
+                WHEN type = 'trigger' THEN 0
+                WHEN type = 'view' THEN 1
+                WHEN type = 'index' THEN 2
+                WHEN sql LIKE 'CREATE VIRTUAL TABLE%' THEN 3
+                ELSE 4
+            END,
+            name
+            ",
+        )?;
+        statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+
+    let transaction = connection.transaction()?;
+    for (object_type, name) in objects {
+        let drop_kind = match object_type.as_str() {
+            "trigger" => "TRIGGER",
+            "view" => "VIEW",
+            "index" => "INDEX",
+            "table" => "TABLE",
+            _ => continue,
+        };
+        let quoted_name = format!("\"{}\"", name.replace('"', "\"\""));
+        transaction.execute_batch(&format!("DROP {drop_kind} IF EXISTS {quoted_name}"))?;
+    }
+    transaction.pragma_update(None, "user_version", 0)?;
+    transaction.commit()?;
     Ok(())
 }
 
@@ -540,6 +618,92 @@ mod tests {
     }
 
     #[test]
+    fn opening_v1_repairs_missing_search_meta_before_upgrade() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let connection = v1_search_connection(&path);
+        seed_catalog_document(&connection);
+        connection
+            .execute_batch("DROP TABLE search_meta")
+            .expect("remove v1 metadata table");
+        drop(connection);
+
+        let connection = open_current_search_connection(&path);
+        assert_eq!(catalog_document_count(&connection), 1);
+    }
+
+    #[test]
+    fn opening_v1_repairs_missing_catalog_table_before_upgrade() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let connection = v1_search_connection(&path);
+        connection
+            .execute_batch("DROP TABLE catalog_documents")
+            .expect("remove v1 catalog table");
+        drop(connection);
+
+        let connection = open_current_search_connection(&path);
+        assert_eq!(catalog_document_count(&connection), 0);
+    }
+
+    #[test]
+    fn opening_v1_repairs_missing_catalog_fts_before_upgrade() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let connection = v1_search_connection(&path);
+        seed_catalog_document(&connection);
+        connection
+            .execute_batch("DROP TABLE catalog_documents_fts")
+            .expect("remove v1 catalog FTS table");
+        drop(connection);
+
+        let connection = open_current_search_connection(&path);
+        assert_eq!(catalog_document_count(&connection), 1);
+    }
+
+    #[test]
+    fn opening_v1_rebuilds_disposable_index_when_repair_stays_invalid() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let connection = v1_search_connection(&path);
+        connection
+            .execute(
+                "INSERT INTO search_meta (key, value) VALUES ('sentinel', 'discarded')",
+                [],
+            )
+            .expect("seed disposable search metadata");
+        connection
+            .execute_batch(
+                "
+                DROP TABLE catalog_documents;
+                CREATE VIEW catalog_documents AS SELECT 1 AS malformed;
+                ",
+            )
+            .expect("replace catalog table with malformed v1 object");
+        drop(connection);
+
+        let connection = open_current_search_connection(&path);
+        let object_type = connection
+            .query_row(
+                "SELECT type FROM sqlite_schema WHERE name = 'catalog_documents'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .expect("catalog object type");
+        let sentinel = connection
+            .query_row(
+                "SELECT value FROM search_meta WHERE key = 'sentinel'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .expect("sentinel metadata query");
+
+        assert_eq!(object_type, "table");
+        assert_eq!(sentinel, None);
+    }
+
+    #[test]
     fn open_workspace_creates_search_sqlite_schema() {
         let temp = tempdir().expect("tempdir");
         let layout =
@@ -662,6 +826,26 @@ mod tests {
     }
 
     #[test]
+    fn schema_rebuild_only_follows_repairable_schema_errors() {
+        let schema_error = SqliteSearchError::Sqlite(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
+            None,
+        ));
+        let locked = SqliteSearchError::Sqlite(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+            None,
+        ));
+        let disk_full = SqliteSearchError::Sqlite(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_FULL),
+            None,
+        ));
+
+        assert!(super::schema_rebuild_can_recover(&schema_error));
+        assert!(!super::schema_rebuild_can_recover(&locked));
+        assert!(!super::schema_rebuild_can_recover(&disk_full));
+    }
+
+    #[test]
     fn wal_checkpoint_reports_reader_contention() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("checkpoint.sqlite3");
@@ -762,5 +946,48 @@ mod tests {
                 .expect("schema object lookup");
             assert!(exists, "{table_name} should exist after repair");
         }
+    }
+
+    fn v1_search_connection(path: &std::path::Path) -> Connection {
+        let mut connection = Connection::open(path).expect("raw v1 connection");
+        super::apply_migration(
+            &mut connection,
+            SEARCH_SQLITE_MIGRATIONS.first().expect("v1 migration"),
+        )
+        .expect("apply v1 migration");
+        connection
+    }
+
+    fn open_current_search_connection(path: &std::path::Path) -> Connection {
+        let store = SqliteSearchStore::open(path, WorkspaceName::default()).expect("open search");
+        let connection = store.connect_for_test().expect("connect");
+        assert!(super::schema_is_current(&connection).expect("validate current schema"));
+        connection
+    }
+
+    fn seed_catalog_document(connection: &Connection) {
+        connection
+            .execute(
+                "
+                INSERT INTO catalog_documents (
+                    workspace,
+                    doc_id,
+                    doc_kind,
+                    title,
+                    payload_json,
+                    snapshot_fingerprint
+                ) VALUES ('default', 'fixture', 'catalog_table', 'Fixture', '{}', 'fixture')
+                ",
+                [],
+            )
+            .expect("seed catalog document");
+    }
+
+    fn catalog_document_count(connection: &Connection) -> i64 {
+        connection
+            .query_row("SELECT COUNT(*) FROM catalog_documents", [], |row| {
+                row.get(0)
+            })
+            .expect("catalog document count")
     }
 }

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -22,7 +22,7 @@ use crate::state::AppStateLayout;
 use crate::storage::fs::create_new_file_private;
 use crate::workspaces::WorkspaceName;
 
-pub(crate) const SEARCH_SQLITE_SCHEMA_VERSION: u32 = 1;
+pub(crate) const SEARCH_SQLITE_SCHEMA_VERSION: u32 = 2;
 
 struct SearchSqliteMigration {
     version: u32,
@@ -32,10 +32,16 @@ struct SearchSqliteMigration {
 // These migrations are intentionally local to the SQLite search sidecar. The
 // schema uses SQLite FTS5/trigram features that are not portable to the shared
 // app database migration stream.
-const SEARCH_SQLITE_MIGRATIONS: &[SearchSqliteMigration] = &[SearchSqliteMigration {
-    version: 1,
-    sql: include_str!("migrations/0001_catalog_search.sql"),
-}];
+const SEARCH_SQLITE_MIGRATIONS: &[SearchSqliteMigration] = &[
+    SearchSqliteMigration {
+        version: 1,
+        sql: include_str!("migrations/0001_catalog_search.sql"),
+    },
+    SearchSqliteMigration {
+        version: 2,
+        sql: include_str!("migrations/0002_observed_values.sql"),
+    },
+];
 
 #[derive(Debug, Clone)]
 pub(crate) struct SqliteSearchStore {
@@ -83,7 +89,7 @@ impl SqliteSearchStore {
         })
     }
 
-    fn connect(&self) -> Result<Connection, SqliteSearchError> {
+    pub(super) fn connect(&self) -> Result<Connection, SqliteSearchError> {
         let connection = Connection::open(&self.path)?;
         configure_connection(&connection)?;
         Ok(connection)
@@ -397,10 +403,12 @@ fn migrate_if_needed(connection: &mut Connection) -> Result<(), SqliteSearchErro
         });
     }
 
+    // Repair mode deliberately reruns every current migration when the version
+    // stamp says "current" but required schema objects are missing. Keep every
+    // migration idempotent: use IF NOT EXISTS and conflict-safe metadata writes.
     let repair_current_version = user_version == SEARCH_SQLITE_SCHEMA_VERSION;
     for migration in SEARCH_SQLITE_MIGRATIONS {
-        let should_apply = migration.version > user_version
-            || (repair_current_version && migration.version == user_version);
+        let should_apply = migration.version > user_version || repair_current_version;
         if !should_apply {
             continue;
         }
@@ -437,7 +445,16 @@ fn schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError>
         return Ok(false);
     }
 
-    for table_name in ["search_meta", "catalog_documents", "catalog_documents_fts"] {
+    for table_name in [
+        "search_meta",
+        "catalog_documents",
+        "catalog_documents_fts",
+        "observed_workspace_generations",
+        "observed_source_generations",
+        "observed_values",
+        "observed_values_fts",
+        "observed_queue_jobs",
+    ] {
         let exists: bool = connection.query_row(
             "
             SELECT EXISTS (
@@ -447,6 +464,28 @@ fn schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError>
             )
             ",
             [table_name],
+            |row| row.get(0),
+        )?;
+        if !exists {
+            return Ok(false);
+        }
+    }
+
+    for index_name in [
+        "idx_observed_queue_jobs_workspace_id",
+        "idx_observed_queue_jobs_source",
+        "idx_observed_queue_jobs_pending_scope",
+        "idx_observed_values_source",
+    ] {
+        let exists: bool = connection.query_row(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM sqlite_master
+                WHERE type = 'index' AND name = ?1
+            )
+            ",
+            [index_name],
             |row| row.get(0),
         )?;
         if !exists {
@@ -481,6 +520,23 @@ mod tests {
         }
 
         assert_eq!(previous_version, SEARCH_SQLITE_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn search_sqlite_migrations_are_rerunnable() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let mut connection = rusqlite::Connection::open(&path).expect("raw connection");
+
+        for migration in SEARCH_SQLITE_MIGRATIONS {
+            super::apply_migration(&mut connection, migration).expect("first apply");
+            super::apply_migration(&mut connection, migration).expect("second apply");
+        }
+
+        let user_version: u32 = connection
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("user_version");
+        assert_eq!(user_version, SEARCH_SQLITE_SCHEMA_VERSION);
     }
 
     #[test]

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -412,19 +412,32 @@ fn migrate_if_needed(connection: &mut Connection) -> Result<(), SqliteSearchErro
     match apply_all_migrations(connection) {
         Ok(()) if schema_is_current(connection)? => return Ok(()),
         Ok(()) => {
-            tracing::warn!(
-                "SQLite search schema remained incomplete after repair; rebuilding the disposable search index"
-            );
+            tracing::warn!("SQLite search schema remained incomplete after replaying migrations");
         }
         Err(error) if schema_rebuild_can_recover(&error) => {
             tracing::warn!(
                 error = %error,
-                "SQLite search schema repair failed; rebuilding the disposable search index"
+                "SQLite search schema repair failed while replaying migrations"
             );
         }
         Err(error) => return Err(error),
     }
 
+    if catalog_schema_is_current(connection)? {
+        tracing::warn!(
+            "resetting incompatible observed-values schema while preserving the catalog index"
+        );
+        discard_observed_values_schema(connection)?;
+        apply_all_migrations(connection)?;
+        if schema_is_current(connection)? {
+            return Ok(());
+        }
+        return Err(SqliteSearchError::IncompleteSchemaAfterRebuild {
+            schema_version: SEARCH_SQLITE_SCHEMA_VERSION,
+        });
+    }
+
+    tracing::warn!("rebuilding the disposable search index after catalog schema repair failed");
     discard_search_index_schema(connection)?;
     apply_all_migrations(connection)?;
     if !schema_is_current(connection)? {
@@ -440,16 +453,69 @@ fn schema_rebuild_can_recover(error: &SqliteSearchError) -> bool {
         error,
         SqliteSearchError::Sqlite(error)
             if matches!(
-                error.sqlite_error_code(),
+                sqlite_error_code(error),
                 Some(ErrorCode::Unknown | ErrorCode::SchemaChanged)
             )
     )
+}
+
+fn sqlite_error_code(error: &rusqlite::Error) -> Option<ErrorCode> {
+    match error {
+        rusqlite::Error::SqliteFailure(error, _) | rusqlite::Error::SqlInputError { error, .. } => {
+            Some(error.code)
+        }
+        _ => None,
+    }
 }
 
 fn apply_all_migrations(connection: &mut Connection) -> Result<(), SqliteSearchError> {
     for migration in SEARCH_SQLITE_MIGRATIONS {
         apply_migration(connection, migration)?;
     }
+    Ok(())
+}
+
+fn discard_observed_values_schema(connection: &mut Connection) -> Result<(), SqliteSearchError> {
+    let objects = {
+        let mut statement = connection.prepare(
+            "
+            SELECT type, name
+            FROM sqlite_schema
+            WHERE type IN ('trigger', 'view', 'index', 'table')
+              AND (
+                  name GLOB 'observed_*'
+                  OR name GLOB 'idx_observed_*'
+              )
+            ORDER BY CASE
+                WHEN type = 'trigger' THEN 0
+                WHEN type = 'view' THEN 1
+                WHEN type = 'index' THEN 2
+                WHEN sql LIKE 'CREATE VIRTUAL TABLE%' THEN 3
+                ELSE 4
+            END,
+            name
+            ",
+        )?;
+        statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+
+    let transaction = connection.transaction()?;
+    for (object_type, name) in objects {
+        let drop_kind = match object_type.as_str() {
+            "trigger" => "TRIGGER",
+            "view" => "VIEW",
+            "index" => "INDEX",
+            "table" => "TABLE",
+            _ => continue,
+        };
+        let quoted_name = format!("\"{}\"", name.replace('"', "\"\""));
+        transaction.execute_batch(&format!("DROP {drop_kind} IF EXISTS {quoted_name}"))?;
+    }
+    transaction.commit()?;
     Ok(())
 }
 
@@ -523,16 +589,157 @@ fn schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError>
         return Ok(false);
     }
 
-    for table_name in [
-        "search_meta",
-        "catalog_documents",
-        "catalog_documents_fts",
-        "observed_workspace_generations",
-        "observed_source_generations",
-        "observed_values",
-        "observed_values_fts",
-        "observed_queue_jobs",
+    Ok(catalog_schema_is_current(connection)? && observed_values_schema_is_current(connection)?)
+}
+
+fn catalog_schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError> {
+    if !tables_exist(
+        connection,
+        &["search_meta", "catalog_documents", "catalog_documents_fts"],
+    )? {
+        return Ok(false);
+    }
+    let search_meta_is_valid = schema_query_is_valid(
+        connection,
+        "SELECT key, value, updated_at FROM search_meta LIMIT 0",
+    )?;
+    let catalog_table_is_valid = schema_query_is_valid(
+        connection,
+        "
+        SELECT
+            workspace,
+            doc_id,
+            doc_kind,
+            source_name,
+            surface_kind,
+            surface_name,
+            field_name,
+            field_role,
+            qualified_name,
+            title,
+            description,
+            payload_json,
+            snapshot_fingerprint,
+            updated_at
+        FROM catalog_documents
+        LIMIT 0
+        ",
+    )?;
+    let catalog_fts_is_valid = schema_query_is_valid(
+        connection,
+        "
+        SELECT
+            workspace,
+            doc_id,
+            title,
+            qualified_name,
+            description,
+            searchable_text
+        FROM catalog_documents_fts
+        LIMIT 0
+        ",
+    )?;
+    Ok(search_meta_is_valid && catalog_table_is_valid && catalog_fts_is_valid)
+}
+
+fn observed_values_schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError> {
+    if !tables_exist(
+        connection,
+        &[
+            "observed_workspace_generations",
+            "observed_source_generations",
+            "observed_values",
+            "observed_values_fts",
+            "observed_queue_jobs",
+        ],
+    )? {
+        return Ok(false);
+    }
+
+    for query in [
+        "
+        SELECT workspace, generation, updated_at
+        FROM observed_workspace_generations
+        LIMIT 0
+        ",
+        "
+        SELECT workspace, source_name, generation, updated_at
+        FROM observed_source_generations
+        LIMIT 0
+        ",
+        "
+        SELECT
+            workspace,
+            owner_source_name,
+            source_name,
+            source_scope_id,
+            surface_kind,
+            surface_name,
+            column_name,
+            value_key,
+            display_value,
+            search_text,
+            first_observed_at,
+            last_observed_at,
+            observation_count,
+            source_generation,
+            workspace_generation
+        FROM observed_values
+        LIMIT 0
+        ",
+        "
+        SELECT
+            workspace,
+            owner_source_name,
+            source_name,
+            source_scope_id,
+            surface_kind,
+            surface_name,
+            column_name,
+            value_key,
+            display_value,
+            search_text
+        FROM observed_values_fts
+        LIMIT 0
+        ",
+        "
+        SELECT
+            id,
+            workspace,
+            owner_source_name,
+            source_name,
+            source_scope_id,
+            surface_kind,
+            surface_name,
+            workspace_generation,
+            source_generation,
+            payload_json,
+            attempts,
+            last_error,
+            created_at,
+            updated_at
+        FROM observed_queue_jobs
+        LIMIT 0
+        ",
     ] {
+        if !schema_query_is_valid(connection, query)? {
+            return Ok(false);
+        }
+    }
+
+    indexes_exist(
+        connection,
+        &[
+            "idx_observed_queue_jobs_workspace_id",
+            "idx_observed_queue_jobs_source",
+            "idx_observed_queue_jobs_pending_scope",
+            "idx_observed_values_source",
+        ],
+    )
+}
+
+fn tables_exist(connection: &Connection, table_names: &[&str]) -> Result<bool, SqliteSearchError> {
+    for table_name in table_names {
         let exists: bool = connection.query_row(
             "
             SELECT EXISTS (
@@ -541,29 +748,7 @@ fn schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError>
                 WHERE type IN ('table', 'virtual table') AND name = ?1
             )
             ",
-            [table_name],
-            |row| row.get(0),
-        )?;
-        if !exists {
-            return Ok(false);
-        }
-    }
-
-    for index_name in [
-        "idx_observed_queue_jobs_workspace_id",
-        "idx_observed_queue_jobs_source",
-        "idx_observed_queue_jobs_pending_scope",
-        "idx_observed_values_source",
-    ] {
-        let exists: bool = connection.query_row(
-            "
-            SELECT EXISTS (
-                SELECT 1
-                FROM sqlite_master
-                WHERE type = 'index' AND name = ?1
-            )
-            ",
-            [index_name],
+            [*table_name],
             |row| row.get(0),
         )?;
         if !exists {
@@ -572,6 +757,42 @@ fn schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError>
     }
 
     Ok(true)
+}
+
+fn indexes_exist(connection: &Connection, index_names: &[&str]) -> Result<bool, SqliteSearchError> {
+    for index_name in index_names {
+        let exists: bool = connection.query_row(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM sqlite_master
+                WHERE type = 'index' AND name = ?1
+            )
+            ",
+            [*index_name],
+            |row| row.get(0),
+        )?;
+        if !exists {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+fn schema_query_is_valid(connection: &Connection, query: &str) -> Result<bool, SqliteSearchError> {
+    match connection.prepare(query) {
+        Ok(_) => Ok(true),
+        Err(error)
+            if matches!(
+                sqlite_error_code(&error),
+                Some(ErrorCode::Unknown | ErrorCode::SchemaChanged)
+            ) =>
+        {
+            Ok(false)
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 #[cfg(test)]
@@ -948,6 +1169,68 @@ mod tests {
         }
     }
 
+    #[test]
+    fn opening_current_version_repairs_observed_schema_without_dropping_data() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let connection = open_current_search_connection(&path);
+        seed_observed_queue_job(&connection);
+        connection
+            .execute_batch("DROP INDEX idx_observed_queue_jobs_workspace_id")
+            .expect("remove observed queue index");
+        drop(connection);
+
+        let connection = open_current_search_connection(&path);
+
+        assert_eq!(observed_queue_job_count(&connection), 1);
+    }
+
+    #[test]
+    fn opening_current_version_resets_only_incompatible_observed_schema() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let connection = open_current_search_connection(&path);
+        seed_catalog_document(&connection);
+        seed_observed_queue_job(&connection);
+        connection
+            .execute(
+                "INSERT INTO search_meta (key, value) VALUES ('sentinel', 'preserved')",
+                [],
+            )
+            .expect("seed preserved search metadata");
+        connection
+            .execute_batch(
+                "
+                DROP TABLE observed_queue_jobs;
+                CREATE TABLE observed_queue_jobs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    workspace TEXT NOT NULL,
+                    owner_source_name TEXT NOT NULL,
+                    source_name TEXT NOT NULL,
+                    surface_kind TEXT NOT NULL,
+                    surface_name TEXT NOT NULL,
+                    workspace_generation INTEGER NOT NULL,
+                    source_generation INTEGER NOT NULL
+                );
+                ",
+            )
+            .expect("replace queue table with incompatible shape");
+        drop(connection);
+
+        let connection = open_current_search_connection(&path);
+        let sentinel = connection
+            .query_row(
+                "SELECT value FROM search_meta WHERE key = 'sentinel'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .expect("preserved search metadata");
+
+        assert_eq!(catalog_document_count(&connection), 1);
+        assert_eq!(observed_queue_job_count(&connection), 0);
+        assert_eq!(sentinel, "preserved");
+    }
+
     fn v1_search_connection(path: &std::path::Path) -> Connection {
         let mut connection = Connection::open(path).expect("raw v1 connection");
         super::apply_migration(
@@ -983,11 +1266,50 @@ mod tests {
             .expect("seed catalog document");
     }
 
+    fn seed_observed_queue_job(connection: &Connection) {
+        connection
+            .execute(
+                "
+                INSERT INTO observed_queue_jobs (
+                    workspace,
+                    owner_source_name,
+                    source_name,
+                    source_scope_id,
+                    surface_kind,
+                    surface_name,
+                    workspace_generation,
+                    source_generation,
+                    payload_json
+                ) VALUES (
+                    'default',
+                    'github',
+                    'github',
+                    'fixture-scope',
+                    'table',
+                    'issues',
+                    0,
+                    0,
+                    '{}'
+                )
+                ",
+                [],
+            )
+            .expect("seed observed queue job");
+    }
+
     fn catalog_document_count(connection: &Connection) -> i64 {
         connection
             .query_row("SELECT COUNT(*) FROM catalog_documents", [], |row| {
                 row.get(0)
             })
             .expect("catalog document count")
+    }
+
+    fn observed_queue_job_count(connection: &Connection) -> i64 {
+        connection
+            .query_row("SELECT COUNT(*) FROM observed_queue_jobs", [], |row| {
+                row.get(0)
+            })
+            .expect("observed queue job count")
     }
 }

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -454,7 +454,11 @@ fn schema_rebuild_can_recover(error: &SqliteSearchError) -> bool {
         SqliteSearchError::Sqlite(error)
             if matches!(
                 sqlite_error_code(error),
-                Some(ErrorCode::Unknown | ErrorCode::SchemaChanged)
+                Some(
+                    ErrorCode::Unknown
+                        | ErrorCode::SchemaChanged
+                        | ErrorCode::ConstraintViolation
+                )
             )
     )
 }
@@ -1056,12 +1060,17 @@ mod tests {
             rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
             None,
         ));
+        let constraint = SqliteSearchError::Sqlite(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
+            None,
+        ));
         let disk_full = SqliteSearchError::Sqlite(rusqlite::Error::SqliteFailure(
             rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_FULL),
             None,
         ));
 
         assert!(super::schema_rebuild_can_recover(&schema_error));
+        assert!(super::schema_rebuild_can_recover(&constraint));
         assert!(!super::schema_rebuild_can_recover(&locked));
         assert!(!super::schema_rebuild_can_recover(&disk_full));
     }
@@ -1215,6 +1224,40 @@ mod tests {
                 ",
             )
             .expect("replace queue table with incompatible shape");
+        drop(connection);
+
+        let connection = open_current_search_connection(&path);
+        let sentinel = connection
+            .query_row(
+                "SELECT value FROM search_meta WHERE key = 'sentinel'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .expect("preserved search metadata");
+
+        assert_eq!(catalog_document_count(&connection), 1);
+        assert_eq!(observed_queue_job_count(&connection), 0);
+        assert_eq!(sentinel, "preserved");
+    }
+
+    #[test]
+    fn opening_current_version_resets_duplicate_observed_rows_after_repair_fails() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let connection = open_current_search_connection(&path);
+        seed_catalog_document(&connection);
+        connection
+            .execute(
+                "INSERT INTO search_meta (key, value) VALUES ('sentinel', 'preserved')",
+                [],
+            )
+            .expect("seed preserved search metadata");
+        connection
+            .execute_batch("DROP INDEX idx_observed_queue_jobs_pending_scope")
+            .expect("remove observed queue uniqueness guard");
+        seed_observed_queue_job(&connection);
+        seed_observed_queue_job(&connection);
+        assert_eq!(observed_queue_job_count(&connection), 2);
         drop(connection);
 
         let connection = open_current_search_connection(&path);

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -22,10 +22,10 @@ use coral_spec::{
     ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter, ParsedTemplate,
 };
 use serde_json::{Value, json};
-use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
+use crate::hash::sha256_hex;
 use crate::sources::SourceName;
 use crate::state::{AppStateLayout, V4ProjectionCatalogFile, V4ProjectionCatalogOrigin};
 use crate::storage::fs;
@@ -1227,12 +1227,6 @@ fn write_yaml<T: serde::Serialize>(path: &Path, value: &T) -> Result<(), AppErro
     let bytes = serde_yaml::to_string(value)?;
     fs::write_atomic(path, bytes.as_bytes())?;
     Ok(())
-}
-
-fn sha256_hex(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
 }
 
 pub(crate) fn new_materialization_suffix(prefix: &str) -> String {


### PR DESCRIPTION
## Summary

- adds the durable SQLite observed-value substrate: migration, source/workspace generations, canonical rows, FTS rows, queue jobs, and enqueue generation checks
- applies bounded collection plus best-effort structured secret suppression for JSON, URL-query, and form-encoded values before persistence; mandatory sensitive-name/value heuristics remain defense in depth rather than a DLP guarantee
- publishes source-scan observations through separate writer, publisher, and source-scope modules while treating runtime-contract and credential identities as opaque app-supplied inputs
- removes the hand-maintained semantic runtime-contract mirror from this storage PR
- repairs migrations first, then resets only irreparable observed-specific objects while preserving the shared SQLite file and catalog state
- keeps this PR inert: no source-authored indexing policy, QueryManager wiring, projection drainage, provider registration, ranking, or user-visible search results

## Commit layout

1. `feat(search): add observed queue storage` owns the migration, queue/store primitives, generations, and storage tests
2. `feat(search): collect governed observed values` owns collection budgets and sensitive-column/value suppression
3. `feat(search): publish source scan observations` owns writer lifecycle, publisher integration, and opaque source-scope derivation
4. Follow-up review commits add structured sanitization, defer semantic scope identity to the app runtime boundary, and recover from irreparable observed duplicates without deleting catalog state

The previous monolithic `source_scan.rs` is split into `observed/writer.rs`, `observed/publisher.rs`, `observed/source_scope.rs`, and focused collection helpers so lifecycle, publication, storage identity, and privacy behavior can be reviewed independently.

## Split boundary

Draft PR #1761 owns source-authored `do_not_index` policy. PR #1480 owns the app runtime-contract fingerprint, credential revision, and lifecycle wiring. Projection, storage-ceiling governance, retrieval policy, provider registration, and public maintenance remain in later stack slices.

## Validation

- focused observed collector, source-scope, queue, migration, and store tests
- strict Clippy and rustdoc through top-of-stack `make rust-checks`
- isolated real-source observation/search smoke through the final stack


## Feature flag

The observed SQLite substrate and migrations may exist while `observed_values_search` is disabled, but no writer is constructed and no observations are enqueued. This PR remains behaviorally dormant until the gated lifecycle wiring in #1480.
