### PR TITLE
feat(spec): parse function artifacts

### DIFF
--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -85,7 +85,7 @@ pub enum SourceBackend {
 /// Normalized scalar data types supported by the source-spec DSL.
 ///
 /// The engine is responsible for mapping these into runtime-specific types.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub enum ManifestDataType {
     Utf8,

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -84,6 +84,7 @@ mod loader;
 mod parser;
 mod schema;
 mod template;
+mod udf;
 pub mod v4;
 mod validate;
 
@@ -118,6 +119,10 @@ pub use parser::{
     ValidatedSourceManifest, parse_source_manifest_value, parse_source_manifest_yaml,
 };
 pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken};
+pub use udf::{
+    FunctionCoralSqlImplementationSpec, FunctionImplementationSpec, FunctionSpec,
+    parse_function_sql,
+};
 pub(crate) use validate::{
     DeclaredRelation, DetailHintDeclaringSurface, DetailHintTargetTable, HttpTableValidation,
     validate_columns, validate_declared_relation_namespace, validate_detail_hint_references,

--- a/crates/coral-spec/src/udf/mod.rs
+++ b/crates/coral-spec/src/udf/mod.rs
@@ -1,0 +1,13 @@
+//! Function artifact parsing and static validation.
+//!
+//! Functions are source-neutral task capabilities. This module validates
+//! function artifact shape and artifact-local invariants. Installed-source
+//! references, SQL planning, result columns, and publish collisions against live
+//! catalog objects are checked by the app/runtime layers.
+
+mod model;
+mod parser;
+mod validation;
+
+pub use model::{FunctionCoralSqlImplementationSpec, FunctionImplementationSpec, FunctionSpec};
+pub use parser::parse_function_sql;

--- a/crates/coral-spec/src/udf/model.rs
+++ b/crates/coral-spec/src/udf/model.rs
@@ -1,0 +1,53 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Validated function artifact.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionSpec {
+    pub(super) name: String,
+    pub(super) schema: String,
+    pub(super) description: String,
+    pub(super) implementation: FunctionImplementationSpec,
+}
+
+/// The executable body behind a function.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FunctionImplementationSpec {
+    /// Read-only Coral SQL using `DataFusion` value parameters like `$argument`.
+    pub coral_sql: FunctionCoralSqlImplementationSpec,
+}
+
+/// Read-only Coral SQL implementation for a function.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FunctionCoralSqlImplementationSpec {
+    /// SQL query executed by Coral after typed argument binding.
+    pub query: String,
+}
+
+impl FunctionSpec {
+    /// Returns the stable function id within one workspace.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the SQL schema where this function is published.
+    #[must_use]
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+
+    /// Returns the user-facing function description.
+    #[must_use]
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// Returns the executable function implementation.
+    #[must_use]
+    pub fn implementation(&self) -> &FunctionImplementationSpec {
+        &self.implementation
+    }
+}

--- a/crates/coral-spec/src/udf/parser.rs
+++ b/crates/coral-spec/src/udf/parser.rs
@@ -1,0 +1,221 @@
+use serde::Deserialize;
+
+use crate::{ManifestError, Result};
+
+use super::model::{FunctionCoralSqlImplementationSpec, FunctionImplementationSpec, FunctionSpec};
+use super::validation::validate_raw_function;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct RawFunctionFrontmatter {
+    pub(super) name: String,
+    pub(super) schema: String,
+    #[serde(default)]
+    pub(super) description: String,
+}
+
+#[derive(Debug)]
+pub(super) struct RawFunctionSpec {
+    pub(super) frontmatter: RawFunctionFrontmatter,
+    pub(super) implementation: FunctionImplementationSpec,
+}
+
+/// Parses and statically validates one function SQL artifact.
+///
+/// # Errors
+///
+/// Returns [`ManifestError`] when the frontmatter cannot be parsed, the SQL
+/// body is empty, or the artifact violates function-local invariants.
+pub fn parse_function_sql(raw: &str) -> Result<FunctionSpec> {
+    let (frontmatter, sql) = split_frontmatter(raw)?;
+    let frontmatter: RawFunctionFrontmatter =
+        serde_yaml::from_str(frontmatter).map_err(|error| {
+            ManifestError::validation(format!(
+                "function artifact SQL comment frontmatter is invalid: {error}"
+            ))
+        })?;
+    validate_raw_function(RawFunctionSpec {
+        frontmatter,
+        implementation: FunctionImplementationSpec {
+            coral_sql: FunctionCoralSqlImplementationSpec {
+                query: sql.trim().to_string(),
+            },
+        },
+    })
+}
+
+fn split_frontmatter(raw: &str) -> Result<(&str, &str)> {
+    let Some(after_open) = raw.strip_prefix("/*") else {
+        return Err(ManifestError::validation(
+            "function artifact must start with SQL comment frontmatter",
+        ));
+    };
+    let Some((frontmatter, sql)) = after_open.split_once("*/") else {
+        return Err(ManifestError::validation(
+            "function artifact SQL comment frontmatter must end with '*/'",
+        ));
+    };
+    if frontmatter.trim().is_empty() {
+        return Err(ManifestError::validation(
+            "function artifact SQL comment frontmatter must not be empty",
+        ));
+    }
+    Ok((frontmatter, sql))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_function_sql;
+
+    #[derive(Clone, Copy)]
+    enum ExpectedError {
+        Exact(&'static str),
+        Contains(&'static str),
+    }
+
+    fn valid_function() -> &'static str {
+        r"/*
+name: github_review_queue
+schema: functions
+description: GitHub PR review queue
+*/
+
+select title, html_url
+from github.pulls(owner => $owner, repo => $repo)
+"
+    }
+
+    fn function_with(replacements: &[(&str, &str)]) -> String {
+        let mut artifact = valid_function().to_string();
+        for (from, to) in replacements {
+            assert!(
+                artifact.contains(from),
+                "function test fixture does not contain replacement target: {from}"
+            );
+            artifact = artifact.replacen(from, to, 1);
+        }
+        artifact
+    }
+
+    fn assert_function_error(name: &str, artifact: &str, expected: ExpectedError) {
+        let error = parse_function_sql(artifact).unwrap_err();
+        match expected {
+            ExpectedError::Exact(message) => assert_eq!(error.to_string(), message, "{name}"),
+            ExpectedError::Contains(message) => {
+                assert!(
+                    error.to_string().contains(message),
+                    "{name}: expected error to contain {message:?}, got {error}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parse_function_sql_accepts_valid_function() {
+        let function = parse_function_sql(valid_function()).expect("function should parse");
+
+        assert_eq!(function.name(), "github_review_queue");
+        assert_eq!(function.schema(), "functions");
+        assert!(
+            function
+                .implementation()
+                .coral_sql
+                .query
+                .contains("github.pulls")
+        );
+    }
+
+    #[test]
+    fn parse_function_sql_rejects_invalid_frontmatter() {
+        let cases = [
+            (
+                "missing frontmatter",
+                "select 1".to_string(),
+                ExpectedError::Exact("function artifact must start with SQL comment frontmatter"),
+            ),
+            (
+                "unterminated frontmatter",
+                "/*\nname: github_review_queue\nschema: functions\nselect 1".to_string(),
+                ExpectedError::Exact(
+                    "function artifact SQL comment frontmatter must end with '*/'",
+                ),
+            ),
+            (
+                "empty frontmatter",
+                "/**/\nselect 1".to_string(),
+                ExpectedError::Exact("function artifact SQL comment frontmatter must not be empty"),
+            ),
+            (
+                "malformed frontmatter",
+                function_with(&[("name: github_review_queue", "name: [")]),
+                ExpectedError::Contains("function artifact SQL comment frontmatter is invalid"),
+            ),
+            (
+                "mixed-case function name",
+                function_with(&[("name: github_review_queue", "name: Demo")]),
+                ExpectedError::Exact("function name 'Demo' must be lowercase"),
+            ),
+            (
+                "unknown field",
+                function_with(&[("description:", "presentation: {}\ndescription:")]),
+                ExpectedError::Contains("unknown field `presentation`"),
+            ),
+            (
+                "empty sql body",
+                function_with(&[(
+                    "select title, html_url\nfrom github.pulls(owner => $owner, repo => $repo)",
+                    "   ",
+                )]),
+                ExpectedError::Exact("function 'github_review_queue' SQL body must not be empty"),
+            ),
+        ];
+
+        for (name, artifact, expected) in cases {
+            assert_function_error(name, &artifact, expected);
+        }
+    }
+
+    #[test]
+    fn parse_function_sql_preserves_body_after_frontmatter_comment() {
+        let function = parse_function_sql(valid_function()).expect("function should parse");
+        let query = &function.implementation().coral_sql.query;
+
+        assert!(
+            query.starts_with("select title"),
+            "unexpected query: {query}"
+        );
+        assert!(!query.contains("github_review_queue"));
+        assert!(!query.contains("*/"));
+    }
+
+    #[test]
+    fn parse_function_sql_rejects_invalid_schema() {
+        let cases = [
+            (
+                "mixed-case table-function schema",
+                function_with(&[("schema: functions", "schema: Functions")]),
+                ExpectedError::Exact(
+                    "function 'github_review_queue' schema 'Functions' must be lowercase",
+                ),
+            ),
+            (
+                "reserved table-function schema",
+                function_with(&[("schema: functions", "schema: __coral_udfs")]),
+                ExpectedError::Exact(
+                    "function 'github_review_queue' schema '__coral_udfs' is reserved",
+                ),
+            ),
+            (
+                "public table-function schema",
+                function_with(&[("schema: functions", "schema: public")]),
+                ExpectedError::Exact(
+                    "function 'github_review_queue' schema 'public' is reserved and cannot be used by manifests",
+                ),
+            ),
+        ];
+
+        for (name, artifact, expected) in cases {
+            assert_function_error(name, &artifact, expected);
+        }
+    }
+}

--- a/crates/coral-spec/src/udf/validation.rs
+++ b/crates/coral-spec/src/udf/validation.rs
@@ -1,0 +1,75 @@
+use crate::{ManifestError, Result, validate_identifier, validate_reserved_source_schema_name};
+
+use super::model::FunctionSpec;
+use super::parser::RawFunctionSpec;
+
+const RESERVED_FUNCTION_SCHEMA_NAMES: &[&str] = &["__coral_udfs"];
+
+pub(super) fn validate_raw_function(raw: RawFunctionSpec) -> Result<FunctionSpec> {
+    FunctionValidator { raw }.validate()
+}
+
+struct FunctionValidator {
+    raw: RawFunctionSpec,
+}
+
+impl FunctionValidator {
+    fn validate(self) -> Result<FunctionSpec> {
+        self.validate_header()?;
+        self.validate_implementation()?;
+        Ok(self.finish())
+    }
+
+    fn validate_header(&self) -> Result<()> {
+        let frontmatter = &self.raw.frontmatter;
+        validate_lowercase_identifier(&frontmatter.name, "function name")?;
+        validate_lowercase_identifier(
+            &frontmatter.schema,
+            &format!("function '{}' schema", frontmatter.name),
+        )?;
+        validate_reserved_source_schema_name(
+            &frontmatter.schema,
+            &format!("function '{}' schema", frontmatter.name),
+        )?;
+        if RESERVED_FUNCTION_SCHEMA_NAMES
+            .iter()
+            .any(|reserved| frontmatter.schema.eq_ignore_ascii_case(reserved))
+        {
+            return Err(ManifestError::validation(format!(
+                "function '{}' schema '{}' is reserved",
+                frontmatter.name, frontmatter.schema
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_implementation(&self) -> Result<()> {
+        if self.raw.implementation.coral_sql.query.trim().is_empty() {
+            return Err(ManifestError::validation(format!(
+                "function '{}' SQL body must not be empty",
+                self.raw.frontmatter.name
+            )));
+        }
+        Ok(())
+    }
+
+    fn finish(self) -> FunctionSpec {
+        let frontmatter = self.raw.frontmatter;
+        FunctionSpec {
+            name: frontmatter.name,
+            schema: frontmatter.schema,
+            description: frontmatter.description,
+            implementation: self.raw.implementation,
+        }
+    }
+}
+
+fn validate_lowercase_identifier(value: &str, context: &str) -> Result<()> {
+    validate_identifier(value, context)?;
+    if value != value.to_ascii_lowercase() {
+        return Err(ManifestError::validation(format!(
+            "{context} '{value}' must be lowercase"
+        )));
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add the `coral-spec` parser/model for user function SQL artifacts.
- Expose the spec surface with `Function*` names only; the `udf` module remains an internal implementation detail.
- Use SQL comment frontmatter so `.sql` files remain valid SQL in editors.
- Parse the remaining SQL body into a Coral SQL implementation for later validation/runtime branches.

## Artifact shape

```sql
/*
name: open_prs
schema: functions
description: All open PRs in the specified repo
*/

select number, title
from github.pulls(owner => $owner, repo => $repo)
```

## Behavior
- Required frontmatter fields: `name`, `schema`.
- Optional frontmatter field: `description`.
- Unknown frontmatter fields are rejected.
- Function names and schemas must be valid lowercase identifiers.
- Reserved schemas such as `coral`, `coral_admin`, and `__coral_udfs` are rejected.
- Empty SQL bodies are rejected.

## Validation
- `cargo fmt --all`
- `cargo test -p coral-spec --all-features --locked parse_function_sql`
- From the top of the stack: `cargo test -p coral-engine --test engine --all-features --locked udf`
- From the top of the stack: `cargo test -p coral-app --all-features --locked functions::manager`