### PR TITLE
feat(sources/community/web_scraper): add local web scraper community source

### DIFF
--- a/sources/community/web_scraper/README.md
+++ b/sources/community/web_scraper/README.md
@@ -1,0 +1,223 @@
+# Web Scraper
+
+**Version:** 0.1.0
+**Backend:** File (JSONL)
+**Tables:** 2
+
+Query scraped web pages and discovered links from local JSONL files. Extract page content, metadata, and link graphs from any website without an API key.
+
+## Installation
+
+1. Run the scraper to generate JSONL files:
+
+```bash
+python3 sources/community/web_scraper/scripts/scrape.py https://example.com https://example.com/about
+```
+
+2. Install the source:
+
+```bash
+coral source add --file sources/community/web_scraper/manifest.yaml
+```
+
+## Prerequisites
+
+- Python 3.8+ (no external dependencies — uses only stdlib)
+
+The scraper uses `urllib.request` for HTTP and `html.parser` for HTML parsing. No `pip install` required.
+
+## Quick Start
+
+```sql
+-- List all scraped pages
+SELECT url, title, status_code, scraped_at
+FROM web_scraper.pages;
+
+-- Get page text content
+SELECT url, title, text
+FROM web_scraper.pages
+WHERE status_code = 200;
+
+-- Find external links
+SELECT source_url, href, text
+FROM web_scraper.links
+WHERE is_external = true
+LIMIT 10;
+
+-- Count links per page
+SELECT source_url, COUNT(*) as link_count
+FROM web_scraper.links
+GROUP BY source_url
+ORDER BY link_count DESC;
+
+-- Find all links to a specific domain
+SELECT source_url, href, text
+FROM web_scraper.links
+WHERE href LIKE '%github.com%';
+```
+
+## Scraper Usage
+
+```bash
+# Scrape specific URLs
+python3 scrape.py https://example.com https://example.com/about
+
+# Scrape URLs from a file (one per line)
+python3 scrape.py --file urls.txt
+
+# Custom output directory
+python3 scrape.py --file urls.txt --output /path/to/output
+
+# Set request timeout (default 30s)
+python3 scrape.py --timeout 60 https://example.com
+```
+
+Default output directory: `~/.coral/web_scraper/`
+
+The scraper auto-prepends `https://` if no scheme is provided.
+
+## Tables
+
+### `pages`
+
+Scraped web pages with extracted text, title, description, and metadata. One row per URL.
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `url` | Utf8 | Original URL that was requested |
+| `final_url` | Utf8 | Final URL after redirects |
+| `title` | Utf8 | Page title from HTML |
+| `description` | Utf8 | Page description from meta tag |
+| `text` | Utf8 | Extracted plain text content (scripts and styles removed) |
+| `status_code` | Int64 | HTTP status code |
+| `content_type` | Utf8 | Content-Type header value |
+| `language` | Utf8 | Language from the HTML lang attribute |
+| `scraped_at` | Utf8 | Timestamp when the page was scraped (ISO 8601 UTC) |
+
+---
+
+### `links`
+
+Links discovered on scraped pages. One row per anchor tag with an href attribute.
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `source_url` | Utf8 | URL of the page where the link was found |
+| `href` | Utf8 | Absolute URL the link points to |
+| `text` | Utf8 | Anchor text of the link |
+| `is_external` | Boolean | Whether the link points to a different domain |
+
+## Source scope
+
+- File-backed source reading from `~/.coral/web_scraper/pages.jsonl` and `~/.coral/web_scraper/links.jsonl`.
+- No API key, no credentials, no rate limits.
+- The scraper uses Python stdlib only (`urllib.request` + `html.parser`). No external dependencies.
+- Data is static — re-run the scraper to refresh.
+- The scraper strips `<script>`, `<style>`, and `<noscript>` tags before extracting text.
+- Links are resolved to absolute URLs. Fragment-only, `javascript:`, `mailto:`, and `tel:` hrefs are excluded.
+- 2 declared test queries (pages + links) are source-independent.
+
+## Limitations
+
+- The scraper uses Python stdlib HTTP — it does not execute JavaScript. JS-rendered SPAs will return empty or partial content. For JS-heavy sites, use the Firecrawl source instead.
+- No built-in crawling — you must provide the list of URLs to scrape. The scraper does not follow links automatically.
+- No proxy, anti-bot, or cookie support. Sites with aggressive bot detection may block requests.
+- HTML parsing uses Python's `html.parser` which is lenient but may miss edge cases that a full parser like lxml handles.
+- The `text` column may contain navigation, header, and footer text. The scraper does not isolate main content.
+- Duplicate links are not deduplicated — if a page has the same link twice, it appears twice in `links.jsonl`.
+
+## Live validation output
+
+Validated by scraping `https://withcoral.com` and `https://withcoral.com/docs`.
+
+```bash
+$ python3 sources/community/web_scraper/scripts/scrape.py https://withcoral.com https://withcoral.com/docs
+  → https://withcoral.com
+  → https://withcoral.com/docs
+
+  ✓ 2 pages → ~/.coral/web_scraper/pages.jsonl
+  ✓ 70 links → ~/.coral/web_scraper/links.jsonl
+```
+
+```bash
+$ coral source lint sources/community/web_scraper/manifest.yaml
+Manifest is valid
+```
+
+```bash
+$ coral source add --file sources/community/web_scraper/manifest.yaml
+Added source web_scraper
+
+  ✓ web_scraper connected successfully
+
+    web_scraper (2 tables)
+    ├─ links
+    └─ pages
+    Query tests
+    2 declared · 2 passed · 0 failed
+
+    ✓ SELECT url, title, status_code FROM web_scraper.pages LIMIT 3
+      2 rows
+
+    ✓ SELECT source_url, href, is_external FROM web_scraper.links LIMIT 5
+      5 rows
+```
+
+**Table introspection:**
+
+```sql
+SELECT table_name, description
+FROM coral.tables
+WHERE schema_name = 'web_scraper'
+ORDER BY table_name;
+```
+
+```text
++------------+-------------------------------------------------------------------------------------------+
+| table_name | description                                                                               |
++------------+-------------------------------------------------------------------------------------------+
+| links      | Links discovered on scraped pages. One row per anchor tag with an href attribute.         |
+| pages      | Scraped web pages with extracted text, title, description, and metadata. One row per URL. |
++------------+-------------------------------------------------------------------------------------------+
+```
+
+**Live pages proof:**
+
+```sql
+SELECT url, title, status_code, language, scraped_at
+FROM web_scraper.pages;
+```
+
+```text
++----------------------------+-------------------------------------------+-------------+----------+----------------------------------+
+| url                        | title                                     | status_code | language | scraped_at                       |
++----------------------------+-------------------------------------------+-------------+----------+----------------------------------+
+| https://withcoral.com      | Coral — The data engine for enterprise AI | 200         | en       | 2026-07-01T21:43:04.544563+00:00 |
+| https://withcoral.com/docs | Introduction to Coral - Coral Docs        | 200         | en       | 2026-07-01T21:43:05.519822+00:00 |
++----------------------------+-------------------------------------------+-------------+----------+----------------------------------+
+```
+
+**Live external links proof:**
+
+```sql
+SELECT source_url, href, text, is_external
+FROM web_scraper.links
+WHERE is_external = true
+LIMIT 5;
+```
+
+```text
++-----------------------+----------------------------------------+------------------+-------------+
+| source_url            | href                                   | text             | is_external |
++-----------------------+----------------------------------------+------------------+-------------+
+| https://withcoral.com | https://github.com/withcoral/coral     | GitHub      5.1K | true        |
+| https://withcoral.com | https://github.com/withcoral/coral     | GitHub      5.1K | true        |
+| https://withcoral.com | https://github.com/withcoral/coral     | GitHub           | true        |
+| https://withcoral.com | https://github.com/withcoral/coral     | GitHub           | true        |
+| https://withcoral.com | https://linkedin.com/company/withcoral | LinkedIn         | true        |
++-----------------------+----------------------------------------+------------------+-------------+
+```

--- a/sources/community/web_scraper/README.md
+++ b/sources/community/web_scraper/README.md
@@ -75,22 +75,23 @@ WHERE href LIKE '%github.com%';
 
 ```bash
 # Scrape specific URLs
-python3 scrape.py https://example.com https://example.com/about
+python3 sources/community/web_scraper/scripts/scrape.py https://example.com https://example.com/about
 
 # Scrape URLs from a file (one per line)
-python3 scrape.py --file urls.txt
+python3 sources/community/web_scraper/scripts/scrape.py --file urls.txt
 
-# JS-rendered pages (requires playwright)
-python3 scrape.py --js https://spa-site.com
-
-# Custom output directory
-python3 scrape.py --file urls.txt --output /path/to/output
+# JS-rendered pages (requires Playwright)
+python3 sources/community/web_scraper/scripts/scrape.py --js https://spa-site.com
 
 # Set request timeout (default 30s)
-python3 scrape.py --timeout 60 https://example.com
+python3 sources/community/web_scraper/scripts/scrape.py --timeout 60 https://example.com
 ```
 
 Default output directory: `~/.coral/web_scraper/`
+
+The scraper writes to temporary files and atomically replaces the output only after a full successful run. If any URL fails, the scraper exits with a non-zero status code.
+
+**Note:** The `--output` flag changes where JSONL files are written, but the manifest hardcodes `file://~/.coral/web_scraper/`. If you use a custom output path, update `source.location` in the manifest to match.
 
 The scraper auto-prepends `https://` if no scheme is provided.
 

--- a/sources/community/web_scraper/README.md
+++ b/sources/community/web_scraper/README.md
@@ -22,9 +22,24 @@ coral source add --file sources/community/web_scraper/manifest.yaml
 
 ## Prerequisites
 
-- Python 3.8+ (no external dependencies — uses only stdlib)
+**Required:**
 
-The scraper uses `urllib.request` for HTTP and `html.parser` for HTML parsing. No `pip install` required.
+```bash
+pip install requests beautifulsoup4 lxml
+```
+
+**Optional (for JS-rendered pages):**
+
+```bash
+pip install playwright && playwright install chromium
+```
+
+| Dependency | Purpose |
+|------------|---------|
+| `requests` | HTTP requests with sessions, cookies, redirects |
+| `beautifulsoup4` | HTML parsing and content extraction |
+| `lxml` | Fast, robust HTML parser backend for BeautifulSoup |
+| `playwright` | (Optional) JavaScript rendering for SPAs via `--js` flag |
 
 ## Quick Start
 
@@ -64,6 +79,9 @@ python3 scrape.py https://example.com https://example.com/about
 
 # Scrape URLs from a file (one per line)
 python3 scrape.py --file urls.txt
+
+# JS-rendered pages (requires playwright)
+python3 scrape.py --js https://spa-site.com
 
 # Custom output directory
 python3 scrape.py --file urls.txt --output /path/to/output
@@ -115,7 +133,8 @@ Links discovered on scraped pages. One row per anchor tag with an href attribute
 
 - File-backed source reading from `~/.coral/web_scraper/pages.jsonl` and `~/.coral/web_scraper/links.jsonl`.
 - No API key, no credentials, no rate limits.
-- The scraper uses Python stdlib only (`urllib.request` + `html.parser`). No external dependencies.
+- The scraper uses `requests` + `beautifulsoup4` + `lxml` for robust HTML parsing.
+- Optional `--js` flag uses Playwright for JavaScript-rendered pages.
 - Data is static — re-run the scraper to refresh.
 - The scraper strips `<script>`, `<style>`, and `<noscript>` tags before extracting text.
 - Links are resolved to absolute URLs. Fragment-only, `javascript:`, `mailto:`, and `tel:` hrefs are excluded.
@@ -123,10 +142,9 @@ Links discovered on scraped pages. One row per anchor tag with an href attribute
 
 ## Limitations
 
-- The scraper uses Python stdlib HTTP — it does not execute JavaScript. JS-rendered SPAs will return empty or partial content. For JS-heavy sites, use the Firecrawl source instead.
+- Without `--js`, the scraper does not execute JavaScript. JS-rendered SPAs will return empty or partial content. Use `--js` for JS-heavy sites (requires Playwright), or use the Firecrawl source.
 - No built-in crawling — you must provide the list of URLs to scrape. The scraper does not follow links automatically.
-- No proxy, anti-bot, or cookie support. Sites with aggressive bot detection may block requests.
-- HTML parsing uses Python's `html.parser` which is lenient but may miss edge cases that a full parser like lxml handles.
+- No proxy or anti-bot evasion. Sites with aggressive bot detection may block requests.
 - The `text` column may contain navigation, header, and footer text. The scraper does not isolate main content.
 - Duplicate links are not deduplicated — if a page has the same link twice, it appears twice in `links.jsonl`.
 

--- a/sources/community/web_scraper/manifest.yaml
+++ b/sources/community/web_scraper/manifest.yaml
@@ -1,0 +1,105 @@
+name: web_scraper
+version: 0.1.0
+dsl_version: 3
+backend: file
+description: >-
+  Query scraped web pages and discovered links from local JSONL files.
+  Extract page content, metadata, and link graphs from any website
+  without an API key.
+
+test_queries:
+  - SELECT url, title, status_code FROM web_scraper.pages LIMIT 3
+  - SELECT source_url, href, is_external FROM web_scraper.links LIMIT 5
+
+tables:
+
+  # --------------------------------------------------------------------------
+  # web_scraper.pages — One row per scraped URL
+  # --------------------------------------------------------------------------
+  - name: pages
+    description: >-
+      Scraped web pages with extracted text, title, description, and
+      metadata. One row per URL.
+    guide: |
+      Start with:
+        SELECT url, title, status_code, scraped_at
+        FROM web_scraper.pages LIMIT 10
+      Use WHERE to filter by URL or status code:
+        SELECT url, title FROM web_scraper.pages
+        WHERE status_code = 200
+    format: jsonl
+    source:
+      location: file://~/.coral/web_scraper/pages.jsonl
+    columns:
+      - name: url
+        type: Utf8
+        nullable: false
+        description: Original URL that was requested.
+      - name: final_url
+        type: Utf8
+        nullable: true
+        description: Final URL after redirects.
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Page title from HTML.
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Page description from meta tag.
+      - name: text
+        type: Utf8
+        nullable: true
+        description: Extracted plain text content (scripts and styles removed).
+      - name: status_code
+        type: Int64
+        nullable: false
+        description: HTTP status code.
+      - name: content_type
+        type: Utf8
+        nullable: true
+        description: Content-Type header value.
+      - name: language
+        type: Utf8
+        nullable: true
+        description: Language from the HTML lang attribute.
+      - name: scraped_at
+        type: Utf8
+        nullable: false
+        description: Timestamp when the page was scraped (ISO 8601 UTC).
+
+  # --------------------------------------------------------------------------
+  # web_scraper.links — One row per discovered link
+  # --------------------------------------------------------------------------
+  - name: links
+    description: >-
+      Links discovered on scraped pages. One row per anchor tag with an
+      href attribute.
+    guide: |
+      Start with:
+        SELECT source_url, href, text, is_external
+        FROM web_scraper.links LIMIT 10
+      Find external links:
+        SELECT source_url, href, text
+        FROM web_scraper.links
+        WHERE is_external = true
+    format: jsonl
+    source:
+      location: file://~/.coral/web_scraper/links.jsonl
+    columns:
+      - name: source_url
+        type: Utf8
+        nullable: false
+        description: URL of the page where the link was found.
+      - name: href
+        type: Utf8
+        nullable: false
+        description: Absolute URL the link points to.
+      - name: text
+        type: Utf8
+        nullable: true
+        description: Anchor text of the link.
+      - name: is_external
+        type: Boolean
+        nullable: false
+        description: Whether the link points to a different domain.

--- a/sources/community/web_scraper/scripts/scrape.py
+++ b/sources/community/web_scraper/scripts/scrape.py
@@ -22,6 +22,7 @@ Output:
 import argparse
 import json
 import os
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -36,6 +37,17 @@ try:
     from bs4 import BeautifulSoup
 except ImportError:
     sys.exit("Missing dependency: pip install beautifulsoup4")
+
+try:
+    import lxml  # noqa: F401
+    BS_PARSER = "lxml"
+except ImportError:
+    BS_PARSER = "html.parser"
+    print(
+        "Warning: lxml not installed, falling back to html.parser. "
+        "Install for better parsing: pip install lxml",
+        file=sys.stderr,
+    )
 
 DEFAULT_OUTPUT = os.path.expanduser("~/.coral/web_scraper")
 USER_AGENT = (
@@ -59,7 +71,7 @@ def fetch_with_requests(url, timeout=30):
         return None
 
 
-def fetch_with_playwright(url, timeout=30):
+def create_playwright_fetcher(timeout=30):
     try:
         from playwright.sync_api import sync_playwright
     except ImportError:
@@ -68,11 +80,13 @@ def fetch_with_playwright(url, timeout=30):
             "  pip install playwright && playwright install chromium"
         )
 
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=True)
+    ctx = sync_playwright().start()
+    browser = ctx.chromium.launch(headless=True)
+
+    def fetch(url, timeout=timeout):
         page = browser.new_page(user_agent=USER_AGENT)
         try:
-            resp = page.goto(url, timeout=timeout * 1000, wait_until="networkidle")
+            resp = page.goto(url, timeout=timeout * 1000, wait_until="load")
             status_code = resp.status if resp else 0
             content_type = resp.headers.get("content-type", "") if resp else ""
             html = page.content()
@@ -87,16 +101,22 @@ def fetch_with_playwright(url, timeout=30):
             print(f"  ✗ {url}: {exc}", file=sys.stderr)
             return None
         finally:
-            browser.close()
+            page.close()
+
+    def cleanup():
+        browser.close()
+        ctx.stop()
+
+    return fetch, cleanup
 
 
 def extract_page(url, result):
-    soup = BeautifulSoup(result["html"], "lxml")
+    soup = BeautifulSoup(result["html"], BS_PARSER)
 
     title_tag = soup.find("title")
     title = title_tag.get_text(strip=True) if title_tag else None
 
-    meta_desc = soup.find("meta", attrs={"name": "description"})
+    meta_desc = soup.find("meta", attrs={"name": re.compile(r"^description$", re.I)})
     description = (
         meta_desc["content"].strip()
         if meta_desc and meta_desc.get("content")
@@ -123,9 +143,10 @@ def extract_page(url, result):
     }
 
 
-def extract_links(url, result):
-    soup = BeautifulSoup(result["html"], "lxml")
-    parsed_base = urlparse(url)
+def extract_links(base_url, result):
+    soup = BeautifulSoup(result["html"], BS_PARSER)
+    final_url = result["final_url"]
+    parsed_base = urlparse(final_url)
     links = []
 
     for a_tag in soup.find_all("a", href=True):
@@ -133,13 +154,13 @@ def extract_links(url, result):
         if not href or href.startswith(("#", "javascript:", "mailto:", "tel:")):
             continue
 
-        absolute = urljoin(url, href)
+        absolute = urljoin(final_url, href)
         parsed = urlparse(absolute)
         is_external = parsed.netloc != parsed_base.netloc
-        link_text = a_tag.get_text(strip=True) or None
+        link_text = a_tag.get_text(" ", strip=True) or None
 
         links.append({
-            "source_url": url,
+            "source_url": base_url,
             "href": absolute,
             "text": link_text,
             "is_external": is_external,
@@ -178,7 +199,11 @@ def main():
     if not urls:
         parser.error("No URLs provided. Pass URLs as arguments or use --file.")
 
-    fetch = fetch_with_playwright if args.js else fetch_with_requests
+    pw_cleanup = None
+    if args.js:
+        fetch, pw_cleanup = create_playwright_fetcher(timeout=args.timeout)
+    else:
+        fetch = fetch_with_requests
 
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -188,25 +213,29 @@ def main():
     pages_count = 0
     links_count = 0
 
-    with open(pages_path, "w") as pages_fh, open(links_path, "w") as links_fh:
-        for url in urls:
-            if not url.startswith(("http://", "https://")):
-                url = "https://" + url
+    try:
+        with open(pages_path, "w") as pages_fh, open(links_path, "w") as links_fh:
+            for url in urls:
+                if not url.startswith(("http://", "https://")):
+                    url = "https://" + url
 
-            mode = "JS" if args.js else "HTTP"
-            print(f"  → [{mode}] {url}")
-            result = fetch(url, timeout=args.timeout)
-            if result is None:
-                continue
+                mode = "JS" if args.js else "HTTP"
+                print(f"  → [{mode}] {url}")
+                result = fetch(url, timeout=args.timeout)
+                if result is None:
+                    continue
 
-            page = extract_page(url, result)
-            pages_fh.write(json.dumps(page) + "\n")
-            pages_count += 1
+                page = extract_page(url, result)
+                pages_fh.write(json.dumps(page) + "\n")
+                pages_count += 1
 
-            page_links = extract_links(url, result)
-            for link in page_links:
-                links_fh.write(json.dumps(link) + "\n")
-                links_count += 1
+                page_links = extract_links(url, result)
+                for link in page_links:
+                    links_fh.write(json.dumps(link) + "\n")
+                    links_count += 1
+    finally:
+        if pw_cleanup:
+            pw_cleanup()
 
     print(f"\n  ✓ {pages_count} pages → {pages_path}")
     print(f"  ✓ {links_count} links → {links_path}")

--- a/sources/community/web_scraper/scripts/scrape.py
+++ b/sources/community/web_scraper/scripts/scrape.py
@@ -24,6 +24,8 @@ import json
 import os
 import re
 import sys
+import tempfile
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
@@ -50,21 +52,49 @@ except ImportError:
     )
 
 DEFAULT_OUTPUT = os.path.expanduser("~/.coral/web_scraper")
+MAX_RESPONSE_BYTES = 10 * 1024 * 1024  # 10 MB
 USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 )
 
 
+def _is_html(content_type):
+    ct = (content_type or "").lower().split(";")[0].strip()
+    return ct in ("text/html", "application/xhtml+xml", "")
+
+
+def _decode_response(resp):
+    encoding = resp.encoding or "utf-8"
+    content = resp.content[:MAX_RESPONSE_BYTES]
+    return content.decode(encoding, errors="replace")
+
+
 def fetch_with_requests(url, timeout=30):
     headers = {"User-Agent": USER_AGENT}
     try:
-        resp = requests.get(url, headers=headers, timeout=timeout, allow_redirects=True)
+        resp = requests.get(
+            url, headers=headers, timeout=timeout,
+            allow_redirects=True, stream=True,
+        )
+        content_type = resp.headers.get("Content-Type", "")
+        if not _is_html(content_type):
+            resp.close()
+            return {
+                "final_url": resp.url,
+                "status_code": resp.status_code,
+                "content_type": content_type,
+                "html": "",
+            }
+        raw = resp.content[:MAX_RESPONSE_BYTES]
+        resp.close()
+        encoding = resp.encoding or "utf-8"
+        html = raw.decode(encoding, errors="replace")
         return {
             "final_url": resp.url,
             "status_code": resp.status_code,
-            "content_type": resp.headers.get("Content-Type", ""),
-            "html": resp.text,
+            "content_type": content_type,
+            "html": html,
         }
     except requests.RequestException as exc:
         print(f"  ✗ {url}: {exc}", file=sys.stderr)
@@ -154,13 +184,20 @@ def extract_links(base_url, result):
     links = []
 
     for a_tag in soup.find_all("a", href=True):
-        href = a_tag["href"].strip()
-        if not href or href.startswith(("#", "javascript:", "mailto:", "tel:")):
+        href = a_tag.get("href")
+        if href is None:
+            continue
+        href = href.strip()
+        if not href or href.lower().startswith(
+            ("#", "javascript:", "mailto:", "tel:")
+        ):
             continue
 
         absolute = urljoin(final_url, href)
         parsed = urlparse(absolute)
-        is_external = parsed.netloc != parsed_base.netloc
+        is_external = (
+            (parsed.hostname or "").lower() != (parsed_base.hostname or "").lower()
+        )
         link_text = a_tag.get_text(" ", strip=True) or None
 
         links.append({
@@ -195,10 +232,10 @@ def main():
     urls = list(args.urls)
     if args.file:
         with open(args.file) as fh:
-            urls.extend(
-                line.strip() for line in fh
-                if line.strip() and not line.startswith("#")
-            )
+            for line in fh:
+                stripped = line.strip()
+                if stripped and not stripped.startswith("#"):
+                    urls.append(stripped)
 
     if not urls:
         parser.error("No URLs provided. Pass URLs as arguments or use --file.")
@@ -216,33 +253,57 @@ def main():
 
     pages_count = 0
     links_count = 0
+    fail_count = 0
+
+    tmp_pages = tempfile.NamedTemporaryFile(
+        mode="w", dir=output_dir, suffix=".jsonl", delete=False
+    )
+    tmp_links = tempfile.NamedTemporaryFile(
+        mode="w", dir=output_dir, suffix=".jsonl", delete=False
+    )
 
     try:
-        with open(pages_path, "w") as pages_fh, open(links_path, "w") as links_fh:
-            for url in urls:
-                if not url.startswith(("http://", "https://")):
-                    url = "https://" + url
+        for url in urls:
+            if not url.startswith(("http://", "https://")):
+                url = "https://" + url
 
-                mode = "JS" if args.js else "HTTP"
-                print(f"  → [{mode}] {url}")
-                result = fetch(url, timeout=args.timeout)
-                if result is None:
-                    continue
+            mode = "JS" if args.js else "HTTP"
+            print(f"  → [{mode}] {url}")
+            result = fetch(url, timeout=args.timeout)
+            if result is None:
+                fail_count += 1
+                continue
 
-                page = extract_page(url, result)
-                pages_fh.write(json.dumps(page) + "\n")
-                pages_count += 1
+            page = extract_page(url, result)
+            tmp_pages.write(json.dumps(page) + "\n")
+            pages_count += 1
 
-                page_links = extract_links(url, result)
-                for link in page_links:
-                    links_fh.write(json.dumps(link) + "\n")
-                    links_count += 1
+            page_links = extract_links(url, result)
+            for link in page_links:
+                tmp_links.write(json.dumps(link) + "\n")
+                links_count += 1
+
+        tmp_pages.close()
+        tmp_links.close()
+
+        shutil.move(tmp_pages.name, pages_path)
+        shutil.move(tmp_links.name, links_path)
+
+    except BaseException:
+        tmp_pages.close()
+        tmp_links.close()
+        os.unlink(tmp_pages.name)
+        os.unlink(tmp_links.name)
+        raise
     finally:
         if pw_cleanup:
             pw_cleanup()
 
     print(f"\n  ✓ {pages_count} pages → {pages_path}")
     print(f"  ✓ {links_count} links → {links_path}")
+    if fail_count:
+        print(f"  ✗ {fail_count} URLs failed", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/sources/community/web_scraper/scripts/scrape.py
+++ b/sources/community/web_scraper/scripts/scrape.py
@@ -78,20 +78,15 @@ def fetch_with_requests(url, timeout=30):
                 "final_url": resp.url,
                 "status_code": resp.status_code,
                 "content_type": content_type,
-                "html": "",
+                "html": b"",
             }
         raw = resp.content[:MAX_RESPONSE_BYTES]
         resp.close()
-        encoding = resp.encoding or "utf-8"
-        try:
-            html = raw.decode(encoding, errors="replace")
-        except LookupError:
-            html = raw.decode("utf-8", errors="replace")
         return {
             "final_url": resp.url,
             "status_code": resp.status_code,
             "content_type": content_type,
-            "html": html,
+            "html": raw,
         }
     except requests.RequestException as exc:
         print(f"  ✗ {url}: {exc}", file=sys.stderr)

--- a/sources/community/web_scraper/scripts/scrape.py
+++ b/sources/community/web_scraper/scripts/scrape.py
@@ -71,9 +71,13 @@ def fetch_with_requests(url, timeout=30):
             url, headers=headers, timeout=timeout,
             allow_redirects=True, stream=True,
         )
+    except requests.RequestException as exc:
+        print(f"  ✗ {url}: {exc}", file=sys.stderr)
+        return None
+
+    try:
         content_type = resp.headers.get("Content-Type", "")
         if not _is_html(content_type):
-            resp.close()
             return {
                 "final_url": resp.url,
                 "status_code": resp.status_code,
@@ -87,7 +91,6 @@ def fetch_with_requests(url, timeout=30):
             bytes_read += len(chunk)
             if bytes_read >= MAX_RESPONSE_BYTES:
                 break
-        resp.close()
         raw = b"".join(chunks)[:MAX_RESPONSE_BYTES]
         return {
             "final_url": resp.url,
@@ -98,6 +101,8 @@ def fetch_with_requests(url, timeout=30):
     except requests.RequestException as exc:
         print(f"  ✗ {url}: {exc}", file=sys.stderr)
         return None
+    finally:
+        resp.close()
 
 
 def create_playwright_fetcher(timeout=30):

--- a/sources/community/web_scraper/scripts/scrape.py
+++ b/sources/community/web_scraper/scripts/scrape.py
@@ -64,12 +64,6 @@ def _is_html(content_type):
     return ct in ("text/html", "application/xhtml+xml", "")
 
 
-def _decode_response(resp):
-    encoding = resp.encoding or "utf-8"
-    content = resp.content[:MAX_RESPONSE_BYTES]
-    return content.decode(encoding, errors="replace")
-
-
 def fetch_with_requests(url, timeout=30):
     headers = {"User-Agent": USER_AGENT}
     try:
@@ -89,7 +83,10 @@ def fetch_with_requests(url, timeout=30):
         raw = resp.content[:MAX_RESPONSE_BYTES]
         resp.close()
         encoding = resp.encoding or "utf-8"
-        html = raw.decode(encoding, errors="replace")
+        try:
+            html = raw.decode(encoding, errors="replace")
+        except LookupError:
+            html = raw.decode("utf-8", errors="replace")
         return {
             "final_url": resp.url,
             "status_code": resp.status_code,

--- a/sources/community/web_scraper/scripts/scrape.py
+++ b/sources/community/web_scraper/scripts/scrape.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Scrape web pages and write structured JSONL for the Coral web_scraper source.
+
+Zero external dependencies — uses only Python stdlib.
+
+Usage:
+    python3 scrape.py https://example.com https://example.com/about
+    python3 scrape.py --file urls.txt
+    python3 scrape.py --file urls.txt --output ~/.coral/web_scraper
+
+Output:
+    pages.jsonl  — one row per URL with title, text, metadata
+    links.jsonl  — one row per discovered link on each page
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
+
+DEFAULT_OUTPUT = os.path.expanduser("~/.coral/web_scraper")
+USER_AGENT = (
+    "Mozilla/5.0 (compatible; CoralWebScraper/1.0; "
+    "+https://github.com/withcoral/coral)"
+)
+
+
+class PageParser(HTMLParser):
+    def __init__(self, base_url):
+        super().__init__()
+        self.base_url = base_url
+        self.title = None
+        self.description = None
+        self.language = None
+        self.links = []
+        self.text_parts = []
+        self._in_title = False
+        self._skip_tags = {"script", "style", "noscript"}
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        attrs_dict = dict(attrs)
+
+        if tag == "html" and "lang" in attrs_dict:
+            self.language = attrs_dict["lang"]
+
+        if tag == "title":
+            self._in_title = True
+
+        if tag in self._skip_tags:
+            self._skip_depth += 1
+
+        if tag == "meta":
+            name = attrs_dict.get("name", "").lower()
+            content = attrs_dict.get("content", "")
+            if name == "description" and content:
+                self.description = content.strip()
+
+        if tag == "a" and "href" in attrs_dict:
+            href = attrs_dict["href"].strip()
+            if href and not href.startswith(("#", "javascript:", "mailto:", "tel:")):
+                self.links.append({"href": href, "text_parts": []})
+
+    def handle_endtag(self, tag):
+        if tag == "title":
+            self._in_title = False
+        if tag in self._skip_tags and self._skip_depth > 0:
+            self._skip_depth -= 1
+        if tag == "a" and self.links and "text_parts" in self.links[-1]:
+            link = self.links[-1]
+            link["text"] = " ".join(link.pop("text_parts")).strip() or None
+
+    def handle_data(self, data):
+        if self._in_title:
+            self.title = (self.title or "") + data
+
+        if self._skip_depth == 0:
+            stripped = data.strip()
+            if stripped:
+                self.text_parts.append(stripped)
+
+        if self.links and "text_parts" in self.links[-1]:
+            self.links[-1]["text_parts"].append(data.strip())
+
+    def get_text(self):
+        return "\n".join(self.text_parts)
+
+    def get_title(self):
+        return self.title.strip() if self.title else None
+
+    def get_links(self):
+        parsed_base = urlparse(self.base_url)
+        result = []
+        for link in self.links:
+            absolute = urljoin(self.base_url, link["href"])
+            parsed = urlparse(absolute)
+            is_external = parsed.netloc != parsed_base.netloc
+            result.append({
+                "source_url": self.base_url,
+                "href": absolute,
+                "text": link.get("text"),
+                "is_external": is_external,
+            })
+        return result
+
+
+def scrape_url(url, timeout=30):
+    req = Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        resp = urlopen(req, timeout=timeout)
+        final_url = resp.url
+        status_code = resp.status
+        content_type = resp.headers.get("Content-Type", "")
+        html = resp.read().decode("utf-8", errors="replace")
+        return {
+            "final_url": final_url,
+            "status_code": status_code,
+            "content_type": content_type,
+            "html": html,
+        }
+    except HTTPError as exc:
+        return {
+            "final_url": url,
+            "status_code": exc.code,
+            "content_type": exc.headers.get("Content-Type", ""),
+            "html": "",
+        }
+    except URLError as exc:
+        print(f"  ✗ {url}: {exc.reason}", file=sys.stderr)
+        return None
+    except Exception as exc:
+        print(f"  ✗ {url}: {exc}", file=sys.stderr)
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scrape URLs to JSONL for Coral")
+    parser.add_argument("urls", nargs="*", help="URLs to scrape")
+    parser.add_argument("--file", "-f", help="File with one URL per line")
+    parser.add_argument(
+        "--output", "-o", default=DEFAULT_OUTPUT,
+        help=f"Output directory (default: {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument("--timeout", "-t", type=int, default=30, help="Request timeout")
+    args = parser.parse_args()
+
+    urls = list(args.urls)
+    if args.file:
+        with open(args.file) as fh:
+            urls.extend(line.strip() for line in fh if line.strip() and not line.startswith("#"))
+
+    if not urls:
+        parser.error("No URLs provided. Pass URLs as arguments or use --file.")
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pages_path = output_dir / "pages.jsonl"
+    links_path = output_dir / "links.jsonl"
+
+    pages_count = 0
+    links_count = 0
+
+    with open(pages_path, "w") as pages_fh, open(links_path, "w") as links_fh:
+        for url in urls:
+            if not url.startswith(("http://", "https://")):
+                url = "https://" + url
+
+            print(f"  → {url}")
+            result = scrape_url(url, timeout=args.timeout)
+            if result is None:
+                continue
+
+            page_parser = PageParser(url)
+            try:
+                page_parser.feed(result["html"])
+            except Exception:
+                pass
+
+            page = {
+                "url": url,
+                "final_url": result["final_url"],
+                "title": page_parser.get_title(),
+                "description": page_parser.description,
+                "text": page_parser.get_text(),
+                "status_code": result["status_code"],
+                "content_type": result["content_type"],
+                "language": page_parser.language,
+                "scraped_at": datetime.now(timezone.utc).isoformat(),
+            }
+            pages_fh.write(json.dumps(page) + "\n")
+            pages_count += 1
+
+            for link in page_parser.get_links():
+                links_fh.write(json.dumps(link) + "\n")
+                links_count += 1
+
+    print(f"\n  ✓ {pages_count} pages → {pages_path}")
+    print(f"  ✓ {links_count} links → {links_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sources/community/web_scraper/scripts/scrape.py
+++ b/sources/community/web_scraper/scripts/scrape.py
@@ -80,8 +80,15 @@ def fetch_with_requests(url, timeout=30):
                 "content_type": content_type,
                 "html": b"",
             }
-        raw = resp.content[:MAX_RESPONSE_BYTES]
+        chunks = []
+        bytes_read = 0
+        for chunk in resp.iter_content(chunk_size=65536):
+            chunks.append(chunk)
+            bytes_read += len(chunk)
+            if bytes_read >= MAX_RESPONSE_BYTES:
+                break
         resp.close()
+        raw = b"".join(chunks)[:MAX_RESPONSE_BYTES]
         return {
             "final_url": resp.url,
             "status_code": resp.status_code,
@@ -278,14 +285,22 @@ def main():
         tmp_pages.close()
         tmp_links.close()
 
+        if fail_count:
+            os.unlink(tmp_pages.name)
+            os.unlink(tmp_links.name)
+            print(f"\n  ✗ {fail_count} URLs failed — existing files preserved",
+                  file=sys.stderr)
+            sys.exit(1)
+
         shutil.move(tmp_pages.name, pages_path)
         shutil.move(tmp_links.name, links_path)
 
     except BaseException:
         tmp_pages.close()
         tmp_links.close()
-        os.unlink(tmp_pages.name)
-        os.unlink(tmp_links.name)
+        for p in (tmp_pages.name, tmp_links.name):
+            if os.path.exists(p):
+                os.unlink(p)
         raise
     finally:
         if pw_cleanup:
@@ -293,9 +308,6 @@ def main():
 
     print(f"\n  ✓ {pages_count} pages → {pages_path}")
     print(f"  ✓ {links_count} links → {links_path}")
-    if fail_count:
-        print(f"  ✗ {fail_count} URLs failed", file=sys.stderr)
-        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/sources/community/web_scraper/scripts/scrape.py
+++ b/sources/community/web_scraper/scripts/scrape.py
@@ -16,7 +16,6 @@ Output:
 import argparse
 import json
 import os
-import re
 import sys
 from datetime import datetime, timezone
 from html.parser import HTMLParser

--- a/sources/community/web_scraper/scripts/scrape.py
+++ b/sources/community/web_scraper/scripts/scrape.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
 """Scrape web pages and write structured JSONL for the Coral web_scraper source.
 
-Zero external dependencies — uses only Python stdlib.
+Uses requests + BeautifulSoup + lxml for robust scraping.
+Optional: --js flag uses Playwright for JavaScript-rendered pages.
 
 Usage:
     python3 scrape.py https://example.com https://example.com/about
     python3 scrape.py --file urls.txt
+    python3 scrape.py --js https://spa-site.com        # JS rendering
     python3 scrape.py --file urls.txt --output ~/.coral/web_scraper
+
+Dependencies:
+    pip install requests beautifulsoup4 lxml             # required
+    pip install playwright && playwright install chromium # optional, for --js
 
 Output:
     pages.jsonl  — one row per URL with title, text, metadata
@@ -18,145 +24,161 @@ import json
 import os
 import sys
 from datetime import datetime, timezone
-from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
-from urllib.request import Request, urlopen
-from urllib.error import HTTPError, URLError
+
+try:
+    import requests
+except ImportError:
+    sys.exit("Missing dependency: pip install requests")
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    sys.exit("Missing dependency: pip install beautifulsoup4")
 
 DEFAULT_OUTPUT = os.path.expanduser("~/.coral/web_scraper")
 USER_AGENT = (
-    "Mozilla/5.0 (compatible; CoralWebScraper/1.0; "
-    "+https://github.com/withcoral/coral)"
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 )
 
 
-class PageParser(HTMLParser):
-    def __init__(self, base_url):
-        super().__init__()
-        self.base_url = base_url
-        self.title = None
-        self.description = None
-        self.language = None
-        self.links = []
-        self.text_parts = []
-        self._in_title = False
-        self._skip_tags = {"script", "style", "noscript"}
-        self._skip_depth = 0
-
-    def handle_starttag(self, tag, attrs):
-        attrs_dict = dict(attrs)
-
-        if tag == "html" and "lang" in attrs_dict:
-            self.language = attrs_dict["lang"]
-
-        if tag == "title":
-            self._in_title = True
-
-        if tag in self._skip_tags:
-            self._skip_depth += 1
-
-        if tag == "meta":
-            name = attrs_dict.get("name", "").lower()
-            content = attrs_dict.get("content", "")
-            if name == "description" and content:
-                self.description = content.strip()
-
-        if tag == "a" and "href" in attrs_dict:
-            href = attrs_dict["href"].strip()
-            if href and not href.startswith(("#", "javascript:", "mailto:", "tel:")):
-                self.links.append({"href": href, "text_parts": []})
-
-    def handle_endtag(self, tag):
-        if tag == "title":
-            self._in_title = False
-        if tag in self._skip_tags and self._skip_depth > 0:
-            self._skip_depth -= 1
-        if tag == "a" and self.links and "text_parts" in self.links[-1]:
-            link = self.links[-1]
-            link["text"] = " ".join(link.pop("text_parts")).strip() or None
-
-    def handle_data(self, data):
-        if self._in_title:
-            self.title = (self.title or "") + data
-
-        if self._skip_depth == 0:
-            stripped = data.strip()
-            if stripped:
-                self.text_parts.append(stripped)
-
-        if self.links and "text_parts" in self.links[-1]:
-            self.links[-1]["text_parts"].append(data.strip())
-
-    def get_text(self):
-        return "\n".join(self.text_parts)
-
-    def get_title(self):
-        return self.title.strip() if self.title else None
-
-    def get_links(self):
-        parsed_base = urlparse(self.base_url)
-        result = []
-        for link in self.links:
-            absolute = urljoin(self.base_url, link["href"])
-            parsed = urlparse(absolute)
-            is_external = parsed.netloc != parsed_base.netloc
-            result.append({
-                "source_url": self.base_url,
-                "href": absolute,
-                "text": link.get("text"),
-                "is_external": is_external,
-            })
-        return result
-
-
-def scrape_url(url, timeout=30):
-    req = Request(url, headers={"User-Agent": USER_AGENT})
+def fetch_with_requests(url, timeout=30):
+    headers = {"User-Agent": USER_AGENT}
     try:
-        resp = urlopen(req, timeout=timeout)
-        final_url = resp.url
-        status_code = resp.status
-        content_type = resp.headers.get("Content-Type", "")
-        html = resp.read().decode("utf-8", errors="replace")
+        resp = requests.get(url, headers=headers, timeout=timeout, allow_redirects=True)
         return {
-            "final_url": final_url,
-            "status_code": status_code,
-            "content_type": content_type,
-            "html": html,
+            "final_url": resp.url,
+            "status_code": resp.status_code,
+            "content_type": resp.headers.get("Content-Type", ""),
+            "html": resp.text,
         }
-    except HTTPError as exc:
-        return {
-            "final_url": url,
-            "status_code": exc.code,
-            "content_type": exc.headers.get("Content-Type", ""),
-            "html": "",
-        }
-    except URLError as exc:
-        print(f"  ✗ {url}: {exc.reason}", file=sys.stderr)
-        return None
-    except Exception as exc:
+    except requests.RequestException as exc:
         print(f"  ✗ {url}: {exc}", file=sys.stderr)
         return None
 
 
+def fetch_with_playwright(url, timeout=30):
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        sys.exit(
+            "Missing dependency for --js mode:\n"
+            "  pip install playwright && playwright install chromium"
+        )
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page(user_agent=USER_AGENT)
+        try:
+            resp = page.goto(url, timeout=timeout * 1000, wait_until="networkidle")
+            status_code = resp.status if resp else 0
+            content_type = resp.headers.get("content-type", "") if resp else ""
+            html = page.content()
+            final_url = page.url
+            return {
+                "final_url": final_url,
+                "status_code": status_code,
+                "content_type": content_type,
+                "html": html,
+            }
+        except Exception as exc:
+            print(f"  ✗ {url}: {exc}", file=sys.stderr)
+            return None
+        finally:
+            browser.close()
+
+
+def extract_page(url, result):
+    soup = BeautifulSoup(result["html"], "lxml")
+
+    title_tag = soup.find("title")
+    title = title_tag.get_text(strip=True) if title_tag else None
+
+    meta_desc = soup.find("meta", attrs={"name": "description"})
+    description = (
+        meta_desc["content"].strip()
+        if meta_desc and meta_desc.get("content")
+        else None
+    )
+
+    html_tag = soup.find("html")
+    language = html_tag.get("lang") if html_tag else None
+
+    for tag in soup(["script", "style", "noscript"]):
+        tag.decompose()
+    text = soup.get_text(separator="\n", strip=True)
+
+    return {
+        "url": url,
+        "final_url": result["final_url"],
+        "title": title,
+        "description": description,
+        "text": text,
+        "status_code": result["status_code"],
+        "content_type": result["content_type"],
+        "language": language,
+        "scraped_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def extract_links(url, result):
+    soup = BeautifulSoup(result["html"], "lxml")
+    parsed_base = urlparse(url)
+    links = []
+
+    for a_tag in soup.find_all("a", href=True):
+        href = a_tag["href"].strip()
+        if not href or href.startswith(("#", "javascript:", "mailto:", "tel:")):
+            continue
+
+        absolute = urljoin(url, href)
+        parsed = urlparse(absolute)
+        is_external = parsed.netloc != parsed_base.netloc
+        link_text = a_tag.get_text(strip=True) or None
+
+        links.append({
+            "source_url": url,
+            "href": absolute,
+            "text": link_text,
+            "is_external": is_external,
+        })
+
+    return links
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Scrape URLs to JSONL for Coral")
+    parser = argparse.ArgumentParser(
+        description="Scrape URLs to JSONL for Coral web_scraper source"
+    )
     parser.add_argument("urls", nargs="*", help="URLs to scrape")
     parser.add_argument("--file", "-f", help="File with one URL per line")
     parser.add_argument(
         "--output", "-o", default=DEFAULT_OUTPUT,
         help=f"Output directory (default: {DEFAULT_OUTPUT})",
     )
-    parser.add_argument("--timeout", "-t", type=int, default=30, help="Request timeout")
+    parser.add_argument(
+        "--js", action="store_true",
+        help="Use Playwright for JS-rendered pages (requires: pip install playwright)",
+    )
+    parser.add_argument(
+        "--timeout", "-t", type=int, default=30, help="Request timeout in seconds"
+    )
     args = parser.parse_args()
 
     urls = list(args.urls)
     if args.file:
         with open(args.file) as fh:
-            urls.extend(line.strip() for line in fh if line.strip() and not line.startswith("#"))
+            urls.extend(
+                line.strip() for line in fh
+                if line.strip() and not line.startswith("#")
+            )
 
     if not urls:
         parser.error("No URLs provided. Pass URLs as arguments or use --file.")
+
+    fetch = fetch_with_playwright if args.js else fetch_with_requests
 
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -171,32 +193,18 @@ def main():
             if not url.startswith(("http://", "https://")):
                 url = "https://" + url
 
-            print(f"  → {url}")
-            result = scrape_url(url, timeout=args.timeout)
+            mode = "JS" if args.js else "HTTP"
+            print(f"  → [{mode}] {url}")
+            result = fetch(url, timeout=args.timeout)
             if result is None:
                 continue
 
-            page_parser = PageParser(url)
-            try:
-                page_parser.feed(result["html"])
-            except Exception:
-                pass
-
-            page = {
-                "url": url,
-                "final_url": result["final_url"],
-                "title": page_parser.get_title(),
-                "description": page_parser.description,
-                "text": page_parser.get_text(),
-                "status_code": result["status_code"],
-                "content_type": result["content_type"],
-                "language": page_parser.language,
-                "scraped_at": datetime.now(timezone.utc).isoformat(),
-            }
+            page = extract_page(url, result)
             pages_fh.write(json.dumps(page) + "\n")
             pages_count += 1
 
-            for link in page_parser.get_links():
+            page_links = extract_links(url, result)
+            for link in page_links:
                 links_fh.write(json.dumps(link) + "\n")
                 links_count += 1
 

--- a/sources/community/web_scraper/scripts/scrape.py
+++ b/sources/community/web_scraper/scripts/scrape.py
@@ -81,7 +81,11 @@ def create_playwright_fetcher(timeout=30):
         )
 
     ctx = sync_playwright().start()
-    browser = ctx.chromium.launch(headless=True)
+    try:
+        browser = ctx.chromium.launch(headless=True)
+    except Exception:
+        ctx.stop()
+        raise
 
     def fetch(url, timeout=timeout):
         page = browser.new_page(user_agent=USER_AGENT)


### PR DESCRIPTION
## Summary

Add a local web scraper community source so Coral can query scraped web pages and discovered links through SQL, without any API key or external service.

## Files contributed

| File | Purpose |
| --- | --- |
| `sources/community/web_scraper/manifest.yaml` | Coral source manifest defining 2 tables: `pages`, `links` |
| `sources/community/web_scraper/README.md` | Full documentation with setup, queries, and validation |
| `sources/community/web_scraper/scripts/scrape.py` | Python scraper using requests + BeautifulSoup + lxml (optional Playwright for JS) |

## Why this source

AI agents sometimes need to scrape websites that block API-based scrapers like Firecrawl, or operate behind firewalls where external API calls are not possible. A local web scraper provides:
- No API key, no credits, no rate limits
- Works behind firewalls and on internal sites
- Data stays local — no content sent to third-party services
- Robust parsing with requests + BeautifulSoup + lxml
- Optional JS rendering via Playwright (`--js` flag)

## Dependencies

| Package | Purpose | Required |
|---------|---------|----------|
| `requests` | HTTP requests with sessions, cookies, redirects | Yes |
| `beautifulsoup4` | HTML parsing and content extraction | Yes |
| `lxml` | Fast HTML parser backend (falls back to html.parser) | Recommended |
| `playwright` | JavaScript rendering for SPAs via `--js` flag | Optional |

## Source shape

| Table | Description |
|-------|-------------|
| `pages` | Scraped web pages with title, text, description, metadata (9 columns) |
| `links` | Discovered links per page with anchor text and external flag (4 columns) |

## Source scope

- **Backend:** `file` with `format: jsonl`
- **Data location:** `~/.coral/web_scraper/pages.jsonl` and `~/.coral/web_scraper/links.jsonl`
- **No credentials required**
- Data is static — re-run the scraper to refresh

## Validation

```bash
$ python3 scrape.py https://withcoral.com https://withcoral.com/docs
  → [HTTP] https://withcoral.com
  → [HTTP] https://withcoral.com/docs

  ✓ 2 pages → ~/.coral/web_scraper/pages.jsonl
  ✓ 70 links → ~/.coral/web_scraper/links.jsonl
```

```bash
$ coral source lint sources/community/web_scraper/manifest.yaml
Manifest is valid
```

```bash
$ coral source add --file sources/community/web_scraper/manifest.yaml
Added source web_scraper

  ✓ web_scraper connected successfully

    web_scraper (2 tables)
    ├─ links
    └─ pages
    Query tests
    2 declared · 2 passed · 0 failed

    ✓ SELECT url, title, status_code FROM web_scraper.pages LIMIT 3
      2 rows

    ✓ SELECT source_url, href, is_external FROM web_scraper.links LIMIT 5
      5 rows
```

### Live pages proof

```sql
SELECT url, title, status_code, language FROM web_scraper.pages;
```

```text
+----------------------------+-------------------------------------------+-------------+----------+
| url                        | title                                     | status_code | language |
+----------------------------+-------------------------------------------+-------------+----------+
| https://withcoral.com      | Coral — The data engine for enterprise AI | 200         | en       |
| https://withcoral.com/docs | Introduction to Coral - Coral Docs        | 200         | en       |
+----------------------------+-------------------------------------------+-------------+----------+
```

### Live links proof

```sql
SELECT href, text FROM web_scraper.links WHERE text LIKE '%GitHub%' LIMIT 3;
```

```text
+------------------------------------+-------------+
| href                               | text        |
+------------------------------------+-------------+
| https://github.com/withcoral/coral | GitHub 5.1K |
| https://github.com/withcoral/coral | GitHub 5.1K |
| https://github.com/withcoral/coral | GitHub      |
+------------------------------------+-------------+
```

Closes #1475