### PR TITLE
fix(app): require trusted import credential transports

### DIFF
--- a/crates/coral-app/src/credential_transport.rs
+++ b/crates/coral-app/src/credential_transport.rs
@@ -1,0 +1,38 @@
+//! Shared transport policy for endpoints that receive credential material.
+
+use url::{Host, Url};
+
+use crate::bootstrap::AppError;
+
+pub(crate) fn validate_credential_endpoint_transport(
+    context: &str,
+    raw_url: &str,
+) -> Result<(), AppError> {
+    let normalized = normalize_endpoint_url(raw_url);
+    let url = Url::parse(&normalized)
+        .map_err(|error| AppError::InvalidInput(format!("{context} is invalid: {error}")))?;
+    if url.scheme() == "https" || (url.scheme() == "http" && is_loopback_url(&url)) {
+        return Ok(());
+    }
+    Err(AppError::InvalidInput(format!(
+        "{context} must use https or loopback http before credentials can be sent"
+    )))
+}
+
+fn normalize_endpoint_url(raw_url: &str) -> String {
+    let trimmed = raw_url.trim().trim_start_matches("//");
+    if trimmed.contains("://") {
+        trimmed.to_string()
+    } else {
+        format!("https://{trimmed}")
+    }
+}
+
+fn is_loopback_url(url: &Url) -> bool {
+    match url.host() {
+        Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => address.is_loopback(),
+        None => false,
+    }
+}

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -26,6 +26,7 @@ use url::{Url, form_urlencoded};
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
+use crate::credential_transport::validate_credential_endpoint_transport;
 use crate::credentials::OAUTH_INTERNAL_KEY_PREFIX;
 
 const SESSION_TTL: Duration = Duration::from_mins(10);
@@ -283,6 +284,7 @@ impl OAuthCredentialService {
     {
         let oauth = request.oauth.clone();
         let endpoints = oauth_endpoint_urls(&oauth, request.source_inputs)?;
+        validate_oauth_setup_endpoint_transports(&endpoints)?;
         let resource = oauth_resource(&oauth, request.source_inputs)?;
         let credential_inputs = normalize_credential_inputs(request.credential_inputs)?;
         reject_unknown_credential_inputs(&oauth, &credential_inputs)?;
@@ -394,6 +396,7 @@ impl OAuthCredentialService {
         credential_inputs: Vec<(String, String)>,
     ) -> Result<(), AppError> {
         let endpoints = oauth_endpoint_urls(oauth, source_inputs)?;
+        validate_oauth_setup_endpoint_transports(&endpoints)?;
         let _resource = oauth_resource(oauth, source_inputs)?;
         let credential_inputs = normalize_credential_inputs(credential_inputs)?;
         reject_unknown_credential_inputs(oauth, &credential_inputs)?;
@@ -546,9 +549,22 @@ impl OAuthCredentialService {
     }
 }
 
+fn validate_oauth_setup_endpoint_transports(
+    endpoints: &ManifestOAuthEndpointUrls,
+) -> Result<(), AppError> {
+    if let Some(url) = endpoints.authorization_url.as_deref() {
+        validate_credential_endpoint_transport("OAuth authorization_url", url)?;
+    }
+    if let Some(url) = endpoints.device_authorization_url.as_deref() {
+        validate_credential_endpoint_transport("OAuth device_authorization_url", url)?;
+    }
+    validate_credential_endpoint_transport("OAuth token_url", &endpoints.token_url)
+}
+
 fn token_http_client(timeout: Duration) -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .expect("OAuth token HTTP client configuration should be valid")
 }
@@ -1454,6 +1470,8 @@ async fn refresh_access_token(
     http: &reqwest::Client,
     refresh: &OAuthRefreshConfig,
 ) -> Result<TokenResponse, AppError> {
+    validate_credential_endpoint_transport("OAuth token refresh token_url", &refresh.token_url)
+        .map_err(|error| AppError::FailedPrecondition(format!("{error}; reconnect the source")))?;
     let mut form = vec![
         ("grant_type", "refresh_token".to_string()),
         ("refresh_token", refresh.refresh_token.clone()),
@@ -2337,6 +2355,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn expired_oauth_material_rejects_cleartext_refresh_token_url() {
+        let oauth = oauth_spec(
+            "https://api.example.com/token",
+            53682,
+            ManifestOAuthPkceMode::Disabled,
+            public_client(),
+        );
+        let mut material = expired_oauth_material("http://api.example.com/token");
+        let service = OAuthCredentialService::new();
+
+        let error = service
+            .refresh_if_needed(
+                RefreshOAuthCredentialRequest::for_source_input("API_TOKEN", &oauth),
+                &mut material,
+            )
+            .await
+            .expect_err("cleartext refresh token URL should fail closed");
+
+        let message = error.to_string();
+        assert!(message.contains("OAuth token refresh token_url must use https"));
+        assert!(message.contains("reconnect the source"));
+    }
+
+    #[tokio::test]
+    async fn oauth_refresh_does_not_follow_token_redirects() {
+        let redirect_url = format!("http://127.0.0.1:{}/capture", free_loopback_port());
+        let raw = Box::leak(
+            format!(
+                "HTTP/1.1 307 Temporary Redirect\r\nlocation: {redirect_url}\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+            )
+            .into_boxed_str(),
+        );
+        let fixture = OAuthFixture::new(Some(raw));
+        let oauth = oauth_spec(
+            &fixture.token_url,
+            free_loopback_port(),
+            ManifestOAuthPkceMode::Disabled,
+            public_client(),
+        );
+        let mut material = expired_oauth_material(&fixture.token_url);
+        let error = OAuthCredentialService::with_token_request_timeout(Duration::from_millis(100))
+            .refresh_if_needed(
+                RefreshOAuthCredentialRequest::for_source_input("API_TOKEN", &oauth),
+                &mut material,
+            )
+            .await
+            .expect_err("redirect token response should fail");
+
+        fixture.token_server.await.expect("token server");
+        assert!(error.to_string().contains("HTTP 307"));
+    }
+
+    #[tokio::test]
     async fn unexpired_oauth_material_does_not_refresh_access_token() {
         let oauth = oauth_spec(
             "http://127.0.0.1:9/token",
@@ -2728,6 +2799,37 @@ mod tests {
         assert_eq!(completed.access_token, "access-token");
         assert_public_dcr_metadata(&completed.internal_metadata, "MCP_ACCESS_TOKEN");
         assert_no_dcr_client_management_metadata(&completed.internal_metadata, "MCP_ACCESS_TOKEN");
+    }
+
+    #[tokio::test]
+    async fn oauth_setup_rejects_cleartext_endpoints_before_events_or_requests() {
+        let mut oauth = oauth_spec(
+            "https://api.example.com/token",
+            53682,
+            ManifestOAuthPkceMode::Required,
+            public_client(),
+        );
+        oauth.authorization_url = Some("http://api.example.com/authorize".to_string());
+
+        let service = OAuthCredentialService::new();
+        let error = service
+            .authorize(
+                StartOAuthCredentialRequest {
+                    input_key: "API_TOKEN",
+                    oauth: &oauth,
+                    source_inputs: &EMPTY_SOURCE_INPUTS,
+                    credential_inputs: Vec::new(),
+                },
+                |_authorization| async {
+                    panic!("authorization callback should not run");
+                },
+            )
+            .await
+            .err()
+            .expect("cleartext OAuth endpoint should fail");
+
+        let message = error.to_string();
+        assert!(message.contains("OAuth authorization_url must use https"));
     }
 
     #[tokio::test]
@@ -3529,6 +3631,35 @@ mod tests {
             .port()
     }
 
+    fn public_client() -> ManifestOAuthClientSpec {
+        ManifestOAuthClientSpec {
+            id: ManifestOAuthClientIdSpec {
+                default: Some("default-client".to_string()),
+                input: None,
+            },
+            secret: None,
+            dynamic_registration: None,
+        }
+    }
+
+    fn expired_oauth_material(token_url: &str) -> BTreeMap<String, String> {
+        let prefix = oauth_metadata_prefix("API_TOKEN");
+        BTreeMap::from([
+            ("API_TOKEN".to_string(), "expired-token".to_string()),
+            (format!("{prefix}method"), "oauth".to_string()),
+            (
+                format!("{prefix}access_token_expires_at"),
+                (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
+            ),
+            (
+                format!("{prefix}refresh_token"),
+                "stored-refresh-token".to_string(),
+            ),
+            (format!("{prefix}client_id"), "stored-client".to_string()),
+            (format!("{prefix}token_url"), token_url.to_string()),
+        ])
+    }
+
     struct OAuthFixture {
         token_url: String,
         token_server: JoinHandle<CapturedTokenRequest>,
@@ -3548,10 +3679,14 @@ mod tests {
                 let response_body = response_body.unwrap_or(
                     r#"{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","scope":"repo read:org","expires_in":3600}"#,
                 );
-                let response = format!(
-                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
-                    response_body.len()
-                );
+                let response = if response_body.starts_with("HTTP/1.1 ") {
+                    response_body.to_string()
+                } else {
+                    format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+                        response_body.len()
+                    )
+                };
                 stream
                     .write_all(response.as_bytes())
                     .await

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -46,6 +46,7 @@ mod authorization_matrix;
 /// Bootstrap entrypoints and local server assembly.
 pub mod bootstrap;
 mod catalog;
+mod credential_transport;
 mod credentials;
 mod encrypted_document;
 pub mod features;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -32,9 +32,11 @@ use crate::query::input_resolver::{
     CredentialRefreshingInputResolver, SourceCredentialSnapshot, StoredCredentialInputResolver,
 };
 use crate::search::observed::{SearchObservationHandle, SearchObservationSource};
-use crate::sources::catalog::resolve_installed_manifest;
+use crate::sources::catalog::{
+    resolve_installed_manifest, validate_imported_manifest_database_persistence,
+};
 use crate::sources::materialization::{SourceDiagnosticReporter, SourceLoadDiagnosticStage};
-use crate::sources::model::InstalledSource;
+use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::sources::runtime_package::{
     RuntimeContractFingerprint, query_source_from_installed_manifest,
 };
@@ -714,6 +716,12 @@ impl QueryManager {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = &installed.source_spec;
         ensure_database_source_feature_enabled(source_spec, self.database_sources_enabled)?;
+        if source.origin == SourceOrigin::Imported {
+            validate_imported_manifest_database_persistence(
+                &installed.manifest_yaml,
+                &source.variables,
+            )?;
+        }
         validate_required_variables(source, source_spec.declared_inputs())?;
         let stored_secrets =
             if let Some(credential_storage) = source.credential_storage_for_material() {
@@ -2908,6 +2916,69 @@ tables:
             recorded.first().expect("recorded task query").status,
             "success"
         );
+    }
+
+    #[tokio::test]
+    async fn load_query_source_revalidates_persisted_imported_credential_transport() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("transport_guard").expect("source name");
+        let manifest_path = fixture
+            .manager
+            .layout
+            .manifest_file(&workspace_name, &source_name);
+        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create source dir");
+        std::fs::write(
+            &manifest_path,
+            r#"
+name: transport_guard
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: "{{input.API_BASE}}"
+inputs:
+  API_BASE:
+    kind: variable
+  API_TOKEN:
+    kind: secret
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: bearer
+      key: API_TOKEN
+tables:
+  - name: items
+    description: Items
+    request:
+      path: /items
+    columns:
+      - name: id
+        type: Utf8
+"#,
+        )
+        .expect("write manifest");
+        let source = InstalledSource {
+            name: source_name.clone(),
+            version: Some("0.1.0".to_string()),
+            variables: BTreeMap::from([(
+                "API_BASE".to_string(),
+                "http://api.example.com".to_string(),
+            )]),
+            secrets: vec!["API_TOKEN".to_string()],
+            credential_storage: Some(CredentialStorageKind::File),
+            credential_revision: uuid::Uuid::default(),
+            origin: SourceOrigin::Imported,
+        };
+
+        let error = fixture
+            .manager
+            .load_query_source(&workspace_name, &source)
+            .expect_err("persisted imported cleartext credential endpoint should fail");
+
+        assert!(error.to_string().contains("base_url must use https"));
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -4,12 +4,14 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use coral_spec::backends::file::{FileObjectStoreSpec, S3AuthSpec};
 use coral_spec::{
-    AuthSpec, BodySpec, HeaderSpec, ManifestInputKind, McpServerSpec, ParsedTemplate,
-    TemplateNamespace, ValidatedSourceManifest, ValueSourceSpec, parse_source_manifest_yaml,
+    AuthSpec, BodySpec, HeaderSpec, ManifestCredentialMethodKind, ManifestInputKind,
+    ManifestInputSpec, McpServerSpec, ParsedTemplate, TemplateNamespace, TemplatePart,
+    ValidatedSourceManifest, ValueSourceSpec, parse_source_manifest_yaml,
 };
 use serde_json::Value as JsonValue;
 
 use crate::bootstrap::AppError;
+use crate::credential_transport::validate_credential_endpoint_transport;
 use crate::sources::SourceName;
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
@@ -136,6 +138,20 @@ pub(crate) fn describe_manifest(
 
 pub(crate) fn validate_imported_manifest_database_persistence(
     manifest_yaml: &str,
+    source_variables: &BTreeMap<String, String>,
+) -> Result<(), AppError> {
+    validate_imported_manifest_database_persistence_inner(manifest_yaml, Some(source_variables))
+}
+
+pub(crate) fn validate_imported_manifest_database_persistence_shape(
+    manifest_yaml: &str,
+) -> Result<(), AppError> {
+    validate_imported_manifest_database_persistence_inner(manifest_yaml, None)
+}
+
+fn validate_imported_manifest_database_persistence_inner(
+    manifest_yaml: &str,
+    source_variables: Option<&BTreeMap<String, String>>,
 ) -> Result<(), AppError> {
     let manifest = parse_source_manifest_yaml(manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;
@@ -146,33 +162,11 @@ pub(crate) fn validate_imported_manifest_database_persistence(
         .collect::<BTreeMap<_, _>>();
 
     if let Some(http) = manifest.as_http() {
-        validate_http_auth_spec_for_database_persistence(&input_kinds, "auth", &http.auth)?;
-        validate_headers_for_database_persistence(
-            &input_kinds,
-            "request_headers",
-            &http.request_headers,
-        )?;
-        for table in &http.tables {
-            validate_request_headers_for_database_persistence(
-                &input_kinds,
-                &format!("table '{}'", table.name()),
-                &table.request,
-            )?;
-            for route in &table.requests {
-                validate_request_headers_for_database_persistence(
-                    &input_kinds,
-                    &format!("table '{}' request route", table.name()),
-                    &route.request,
-                )?;
-            }
-        }
-        for function in &http.functions {
-            validate_request_headers_for_database_persistence(
-                &input_kinds,
-                &format!("function '{}'", function.name),
-                &function.request,
-            )?;
-        }
+        validate_http_source_for_database_persistence(&input_kinds, source_variables, http)?;
+    }
+
+    if let Some(source_variables) = source_variables {
+        validate_oauth_endpoint_transports(manifest.declared_inputs(), source_variables)?;
     }
 
     if let Some(file) = manifest.as_file() {
@@ -190,35 +184,104 @@ pub(crate) fn validate_imported_manifest_database_persistence(
     }
 
     if let Some(v4) = manifest.as_v4() {
-        match &v4.surface.runtime {
-            coral_spec::v4::SurfaceRuntimeConfig::OpenApi(runtime) => {
-                validate_http_auth_spec_for_database_persistence(
-                    &input_kinds,
-                    "surface auth",
-                    &runtime.auth,
-                )?;
-                validate_headers_for_database_persistence(
-                    &input_kinds,
-                    "surface request_headers",
-                    &runtime.request_headers,
-                )?;
-            }
-            coral_spec::v4::SurfaceRuntimeConfig::Mcp(runtime) => {
-                validate_mcp_server_for_database_persistence(
-                    &input_kinds,
-                    "surface server",
-                    &runtime.server,
-                )?;
-            }
-            coral_spec::v4::SurfaceRuntimeConfig::Database(_) => {
-                // Database surfaces carry their credentials in the connection
-                // spec, which the database connection layer validates on its
-                // own. There is no surface auth/header/base_url transport to
-                // guard for imported-manifest persistence here.
-            }
-        }
+        validate_v4_source_for_database_persistence(&input_kinds, source_variables, v4)?;
     }
 
+    Ok(())
+}
+
+fn validate_http_source_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    source_variables: Option<&BTreeMap<String, String>>,
+    http: &coral_spec::backends::http::HttpSourceManifest,
+) -> Result<(), AppError> {
+    let mut needs_transport_guard =
+        validate_http_auth_spec_for_database_persistence(input_kinds, "auth", &http.auth)?;
+    needs_transport_guard |= validate_headers_for_database_persistence(
+        input_kinds,
+        "request_headers",
+        &http.request_headers,
+    )?;
+    for table in &http.tables {
+        needs_transport_guard |= validate_request_headers_for_database_persistence(
+            input_kinds,
+            &format!("table '{}'", table.name()),
+            &table.request,
+        )?;
+        for route in &table.requests {
+            needs_transport_guard |= validate_request_headers_for_database_persistence(
+                input_kinds,
+                &format!("table '{}' request route", table.name()),
+                &route.request,
+            )?;
+        }
+    }
+    for function in &http.functions {
+        needs_transport_guard |= validate_request_headers_for_database_persistence(
+            input_kinds,
+            &format!("function '{}'", function.name),
+            &function.request,
+        )?;
+    }
+    needs_transport_guard |= template_references_secret_input(input_kinds, &http.base_url);
+    if let Some(source_variables) = source_variables
+        && needs_transport_guard
+    {
+        validate_endpoint_template_transport(
+            input_kinds,
+            source_variables,
+            "base_url",
+            &http.base_url,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_v4_source_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    source_variables: Option<&BTreeMap<String, String>>,
+    v4: &coral_spec::v4::V4SourceManifest,
+) -> Result<(), AppError> {
+    match &v4.surface.runtime {
+        coral_spec::v4::SurfaceRuntimeConfig::OpenApi(runtime) => {
+            let mut needs_transport_guard = validate_http_auth_spec_for_database_persistence(
+                input_kinds,
+                "surface auth",
+                &runtime.auth,
+            )?;
+            needs_transport_guard |= validate_headers_for_database_persistence(
+                input_kinds,
+                "surface request_headers",
+                &runtime.request_headers,
+            )?;
+            needs_transport_guard |=
+                template_references_secret_input(input_kinds, &runtime.base_url);
+            if let Some(source_variables) = source_variables
+                && needs_transport_guard
+                && !runtime.base_url.is_empty()
+            {
+                validate_endpoint_template_transport(
+                    input_kinds,
+                    source_variables,
+                    "surface base_url",
+                    &runtime.base_url,
+                )?;
+            }
+        }
+        coral_spec::v4::SurfaceRuntimeConfig::Database(_) => {
+            // Database surfaces carry their credentials in the connection
+            // spec, which the database connection layer validates on its
+            // own. There is no surface auth/header/base_url transport to
+            // guard for imported-manifest persistence here.
+        }
+        coral_spec::v4::SurfaceRuntimeConfig::Mcp(runtime) => {
+            validate_mcp_server_for_database_persistence(
+                input_kinds,
+                "surface server",
+                &runtime.server,
+            )?;
+        }
+    }
     Ok(())
 }
 
@@ -242,8 +305,8 @@ fn validate_http_auth_spec_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     auth: &AuthSpec,
-) -> Result<(), AppError> {
-    match auth {
+) -> Result<bool, AppError> {
+    let needs_transport_guard = match auth {
         AuthSpec::BasicAuth(basic) => {
             if basic_auth_username_needs_secret(&basic.username) {
                 validate_secret_template_for_database_persistence(
@@ -257,22 +320,31 @@ fn validate_http_auth_spec_for_database_persistence(
                 &format!("{context}.password"),
                 &basic.password,
             )?;
+            true
         }
         AuthSpec::HeaderAuth(header_auth) => {
-            validate_headers_for_database_persistence(input_kinds, context, &header_auth.headers)?;
+            validate_headers_for_database_persistence(input_kinds, context, &header_auth.headers)?
         }
         AuthSpec::CustomAuth(custom) => {
+            let mut found = false;
             for (key, value) in &custom.config {
-                validate_custom_auth_value_for_database_persistence(
+                found |= validate_custom_auth_value_for_database_persistence(
                     input_kinds,
                     &format!("{context}.{key}"),
                     sensitive_key_name(key),
                     value,
                 )?;
             }
+            found || declares_secret_input(input_kinds)
         }
-    }
-    Ok(())
+    };
+    Ok(needs_transport_guard)
+}
+
+fn declares_secret_input(input_kinds: &BTreeMap<String, ManifestInputKind>) -> bool {
+    input_kinds
+        .values()
+        .any(|kind| *kind == ManifestInputKind::Secret)
 }
 
 fn validate_file_source_for_database_persistence(
@@ -337,59 +409,68 @@ fn validate_request_headers_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     request: &coral_spec::RequestSpec,
-) -> Result<(), AppError> {
-    validate_headers_for_database_persistence(
+) -> Result<bool, AppError> {
+    let mut needs_transport_guard = template_references_secret_input(input_kinds, &request.path);
+    needs_transport_guard |= validate_headers_for_database_persistence(
         input_kinds,
         &format!("{context} request headers"),
         &request.headers,
     )?;
     for param in &request.query {
+        needs_transport_guard |= value_source_references_secret_input(input_kinds, &param.value);
         if sensitive_query_param_name(&param.name) {
             validate_sensitive_value_source_for_database_persistence(
                 input_kinds,
                 &format!("{context} query param '{}'", param.name),
                 &param.value,
             )?;
+            needs_transport_guard = true;
         }
     }
     match &request.body {
         BodySpec::Json { fields } => {
             for field in fields {
+                needs_transport_guard |=
+                    value_source_references_secret_input(input_kinds, &field.value);
                 if field.path.iter().any(|segment| sensitive_key_name(segment)) {
                     validate_sensitive_value_source_for_database_persistence(
                         input_kinds,
                         &format!("{context} body field '{}'", field.path.join(".")),
                         &field.value,
                     )?;
+                    needs_transport_guard = true;
                 }
             }
         }
         BodySpec::Text { content } => {
-            validate_text_body_for_database_persistence(
+            needs_transport_guard |= validate_text_body_for_database_persistence(
                 input_kinds,
                 &format!("{context} request body text"),
                 content,
             )?;
         }
     }
-    Ok(())
+    Ok(needs_transport_guard)
 }
 
 fn validate_headers_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     headers: &[HeaderSpec],
-) -> Result<(), AppError> {
+) -> Result<bool, AppError> {
+    let mut needs_transport_guard = false;
     for header in headers {
+        needs_transport_guard |= value_source_references_secret_input(input_kinds, &header.value);
         if sensitive_http_header_name(&header.name) {
             validate_sensitive_value_source_for_database_persistence(
                 input_kinds,
                 &format!("{context} header '{}'", header.name),
                 &header.value,
             )?;
+            needs_transport_guard = true;
         }
     }
-    Ok(())
+    Ok(needs_transport_guard)
 }
 
 fn basic_auth_username_needs_secret(template: &ParsedTemplate) -> bool {
@@ -449,11 +530,40 @@ fn validate_text_body_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     value: &ValueSourceSpec,
-) -> Result<(), AppError> {
-    if text_body_value_source_needs_secret(value) {
+) -> Result<bool, AppError> {
+    let sensitive_value = text_body_value_source_needs_secret(value);
+    if sensitive_value {
         validate_sensitive_value_source_for_database_persistence(input_kinds, context, value)?;
     }
-    Ok(())
+    Ok(sensitive_value || value_source_references_secret_input(input_kinds, value))
+}
+
+fn value_source_references_secret_input(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    value: &ValueSourceSpec,
+) -> bool {
+    match value {
+        ValueSourceSpec::Template { template } => {
+            template_references_secret_input(input_kinds, template)
+        }
+        ValueSourceSpec::OneOf { values } => values
+            .iter()
+            .any(|value| value_source_references_secret_input(input_kinds, value)),
+        ValueSourceSpec::Input { key } | ValueSourceSpec::Bearer { key } => {
+            input_kinds.get(key) == Some(&ManifestInputKind::Secret)
+        }
+        _ => false,
+    }
+}
+
+fn template_references_secret_input(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    template: &ParsedTemplate,
+) -> bool {
+    template.tokens().any(|token| {
+        token.namespace() == &TemplateNamespace::Input
+            && input_kinds.get(token.key()) == Some(&ManifestInputKind::Secret)
+    })
 }
 
 fn text_body_value_source_needs_secret(value: &ValueSourceSpec) -> bool {
@@ -512,43 +622,124 @@ fn text_body_contains_sensitive_marker(raw: &str) -> bool {
     })
 }
 
+fn validate_oauth_endpoint_transports(
+    inputs: &[ManifestInputSpec],
+    source_variables: &BTreeMap<String, String>,
+) -> Result<(), AppError> {
+    for input in inputs {
+        let Some(credential) = input.credential.as_ref() else {
+            continue;
+        };
+        for method in &credential.methods {
+            if method.kind != ManifestCredentialMethodKind::OAuth {
+                continue;
+            }
+            let Some(oauth) = method.oauth.as_ref() else {
+                continue;
+            };
+            let endpoints = oauth
+                .endpoint_urls(source_variables)
+                .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+            if let Some(url) = endpoints.authorization_url.as_deref() {
+                validate_credential_endpoint_transport("oauth authorization_url", url)?;
+            }
+            if let Some(url) = endpoints.device_authorization_url.as_deref() {
+                validate_credential_endpoint_transport("oauth device_authorization_url", url)?;
+            }
+            validate_credential_endpoint_transport("oauth token_url", &endpoints.token_url)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_endpoint_template_transport(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    source_variables: &BTreeMap<String, String>,
+    context: &str,
+    template: &ParsedTemplate,
+) -> Result<(), AppError> {
+    let rendered =
+        render_source_variable_template(input_kinds, source_variables, context, template)?;
+    validate_credential_endpoint_transport(context, &rendered)
+}
+
+fn render_source_variable_template(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    source_variables: &BTreeMap<String, String>,
+    context: &str,
+    template: &ParsedTemplate,
+) -> Result<String, AppError> {
+    let mut rendered = String::with_capacity(template.raw().len());
+    for part in template.parts() {
+        match part {
+            TemplatePart::Literal(literal) => rendered.push_str(literal),
+            TemplatePart::Token(token) if token.namespace() == &TemplateNamespace::Input => {
+                if input_kinds.get(token.key()) != Some(&ManifestInputKind::Variable) {
+                    return Err(AppError::InvalidInput(format!(
+                        "{context} input '{}' must be a variable to validate imported credential transport",
+                        token.key()
+                    )));
+                }
+                let value = source_variables.get(token.key()).ok_or_else(|| {
+                    AppError::InvalidInput(format!(
+                        "{context} references unresolved source variable '{}'",
+                        token.key()
+                    ))
+                })?;
+                rendered.push_str(value);
+            }
+            TemplatePart::Token(token) => {
+                return Err(AppError::InvalidInput(format!(
+                    "{context} uses unsupported transport template token '{}'",
+                    token.raw()
+                )));
+            }
+        }
+    }
+    Ok(rendered)
+}
+
 fn validate_custom_auth_value_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     sensitive_context: bool,
     value: &JsonValue,
-) -> Result<(), AppError> {
+) -> Result<bool, AppError> {
     match value {
         JsonValue::Object(map) => {
+            let mut found = false;
             for (key, value) in map {
-                validate_custom_auth_value_for_database_persistence(
+                found |= validate_custom_auth_value_for_database_persistence(
                     input_kinds,
                     &format!("{context}.{key}"),
                     sensitive_context || sensitive_key_name(key),
                     value,
                 )?;
             }
-            Ok(())
+            Ok(found)
         }
         JsonValue::Array(values) => {
+            let mut found = false;
             for (index, value) in values.iter().enumerate() {
-                validate_custom_auth_value_for_database_persistence(
+                found |= validate_custom_auth_value_for_database_persistence(
                     input_kinds,
                     &format!("{context}[{index}]"),
                     sensitive_context,
                     value,
                 )?;
             }
-            Ok(())
+            Ok(found)
         }
         JsonValue::String(raw) if sensitive_context => {
             let template = ParsedTemplate::parse(raw)
                 .map_err(|error| AppError::InvalidInput(error.to_string()))?;
-            validate_secret_template_for_database_persistence(input_kinds, context, &template)
+            validate_secret_template_for_database_persistence(input_kinds, context, &template)?;
+            Ok(true)
         }
-        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => {
-            Ok(())
-        }
+        JsonValue::String(raw) => Ok(ParsedTemplate::parse(raw)
+            .ok()
+            .is_some_and(|template| template_references_secret_input(input_kinds, &template))),
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => Ok(false),
     }
 }
 
@@ -653,7 +844,7 @@ mod tests {
         reason = "manifest input order assertions intentionally fail loudly in tests"
     )]
 
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use coral_spec::ManifestInputKind;
 
@@ -666,8 +857,12 @@ mod tests {
     use crate::sources::model::SourceOrigin;
 
     fn minimal_http_manifest(extra_top_level: &str) -> String {
+        minimal_http_manifest_at("https://example.com", extra_top_level)
+    }
+
+    fn minimal_http_manifest_at(base_url: &str, extra_top_level: &str) -> String {
         format!(
-            "name: demo\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: https://example.com\n{extra_top_level}tables:\n  - name: messages\n    description: Demo messages\n    request:\n      method: GET\n      path: /messages\n    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
+            "name: demo\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: {base_url}\n{extra_top_level}tables:\n  - name: messages\n    description: Demo messages\n    request:\n      method: GET\n      path: /messages\n    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
         )
     }
 
@@ -888,6 +1083,21 @@ tables:
                 "table 'messages' request body text must reference a secret input",
             ),
             (
+                minimal_http_manifest_at(
+                    "\"http://api.example.com/{{input.API_TOKEN}}\"",
+                    "inputs:\n  API_TOKEN:\n    kind: secret\n",
+                ),
+                "base_url input 'API_TOKEN' must be a variable",
+            ),
+            (
+                minimal_http_manifest_at(
+                    "http://api.example.com",
+                    "inputs:\n  API_TOKEN:\n    kind: secret\n",
+                )
+                .replace("path: /messages", "path: /{{input.API_TOKEN}}"),
+                "base_url must use https or loopback http",
+            ),
+            (
                 minimal_v4_openapi_manifest(
                     "  auth:\n    type: HeaderAuth\n    headers:\n      - name: Authorization\n        from: literal\n        value: Bearer hardcoded-token\n",
                 ),
@@ -920,8 +1130,9 @@ tables:
         ];
 
         for (manifest, expected) in cases {
-            let error = validate_imported_manifest_database_persistence(&manifest)
-                .expect_err("literal sensitive value should be rejected");
+            let error =
+                validate_imported_manifest_database_persistence(&manifest, &BTreeMap::new())
+                    .expect_err("literal sensitive value should be rejected");
             assert!(
                 error.to_string().contains(expected),
                 "expected {expected:?}, got {error}"
@@ -931,9 +1142,12 @@ tables:
 
     #[test]
     fn database_persistence_rejects_basic_auth_username_when_it_is_credential_marked() {
-        let error = validate_imported_manifest_database_persistence(&minimal_http_manifest(
-            "inputs:\n  WOOCOMMERCE_CONSUMER_KEY:\n    kind: variable\n  API_PASSWORD:\n    kind: secret\nauth:\n  type: BasicAuth\n  username: \"{{input.WOOCOMMERCE_CONSUMER_KEY}}\"\n  password: \"{{input.API_PASSWORD}}\"\n",
-        ))
+        let error = validate_imported_manifest_database_persistence(
+            &minimal_http_manifest(
+                "inputs:\n  WOOCOMMERCE_CONSUMER_KEY:\n    kind: variable\n  API_PASSWORD:\n    kind: secret\nauth:\n  type: BasicAuth\n  username: \"{{input.WOOCOMMERCE_CONSUMER_KEY}}\"\n  password: \"{{input.API_PASSWORD}}\"\n",
+            ),
+            &BTreeMap::new(),
+        )
         .expect_err("credential-marked BasicAuth username should be rejected");
 
         assert!(
@@ -946,9 +1160,12 @@ tables:
 
     #[test]
     fn database_persistence_rejects_one_of_sensitive_fallbacks() {
-        let error = validate_imported_manifest_database_persistence(&minimal_http_manifest(
-            "inputs:\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: one_of\n      values:\n        - from: input\n          key: API_TOKEN\n        - from: literal\n          value: Bearer fallback-token\n",
-        ))
+        let error = validate_imported_manifest_database_persistence(
+            &minimal_http_manifest(
+                "inputs:\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: one_of\n      values:\n        - from: input\n          key: API_TOKEN\n        - from: literal\n          value: Bearer fallback-token\n",
+            ),
+            &BTreeMap::new(),
+        )
         .expect_err("literal one_of fallback should be rejected");
 
         assert!(
@@ -986,8 +1203,9 @@ tables:
         ];
 
         for (manifest, expected) in cases {
-            let error = validate_imported_manifest_database_persistence(&manifest)
-                .expect_err("S3 credential should be rejected");
+            let error =
+                validate_imported_manifest_database_persistence(&manifest, &BTreeMap::new())
+                    .expect_err("S3 credential should be rejected");
             assert!(
                 error.to_string().contains(expected),
                 "expected {expected:?}, got {error}"
@@ -1013,8 +1231,9 @@ tables:
         ];
 
         for (manifest, expected) in cases {
-            let error = validate_imported_manifest_database_persistence(&manifest)
-                .expect_err("sensitive MCP env value should be rejected");
+            let error =
+                validate_imported_manifest_database_persistence(&manifest, &BTreeMap::new())
+                    .expect_err("sensitive MCP env value should be rejected");
             assert!(
                 error.to_string().contains(expected),
                 "expected {expected:?}, got {error}"
@@ -1023,23 +1242,61 @@ tables:
     }
 
     #[test]
+    fn database_persistence_rejects_untrusted_variable_endpoints_for_secrets() {
+        let variables =
+            BTreeMap::from([("API_BASE".to_string(), "http://api.example.com".to_string())]);
+        let manifest = minimal_http_manifest_at(
+            "\"{{input.API_BASE}}\"",
+            "inputs:\n  API_BASE:\n    kind: variable\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: X-Session\n      from: template\n      template: \"{{input.API_TOKEN}}\"\n",
+        );
+        let error = validate_imported_manifest_database_persistence(&manifest, &variables)
+            .expect_err("cleartext rendered base_url should be rejected");
+        assert!(error.to_string().contains("base_url must use https"));
+    }
+
+    #[test]
+    fn database_persistence_rejects_custom_auth_cleartext_endpoint_when_secrets_exist() {
+        let variables =
+            BTreeMap::from([("API_BASE".to_string(), "http://api.example.com".to_string())]);
+        let manifest = minimal_http_manifest_at(
+            "\"{{input.API_BASE}}\"",
+            "inputs:\n  API_BASE:\n    kind: variable\n  API_TOKEN:\n    kind: secret\nauth:\n  type: CustomAuth\n  authenticator: demo_auth\n  prefix: Bearer\n",
+        );
+
+        let error = validate_imported_manifest_database_persistence(&manifest, &variables)
+            .expect_err("custom auth can read declared secret inputs");
+
+        assert!(error.to_string().contains("base_url must use https"));
+    }
+
+    #[test]
+    fn database_persistence_rejects_untrusted_oauth_endpoints() {
+        let manifest = minimal_http_manifest(
+            "inputs:\n  API_TOKEN:\n    kind: secret\n    credential:\n      methods:\n        - type: oauth\n          oauth:\n            flow:\n              type: device_code\n            endpoints:\n              device_authorization_url: http://api.example.com/device\n              token_url: https://api.example.com/token\n            client:\n              id:\n                default: demo\n",
+        );
+        let error = validate_imported_manifest_database_persistence(&manifest, &BTreeMap::new())
+            .expect_err("cleartext OAuth endpoint should be rejected");
+        assert!(format!("{error}").contains("device_authorization_url must use https"));
+    }
+
+    #[test]
     fn database_persistence_allows_literal_non_secret_headers() {
-        validate_imported_manifest_database_persistence(&minimal_http_manifest("auth:\n  type: HeaderAuth\n  headers:\n    - name: Travis-API-Version\n      from: literal\n      value: \"3\"\nrequest_headers:\n  - name: Accept\n    from: literal\n    value: application/json\n"))
+        validate_imported_manifest_database_persistence(&minimal_http_manifest("auth:\n  type: HeaderAuth\n  headers:\n    - name: Travis-API-Version\n      from: literal\n      value: \"3\"\nrequest_headers:\n  - name: Accept\n    from: literal\n    value: application/json\n"), &BTreeMap::new())
         .expect("non-secret literal headers should be allowed");
 
-        validate_imported_manifest_database_persistence(&minimal_http_manifest_with_request("      body:\n        format: text\n        content:\n          from: literal\n          value: \"SELECT id, name FROM users FORMAT JSONEachRow\"\n"))
+        validate_imported_manifest_database_persistence(&minimal_http_manifest_with_request("      body:\n        format: text\n        content:\n          from: literal\n          value: \"SELECT id, name FROM users FORMAT JSONEachRow\"\n"), &BTreeMap::new())
         .expect("non-secret literal text bodies should be allowed");
 
-        validate_imported_manifest_database_persistence(&minimal_http_manifest_with_request("      query:\n        - name: page_token\n          from: filter\n          key: page_token\n"))
+        validate_imported_manifest_database_persistence(&minimal_http_manifest_with_request("      query:\n        - name: page_token\n          from: filter\n          key: page_token\n"), &BTreeMap::new())
         .expect("pagination token filters should not be treated as credentials");
     }
 
     #[test]
     fn database_persistence_allows_sensitive_header_from_secret_input() {
-        validate_imported_manifest_database_persistence(&minimal_http_manifest("inputs:\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n"))
+        validate_imported_manifest_database_persistence(&minimal_http_manifest("inputs:\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n"), &BTreeMap::new())
         .expect("secret-backed auth header should be allowed");
 
-        validate_imported_manifest_database_persistence(&minimal_http_manifest("inputs:\n  API_PASSWORD:\n    kind: secret\nauth:\n  type: BasicAuth\n  username: public-user\n  password: \"{{input.API_PASSWORD}}\"\n"))
+        validate_imported_manifest_database_persistence(&minimal_http_manifest("inputs:\n  API_PASSWORD:\n    kind: secret\nauth:\n  type: BasicAuth\n  username: public-user\n  password: \"{{input.API_PASSWORD}}\"\n"), &BTreeMap::new())
         .expect("public BasicAuth username should be allowed with a secret-backed password");
     }
 }

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -4,9 +4,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use coral_spec::backends::file::{FileObjectStoreSpec, S3AuthSpec};
 use coral_spec::{
-    AuthSpec, BodySpec, HeaderSpec, ManifestCredentialMethodKind, ManifestInputKind,
-    ManifestInputSpec, McpServerSpec, ParsedTemplate, TemplateNamespace, TemplatePart,
-    ValidatedSourceManifest, ValueSourceSpec, parse_source_manifest_yaml,
+    AuthSpec, BodySpec, DatabaseConnectionSpec, HeaderSpec, ManifestCredentialMethodKind,
+    ManifestInputKind, ManifestInputSpec, McpServerSpec, ParsedTemplate, TemplateNamespace,
+    TemplatePart, ValidatedSourceManifest, ValueSourceSpec, parse_source_manifest_yaml,
 };
 use serde_json::Value as JsonValue;
 
@@ -268,11 +268,17 @@ fn validate_v4_source_for_database_persistence(
                 )?;
             }
         }
-        coral_spec::v4::SurfaceRuntimeConfig::Database(_) => {
-            // Database surfaces carry their credentials in the connection
-            // spec, which the database connection layer validates on its
-            // own. There is no surface auth/header/base_url transport to
-            // guard for imported-manifest persistence here.
+        coral_spec::v4::SurfaceRuntimeConfig::Database(runtime) => {
+            let password = match &runtime.connection {
+                DatabaseConnectionSpec::Postgres(connection) => &connection.password,
+                DatabaseConnectionSpec::MySql(connection) => &connection.password,
+                DatabaseConnectionSpec::Sqlite(_) => return Ok(()),
+            };
+            validate_secret_template_for_database_persistence(
+                input_kinds,
+                "surface connection.password",
+                password,
+            )?;
         }
         coral_spec::v4::SurfaceRuntimeConfig::Mcp(runtime) => {
             validate_mcp_server_for_database_persistence(
@@ -878,6 +884,12 @@ mod tests {
         )
     }
 
+    fn minimal_v4_postgres_manifest(inputs: &str, password: &str) -> String {
+        format!(
+            "name: demo\ndsl_version: 4\n{inputs}surface:\n  type: database\n  provider: postgres\n  connection:\n    host: localhost\n    port: \"5432\"\n    database: demo\n    user: demo\n    password: \"{password}\"\n"
+        )
+    }
+
     fn minimal_http_manifest_with_route(route_extra: &str) -> String {
         format!(
             "name: demo\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: https://example.com\ntables:\n  - name: messages\n    description: Demo messages\n    filters:\n      - name: id\n    request:\n      method: GET\n      path: /messages\n    requests:\n      - when_filters:\n          - id\n        method: GET\n        path: /messages/{{{{filter.id}}}}\n{route_extra}    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
@@ -1038,6 +1050,10 @@ tables:
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the table keeps every sensitive manifest surface in one persistence contract"
+    )]
     fn database_persistence_rejects_literal_sensitive_values() {
         let cases = [
             (
@@ -1108,6 +1124,17 @@ tables:
                     "  request_headers:\n    - name: Cookie\n      from: literal\n      value: session=hardcoded-token\n",
                 ),
                 "surface request_headers header 'Cookie' must reference a secret input",
+            ),
+            (
+                minimal_v4_postgres_manifest("", "hardcoded-password"),
+                "surface connection.password must reference a secret input",
+            ),
+            (
+                minimal_v4_postgres_manifest(
+                    "inputs:\n  CONNECTION_VALUE:\n    kind: variable\n",
+                    "{{input.CONNECTION_VALUE}}",
+                ),
+                "surface connection.password must reference a secret input",
             ),
             (
                 minimal_http_manifest(
@@ -1298,5 +1325,14 @@ tables:
 
         validate_imported_manifest_database_persistence(&minimal_http_manifest("inputs:\n  API_PASSWORD:\n    kind: secret\nauth:\n  type: BasicAuth\n  username: public-user\n  password: \"{{input.API_PASSWORD}}\"\n"), &BTreeMap::new())
         .expect("public BasicAuth username should be allowed with a secret-backed password");
+
+        validate_imported_manifest_database_persistence(
+            &minimal_v4_postgres_manifest(
+                "inputs:\n  DB_PASSWORD:\n    kind: secret\n",
+                "{{input.DB_PASSWORD}}",
+            ),
+            &BTreeMap::new(),
+        )
+        .expect("database password backed by a secret input should be allowed");
     }
 }

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -22,6 +22,7 @@ use crate::search::sqlite_store::SqliteSearchStore;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
     validate_imported_manifest_database_persistence,
+    validate_imported_manifest_database_persistence_shape,
 };
 use crate::sources::materialization::{
     MaterializationBuild, MaterializationInputs, SourceDiagnosticReporter,
@@ -493,6 +494,11 @@ impl SourceManager {
             &BTreeSet::new(),
         )?;
         let bindings = validate_bindings(candidate, bindings, &stored_material)?;
+        if origin == SourceOrigin::Imported
+            && let Some(manifest_yaml) = manifest_yaml
+        {
+            validate_imported_manifest_database_persistence(manifest_yaml, &bindings.variables)?;
+        }
         let materialization_inputs =
             materialization_inputs_from_bindings(&bindings, &stored_material);
         self.persist_source(
@@ -558,6 +564,14 @@ impl SourceManager {
             &stored_material,
             &oauth_credential_retrievals,
         )?;
+        if origin == SourceOrigin::Imported
+            && let Some(manifest_yaml) = manifest_yaml.as_deref()
+        {
+            validate_imported_manifest_database_persistence(
+                manifest_yaml,
+                &preflight_bindings.variables,
+            )?;
+        }
         let oauth_material = self
             .retrieve_oauth_material(
                 &candidate,
@@ -756,7 +770,7 @@ impl SourceManager {
         let manifest = parse_source_manifest_yaml(manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let manifest_yaml = durable_import_manifest_yaml(manifest_yaml, &manifest)?;
-        validate_imported_manifest_database_persistence(&manifest_yaml)?;
+        validate_imported_manifest_database_persistence_shape(&manifest_yaml)?;
         let mut candidate =
             describe_manifest(manifest_yaml.as_str(), SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -625,7 +625,7 @@ mod tests {
             .mode();
         fs::set_permissions(layout.config_dir(), fs::Permissions::from_mode(0o500))
             .expect("make config dir read-only");
-        let report = import_config_source_catalog(&db, &config_store, 11).await;
+        let report = import_config_source_catalog(&db, &config_store, &layout, 11).await;
         fs::set_permissions(
             layout.config_dir(),
             fs::Permissions::from_mode(original_mode),
@@ -651,7 +651,7 @@ mod tests {
         assert!(
             session
                 .state_migrations()
-                .has_completed(SOURCE_CATALOG_IMPORT_ID)
+                .has_completed(&source_catalog_import_id(&layout))
                 .await
                 .expect("read source import marker")
         );
@@ -678,7 +678,7 @@ mod tests {
             tx.commit().await.expect("commit delete tx");
         }
 
-        let report = import_config_source_catalog(&db, &config_store, 99)
+        let report = import_config_source_catalog(&db, &config_store, &layout, 99)
             .await
             .expect("completed source import should not reimport stale config");
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -27,8 +27,12 @@ use crate::harness::{
 };
 
 fn auth_manifest_yaml(inputs: &str, auth: &str) -> String {
+    auth_manifest_yaml_at("https://example.com", inputs, auth)
+}
+
+fn auth_manifest_yaml_at(base_url: &str, inputs: &str, auth: &str) -> String {
     format!(
-        "name: hardcoded_auth\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: https://example.com\n{inputs}{auth}tables:\n  - name: messages\n    description: Demo messages\n    request:\n      method: GET\n      path: /messages\n    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
+        "name: hardcoded_auth\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: {base_url}\n{inputs}{auth}tables:\n  - name: messages\n    description: Demo messages\n    request:\n      method: GET\n      path: /messages\n    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
     )
 }
 
@@ -43,6 +47,14 @@ fn variable_backed_sensitive_auth_manifest_yaml() -> String {
     auth_manifest_yaml(
         "inputs:\n  HEADER_VALUE:\n    kind: variable\n",
         "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.HEADER_VALUE}}\n",
+    )
+}
+
+fn secret_auth_manifest_yaml_at(base_url: &str) -> String {
+    auth_manifest_yaml_at(
+        base_url,
+        "inputs:\n  API_TOKEN:\n    kind: secret\n",
+        "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n",
     )
 }
 
@@ -317,14 +329,90 @@ async fn import_rejects_sensitive_auth_template_backed_by_variable() {
 }
 
 #[tokio::test]
-async fn import_with_oauth_rejects_literal_sensitive_auth_header_before_authorization() {
+async fn import_rejects_cleartext_secret_endpoint_without_database_state() {
+    let harness = GrpcHarness::new().await;
+    let error = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: secret_auth_manifest_yaml_at("http://api.example.com"),
+            variables: Vec::new(),
+            secrets: vec![SourceSecret {
+                key: "API_TOKEN".into(),
+                value: "secret-token".into(),
+            }],
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("cleartext credential endpoint should fail");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(error.message().contains("base_url"));
+    assert!(harness.list_sources().await.is_empty());
+}
+
+#[tokio::test]
+async fn import_rejects_variable_rendered_cleartext_secret_endpoint() {
+    let harness = GrpcHarness::new().await;
+    let error = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: auth_manifest_yaml_at(
+                "\"{{input.API_BASE}}\"",
+                "inputs:\n  API_BASE:\n    kind: variable\n  API_TOKEN:\n    kind: secret\n",
+                "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n",
+            ),
+            variables: vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "http://api.example.com".to_string(),
+            }],
+            secrets: vec![SourceSecret {
+                key: "API_TOKEN".into(),
+                value: "secret-token".into(),
+            }],
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("rendered cleartext credential endpoint should fail");
+
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(
+        error.message().contains("base_url"),
+        "message: {}",
+        error.message()
+    );
+    assert!(harness.list_sources().await.is_empty());
+}
+
+#[tokio::test]
+async fn import_allows_loopback_secret_endpoint() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            secret_auth_manifest_yaml_at("http://127.0.0.1:9"),
+            Vec::new(),
+            vec![SourceSecret {
+                key: "API_TOKEN".into(),
+                value: "secret-token".into(),
+            }],
+        )
+        .await;
+
+    assert_eq!(harness.list_sources().await.len(), 1);
+}
+
+#[tokio::test]
+async fn import_with_oauth_rejects_cleartext_endpoint_before_authorization() {
     let harness = GrpcHarness::new().await;
 
     let mut stream = harness
         .source_client()
         .import_source(Request::new(ImportSourceRequest {
             workspace: Some(default_workspace()),
-            manifest_yaml: literal_sensitive_auth_manifest_yaml(),
+            manifest_yaml: auth_manifest_yaml(
+                "inputs:\n  API_TOKEN:\n    kind: secret\n    credential:\n      methods:\n        - type: oauth\n          oauth:\n            flow:\n              type: device_code\n            endpoints:\n              device_authorization_url: http://api.example.com/device\n              token_url: https://api.example.com/token\n            client:\n              id:\n                default: demo\n",
+                "",
+            ),
             variables: Vec::new(),
             secrets: Vec::new(),
             oauth_credential_retrievals: vec![OAuthCredentialRetrieval {
@@ -337,12 +425,10 @@ async fn import_with_oauth_rejects_literal_sensitive_auth_header_before_authoriz
         .expect("OAuth import request should create a response stream")
         .into_inner();
 
-    let error = stream
-        .message()
-        .await
-        .expect_err("literal sensitive auth should fail before OAuth authorization");
+    let error = stream.message().await.expect_err("cleartext endpoint");
     assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(error.message().contains("Authorization"));
+    assert!(error.message().contains("device_authorization_url"));
+    assert!(harness.list_sources().await.is_empty());
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -330,7 +330,7 @@ async fn import_rejects_sensitive_auth_template_backed_by_variable() {
 
 #[tokio::test]
 async fn import_rejects_cleartext_secret_endpoint_without_database_state() {
-    let harness = GrpcHarness::new().await;
+    let harness = GrpcHarness::with_workspace().await;
     let error = harness
         .source_client()
         .import_source(Request::new(ImportSourceRequest {
@@ -352,7 +352,7 @@ async fn import_rejects_cleartext_secret_endpoint_without_database_state() {
 
 #[tokio::test]
 async fn import_rejects_variable_rendered_cleartext_secret_endpoint() {
-    let harness = GrpcHarness::new().await;
+    let harness = GrpcHarness::with_workspace().await;
     let error = harness
         .source_client()
         .import_source(Request::new(ImportSourceRequest {
@@ -386,7 +386,7 @@ async fn import_rejects_variable_rendered_cleartext_secret_endpoint() {
 
 #[tokio::test]
 async fn import_allows_loopback_secret_endpoint() {
-    let harness = GrpcHarness::new().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             secret_auth_manifest_yaml_at("http://127.0.0.1:9"),
@@ -403,7 +403,7 @@ async fn import_allows_loopback_secret_endpoint() {
 
 #[tokio::test]
 async fn import_with_oauth_rejects_cleartext_endpoint_before_authorization() {
-    let harness = GrpcHarness::new().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let mut stream = harness
         .source_client()

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -104,13 +104,17 @@ pub(super) fn default_http_client(
 ) -> Result<reqwest::Client> {
     registration
         .default_http_client(credential_safe, || {
-            let mut builder = reqwest::Client::builder()
+            let redirect_policy = if credential_safe {
+                credential_safe_redirect_policy()
+            } else {
+                source_redirect_policy()
+            };
+            reqwest::Client::builder()
                 .timeout(Duration::from_secs(DEFAULT_HTTP_REQUEST_TIMEOUT_SECS))
-                .user_agent(DEFAULT_HTTP_USER_AGENT);
-            if credential_safe {
-                builder = builder.redirect(credential_safe_redirect_policy());
-            }
-            builder.build().map_err(|error| error.to_string())
+                .redirect(redirect_policy)
+                .user_agent(DEFAULT_HTTP_USER_AGENT)
+                .build()
+                .map_err(|error| error.to_string())
         })
         .map_err(|error| {
             DataFusionError::Execution(format!(
@@ -135,6 +139,30 @@ fn credential_safe_redirect_policy() -> reqwest::redirect::Policy {
 
 fn credential_safe_redirect_target(previous: &reqwest::Url, next: &reqwest::Url) -> bool {
     previous.origin() == next.origin() && is_credential_safe_auth_transport(next)
+}
+
+fn source_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() > 10 {
+            return attempt.error(std::io::Error::other("too many redirects"));
+        }
+        let Some(previous) = attempt.previous().last() else {
+            return attempt.follow();
+        };
+        if same_origin(previous, attempt.url()) {
+            attempt.follow()
+        } else {
+            attempt.error(std::io::Error::other(
+                "cross-origin redirects are disabled for source HTTP requests",
+            ))
+        }
+    })
+}
+
+fn same_origin(left: &reqwest::Url, right: &reqwest::Url) -> bool {
+    left.scheme() == right.scheme()
+        && left.host_str() == right.host_str()
+        && left.port_or_known_default() == right.port_or_known_default()
 }
 
 impl HttpSourceClient {

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -2538,6 +2538,82 @@ async fn auth_headers_sent_correctly() {
 }
 
 #[tokio::test]
+async fn source_http_client_follows_same_origin_redirects() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(header("authorization", "Bearer secret-token"))
+        .respond_with(
+            ResponseTemplate::new(307)
+                .append_header("Location", format!("{}/api/redirected-users", server.uri())),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/redirected-users"))
+        .and(header("authorization", "Bearer secret-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_same_origin_redirect", &server.uri());
+    manifest["inputs"] = json!({"API_TOKEN": { "kind": "secret" }});
+    manifest["auth"] = json!({"type": "HeaderAuth", "headers": [{
+        "name": "Authorization", "from": "bearer", "key": "API_TOKEN"
+    }]});
+    let source = build_source_with_secrets(manifest, [("API_TOKEN", "secret-token")]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT COUNT(*) AS n FROM http_same_origin_redirect.users",
+        )
+        .await
+        .expect("same-origin redirect should succeed"),
+    );
+
+    assert_eq!(rows, vec![json!({"n": 3})]);
+}
+
+#[tokio::test]
+async fn source_http_client_rejects_cross_origin_redirects() {
+    let server = MockServer::start().await;
+    let recorder = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(header("authorization", "Bearer secret-token"))
+        .respond_with(
+            ResponseTemplate::new(307)
+                .append_header("Location", format!("{}/capture", recorder.uri())),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(path("/capture"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(0)
+        .mount(&recorder)
+        .await;
+
+    let mut manifest = base_http_manifest("http_redirect", &server.uri());
+    manifest["inputs"] = json!({"API_TOKEN": { "kind": "secret" }});
+    manifest["auth"] = json!({"type": "HeaderAuth", "headers": [{
+        "name": "Authorization", "from": "bearer", "key": "API_TOKEN"
+    }]});
+    let source = build_source_with_secrets(manifest, [("API_TOKEN", "secret-token")]);
+
+    CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT COUNT(*) AS n FROM http_redirect.users",
+    )
+    .await
+    .expect_err("cross-origin redirect should fail");
+}
+
+#[tokio::test]
 async fn auth_header_one_of_uses_bearer_fallback() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))


### PR DESCRIPTION
Intent

Prevent imported source credentials and OAuth credential material from being sent to cleartext non-loopback endpoints when manifest data is persisted, refreshed, used to start setup flows, or sent by runtime HTTP clients.

What it enables

Ensures imported secret-backed HTTP sources and OAuth flows fail closed unless credential-bearing endpoints resolve to HTTPS or loopback HTTP, including stored OAuth refresh metadata, setup endpoints, direct secret URL/path interpolation, and redirect attempts.

Usage examples

- `coral source add --file source.yaml` with `base_url: https://api.example.com` and secret-backed Authorization continues to work.

- The same source with `base_url: http://api.example.com` is rejected before install, while loopback HTTP remains allowed for local providers.

- Secret input interpolation in `base_url` or request paths is treated as credential-bearing endpoint construction and must resolve to a trusted transport.

- OAuth setup endpoints such as `authorization_url`, `device_authorization_url`, and `token_url` must resolve to HTTPS or loopback HTTP.

- Credential-bearing OAuth and source HTTP requests do not follow redirects; providers must return a direct trusted endpoint.